### PR TITLE
e2e-tests: right-size create-order spec — drop redundant tax-amount assertions

### DIFF
--- a/plugins/woocommerce/changelog/testops-183-right-size-create-order-spec
+++ b/plugins/woocommerce/changelog/testops-183-right-size-create-order-spec
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Remove redundant tax-amount assertions from create-order E2E spec; tax calculation logic is already covered by API and PHPUnit tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.ts
@@ -42,8 +42,6 @@ const taxRates = [
 		class: 'tax-class-external',
 	},
 ];
-const taxTotals = [ '10.00', '20.00', '240.00' ];
-
 async function getOrderIdFromPage( page: Page ) {
 	// get order ID from the page
 	const orderText = await page
@@ -578,15 +576,6 @@ test.describe(
 				await expect(
 					page.locator( `th.line_tax >> nth=${ i }` )
 				).toHaveText( taxRate.name );
-				i++;
-			}
-
-			// verify tax amounts
-			i = 1; // subtotal line is 0 here
-			for ( const taxAmount of taxTotals ) {
-				await expect(
-					page.locator( `.wc-order-totals td.total >> nth=${ i }` )
-				).toContainText( taxAmount );
 				i++;
 			}
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the brittle tax-amount assertion block from the complex-order E2E test in `create-order.spec.ts`.

The removed assertions (`taxTotals = ['10.00', '20.00', '240.00']`) verified hardcoded totals produced by the `calculate_taxes()` engine. That logic is already covered at lower tiers:

- **API**: `tests/e2e-pw/tests/api-tests/orders/order-complex.test.ts` asserts `total_tax` and per-line-item tax across product types
- **PHPUnit**: `tests/php/includes/abstracts/class-wc-abstract-order-test.php` asserts `get_total_tax()` from `calculate_totals()` including both rounding modes

**Retained:** The Recalculate button click and tax-name render assertions are kept — they exercise the browser-only AJAX post → totals panel re-render seam that no lower tier covers.

Closes TESTOPS-183.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Run the full `create-order.spec.ts` suite: `pnpm test:e2e tests/order/create-order.spec.ts`
3. Confirm all 4 tests pass (simple guest order, existing customer order, new order, complex order)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
