### PR TITLE
Check product status when saving items to shopper lists

### DIFF
--- a/plugins/woocommerce/changelog/fix-shopper-lists-non-published-products
+++ b/plugins/woocommerce/changelog/fix-shopper-lists-non-published-products
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Only save publicly available products to shopper lists.
+Only save published products to shopper lists.

--- a/plugins/woocommerce/changelog/fix-shopper-lists-non-published-products
+++ b/plugins/woocommerce/changelog/fix-shopper-lists-non-published-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only save publicly available products to shopper lists.

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -134,7 +134,7 @@ class ShopperListItem {
 	 */
 	public static function from_product( int $product_or_variation_id, array $variation = array(), int $quantity = 1 ): ?self {
 		$product = wc_get_product( absint( $product_or_variation_id ) );
-		if ( ! $product ) {
+		if ( ! $product || ! self::product_is_live( $product ) ) {
 			return null;
 		}
 
@@ -152,7 +152,7 @@ class ShopperListItem {
 			$variation    = array();
 		}
 
-		$item = new self(
+		return new self(
 			self::generate_key( $product_id, $variation_id, $variation ),
 			$product_id,
 			$variation_id,
@@ -161,12 +161,6 @@ class ShopperListItem {
 			current_time( 'mysql', true ),
 			$product->get_title()
 		);
-
-		if ( ! $item->is_live() ) {
-			return null;
-		}
-
-		return $item;
 	}
 
 	/**
@@ -319,7 +313,16 @@ class ShopperListItem {
 	 */
 	public function is_live(): bool {
 		$product = $this->get_product();
-		if ( ! $product instanceof \WC_Product || ProductStatus::PUBLISH !== $product->get_status() ) {
+		return $product instanceof \WC_Product && self::product_is_live( $product );
+	}
+
+	/**
+	 * Whether a resolved product (and its parent, for variations) is `publish`.
+	 *
+	 * @param \WC_Product $product Resolved product or variation.
+	 */
+	private static function product_is_live( \WC_Product $product ): bool {
+		if ( ProductStatus::PUBLISH !== $product->get_status() ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -130,7 +130,7 @@ class ShopperListItem {
 	 * @param int   $product_or_variation_id Product or variation ID.
 	 * @param array $variation               Variation attributes keyed by attribute name.
 	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
-	 * @return self|null Null if the underlying product can't be resolved or isn't publicly live.
+	 * @return self|null Null if the underlying product can't be resolved or isn't published.
 	 */
 	public static function from_product( int $product_or_variation_id, array $variation = array(), int $quantity = 1 ): ?self {
 		$product = wc_get_product( absint( $product_or_variation_id ) );

--- a/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
+++ b/plugins/woocommerce/src/Internal/ShopperLists/ShopperListItem.php
@@ -130,7 +130,7 @@ class ShopperListItem {
 	 * @param int   $product_or_variation_id Product or variation ID.
 	 * @param array $variation               Variation attributes keyed by attribute name.
 	 * @param int   $quantity                Saved quantity. Coerced to a minimum of 1.
-	 * @return self|null Null if the underlying product can't be resolved.
+	 * @return self|null Null if the underlying product can't be resolved or isn't publicly live.
 	 */
 	public static function from_product( int $product_or_variation_id, array $variation = array(), int $quantity = 1 ): ?self {
 		$product = wc_get_product( absint( $product_or_variation_id ) );
@@ -152,7 +152,7 @@ class ShopperListItem {
 			$variation    = array();
 		}
 
-		return new self(
+		$item = new self(
 			self::generate_key( $product_id, $variation_id, $variation ),
 			$product_id,
 			$variation_id,
@@ -161,6 +161,12 @@ class ShopperListItem {
 			current_time( 'mysql', true ),
 			$product->get_title()
 		);
+
+		if ( ! $item->is_live() ) {
+			return null;
+		}
+
+		return $item;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -96,6 +96,19 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox from_product should return null for a non-published variable product, not a variation error.
+	 */
+	public function test_from_product_returns_null_for_non_published_variable_product(): void {
+		$variable = \WC_Helper_Product::create_variation_product();
+		$variable->set_status( 'draft' );
+		$variable->save();
+
+		$this->assertNull( ShopperListItem::from_product( $variable->get_id() ) );
+
+		$variable->delete( true );
+	}
+
+	/**
 	 * @testdox from_product validates the variation array against the variation product, like cart does.
 	 */
 	public function test_from_variation_validates_against_variation_product(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ShopperLists/ShopperListItemTests.php
@@ -86,6 +86,16 @@ class ShopperListItemTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox from_product should return null for a product that isn't publicly live.
+	 */
+	public function test_from_product_returns_null_for_non_published_product(): void {
+		$this->product->set_status( 'private' );
+		$this->product->save();
+
+		$this->assertNull( ShopperListItem::from_product( $this->product->get_id() ) );
+	}
+
+	/**
 	 * @testdox from_product validates the variation array against the variation product, like cart does.
 	 */
 	public function test_from_variation_validates_against_variation_product(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When saving an item to a shopper list through the Store API, the item was built from the product with no status check, so non-published products could be saved. This PR adds a status check for the "add" workflow.
Items already saved are unaffected and still render from their stored snapshot.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the experimental wishlist feature via WC > Settings > Advanced > Features or the WP-CLI `wp option update woocommerce_product_wishlist_enabled yes`.
2. As an admin, create a product and set its status to **Draft**. Note its ID.
3. As a logged-in customer, make a POST request to `/wp-json/wc/store/v1/shopper-lists/wishlist/items` with body:
   ```json
   { "product_id": <YOUR PRODUCT ID>, "quantity": 1 }
   ```
4. Confirm the response is `404 woocommerce_rest_shopper_list_unknown_product`.
5. Change the product to **Published** and repeat the above. This time the product should be saved.

<!-- End testing instructions -->

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)