### PR TITLE
Add email preview shipping details filter

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6842-email-preview-shipping-details-filter
+++ b/plugins/woocommerce/changelog/wooplug-6842-email-preview-shipping-details-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add a filter to hide shipping details in email previews.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -428,28 +428,33 @@ class EmailPreview {
 		$order->set_date_created( time() );
 		$order->set_currency( 'USD' );
 		$order->set_discount_total( 10 );
-		$order->set_shipping_total( 5 );
-		$order->set_total( 80 );
 		$order->set_payment_method_title( __( 'Direct bank transfer', 'woocommerce' ) );
 		$order->set_transaction_id( '999999999' );
 		$order->set_customer_note( __( "This is a customer note. Customers can add a note to their order on checkout.\n\nIt can be multiple lines. If there's no note, this section is hidden.", 'woocommerce' ) );
 
 		$order = $this->apply_dummy_order_status( $order );
 
-		// Add shipping method.
-		$shipping_item = new WC_Order_Item_Shipping();
-		$shipping_item->set_props(
-			array(
-				'method_title' => __( 'Flat rate', 'woocommerce' ),
-				'method_id'    => 'flat_rate',
-				'total'        => '5.00',
-			)
-		);
-		$order->add_item( $shipping_item );
+		$show_shipping_details = $this->should_show_shipping_details( $order );
+		$order->set_shipping_total( $show_shipping_details ? 5 : 0 );
+		$order->set_total( $show_shipping_details ? 80 : 75 );
+
+		if ( $show_shipping_details ) {
+			$shipping_item = new WC_Order_Item_Shipping();
+			$shipping_item->set_props(
+				array(
+					'method_title' => __( 'Flat rate', 'woocommerce' ),
+					'method_id'    => 'flat_rate',
+					'total'        => '5.00',
+				)
+			);
+			$order->add_item( $shipping_item );
+		}
 
 		$address = $this->get_dummy_address();
 		$order->set_billing_address( $address );
-		$order->set_shipping_address( $address );
+		if ( $show_shipping_details ) {
+			$order->set_shipping_address( $address );
+		}
 
 		/**
 		 * A dummy WC_Order used in email preview.
@@ -620,8 +625,8 @@ class EmailPreview {
 	 */
 	public function set_up_filters() {
 		$this->switch_to_site_locale();
-		// Always show shipping address in the preview email.
-		add_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
+		// Show shipping address in preview emails unless preview shipping details are hidden.
+		add_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ), 10, 3 );
 		// Email templates fetch product from the database to show additional information, which are not
 		// saved in WC_Order_Item_Product. This filter enables fetching that data also in email preview.
 		add_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10, 1 );
@@ -651,13 +656,34 @@ class EmailPreview {
 	}
 
 	/**
-	 * Enable shipping address in the preview email. Not using __return_true so
-	 * we don't accidentally remove the same filter used by other plugin or theme.
+	 * Enable shipping address in the preview email unless shipping details are hidden.
 	 *
-	 * @return true
+	 * @param bool          $needs_shipping_address Current value.
+	 * @param array         $hidden_shipping_methods Hidden shipping method IDs.
+	 * @param WC_Order|null $order Order object.
+	 * @return bool
 	 */
-	public function enable_shipping_address() {
-		return true;
+	public function enable_shipping_address( $needs_shipping_address = true, $hidden_shipping_methods = array(), $order = null ) {
+		return $this->should_show_shipping_details( $order );
+	}
+
+	/**
+	 * Check whether preview shipping details should be shown.
+	 *
+	 * @param WC_Order|null $order Preview order object.
+	 * @return bool
+	 */
+	private function should_show_shipping_details( $order = null ) {
+		/**
+		 * Filters whether shipping details should be shown in email previews.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool          $show_shipping_details Whether to show shipping details. Default true.
+		 * @param WC_Order|null $order Preview order object.
+		 * @param string|null   $email_type Email type being previewed.
+		 */
+		return (bool) apply_filters( 'woocommerce_email_preview_show_shipping_details', true, $order, $this->email_type );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -183,6 +183,37 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Email preview shipping details can be hidden.
+	 */
+	public function test_shipping_details_filter_can_hide_preview_shipping_details(): void {
+		$captured_order = null;
+		$captured_args  = null;
+		$hide_shipping  = function ( $show_shipping_details, $order, $email_type ) use ( &$captured_args ) {
+			$captured_args = array( $show_shipping_details, $order, $email_type );
+			return false;
+		};
+		$capture_order  = function ( $order ) use ( &$captured_order ) {
+			$captured_order = $order;
+			return $order;
+		};
+		add_filter( 'woocommerce_email_preview_show_shipping_details', $hide_shipping, 10, 3 );
+		add_filter( 'woocommerce_email_preview_dummy_order', $capture_order, 10, 1 );
+
+		$content = $this->sut->render();
+
+		remove_filter( 'woocommerce_email_preview_show_shipping_details', $hide_shipping, 10 );
+		remove_filter( 'woocommerce_email_preview_dummy_order', $capture_order, 10 );
+
+		$this->assertInstanceOf( PreviewOrder::class, $captured_order );
+		$this->assertSame( array(), $captured_order->get_shipping_methods(), 'Hidden preview shipping details should remove the dummy shipping method.' );
+		$this->assertSame( '0', $captured_order->get_shipping_total(), 'Hidden preview shipping details should remove the dummy shipping total.' );
+		$this->assertSame( '', $captured_order->get_shipping_address_1(), 'Hidden preview shipping details should remove the dummy shipping address.' );
+		$this->assertSame( array( true, $captured_order, EmailPreview::DEFAULT_EMAIL_TYPE ), $captured_args, 'Filter should receive the default visibility, preview order, and email type.' );
+		$this->assertStringNotContainsString( 'Flat rate', $content, 'Hidden preview shipping details should not render the dummy shipping method.' );
+		$this->assertStringNotContainsString( 'Shipping address', $content, 'Hidden preview shipping details should not render the shipping address section.' );
+	}
+
+	/**
 	 * Test dummy address filter - woocommerce_email_preview_dummy_address
 	 */
 	public function test_dummy_address_filter() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Email previews always include dummy shipping details, which can misrepresent extension-specific emails where shipping is not charged. This adds the `woocommerce_email_preview_show_shipping_details` filter so extensions can hide dummy preview shipping totals, methods, and shipping address sections while preserving the current default preview behavior.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #57843, closes WOOPLUG-6842

### Screenshots or screen recordings:

| Before | After | 
| ---- | ---- | 
|  <img width="702" height="1015" alt="Screenshot 2026-06-19 at 14 03 10" src="https://github.com/user-attachments/assets/a80575e0-8724-4d4d-b94e-5cd76b3ea4d2" /> | <img width="706" height="1014" alt="Screenshot 2026-06-19 at 14 05 45" src="https://github.com/user-attachments/assets/5336c2dd-8725-42bd-95ed-8590ce3a4e60" /> | 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a temporary `add_filter('woocommerce_email_preview_show_shipping_details', '__return_false');`.
2. Open a WooCommerce email preview.
3. Confirm the preview does not show the dummy shipping method, shipping total, or shipping address section.
4. Remove the temporary filter and confirm the preview shows the default shipping details again.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Ran focused PHP email preview tests, PHP lint for changed files, and PHPStan on the touched source file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
