### PR TITLE
Add a new script that will throw an error if new bare functions are added

### DIFF
--- a/plugins/woocommerce/bin/check-new-functions.php
+++ b/plugins/woocommerce/bin/check-new-functions.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * WooCommerce New Functions Checker
+ *
+ * This script checks for new functions added in the "includes" or "src"
+ * directories between two git branches.
+ *
+ * Usage: php check_new_functions.php <pr_branch> <compare_branch>
+ * Example: php check_new_functions.php feature/new-functions trunk
+ */
+
+// Check if we have the required arguments
+if ( $argc < 3 ) {
+	echo "Usage: php check_new_functions.php <pr_branch> <compare_branch>\n";
+	echo "Example: php check_new_functions.php feature/new-functions trunk\n";
+	exit( 1 );
+}
+
+$pr_branch      = $argv[1];
+$compare_branch = $argv[2];
+
+// Get the root of the repository
+$get_repo_root_command = 'git rev-parse --show-toplevel';
+$output                = array();
+$return_code           = 0;
+
+exec( $get_repo_root_command, $output, $return_code );
+
+if ( $return_code !== 0 ) {
+	echo "Error: Failed to execute git rev-parse command\n";
+	echo "Command: $get_repo_root_command\n";
+	exit( 1 );
+}
+$repo_root = current( $output );
+
+// Execute git diff command to get changes between branches for includes/ and src/ directories only
+$diff_command = "git diff $compare_branch..$pr_branch -- {$repo_root}/plugins/woocommerce/includes/ {$repo_root}/plugins/woocommerce/src/";
+$output       = array();
+$return_code  = 0;
+
+exec( $diff_command, $output, $return_code );
+
+if ( $return_code !== 0 ) {
+	echo "Error: Failed to execute git diff command\n";
+	echo "Command: $diff_command\n";
+	exit( 1 );
+}
+
+if ( empty( $output ) ) {
+	echo "No changes found in includes/ or src/ directories.\n";
+	exit( 0 );
+}
+
+// Parse the diff output to find added and deleted functions
+$added_function_file_map = array();
+$deleted_functions       = array();
+
+$current_file = '';
+foreach ( $output as $line ) {
+	// Track current file being processed
+	if ( preg_match( '/^diff --git a\/(.+?) b\/(.+?)$/', $line, $matches ) ) {
+		$current_file = $matches[2]; // Use the 'b' (new) file path
+	} elseif ( preg_match( '/^\+\+\+ b\/(.+?)$/', $line, $matches ) ) {
+		$current_file = $matches[1]; // Alternative way to get file path
+	}
+
+	// Look for added functions (lines starting with +)
+	if ( preg_match( '/^\+.*?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
+		$function_name                             = $matches[1];
+		$added_function_file_map[ $function_name ] = $current_file;
+	}
+
+	// Look for deleted functions (lines starting with -)
+	if ( preg_match( '/^\-.*?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
+		$function_name       = $matches[1];
+		$deleted_functions[] = $function_name;
+	}
+}
+
+// Calculate net added functions (added minus deleted) and clean file paths
+$net_function_file_map = array();
+foreach ( $added_function_file_map as $function => $file_path ) {
+	// Skip functions that were also deleted (net zero change)
+	if ( in_array( $function, $deleted_functions ) ) {
+		continue;
+	}
+
+	// Remove "plugins/woocommerce/" prefix from file path
+	if ( strpos( $file_path, 'plugins/woocommerce/' ) === 0 ) {
+		$file_path = substr( $file_path, 19 ); // Remove "plugins/woocommerce/" (19 characters)
+	}
+	$net_function_file_map[ $function ] = $file_path;
+}
+
+// Check if there are any net added functions
+if ( empty( $net_function_file_map ) ) {
+	exit( 0 );
+}
+
+// Print error message and formatted table
+echo "The following new functions are added in $pr_branch:\n\n";
+
+// Find the longest function name to determine column width
+$max_function_length = max( array_map( 'strlen', array_keys( $net_function_file_map ) ) );
+$column_width        = max( 15, $max_function_length + 2 ); // Minimum width of 15, plus 2 for padding
+
+// Format as table
+printf( "%-{$column_width}s | %s\n", 'Function Name', 'File Path' );
+echo str_repeat( '-', $column_width + 3 ) . str_repeat( '-', 50 ) . "\n";
+foreach ( $net_function_file_map as $function => $file ) {
+	printf( "%-{$column_width}s | %s\n", $function, $file );
+}
+
+echo "\nNo new functions are allowed in WooCommerce. All the new code should go into classes in the src directory.\n\n";
+echo "If any of these is actually a new class method, add a visibility modifier (public, private or protected) to it.\n";
+
+exit( 1 );

--- a/plugins/woocommerce/bin/check-new-functions.php
+++ b/plugins/woocommerce/bin/check-new-functions.php
@@ -33,8 +33,12 @@ if ( $return_code !== 0 ) {
 }
 $repo_root = current( $output );
 
-// Execute git diff command to get changes between branches for includes/ and src/ directories only
-$diff_command = "git diff $compare_branch..$pr_branch -- {$repo_root}/plugins/woocommerce/includes/ {$repo_root}/plugins/woocommerce/src/";
+// Execute git diff command to get changes between branches for includes/ and src/ directories only.
+// Use the three-dot form so we diff against the merge-base (the point where the PR branch
+// diverged from the compare branch) rather than comparing branch tips. This prevents false
+// positives when the PR branch is behind the compare branch: a two-dot diff would otherwise
+// report functions that the compare branch removed/changed as if the PR had added them.
+$diff_command = "git diff $compare_branch...$pr_branch -- {$repo_root}/plugins/woocommerce/includes/ {$repo_root}/plugins/woocommerce/src/";
 $output       = array();
 $return_code  = 0;
 
@@ -55,6 +59,14 @@ if ( empty( $output ) ) {
 $added_function_file_map = array();
 $deleted_functions       = array();
 
+// Files that are allowed to define standalone functions and are therefore not checked.
+// WooCommerce database updates must be global functions: they are registered by name in
+// WC_Install::$db_updates and invoked dynamically, so they cannot be class methods.
+$excluded_files = array(
+	'plugins/woocommerce/includes/wc-update-functions.php',
+	'plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php',
+);
+
 $current_file = '';
 foreach ( $output as $line ) {
 	// Track current file being processed
@@ -64,16 +76,72 @@ foreach ( $output as $line ) {
 		$current_file = $matches[1]; // Alternative way to get file path
 	}
 
-	// Look for added functions (lines starting with +)
-	if ( preg_match( '/^\+.*?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
+	// Skip files that are allowed to define standalone functions.
+	if ( in_array( $current_file, $excluded_files, true ) ) {
+		continue;
+	}
+
+	// Look for added functions (lines starting with +).
+	// "function" must be the first token on the line (after the diff "+" and any indentation),
+	// so this matches standalone functions and methods declared without a visibility modifier,
+	// but not properly declared methods (public/private/protected ...) nor comment/docblock lines.
+	// Candidates are confirmed to be real PHP declarations (not embedded JavaScript) further below.
+	if ( preg_match( '/^\+\s*function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
 		$function_name                             = $matches[1];
 		$added_function_file_map[ $function_name ] = $current_file;
 	}
 
-	// Look for deleted functions (lines starting with -)
-	if ( preg_match( '/^\-.*?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
+	// Look for deleted functions (lines starting with -), using the same definition as above.
+	if ( preg_match( '/^\-\s*function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $matches ) ) {
 		$function_name       = $matches[1];
 		$deleted_functions[] = $function_name;
+	}
+}
+
+// Confirm that each candidate is a real PHP function declaration and not JavaScript that happens to
+// live inside a PHP file (for example inside an inline <script> block, or a string passed to
+// wp_add_inline_script()). The PHP tokenizer reports such JavaScript as inline HTML or string
+// tokens, never as a T_FUNCTION declaration, so it tells the two apart reliably, regardless of
+// indentation or how the script is embedded.
+$php_functions_by_file = array();
+foreach ( array_unique( array_values( $added_function_file_map ) ) as $file ) {
+	$file_lines  = array();
+	$return_code = 0;
+	exec( 'git show ' . escapeshellarg( "$pr_branch:$file" ), $file_lines, $return_code );
+
+	// If the file cannot be read, keep its candidates rather than risk hiding a real function.
+	if ( 0 !== $return_code ) {
+		continue;
+	}
+
+	$names  = array();
+	$tokens = token_get_all( implode( "\n", $file_lines ) );
+	$count  = count( $tokens );
+	for ( $i = 0; $i < $count; $i++ ) {
+		if ( ! is_array( $tokens[ $i ] ) || T_FUNCTION !== $tokens[ $i ][0] ) {
+			continue;
+		}
+		// The function name is the first meaningful token after "function".
+		for ( $j = $i + 1; $j < $count; $j++ ) {
+			$token = $tokens[ $j ];
+			if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+				continue;
+			}
+			if ( '&' === $token ) {
+				continue; // Return-by-reference functions.
+			}
+			if ( is_array( $token ) && T_STRING === $token[0] ) {
+				$names[] = $token[1];
+			}
+			break; // Name found, or this is an anonymous function.
+		}
+	}
+	$php_functions_by_file[ $file ] = $names;
+}
+
+foreach ( $added_function_file_map as $function => $file ) {
+	if ( isset( $php_functions_by_file[ $file ] ) && ! in_array( $function, $php_functions_by_file[ $file ], true ) ) {
+		unset( $added_function_file_map[ $function ] );
 	}
 }
 
@@ -86,8 +154,9 @@ foreach ( $added_function_file_map as $function => $file_path ) {
 	}
 
 	// Remove "plugins/woocommerce/" prefix from file path
-	if ( strpos( $file_path, 'plugins/woocommerce/' ) === 0 ) {
-		$file_path = substr( $file_path, 19 ); // Remove "plugins/woocommerce/" (19 characters)
+	$plugin_path_prefix = 'plugins/woocommerce/';
+	if ( strpos( $file_path, $plugin_path_prefix ) === 0 ) {
+		$file_path = substr( $file_path, strlen( $plugin_path_prefix ) );
 	}
 	$net_function_file_map[ $function ] = $file_path;
 }

--- a/plugins/woocommerce/bin/check-new-functions.php
+++ b/plugins/woocommerce/bin/check-new-functions.php
@@ -7,9 +7,15 @@
  *
  * Usage: php check_new_functions.php <pr_branch> <compare_branch>
  * Example: php check_new_functions.php feature/new-functions trunk
+ *
+ * @package WooCommerce
  */
 
-// Check if we have the required arguments
+// This is a CLI-only script: it shells out to git via exec() and writes plain text to stdout.
+// WordPress's web-oriented escaping and system-call sniffs therefore don't apply here.
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+
+// Check if we have the required arguments.
 if ( $argc < 3 ) {
 	echo "Usage: php check_new_functions.php <pr_branch> <compare_branch>\n";
 	echo "Example: php check_new_functions.php feature/new-functions trunk\n";
@@ -19,14 +25,14 @@ if ( $argc < 3 ) {
 $pr_branch      = $argv[1];
 $compare_branch = $argv[2];
 
-// Get the root of the repository
+// Get the root of the repository.
 $get_repo_root_command = 'git rev-parse --show-toplevel';
 $output                = array();
 $return_code           = 0;
 
 exec( $get_repo_root_command, $output, $return_code );
 
-if ( $return_code !== 0 ) {
+if ( 0 !== $return_code ) {
 	echo "Error: Failed to execute git rev-parse command\n";
 	echo "Command: $get_repo_root_command\n";
 	exit( 1 );
@@ -44,7 +50,7 @@ $return_code  = 0;
 
 exec( $diff_command, $output, $return_code );
 
-if ( $return_code !== 0 ) {
+if ( 0 !== $return_code ) {
 	echo "Error: Failed to execute git diff command\n";
 	echo "Command: $diff_command\n";
 	exit( 1 );
@@ -55,7 +61,7 @@ if ( empty( $output ) ) {
 	exit( 0 );
 }
 
-// Parse the diff output to find added and deleted functions
+// Parse the diff output to find added and deleted functions.
 $added_function_file_map = array();
 $deleted_functions       = array();
 
@@ -69,11 +75,13 @@ $excluded_files = array(
 
 $current_file = '';
 foreach ( $output as $line ) {
-	// Track current file being processed
+	// Track current file being processed.
 	if ( preg_match( '/^diff --git a\/(.+?) b\/(.+?)$/', $line, $matches ) ) {
-		$current_file = $matches[2]; // Use the 'b' (new) file path
+		// Use the 'b' (new) file path.
+		$current_file = $matches[2];
 	} elseif ( preg_match( '/^\+\+\+ b\/(.+?)$/', $line, $matches ) ) {
-		$current_file = $matches[1]; // Alternative way to get file path
+		// Alternative way to get the file path.
+		$current_file = $matches[1];
 	}
 
 	// Skip files that are allowed to define standalone functions.
@@ -114,9 +122,9 @@ foreach ( array_unique( array_values( $added_function_file_map ) ) as $file ) {
 		continue;
 	}
 
-	$names  = array();
-	$tokens = token_get_all( implode( "\n", $file_lines ) );
-	$count  = count( $tokens );
+	$function_names = array();
+	$tokens         = token_get_all( implode( "\n", $file_lines ) );
+	$count          = count( $tokens );
 	for ( $i = 0; $i < $count; $i++ ) {
 		if ( ! is_array( $tokens[ $i ] ) || T_FUNCTION !== $tokens[ $i ][0] ) {
 			continue;
@@ -128,15 +136,17 @@ foreach ( array_unique( array_values( $added_function_file_map ) ) as $file ) {
 				continue;
 			}
 			if ( '&' === $token ) {
-				continue; // Return-by-reference functions.
+				// Return-by-reference functions.
+				continue;
 			}
 			if ( is_array( $token ) && T_STRING === $token[0] ) {
-				$names[] = $token[1];
+				$function_names[] = $token[1];
 			}
-			break; // Name found, or this is an anonymous function.
+			// Name found, or this is an anonymous function.
+			break;
 		}
 	}
-	$php_functions_by_file[ $file ] = $names;
+	$php_functions_by_file[ $file ] = $function_names;
 }
 
 foreach ( $added_function_file_map as $function => $file ) {
@@ -145,15 +155,15 @@ foreach ( $added_function_file_map as $function => $file ) {
 	}
 }
 
-// Calculate net added functions (added minus deleted) and clean file paths
+// Calculate net added functions (added minus deleted) and clean file paths.
 $net_function_file_map = array();
 foreach ( $added_function_file_map as $function => $file_path ) {
-	// Skip functions that were also deleted (net zero change)
-	if ( in_array( $function, $deleted_functions ) ) {
+	// Skip functions that were also deleted (net zero change).
+	if ( in_array( $function, $deleted_functions, true ) ) {
 		continue;
 	}
 
-	// Remove "plugins/woocommerce/" prefix from file path
+	// Remove "plugins/woocommerce/" prefix from file path.
 	$plugin_path_prefix = 'plugins/woocommerce/';
 	if ( strpos( $file_path, $plugin_path_prefix ) === 0 ) {
 		$file_path = substr( $file_path, strlen( $plugin_path_prefix ) );
@@ -161,19 +171,21 @@ foreach ( $added_function_file_map as $function => $file_path ) {
 	$net_function_file_map[ $function ] = $file_path;
 }
 
-// Check if there are any net added functions
+// Check if there are any net added functions.
 if ( empty( $net_function_file_map ) ) {
 	exit( 0 );
 }
 
-// Print error message and formatted table
+// Print error message and formatted table.
 echo "The following new functions are added in $pr_branch:\n\n";
 
-// Find the longest function name to determine column width
+// Find the longest function name to determine column width.
 $max_function_length = max( array_map( 'strlen', array_keys( $net_function_file_map ) ) );
-$column_width        = max( 15, $max_function_length + 2 ); // Minimum width of 15, plus 2 for padding
 
-// Format as table
+// Minimum width of 15, plus 2 for padding.
+$column_width = max( 15, $max_function_length + 2 );
+
+// Format as table.
 printf( "%-{$column_width}s | %s\n", 'Function Name', 'File Path' );
 echo str_repeat( '-', $column_width + 3 ) . str_repeat( '-', 50 ) . "\n";
 foreach ( $net_function_file_map as $function => $file ) {

--- a/plugins/woocommerce/bin/check-new-functions.php
+++ b/plugins/woocommerce/bin/check-new-functions.php
@@ -44,7 +44,15 @@ $repo_root = current( $output );
 // diverged from the compare branch) rather than comparing branch tips. This prevents false
 // positives when the PR branch is behind the compare branch: a two-dot diff would otherwise
 // report functions that the compare branch removed/changed as if the PR had added them.
-$diff_command = "git diff $compare_branch...$pr_branch -- {$repo_root}/plugins/woocommerce/includes/ {$repo_root}/plugins/woocommerce/src/";
+//
+// Every interpolated value is passed through escapeshellarg(). The branch names come from the
+// caller (CI passes the fixed values "HEAD" and "origin/trunk"), so this is defense-in-depth
+// rather than a fix for a known exposure; escaping the paths also keeps the command correct
+// when the repository lives under a path that contains spaces. The two escaped refs are joined
+// around the literal "..." so the shell collapses them into a single "<base>...<head>" argument.
+$diff_command = 'git diff ' . escapeshellarg( $compare_branch ) . '...' . escapeshellarg( $pr_branch )
+	. ' -- ' . escapeshellarg( "$repo_root/plugins/woocommerce/includes/" )
+	. ' ' . escapeshellarg( "$repo_root/plugins/woocommerce/src/" );
 $output       = array();
 $return_code  = 0;
 

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -19,3 +19,7 @@ if [[ -z $changedFiles ]]; then
 fi
 
 composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+
+# Also verify that no new PHP functions are added.
+
+pnpm run lint:php:no-new-functions HEAD $baseBranch

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -18,8 +18,13 @@ if [[ -z $changedFiles ]]; then
     exit 0
 fi
 
-composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+# Run all checks even if an earlier one fails, then report a non-zero status if any failed,
+# so a failure in one check is never masked by a later one passing.
+status=0
+
+composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles || status=1
 
 # Also verify that no new PHP functions are added.
+php ./bin/check-new-functions.php HEAD "$baseBranch" || status=1
 
-pnpm run lint:php:no-new-functions HEAD $baseBranch
+exit $status

--- a/plugins/woocommerce/changelog/65845-add-new-functions-check-script
+++ b/plugins/woocommerce/changelog/65845-add-new-functions-check-script
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add a CI check that prevents new standalone functions from being added to the `includes` and `src` directories.

--- a/plugins/woocommerce/changelog/65845-add-new-functions-check-script
+++ b/plugins/woocommerce/changelog/65845-add-new-functions-check-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a CI check that prevents new standalone functions from being added to the `includes` and `src` directories.

--- a/plugins/woocommerce/changelog/add-new-functions-check-script
+++ b/plugins/woocommerce/changelog/add-new-functions-check-script
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add a CI check that prevents new standalone functions from being added to the includes and src directories.

--- a/plugins/woocommerce/includes/README.md
+++ b/plugins/woocommerce/includes/README.md
@@ -2,6 +2,10 @@
 
 This directory contains WooCommerce legacy code. Ideally, the code in this folder should only get the minimum required changes for bug fixing, and any new code should go in [the `src` directory](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/README.md) instead.
 
+This applies especially to standalone (global) functions: **new functions must not be added to `includes` (nor to `src`)**: all new logic belongs in classes. This rule is enforced by a CI check (`bin/check-new-functions.php`) that fails any pull request adding a new function in either directory. The only exceptions are the database update files (`wc-update-functions.php` and `react-admin/wc-admin-update-functions.php`), whose routines have to be global functions because `WC_Install::$db_updates` registers and invokes them by name; those two files are excluded from the check.
+
+Adding a new public or protected method to an existing class in `includes/` is also discouraged, but (unlike a new function) it may be acceptable in special, well-justified cases (for example, as part of a bug fix).
+
 
 ## A note on `@internal` annotations
 

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -51,7 +51,7 @@
 		"lint:php:changes:branch": "composer run-script lint-branch",
 		"lint:php:changes:staged": "composer run-script lint-staged",
 		"lint:php:fix": "composer run-script phpcbf",
-		"lint:php:no-new-functions": "php ./bin/check-new-functions.php HEAD trunk",
+		"lint:php:no-new-functions": "php ./bin/check-new-functions.php",
 		"phpstan": "composer run-script phpstan",
 		"phpstan:baseline": "composer run-script phpstan:baseline",
 		"make:collection": "pnpm exec wc-api-tests make:collection",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -51,7 +51,7 @@
 		"lint:php:changes:branch": "composer run-script lint-branch",
 		"lint:php:changes:staged": "composer run-script lint-staged",
 		"lint:php:fix": "composer run-script phpcbf",
-		"lint:php:no-new-functions": "php ./bin/check-new-functions.php",
+		"lint:php:no-new-functions": "php ./bin/check-new-functions.php HEAD origin/trunk",
 		"phpstan": "composer run-script phpstan",
 		"phpstan:baseline": "composer run-script phpstan:baseline",
 		"make:collection": "pnpm exec wc-api-tests make:collection",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -51,6 +51,7 @@
 		"lint:php:changes:branch": "composer run-script lint-branch",
 		"lint:php:changes:staged": "composer run-script lint-staged",
 		"lint:php:fix": "composer run-script phpcbf",
+		"lint:php:no-new-functions": "php ./bin/check-new-functions.php HEAD trunk",
 		"phpstan": "composer run-script phpstan",
 		"phpstan:baseline": "composer run-script phpstan:baseline",
 		"make:collection": "pnpm exec wc-api-tests make:collection",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce backend code [should not introduce new **standalone (global) functions**](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/README.md#woocommerce-includes-files): all new logic belongs in classes under `src/`. This PR adds a CI guardrail that enforces that convention so it no longer relies on reviewers spotting it manually.

**What it does**

- Adds `plugins/woocommerce/bin/check-new-functions.php`, a script that compares a PR branch against a base branch and fails (exit code `1`) if the diff adds any new standalone function in `includes/` or `src/`.
- Adds a `lint:php:no-new-functions` script to `plugins/woocommerce/package.json` for manual invocation.
- Wires the check into `plugins/woocommerce/bin/lint-branch.sh`, which already runs in the existing **Lint** CI job (`config.ci.lint` → `lint:changes:branch` → `lint:php:changes:branch` → `composer run-script lint-branch`). No new workflow is added; the check runs automatically on every pull request (on open and on each update/synchronize).

**How a function is detected**

A line is treated as a *new standalone function* when, on an added (`+`) line in `includes/` or `src/`, `function` is the first token (after optional indentation) followed by a name. This intentionally also catches **class methods declared without a visibility modifier** (which should always declare one). It does **not** match properly declared methods (`public`/`private`/`protected`, including `static`/`final`/`abstract`), nor comment/docblock lines.

**Robustness built into the check**

- **Merge-base comparison.** The diff uses the three-dot form (`base...HEAD`), i.e. it compares against the merge-base, so a PR that is simply behind trunk is never falsely blamed for functions that trunk removed or changed.
- **PHP-tokenizer verification.** Each candidate is confirmed to be a real PHP `T_FUNCTION` declaration via `token_get_all()`. JavaScript that lives inside a PHP file (whether in an inline `<script>` block or in a string passed to `wp_add_inline_script()`/`wc_enqueue_js()`) is reported by the tokenizer as inline HTML or string tokens, never as a function declaration, so it is never flagged. This is independent of indentation or how the script is embedded.
- **Database update functions are excluded.** `includes/wc-update-functions.php` and `includes/react-admin/wc-admin-update-functions.php` are skipped, because DB updates **must** be global functions: `WC_Install::$db_updates` registers and invokes them by name, so they cannot be class methods.
- **No masking of other lint failures.** `lint-branch.sh` now aggregates exit codes and runs the checker directly, so a `phpcs-changed` failure can never be hidden by the new check passing (or vice versa).

**Note on legitimate additions:** in the rare case where a new global function is genuinely justified (e.g. a public `wc_*` template/API helper), the Lint job can be bypassed and the PR force-merged at a maintainer's discretion. The check is a guardrail, not an absolute block.

### How to test the changes in this Pull Request:

These instructions use a **fork of WooCommerce** so the real CI workflow runs end-to-end without touching the upstream repository. There are two ways to test: locally (fast iteration) and via CI on your fork (validates the actual gate). Run through the case matrix with at least one of them.

#### Setup

1. Fork `woocommerce/woocommerce` to your GitHub account (if you don't already have a fork).
2. Clone the fork and check out this branch:
   ```sh
   git clone git@github.com:<your-account>/woocommerce.git
   cd woocommerce
   git remote add upstream https://github.com/woocommerce/woocommerce.git
   git fetch upstream
   git checkout add-new-functions-check-script   # this branch
   pnpm install
   ```
3. Make sure `origin/trunk` (your fork's trunk) is reasonably up to date, since the check compares against it:
   ```sh
   git fetch origin trunk
   ```

#### Option A: Run the check locally (fast)

The script runs from your working tree but compares the **two git refs you pass it**: the checked-out branch only needs to *contain the script file* (`bin/check-new-functions.php`), which `trunk` does not yet have. So branch your throwaway off **this PR branch** (`add-new-functions-check-script`): it already carries the script, your test edit sits on top, and the PR's own changes don't touch any `.php` file under `includes/`/`src/`, so they never interfere with the result.

From `plugins/woocommerce`, for each test case below: branch off `add-new-functions-check-script`, make the edit, commit it, then run **either**:

```sh
# Direct invocation: php bin/check-new-functions.php <pr_ref> <base_ref>
php bin/check-new-functions.php HEAD origin/trunk

# ...or the same path CI uses (also runs phpcs-changed):
pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:changes:branch
```

- **Exit code `1`** and a printed table of function names → the check **blocks** the change.
- **Exit code `0`** (and "No changes..."/silent) → the check **passes**.

Check the exit code with `echo $?` right after the command.

> Don't branch off `origin/trunk` for these cases: trunk has no `bin/check-new-functions.php`, so the direct invocation fails with "Could not open input file" and the CI path (`lint-branch.sh`, which hardcodes `HEAD`) has nothing to run. Case 13 is the one exception, handled in its own row below.

#### Option B: Run the real CI gate on your fork

1. On your fork, go to **Settings → Actions → General** and enable workflows.
2. Create a branch off `add-new-functions-check-script` (**not** your fork's `trunk`, which doesn't contain the checker yet), make one of the edits below, commit, and push it to your fork. Because the branch descends from this PR, the CI checkout has the script and the gate runs exactly as it will once this PR lands on trunk.
3. Open a pull request **within your fork** (base: `trunk` of your fork, compare: your test branch). This triggers the `CI` workflow.
4. Wait for the **`Lint - @woocommerce/plugin-woocommerce`** job and confirm it **fails** for the "should be BLOCKED" cases and **passes** for the "should PASS" cases. The job log prints the offending function names and the explanatory message.
5. Push a follow-up commit that reverts/fixes the change and confirm the job turns green (this also exercises the on-update / synchronize trigger).

#### Case matrix - all supported cases

Add the snippet to the indicated location, in a commit on top of `add-new-functions-check-script` (so the script is present in your working tree), then run the check. The one exception is case 13, which must branch off an older `trunk` commit; see its row.

| # | Case | Where to add | Snippet | Expected |
|---|------|-------------|---------|----------|
| 1 | New standalone function (includes) | end of `includes/wc-core-functions.php` | `function wc_zz_test_helper() { return true; }` | ❌ BLOCKED |
| 2 | New standalone function (src) | end of any file in `src/`, outside the class | `function wc_zz_src_helper() { return true; }` | ❌ BLOCKED |
| 3 | `function_exists()`-guarded function (1-tab indented) | `includes/wc-template-functions.php` | `if ( ! function_exists( 'wc_zz_guarded' ) ) {`<br>`	function wc_zz_guarded() {} }` | ❌ BLOCKED |
| 4 | Class method **without** a visibility modifier | inside any class in `src/` | `function zz_unscoped_method() {}` | ❌ BLOCKED |
| 5 | Properly declared method (any visibility) | inside any class in `src/` | `public function zz_scoped_method() {}` (also try `private`/`protected`/`public static`/`final protected`) | ✅ PASS |
| 6 | DB update function (core) | `includes/wc-update-functions.php` | `function wc_update_9999_test() {}` | ✅ PASS (excluded) |
| 7 | DB update function (admin) | `includes/react-admin/wc-admin-update-functions.php` | `function wc_update_9999_admin_test() {}` | ✅ PASS (excluded) |
| 8 | JS function inside an inline `<script>` in a PHP file | inside a `<script>` block in an admin PHP file, on its own line | `<script>`<br>`function jsInScript() {}`<br>`</script>` | ✅ PASS (not PHP) |
| 9 | JS function inside a PHP string | any PHP file, function on its own line inside the string | `wp_add_inline_script( $h, "`<br>`function jsInString() {}`<br>`" );` | ✅ PASS (not PHP) |
| 10 | Function added **and** removed in the same PR | `includes/wc-core-functions.php` | add `function wc_zz_tmp() {}` in commit A, delete it in commit B (net zero) | ✅ PASS (net-zero) |
| 11 | Comment / docblock mentioning a function | any PHP file | `// see function wc_get_product() for details` | ✅ PASS (comment) |
| 12 | Changes only outside `includes/` and `src/` | e.g. `client/`, `tests/`, `bin/`, `*.js` | add `function whatever() {}` to a file outside `includes/`/`src/` | ✅ PASS (not scanned) |
| 13 | Branch behind trunk where trunk removed a function | n/a - branch off an older trunk commit (which lacks the script), then from the `add-new-functions-check-script` checkout run `php bin/check-new-functions.php <that-branch> origin/trunk` (pass the branch by name, **not** `HEAD`) | (no edit needed) | ✅ PASS (merge-base, no false positive) |
| 14 | No PHP changes at all | edit only a `.md` or `.json` file | (any non-PHP edit) | ✅ PASS (nothing to check) |
| 15 | Existing function gets a new (optional) argument | an existing function in `includes/wc-core-functions.php` | change `function wc_foo( $a ) {}` to `function wc_foo( $a, $b = null ) {}` | ✅ PASS (net zero: signature line is both removed and re-added under the same name) |

> Tip: cases 1–4 should each print the offending function name(s) in a table followed by the message explaining that new functions are not allowed and that methods need a visibility modifier.

<!-- End testing instructions -->

### Testing that has already taken place:

- Unit-level verification of the detection regex (standalone functions and visibility-less methods flagged; `public`/`private`/`protected`/`static`/`final` methods, closures, comment lines, and `function_exists()` calls not flagged).
- Verified the merge-base (three-dot) behavior in an isolated repository: a branch that is behind a base which removed a function is **not** flagged, whereas a two-dot comparison would have produced a false positive.
- Verified tokenizer behavior against real WooCommerce commits where JavaScript `function` declarations live inside PHP files (both inside `<script>` blocks and inside a string passed to `wp_add_inline_script()`) confirming neither is flagged.
- **Historical replay:** ran the check against all 929 commits merged to `trunk` between 2025-09-26 and 2026-06-18 that touched `includes/` or `src/` PHP. After the DB-update exclusions and tokenizer verification, **926 passed and only 3 were flagged - all of them genuine new `wc_*` global functions** (variation gallery helpers, a review-order URL helper, and the interactivity-API loaders). No false positives remained.
- `php -l` passes on the script (compatible with the PHP 7.4–8.5 range used in CI); `bash -n` passes on `lint-branch.sh`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Add a CI check that prevents new standalone functions from being added to the `includes` and `src` directories.

</details>