### PR TITLE
Add setting to enable/disable backorder notifications

### DIFF
--- a/plugins/woocommerce/changelog/31365-add-backorder-notification-setting
+++ b/plugins/woocommerce/changelog/31365-add-backorder-notification-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a setting to enable or disable backorder stock notification emails, plus a woocommerce_should_send_backorder_notification filter, mirroring the existing low stock and out of stock notifications.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -289,6 +289,16 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'id'            => 'woocommerce_notify_no_stock',
 					'default'       => 'yes',
 					'type'          => 'checkbox',
+					'checkboxgroup' => '',
+					'autoload'      => false,
+					'class'         => 'manage_stock_field',
+				),
+
+				array(
+					'desc'          => __( 'Enable backorder notifications', 'woocommerce' ),
+					'id'            => 'woocommerce_notify_backorder',
+					'default'       => 'yes',
+					'type'          => 'checkbox',
 					'checkboxgroup' => 'end',
 					'autoload'      => false,
 					'class'         => 'manage_stock_field',

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -1212,7 +1212,6 @@ class WC_Emails {
 		 *
 		 * @param bool $send       Whether the backorder notification should be sent.
 		 * @param int  $product_id The backordered product id.
-		 *
 		 * @since 11.0.0
 		 */
 		if ( false === apply_filters( 'woocommerce_should_send_backorder_notification', true, $args['product']->get_id() ) ) {

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -1196,7 +1196,7 @@ class WC_Emails {
 		$order = wc_get_order( $args['order_id'] );
 		if (
 		! $args['product'] ||
-		! is_object( $args['product'] ) ||
+		! $args['product'] instanceof WC_Product ||
 		! $args['quantity'] ||
 		! $order
 		) {

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -1203,6 +1203,22 @@ class WC_Emails {
 			return;
 		}
 
+		if ( 'no' === get_option( 'woocommerce_notify_backorder', 'yes' ) ) {
+			return;
+		}
+
+		/**
+		 * Determine if the current product should trigger a backorder notification.
+		 *
+		 * @param bool $send       Whether the backorder notification should be sent.
+		 * @param int  $product_id The backordered product id.
+		 *
+		 * @since 11.0.0
+		 */
+		if ( false === apply_filters( 'woocommerce_should_send_backorder_notification', true, $args['product']->get_id() ) ) {
+			return;
+		}
+
 		$stock_before         = $args['quantity'] + $args['product']->get_stock_quantity();
 		$backordered_quantity = $args['quantity'] - max( 0, $stock_before );
 

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -11617,18 +11617,6 @@ parameters:
 			path: includes/class-wc-emails.php
 
 		-
-			message: '#^Call to an undefined method object\:\:get_formatted_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/class-wc-emails.php
-
-		-
-			message: '#^Call to an undefined method object\:\:get_stock_quantity\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/class-wc-emails.php
-
-		-
 			message: '#^Cannot call method get_id\(\) on WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -121,4 +121,71 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'Test meta key', $content );
 		$this->assertStringContainsString( 'test_meta_value', $content );
 	}
+
+	/**
+	 * Build a valid set of arguments for WC_Emails::backorder().
+	 *
+	 * @return array
+	 */
+	private function get_backorder_args() {
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		return array(
+			'product'  => $product,
+			'quantity' => 2,
+			'order_id' => $order->get_id(),
+		);
+	}
+
+	/**
+	 * @testdox backorder() sends a notification when the setting is enabled (default).
+	 */
+	public function test_backorder_sends_when_setting_enabled() {
+		update_option( 'woocommerce_notify_backorder', 'yes' );
+		$args = $this->get_backorder_args();
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		( new WC_Emails() )->backorder( $args );
+		$after = count( $mailer->mock_sent );
+
+		$this->assertSame( $before + 1, $after, 'Backorder notification should be sent when the setting is enabled.' );
+	}
+
+	/**
+	 * @testdox backorder() does not send a notification when the setting is disabled.
+	 */
+	public function test_backorder_does_not_send_when_setting_disabled() {
+		update_option( 'woocommerce_notify_backorder', 'no' );
+		$args = $this->get_backorder_args();
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		( new WC_Emails() )->backorder( $args );
+		$after = count( $mailer->mock_sent );
+
+		$this->assertSame( $before, $after, 'Backorder notification must not be sent when the setting is disabled.' );
+
+		update_option( 'woocommerce_notify_backorder', 'yes' );
+	}
+
+	/**
+	 * @testdox backorder() does not send a notification when the woocommerce_should_send_backorder_notification filter returns false.
+	 */
+	public function test_backorder_does_not_send_when_filter_returns_false() {
+		update_option( 'woocommerce_notify_backorder', 'yes' );
+		$args = $this->get_backorder_args();
+
+		add_filter( 'woocommerce_should_send_backorder_notification', '__return_false' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$before = count( $mailer->mock_sent );
+		( new WC_Emails() )->backorder( $args );
+		$after = count( $mailer->mock_sent );
+
+		remove_filter( 'woocommerce_should_send_backorder_notification', '__return_false' );
+
+		$this->assertSame( $before, $after, 'Backorder notification must not be sent when the filter returns false.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -128,6 +128,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_hold_stock_minutes'      => 'number',
 			'woocommerce_notify_low_stock'        => 'checkbox',
 			'woocommerce_notify_no_stock'         => 'checkbox',
+			'woocommerce_notify_backorder'        => 'checkbox',
 			'woocommerce_stock_email_recipient'   => 'text',
 			'woocommerce_notify_low_stock_amount' => 'number',
 			'woocommerce_notify_no_stock_amount'  => 'number',


### PR DESCRIPTION
### Summary

Closes #31365.

Backorder stock notification emails currently can't be turned off without custom code, unlike low stock and out of stock notifications which each have a setting. Stores that sell on backorder by design get a steady stream of these emails with no built-in way to disable them.

This adds a setting for backorder notifications that mirrors the existing two, plus a matching filter for developers.

### Changes

- **Setting:** new `woocommerce_notify_backorder` checkbox under **Settings → Products → Inventory → Notifications**, next to "Enable low stock notifications" and "Enable out of stock notifications". Defaults to `yes`, so existing stores keep receiving backorder emails — no behavior change on upgrade.
- **Gate:** `WC_Emails::backorder()` now returns early when the setting is off, the same way `low_stock()` / `no_stock()` already do.
- **Filter:** new `woocommerce_should_send_backorder_notification` filter (mirrors `woocommerce_should_send_low_stock_notification` / `..._no_stock_notification`) for a code-level override. Thanks to @nviitala for suggesting this in the issue.

### How to test

1. Create a product, enable stock management, allow backorders, set stock so an order puts it on backorder.
2. Confirm a backorder notification email is sent (default behaviour, unchanged).
3. Go to **Settings → Products → Inventory**, uncheck **Enable backorder notifications**, save.
4. Place another backorder order and confirm no backorder email is sent. Low stock / out of stock notifications still behave as before.
5. With the setting on, add `add_filter( 'woocommerce_should_send_backorder_notification', '__return_false' );` and confirm the email is suppressed.

### Screenshots

| Before | After | 
| ----- | ---- | 
|  <img width="1281" height="601" alt="Screenshot 2026-07-03 at 11 54 19" src="https://github.com/user-attachments/assets/84ea091b-e540-4503-89b8-2ab99144d3e3" /> | <img width="1170" height="680" alt="Screenshot 2026-07-03 at 11 53 08" src="https://github.com/user-attachments/assets/fc3d636d-7674-48a0-9db6-2a26183fc5b5" /> | 

### Notes

Opening as a **draft** — I'm a PM, not the code owner here, so this is a starting point for the email/inventory team to review and refine (naming, placement, test coverage). Flagging @arcangelini / the email folks. Happy to adjust.
