### PR TITLE
Harden embedded KYC loader failures

### DIFF
--- a/plugins/woocommerce/changelog/fix-embedded-kyc-loader-failure-hardening
+++ b/plugins/woocommerce/changelog/fix-embedded-kyc-loader-failure-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent embedded WooPayments business verification from hanging when the Stripe loader fails.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
@@ -65,6 +65,11 @@ const getObjectKeys = ( value: unknown ): string[] =>
 const isNonEmptyString = ( value: unknown ): value is string =>
 	typeof value === 'string' && value.trim() !== '';
 
+const normalizeLocale = ( value: unknown ): string =>
+	isNonEmptyString( value )
+		? value.trim().replace( /_/g, '-' )
+		: defaultLocale;
+
 const validateEmbeddedKycSessionCreateResult = (
 	result: unknown
 ):
@@ -102,9 +107,7 @@ const validateEmbeddedKycSessionCreateResult = (
 		...( session as unknown as EmbeddedKycSession ),
 		clientSecret: session.clientSecret,
 		publishableKey: session.publishableKey,
-		locale: isNonEmptyString( session.locale )
-			? session.locale
-			: defaultLocale,
+		locale: normalizeLocale( session.locale ),
 	};
 
 	return { result: { session: normalizedSession } };
@@ -153,17 +156,14 @@ const useInitializeStripe = ( onboardingData: OnboardingFields ) => {
 						overlays: 'drawer',
 						...appearance,
 					},
-					locale: locale.replace( '_', '-' ),
+					locale,
 				} );
 
 				setStripeConnectInstance( instance );
 			} catch ( err ) {
 				setInitializationError( {
 					reason: 'init_error',
-					message:
-						err instanceof Error
-							? err.message
-							: genericInitializationError,
+					message: genericInitializationError,
 				} );
 			} finally {
 				setLoading( false );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { createEmbeddedKycSession } from '../../utils/actions';
 import appearance from './appearance';
 import {
+	type EmbeddedAccountInitializationFailure,
 	EmbeddedKycSession,
 	EmbeddedKycSessionCreateResult,
 	OnboardingFields,
@@ -30,14 +31,6 @@ import { useOnboardingContext } from '../../../../data/onboarding-context';
 interface EmbeddedComponentProps {
 	onLoaderStart?: ( { elementTagName }: LoaderStart ) => void;
 	onLoadError?: ( { error, elementTagName }: LoadError ) => void;
-}
-
-type EmbeddedAccountInitializationFailureReason = 'bad_session' | 'init_error';
-
-export interface EmbeddedAccountInitializationFailure {
-	reason: EmbeddedAccountInitializationFailureReason;
-	message: string;
-	receivedKeys?: string[];
 }
 
 interface EmbeddedAccountOnboardingProps extends EmbeddedComponentProps {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/index.tsx
@@ -19,7 +19,11 @@ import { __ } from '@wordpress/i18n';
  */
 import { createEmbeddedKycSession } from '../../utils/actions';
 import appearance from './appearance';
-import { OnboardingFields } from '../../types';
+import {
+	EmbeddedKycSession,
+	EmbeddedKycSessionCreateResult,
+	OnboardingFields,
+} from '../../types';
 import BannerNotice from '../../../../components/banner-notice';
 import { useOnboardingContext } from '../../../../data/onboarding-context';
 
@@ -28,12 +32,83 @@ interface EmbeddedComponentProps {
 	onLoadError?: ( { error, elementTagName }: LoadError ) => void;
 }
 
+type EmbeddedAccountInitializationFailureReason = 'bad_session' | 'init_error';
+
+export interface EmbeddedAccountInitializationFailure {
+	reason: EmbeddedAccountInitializationFailureReason;
+	message: string;
+	receivedKeys?: string[];
+}
+
 interface EmbeddedAccountOnboardingProps extends EmbeddedComponentProps {
 	onboardingData: OnboardingFields;
 	onExit: () => void;
 	onStepChange?: ( step: string ) => void;
+	onInitializationError?: (
+		failure: EmbeddedAccountInitializationFailure
+	) => void;
 	collectPayoutRequirements?: boolean;
 }
+
+const defaultLocale = 'en-US';
+const genericInitializationError = __(
+	'Unable to start the business verification session. If this problem persists, please contact support.',
+	'woocommerce'
+);
+
+const isObjectRecord = ( value: unknown ): value is Record< string, unknown > =>
+	!! value && typeof value === 'object' && ! Array.isArray( value );
+
+const getObjectKeys = ( value: unknown ): string[] =>
+	isObjectRecord( value ) ? Object.keys( value ).sort() : [];
+
+const isNonEmptyString = ( value: unknown ): value is string =>
+	typeof value === 'string' && value.trim() !== '';
+
+const validateEmbeddedKycSessionCreateResult = (
+	result: unknown
+):
+	| { result: EmbeddedKycSessionCreateResult }
+	| { error: EmbeddedAccountInitializationFailure } => {
+	const session = isObjectRecord( result ) ? result.session : undefined;
+	const receivedKeys = isObjectRecord( session )
+		? getObjectKeys( session )
+		: getObjectKeys( result );
+
+	if ( ! isObjectRecord( session ) ) {
+		return {
+			error: {
+				reason: 'bad_session',
+				message: genericInitializationError,
+				receivedKeys,
+			},
+		};
+	}
+
+	if (
+		! isNonEmptyString( session.clientSecret ) ||
+		! isNonEmptyString( session.publishableKey )
+	) {
+		return {
+			error: {
+				reason: 'bad_session',
+				message: genericInitializationError,
+				receivedKeys,
+			},
+		};
+	}
+
+	const normalizedSession: EmbeddedKycSession = {
+		...( session as unknown as EmbeddedKycSession ),
+		clientSecret: session.clientSecret,
+		publishableKey: session.publishableKey,
+		locale: isNonEmptyString( session.locale )
+			? session.locale
+			: defaultLocale,
+	};
+
+	return { result: { session: normalizedSession } };
+};
 
 /**
  * Hook to initialize Stripe Connect.
@@ -47,9 +122,9 @@ const useInitializeStripe = ( onboardingData: OnboardingFields ) => {
 		useState< StripeConnectInstance | null >( null );
 	const { currentStep, sessionEntryPoint: onboardingSource } =
 		useOnboardingContext();
-	const [ initializationError, setInitializationError ] = useState<
-		string | null
-	>( null );
+	const kycSessionUrl = currentStep?.actions?.kyc_session?.href ?? '';
+	const [ initializationError, setInitializationError ] =
+		useState< EmbeddedAccountInitializationFailure | null >( null );
 	const [ loading, setLoading ] = useState< boolean >( true );
 
 	useEffect( () => {
@@ -57,20 +132,19 @@ const useInitializeStripe = ( onboardingData: OnboardingFields ) => {
 			try {
 				const accountSession = await createEmbeddedKycSession(
 					onboardingData,
-					currentStep?.actions?.kyc_session?.href ?? '',
+					kycSessionUrl,
 					onboardingSource
 				);
 
-				const { clientSecret, publishableKey } = accountSession.session;
-
-				if ( ! publishableKey ) {
-					throw new Error(
-						__(
-							'Unable to start the business verification session. If this problem persists, please contact support.',
-							'woocommerce'
-						)
-					);
+				const validation =
+					validateEmbeddedKycSessionCreateResult( accountSession );
+				if ( 'error' in validation ) {
+					setInitializationError( validation.error );
+					return;
 				}
+
+				const { clientSecret, publishableKey, locale } =
+					validation.result.session;
 
 				const instance = loadConnectAndInitialize( {
 					publishableKey,
@@ -79,26 +153,25 @@ const useInitializeStripe = ( onboardingData: OnboardingFields ) => {
 						overlays: 'drawer',
 						...appearance,
 					},
-					locale: accountSession.session.locale.replace( '_', '-' ),
+					locale: locale.replace( '_', '-' ),
 				} );
 
 				setStripeConnectInstance( instance );
 			} catch ( err ) {
-				setInitializationError(
-					err instanceof Error
-						? err.message
-						: __(
-								'Unable to start the business verification session. If this problem persists, please contact support.',
-								'woocommerce'
-						  )
-				);
+				setInitializationError( {
+					reason: 'init_error',
+					message:
+						err instanceof Error
+							? err.message
+							: genericInitializationError,
+				} );
 			} finally {
 				setLoading( false );
 			}
 		};
 
 		initializeStripe();
-	}, [ onboardingData ] );
+	}, [ kycSessionUrl, onboardingData, onboardingSource ] );
 
 	return { stripeConnectInstance, initializationError, loading };
 };
@@ -112,6 +185,7 @@ const useInitializeStripe = ( onboardingData: OnboardingFields ) => {
  * @param onLoaderStart                     - Callback function when the onboarding loader starts.
  * @param onLoadError                       - Callback function when the onboarding load error occurs.
  * @param [onStepChange]                    - Callback function when the onboarding step changes.
+ * @param [onInitializationError]           - Callback function when the onboarding initialization fails.
  * @param [collectPayoutRequirements=false] - Whether to collect payout requirements.
  *
  * @return Rendered Account Onboarding component.
@@ -124,16 +198,23 @@ export const EmbeddedAccountOnboarding: React.FC<
 	onLoaderStart,
 	onLoadError,
 	onStepChange,
+	onInitializationError,
 	collectPayoutRequirements = false,
 } ) => {
 	const { stripeConnectInstance, initializationError } =
 		useInitializeStripe( onboardingData );
 
+	useEffect( () => {
+		if ( initializationError ) {
+			onInitializationError?.( initializationError );
+		}
+	}, [ initializationError, onInitializationError ] );
+
 	return (
 		<>
-			{ initializationError && (
+			{ initializationError && ! onInitializationError && (
 				<BannerNotice status="error">
-					{ initializationError }
+					{ initializationError.message }
 				</BannerNotice>
 			) }
 			{ stripeConnectInstance && (

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
@@ -41,7 +41,11 @@ const embeddedKycLoadTimeoutMs = 20000;
 const embeddedKycTroubleshootingUrl =
 	'https://woocommerce.com/document/woopayments/startup-guide/#requirements';
 const embeddedKycFailureMessage = __(
-	"Unable to start onboarding. This may be caused by your site's security or server configuration. Please check our documentation and contact support if this error persists.",
+	"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists.",
+	'woocommerce'
+);
+const embeddedKycHttpsFailureMessage = __(
+	'Payment activation through our financial partner requires HTTPS and cannot be completed.',
 	'woocommerce'
 );
 
@@ -54,7 +58,7 @@ const getFailureTrackingDetails = (
 		details.error_type = failure.errorType;
 	}
 
-	if ( failure.message ) {
+	if ( failure.message && failure.reason !== 'init_error' ) {
 		details.error_message = failure.message;
 	}
 
@@ -64,6 +68,25 @@ const getFailureTrackingDetails = (
 
 	return details;
 };
+
+const getFailureNoticeMessage = ( failure: EmbeddedKycLoadFailure ) => {
+	if (
+		failure.reason === 'load_error' &&
+		failure.errorType === 'invalid_request_error'
+	) {
+		return embeddedKycHttpsFailureMessage;
+	}
+
+	return embeddedKycFailureMessage;
+};
+
+const getFailureNoticeStatus = (
+	failure: EmbeddedKycLoadFailure
+): 'error' | 'warning' =>
+	failure.reason === 'load_error' &&
+	failure.errorType === 'invalid_request_error'
+		? 'warning'
+		: 'error';
 
 const EmbeddedKyc: React.FC< Props > = ( {
 	collectPayoutRequirements = false,
@@ -91,7 +114,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 			setLoading( false );
 			setLoadFailure( failure );
 			recordPaymentsOnboardingEvent(
-				'woopayments_onboarding_modal_kyc_load_failed',
+				'woopayments_onboarding_modal_kyc_load_error',
 				{
 					reason: failure.reason,
 					collect_payout_requirements: collectPayoutRequirements,
@@ -180,7 +203,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 			{ loadFailure && (
 				<BannerNotice
 					className="woopayments-banner-notice--embedded-kyc"
-					status="error"
+					status={ getFailureNoticeStatus( loadFailure ) }
 					isDismissible={ false }
 					actions={ [
 						{
@@ -196,7 +219,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 						},
 					] }
 				>
-					{ embeddedKycFailureMessage }
+					{ getFailureNoticeMessage( loadFailure ) }
 				</BannerNotice>
 			) }
 			{ loading && (

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
@@ -13,10 +13,8 @@ import StripeSpinner from '../../../components/stripe-spinner';
 import BannerNotice from '../../../components/banner-notice';
 import { useBusinessVerificationContext } from '../data/business-verification-context';
 import { finalizeEmbeddedKycSession } from '../utils/actions';
-import {
-	type EmbeddedAccountInitializationFailure,
-	EmbeddedAccountOnboarding,
-} from '../components/embedded';
+import { EmbeddedAccountOnboarding } from '../components/embedded';
+import { type EmbeddedAccountInitializationFailure } from '../types';
 import { recordPaymentsOnboardingEvent } from '~/settings-payments/utils';
 
 interface Props {
@@ -46,6 +44,11 @@ const embeddedKycFailureMessage = __(
 );
 const embeddedKycHttpsFailureMessage = __(
 	'Payment activation through our financial partner requires HTTPS and cannot be completed.',
+	'woocommerce'
+);
+const embeddedKycLoadingMessage = __( 'Loading onboarding…', 'woocommerce' );
+const embeddedKycFinalizingMessage = __(
+	'Finalizing onboarding…',
 	'woocommerce'
 );
 
@@ -102,6 +105,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	const [ loadFailure, setLoadFailure ] =
 		useState< EmbeddedKycLoadFailure | null >( null );
 	const loadFailureRef = useRef( false );
+	const loadFailureNoticeRef = useRef< HTMLDivElement >( null );
 	const fallbackUrl = currentStep?.actions?.kyc_fallback?.href ?? '';
 
 	const failEmbeddedKycLoad = useCallback(
@@ -137,6 +141,19 @@ const EmbeddedKyc: React.FC< Props > = ( {
 
 		return () => window.clearTimeout( timerId );
 	}, [ failEmbeddedKycLoad, finalizingSession, loadFailure, loading ] );
+
+	useEffect( () => {
+		if ( ! loadFailure ) {
+			return;
+		}
+
+		const notice = loadFailureNoticeRef.current;
+		const activeElement = notice?.ownerDocument.activeElement ?? null;
+
+		if ( notice && ! notice.contains( activeElement ) ) {
+			notice.focus();
+		}
+	}, [ loadFailure ] );
 
 	const handleStepChange = ( step: string ) => {
 		recordPaymentsOnboardingEvent(
@@ -192,43 +209,55 @@ const EmbeddedKyc: React.FC< Props > = ( {
 		} );
 	};
 
-	const handleInitializationError = (
-		failure: EmbeddedAccountInitializationFailure
-	) => {
-		failEmbeddedKycLoad( failure );
-	};
+	const handleInitializationError = useCallback(
+		( failure: EmbeddedAccountInitializationFailure ) => {
+			failEmbeddedKycLoad( failure );
+		},
+		[ failEmbeddedKycLoad ]
+	);
 
 	return (
 		<>
 			{ loadFailure && (
-				<BannerNotice
-					className="woopayments-banner-notice--embedded-kyc"
-					status={ getFailureNoticeStatus( loadFailure ) }
-					isDismissible={ false }
-					actions={ [
-						{
-							label: __( 'Learn more', 'woocommerce' ),
-							variant: 'primary',
-							url: embeddedKycTroubleshootingUrl,
-							urlTarget: '_blank',
-						},
-						{
-							label: __( 'Cancel', 'woocommerce' ),
-							variant: 'link',
-							url: fallbackUrl,
-						},
-					] }
-				>
-					{ getFailureNoticeMessage( loadFailure ) }
-				</BannerNotice>
+				<div ref={ loadFailureNoticeRef } tabIndex={ -1 }>
+					<BannerNotice
+						className="woopayments-banner-notice--embedded-kyc"
+						status={ getFailureNoticeStatus( loadFailure ) }
+						isDismissible={ false }
+						actions={ [
+							{
+								label: __( 'Learn more', 'woocommerce' ),
+								variant: 'primary',
+								url: embeddedKycTroubleshootingUrl,
+								urlTarget: '_blank',
+							},
+							{
+								label: __( 'Cancel', 'woocommerce' ),
+								variant: 'link',
+								url: fallbackUrl,
+							},
+						] }
+					>
+						{ getFailureNoticeMessage( loadFailure ) }
+					</BannerNotice>
+				</div>
 			) }
 			{ loading && (
-				<div className="embedded-kyc-loader-wrapper padded">
+				<div
+					className="embedded-kyc-loader-wrapper padded"
+					role="status"
+				>
+					<span className="screen-reader-text">
+						{ embeddedKycLoadingMessage }
+					</span>
 					<StripeSpinner />
 				</div>
 			) }
 			{ finalizingSession && (
-				<div className="embedded-kyc-loader-wrapper">
+				<div className="embedded-kyc-loader-wrapper" role="status">
+					<span className="screen-reader-text">
+						{ embeddedKycFinalizingMessage }
+					</span>
 					<StripeSpinner />
 				</div>
 			) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { LoadError } from '@stripe/connect-js';
 
@@ -13,13 +13,57 @@ import StripeSpinner from '../../../components/stripe-spinner';
 import BannerNotice from '../../../components/banner-notice';
 import { useBusinessVerificationContext } from '../data/business-verification-context';
 import { finalizeEmbeddedKycSession } from '../utils/actions';
-import { EmbeddedAccountOnboarding } from '../components/embedded';
+import {
+	type EmbeddedAccountInitializationFailure,
+	EmbeddedAccountOnboarding,
+} from '../components/embedded';
 import { recordPaymentsOnboardingEvent } from '~/settings-payments/utils';
 
 interface Props {
 	continueKyc?: boolean;
 	collectPayoutRequirements?: boolean;
 }
+
+type EmbeddedKycLoadFailureReason =
+	| 'timeout'
+	| 'load_error'
+	| 'bad_session'
+	| 'init_error';
+
+type EmbeddedKycLoadFailure = {
+	reason: EmbeddedKycLoadFailureReason;
+	message?: string;
+	errorType?: string;
+	receivedKeys?: string[];
+};
+
+const embeddedKycLoadTimeoutMs = 20000;
+const embeddedKycTroubleshootingUrl =
+	'https://woocommerce.com/document/woopayments/startup-guide/#requirements';
+const embeddedKycFailureMessage = __(
+	"Unable to start onboarding. This may be caused by your site's security or server configuration. Please check our documentation and contact support if this error persists.",
+	'woocommerce'
+);
+
+const getFailureTrackingDetails = (
+	failure: EmbeddedKycLoadFailure
+): Record< string, string > => {
+	const details: Record< string, string > = {};
+
+	if ( failure.errorType ) {
+		details.error_type = failure.errorType;
+	}
+
+	if ( failure.message ) {
+		details.error_message = failure.message;
+	}
+
+	if ( failure.receivedKeys ) {
+		details.received_keys = failure.receivedKeys.join( ',' ) || 'none';
+	}
+
+	return details;
+};
 
 const EmbeddedKyc: React.FC< Props > = ( {
 	collectPayoutRequirements = false,
@@ -32,8 +76,44 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	} = useOnboardingContext();
 	const [ finalizingSession, setFinalizingSession ] = useState( false );
 	const [ loading, setLoading ] = useState( true );
-	const [ loadError, setLoadError ] = useState< LoadError | null >( null );
+	const [ loadFailure, setLoadFailure ] =
+		useState< EmbeddedKycLoadFailure | null >( null );
+	const loadFailureRef = useRef( false );
 	const fallbackUrl = currentStep?.actions?.kyc_fallback?.href ?? '';
+
+	const failEmbeddedKycLoad = useCallback(
+		( failure: EmbeddedKycLoadFailure ) => {
+			if ( loadFailureRef.current ) {
+				return;
+			}
+
+			loadFailureRef.current = true;
+			setLoading( false );
+			setLoadFailure( failure );
+			recordPaymentsOnboardingEvent(
+				'woopayments_onboarding_modal_kyc_load_failed',
+				{
+					reason: failure.reason,
+					collect_payout_requirements: collectPayoutRequirements,
+					source: onboardingSource,
+					...getFailureTrackingDetails( failure ),
+				}
+			);
+		},
+		[ collectPayoutRequirements, onboardingSource ]
+	);
+
+	useEffect( () => {
+		if ( ! loading || loadFailure || finalizingSession ) {
+			return;
+		}
+
+		const timerId = window.setTimeout( () => {
+			failEmbeddedKycLoad( { reason: 'timeout' } );
+		}, embeddedKycLoadTimeoutMs );
+
+		return () => window.clearTimeout( timerId );
+	}, [ failEmbeddedKycLoad, finalizingSession, loadFailure, loading ] );
 
 	const handleStepChange = ( step: string ) => {
 		recordPaymentsOnboardingEvent(
@@ -66,6 +146,10 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	};
 
 	const handleLoaderStart = () => {
+		if ( loadFailureRef.current ) {
+			return;
+		}
+
 		recordPaymentsOnboardingEvent(
 			'woopayments_onboarding_modal_kyc_started_loading',
 			{
@@ -78,55 +162,43 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	};
 
 	const handleLoadError = ( err: LoadError ) => {
-		recordPaymentsOnboardingEvent(
-			'woopayments_onboarding_modal_kyc_load_error',
-			{
-				error_type: err.error.type,
-				error_message: err.error.message || 'no_message',
-				collect_payout_requirements: collectPayoutRequirements,
-				source: onboardingSource,
-			}
-		);
+		failEmbeddedKycLoad( {
+			reason: 'load_error',
+			errorType: err.error.type,
+			message: err.error.message || 'no_message',
+		} );
+	};
 
-		setLoadError( err );
+	const handleInitializationError = (
+		failure: EmbeddedAccountInitializationFailure
+	) => {
+		failEmbeddedKycLoad( failure );
 	};
 
 	return (
 		<>
-			{ loadError &&
-				( loadError.error.type === 'invalid_request_error' ? (
-					<BannerNotice
-						className={ 'woopayments-banner-notice--embedded-kyc' }
-						status="warning"
-						isDismissible={ false }
-						actions={ [
-							{
-								label: 'Learn more',
-								variant: 'primary',
-								url: 'https://woocommerce.com/document/woopayments/startup-guide/#requirements',
-								urlTarget: '_blank',
-							},
-							{
-								label: 'Cancel',
-								variant: 'link',
-								url: fallbackUrl,
-							},
-						] }
-					>
-						{ __(
-							'Payment activation through our financial partner requires HTTPS and cannot be completed.',
-							'woocommerce'
-						) }
-					</BannerNotice>
-				) : (
-					<BannerNotice
-						className={ 'woopayments-banner-notice--embedded-kyc' }
-						status="error"
-						isDismissible={ false }
-					>
-						{ loadError.error.message }
-					</BannerNotice>
-				) ) }
+			{ loadFailure && (
+				<BannerNotice
+					className="woopayments-banner-notice--embedded-kyc"
+					status="error"
+					isDismissible={ false }
+					actions={ [
+						{
+							label: __( 'Learn more', 'woocommerce' ),
+							variant: 'primary',
+							url: embeddedKycTroubleshootingUrl,
+							urlTarget: '_blank',
+						},
+						{
+							label: __( 'Cancel', 'woocommerce' ),
+							variant: 'link',
+							url: fallbackUrl,
+						},
+					] }
+				>
+					{ embeddedKycFailureMessage }
+				</BannerNotice>
+			) }
 			{ loading && (
 				<div className="embedded-kyc-loader-wrapper padded">
 					<StripeSpinner />
@@ -137,16 +209,17 @@ const EmbeddedKyc: React.FC< Props > = ( {
 					<StripeSpinner />
 				</div>
 			) }
-			{
+			{ ! loadFailure && (
 				<EmbeddedAccountOnboarding
 					onExit={ handleOnExit }
 					onStepChange={ handleStepChange }
 					onLoaderStart={ handleLoaderStart }
 					onLoadError={ handleLoadError }
+					onInitializationError={ handleInitializationError }
 					onboardingData={ data }
 					collectPayoutRequirements={ collectPayoutRequirements }
 				/>
-			}
+			) }
 		</>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
@@ -132,7 +132,8 @@ describe( 'EmbeddedAccountOnboarding', () => {
 		await waitFor( () =>
 			expect( mockOnInitializationError ).toHaveBeenCalledWith( {
 				reason: 'init_error',
-				message: 'Network unavailable.',
+				message:
+					'Unable to start the business verification session. If this problem persists, please contact support.',
 			} )
 		);
 		expect(
@@ -161,4 +162,24 @@ describe( 'EmbeddedAccountOnboarding', () => {
 			);
 		}
 	);
+
+	it.each( [
+		[ 'en_US', 'en-US' ],
+		[ ' sr_Latn_RS ', 'sr-Latn-RS' ],
+	] )( 'normalizes locale %p to %p', async ( locale, expectedLocale ) => {
+		mockCreateEmbeddedKycSession.mockResolvedValue(
+			createSession( { locale } )
+		);
+
+		renderEmbeddedAccountOnboarding();
+
+		expect(
+			await screen.findByTestId( 'connect-account-onboarding' )
+		).toBeInTheDocument();
+		expect( mockLoadConnectAndInitialize ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				locale: expectedLocale,
+			} )
+		);
+	} );
 } );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
@@ -182,4 +182,29 @@ describe( 'EmbeddedAccountOnboarding', () => {
 			} )
 		);
 	} );
+
+	it( 'passes session credentials through to Stripe for a valid session', async () => {
+		renderEmbeddedAccountOnboarding();
+
+		expect(
+			await screen.findByTestId( 'connect-account-onboarding' )
+		).toBeInTheDocument();
+
+		const [ firstInitializeCall ] = mockLoadConnectAndInitialize.mock.calls;
+		const initializeOptions = firstInitializeCall?.[ 0 ];
+
+		if ( ! initializeOptions ) {
+			throw new Error( 'Expected Stripe initialization options.' );
+		}
+
+		expect( initializeOptions ).toEqual(
+			expect.objectContaining( {
+				publishableKey: 'test-key',
+				locale: 'en-US',
+			} )
+		);
+		await expect( initializeOptions.fetchClientSecret() ).resolves.toBe(
+			'test-secret'
+		);
+	} );
 } );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-account-onboarding.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import { loadConnectAndInitialize } from '@stripe/connect-js';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { EmbeddedAccountOnboarding } from '../components/embedded';
+import { createEmbeddedKycSession } from '../utils/actions';
+import { useOnboardingContext } from '../../../data/onboarding-context';
+import type { EmbeddedKycSessionCreateResult } from '../types';
+
+jest.mock( '@stripe/connect-js', () => ( {
+	loadConnectAndInitialize: jest.fn( () => ( {
+		mockStripeConnectInstance: true,
+	} ) ),
+} ) );
+
+jest.mock( '@stripe/react-connect-js', () => ( {
+	ConnectComponentsProvider: ( {
+		children,
+	}: {
+		children: React.ReactNode;
+	} ) => <div data-testid="connect-components-provider">{ children }</div>,
+	ConnectAccountOnboarding: () => (
+		<div data-testid="connect-account-onboarding" />
+	),
+} ) );
+
+jest.mock( '../utils/actions', () => ( {
+	createEmbeddedKycSession: jest.fn(),
+} ) );
+
+jest.mock( '../../../data/onboarding-context', () => ( {
+	useOnboardingContext: jest.fn(),
+} ) );
+
+const mockCreateEmbeddedKycSession =
+	createEmbeddedKycSession as jest.MockedFunction<
+		typeof createEmbeddedKycSession
+	>;
+const mockLoadConnectAndInitialize =
+	loadConnectAndInitialize as jest.MockedFunction<
+		typeof loadConnectAndInitialize
+	>;
+const mockUseOnboardingContext = useOnboardingContext as jest.Mock;
+
+const createSession = (
+	overrides: Partial< EmbeddedKycSessionCreateResult[ 'session' ] > = {}
+): EmbeddedKycSessionCreateResult => ( {
+	session: {
+		clientSecret: 'test-secret',
+		publishableKey: 'test-key',
+		locale: 'en_US',
+		expiresAt: 1234567890,
+		accountId: 'acct_test',
+		isLive: false,
+		accountCreated: true,
+		...overrides,
+	},
+} );
+
+const renderEmbeddedAccountOnboarding = (
+	overrides: Partial<
+		React.ComponentProps< typeof EmbeddedAccountOnboarding >
+	> = {}
+) => {
+	return render(
+		<EmbeddedAccountOnboarding
+			onboardingData={ {} }
+			onExit={ jest.fn() }
+			{ ...overrides }
+		/>
+	);
+};
+
+describe( 'EmbeddedAccountOnboarding', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseOnboardingContext.mockReturnValue( {
+			currentStep: {
+				actions: {
+					kyc_session: {
+						href: 'https://example.com/session',
+					},
+				},
+			},
+			sessionEntryPoint: 'settings',
+		} );
+		mockCreateEmbeddedKycSession.mockResolvedValue( createSession() );
+	} );
+
+	it( 'notifies the parent when the KYC session shape is invalid', async () => {
+		const mockOnInitializationError = jest.fn();
+		mockCreateEmbeddedKycSession.mockResolvedValue( {
+			session: {
+				unexpected: 'value',
+			},
+		} as never );
+
+		renderEmbeddedAccountOnboarding( {
+			onInitializationError: mockOnInitializationError,
+		} );
+
+		await waitFor( () =>
+			expect( mockOnInitializationError ).toHaveBeenCalledWith( {
+				reason: 'bad_session',
+				message:
+					'Unable to start the business verification session. If this problem persists, please contact support.',
+				receivedKeys: [ 'unexpected' ],
+			} )
+		);
+		expect(
+			screen.queryByTestId( 'connect-account-onboarding' )
+		).not.toBeInTheDocument();
+		expect( mockLoadConnectAndInitialize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'notifies the parent when initialization throws unexpectedly', async () => {
+		const mockOnInitializationError = jest.fn();
+		mockCreateEmbeddedKycSession.mockRejectedValue(
+			new Error( 'Network unavailable.' )
+		);
+
+		renderEmbeddedAccountOnboarding( {
+			onInitializationError: mockOnInitializationError,
+		} );
+
+		await waitFor( () =>
+			expect( mockOnInitializationError ).toHaveBeenCalledWith( {
+				reason: 'init_error',
+				message: 'Network unavailable.',
+			} )
+		);
+		expect(
+			screen.queryByTestId( 'connect-account-onboarding' )
+		).not.toBeInTheDocument();
+	} );
+
+	it.each( [ undefined, '', 42 ] )(
+		'defaults the locale when the KYC session returns %p',
+		async ( locale ) => {
+			mockCreateEmbeddedKycSession.mockResolvedValue(
+				createSession( {
+					locale: locale as never,
+				} )
+			);
+
+			renderEmbeddedAccountOnboarding();
+
+			expect(
+				await screen.findByTestId( 'connect-account-onboarding' )
+			).toBeInTheDocument();
+			expect( mockLoadConnectAndInitialize ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					locale: 'en-US',
+				} )
+			);
+		}
+	);
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
@@ -96,6 +96,14 @@ describe( 'EmbeddedKyc', () => {
 		jest.useRealTimers();
 	} );
 
+	it( 'announces the loading state while waiting for the embedded loader', () => {
+		render( <EmbeddedKyc /> );
+
+		expect(
+			screen.getByRole( 'status', { name: 'Loading onboarding…' } )
+		).toBeInTheDocument();
+	} );
+
 	it( 'shows a unified error when the embedded loader does not start before the timeout', () => {
 		jest.useFakeTimers();
 
@@ -105,12 +113,12 @@ describe( 'EmbeddedKyc', () => {
 			jest.advanceTimersByTime( 20000 );
 		} );
 
-		expect(
-			screen.getByText(
-				"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists.",
-				{ selector: '.woopayments-banner-notice__content' }
-			)
-		).toBeInTheDocument();
+		const noticeMessage = screen.getByText(
+			"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists."
+		);
+
+		expect( noticeMessage ).toBeInTheDocument();
+		expect( noticeMessage.closest( '[tabindex="-1"]' ) ).toHaveFocus();
 		expect(
 			screen.getByRole( 'link', { name: 'Learn more' } )
 		).toHaveAttribute(

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
@@ -107,7 +107,7 @@ describe( 'EmbeddedKyc', () => {
 
 		expect(
 			screen.getByText(
-				"Unable to start onboarding. This may be caused by your site's security or server configuration. Please check our documentation and contact support if this error persists.",
+				"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists.",
 				{ selector: '.woopayments-banner-notice__content' }
 			)
 		).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe( 'EmbeddedKyc', () => {
 			screen.queryByTestId( 'embedded-account-onboarding' )
 		).not.toBeInTheDocument();
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
-			'woopayments_onboarding_modal_kyc_load_failed',
+			'woopayments_onboarding_modal_kyc_load_error',
 			{
 				reason: 'timeout',
 				collect_payout_requirements: false,
@@ -158,7 +158,7 @@ describe( 'EmbeddedKyc', () => {
 			}
 		);
 		expect( mockRecordPaymentsOnboardingEvent ).not.toHaveBeenCalledWith(
-			'woopayments_onboarding_modal_kyc_load_failed',
+			'woopayments_onboarding_modal_kyc_load_error',
 			expect.anything()
 		);
 	} );
@@ -180,11 +180,41 @@ describe( 'EmbeddedKyc', () => {
 			screen.getByRole( 'link', { name: 'Learn more' } )
 		).toBeInTheDocument();
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
-			'woopayments_onboarding_modal_kyc_load_failed',
+			'woopayments_onboarding_modal_kyc_load_error',
 			{
 				reason: 'load_error',
 				error_type: 'api_connection_error',
 				error_message: 'Stripe failed to load.',
+				collect_payout_requirements: false,
+				source: 'settings',
+			}
+		);
+	} );
+
+	it( 'shows HTTPS-specific copy when Stripe reports an invalid request', () => {
+		render( <EmbeddedKyc /> );
+
+		act( () => {
+			mockEmbeddedAccountOnboardingProps.onLoadError?.( {
+				error: {
+					type: 'invalid_request_error',
+					message: 'This application requires HTTPS.',
+				},
+				elementTagName: 'connect-account-onboarding',
+			} );
+		} );
+
+		expect(
+			screen.getByText(
+				'Payment activation through our financial partner requires HTTPS and cannot be completed.'
+			)
+		).toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_error',
+			{
+				reason: 'load_error',
+				error_type: 'invalid_request_error',
+				error_message: 'This application requires HTTPS.',
 				collect_payout_requirements: false,
 				source: 'settings',
 			}
@@ -206,11 +236,36 @@ describe( 'EmbeddedKyc', () => {
 			screen.getByRole( 'link', { name: 'Learn more' } )
 		).toBeInTheDocument();
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
-			'woopayments_onboarding_modal_kyc_load_failed',
+			'woopayments_onboarding_modal_kyc_load_error',
 			{
 				reason: 'bad_session',
 				error_message: 'Unable to start onboarding.',
 				received_keys: 'unexpected',
+				collect_payout_requirements: false,
+				source: 'settings',
+			}
+		);
+	} );
+
+	it( 'omits initialization error messages from analytics', () => {
+		render( <EmbeddedKyc /> );
+
+		act( () => {
+			mockEmbeddedAccountOnboardingProps.onInitializationError?.( {
+				reason: 'init_error',
+				message: 'Network failed for https://internal.example/token.',
+			} );
+		} );
+
+		expect(
+			screen.getByText(
+				"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists."
+			)
+		).toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_error',
+			{
+				reason: 'init_error',
 				collect_payout_requirements: false,
 				source: 'settings',
 			}
@@ -238,7 +293,7 @@ describe( 'EmbeddedKyc', () => {
 		).not.toBeInTheDocument();
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledTimes( 1 );
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
-			'woopayments_onboarding_modal_kyc_load_failed',
+			'woopayments_onboarding_modal_kyc_load_error',
 			expect.objectContaining( { reason: 'timeout' } )
 		);
 	} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
@@ -84,6 +84,18 @@ const mockContexts = () => {
 	} );
 };
 
+const getFailureNotice = (): HTMLElement => {
+	const notice = screen
+		.getByRole( 'link', { name: 'Learn more' } )
+		.closest< HTMLElement >( '[tabindex="-1"]' );
+
+	if ( ! notice ) {
+		throw new Error( 'Expected focused failure notice.' );
+	}
+
+	return notice;
+};
+
 describe( 'EmbeddedKyc', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -99,9 +111,9 @@ describe( 'EmbeddedKyc', () => {
 	it( 'announces the loading state while waiting for the embedded loader', () => {
 		render( <EmbeddedKyc /> );
 
-		expect(
-			screen.getByRole( 'status', { name: 'Loading onboarding…' } )
-		).toBeInTheDocument();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
+			'Loading onboarding…'
+		);
 	} );
 
 	it( 'shows a unified error when the embedded loader does not start before the timeout', () => {
@@ -113,12 +125,12 @@ describe( 'EmbeddedKyc', () => {
 			jest.advanceTimersByTime( 20000 );
 		} );
 
-		const noticeMessage = screen.getByText(
+		const notice = getFailureNotice();
+
+		expect( notice ).toHaveTextContent(
 			"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists."
 		);
-
-		expect( noticeMessage ).toBeInTheDocument();
-		expect( noticeMessage.closest( '[tabindex="-1"]' ) ).toHaveFocus();
+		expect( notice ).toHaveFocus();
 		expect(
 			screen.getByRole( 'link', { name: 'Learn more' } )
 		).toHaveAttribute(
@@ -212,11 +224,9 @@ describe( 'EmbeddedKyc', () => {
 			} );
 		} );
 
-		expect(
-			screen.getByText(
-				'Payment activation through our financial partner requires HTTPS and cannot be completed.'
-			)
-		).toBeInTheDocument();
+		expect( getFailureNotice() ).toHaveTextContent(
+			'Payment activation through our financial partner requires HTTPS and cannot be completed.'
+		);
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
 			'woopayments_onboarding_modal_kyc_load_error',
 			{
@@ -265,11 +275,9 @@ describe( 'EmbeddedKyc', () => {
 			} );
 		} );
 
-		expect(
-			screen.getByText(
-				"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists."
-			)
-		).toBeInTheDocument();
+		expect( getFailureNotice() ).toHaveTextContent(
+			"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists."
+		);
 		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
 			'woopayments_onboarding_modal_kyc_load_error',
 			{

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import EmbeddedKyc from '../sections/embedded-kyc';
+import { useOnboardingContext } from '../../../data/onboarding-context';
+import { useBusinessVerificationContext } from '../data/business-verification-context';
+import { recordPaymentsOnboardingEvent } from '~/settings-payments/utils';
+
+type MockEmbeddedAccountOnboardingProps = {
+	onLoaderStart?: ( value: { elementTagName: string } ) => void;
+	onLoadError?: ( value: {
+		error: { type: string; message?: string };
+		elementTagName: string;
+	} ) => void;
+	onInitializationError?: ( failure: {
+		reason: 'bad_session' | 'init_error';
+		message: string;
+		receivedKeys?: string[];
+	} ) => void;
+	[ key: string ]: unknown;
+};
+
+let mockEmbeddedAccountOnboardingProps: MockEmbeddedAccountOnboardingProps;
+
+jest.mock( '../components/embedded', () => ( {
+	EmbeddedAccountOnboarding: (
+		props: MockEmbeddedAccountOnboardingProps
+	) => {
+		mockEmbeddedAccountOnboardingProps = props;
+		return <div data-testid="embedded-account-onboarding" />;
+	},
+} ) );
+
+jest.mock( '../../../data/onboarding-context', () => ( {
+	useOnboardingContext: jest.fn(),
+} ) );
+
+jest.mock( '../data/business-verification-context', () => ( {
+	useBusinessVerificationContext: jest.fn(),
+} ) );
+
+jest.mock( '../../../components/stripe-spinner', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="stripe-spinner" />,
+} ) );
+
+jest.mock( '../utils/actions', () => ( {
+	finalizeEmbeddedKycSession: jest.fn(),
+} ) );
+
+jest.mock( '~/settings-payments/utils', () => ( {
+	recordPaymentsOnboardingEvent: jest.fn(),
+} ) );
+
+const mockUseOnboardingContext = useOnboardingContext as jest.Mock;
+const mockUseBusinessVerificationContext =
+	useBusinessVerificationContext as jest.Mock;
+const mockRecordPaymentsOnboardingEvent =
+	recordPaymentsOnboardingEvent as jest.MockedFunction<
+		typeof recordPaymentsOnboardingEvent
+	>;
+
+const mockContexts = () => {
+	mockUseBusinessVerificationContext.mockReturnValue( { data: {} } );
+	mockUseOnboardingContext.mockReturnValue( {
+		currentStep: {
+			actions: {
+				kyc_fallback: {
+					href: 'https://example.com/fallback',
+				},
+				kyc_session_finish: {
+					href: 'https://example.com/session/finish',
+				},
+			},
+		},
+		navigateToNextStep: jest.fn(),
+		sessionEntryPoint: 'settings',
+	} );
+};
+
+describe( 'EmbeddedKyc', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useRealTimers();
+		mockEmbeddedAccountOnboardingProps = {};
+		mockContexts();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'shows a unified error when the embedded loader does not start before the timeout', () => {
+		jest.useFakeTimers();
+
+		render( <EmbeddedKyc /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 20000 );
+		} );
+
+		expect(
+			screen.getByText(
+				"Unable to start onboarding. This may be caused by your site's security or server configuration. Please check our documentation and contact support if this error persists.",
+				{ selector: '.woopayments-banner-notice__content' }
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/woopayments/startup-guide/#requirements'
+		);
+		expect(
+			screen.queryByTestId( 'embedded-account-onboarding' )
+		).not.toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_failed',
+			{
+				reason: 'timeout',
+				collect_payout_requirements: false,
+				source: 'settings',
+			}
+		);
+	} );
+
+	it( 'clears the timeout when the embedded loader starts', () => {
+		jest.useFakeTimers();
+
+		render( <EmbeddedKyc collectPayoutRequirements /> );
+
+		act( () => {
+			mockEmbeddedAccountOnboardingProps.onLoaderStart?.( {
+				elementTagName: 'connect-account-onboarding',
+			} );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 20000 );
+		} );
+
+		expect(
+			screen.queryByRole( 'link', { name: 'Learn more' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByTestId( 'embedded-account-onboarding' )
+		).toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_started_loading',
+			{
+				collect_payout_requirements: true,
+				source: 'settings',
+			}
+		);
+		expect( mockRecordPaymentsOnboardingEvent ).not.toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_failed',
+			expect.anything()
+		);
+	} );
+
+	it( 'shows a unified error when Stripe reports a load error', () => {
+		render( <EmbeddedKyc /> );
+
+		act( () => {
+			mockEmbeddedAccountOnboardingProps.onLoadError?.( {
+				error: {
+					type: 'api_connection_error',
+					message: 'Stripe failed to load.',
+				},
+				elementTagName: 'connect-account-onboarding',
+			} );
+		} );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_failed',
+			{
+				reason: 'load_error',
+				error_type: 'api_connection_error',
+				error_message: 'Stripe failed to load.',
+				collect_payout_requirements: false,
+				source: 'settings',
+			}
+		);
+	} );
+
+	it( 'shows a unified error when initialization fails', () => {
+		render( <EmbeddedKyc /> );
+
+		act( () => {
+			mockEmbeddedAccountOnboardingProps.onInitializationError?.( {
+				reason: 'bad_session',
+				message: 'Unable to start onboarding.',
+				receivedKeys: [ 'unexpected' ],
+			} );
+		} );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_failed',
+			{
+				reason: 'bad_session',
+				error_message: 'Unable to start onboarding.',
+				received_keys: 'unexpected',
+				collect_payout_requirements: false,
+				source: 'settings',
+			}
+		);
+	} );
+
+	it( 'keeps the unified error when the loader starts after the timeout', () => {
+		jest.useFakeTimers();
+
+		render( <EmbeddedKyc /> );
+		const onLoaderStart = mockEmbeddedAccountOnboardingProps.onLoaderStart;
+
+		act( () => {
+			jest.advanceTimersByTime( 20000 );
+			onLoaderStart?.( {
+				elementTagName: 'connect-account-onboarding',
+			} );
+		} );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'embedded-account-onboarding' )
+		).not.toBeInTheDocument();
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordPaymentsOnboardingEvent ).toHaveBeenCalledWith(
+			'woopayments_onboarding_modal_kyc_load_failed',
+			expect.objectContaining( { reason: 'timeout' } )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/types.ts
@@ -63,6 +63,16 @@ export interface EmbeddedKycSessionCreateResult {
 	session: EmbeddedKycSession;
 }
 
+export type EmbeddedAccountInitializationFailureReason =
+	| 'bad_session'
+	| 'init_error';
+
+export interface EmbeddedAccountInitializationFailure {
+	reason: EmbeddedAccountInitializationFailureReason;
+	message: string;
+	receivedKeys?: string[];
+}
+
 /**
  * Finalize embedded KYC session response.
  */


### PR DESCRIPTION
Closes WOOPMNT-6241

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Hardens WooPayments NOX embedded business verification so merchants are not left on an indefinite spinner when Stripe Connect.js fails to load or initialize.

This PR:

- adds a 20s watchdog for the embedded KYC loader;
- funnels timeouts, Stripe load errors, malformed KYC sessions, and initialization errors into one actionable error banner;
- stops rendering the embedded component after a terminal failure so late Stripe callbacks cannot clear the error;
- validates `clientSecret` / `publishableKey` and defaults missing or malformed `locale` to `en-US` before initializing Stripe;
- records a generic failure event with `reason: timeout | load_error | bad_session | init_error`.

### Screenshots or screen recordings:

<img width="2400" height="1524" alt="pr-65863-embedded-kyc-csp-failure-viewport" src="https://github.com/user-attachments/assets/f8a8e4bc-f0d7-4fc8-8e7c-b5c9c4e1f3ea" />

### How to test the changes in this Pull Request:

#### Setup

1. Check out this branch and build the admin assets:
   ```sh
   pnpm install --frozen-lockfile
   pnpm --filter=@woocommerce/plugin-woocommerce build:admin
   ```
2. Use a test store where WooPayments onboarding is available.
3. Go to **WooCommerce > Settings > Payments** and start/continue WooPayments onboarding until the embedded business verification/onboarding step.

#### Simulate a broken embedded onboarding load

Use either option below.

**Option A: Chrome request blocking, no code changes**

1. Open Chrome DevTools.
2. Open the Command Menu and search for **Show Network request blocking**.
3. Enable request blocking and add this pattern:
   ```text
   *connect-js.stripe.com*
   ```
4. Reload the embedded onboarding step.
5. Confirm DevTools shows the Stripe Connect.js request blocked.
6. Wait up to ~20 seconds.
7. Confirm the spinner is replaced by the error banner instead of spinning forever.
8. Confirm the banner says:
   > Unable to start onboarding. This may be caused by your site's security or server configuration. Please check our documentation and contact support if this error persists.
9. Confirm **Learn more** opens `https://woocommerce.com/document/woopayments/startup-guide/#requirements`.
10. Confirm **Cancel** returns to **WooCommerce > Settings > Payments**.

**Option B: restrictive CSP via a temporary MU plugin**

1. Create `wp-content/mu-plugins/woopayments-onboarding-csp-smoke.php` with:
   ```php
   <?php
   add_action(
       'admin_init',
       function () {
           if ( ! isset( $_GET['woopayments_kyc_csp_smoke'] ) ) {
               return;
           }

           $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
           $tab  = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : '';
           $path = isset( $_GET['path'] ) ? sanitize_text_field( wp_unslash( $_GET['path'] ) ) : '';

           if ( 'wc-settings' !== $page || 'checkout' !== $tab || 0 !== strpos( $path, '/woopayments/onboarding' ) ) {
               return;
           }

           header( "Content-Security-Policy: script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com; frame-src 'self' https://js.stripe.com; connect-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';", false );
       },
       PHP_INT_MAX
   );
   ```
2. Open/reload onboarding with the smoke-test query arg, for example:
   ```text
   /wp-admin/admin.php?page=wc-settings&tab=checkout&path=%2Fwoopayments%2Fonboarding&woopayments_kyc_csp_smoke=1
   ```
3. Continue to the embedded business verification/onboarding step if needed.
4. Confirm the browser console shows a CSP error for `https://connect-js.stripe.com/v1.0/connect.js`.
5. Wait up to ~20 seconds.
6. Confirm the same banner, **Learn more**, and **Cancel** behavior from Option A.
7. Remove the temporary MU plugin after testing.

#### Regression check

After testing the failure path, disable request blocking or remove the temporary CSP plugin, then reload onboarding and confirm the embedded component can start normally in an environment where Stripe resources are allowed.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

Manual changelog added: `plugins/woocommerce/changelog/fix-embedded-kyc-loader-failure-hardening`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

