### PR TITLE
Fix product variation CLI listing

### DIFF
--- a/plugins/woocommerce/changelog/28773-product-variation-list-cli
+++ b/plugins/woocommerce/changelog/28773-product-variation-list-cli
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow WP-CLI to list product variations without a product ID.

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -218,7 +218,7 @@ class WC_CLI_REST_Command {
 			$assoc_args['per_page'] = '100';
 		}
 
-		list( $status, $body, $headers ) = $this->do_request( $method, $this->get_filled_route( $args ), $assoc_args );
+		list( $status, $body, $headers ) = $this->do_request( $method, $this->get_list_route( $args, $assoc_args ), $assoc_args );
 		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
 			$items = array_column( $body, 'id' );
 		} else {
@@ -413,18 +413,66 @@ EOT;
 		$route                = $this->route;
 
 		foreach ( $this->get_supported_ids() as $id_name => $id_desc ) {
-			if ( 'id' !== $id_name && strpos( $route, '<' . $id_name . '>' ) !== false && ! empty( $args ) ) {
-				$route                = str_replace( array( '(?P<' . $id_name . '>[\d]+)', '(?P<' . $id_name . '>\w[\w\s\-]*)' ), $args[0], $route );
+			if ( 'id' !== $id_name && $this->route_contains_id( $route, $id_name ) && ! empty( $args ) ) {
+				$route                = str_replace( array( '(?P<' . $id_name . '>[\d]+)', '(?P<' . $id_name . '>\w[\w\s\-]*)', '<' . $id_name . '>' ), $args[0], $route );
 				$supported_id_matched = true;
 			}
 		}
 
 		if ( ! empty( $args ) ) {
 			$id_replacement = $supported_id_matched && ! empty( $args[1] ) ? $args[1] : $args[0];
-			$route          = str_replace( array( '(?P<id>[\d]+)', '(?P<id>[\w-]+)' ), $id_replacement, $route );
+			$route          = str_replace( array( '(?P<id>[\d]+)', '(?P<id>[\w-]+)', '<id>' ), $id_replacement, $route );
 		}
 
 		return rtrim( $route );
+	}
+
+	/**
+	 * Check if a route contains a supported ID.
+	 *
+	 * @param string $route   Route path.
+	 * @param string $id_name ID name.
+	 * @return bool
+	 */
+	private function route_contains_id( $route, $id_name ) {
+		return false !== strpos( $route, '<' . $id_name . '>' ) || false !== strpos( $route, '(?P<' . $id_name . '>' );
+	}
+
+	/**
+	 * Get the route for listing this resource.
+	 *
+	 * @param array $args       Positional arguments passed to the originating WP-CLI command.
+	 * @param array $assoc_args Associative arguments passed to the originating WP-CLI command.
+	 * @return string
+	 */
+	private function get_list_route( $args = array(), $assoc_args = array() ) {
+		if ( $this->is_product_variations_collection_route() ) {
+			if ( ! empty( $args ) ) {
+				return $this->get_filled_route( $args );
+			}
+
+			if ( ! empty( $assoc_args['product_id'] ) ) {
+				return $this->get_filled_route( array( $assoc_args['product_id'] ) );
+			}
+
+			return '/wc/v3/variations';
+		}
+
+		return $this->get_filled_route( $args );
+	}
+
+	/**
+	 * Check if this command maps to the nested product variations collection route.
+	 *
+	 * @return bool
+	 */
+	private function is_product_variations_collection_route() {
+		$normalized_route = rtrim( $this->route, '/' );
+
+		return 'product_variation' === $this->name
+			&& false !== strpos( $this->route, '/products/' )
+			&& false !== strpos( $this->route, 'product_id' )
+			&& '/variations' === substr( $normalized_route, -11 );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/cli/class-wc-cli-runner.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-runner.php
@@ -157,12 +157,12 @@ class WC_CLI_Runner {
 			$ids      = array();
 
 			foreach ( $supported_ids as $id_name => $id_desc ) {
-				if ( strpos( $route, '<' . $id_name . '>' ) !== false ) {
+				if ( self::route_contains_id( $route, $id_name ) ) {
 					$synopsis[] = array(
 						'name'        => $id_name,
 						'type'        => 'positional',
 						'description' => $id_desc,
-						'optional'    => false,
+						'optional'    => self::is_optional_positional_id( $route_data['schema']['title'], $route, $command, $id_name ),
 					);
 					$ids[]      = $id_name;
 				}
@@ -250,5 +250,46 @@ class WC_CLI_Runner {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Check if a route contains a supported ID.
+	 *
+	 * @param string $route   Route path.
+	 * @param string $id_name ID name.
+	 * @return bool
+	 */
+	private static function route_contains_id( $route, $id_name ) {
+		return false !== strpos( $route, '<' . $id_name . '>' ) || false !== strpos( $route, '(?P<' . $id_name . '>' );
+	}
+
+	/**
+	 * Check if a positional ID should be optional for a generated command.
+	 *
+	 * @param string $name    Command name.
+	 * @param string $route   Route path.
+	 * @param string $command Command name.
+	 * @param string $id_name ID name.
+	 * @return bool
+	 */
+	private static function is_optional_positional_id( $name, $route, $command, $id_name ) {
+		return 'product_variation' === $name
+			&& 'list' === $command
+			&& 'product_id' === $id_name
+			&& self::is_product_variations_collection_route( $route );
+	}
+
+	/**
+	 * Check if a route is the nested product variations collection route.
+	 *
+	 * @param string $route Route path.
+	 * @return bool
+	 */
+	private static function is_product_variations_collection_route( $route ) {
+		$normalized_route = rtrim( $route, '/' );
+
+		return false !== strpos( $route, '/products/' )
+			&& false !== strpos( $route, 'product_id' )
+			&& '/variations' === substr( $normalized_route, -11 );
 	}
 }

--- a/plugins/woocommerce/tests/cli/features/product.feature
+++ b/plugins/woocommerce/tests/cli/features/product.feature
@@ -87,3 +87,17 @@ Scenario: CRUD a product
 		"""
 		Success
 		"""
+
+Scenario: List product variations without a product ID
+
+	When I run `wp wc product create --user=admin --name='Test Variable Product' --type='variable' --attributes='[{ "id": 0, "name": "Size", "position": 0, "visible": true, "variation": true, "options": ["Small", "Large"]}]' --porcelain`
+	Then save STDOUT as {PRODUCT_ID}
+
+	When I run `wp wc product_variation create {PRODUCT_ID} --user=admin --regular_price='12.00' --attributes='[{ "name": "Size", "option": "Small" }]' --porcelain`
+	Then save STDOUT as {VARIATION_ID}
+
+	When I run `wp wc product_variation list --user=admin --format=ids`
+	Then STDOUT should contain:
+		"""
+		{VARIATION_ID}
+		"""


### PR DESCRIPTION
## Summary
- Allow `wp wc product_variation list` to run without a parent product ID by using the global variations REST endpoint for no-parent list requests.
- Keep product-specific variation listing on the nested product variations route when a product ID is supplied.
- Add a CLI regression scenario and changelog entry.

Fixes #28773.

## Testing
- `php -l plugins/woocommerce/includes/cli/class-wc-cli-runner.php`
- `php -l plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php`
- `composer run lint`
- `git diff --check`
- Focused route-selection check with `php -r`
