### PR TITLE
fix: align cart-link icon size with mini-cart

### DIFF
--- a/plugins/woocommerce/changelog/65875-fix-cart-link-icon-size
+++ b/plugins/woocommerce/changelog/65875-fix-cart-link-icon-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cart Link block: set the cart icon width to match the Mini-Cart icon size (1.5em) so it no longer renders oversized.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/style.scss
@@ -11,6 +11,7 @@
 	.wc-block-mini-cart__icon {
 		display: inline-flex;
 		margin: 0;
+		width: em($grid-unit-30);
 		height: auto;
 	}
 


### PR DESCRIPTION
<p>The cart icon renders at different sizes depending on which header is used.</p>
<ul>
<li>Standard site headers use the <code>mini-cart</code> block, which sets <code>.wc-block-mini-cart__icon</code> to <code>1.5em</code> (24px) inside <code>.wc-block-mini-cart__button</code>.</li>
<li>The checkout header uses the <code>cart-link</code> block, which overrides <code>height</code> and <code>margin</code> on the same class but never sets <code>width</code>. Width falls through to the base <code>2em</code> (32px) defined in <code>quantity-badge/style.scss</code>.</li>
</ul>
<p>Both blocks render the same SVG glyph on the same class. The size difference is a missing <code>width</code> declaration in <code>cart-link/style.scss</code>.</p>
<p><strong>Fix:</strong> added <code>width: em($grid-unit-30)</code> to the <code>.wc-block-cart-link .wc-block-mini-cart__icon</code> rule.</p>

  | Before | After
-- | -- | --
Checkout header icon | 2em (32px) | 1.5em (24px)
Site header icon | 1.5em (24px) | 1.5em (24px)


<p>One line added. No markup or template changes.</p>

Main header reference:

<img width="991" height="101" alt="Capture d’écran 2026-06-19 à 12 55 42" src="https://github.com/user-attachments/assets/8909f5bd-3f6f-4b21-bb7a-5d08f549e0b4" />

Before:

<img width="992" height="289" alt="Capture d’écran 2026-06-19 à 12 56 51" src="https://github.com/user-attachments/assets/c7f1dcc5-fef3-4235-9934-e508a8af5b42" />

After:

<img width="988" height="755" alt="Capture d’écran 2026-06-19 à 12 55 52" src="https://github.com/user-attachments/assets/7f1b6efa-2cca-4f41-98b0-c203fb3151a8" />

