### PR TITLE
Fix linting issues in woocommerce-subscriptions-engine

### DIFF
--- a/packages/php/woocommerce-subscriptions-engine/changelog/fix-linting-issues-in-core-entities
+++ b/packages/php/woocommerce-subscriptions-engine/changelog/fix-linting-issues-in-core-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix PHPDoc formatting issues that were flagged as linting problems

--- a/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/Contract.php
+++ b/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/Contract.php
@@ -245,28 +245,7 @@ final class Contract {
 	/**
 	 * Build a new, unsaved contract.
 	 *
-	 * @param array{
-	 *     customer_id: int,
-	 *     currency: string,
-	 *     selling_plan_id: int,
-	 *     origin_order_id: int,
-	 *     start_gmt: string,
-	 *     status?: string,
-	 *     extension_slug?: string,
-	 *     payment_method?: string,
-	 *     payment_method_title?: string,
-	 *     payment_token_id?: int,
-	 *     billing_total: string,
-	 *     discount_total?: string,
-	 *     shipping_total?: string,
-	 *     tax_total?: string,
-	 *     next_payment_gmt?: string,
-	 *     trial_end_gmt?: string,
-	 *     schedule_source: string,
-	 *     items: array<int, array<string, mixed>>,
-	 *     addresses: array{ billing: array<string, mixed>, shipping: array<string, mixed> },
-	 *     meta: array<string, string>,
-	 * } $args Contract attributes.
+	 * @param array<string, mixed> $args Contract attributes.
 	 * @throws DomainException If the contract attributes are not valid.
 	 */
 	public static function create( array $args ): self {

--- a/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/Plan.php
+++ b/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/Plan.php
@@ -140,17 +140,8 @@ final class Plan {
 	/**
 	 * Build a new, unsaved plan.
 	 *
-	 * @param int    $group_id Parent plan group id.
-	 * @param array{
-	 *     name: string,
-	 *     billing_policy: BillingPolicy,
-	 *     description?: string,
-	 *     options?: array<int, mixed>,
-	 *     delivery_policy?: DeliveryPolicy,
-	 *     pricing_policy?: PricingPolicy,
-	 *     category: string,
-	 *     extension_slug?: string,
-	 * } $args     Plan attributes.
+	 * @param int                  $group_id Parent plan group id.
+	 * @param array<string, mixed> $args     Plan attributes.
 	 * @throws InvalidArgumentException If pricing_policy entries fail validation.
 	 */
 	public static function create( int $group_id, array $args ): self {

--- a/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/PlanGroup.php
+++ b/packages/php/woocommerce-subscriptions-engine/src/Core/Entity/PlanGroup.php
@@ -78,12 +78,7 @@ final class PlanGroup {
 	/**
 	 * Build a new, unsaved group.
 	 *
-	 * @param array{
-	 *     name: string,
-	 *     merchant_code?: string|null,
-	 *     options_display?: array<int, mixed>,
-	 *     app_id?: string|null,
-	 * } $args Group attributes.
+	 * @param array<string, mixed> $args Group attributes.
 	 */
 	public static function create( array $args ): self {
 		return new self(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR addresses the linting issues in the `woocommerce-subscriptions-engine` package, which all stemmed from PHPStan-formatted parameter definitions. I have switched back to more basic PHPDoc parameters for now, and will re-introduce the richer, more specific parameter definitions as part of a separate PR addressing PHPStan issues, as I'm working on introducing automated PHPStan checks in #65876.

Related to #65872.
Related to WOOSUBS-1724

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Verify that the linting CI job for this branch is clean.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
Local phpcs runs are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
