### PR TITLE
Fix e2e-pw ESLint import/no-extraneous-dependencies false positives

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/.eslintrc.cjs
+++ b/plugins/woocommerce/tests/e2e-pw/.eslintrc.cjs
@@ -1,3 +1,4 @@
+const path = require( 'path' );
 const rulesDirPlugin = require( 'eslint-plugin-rulesdir' );
 rulesDirPlugin.RULES_DIR = `${ __dirname }/rules/blocks`;
 
@@ -15,14 +16,24 @@ module.exports = {
 		'jest/valid-title': 'off',
 		'testing-library/await-async-utils': 'off',
 		/*
-		 * The e2e-pw tests use dependencies from the parent woocommerce package.
-		 * This configuration tells ESLint to check both the local package.json
-		 * and the parent package.json when validating imports.
+		 * The e2e-pw tests use dependencies from the parent woocommerce package
+		 * (this directory has no package.json of its own). Resolve packageDir from
+		 * __dirname so the check is independent of ESLint's working directory: VS
+		 * Code / root-level ESLint can run from the monorepo root, and relative
+		 * entries would otherwise point at the wrong package.json.
+		 *
+		 * Both entries must point at directories that contain a package.json:
+		 * eslint-plugin-import throws on the first missing one and aborts the
+		 * whole dependency merge, so we list the parent woocommerce package and
+		 * the monorepo root rather than this dir.
 		 */
 		'import/no-extraneous-dependencies': [
 			'warn',
 			{
-				packageDir: [ '.', '../..' ],
+				packageDir: [
+					path.resolve( __dirname, '../..' ),
+					path.resolve( __dirname, '../../../..' ),
+				],
 			},
 		],
 	},


### PR DESCRIPTION

### Changes proposed in this Pull Request:

VS Code and root-level ESLint runs surfaced false `import/no-extraneous-dependencies` warnings in `plugins/woocommerce/tests/e2e-pw`, flagging `@playwright/test` and others as missing. The cause was `packageDir: [ '.', '../..' ]` - those entries point at the wrong `package.json`.

### How to test the changes in this Pull Request:

1. Check out this branch and ensure dependencies are installed.
2. From the monorepo root, run ESLint on an e2e-pw file that imports the affected packages: 

```
pnpm exec eslint plugins/woocommerce/tests/e2e-pw/playwright.config.ts
```

3. Repeat from `plugins/woocommerce` and from `plugins/woocommerce/tests/e2e-pw` — all three should be clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
