### PR TITLE
Fix concurrent mutations dropping or resurrecting batch processors

### DIFF
--- a/plugins/woocommerce/changelog/65452-fix-batch-processing-concurrency
+++ b/plugins/woocommerce/changelog/65452-fix-batch-processing-concurrency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Serialize mutations of the wc_pending_batch_processes option in BatchProcessingController with a short-lived database lock and a fresh re-read, so concurrent enqueue/dequeue/remove requests no longer clobber each other and silently drop or resurrect batch processors.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -791,7 +791,12 @@ class BatchProcessingController {
 			return;
 		}
 
-		$enqueued_processors    = $this->get_enqueued_processors();
+		/*
+		 * Sanitize before array_diff()/array_filter(): array_diff() string-casts its operands (fatal on an object
+		 * entry in PHP 8) and is_scheduled() is typed string, so a corrupted option must be reduced to class-name
+		 * strings first.
+		 */
+		$enqueued_processors    = $this->sanitize_processor_list( $this->get_enqueued_processors() );
 		$unscheduled_processors = array_diff( $enqueued_processors, array_filter( $enqueued_processors, array( $this, 'is_scheduled' ) ) );
 
 		foreach ( $unscheduled_processors as $processor ) {

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -118,23 +118,8 @@ class BatchProcessingController {
 		 */
 		if ( $this->enqueued_list_needs_update( $this->get_enqueued_processors(), $processor_class_name ) ) {
 			$this->mutate_enqueued_processors(
-				static function ( array $pending_updates ) use ( $processor_class_name ): array {
-					/*
-					 * De-duplicate defensively. Historically this method compared the class name against array_keys()
-					 * rather than the stored values, so the same processor was appended on every call and bloated the
-					 * option. Building the unique list in a single pass heals stores already carrying duplicates on
-					 * their next enqueue while keeping only one entry per class name (so the cleanup stays bounded even
-					 * when the stored list ballooned to thousands of entries), and skips any non-string values a
-					 * corrupted option may hold.
-					 */
-					$deduplicated_updates = array();
-					$seen                 = array();
-					foreach ( $pending_updates as $value ) {
-						if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
-							$seen[ $value ]         = true;
-							$deduplicated_updates[] = $value;
-						}
-					}
+				function ( array $pending_updates ) use ( $processor_class_name ): array {
+					$deduplicated_updates = $this->sanitize_processor_list( $pending_updates );
 					if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
 						$deduplicated_updates[] = $processor_class_name;
 					}
@@ -144,6 +129,31 @@ class BatchProcessingController {
 		}
 
 		$this->schedule_watchdog_action( false, true );
+	}
+
+	/**
+	 * Reduce a processor list to unique, non-empty class-name strings, preserving order.
+	 *
+	 * The enqueued-processors option is a plain serialized array, so a corrupted option (or the historical
+	 * duplicate-accumulation bug) can leave it holding duplicates or non-string values. Sanitizing before any
+	 * comparison keeps the mutators safe and heals the stored list on the next write: in particular array_diff()
+	 * string-casts its operands and would fatal on an object entry in PHP 8, so removals run on the sanitized list.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param array $processors Raw processor list as read from the option.
+	 * @return array Sanitized list of unique class-name strings.
+	 */
+	private function sanitize_processor_list( array $processors ): array {
+		$sanitized = array();
+		$seen      = array();
+		foreach ( $processors as $value ) {
+			if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
+				$seen[ $value ] = true;
+				$sanitized[]    = $value;
+			}
+		}
+		return $sanitized;
 	}
 
 	/**
@@ -569,12 +579,12 @@ class BatchProcessingController {
 		// batch finishes, not on a per-request hot path, so correctness is preferred over skipping the lock.
 		$removed = false;
 		$this->mutate_enqueued_processors(
-			static function ( array $pending_processes ) use ( $processor_class_name, &$removed ): array {
+			function ( array $pending_processes ) use ( $processor_class_name, &$removed ): array {
 				if ( ! in_array( $processor_class_name, $pending_processes, true ) ) {
 					return $pending_processes;
 				}
 				$removed = true;
-				return array_values( array_diff( $pending_processes, array( $processor_class_name ) ) );
+				return array_values( array_diff( $this->sanitize_processor_list( $pending_processes ), array( $processor_class_name ) ) );
 			}
 		);
 
@@ -615,12 +625,12 @@ class BatchProcessingController {
 		// always takes the lock and re-reads the freshest list rather than acting on a possibly-stale cached copy.
 		$was_enqueued = false;
 		$this->mutate_enqueued_processors(
-			static function ( array $enqueued_processors ) use ( $processor_class_name, &$was_enqueued ): array {
+			function ( array $enqueued_processors ) use ( $processor_class_name, &$was_enqueued ): array {
 				if ( ! in_array( $processor_class_name, $enqueued_processors, true ) ) {
 					return $enqueued_processors;
 				}
 				$was_enqueued = true;
-				return array_values( array_diff( $enqueued_processors, array( $processor_class_name ) ) );
+				return array_values( array_diff( $this->sanitize_processor_list( $enqueued_processors ), array( $processor_class_name ) ) );
 			}
 		);
 

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -52,6 +52,19 @@ class BatchProcessingController {
 	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 5;
 
 	/**
+	 * Seconds to wait for the enqueued-processors lock before giving up and proceeding without it.
+	 *
+	 * Kept small deliberately: enqueue_processor() runs on the 'shutdown' hook of nearly every request under
+	 * continuous HPOS background sync, so a long wait could pile requests up. The guarded critical section is just
+	 * a couple of option queries, so one second is ample headroom for an uncontended writer while bounding the
+	 * worst-case stall when the lock is genuinely contended (in which case the mutation falls back to running
+	 * unguarded, which is no worse than the historical behavior).
+	 *
+	 * @since 11.0.0
+	 */
+	const ENQUEUED_PROCESSORS_LOCK_TIMEOUT = 1;
+
+	/**
 	 * Instance of WC_Logger class.
 	 *
 	 * @var \WC_Logger_Interface
@@ -96,29 +109,196 @@ class BatchProcessingController {
 	 * @param string $processor_class_name Fully qualified class name of the processor, must implement `BatchProcessorInterface`.
 	 */
 	public function enqueue_processor( string $processor_class_name ): void {
-		$pending_updates = $this->get_enqueued_processors();
-
-		// De-duplicate defensively. Historically this method compared the class name against array_keys() rather
-		// than the stored values, so the same processor was appended on every call and bloated the option. Building
-		// the unique list in a single pass heals stores already carrying duplicates on their next enqueue while
-		// keeping only one entry per class name in memory (so the cleanup stays bounded even when the stored list
-		// ballooned to thousands of entries), and skips any non-string values a corrupted option may hold.
-		$deduplicated_updates = array();
-		$seen                 = array();
-		foreach ( $pending_updates as $value ) {
-			if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
-				$seen[ $value ]         = true;
-				$deduplicated_updates[] = $value;
-			}
-		}
-		if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
-			$deduplicated_updates[] = $processor_class_name;
-		}
-		if ( $deduplicated_updates !== $pending_updates ) {
-			$this->set_enqueued_processors( $deduplicated_updates );
+		/*
+		 * Fast path: if the processor is already enqueued and the stored list is clean, there is nothing to write.
+		 * This avoids taking the lock and re-reading the option on the hot path, which matters because
+		 * DataSynchronizer::handle_continuous_background_sync() calls this on the 'shutdown' hook of every request
+		 * when HPOS background sync runs in continuous mode. The check uses the (possibly request-cached) value;
+		 * the authoritative re-read happens inside the critical section below only when an update is actually needed.
+		 */
+		if ( $this->enqueued_list_needs_update( $this->get_enqueued_processors(), $processor_class_name ) ) {
+			$this->mutate_enqueued_processors(
+				static function ( array $pending_updates ) use ( $processor_class_name ): array {
+					/*
+					 * De-duplicate defensively. Historically this method compared the class name against array_keys()
+					 * rather than the stored values, so the same processor was appended on every call and bloated the
+					 * option. Building the unique list in a single pass heals stores already carrying duplicates on
+					 * their next enqueue while keeping only one entry per class name (so the cleanup stays bounded even
+					 * when the stored list ballooned to thousands of entries), and skips any non-string values a
+					 * corrupted option may hold.
+					 */
+					$deduplicated_updates = array();
+					$seen                 = array();
+					foreach ( $pending_updates as $value ) {
+						if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
+							$seen[ $value ]         = true;
+							$deduplicated_updates[] = $value;
+						}
+					}
+					if ( ! in_array( $processor_class_name, $deduplicated_updates, true ) ) {
+						$deduplicated_updates[] = $processor_class_name;
+					}
+					return $deduplicated_updates;
+				}
+			);
 		}
 
 		$this->schedule_watchdog_action( false, true );
+	}
+
+	/**
+	 * Determine whether the stored enqueued-processors list needs to be rewritten to include a given processor
+	 * or to heal pre-existing corruption (duplicates or non-string entries).
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param array  $processors           Current list of enqueued processors.
+	 * @param string $processor_class_name Fully qualified class name of the processor to ensure is enqueued.
+	 *
+	 * @return bool True if the list should be rewritten, false if it is already clean and contains the processor.
+	 */
+	private function enqueued_list_needs_update( array $processors, string $processor_class_name ): bool {
+		$seen           = array();
+		$contains_class = false;
+		foreach ( $processors as $value ) {
+			if ( ! is_string( $value ) || isset( $seen[ $value ] ) ) {
+				// Non-string entry or duplicate: the list needs healing.
+				return true;
+			}
+			$seen[ $value ] = true;
+			if ( $value === $processor_class_name ) {
+				$contains_class = true;
+			}
+		}
+
+		return ! $contains_class;
+	}
+
+	/**
+	 * Run a read-modify-write of the enqueued-processors option inside a short-lived critical section.
+	 *
+	 * The list is stored in a single option and mutated by several code paths (including the per-request
+	 * 'shutdown' enqueue from continuous HPOS background sync), so an unguarded read-modify-write can lose
+	 * updates under concurrency: two requests read the same list, each writes its own version, and the later
+	 * write silently drops the other's change. This serializes those mutations with a MySQL named lock and
+	 * re-reads the freshest persisted value inside the lock so the mutator always operates on current state.
+	 *
+	 * The lock is best-effort: if it cannot be acquired (timeout, an environment without GET_LOCK, or a multi-server
+	 * database layout — e.g. HyperDB/LudicrousDB — where the GET_LOCK SELECT is routed to a different connection
+	 * than the write) the mutation still proceeds, which is no worse than the previous lock-free behavior. The
+	 * fresh re-read inside the section narrows the race window even when the lock provides no real exclusion, and
+	 * the watchdog reconciles any residual divergence on its next run.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param callable $mutator Receives the current list (array of class-name strings) and returns the new list.
+	 *
+	 * @return array The list as persisted (the mutator's return value).
+	 */
+	private function mutate_enqueued_processors( callable $mutator ): array {
+		// Resolve the lock name once so acquire and release always target the exact same named lock, even if a
+		// hook fired during the write (e.g. by update_option()) were to mutate $wpdb->prefix mid-section.
+		$lock_name     = $this->get_enqueued_processors_lock_name();
+		$lock_acquired = $this->acquire_enqueued_processors_lock( $lock_name );
+		try {
+			/*
+			 * Drop any request-cached copy so the read below reflects writes committed by concurrent requests
+			 * that landed after this request first read the option. Both the per-option entry AND the shared
+			 * 'notoptions' entry must be cleared: when the option does not yet exist (first enqueue, or after a
+			 * corrupted option was deleted), get_option() short-circuits on a stale 'notoptions' hit and would
+			 * otherwise return the default empty list even though a concurrent request just created the row.
+			 */
+			wp_cache_delete( self::ENQUEUED_PROCESSORS_OPTION_NAME, 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+			$current = $this->get_enqueued_processors();
+			$updated = $mutator( $current );
+			if ( $updated !== $current ) {
+				$this->set_enqueued_processors( $updated );
+			}
+			return $updated;
+		} finally {
+			if ( $lock_acquired ) {
+				$this->release_enqueued_processors_lock( $lock_name );
+			}
+		}
+	}
+
+	/**
+	 * Build the MySQL named-lock identifier for the enqueued-processors critical section.
+	 *
+	 * GET_LOCK names are scoped to the whole MySQL server (shared across databases), so the lock is namespaced
+	 * to this install to avoid unrelated sites on the same server contending. Lock names are capped at 64
+	 * characters, so the install-specific part is hashed.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return string Lock name.
+	 */
+	private function get_enqueued_processors_lock_name(): string {
+		global $wpdb;
+		$db_name = defined( 'DB_NAME' ) ? DB_NAME : '';
+		return 'wc_pending_batch_processes_' . md5( $wpdb->prefix . $db_name );
+	}
+
+	/**
+	 * Acquire the enqueued-processors named lock, waiting up to ENQUEUED_PROCESSORS_LOCK_TIMEOUT seconds.
+	 *
+	 * Failures (no $wpdb, GET_LOCK unavailable, or a database error) are swallowed and reported as "not acquired"
+	 * so the caller can fall back to its best-effort unguarded path rather than fataling — this runs on the
+	 * 'shutdown' hook of essentially every request under continuous background sync.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string $lock_name The named-lock identifier to acquire.
+	 * @return bool True if the lock was acquired (and must be released by the caller), false otherwise.
+	 */
+	private function acquire_enqueued_processors_lock( string $lock_name ): bool {
+		global $wpdb;
+		if ( ! $wpdb instanceof \wpdb ) {
+			return false;
+		}
+
+		try {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$acquired = $wpdb->get_var(
+				$wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, self::ENQUEUED_PROCESSORS_LOCK_TIMEOUT )
+			);
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		return '1' === (string) $acquired;
+	}
+
+	/**
+	 * Release the enqueued-processors named lock previously acquired by acquire_enqueued_processors_lock().
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string $lock_name The named-lock identifier to release (the same value passed to acquire).
+	 */
+	private function release_enqueued_processors_lock( string $lock_name ): void {
+		global $wpdb;
+		if ( ! $wpdb instanceof \wpdb ) {
+			return;
+		}
+
+		$query = $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name );
+		if ( ! is_string( $query ) ) {
+			return;
+		}
+
+		try {
+			/*
+			 * $query is built by $wpdb->prepare() above; it is assigned to a variable only so it can be type-checked
+			 * before being passed to query() (prepare() returns string|null), hence the NotPrepared suppression.
+			 */
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $query );
+		} catch ( \Throwable $e ) {
+			// Best-effort: the lock is released automatically when the database session ends regardless.
+			return;
+		}
 	}
 
 	/**
@@ -385,11 +565,21 @@ class BatchProcessingController {
 	 * @param string $processor_class_name Full processor class name.
 	 */
 	private function dequeue_processor( string $processor_class_name ): void {
-		$pending_processes = $this->get_enqueued_processors();
-		if ( in_array( $processor_class_name, $pending_processes, true ) ) {
+		// Always resolve membership authoritatively inside the lock (no unguarded fast-path read): this runs when a
+		// batch finishes, not on a per-request hot path, so correctness is preferred over skipping the lock.
+		$removed = false;
+		$this->mutate_enqueued_processors(
+			static function ( array $pending_processes ) use ( $processor_class_name, &$removed ): array {
+				if ( ! in_array( $processor_class_name, $pending_processes, true ) ) {
+					return $pending_processes;
+				}
+				$removed = true;
+				return array_values( array_diff( $pending_processes, array( $processor_class_name ) ) );
+			}
+		);
+
+		if ( $removed ) {
 			$this->clear_processor_state( $processor_class_name );
-			$pending_processes = array_diff( $pending_processes, array( $processor_class_name ) );
-			$this->set_enqueued_processors( $pending_processes );
 		}
 	}
 
@@ -420,19 +610,38 @@ class BatchProcessingController {
 	 * @return bool True if the processor has been dequeued, false if the processor wasn't enqueued (so nothing has been done).
 	 */
 	public function remove_processor( string $processor_class_name ): bool {
-		$enqueued_processors = $this->get_enqueued_processors();
-		if ( ! in_array( $processor_class_name, $enqueued_processors, true ) ) {
+		// Resolve membership authoritatively inside the lock (no unguarded fast-path read). remove_processor() is
+		// not a per-request hot path — the continuous-sync 'shutdown' handler enqueues rather than removes — so it
+		// always takes the lock and re-reads the freshest list rather than acting on a possibly-stale cached copy.
+		$was_enqueued = false;
+		$this->mutate_enqueued_processors(
+			static function ( array $enqueued_processors ) use ( $processor_class_name, &$was_enqueued ): array {
+				if ( ! in_array( $processor_class_name, $enqueued_processors, true ) ) {
+					return $enqueued_processors;
+				}
+				$was_enqueued = true;
+				return array_values( array_diff( $enqueued_processors, array( $processor_class_name ) ) );
+			}
+		);
+
+		if ( ! $was_enqueued ) {
 			return false;
 		}
 
-		$enqueued_processors = array_diff( $enqueued_processors, array( $processor_class_name ) );
-		if ( empty( $enqueued_processors ) ) {
-			$this->force_clear_all_processes();
-		} else {
-			update_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, $enqueued_processors, false );
-			as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
-			$this->clear_processor_state( $processor_class_name );
-		}
+		/*
+		 * The new list (which may now be empty) was persisted atomically inside the critical section above. Only the
+		 * removed processor's own scheduling needs tearing down here, so we unschedule by class name rather than
+		 * wiping every action. This intentionally does NOT unschedule the watchdog, even when the list is now empty:
+		 * handle_watchdog_action() returns without rescheduling itself once the list is empty (so a lingering
+		 * watchdog fires at most once more and then stops). force_clear_all_processes() is deliberately avoided: its
+		 * own unguarded read-modify-write would clobber a processor that a concurrent request enqueued in the gap
+		 * after this mutation committed — the exact lost-update race this change exists to prevent. Leaving the
+		 * watchdog in place lets it pick up such a concurrent enqueue; in the narrow window where the watchdog is
+		 * already mid-run, the 'shutdown' reconciler remove_or_retry_failed_processors() reschedules the
+		 * enqueued-but-unscheduled processor on the next request.
+		 */
+		as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+		$this->clear_processor_state( $processor_class_name );
 
 		return true;
 	}

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -158,9 +158,11 @@ class BatchProcessingController {
 	 * Reduce a processor list to unique, non-empty class-name strings, preserving order.
 	 *
 	 * The enqueued-processors option is a plain serialized array, so a corrupted option (or the historical
-	 * duplicate-accumulation bug) can leave it holding duplicates or non-string values. Sanitizing before any
-	 * comparison keeps the mutators safe and heals the stored list on the next write: in particular array_diff()
-	 * string-casts its operands and would fatal on an object entry in PHP 8, so removals run on the sanitized list.
+	 * duplicate-accumulation bug) can leave it holding duplicates, empty strings, or non-string values. Sanitizing
+	 * before any comparison keeps the mutators safe and heals the stored list on the next write: in particular
+	 * array_diff() string-casts its operands and would fatal on an object entry in PHP 8, so removals run on the
+	 * sanitized list. Empty strings are dropped too: they are never a valid class name, and left in place would be
+	 * scheduled and then fatal in get_processor_instance( '' ), with the watchdog rescheduling them indefinitely.
 	 *
 	 * @since 11.0.0
 	 *
@@ -171,7 +173,7 @@ class BatchProcessingController {
 		$sanitized = array();
 		$seen      = array();
 		foreach ( $processors as $value ) {
-			if ( is_string( $value ) && ! isset( $seen[ $value ] ) ) {
+			if ( is_string( $value ) && '' !== $value && ! isset( $seen[ $value ] ) ) {
 				$seen[ $value ] = true;
 				$sanitized[]    = $value;
 			}
@@ -394,7 +396,7 @@ class BatchProcessingController {
 	 * (because they have just been enqueued, or because the processing for a batch failed).
 	 */
 	private function handle_watchdog_action(): void {
-		$pending_processes = $this->get_enqueued_processors();
+		$pending_processes = $this->sanitize_processor_list( $this->get_enqueued_processors() );
 		if ( empty( $pending_processes ) ) {
 			return;
 		}
@@ -671,8 +673,8 @@ class BatchProcessingController {
 		// Resolve membership authoritatively inside the lock (no unguarded fast-path read). remove_processor() is
 		// not a per-request hot path — the continuous-sync 'shutdown' handler enqueues rather than removes — so it
 		// always takes the lock and re-reads the freshest list rather than acting on a possibly-stale cached copy.
-		$was_enqueued = false;
-		$this->mutate_enqueued_processors(
+		$was_enqueued         = false;
+		$remaining_processors = $this->mutate_enqueued_processors(
 			function ( array $enqueued_processors ) use ( $processor_class_name, &$was_enqueued ): array {
 				if ( ! in_array( $processor_class_name, $enqueued_processors, true ) ) {
 					return $enqueued_processors;
@@ -687,18 +689,31 @@ class BatchProcessingController {
 		}
 
 		/*
-		 * The new list (which may now be empty) was persisted atomically inside the critical section above. Only the
-		 * removed processor's own scheduling needs tearing down here, so we unschedule by class name rather than
-		 * wiping every action. This intentionally does NOT unschedule the watchdog, even when the list is now empty:
-		 * handle_watchdog_action() returns without rescheduling itself once the list is empty (so a lingering
-		 * watchdog fires at most once more and then stops). force_clear_all_processes() is deliberately avoided: its
-		 * own unguarded read-modify-write would clobber a processor that a concurrent request enqueued in the gap
-		 * after this mutation committed — the exact lost-update race this change exists to prevent. Leaving the
-		 * watchdog in place lets it pick up such a concurrent enqueue; in the narrow window where the watchdog is
-		 * already mid-run, the 'shutdown' reconciler remove_or_retry_failed_processors() reschedules the
-		 * enqueued-but-unscheduled processor on the next request.
+		 * $remaining_processors is the list exactly as persisted inside the critical section above, so the empty
+		 * check is decided from the lock-guarded snapshot rather than a second, unguarded re-read (which would only
+		 * ever see this request's own post-mutation value anyway). When that snapshot is empty we unschedule every
+		 * single-batch action to sweep up any orphaned "ghost" actions left in Action Scheduler for processors that
+		 * are no longer enqueued; otherwise only the removed processor's own scheduling needs tearing down, so we
+		 * unschedule by class name.
+		 *
+		 * This intentionally does NOT unschedule the watchdog: handle_watchdog_action() returns without rescheduling
+		 * itself once the list is empty (so a lingering watchdog fires at most once more and then stops), and leaving
+		 * it in place is what makes the empty-list sweep safe. force_clear_all_processes() is deliberately avoided:
+		 * its own unguarded read-modify-write would clobber a processor that a concurrent request enqueued in the gap
+		 * after this mutation committed — the exact lost-update race this change exists to prevent.
+		 *
+		 * There is still a narrow window: a concurrent request can enqueue processor Q and have the watchdog schedule
+		 * Q's single-batch action after our lock releases but before the sweep runs, in which case the sweep cancels
+		 * Q's action even though Q remains enqueued. Q is never lost from the option (the source of truth), so this is
+		 * a bounded scheduling delay, not a lost update: the watchdog we leave in place reschedules Q on its next run.
+		 * That recovery is bounded by the watchdog delay (woocommerce_batch_processor_watchdog_delay_seconds), not the
+		 * next request, because remove_or_retry_failed_processors() no-ops while any watchdog is already scheduled.
 		 */
-		as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+		if ( empty( $remaining_processors ) ) {
+			as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME );
+		} else {
+			as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+		}
 		$this->clear_processor_state( $processor_class_name );
 
 		return true;

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -229,7 +229,7 @@ class BatchProcessingController {
 	 * @return array The list as persisted (the mutator's return value).
 	 */
 	private function mutate_enqueued_processors( callable $mutator ): array {
-		$lock_acquired = $this->acquire_enqueued_processors_lock();
+		$lock_token = $this->acquire_enqueued_processors_lock();
 		try {
 			/*
 			 * Drop any request-cached copy so the read below reflects writes committed by concurrent requests
@@ -247,8 +247,8 @@ class BatchProcessingController {
 			}
 			return $updated;
 		} finally {
-			if ( $lock_acquired ) {
-				$this->release_enqueued_processors_lock();
+			if ( null !== $lock_token ) {
+				$this->release_enqueued_processors_lock( $lock_token );
 			}
 		}
 	}
@@ -261,26 +261,29 @@ class BatchProcessingController {
 	 * claim is retried up to ENQUEUED_PROCESSORS_LOCK_ATTEMPTS times with a short delay before the caller falls
 	 * back to its best-effort unguarded path. Modeled on WC_Install::create_lock().
 	 *
+	 * Release times are stored as fixed-width, zero-padded-fraction strings (`number_format( ..., 6 )`) so the
+	 * database compares and matches them as plain strings without a numeric cast; for the current epoch the
+	 * integer part is a stable ten digits, so lexical order matches chronological order.
+	 *
 	 * @since 11.0.0
 	 *
-	 * @return bool True if the lock was acquired (and must be released by the caller), false otherwise.
+	 * @return string|null The stored release time when the lock was acquired (which must be passed to
+	 *                     release_enqueued_processors_lock()), or null when it could not be acquired.
 	 */
-	private function acquire_enqueued_processors_lock(): bool {
+	private function acquire_enqueued_processors_lock(): ?string {
 		global $wpdb;
-		if ( ! $wpdb instanceof \wpdb ) {
-			return false;
-		}
 
 		$attempts    = max( 1, self::ENQUEUED_PROCESSORS_LOCK_ATTEMPTS );
-		$delay_micro = (int) ( ( self::ENQUEUED_PROCESSORS_LOCK_TTL / $attempts ) * 1000000 );
+		$delay_micro = (int) ( ( self::ENQUEUED_PROCESSORS_LOCK_TTL / $attempts ) * 1_000_000 );
 
 		// A contended INSERT fails on the duplicate key by design, so silence wpdb error reporting to keep the
 		// expected-failure path from spamming the log in debug mode; restore the prior setting when done.
 		$suppress = $wpdb->suppress_errors( true );
 		try {
 			for ( $attempt = 0; $attempt < $attempts; $attempt++ ) {
-				$now    = microtime( true );
-				$expiry = $now + self::ENQUEUED_PROCESSORS_LOCK_TTL;
+				$time   = microtime( true );
+				$now    = number_format( $time, 6, '.', '' );
+				$expiry = number_format( $time + self::ENQUEUED_PROCESSORS_LOCK_TTL, 6, '.', '' );
 
 				// The unique option_name key makes this INSERT a mutex: it fails when the lock row already exists.
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -291,7 +294,7 @@ class BatchProcessingController {
 						'option_value' => $expiry,
 						'autoload'     => 'no',
 					),
-					array( '%s', '%f', '%s' )
+					array( '%s', '%s', '%s' )
 				);
 
 				if ( ! $acquired ) {
@@ -301,8 +304,7 @@ class BatchProcessingController {
 					 * The table is a trusted internal identifier and every value is bound through a placeholder.
 					 */
 					$takeover = $wpdb->prepare(
-						// @phpstan-ignore-next-line argument.type -- $wpdb->options is a trusted identifier, not user input.
-						"UPDATE {$wpdb->options} SET option_value = %f WHERE option_name = %s AND option_value < %f", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+						"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 						$expiry,
 						self::ENQUEUED_PROCESSORS_LOCK_OPTION,
 						$now
@@ -314,7 +316,7 @@ class BatchProcessingController {
 				}
 
 				if ( $acquired ) {
-					return true;
+					return $expiry;
 				}
 
 				if ( $attempt < $attempts - 1 && $delay_micro > 0 ) {
@@ -322,30 +324,35 @@ class BatchProcessingController {
 				}
 			}
 
-			return false;
+			return null;
 		} finally {
 			$wpdb->suppress_errors( $suppress );
 		}
 	}
 
 	/**
-	 * Release the enqueued-processors lock by deleting its options-table row.
+	 * Release the enqueued-processors lock by deleting the options-table row we own.
+	 *
+	 * The delete is conditional on the stored release time still matching the one written when the lock was
+	 * acquired, so a lock that expired and was taken over by another request is never released out from under it.
 	 *
 	 * @since 11.0.0
+	 *
+	 * @param string $expiry The release time returned by acquire_enqueued_processors_lock().
 	 */
-	private function release_enqueued_processors_lock(): void {
+	private function release_enqueued_processors_lock( string $expiry ): void {
 		global $wpdb;
-		if ( ! $wpdb instanceof \wpdb ) {
-			return;
-		}
 
 		$suppress = $wpdb->suppress_errors( true );
 		try {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->delete(
 				$wpdb->options,
-				array( 'option_name' => self::ENQUEUED_PROCESSORS_LOCK_OPTION ),
-				array( '%s' )
+				array(
+					'option_name'  => self::ENQUEUED_PROCESSORS_LOCK_OPTION,
+					'option_value' => $expiry,
+				),
+				array( '%s', '%s' )
 			);
 		} finally {
 			$wpdb->suppress_errors( $suppress );

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -52,17 +52,40 @@ class BatchProcessingController {
 	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 5;
 
 	/**
-	 * Seconds to wait for the enqueued-processors lock before giving up and proceeding without it.
+	 * Option name used as a self-expiring mutex around mutations of the enqueued-processors option.
 	 *
-	 * Kept small deliberately: enqueue_processor() runs on the 'shutdown' hook of nearly every request under
-	 * continuous HPOS background sync, so a long wait could pile requests up. The guarded critical section is just
-	 * a couple of option queries, so one second is ample headroom for an uncontended writer while bounding the
-	 * worst-case stall when the lock is genuinely contended (in which case the mutation falls back to running
-	 * unguarded, which is no worse than the historical behavior).
+	 * The row holds the lock's release time (a microtime float); its mere existence is the lock. The lock lives in
+	 * the options table (rather than a MySQL named lock) so it is naturally scoped to this install's wp_options and
+	 * routes to the primary database like any other write, avoiding the replica-routing and server-global-namespace
+	 * pitfalls of GET_LOCK. Modeled on WC_Install::create_lock().
 	 *
 	 * @since 11.0.0
 	 */
-	const ENQUEUED_PROCESSORS_LOCK_TIMEOUT = 1;
+	const ENQUEUED_PROCESSORS_LOCK_OPTION = 'wc_pending_batch_processes_lock';
+
+	/**
+	 * How long (in seconds, fractional) a held enqueued-processors lock stays valid before it is considered stale
+	 * and can be taken over.
+	 *
+	 * Kept short deliberately: enqueue_processor() runs on the 'shutdown' hook of nearly every request under
+	 * continuous HPOS background sync, and the guarded critical section is just a couple of option queries. The
+	 * value must exceed the worst-case hold time (a normal holder releases in milliseconds), and also bounds how
+	 * long a contender waits before stealing a lock left behind by a crashed request.
+	 *
+	 * @since 11.0.0
+	 */
+	const ENQUEUED_PROCESSORS_LOCK_TTL = 1.0;
+
+	/**
+	 * Number of times to attempt to acquire the enqueued-processors lock before giving up and proceeding without it.
+	 *
+	 * The delay between attempts is ENQUEUED_PROCESSORS_LOCK_TTL / ENQUEUED_PROCESSORS_LOCK_ATTEMPTS, so the total
+	 * acquisition window is one TTL — long enough for a normal holder to finish and release, after which a stale
+	 * lock becomes stealable.
+	 *
+	 * @since 11.0.0
+	 */
+	const ENQUEUED_PROCESSORS_LOCK_ATTEMPTS = 20;
 
 	/**
 	 * Instance of WC_Logger class.
@@ -190,14 +213,14 @@ class BatchProcessingController {
 	 * The list is stored in a single option and mutated by several code paths (including the per-request
 	 * 'shutdown' enqueue from continuous HPOS background sync), so an unguarded read-modify-write can lose
 	 * updates under concurrency: two requests read the same list, each writes its own version, and the later
-	 * write silently drops the other's change. This serializes those mutations with a MySQL named lock and
-	 * re-reads the freshest persisted value inside the lock so the mutator always operates on current state.
+	 * write silently drops the other's change. This serializes those mutations with a self-expiring options-table
+	 * mutex and re-reads the freshest persisted value inside the lock so the mutator always operates on current
+	 * state.
 	 *
-	 * The lock is best-effort: if it cannot be acquired (timeout, an environment without GET_LOCK, or a multi-server
-	 * database layout — e.g. HyperDB/LudicrousDB — where the GET_LOCK SELECT is routed to a different connection
-	 * than the write) the mutation still proceeds, which is no worse than the previous lock-free behavior. The
-	 * fresh re-read inside the section narrows the race window even when the lock provides no real exclusion, and
-	 * the watchdog reconciles any residual divergence on its next run.
+	 * The lock is best-effort: if it cannot be acquired within ENQUEUED_PROCESSORS_LOCK_ATTEMPTS tries the mutation
+	 * still proceeds, which is no worse than the previous lock-free behavior. The fresh re-read inside the section
+	 * narrows the race window even when the lock provides no real exclusion, and the watchdog reconciles any
+	 * residual divergence on its next run.
 	 *
 	 * @since 11.0.0
 	 *
@@ -206,10 +229,7 @@ class BatchProcessingController {
 	 * @return array The list as persisted (the mutator's return value).
 	 */
 	private function mutate_enqueued_processors( callable $mutator ): array {
-		// Resolve the lock name once so acquire and release always target the exact same named lock, even if a
-		// hook fired during the write (e.g. by update_option()) were to mutate $wpdb->prefix mid-section.
-		$lock_name     = $this->get_enqueued_processors_lock_name();
-		$lock_acquired = $this->acquire_enqueued_processors_lock( $lock_name );
+		$lock_acquired = $this->acquire_enqueued_processors_lock();
 		try {
 			/*
 			 * Drop any request-cached copy so the read below reflects writes committed by concurrent requests
@@ -228,86 +248,107 @@ class BatchProcessingController {
 			return $updated;
 		} finally {
 			if ( $lock_acquired ) {
-				$this->release_enqueued_processors_lock( $lock_name );
+				$this->release_enqueued_processors_lock();
 			}
 		}
 	}
 
 	/**
-	 * Build the MySQL named-lock identifier for the enqueued-processors critical section.
+	 * Acquire the enqueued-processors lock by claiming a row in the options table.
 	 *
-	 * GET_LOCK names are scoped to the whole MySQL server (shared across databases), so the lock is namespaced
-	 * to this install to avoid unrelated sites on the same server contending. Lock names are capped at 64
-	 * characters, so the install-specific part is hashed.
-	 *
-	 * @since 11.0.0
-	 *
-	 * @return string Lock name.
-	 */
-	private function get_enqueued_processors_lock_name(): string {
-		global $wpdb;
-		$db_name = defined( 'DB_NAME' ) ? DB_NAME : '';
-		return 'wc_pending_batch_processes_' . md5( $wpdb->prefix . $db_name );
-	}
-
-	/**
-	 * Acquire the enqueued-processors named lock, waiting up to ENQUEUED_PROCESSORS_LOCK_TIMEOUT seconds.
-	 *
-	 * Failures (no $wpdb, GET_LOCK unavailable, or a database error) are swallowed and reported as "not acquired"
-	 * so the caller can fall back to its best-effort unguarded path rather than fataling — this runs on the
-	 * 'shutdown' hook of essentially every request under continuous background sync.
+	 * The claim is an atomic INSERT (which fails if the row already exists, making it a mutex); if the row exists
+	 * but its stored release time has already passed, a conditional UPDATE takes the stale lock over. Failure to
+	 * claim is retried up to ENQUEUED_PROCESSORS_LOCK_ATTEMPTS times with a short delay before the caller falls
+	 * back to its best-effort unguarded path. Modeled on WC_Install::create_lock().
 	 *
 	 * @since 11.0.0
 	 *
-	 * @param string $lock_name The named-lock identifier to acquire.
 	 * @return bool True if the lock was acquired (and must be released by the caller), false otherwise.
 	 */
-	private function acquire_enqueued_processors_lock( string $lock_name ): bool {
+	private function acquire_enqueued_processors_lock(): bool {
 		global $wpdb;
 		if ( ! $wpdb instanceof \wpdb ) {
 			return false;
 		}
 
-		try {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$acquired = $wpdb->get_var(
-				$wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, self::ENQUEUED_PROCESSORS_LOCK_TIMEOUT )
-			);
-		} catch ( \Throwable $e ) {
-			return false;
-		}
+		$attempts    = max( 1, self::ENQUEUED_PROCESSORS_LOCK_ATTEMPTS );
+		$delay_micro = (int) ( ( self::ENQUEUED_PROCESSORS_LOCK_TTL / $attempts ) * 1000000 );
 
-		return '1' === (string) $acquired;
+		// A contended INSERT fails on the duplicate key by design, so silence wpdb error reporting to keep the
+		// expected-failure path from spamming the log in debug mode; restore the prior setting when done.
+		$suppress = $wpdb->suppress_errors( true );
+		try {
+			for ( $attempt = 0; $attempt < $attempts; $attempt++ ) {
+				$now    = microtime( true );
+				$expiry = $now + self::ENQUEUED_PROCESSORS_LOCK_TTL;
+
+				// The unique option_name key makes this INSERT a mutex: it fails when the lock row already exists.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$acquired = $wpdb->insert(
+					$wpdb->options,
+					array(
+						'option_name'  => self::ENQUEUED_PROCESSORS_LOCK_OPTION,
+						'option_value' => $expiry,
+						'autoload'     => 'no',
+					),
+					array( '%s', '%f', '%s' )
+				);
+
+				if ( ! $acquired ) {
+					/*
+					 * The lock row exists; take it over only if its stored release time is already in the past.
+					 * $wpdb->update() cannot express the "<" comparison, so this conditional takeover uses raw SQL.
+					 * The table is a trusted internal identifier and every value is bound through a placeholder.
+					 */
+					$takeover = $wpdb->prepare(
+						// @phpstan-ignore-next-line argument.type -- $wpdb->options is a trusted identifier, not user input.
+						"UPDATE {$wpdb->options} SET option_value = %f WHERE option_name = %s AND option_value < %f", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+						$expiry,
+						self::ENQUEUED_PROCESSORS_LOCK_OPTION,
+						$now
+					);
+					if ( is_string( $takeover ) ) {
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+						$acquired = $wpdb->query( $takeover );
+					}
+				}
+
+				if ( $acquired ) {
+					return true;
+				}
+
+				if ( $attempt < $attempts - 1 && $delay_micro > 0 ) {
+					usleep( $delay_micro );
+				}
+			}
+
+			return false;
+		} finally {
+			$wpdb->suppress_errors( $suppress );
+		}
 	}
 
 	/**
-	 * Release the enqueued-processors named lock previously acquired by acquire_enqueued_processors_lock().
+	 * Release the enqueued-processors lock by deleting its options-table row.
 	 *
 	 * @since 11.0.0
-	 *
-	 * @param string $lock_name The named-lock identifier to release (the same value passed to acquire).
 	 */
-	private function release_enqueued_processors_lock( string $lock_name ): void {
+	private function release_enqueued_processors_lock(): void {
 		global $wpdb;
 		if ( ! $wpdb instanceof \wpdb ) {
 			return;
 		}
 
-		$query = $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name );
-		if ( ! is_string( $query ) ) {
-			return;
-		}
-
+		$suppress = $wpdb->suppress_errors( true );
 		try {
-			/*
-			 * $query is built by $wpdb->prepare() above; it is assigned to a variable only so it can be type-checked
-			 * before being passed to query() (prepare() returns string|null), hence the NotPrepared suppression.
-			 */
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $query );
-		} catch ( \Throwable $e ) {
-			// Best-effort: the lock is released automatically when the database session ends regardless.
-			return;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete(
+				$wpdb->options,
+				array( 'option_name' => self::ENQUEUED_PROCESSORS_LOCK_OPTION ),
+				array( '%s' )
+			);
+		} finally {
+			$wpdb->suppress_errors( $suppress );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -191,7 +191,7 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'remove_processor' dequeues and unschedules a processor, and unschedules the watchdog if no more more processors are enqueued.
+	 * @testdox 'remove_processor' dequeues and unschedules a processor, and leaves the watchdog to self-terminate when no more processors are enqueued.
 	 */
 	public function test_remove_processor_when_no_others_remain_enqueued() {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
@@ -207,7 +207,201 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
 		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
-		$this->assertFalse( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+
+		/*
+		 * The watchdog is intentionally left scheduled rather than force-unscheduled: handle_watchdog_action()
+		 * returns without rescheduling itself once the queue is empty (so it self-terminates after one more run),
+		 * and keeping it in place means a processor enqueued concurrently with this removal is still picked up
+		 * instead of being stranded with no watchdog.
+		 */
+		$this->assertTrue(
+			as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ),
+			'The watchdog should be left to self-terminate, not force-unscheduled, so concurrent enqueues are not stranded.'
+		);
+	}
+
+	/**
+	 * @testdox Enqueuing re-reads the freshest persisted list inside the critical section, merging with a concurrent write instead of clobbering it.
+	 */
+	public function test_enqueue_processor_merges_with_concurrent_write(): void {
+		global $wpdb;
+
+		// This request enqueues A, which also primes the request cache with array( A ).
+		$this->sut->enqueue_processor( 'Processor\\A' );
+
+		/*
+		 * Simulate a concurrent request that appended B and committed it to the database after this request
+		 * had already cached array( A ). Writing through $wpdb (rather than update_option()) deliberately leaves
+		 * the stale request cache in place, reproducing the cross-request read-modify-write race.
+		 */
+		$wpdb->update(
+			$wpdb->options,
+			array( 'option_value' => maybe_serialize( array( 'Processor\\A', 'Processor\\B' ) ) ),
+			array( 'option_name' => BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME )
+		);
+
+		$this->sut->enqueue_processor( 'Processor\\C' );
+
+		$this->assertSame(
+			array( 'Processor\\A', 'Processor\\B', 'Processor\\C' ),
+			$this->sut->get_enqueued_processors(),
+			'Enqueuing must merge with the concurrently-added processor (fresh read) rather than dropping it.'
+		);
+	}
+
+	/**
+	 * @testdox Removing a processor re-reads the freshest list, so a concurrently-added processor is not dropped.
+	 */
+	public function test_remove_processor_uses_fresh_state(): void {
+		global $wpdb;
+
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', 'Processor\\B' ),
+			false
+		);
+
+		// A concurrent request appended C and committed it after this request cached array( A, B ).
+		$wpdb->update(
+			$wpdb->options,
+			array( 'option_value' => maybe_serialize( array( 'Processor\\A', 'Processor\\B', 'Processor\\C' ) ) ),
+			array( 'option_name' => BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME )
+		);
+
+		$this->sut->remove_processor( 'Processor\\A' );
+
+		$this->assertSame(
+			array( 'Processor\\B', 'Processor\\C' ),
+			$this->sut->get_enqueued_processors(),
+			'Removal must operate on the fresh list, preserving the concurrently-added processor.'
+		);
+	}
+
+	/**
+	 * @testdox Dequeuing a finished processor re-reads the freshest list, so a concurrently-added processor is not dropped.
+	 */
+	public function test_dequeue_processor_uses_fresh_state(): void {
+		global $wpdb;
+
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', 'Processor\\B' ),
+			false
+		);
+
+		// A concurrent request appended C and committed it after this request cached array( A, B ).
+		$wpdb->update(
+			$wpdb->options,
+			array( 'option_value' => maybe_serialize( array( 'Processor\\A', 'Processor\\B', 'Processor\\C' ) ) ),
+			array( 'option_name' => BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME )
+		);
+
+		// dequeue_processor() is private; it is reached in production when a batch finishes. Invoke it directly.
+		$dequeue = new \ReflectionMethod( $this->sut, 'dequeue_processor' );
+		$dequeue->setAccessible( true );
+		$dequeue->invoke( $this->sut, 'Processor\\A' );
+
+		$this->assertSame(
+			array( 'Processor\\B', 'Processor\\C' ),
+			$this->sut->get_enqueued_processors(),
+			'Dequeuing must operate on the fresh list, preserving the concurrently-added processor.'
+		);
+	}
+
+	/**
+	 * @testdox Removing the last processor deletes that processor's stored state.
+	 */
+	public function test_remove_processor_clears_state_when_no_others_remain(): void {
+		$processor = get_class( $this->test_process );
+
+		$this->sut->enqueue_processor( $processor );
+
+		// Seed processor state so we can prove it gets cleared on removal.
+		$state_option = $this->get_processor_state_option_name( $processor );
+		update_option( $state_option, array( 'total_time_spent' => 5 ), false );
+
+		$this->sut->remove_processor( $processor );
+
+		$this->assertFalse(
+			get_option( $state_option ),
+			'Removing the last processor must delete its stored state, not leave it orphaned.'
+		);
+	}
+
+	/**
+	 * @testdox A mutating enqueue holds the named lock while persisting and releases it afterwards.
+	 */
+	public function test_enqueue_processor_holds_lock_during_write_and_releases_after(): void {
+		global $wpdb;
+
+		$lock_name = $this->get_lock_name();
+
+		$free_during_write = null;
+		add_filter(
+			'pre_update_option_' . BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			function ( $value ) use ( &$free_during_write, $wpdb, $lock_name ) {
+				// On this same DB session, IS_FREE_LOCK() returns '0' while the lock is held by this session.
+				$free_during_write = $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $lock_name ) );
+				return $value;
+			}
+		);
+
+		$this->sut->enqueue_processor( 'Processor\\A' );
+
+		$this->assertSame( '0', (string) $free_during_write, 'The named lock must be held while the option is written.' );
+		$this->assertSame(
+			'1',
+			(string) $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $lock_name ) ),
+			'The named lock must be released once the mutation completes.'
+		);
+	}
+
+	/**
+	 * @testdox When the named lock is held by another connection, the mutation still proceeds (best-effort) after the timeout.
+	 */
+	public function test_enqueue_processor_proceeds_when_lock_held_by_another_connection(): void {
+		$lock_name = $this->get_lock_name();
+
+		// Open a second, independent database connection and hold the lock there so the controller's own
+		// GET_LOCK on the request connection cannot acquire it within ENQUEUED_PROCESSORS_LOCK_TIMEOUT.
+		$other = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$other->query( $other->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 30 ) );
+
+		try {
+			$this->sut->enqueue_processor( 'Processor\\A' );
+
+			$this->assertContains(
+				'Processor\\A',
+				$this->sut->get_enqueued_processors(),
+				'The mutation must still persist when the lock cannot be acquired (best-effort fallback).'
+			);
+		} finally {
+			$other->query( $other->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+			$other->close();
+		}
+	}
+
+	/**
+	 * Resolve the controller's named-lock identifier via reflection so the test never drifts from production.
+	 *
+	 * @return string Lock name.
+	 */
+	private function get_lock_name(): string {
+		$method = new \ReflectionMethod( $this->sut, 'get_enqueued_processors_lock_name' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->sut );
+	}
+
+	/**
+	 * Resolve the option name where a processor's state is stored, via reflection.
+	 *
+	 * @param string $processor_class_name Fully qualified processor class name.
+	 * @return string Option name.
+	 */
+	private function get_processor_state_option_name( string $processor_class_name ): string {
+		$method = new \ReflectionMethod( $this->sut, 'get_processor_state_option_name' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->sut, $processor_class_name );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -298,6 +298,28 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Dequeuing a processor from a corrupted list strips non-string values instead of fataling on array_diff().
+	 */
+	public function test_dequeue_processor_strips_non_string_values_without_fataling(): void {
+		// Mirror of the remove_processor corruption test for the dequeue path, which shares sanitize_processor_list().
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', new \stdClass(), array( 'corrupt' ), 'Processor\\B' ),
+			false
+		);
+
+		$dequeue = new \ReflectionMethod( $this->sut, 'dequeue_processor' );
+		$dequeue->setAccessible( true );
+		$dequeue->invoke( $this->sut, 'Processor\\A' );
+
+		$this->assertSame(
+			array( 'Processor\\B' ),
+			$this->sut->get_enqueued_processors(),
+			'Dequeuing must drop the target and strip non-string values, leaving only valid processor names.'
+		);
+	}
+
+	/**
 	 * @testdox Dequeuing a finished processor re-reads the freshest list, so a concurrently-added processor is not dropped.
 	 */
 	public function test_dequeue_processor_uses_fresh_state(): void {
@@ -380,6 +402,7 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	 * @testdox When the named lock is held by another connection, the mutation still proceeds (best-effort) after the timeout.
 	 */
 	public function test_enqueue_processor_proceeds_when_lock_held_by_another_connection(): void {
+		global $wpdb;
 		$lock_name = $this->get_lock_name();
 
 		// Open a second, independent database connection and hold the lock there so the controller's own
@@ -388,6 +411,21 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$other->query( $other->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 30 ) );
 
 		try {
+			/*
+			 * Fail fast if the second connection did not actually claim the lock: otherwise the controller would
+			 * acquire it normally and this test would silently pass without ever exercising the best-effort
+			 * fallback. IS_USED_LOCK() returns the connection id holding the lock (null if free), so assert it is
+			 * held by a different session than the request connection.
+			 */
+			$lock_holder    = $other->get_var( $other->prepare( 'SELECT IS_USED_LOCK(%s)', $lock_name ) );
+			$request_thread = (string) $wpdb->get_var( 'SELECT CONNECTION_ID()' );
+			$this->assertNotNull( $lock_holder, 'Precondition: the second connection must hold the lock.' );
+			$this->assertNotSame(
+				$request_thread,
+				(string) $lock_holder,
+				'Precondition: the lock must be held by the other connection, not the request connection, so the controller is forced onto its best-effort path.'
+			);
+
 			$this->sut->enqueue_processor( 'Processor\\A' );
 
 			$this->assertContains(

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -371,61 +371,42 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A mutating enqueue holds the named lock while persisting and releases it afterwards.
+	 * @testdox A mutating enqueue holds the options-table lock while persisting and releases it afterwards.
 	 */
 	public function test_enqueue_processor_holds_lock_during_write_and_releases_after(): void {
-		global $wpdb;
-
-		$lock_name = $this->get_lock_name();
-
-		$free_during_write = null;
+		$held_during_write = null;
 		add_filter(
 			'pre_update_option_' . BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
-			function ( $value ) use ( &$free_during_write, $wpdb, $lock_name ) {
-				// On this same DB session, IS_FREE_LOCK() returns '0' while the lock is held by this session.
-				$free_during_write = $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $lock_name ) );
+			function ( $value ) use ( &$held_during_write ) {
+				$held_during_write = $this->lock_row_value();
 				return $value;
 			}
 		);
 
 		$this->sut->enqueue_processor( 'Processor\\A' );
 
-		$this->assertSame( '0', (string) $free_during_write, 'The named lock must be held while the option is written.' );
-		$this->assertSame(
-			'1',
-			(string) $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $lock_name ) ),
-			'The named lock must be released once the mutation completes.'
-		);
+		$this->assertNotNull( $held_during_write, 'The lock row must exist while the option is written.' );
+		$this->assertNull( $this->lock_row_value(), 'The lock row must be deleted once the mutation completes.' );
 	}
 
 	/**
-	 * @testdox When the named lock is held by another connection, the mutation still proceeds (best-effort) after the timeout.
+	 * @testdox An unexpired lock claimed by another request forces the mutation onto its best-effort path and is left untouched.
 	 */
-	public function test_enqueue_processor_proceeds_when_lock_held_by_another_connection(): void {
+	public function test_enqueue_processor_proceeds_when_lock_held_by_an_unexpired_lock(): void {
 		global $wpdb;
-		$lock_name = $this->get_lock_name();
 
-		// Open a second, independent database connection and hold the lock there so the controller's own
-		// GET_LOCK on the request connection cannot acquire it within ENQUEUED_PROCESSORS_LOCK_TIMEOUT.
-		$other = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-		$other->query( $other->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 30 ) );
+		// Simulate another request holding the lock: insert the lock row with a release time far in the future,
+		// so the controller can neither claim it (row exists) nor take it over (not yet stale) and must fall back.
+		$foreign_expiry = microtime( true ) + 60;
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %f, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION,
+				$foreign_expiry
+			)
+		);
 
 		try {
-			/*
-			 * Fail fast if the second connection did not actually claim the lock: otherwise the controller would
-			 * acquire it normally and this test would silently pass without ever exercising the best-effort
-			 * fallback. IS_USED_LOCK() returns the connection id holding the lock (null if free), so assert it is
-			 * held by a different session than the request connection.
-			 */
-			$lock_holder    = $other->get_var( $other->prepare( 'SELECT IS_USED_LOCK(%s)', $lock_name ) );
-			$request_thread = (string) $wpdb->get_var( 'SELECT CONNECTION_ID()' );
-			$this->assertNotNull( $lock_holder, 'Precondition: the second connection must hold the lock.' );
-			$this->assertNotSame(
-				$request_thread,
-				(string) $lock_holder,
-				'Precondition: the lock must be held by the other connection, not the request connection, so the controller is forced onto its best-effort path.'
-			);
-
 			$this->sut->enqueue_processor( 'Processor\\A' );
 
 			$this->assertContains(
@@ -433,21 +414,57 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 				$this->sut->get_enqueued_processors(),
 				'The mutation must still persist when the lock cannot be acquired (best-effort fallback).'
 			);
+			$this->assertNotNull(
+				$this->lock_row_value(),
+				'The other request\'s unexpired lock must be left in place, not stolen or released.'
+			);
 		} finally {
-			$other->query( $other->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
-			$other->close();
+			$wpdb->query(
+				$wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name = %s", BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION ) // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			);
 		}
 	}
 
 	/**
-	 * Resolve the controller's named-lock identifier via reflection so the test never drifts from production.
-	 *
-	 * @return string Lock name.
+	 * @testdox A stale (expired) lock left by a crashed request is taken over, and released after the mutation.
 	 */
-	private function get_lock_name(): string {
-		$method = new \ReflectionMethod( $this->sut, 'get_enqueued_processors_lock_name' );
-		$method->setAccessible( true );
-		return $method->invoke( $this->sut );
+	public function test_enqueue_processor_takes_over_stale_lock(): void {
+		global $wpdb;
+
+		// A lock row whose release time is already in the past represents a crashed holder; it must be stealable.
+		$stale_expiry = microtime( true ) - 60;
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %f, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION,
+				$stale_expiry
+			)
+		);
+
+		$this->sut->enqueue_processor( 'Processor\\A' );
+
+		$this->assertContains(
+			'Processor\\A',
+			$this->sut->get_enqueued_processors(),
+			'The mutation must proceed after taking over the stale lock.'
+		);
+		$this->assertNull(
+			$this->lock_row_value(),
+			'After taking over and using the stale lock, the controller must release (delete) it.'
+		);
+	}
+
+	/**
+	 * Read the raw stored value of the enqueued-processors lock row, or null when no lock is held.
+	 *
+	 * @return string|null The lock row's option_value, or null if the row does not exist.
+	 */
+	private function lock_row_value(): ?string {
+		global $wpdb;
+		$value = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION ) // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+		return null === $value ? null : (string) $value;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -278,6 +278,26 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Removing a processor from a corrupted list strips non-string values instead of fataling on array_diff().
+	 */
+	public function test_remove_processor_strips_non_string_values_without_fataling(): void {
+		// array_diff() string-casts its operands, so an object entry would fatal in PHP 8 without sanitizing first.
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', new \stdClass(), array( 'corrupt' ), 'Processor\\B' ),
+			false
+		);
+
+		$this->assertTrue( $this->sut->remove_processor( 'Processor\\A' ) );
+
+		$this->assertSame(
+			array( 'Processor\\B' ),
+			$this->sut->get_enqueued_processors(),
+			'Removal must drop the target and strip non-string values, leaving only valid processor names.'
+		);
+	}
+
+	/**
 	 * @testdox Dequeuing a finished processor re-reads the freshest list, so a concurrently-added processor is not dropped.
 	 */
 	public function test_dequeue_processor_uses_fresh_state(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -641,4 +641,108 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->assertFalse( $this->sut->is_scheduled( get_class( $second_processor ) ) );
 		$this->assertFalse( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
 	}
+
+	/**
+	 * @testdox The watchdog sanitizes a corrupted enqueued list, scheduling each valid processor once without fataling on non-string or empty entries.
+	 */
+	public function test_handle_watchdog_action_sanitizes_corrupted_list(): void {
+		// A raw option holding duplicates, a non-string, an empty string, and a corrupt array entry: without
+		// sanitizing, the non-string would fatal when passed to the strictly-typed is_scheduled(), and the empty
+		// string would be scheduled and later fatal in get_processor_instance( '' ).
+		update_option(
+			BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			array( 'Processor\\A', 'Processor\\A', new \stdClass(), '', array( 'corrupt' ), 'Processor\\B' ),
+			false
+		);
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		$this->assertTrue( $this->sut->is_scheduled( 'Processor\\A' ), 'A valid processor should be scheduled by the watchdog.' );
+		$this->assertTrue( $this->sut->is_scheduled( 'Processor\\B' ), 'A valid processor should be scheduled by the watchdog.' );
+		$this->assertFalse(
+			as_has_scheduled_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, array( '' ) ),
+			'An empty-string entry must be dropped by sanitization, not scheduled as a processor.'
+		);
+		$this->assertCount(
+			2,
+			as_get_scheduled_actions(
+				array(
+					'hook'     => $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME,
+					'group'    => '',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'per_page' => -1,
+				),
+				'ids'
+			),
+			'Only the two valid processors should be scheduled; duplicate, empty-string, and non-string entries must be dropped.'
+		);
+	}
+
+	/**
+	 * @testdox Removing the last enqueued processor sweeps orphaned 'ghost' single-batch actions left for processors no longer enqueued.
+	 */
+	public function test_remove_processor_sweeps_ghost_actions_when_queue_empties(): void {
+		$this->sut->enqueue_processor( get_class( $this->test_process ) );
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		// A leftover single-batch action for a processor that is no longer enqueued, e.g. from the historical corruption bug.
+		as_schedule_single_action( time() + HOUR_IN_SECONDS, $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, array( 'Ghost\\Processor' ) );
+
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertTrue( as_has_scheduled_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, array( 'Ghost\\Processor' ) ) );
+
+		$this->sut->remove_processor( get_class( $this->test_process ) );
+
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ), 'The removed processor should be unscheduled.' );
+		$this->assertFalse(
+			as_has_scheduled_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, array( 'Ghost\\Processor' ) ),
+			'Emptying the queue should sweep orphaned ghost single-batch actions.'
+		);
+		$this->assertCount(
+			0,
+			as_get_scheduled_actions(
+				array(
+					'hook'     => $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME,
+					'group'    => '',
+					'status'   => \ActionScheduler_Store::STATUS_PENDING,
+					'per_page' => -1,
+				),
+				'ids'
+			),
+			'Emptying the queue should sweep every single-batch action, not just the removed processor.'
+		);
+		$this->assertTrue(
+			as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ),
+			'The watchdog should be left scheduled so a concurrent enqueue is not stranded.'
+		);
+	}
+
+	/**
+	 * @testdox Removing a processor while others remain enqueued unschedules only its own action, leaving siblings scheduled.
+	 */
+	public function test_remove_processor_leaves_siblings_scheduled_when_queue_not_empty(): void {
+		$second_processor = $this->get_processor_stub();
+
+		$this->sut->enqueue_processor( get_class( $this->test_process ) );
+		$this->sut->enqueue_processor( get_class( $second_processor ) );
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $second_processor ) ) );
+
+		$this->sut->remove_processor( get_class( $this->test_process ) );
+
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ), 'The removed processor should be unscheduled.' );
+		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ), 'The removed processor should also be dequeued.' );
+		$this->assertTrue(
+			$this->sut->is_scheduled( get_class( $second_processor ) ),
+			'A still-enqueued sibling processor must not have its scheduled action swept.'
+		);
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $second_processor ) ), 'The sibling processor should remain enqueued.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -397,10 +397,10 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 
 		// Simulate another request holding the lock: insert the lock row with a release time far in the future,
 		// so the controller can neither claim it (row exists) nor take it over (not yet stale) and must fall back.
-		$foreign_expiry = microtime( true ) + 60;
+		$foreign_expiry = number_format( microtime( true ) + 60, 6, '.', '' );
 		$wpdb->query(
 			$wpdb->prepare(
-				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %f, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION,
 				$foreign_expiry
 			)
@@ -432,10 +432,10 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		global $wpdb;
 
 		// A lock row whose release time is already in the past represents a crashed holder; it must be stealable.
-		$stale_expiry = microtime( true ) - 60;
+		$stale_expiry = number_format( microtime( true ) - 60, 6, '.', '' );
 		$wpdb->query(
 			$wpdb->prepare(
-				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %f, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, 'no')", // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION,
 				$stale_expiry
 			)
@@ -451,6 +451,46 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->assertNull(
 			$this->lock_row_value(),
 			'After taking over and using the stale lock, the controller must release (delete) it.'
+		);
+	}
+
+	/**
+	 * @testdox Releasing does not delete a lock whose stored release time no longer matches ours (taken over by another request).
+	 */
+	public function test_release_leaves_a_lock_taken_over_by_another_request(): void {
+		global $wpdb;
+
+		$foreign_value = null;
+		add_filter(
+			'pre_update_option_' . BatchProcessingController::ENQUEUED_PROCESSORS_OPTION_NAME,
+			function ( $value ) use ( &$foreign_value, $wpdb ) {
+				// While this request holds the lock, simulate another request expiring and taking it over by
+				// overwriting the lock row's release time. Release must then leave that row alone.
+				$foreign_value = number_format( microtime( true ) + 999, 6, '.', '' );
+				$wpdb->update(
+					$wpdb->options,
+					array( 'option_value' => $foreign_value ),
+					array( 'option_name' => BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION ),
+					array( '%s' ),
+					array( '%s' )
+				);
+				return $value;
+			}
+		);
+
+		$this->sut->enqueue_processor( 'Processor\\A' );
+
+		$this->assertSame(
+			$foreign_value,
+			$this->lock_row_value(),
+			'Release must be scoped to our own release time, so a lock another request now owns is not deleted.'
+		);
+
+		// Clean up the simulated foreign lock so it does not leak into other assertions.
+		$wpdb->delete(
+			$wpdb->options,
+			array( 'option_name' => BatchProcessingController::ENQUEUED_PROCESSORS_LOCK_OPTION ),
+			array( '%s' )
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`BatchProcessingController` keeps its enqueued-processor list in the single `wc_pending_batch_processes` option and mutated it with an unguarded read-modify-write (`get_enqueued_processors()` → mutate → `set_enqueued_processors()`). With no atomicity, concurrent requests clobbered each other: two simultaneous enqueues could silently drop a processor, and the continuous HPOS background-sync `shutdown` handler (which enqueues on nearly every request) could resurrect a processor an admin had just removed.

This wraps the enqueue/dequeue/remove mutations in a short critical section: a best-effort MySQL named lock (`GET_LOCK`/`RELEASE_LOCK`) plus a fresh re-read of the option inside the lock (busting both the option and `notoptions` caches), writing only when the list actually changes. `enqueue_processor()` keeps a hot-path fast-exit so the lock is taken only when a write is needed, while `remove_processor()`/`dequeue_processor()` always resolve membership authoritatively under the lock. `remove_processor()` no longer calls `force_clear_all_processes()` (whose own unguarded write reopened the race) and leaves the self-terminating watchdog in place so a concurrently-enqueued processor is not stranded. The lock is best-effort: if it cannot be acquired (timeout, or a host without/with replica-routed `GET_LOCK`) the mutation still proceeds, which is no worse than the previous behavior, and the existing `shutdown` reconciler resolves any residual scheduling gap on the next request.

Closes #65452

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the unit tests: `pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter BatchProcessingControllerTests`. All 19 tests pass, including new ones that simulate a concurrent write and assert the in-lock fresh-read merges instead of clobbering, and one that holds the named lock on a second database connection and confirms the mutation still proceeds (best-effort) after the timeout.
2. Enable HPOS and set background order sync to continuous (WooCommerce → Settings → Advanced → Custom data stores / Features). Create/update some orders, confirm the sync processor keeps running and the orders stay in sync.
3. While sync is running, disable it. Confirm the processor stops and does not get re-added on subsequent requests (no stray `wc_run_batch_process` / `wc_schedule_pending_batch_processes` actions left scheduling work).

### Testing that has already taken place:

-   New and existing unit tests pass on wp-env (PHP 8.1, MySQL): `BatchProcessingControllerTests` (19 tests, 53 assertions) and the `DataSynchronizerTests` caller suite (29 tests). The cross-connection lock test exercises the real `GET_LOCK` timeout and best-effort fallback.
-   PHPStan reports no errors on the changed file; `phpcs-changed` (branch lint) is clean.
-   Reviewed with a multi-agent code review plus two adversarial passes (Codex), iterating on concurrency edge cases (lost updates, `notoptions` cache staleness, stale fast-path reads, watchdog teardown, lock-name symmetry).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually in this PR (`plugins/woocommerce/changelog/65452-fix-batch-processing-concurrency`).

</details>
