### PR TITLE
Fix email preview downloadable file data

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6883-email-preview-download-file-object
+++ b/plugins/woocommerce/changelog/wooplug-6883-email-preview-download-file-object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email previews for orders with downloadable products.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -15,6 +15,7 @@ use WC_Order;
 use WC_Order_Item_Product;
 use WC_Order_Item_Shipping;
 use WC_Product;
+use WC_Product_Download;
 use WC_Product_Variation;
 use WP_User;
 
@@ -705,14 +706,14 @@ class EmailPreview {
 	/**
 	 * Provide a dummy product file so product->has_file() returns true in preview.
 	 *
-	 * @param array|null $file Current file array or null.
-	 * @return array|null
+	 * @param WC_Product_Download|array|null $file Current file object, array, or null.
+	 * @return WC_Product_Download|array|null
 	 */
 	public function provide_dummy_product_file( $file ) {
 		/**
 		 * Filters whether the current request is an email preview.
 		 *
-		 * When true, provide a dummy product file array so downloadable template parts
+		 * When true, provide a dummy product file so downloadable template parts
 		 * can render during preview.
 		 *
 		 * @since 9.6.0
@@ -720,10 +721,11 @@ class EmailPreview {
 		 * @param bool $is_email_preview Whether preview mode is active.
 		 */
 		if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
-			return array(
-				'name' => __( 'Sample Download File.pdf', 'woocommerce' ),
-				'file' => 'sample-download.pdf',
-			);
+			$dummy_file = new WC_Product_Download();
+			$dummy_file->set_id( 'preview-dummy' );
+			$dummy_file->set_name( __( 'Sample Download File.pdf', 'woocommerce' ) );
+			$dummy_file->set_file( 'sample-download.pdf' );
+			return $dummy_file;
 		}
 		return $file;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Internal\Admin\EmailPreview\PreviewOrder;
 use WC_Emails;
 use WC_Helper_Order;
 use WC_Product;
+use WC_Product_Download;
 use WC_Unit_Test_Case;
 
 /**
@@ -235,6 +236,21 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( 'Your ' . self::SITE_TITLE . ' order has been received!', $subject );
 
 		remove_filter( 'woocommerce_prepare_email_for_preview', $email_filter, 10 );
+	}
+
+	/**
+	 * @testdox Email preview provides dummy product files as download objects.
+	 */
+	public function test_provide_dummy_product_file_returns_download_object_in_preview(): void {
+		add_filter( 'woocommerce_is_email_preview', '__return_true' );
+
+		$file = $this->sut->provide_dummy_product_file( null );
+
+		remove_filter( 'woocommerce_is_email_preview', '__return_true' );
+
+		$this->assertInstanceOf( WC_Product_Download::class, $file );
+		$this->assertSame( 'Sample Download File.pdf', $file->get_name() );
+		$this->assertSame( 'sample-download.pdf', $file->get_file() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Email previews can force products to be downloadable so the downloads section renders, but the dummy product file was returned as an array. Downstream order item download rendering expects a `WC_Product_Download` object, so this returns a proper dummy download object during email preview mode.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #65853, closes WOOPLUG-6883.

### How to reproduce the bug on trunk (before this fix):

The email preview builds a synthetic order with id `0` and billing email `john@company.com`, plus a dummy downloadable product with id `0`. When rendering downloads, `WC_Order_Item_Product::get_item_downloads()` queries the `woocommerce_downloadable_product_permissions` table. Because the preview order id and dummy product id are both `0` (falsy), the data store drops those `WHERE` clauses and filters by `user_email` only. So **any** permission row with that email makes the loop run and call `get_data()` on the dummy file, which on trunk is a plain array → fatal.

Steps to reproduce:

1. Check out `trunk` (with **block email editor** feature disabled).
2. Insert one download-permission row matching the preview's billing email:

   ```sh
   npx wp-env run cli wp db query "INSERT INTO wp_woocommerce_downloadable_product_permissions (download_id, product_id, order_id, order_key, user_email, user_id, downloads_remaining, access_granted, access_expires, download_count) VALUES ('repro-1', 999999, 999999, 'wc_repro_key', 'john@company.com', 0, '', NOW(), NULL, 0)"
   ```

3. Go to **WooCommerce > Settings > Emails**.
4. The preview should fail with fatal.
5. Switch to this PR's branch and verify preview renders correctly.

### Screenshots or screen recordings:

| Before | After | 
| ---- | ---- | 
| <img width="704" height="987" alt="Screenshot 2026-06-19 at 13 02 13" src="https://github.com/user-attachments/assets/f4269d1b-f701-487b-b7b5-d7aeea576c55" /> | <img width="705" height="985" alt="Screenshot 2026-06-19 at 13 02 57" src="https://github.com/user-attachments/assets/7e15c341-3b59-422b-8170-a4d87224bfca" /> |


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

