### PR TITLE
Fix pending cancelled order admin emails

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6880-pending-cancelled-admin-email
+++ b/plugins/woocommerce/changelog/wooplug-6880-pending-cancelled-admin-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send cancelled order admin emails when pending orders are cancelled.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -104,6 +104,7 @@ class WC_Emails {
 				'woocommerce_order_status_pending_to_processing',
 				'woocommerce_order_status_pending_to_completed',
 				'woocommerce_order_status_processing_to_cancelled',
+				'woocommerce_order_status_pending_to_cancelled',
 				'woocommerce_order_status_pending_to_failed',
 				'woocommerce_order_status_pending_to_on-hold',
 				'woocommerce_order_status_failed_to_processing',

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -43,18 +43,19 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 			// Triggers for this email.
 			add_action( 'woocommerce_order_status_processing_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
 			add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_pending_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
 
 			// Call parent constructor.
 			parent::__construct();
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Receive an email notification when an order that was processing or on hold gets cancelled', 'woocommerce' )
-				: __( 'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).', 'woocommerce' );
+				? __( 'Receive an email notification when an order that was pending, processing, or on hold gets cancelled', 'woocommerce' )
+				: __( 'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously pending, processing, or on-hold).', 'woocommerce' );
 
 			if ( $this->block_email_editor_enabled ) {
 				$this->title       = __( 'Canceled order', 'woocommerce' );
-				$this->description = __( 'Notifies admins when an order that was processing or on hold has been canceled.', 'woocommerce' );
+				$this->description = __( 'Notifies admins when an order that was pending, processing, or on hold has been canceled.', 'woocommerce' );
 			}
 
 			// Other settings.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.ts
@@ -166,7 +166,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'email_cancelled_order',
 						label: 'Cancelled order',
 						description:
-							'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).',
+							'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously pending, processing, or on-hold).',
 						parent_id: 'email',
 						sub_groups: expect.arrayContaining( [] ),
 					} ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -62,6 +62,48 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Pending to cancelled order status changes trigger transactional email notifications.
+	 */
+	public function test_pending_to_cancelled_status_change_triggers_transactional_email_notifications(): void {
+		$hook             = 'woocommerce_order_status_pending_to_cancelled';
+		$captured_actions = array();
+		$email_actions    = function ( $actions ) use ( &$captured_actions, $hook ) {
+			$captured_actions = $actions;
+			return in_array( $hook, $actions, true ) ? array( $hook ) : array();
+		};
+
+		remove_action( $hook, array( 'WC_Emails', 'send_transactional_email' ), 10 );
+		remove_action( $hook, array( 'WC_Emails', 'queue_transactional_email' ), 10 );
+		add_filter( 'woocommerce_email_actions', $email_actions, 999 );
+		add_filter( 'woocommerce_defer_transactional_emails', '__return_false', 999 );
+
+		WC_Emails::init_transactional_emails();
+
+		remove_filter( 'woocommerce_email_actions', $email_actions, 999 );
+		remove_filter( 'woocommerce_defer_transactional_emails', '__return_false', 999 );
+
+		$this->assertContains( $hook, $captured_actions, 'Pending to cancelled status changes should be part of the default transactional email action list.' );
+		$this->assertSame( 10, has_action( $hook, array( 'WC_Emails', 'send_transactional_email' ) ), 'Pending to cancelled status changes should dispatch transactional emails.' );
+
+		remove_action( $hook, array( 'WC_Emails', 'send_transactional_email' ), 10 );
+	}
+
+	/**
+	 * @testdox Admin cancelled order email listens for pending to cancelled notifications.
+	 */
+	public function test_cancelled_order_email_listens_for_pending_to_cancelled_notifications(): void {
+		$email_object    = new WC_Emails();
+		$emails          = $email_object->get_emails();
+		$cancelled_email = $emails['WC_Email_Cancelled_Order'];
+
+		$this->assertSame(
+			10,
+			has_action( 'woocommerce_order_status_pending_to_cancelled_notification', array( $cancelled_email, 'trigger' ) ),
+			'Cancelled order emails should notify admins when a pending order is cancelled.'
+		);
+	}
+
+	/**
 	 * Test that order meta function outputs linked meta.
 	 */
 	public function test_order_meta() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Pending-to-cancelled order transitions did not enter the transactional email dispatcher for admin cancelled order emails, so store admins were not notified when pending payment orders were cancelled. This adds that transition to the email actions list, registers the admin cancelled order email listener, and updates the admin email description to include pending orders.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #65841, closes WOOPLUG-6880.

### Screenshots or screen recordings:

Not applicable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order and leave it in Pending payment status.
2. Change the order status to Cancelled.
3. Confirm the configured admin recipient receives the Cancelled order email.
4. Confirm cancelled emails for processing and on-hold orders still work.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Ran focused PHP email tests, PHP lint for changed files, and PHPStan on the touched production files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
