### PR TITLE
Ensure email previews return only the dummy downloadable item

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-preview-downloadable-items
+++ b/plugins/woocommerce/changelog/fix-email-preview-downloadable-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent email previews from showing unrelated dummy products as downloadable items.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -634,7 +634,7 @@ class EmailPreview {
 		add_filter( 'woocommerce_is_downloadable', array( $this, 'force_product_downloadable' ), 10, 1 );
 		add_filter( 'woocommerce_product_file', array( $this, 'provide_dummy_product_file' ), 10, 1 );
 		// Provide dummy downloadable items for email preview.
-		add_filter( 'woocommerce_order_get_downloadable_items', array( $this, 'get_dummy_downloadable_items' ), 10, 1 );
+		add_filter( 'woocommerce_order_get_downloadable_items', array( $this, 'get_dummy_downloadable_items' ) );
 	}
 
 	/**
@@ -733,10 +733,9 @@ class EmailPreview {
 	/**
 	 * Get dummy downloadable items for email preview.
 	 *
-	 * @param array $downloads Existing downloads.
 	 * @return array
 	 */
-	public function get_dummy_downloadable_items( $downloads ) {
+	public function get_dummy_downloadable_items() {
 		$dummy_downloads = array(
 			array(
 				'product_name'   => $this->get_dummy_downloadable_product()->get_name(),
@@ -747,7 +746,7 @@ class EmailPreview {
 			),
 		);
 
-		return array_merge( $downloads, $dummy_downloads );
+		return $dummy_downloads;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -254,6 +254,39 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Email preview downloadable items ignore downloads resolved from the dummy order.
+	 */
+	public function test_get_dummy_downloadable_items_returns_only_preview_downloads(): void {
+		$downloads = array(
+			array(
+				'product_name'   => 'Unexpected Dummy Product',
+				'product_id'     => 0,
+				'download_url'   => 'https://example.com/unexpected',
+				'download_name'  => 'Unexpected Download.pdf',
+				'access_expires' => time() + DAY_IN_SECONDS,
+			),
+		);
+
+		try {
+			$this->sut->set_up_filters();
+			/**
+			 * Filters the list of downloadable items for an order.
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param array    $downloads Downloadable items.
+			 * @param WC_Order $order     Order object.
+			 */
+			$result = apply_filters( 'woocommerce_order_get_downloadable_items', $downloads, new PreviewOrder() );
+		} finally {
+			$this->sut->clean_up_filters();
+		}
+
+		$this->assertCount( 1, $result, 'Existing downloads from dummy order permission records must not be merged into preview output.' );
+		$this->assertSame( 'Sample Download File.pdf', $result[0]['download_name'], 'Preview output should keep the synthetic downloadable item.' );
+	}
+
+	/**
 	 * Test that downloadable product appears in email content.
 	 */
 	public function test_downloadable_product_in_email_content() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an email preview issue where unrelated dummy products could appear as downloadable items.

Email previews use a dummy order and dummy products with placeholder IDs. If the database contains a download permission row that matches those dummy values, WooCommerce can resolve existing downloadable items for the dummy order. The preview helper then merged those resolved downloads with the intended dummy preview download, causing non-downloadable dummy products to show as downloadable.

Related https://github.com/woocommerce/woocommerce/pull/65856.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1328" height="1774" alt="gcGnllrrLvU1ag6b@2x" src="https://github.com/user-attachments/assets/e5add473-1b06-4345-aad9-a83bf7371670" /> | <img width="1332" height="1778" alt="nZDpr8VDQipvKwRH@2x" src="https://github.com/user-attachments/assets/88ae10f3-534c-427c-a32c-5ae4ad4ed382" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out `trunk` (with **block email editor** feature disabled).
2. Insert one download-permission row matching the preview's billing email:

   ```sh
   npx wp-env run cli wp db query "INSERT INTO wp_woocommerce_downloadable_product_permissions (download_id, product_id, order_id, order_key, user_email, user_id, downloads_remaining, access_granted, access_expires, download_count) VALUES ('repro-1', 999999, 999999, 'wc_repro_key', 'john@company.com', 0, '', NOW(), NULL, 0)"
   ```

3. Go to **WooCommerce > Settings > Emails**.
4. The preview should render the Dummy Product(s) incorrectly in the "Downloads" sections.
5. Switch to this PR's branch and verify preview renders only the expected Dummy Downloadable Product.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
