### PR TITLE
Fix email editor column percentage widths

### DIFF
--- a/packages/php/email-editor/changelog/stomail-8193-column-width-doesnt-work-in-the-alpha-block-editor
+++ b/packages/php/email-editor/changelog/stomail-8193-column-width-doesnt-work-in-the-alpha-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve percentage widths for email editor columns in previews and rendered emails.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
@@ -121,9 +121,25 @@ class Column extends Abstract_Block_Renderer {
 		$wrapper_cell_attrs = array(
 			'class' => $wrapper_classname,
 			'style' => $wrapper_styles['css'],
-			'width' => Styles_Helper::parse_value( $block_attributes['width'] ),
+			'width' => $this->get_width_attribute_value( $block_attributes['width'] ),
 		);
 
 		return Table_Wrapper_Helper::render_table_cell( $inner_table, $wrapper_cell_attrs );
+	}
+
+	/**
+	 * Returns a table cell width attribute value.
+	 *
+	 * @param string $width Column width.
+	 * @return string
+	 */
+	private function get_width_attribute_value( $width ): string {
+		$parsed_width = Styles_Helper::parse_value( $width );
+
+		if ( is_string( $width ) && preg_match( '/%\s*$/', $width ) ) {
+			return $parsed_width . '%';
+		}
+
+		return (string) $parsed_width;
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
@@ -183,6 +183,29 @@ class Column_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it preserves percentage width attributes.
+	 */
+	public function testItPreservesPercentageWidthAttributes(): void {
+		$parsed_column                   = $this->parsed_column;
+		$parsed_column['attrs']['width'] = '33.33%';
+		$rendered                        = $this->column_renderer->render( '<p>Column content</p>', $parsed_column, $this->rendering_context );
+		$this->checkValidHTML( $rendered );
+		$this->assertStringContainsString( 'width="33.33%"', $rendered );
+	}
+
+	/**
+	 * Test it uses numeric width attributes for pixel widths.
+	 */
+	public function testItUsesNumericWidthAttributesForPixelWidths(): void {
+		$parsed_column                   = $this->parsed_column;
+		$parsed_column['attrs']['width'] = '220px';
+		$rendered                        = $this->column_renderer->render( '<p>Column content</p>', $parsed_column, $this->rendering_context );
+		$this->checkValidHTML( $rendered );
+		$this->assertStringContainsString( 'width="220"', $rendered );
+		$this->assertStringNotContainsString( 'width="220px"', $rendered );
+	}
+
+	/**
 	 * Test it applies padding-left from email_attrs (set by Spacing_Preprocessor for columns blockGap)
 	 */
 	public function testItAppliesPaddingLeftFromEmailAttrs(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes Email Editor column rendering when a `core/column` block uses percentage widths.

Previously, the column renderer passed the column width through `Styles_Helper::parse_value()` before writing it to the outer table cell `width` attribute. That stripped the `%` unit from values like `33.33%` and `66.66%`, causing email to render those columns with widths that varied based on their content.

This PR preserves percentage widths for table cell attributes while continuing to normalize pixel widths to numeric table attribute values.

Related [STOMAIL-8193: Column width doesn't work in the Alpha block editor](https://linear.app/a8c/issue/STOMAIL-8193/column-width-doesnt-work-in-the-alpha-block-editor).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1356" height="1366" alt="njhXlNmkqJiJH4Un@2x" src="https://github.com/user-attachments/assets/44e4f0de-040f-4f1d-b595-300c6eecdfca" /> | <img width="1356" height="1366" alt="l0PL39gKWZ5iIkBx@2x" src="https://github.com/user-attachments/assets/4571a3a1-7fe0-4194-bd30-7a480e5cc9d5" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
2. Open an email in the editor WooCommerce → Settings → **Emails**
3. Add a Columns block with 66 / 33 layout.
4. Open the email preview. Inspect the column and confirm width attributes of the `<td>` wrappers have unitless values. Also, the rendered width of the columns may vary based on their content.
5. Checkout this branch and reload the email preview. Columns should now use percentage width values.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column width rendering in the email editor to properly preserve percentage-based widths (e.g., 33.33%) in both previews and final rendered emails. Pixel-based widths are now correctly handled as numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->