### PR TITLE
Fix tax country code autocomplete to not be based on full country name

### DIFF
--- a/plugins/woocommerce/changelog/65879-40653-country-code
+++ b/plugins/woocommerce/changelog/65879-40653-country-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix tax country code autocomplete to not be based on full country name

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -5,6 +5,29 @@
 	.components-panel__body {
 		background: #fff;
 		border: 1px solid $gray-200;
+		overflow: hidden;
+
+		&:first-child,
+		&.is-opened + .components-panel__body {
+			border-top-left-radius: 8px;
+			border-top-right-radius: 8px;
+
+			.components-panel__body-toggle {
+				border-top-left-radius: 8px;
+				border-top-right-radius: 8px;
+			}
+		}
+
+		&:last-child,
+		&.is-opened {
+			border-bottom-left-radius: 8px;
+			border-bottom-right-radius: 8px;
+
+			&:not(.is-opened) .components-panel__body-toggle {
+				border-bottom-left-radius: 8px;
+				border-bottom-right-radius: 8px;
+			}
+		}
 
 		&.is-opened {
 			margin-bottom: $gap-large;

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/style.scss
@@ -5,29 +5,6 @@
 	.components-panel__body {
 		background: #fff;
 		border: 1px solid $gray-200;
-		overflow: hidden;
-
-		&:first-child,
-		&.is-opened + .components-panel__body {
-			border-top-left-radius: 8px;
-			border-top-right-radius: 8px;
-
-			.components-panel__body-toggle {
-				border-top-left-radius: 8px;
-				border-top-right-radius: 8px;
-			}
-		}
-
-		&:last-child,
-		&.is-opened {
-			border-bottom-left-radius: 8px;
-			border-bottom-right-radius: 8px;
-
-			&:not(.is-opened) .components-panel__body-toggle {
-				border-bottom-left-radius: 8px;
-				border-bottom-right-radius: 8px;
-			}
-		}
 
 		&.is-opened {
 			margin-bottom: $gap-large;

--- a/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
@@ -21,6 +21,29 @@
 			$pagination        = $( '#rates-pagination, #rates-bottom-pagination' ),
 			$search_field      = $( '#rates-search .wc-tax-rates-search-field' ),
 			$submit            = $( '.woocommerce-save-button[type=submit]' ),
+			countryAutocompleteSource = function( request, response ) {
+				var term    = request.term.toLowerCase(),
+					matcher = new RegExp( $.ui.autocomplete.escapeRegex( term ), 'i' ),
+					matches = $.grep( data.countries, function( country ) {
+						return matcher.test( country.value ) || matcher.test( country.label );
+					} );
+
+				response( _.sortBy( matches, function( country ) {
+					var value = country.value.toLowerCase(),
+						label = country.label.toLowerCase();
+
+					if ( value === term ) {
+						return 0;
+					}
+					if ( 0 === value.indexOf( term ) ) {
+						return 1;
+					}
+					if ( 0 === label.indexOf( term ) ) {
+						return 2;
+					}
+					return 3;
+				} ) );
+			},
 			WCTaxTableModelConstructor = Backbone.Model.extend({
 				changes: {},
 				setRateAttribute: function( rateID, attribute, value ) {
@@ -154,7 +177,7 @@
 
 					// Initialize autocomplete for countries.
 					this.$el.find( 'td.country input' ).autocomplete({
-						source: data.countries,
+						source: countryAutocompleteSource,
 						minLength: 2
 					});
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix tax country code autocomplete to not be based on full country name

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #40653  .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="349" height="457" alt="image" src="https://github.com/user-attachments/assets/69ddb5e1-c677-45f2-b0e8-3a47c98f6782" />  |  <img width="379" height="621" alt="image" src="https://github.com/user-attachments/assets/365d4147-3480-465e-9016-55821735b4b9" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Try adding a new tax rate country
2. Enter the country code (like PT for Portugal or IN for India)
3. Verify that the country corresponding to the country code actually appears first in the list, followed by the other suggestions

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix tax country code autocomplete to not be based on full country name

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
