### PR TITLE
Match orders and stock home panel border with other cards

### DIFF
--- a/plugins/woocommerce/changelog/65864-34487-different-border
+++ b/plugins/woocommerce/changelog/65864-34487-different-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Match orders and stock home panel border with other cards

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -31,6 +31,12 @@
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
 			}
+
+			.components-panel__row {
+				border-bottom-left-radius: inherit;
+				border-bottom-right-radius: inherit;
+				overflow: hidden;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -5,22 +5,13 @@
 	.components-panel__body {
 		background: #fff;
 		border: 1px solid $gray-200;
-		overflow: hidden;
 
 		&:first-child {
-			border-radius: 8px 8px 0 0;
+			border-top-left-radius: 8px;
+			border-top-right-radius: 8px;
 		}
 
 		&:last-child {
-			border-radius: 0 0 8px 8px;
-		}
-
-		&:only-child,
-		&.is-opened:first-child {
-			border-radius: 8px;
-		}
-
-		&.is-opened {
 			border-bottom-left-radius: 8px;
 			border-bottom-right-radius: 8px;
 		}
@@ -32,6 +23,8 @@
 
 		&.is-opened {
 			margin-bottom: $gap-large;
+			border-bottom-left-radius: 8px;
+			border-bottom-right-radius: 8px;
 
 			.components-panel__body-toggle {
 				border-bottom: 1px solid $gray-200;
@@ -52,6 +45,7 @@
 		}
 	}
 
+	.components-panel__body-title,
 	.components-panel__body-toggle {
 		border-radius: inherit;
 

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -7,16 +7,27 @@
 		border: 1px solid $gray-200;
 		overflow: hidden;
 
-		&:first-child,
-		&.is-opened + .components-panel__body {
-			border-top-left-radius: 8px;
-			border-top-right-radius: 8px;
+		&:first-child {
+			border-radius: 8px 8px 0 0;
 		}
 
-		&:last-child,
+		&:last-child {
+			border-radius: 0 0 8px 8px;
+		}
+
+		&:only-child,
+		&.is-opened:first-child {
+			border-radius: 8px;
+		}
+
 		&.is-opened {
 			border-bottom-left-radius: 8px;
 			border-bottom-right-radius: 8px;
+		}
+
+		&.is-opened + .components-panel__body {
+			border-top-left-radius: 8px;
+			border-top-right-radius: 8px;
 		}
 
 		&.is-opened {

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -1,28 +1,37 @@
 .woocommerce-homescreen .woocommerce-activity-panel {
-	background: #fff;
-	border: 1px solid $gray-200;
-	border-radius: 8px;
-	overflow: hidden;
+	background: transparent;
+	border: 0;
 
 	.components-panel__body {
 		background: #fff;
-		border: 0;
+		border: 1px solid $gray-200;
+		overflow: hidden;
+
+		&:first-child,
+		&.is-opened + .components-panel__body {
+			border-top-left-radius: 8px;
+			border-top-right-radius: 8px;
+		}
+
+		&:last-child,
+		&.is-opened {
+			border-bottom-left-radius: 8px;
+			border-bottom-right-radius: 8px;
+		}
 
 		&.is-opened {
-			margin-bottom: 0;
+			margin-bottom: $gap-large;
 
 			.components-panel__body-toggle {
 				border-bottom: 1px solid $gray-200;
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
 			}
 		}
 	}
 
 	&.components-panel > .components-panel__body:last-child {
-		border-bottom: 0;
-	}
-
-	&.components-panel > .components-panel__body + .components-panel__body {
-		border-top: 1px solid $gray-200;
+		border-bottom: 1px solid $gray-200;
 	}
 
 	.components-panel__row {
@@ -33,12 +42,7 @@
 	}
 
 	.components-panel__body-toggle {
-		border-radius: 0;
-
-		&:focus:not(:focus-visible) {
-			box-shadow: none;
-			outline: none;
-		}
+		border-radius: inherit;
 
 		&:disabled {
 			opacity: 1;

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -9,7 +9,7 @@
 		border: 0;
 
 		&.is-opened {
-			margin-bottom: $gap-large;
+			margin-bottom: 0;
 
 			.components-panel__body-toggle {
 				border-bottom: 1px solid $gray-200;
@@ -34,6 +34,11 @@
 
 	.components-panel__body-toggle {
 		border-radius: 0;
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+			outline: none;
+		}
 
 		&:disabled {
 			opacity: 1;

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -1,10 +1,12 @@
 .woocommerce-homescreen .woocommerce-activity-panel {
-	background: transparent;
-	border: 0;
+	background: #fff;
+	border: 1px solid $gray-200;
+	border-radius: 8px;
+	overflow: hidden;
 
 	.components-panel__body {
 		background: #fff;
-		border: 1px solid $gray-200;
+		border: 0;
 
 		&.is-opened {
 			margin-bottom: $gap-large;
@@ -16,7 +18,11 @@
 	}
 
 	&.components-panel > .components-panel__body:last-child {
-		border-bottom: 1px solid $gray-200;
+		border-bottom: 0;
+	}
+
+	&.components-panel > .components-panel__body + .components-panel__body {
+		border-top: 1px solid $gray-200;
 	}
 
 	.components-panel__row {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updated the CSS to match orders and stock home panel border with other cards

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #34487 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1196" height="690" alt="image" src="https://github.com/user-attachments/assets/b19f281a-fc27-42c4-bec1-c332ce106865" /> |  <img width="1194" height="682" alt="image" src="https://github.com/user-attachments/assets/316d85c5-6550-40dd-ab22-e821d7d9d51e" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Check the WooCommerce home in the WordPress Admin Dashboard.
2. Verify the the stocks and orders panel has the same border as the other cards on the page

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Match orders and stock home panel border with other cards

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
