### PR TITLE
Fix WooPayments activation after test account disable

### DIFF
--- a/plugins/woocommerce/changelog/fix-woopayments-activate-payments-lock
+++ b/plugins/woocommerce/changelog/fix-woopayments-activate-payments-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the WooPayments test account activation flow requiring a second click when switching to live payments.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1501,40 +1501,39 @@ class WooPaymentsService {
 		$event_props = array();
 		$source      = $this->validate_onboarding_source( $source );
 
-		// Lock the onboarding to prevent concurrent actions.
+		$had_test_account    = false;
+		$had_sandbox_account = false;
+		$endpoint            = '';
+		$params              = array();
+
+		// Briefly lock the onboarding while Core determines the account transition to perform.
+		// The internal WooPayments endpoint must run after this lock is cleared because it may
+		// trigger account deletion webhooks that also touch the shared NOX lock option.
 		$this->set_onboarding_lock();
 
 		try {
-			$has_test_account    = $this->has_test_account();
-			$has_sandbox_account = $this->has_sandbox_account();
+			$had_test_account    = $this->has_test_account();
+			$had_sandbox_account = $this->has_sandbox_account();
 
 			$event_props = array(
-				'account_type' => $has_test_account ? 'test_drive' : ( $has_sandbox_account ? 'sandbox' : 'unknown' ),
+				'account_type' => $had_test_account ? 'test_drive' : ( $had_sandbox_account ? 'sandbox' : 'unknown' ),
 				'source'       => $source,
 			);
 
 			// First, check if we have a test account to disable.
-			if ( $has_test_account ) {
+			if ( $had_test_account ) {
 				// Call the WooPayments API to disable the test account and prepare for the switch to live.
-				$response = $this->proxy->call_static(
-					Utils::class,
-					'rest_endpoint_post_request',
-					'/wc/v3/payments/onboarding/test_drive_account/disable',
-					array(
-						'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-						'source' => $source,
-					)
+				$endpoint = '/wc/v3/payments/onboarding/test_drive_account/disable';
+				$params   = array(
+					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+					'source' => $source,
 				);
-			} elseif ( $has_sandbox_account ) {
+			} elseif ( $had_sandbox_account ) {
 				// Call the WooPayments API to reset onboarding.
-				$response = $this->proxy->call_static(
-					Utils::class,
-					'rest_endpoint_post_request',
-					'/wc/v3/payments/onboarding/reset',
-					array(
-						'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-						'source' => $source,
-					)
+				$endpoint = '/wc/v3/payments/onboarding/reset';
+				$params   = array(
+					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+					'source' => $source,
 				);
 			}
 		} catch ( Exception $e ) {
@@ -1548,10 +1547,36 @@ class WooPaymentsService {
 					'trace'   => $e->getTrace(),
 				)
 			);
+		} finally {
+			// Unlock before making the internal WooPayments request to avoid self-conflicting
+			// with WooPayments account cleanup and account.deleted webhook side effects.
+			$this->clear_onboarding_lock();
 		}
 
-		// Unlock the onboarding after the API call finished or errored.
-		$this->clear_onboarding_lock();
+		if ( ! is_wp_error( $response ) && ! empty( $endpoint ) ) {
+			try {
+				$response = $this->proxy->call_static(
+					Utils::class,
+					'rest_endpoint_post_request',
+					$endpoint,
+					$params
+				);
+			} catch ( Exception $e ) {
+				// Catch any exceptions to allow for proper error handling and onboarding unlock.
+				$response = new WP_Error(
+					'woocommerce_woopayments_onboarding_client_api_exception',
+					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
+					array(
+						'code'    => $e->getCode(),
+						'message' => $e->getMessage(),
+						'trace'   => $e->getTrace(),
+					)
+				);
+			} finally {
+				// Normalize the shared lock option after WooPayments webhooks may have deleted it.
+				$this->clear_onboarding_lock();
+			}
+		}
 
 		// Make sure the onboarding mode is reset.
 		if ( class_exists( 'WC_Payments_Onboarding_Service' ) && defined( 'WC_Payments_Onboarding_Service::TEST_MODE_OPTION' ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1808,6 +1808,13 @@ class WooPaymentsService {
 	/**
 	 * Unlock the onboarding.
 	 *
+	 * WARNING: this writes 0 unconditionally and has no ownership check, so it clears whatever
+	 * lock is currently set — including one a concurrent request acquired. Only call it to
+	 * release a lock this same request set (e.g. in the finally that pairs with
+	 * set_onboarding_lock()). Do NOT call it after work that runs unlocked, where another
+	 * request may have taken the lock in the meantime. Safe concurrent release would require a
+	 * per-request token (compare-and-swap), which is deferred to the broader shared-lock work.
+	 *
 	 * @return void
 	 */
 	private function clear_onboarding_lock(): void {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1610,13 +1610,17 @@ class WooPaymentsService {
 	 * @return WP_Error
 	 */
 	private function get_onboarding_client_api_exception_error( Exception $e, string $message ): WP_Error {
+		// Deliberately exclude the exception stack trace from this error data. The data is
+		// passed to ApiException as additional data (documented as exposable in the error
+		// response) and is persisted to the NOX profile option by the onboarding step-failed
+		// handlers, so it must stay free of stack frames, whose arguments can carry file
+		// paths, tokens, and other sensitive values. Keep only these bounded scalars.
 		return new WP_Error(
 			'woocommerce_woopayments_onboarding_client_api_exception',
 			$message,
 			array(
 				'code'    => $e->getCode(),
 				'message' => $e->getMessage(),
-				'trace'   => $e->getTrace(),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1570,9 +1570,6 @@ class WooPaymentsService {
 						'trace'   => $e->getTrace(),
 					)
 				);
-			} finally {
-				// Normalize the shared lock option after WooPayments webhooks may have deleted it.
-				$this->clear_onboarding_lock();
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1502,7 +1502,15 @@ class WooPaymentsService {
 		$source      = $this->validate_onboarding_source( $source );
 
 		$endpoint = '';
-		$params   = array();
+
+		// Both internal calls take the same parameters; only the endpoint differs per account type.
+		$params = array(
+			'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+			'source' => $source,
+		);
+
+		// The same message is reused wherever an unexpected exception is converted to a WP_Error.
+		$exception_error_message = esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' );
 
 		// Briefly lock the onboarding while Core determines the account transition to perform.
 		// The internal WooPayments endpoint must run after this lock is cleared because it may
@@ -1521,24 +1529,13 @@ class WooPaymentsService {
 			if ( $had_test_account ) {
 				// Prepare the WooPayments API disable call for Phase 2, after the lock is released.
 				$endpoint = '/wc/v3/payments/onboarding/test_drive_account/disable';
-				$params   = array(
-					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-					'source' => $source,
-				);
 			} elseif ( $had_sandbox_account ) {
 				// Prepare the WooPayments API onboarding reset call for Phase 2, after the lock is released.
 				$endpoint = '/wc/v3/payments/onboarding/reset';
-				$params   = array(
-					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-					'source' => $source,
-				);
 			}
 		} catch ( Exception $e ) {
 			// Convert the exception to a WP_Error; the onboarding lock is released in the finally below.
-			$response = $this->get_onboarding_client_api_exception_error(
-				$e,
-				esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' )
-			);
+			$response = $this->get_onboarding_client_api_exception_error( $e, $exception_error_message );
 		} finally {
 			// Unlock before making the internal WooPayments request to avoid self-conflicting
 			// with WooPayments account cleanup and account.deleted webhook side effects.
@@ -1546,10 +1543,12 @@ class WooPaymentsService {
 		}
 
 		// Phase 2 runs after the shared lock is released to avoid the account.deleted webhook
-		// self-conflict. The WooPayments endpoint is not idempotent but fails safe: a duplicate
-		// concurrent call short-circuits on is_stripe_connected() === false and returns a benign
-		// "account does not exist" error rather than re-deleting the account. Request-scoped
-		// locking is deferred to the broader Core/WooPayments shared-lock contract.
+		// self-conflict. The WooPayments endpoint is not idempotent: a duplicate concurrent call is
+		// guarded against re-deleting the account (WooPayments overwrites its account cache before
+		// the delete, so is_stripe_connected() short-circuits), but it still surfaces to the second
+		// caller as a hard ApiException( FAILED_DEPENDENCY ) via the is_wp_error() check below.
+		// Request-scoped locking for that residual window is deferred to the broader
+		// Core/WooPayments shared-lock contract.
 		if ( ! is_wp_error( $response ) && ! empty( $endpoint ) ) {
 			try {
 				$response = $this->proxy->call_static(
@@ -1560,10 +1559,7 @@ class WooPaymentsService {
 				);
 			} catch ( Exception $e ) {
 				// Convert the exception to a WP_Error so the failure is surfaced to the caller.
-				$response = $this->get_onboarding_client_api_exception_error(
-					$e,
-					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' )
-				);
+				$response = $this->get_onboarding_client_api_exception_error( $e, $exception_error_message );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1534,15 +1534,10 @@ class WooPaymentsService {
 				);
 			}
 		} catch ( Exception $e ) {
-			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+			// Convert the exception to a WP_Error; the onboarding lock is released in the finally below.
+			$response = $this->get_onboarding_client_api_exception_error(
+				$e,
+				esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' )
 			);
 		} finally {
 			// Unlock before making the internal WooPayments request to avoid self-conflicting
@@ -1560,15 +1555,10 @@ class WooPaymentsService {
 					$params
 				);
 			} catch ( Exception $e ) {
-				// Catch any exceptions to allow for proper error handling and onboarding unlock.
-				$response = new WP_Error(
-					'woocommerce_woopayments_onboarding_client_api_exception',
-					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
-					array(
-						'code'    => $e->getCode(),
-						'message' => $e->getMessage(),
-						'trace'   => $e->getTrace(),
-					)
+				// Convert the exception to a WP_Error so the failure is surfaced to the caller.
+				$response = $this->get_onboarding_client_api_exception_error(
+					$e,
+					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' )
 				);
 			}
 		}
@@ -1629,6 +1619,26 @@ class WooPaymentsService {
 		);
 
 		return $response;
+	}
+
+	/**
+	 * Build a WP_Error for an exception thrown while talking to the internal WooPayments onboarding API.
+	 *
+	 * @param Exception $e       The caught exception.
+	 * @param string    $message The human-readable, already-escaped error message.
+	 *
+	 * @return WP_Error
+	 */
+	private function get_onboarding_client_api_exception_error( Exception $e, string $message ): WP_Error {
+		return new WP_Error(
+			'woocommerce_woopayments_onboarding_client_api_exception',
+			$message,
+			array(
+				'code'    => $e->getCode(),
+				'message' => $e->getMessage(),
+				'trace'   => $e->getTrace(),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1001,14 +1001,9 @@ class WooPaymentsService {
 			);
 		} catch ( Exception $e ) {
 			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while initializing the test account.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+			$response = $this->get_onboarding_client_api_exception_error(
+				$e,
+				esc_html__( 'An unexpected error happened while initializing the test account.', 'woocommerce' )
 			);
 		}
 
@@ -1138,14 +1133,9 @@ class WooPaymentsService {
 			);
 		} catch ( Exception $e ) {
 			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while creating the KYC session.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+			$response = $this->get_onboarding_client_api_exception_error(
+				$e,
+				esc_html__( 'An unexpected error happened while creating the KYC session.', 'woocommerce' )
 			);
 		}
 
@@ -1251,14 +1241,9 @@ class WooPaymentsService {
 			);
 		} catch ( Exception $e ) {
 			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while finalizing the KYC session.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+			$response = $this->get_onboarding_client_api_exception_error(
+				$e,
+				esc_html__( 'An unexpected error happened while finalizing the KYC session.', 'woocommerce' )
 			);
 		}
 
@@ -1426,14 +1411,9 @@ class WooPaymentsService {
 			}
 		} catch ( Exception $e ) {
 			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while resetting onboarding.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+			$response = $this->get_onboarding_client_api_exception_error(
+				$e,
+				esc_html__( 'An unexpected error happened while resetting onboarding.', 'woocommerce' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1793,11 +1793,15 @@ class WooPaymentsService {
 	 * Unlock the onboarding.
 	 *
 	 * WARNING: this writes 0 unconditionally and has no ownership check, so it clears whatever
-	 * lock is currently set — including one a concurrent request acquired. Only call it to
-	 * release a lock this same request set (e.g. in the finally that pairs with
-	 * set_onboarding_lock()). Do NOT call it after work that runs unlocked, where another
-	 * request may have taken the lock in the meantime. Safe concurrent release would require a
-	 * per-request token (compare-and-swap), which is deferred to the broader shared-lock work.
+	 * lock is currently set — including one a concurrent request acquired. Call it only when
+	 * clearing the lock is safe regardless of ownership:
+	 *   - to release a lock this same request set (e.g. in the finally that pairs with
+	 *     set_onboarding_lock()); or
+	 *   - to self-heal a lock that has already exceeded its TTL (see is_onboarding_locked()),
+	 *     where the stale timestamp means no live request is expected to still hold it.
+	 * Do NOT call it after work that runs unlocked, where another request may have taken the
+	 * lock in the meantime. Safe concurrent release would require a per-request token
+	 * (compare-and-swap), which is deferred to the broader shared-lock work.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1545,7 +1545,11 @@ class WooPaymentsService {
 			$this->clear_onboarding_lock();
 		}
 
-		// Phase 2 assumes duplicate concurrent WooPayments endpoint calls are idempotent; unverified.
+		// Phase 2 runs after the shared lock is released to avoid the account.deleted webhook
+		// self-conflict. The WooPayments endpoint is not idempotent but fails safe: a duplicate
+		// concurrent call short-circuits on is_stripe_connected() === false and returns a benign
+		// "account does not exist" error rather than re-deleting the account. Request-scoped
+		// locking is deferred to the broader Core/WooPayments shared-lock contract.
 		if ( ! is_wp_error( $response ) && ! empty( $endpoint ) ) {
 			try {
 				$response = $this->proxy->call_static(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -472,6 +472,31 @@ class WooPaymentsService {
 	public function mark_onboarding_step_completed( string $step_id, string $location, bool $overwrite = false, ?string $source = self::SESSION_ENTRY_DEFAULT ): bool {
 		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
+		return $this->record_onboarding_step_completed( $step_id, $location, $overwrite, $source );
+	}
+
+	/**
+	 * Record an onboarding step as completed without re-checking whether a new onboarding action is allowed.
+	 *
+	 * This is for internal use only, by callers that have already committed an account mutation and
+	 * just need to sync the resulting NOX onboarding state. Unlike mark_onboarding_step_completed(),
+	 * it deliberately skips check_if_onboarding_step_action_is_acceptable() — including the shared
+	 * onboarding lock check — because the state change is the consequence of work that already
+	 * happened, not a new user action. Re-checking the lock here would let a concurrent request that
+	 * acquired the lock during an unlocked phase turn an already-successful mutation into an
+	 * onboarding-locked error. This mirrors mark_onboarding_step_failed() and
+	 * mark_onboarding_step_blocked(), which skip the same checks for the same reason.
+	 *
+	 * @param string      $step_id   The ID of the onboarding step.
+	 * @param string      $location  The location for which we are onboarding.
+	 *                               This is an ISO 3166-1 alpha-2 country code.
+	 * @param bool        $overwrite Whether to overwrite the step status if it is already completed and update the timestamp.
+	 * @param string|null $source    Optional. The source for the current onboarding flow.
+	 *                               If not provided, it will identify the source as the WC Admin Payments settings.
+	 *
+	 * @return bool Whether the onboarding step was marked as completed.
+	 */
+	private function record_onboarding_step_completed( string $step_id, string $location, bool $overwrite = false, ?string $source = self::SESSION_ENTRY_DEFAULT ): bool {
 		// Clear possible failed status for the step.
 		$this->clear_onboarding_step_failed( $step_id, $location );
 
@@ -1576,12 +1601,19 @@ class WooPaymentsService {
 			);
 		}
 
+		// The account mutation above has already committed, so the following is internal NOX state
+		// sync, not a new user action. Use the internal record path that does not re-check the
+		// onboarding lock: Phase 2 ran unlocked, so a concurrent request may now hold the lock, and
+		// re-checking it here would turn an already-successful disable into an onboarding-locked
+		// error (the shared, token-less lock also can't be safely reacquired around this bookkeeping).
+		// See record_onboarding_step_completed().
+
 		// For sanity, make sure the payment methods step is marked as completed.
 		// This is to avoid the user being prompted to set up payment methods again.
-		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_PAYMENT_METHODS, $location );
+		$this->record_onboarding_step_completed( self::ONBOARDING_STEP_PAYMENT_METHODS, $location );
 		// For sanity, make sure the test account step is marked as completed and not blocked or failed.
 		// After disabling a test account, the user should be prompted to set up a live account.
-		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+		$this->record_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		$this->clear_onboarding_step_blocked( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		$this->clear_onboarding_step_failed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		// Clear the NOX profile data for the business verification step sub-step data.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1501,10 +1501,8 @@ class WooPaymentsService {
 		$event_props = array();
 		$source      = $this->validate_onboarding_source( $source );
 
-		$had_test_account    = false;
-		$had_sandbox_account = false;
-		$endpoint            = '';
-		$params              = array();
+		$endpoint = '';
+		$params   = array();
 
 		// Briefly lock the onboarding while Core determines the account transition to perform.
 		// The internal WooPayments endpoint must run after this lock is cleared because it may
@@ -1520,16 +1518,15 @@ class WooPaymentsService {
 				'source'       => $source,
 			);
 
-			// First, check if we have a test account to disable.
 			if ( $had_test_account ) {
-				// Call the WooPayments API to disable the test account and prepare for the switch to live.
+				// Prepare the WooPayments API disable call for Phase 2, after the lock is released.
 				$endpoint = '/wc/v3/payments/onboarding/test_drive_account/disable';
 				$params   = array(
 					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
 					'source' => $source,
 				);
 			} elseif ( $had_sandbox_account ) {
-				// Call the WooPayments API to reset onboarding.
+				// Prepare the WooPayments API onboarding reset call for Phase 2, after the lock is released.
 				$endpoint = '/wc/v3/payments/onboarding/reset';
 				$params   = array(
 					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
@@ -1553,6 +1550,7 @@ class WooPaymentsService {
 			$this->clear_onboarding_lock();
 		}
 
+		// Phase 2 assumes duplicate concurrent WooPayments endpoint calls are idempotent; unverified.
 		if ( ! is_wp_error( $response ) && ! empty( $endpoint ) ) {
 			try {
 				$response = $this->proxy->call_static(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8091,6 +8091,308 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should preserve internal lock failures after the internal request deletes the account.
+	 */
+	public function test_disable_test_account_preserves_internal_lock_failure_after_account_delete(): void {
+		$location = 'US';
+
+		$this->mock_working_wpcom_connection();
+
+		$account_is_connected = true;
+		$account_status       = array(
+			'status'           => 'complete',
+			'testDrive'        => true,
+			'isLive'           => false,
+			'paymentsEnabled'  => true,
+			'detailsSubmitted' => true,
+		);
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturnCallback(
+				function () use ( &$account_is_connected ) {
+					return $account_is_connected;
+				}
+			);
+		$this->mock_account_service
+			->expects( $this->any() )
+			->method( 'get_account_status_data' )
+			->willReturnCallback(
+				function () use ( &$account_status ) {
+					return $account_status;
+				}
+			);
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$stored_profile  = array();
+		$updated_profile = array();
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option'    => function ( $option_name, $default_value = null ) use ( &$lock_value, &$updated_profile, $stored_profile ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return $lock_value ?? $default_value;
+					}
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						return ! empty( $updated_profile ) ? $updated_profile : $stored_profile;
+					}
+
+					return $default_value;
+				},
+				'update_option' => function ( $option_name, $value ) use ( &$lock_value, &$lock_changes, &$updated_profile ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						$lock_value     = $value;
+						$lock_changes[] = $value;
+
+						return true;
+					}
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						$updated_profile = $value;
+
+						return true;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		$requests_made = array();
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( &$account_status, &$lock_value, &$lock_changes, &$requests_made ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							$requests_made[] = $params;
+							$account_status  = array(
+								'error' => true,
+							);
+							$lock_value     = null;
+							$lock_changes[] = null;
+
+							return new WP_Error(
+								'woocommerce_settings_payments_rest_error',
+								'REST request POST /wc/v3/payments/onboarding/test_drive_account/disable failed with: (woocommerce_woopayments_onboarding_locked) Another onboarding action is already in progress. Please wait for it to finish.',
+								array(
+									'code'    => 'woocommerce_woopayments_onboarding_locked',
+									'message' => 'Another onboarding action is already in progress. Please wait for it to finish.',
+									'data'    => array(
+										'status' => 409,
+									),
+								)
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		try {
+			$this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_client_api_error', $e->getErrorCode() );
+			$this->assertSame( \WP_Http::FAILED_DEPENDENCY, $e->getCode() );
+		}
+
+		$this->assertCount( 1, $requests_made, 'The internal test-drive disable endpoint should be called once.' );
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should finish normalized to 0.' );
+		$this->assertSame(
+			array( $this->current_time, 0, null, 0 ),
+			$lock_changes,
+			'Core should set and clear its preflight lock, observe the webhook delete, and normalize it to 0.'
+		);
+		$this->assertSame(
+			array(),
+			$updated_profile,
+			'NOX steps should not be marked completed when the internal disable request fails.'
+		);
+	}
+
+	/**
+	 * @testdox Should clear the onboarding lock when internal test account disable throws an unexpected error.
+	 */
+	public function test_disable_test_account_clears_lock_when_internal_disable_throws_unexpected_error(): void {
+		$location = 'US';
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							throw new \Error( 'Simulated engine failure.' );
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		try {
+			$this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+			$this->fail( 'Expected Error not thrown.' );
+		} catch ( \Error $e ) {
+			$this->assertSame( 'Simulated engine failure.', $e->getMessage() );
+		}
+
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared even when an unexpected error escapes.' );
+		$this->assertSame( array( $this->current_time, 0, 0 ), $lock_changes );
+	}
+
+	/**
+	 * @testdox Should preserve internal non-200 failures as client API errors and unlock.
+	 */
+	public function test_disable_test_account_preserves_internal_non_200_as_client_api_error_and_unlocks(): void {
+		$location = 'US';
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							return new WP_Error(
+								'woocommerce_settings_payments_rest_error',
+								'Internal WooPayments bad request.',
+								array(
+									'code'    => 'wcpay_bad_request',
+									'message' => 'Internal WooPayments bad request.',
+									'data'    => array(
+										'status' => 400,
+									),
+								)
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		try {
+			$this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_client_api_error', $e->getErrorCode() );
+			$this->assertSame( \WP_Http::FAILED_DEPENDENCY, $e->getCode() );
+		}
+
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after non-lock internal failures.' );
+		$this->assertSame( array( $this->current_time, 0, 0 ), $lock_changes );
+		$this->assertSame( array(), $updated_profile, 'NOX steps should not be marked completed when the disable failed.' );
+	}
+
+	/**
+	 * @testdox Should reject an active onboarding lock before calling internal test account disable.
+	 */
+	public function test_disable_test_account_rejects_active_onboarding_lock_before_internal_disable(): void {
+		$location = 'US';
+
+		$endpoint_calls = 0;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function () use ( &$endpoint_calls ) {
+						$endpoint_calls++;
+
+						return array(
+							'success' => true,
+						);
+					},
+				),
+			)
+		);
+
+		$lock_value      = $this->current_time;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		try {
+			$this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+			$this->assertSame( \WP_Http::CONFLICT, $e->getCode() );
+		}
+
+		$this->assertSame( 0, $endpoint_calls, 'The internal WooPayments endpoint should not be called while the lock is active.' );
+		$this->assertSame( $this->current_time, $lock_value, 'The active lock should remain untouched.' );
+		$this->assertSame( array(), $lock_changes, 'Core should not set or clear its own lock after rejecting an active lock.' );
+	}
+
+	/**
+	 * @testdox Should self-heal an expired onboarding lock before disabling the test account.
+	 */
+	public function test_disable_test_account_self_heals_expired_onboarding_lock_before_internal_disable(): void {
+		$location = 'US';
+
+		$this->mock_working_wpcom_connection();
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+
+		$endpoint_calls = 0;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$account_exists, &$endpoint_calls ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							$endpoint_calls++;
+							$account_exists = false;
+
+							return array(
+								'success' => true,
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		$lock_value      = $this->current_time - WooPaymentsService::NOX_ONBOARDING_LOCKED_TTL_SECONDS - 1;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result );
+		$this->assertSame( 1, $endpoint_calls, 'The internal WooPayments endpoint should be called after the stale lock self-heals.' );
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should finish normalized to 0.' );
+		$this->assertSame(
+			array( 0, $this->current_time, 0, 0 ),
+			$lock_changes,
+			'Core should clear the stale lock, acquire and clear its preflight lock, and normalize the lock after the disable call.'
+		);
+	}
+
+	/**
 	 * Test get_onboarding_kyc_session throws exception when extension is not active.
 	 *
 	 * @return void
@@ -9551,6 +9853,88 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'Explicit stored apple_google should take precedence over OR/recommended.' );
+	}
+
+	/**
+	 * Mock a working WPCOM connection.
+	 */
+	private function mock_working_wpcom_connection(): void {
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+	}
+
+	/**
+	 * Mock a WooPayments account state for test-drive disable tests.
+	 *
+	 * @param bool $account_exists Whether the account is currently connected.
+	 */
+	private function mock_account_state( bool &$account_exists ): void {
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturnCallback(
+				function () use ( &$account_exists ) {
+					return $account_exists;
+				}
+			);
+		$this->mock_account_service
+			->expects( $this->any() )
+			->method( 'get_account_status_data' )
+			->willReturn(
+				array(
+					'status'           => 'complete',
+					'testDrive'        => true,
+					'isLive'           => false,
+					'paymentsEnabled'  => true,
+					'detailsSubmitted' => true,
+				)
+			);
+	}
+
+	/**
+	 * Mock NOX lock and profile options for test-drive disable tests.
+	 *
+	 * @param mixed $lock_value The current lock value.
+	 * @param array $lock_changes Recorded lock writes.
+	 * @param array $updated_profile The current updated NOX profile.
+	 * @param array $stored_profile The initial stored NOX profile.
+	 */
+	private function mock_disable_test_account_option_state( &$lock_value, array &$lock_changes, array &$updated_profile, array $stored_profile = array() ): void {
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option'    => function ( $option_name, $default_value = null ) use ( &$lock_value, &$updated_profile, $stored_profile ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return $lock_value ?? $default_value;
+					}
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						return ! empty( $updated_profile ) ? $updated_profile : $stored_profile;
+					}
+
+					return $default_value;
+				},
+				'update_option' => function ( $option_name, $value ) use ( &$lock_value, &$lock_changes, &$updated_profile ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						$lock_value     = $value;
+						$lock_changes[] = $value;
+
+						return true;
+					}
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						$updated_profile = $value;
+
+						return true;
+					}
+
+					return true;
+				},
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8488,6 +8488,106 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should disable a test-drive account via the test-drive endpoint and mark steps completed on success.
+	 */
+	public function test_disable_test_account_marks_steps_completed_on_successful_test_drive_disable(): void {
+		$location = 'US';
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$requested_endpoints = array();
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$requested_endpoints ) {
+						$requested_endpoints[] = $endpoint;
+
+						return array(
+							'success' => true,
+						);
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'Disabling a test-drive account should succeed.' );
+		$this->assertSame(
+			array( '/wc/v3/payments/onboarding/test_drive_account/disable' ),
+			$requested_endpoints,
+			'A test-drive account should be disabled via the test-drive disable endpoint, not the onboarding reset endpoint.'
+		);
+		$this->assertSame(
+			array( $this->current_time, 0 ),
+			$lock_changes,
+			'Core should set its preflight lock and clear it before the Phase 2 disable call.'
+		);
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after the disable call.' );
+		$this->assertNotEmpty( $updated_profile, 'NOX steps should be marked completed on a successful test-drive disable.' );
+	}
+
+	/**
+	 * @testdox Should not write the onboarding lock during or after the Phase 2 internal call.
+	 */
+	public function test_disable_test_account_does_not_write_onboarding_lock_during_phase_2(): void {
+		// Guards the invariant that Phase 2 must not call clear_onboarding_lock(): because the lock
+		// is a shared, token-less option, an unconditional Phase 2 clear would stomp a concurrent
+		// request's freshly acquired lock. The proof is that no lock write happens once Phase 2 runs.
+		$location = 'US';
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$lock_writes_at_phase_2 = null;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$lock_changes, &$lock_writes_at_phase_2 ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							// Snapshot the lock writes that happened before the internal call ran.
+							$lock_writes_at_phase_2 = $lock_changes;
+
+							return array(
+								'success' => true,
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'Disabling the test-drive account should succeed.' );
+		$this->assertSame(
+			array( $this->current_time, 0 ),
+			$lock_writes_at_phase_2,
+			'By the time the Phase 2 internal call runs, Core should have already set and cleared its preflight lock.'
+		);
+		$this->assertSame(
+			$lock_writes_at_phase_2,
+			$lock_changes,
+			'Phase 2 and the post-call step bookkeeping must not write the onboarding lock again; an extra write means an unconditional Phase 2 clear was re-introduced.'
+		);
+	}
+
+	/**
 	 * Test get_onboarding_kyc_session throws exception when extension is not active.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8197,11 +8197,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		}
 
 		$this->assertCount( 1, $requests_made, 'The internal test-drive disable endpoint should be called once.' );
-		$this->assertSame( 0, $lock_value, 'The onboarding lock should finish normalized to 0.' );
+		$this->assertNull( $lock_value, 'The webhook-deleted onboarding lock should remain deleted after the internal request fails.' );
 		$this->assertSame(
-			array( $this->current_time, 0, null, 0 ),
+			array( $this->current_time, 0, null ),
 			$lock_changes,
-			'Core should set and clear its preflight lock, observe the webhook delete, and normalize it to 0.'
+			'Core should set and clear its preflight lock, then surface the webhook-triggered internal lock failure.'
 		);
 		$this->assertSame(
 			array(),
@@ -8247,7 +8247,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		}
 
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared even when an unexpected error escapes.' );
-		$this->assertSame( array( $this->current_time, 0, 0 ), $lock_changes );
+		$this->assertSame( array( $this->current_time, 0 ), $lock_changes );
 	}
 
 	/**
@@ -8298,7 +8298,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		}
 
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after non-lock internal failures.' );
-		$this->assertSame( array( $this->current_time, 0, 0 ), $lock_changes );
+		$this->assertSame( array( $this->current_time, 0 ), $lock_changes );
 		$this->assertSame( array(), $updated_profile, 'NOX steps should not be marked completed when the disable failed.' );
 	}
 
@@ -8397,9 +8397,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->assertSame( 1, $endpoint_calls, 'The internal WooPayments endpoint should be called after the stale lock self-heals.' );
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should finish normalized to 0.' );
 		$this->assertSame(
-			array( 0, $this->current_time, 0, 0 ),
+			array( 0, $this->current_time, 0 ),
 			$lock_changes,
-			'Core should clear the stale lock, acquire and clear its preflight lock, and normalize the lock after the disable call.'
+			'Core should clear the stale lock, acquire and clear its preflight lock.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -10249,19 +10249,23 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @param array $stored_profile   The initial stored NOX profile.
 	 */
 	private function mock_disable_test_account_option_state( &$lock_value, array &$lock_changes, array &$updated_profile, array $stored_profile = array() ): void {
+		// Track writes explicitly rather than inferring them from a non-empty profile, so that an
+		// intentional write of an empty profile is distinct from "never written" and reads do not
+		// silently fall back to the stored profile.
+		$profile_written = false;
 		$this->mockable_proxy->register_function_mocks(
 			array(
-				'get_option'    => function ( $option_name, $default_value = null ) use ( &$lock_value, &$updated_profile, $stored_profile ) {
+				'get_option'    => function ( $option_name, $default_value = null ) use ( &$lock_value, &$updated_profile, &$profile_written, $stored_profile ) {
 					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
 						return $lock_value ?? $default_value;
 					}
 					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
-						return ! empty( $updated_profile ) ? $updated_profile : $stored_profile;
+						return $profile_written ? $updated_profile : $stored_profile;
 					}
 
 					return $default_value;
 				},
-				'update_option' => function ( $option_name, $value ) use ( &$lock_value, &$lock_changes, &$updated_profile ) {
+				'update_option' => function ( $option_name, $value ) use ( &$lock_value, &$lock_changes, &$updated_profile, &$profile_written ) {
 					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
 						$lock_value     = $value;
 						$lock_changes[] = $value;
@@ -10270,6 +10274,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					}
 					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
 						$updated_profile = $value;
+						$profile_written = true;
 
 						return true;
 					}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8096,8 +8096,6 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	public function test_disable_test_account_preserves_internal_lock_failure_after_account_delete(): void {
 		$location = 'US';
 
-		$this->mock_working_wpcom_connection();
-
 		$account_is_connected = true;
 		$account_status       = array(
 			'status'           => 'complete',
@@ -8350,27 +8348,34 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	public function test_disable_test_account_self_heals_expired_onboarding_lock_before_internal_disable(): void {
 		$location = 'US';
 
-		$this->mock_working_wpcom_connection();
-
 		$account_exists = true;
 		$this->mock_account_state( $account_exists );
 
-		$endpoint_calls = 0;
+		$endpoint_calls              = 0;
+		$disable_test_account_result = function ( string $endpoint ) use ( &$account_exists, &$endpoint_calls ) {
+			if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+				++$endpoint_calls;
+				$account_exists = false;
+
+				return new WP_Error(
+					'woocommerce_settings_payments_rest_error',
+					'Internal WooPayments bad request.',
+					array(
+						'code'    => 'wcpay_bad_request',
+						'message' => 'Internal WooPayments bad request.',
+						'data'    => array(
+							'status' => 400,
+						),
+					)
+				);
+			}
+
+			throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+		};
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$account_exists, &$endpoint_calls ) {
-						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
-							$endpoint_calls++;
-							$account_exists = false;
-
-							return array(
-								'success' => true,
-							);
-						}
-
-						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
-					},
+					'rest_endpoint_post_request' => $disable_test_account_result,
 				),
 			)
 		);
@@ -8380,9 +8385,15 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$updated_profile = array();
 		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
 
-		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+		try {
+			$this->sut->disable_test_account( $location, 'test-from', 'test-source' );
 
-		$this->assertSame( array( 'success' => true ), $result );
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_client_api_error', $e->getErrorCode() );
+			$this->assertSame( \WP_Http::FAILED_DEPENDENCY, $e->getCode() );
+		}
+
 		$this->assertSame( 1, $endpoint_calls, 'The internal WooPayments endpoint should be called after the stale lock self-heals.' );
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should finish normalized to 0.' );
 		$this->assertSame(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -9969,7 +9969,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * Mock a WooPayments account state for test-drive disable tests.
 	 *
-	 * @param bool $account_exists Whether the account is currently connected.
+	 * @param bool &$account_exists Whether the account is currently connected.
 	 */
 	private function mock_account_state( bool &$account_exists ): void {
 		$this->mock_provider
@@ -9997,10 +9997,10 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * Mock NOX lock and profile options for test-drive disable tests.
 	 *
-	 * @param mixed $lock_value The current lock value.
-	 * @param array $lock_changes Recorded lock writes.
-	 * @param array $updated_profile The current updated NOX profile.
-	 * @param array $stored_profile The initial stored NOX profile.
+	 * @param mixed &$lock_value      The current lock value.
+	 * @param array &$lock_changes    Recorded lock writes.
+	 * @param array &$updated_profile The current updated NOX profile.
+	 * @param array $stored_profile   The initial stored NOX profile.
 	 */
 	private function mock_disable_test_account_option_state( &$lock_value, array &$lock_changes, array &$updated_profile, array $stored_profile = array() ): void {
 		$this->mockable_proxy->register_function_mocks(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8131,14 +8131,15 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( &$account_status, &$lock_value, &$lock_changes, &$requests_made ) {
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( &$account_status, &$lock_value, &$requests_made ) {
 						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
 							$requests_made[] = $params;
 							$account_status  = array(
 								'error' => true,
 							);
-							$lock_value     = null;
-							$lock_changes[] = null;
+							// Simulate the WooPayments account.deleted webhook deleting the shared lock
+							// option (a delete_option call, which Core's update_option tracker does not see).
+							$lock_value = null;
 
 							return new WP_Error(
 								'woocommerce_settings_payments_rest_error',
@@ -8171,9 +8172,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->assertCount( 1, $requests_made, 'The internal test-drive disable endpoint should be called once.' );
 		$this->assertNull( $lock_value, 'The webhook-deleted onboarding lock should remain deleted after the internal request fails.' );
 		$this->assertSame(
-			array( $this->current_time, 0, null ),
+			array( $this->current_time, 0 ),
 			$lock_changes,
-			'Core should set and clear its preflight lock, then surface the webhook-triggered internal lock failure.'
+			'Core should set and then clear its own preflight lock (two update_option writes); the webhook-triggered delete is not an update_option event.'
 		);
 		$this->assertSame(
 			array(),
@@ -8183,9 +8184,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should clear the onboarding lock when internal test account disable throws an unexpected error.
+	 * @testdox Should clear the onboarding lock before the internal disable call, even when that call throws an unexpected error.
 	 */
-	public function test_disable_test_account_clears_lock_when_internal_disable_throws_unexpected_error(): void {
+	public function test_disable_test_account_clears_lock_before_internal_disable_even_when_it_throws(): void {
 		$location = 'US';
 
 		$account_exists = true;
@@ -8215,10 +8216,12 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 
 			$this->fail( 'Expected Error not thrown.' );
 		} catch ( \Error $e ) {
+			// The internal call runs in Phase 2, which only catches Exception, so a fatal \Error
+			// propagates by design. The lock was already cleared in Phase 1's finally beforehand.
 			$this->assertSame( 'Simulated engine failure.', $e->getMessage() );
 		}
 
-		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared even when an unexpected error escapes.' );
+		$this->assertSame( 0, $lock_value, 'The onboarding lock is cleared in Phase 1 before the internal call, so it stays cleared even when that call throws.' );
 		$this->assertSame( array( $this->current_time, 0 ), $lock_changes );
 	}
 
@@ -9836,20 +9839,6 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'Explicit stored apple_google should take precedence over OR/recommended.' );
-	}
-
-	/**
-	 * Mock a working WPCOM connection.
-	 */
-	private function mock_working_wpcom_connection(): void {
-		$this->mock_wpcom_connection_manager
-			->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( true );
-		$this->mock_wpcom_connection_manager
-			->expects( $this->any() )
-			->method( 'has_connected_owner' )
-			->willReturn( true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8091,7 +8091,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should preserve internal lock failures after the internal request deletes the account.
+	 * @testdox Should preserve an internal request failure even when the account.deleted webhook clears the shared lock.
 	 */
 	public function test_disable_test_account_preserves_internal_lock_failure_after_account_delete(): void {
 		$location = 'US';
@@ -8141,14 +8141,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 							// option (a delete_option call, which Core's update_option tracker does not see).
 							$lock_value = null;
 
+							// The internal test-drive disable endpoint surfaces every thrown exception as
+							// HTTP 400 / bad_request (disable_test_drive_account in the WooPayments client),
+							// so that is what rest_endpoint_post_request returns to Core here.
 							return new WP_Error(
 								'woocommerce_settings_payments_rest_error',
-								'REST request POST /wc/v3/payments/onboarding/test_drive_account/disable failed with: (woocommerce_woopayments_onboarding_locked) Another onboarding action is already in progress. Please wait for it to finish.',
+								'REST request POST /wc/v3/payments/onboarding/test_drive_account/disable failed with: (bad_request) Failed to disable the test-drive account.',
 								array(
-									'code'    => 'woocommerce_woopayments_onboarding_locked',
-									'message' => 'Another onboarding action is already in progress. Please wait for it to finish.',
+									'code'    => 'bad_request',
+									'message' => 'Failed to disable the test-drive account.',
 									'data'    => array(
-										'status' => 409,
+										'status' => 400,
 									),
 								)
 							);
@@ -8170,6 +8173,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		}
 
 		$this->assertCount( 1, $requests_made, 'The internal test-drive disable endpoint should be called once.' );
+		// Core never re-writes the lock after Phase 1, so the webhook's delete (modeled as null)
+		// survives; the get_option mock resolves null via "$lock_value ?? $default_value", so a
+		// webhook-deleted lock and a Core-cleared 0 are indistinguishable to is_onboarding_locked().
 		$this->assertNull( $lock_value, 'The webhook-deleted onboarding lock should remain deleted after the internal request fails.' );
 		$this->assertSame(
 			array( $this->current_time, 0 ),
@@ -8435,7 +8441,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			'Core should set its preflight lock and clear it before the Phase 2 reset call.'
 		);
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after the reset call.' );
-		$this->assertNotEmpty( $updated_profile, 'NOX steps should be marked completed on a successful disable.' );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT );
 	}
 
 	/**
@@ -8531,7 +8538,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			'Core should set its preflight lock and clear it before the Phase 2 disable call.'
 		);
 		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after the disable call.' );
-		$this->assertNotEmpty( $updated_profile, 'NOX steps should be marked completed on a successful test-drive disable.' );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT );
 	}
 
 	/**
@@ -10069,17 +10077,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * Mock a WooPayments account state for test-drive disable tests.
 	 *
-	 * @param bool &$account_exists Whether the account is currently connected.
+	 * @param bool $account_exists Whether the account is currently connected.
 	 */
-	private function mock_account_state( bool &$account_exists ): void {
+	private function mock_account_state( bool $account_exists ): void {
 		$this->mock_provider
 			->expects( $this->any() )
 			->method( 'is_account_connected' )
-			->willReturnCallback(
-				function () use ( &$account_exists ) {
-					return $account_exists;
-				}
-			);
+			->willReturn( $account_exists );
 		$this->mock_account_service
 			->expects( $this->any() )
 			->method( 'get_account_status_data' )
@@ -10131,6 +10135,28 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					return true;
 				},
 			)
+		);
+	}
+
+	/**
+	 * Assert that an onboarding step is recorded as completed in the NOX profile.
+	 *
+	 * @param array  $profile  The full NOX profile option value.
+	 * @param string $location The onboarding location (ISO 3166-1 alpha-2 country code).
+	 * @param string $step_id  The onboarding step ID that should be completed.
+	 */
+	private function assert_onboarding_step_completed( array $profile, string $location, string $step_id ): void {
+		$steps = $profile['onboarding'][ $location ]['steps'] ?? array();
+
+		$this->assertArrayHasKey(
+			$step_id,
+			$steps,
+			sprintf( 'The "%s" onboarding step should be recorded on a successful disable.', $step_id )
+		);
+		$this->assertArrayHasKey(
+			WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+			$steps[ $step_id ]['statuses'] ?? array(),
+			sprintf( 'The "%s" onboarding step should be marked completed on a successful disable.', $step_id )
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8217,12 +8217,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			$this->fail( 'Expected Error not thrown.' );
 		} catch ( \Error $e ) {
 			// The internal call runs in Phase 2, which only catches Exception, so a fatal \Error
-			// propagates by design. The lock was already cleared in Phase 1's finally beforehand.
-			$this->assertSame( 'Simulated engine failure.', $e->getMessage() );
+			// propagates by design. The lock must already be cleared by Phase 1's finally at this point.
+			$this->assertSame( 0, $lock_value, 'The lock is cleared in Phase 1 before the internal call, so it is already cleared when a Phase 2 \Error propagates.' );
 		}
 
-		$this->assertSame( 0, $lock_value, 'The onboarding lock is cleared in Phase 1 before the internal call, so it stays cleared even when that call throws.' );
-		$this->assertSame( array( $this->current_time, 0 ), $lock_changes );
+		$this->assertSame( array( $this->current_time, 0 ), $lock_changes, 'Core sets then clears its own preflight lock; a propagating \Error adds no further lock writes.' );
 	}
 
 	/**
@@ -8327,10 +8326,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mock_account_state( $account_exists );
 
 		$endpoint_calls              = 0;
-		$disable_test_account_result = function ( string $endpoint ) use ( &$account_exists, &$endpoint_calls ) {
+		$disable_test_account_result = function ( string $endpoint ) use ( &$endpoint_calls ) {
 			if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
 				++$endpoint_calls;
-				$account_exists = false;
 
 				return new WP_Error(
 					'woocommerce_settings_payments_rest_error',
@@ -8376,6 +8374,117 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			$lock_changes,
 			'Core should clear the stale lock, acquire and clear its preflight lock.'
 		);
+	}
+
+	/**
+	 * @testdox Should disable a sandbox account via the onboarding reset endpoint and clear the lock around it.
+	 */
+	public function test_disable_test_account_uses_reset_endpoint_for_sandbox_account(): void {
+		$location = 'US';
+
+		// A connected account that is neither a test-drive nor a live account is a sandbox account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
+		$this->mock_account_service
+			->expects( $this->any() )
+			->method( 'get_account_status_data' )
+			->willReturn(
+				array(
+					'status'           => 'complete',
+					'testDrive'        => false,
+					'isLive'           => false,
+					'paymentsEnabled'  => true,
+					'detailsSubmitted' => true,
+				)
+			);
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$requested_endpoints = array();
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$requested_endpoints ) {
+						$requested_endpoints[] = $endpoint;
+
+						return array(
+							'success' => true,
+						);
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'Disabling a sandbox account should succeed.' );
+		$this->assertSame(
+			array( '/wc/v3/payments/onboarding/reset' ),
+			$requested_endpoints,
+			'A sandbox account should be disabled via the onboarding reset endpoint, not the test-drive disable endpoint.'
+		);
+		$this->assertSame(
+			array( $this->current_time, 0 ),
+			$lock_changes,
+			'Core should set its preflight lock and clear it before the Phase 2 reset call.'
+		);
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after the reset call.' );
+		$this->assertNotEmpty( $updated_profile, 'NOX steps should be marked completed on a successful disable.' );
+	}
+
+	/**
+	 * @testdox Should make no internal request and still succeed when there is no test or sandbox account to disable.
+	 */
+	public function test_disable_test_account_makes_no_request_when_no_test_or_sandbox_account(): void {
+		$location = 'US';
+
+		// No connected account means there is neither a test-drive nor a sandbox account to disable.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( false );
+		$this->mock_account_service
+			->expects( $this->any() )
+			->method( 'get_account_status_data' )
+			->willReturn( array() );
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		$endpoint_calls = 0;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function () use ( &$endpoint_calls ) {
+						++$endpoint_calls;
+
+						return array(
+							'success' => true,
+						);
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'The no-op disable should return a success response.' );
+		$this->assertSame( 0, $endpoint_calls, 'No internal WooPayments request should be made when there is no account to disable.' );
+		$this->assertSame(
+			array( $this->current_time, 0 ),
+			$lock_changes,
+			'Core should still set and clear its preflight lock even when the Phase 2 request is skipped.'
+		);
+		$this->assertSame( 0, $lock_value, 'The onboarding lock should be cleared after the no-op.' );
 	}
 
 	/**
@@ -9839,6 +9948,22 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'Explicit stored apple_google should take precedence over OR/recommended.' );
+	}
+
+	/**
+	 * Mock a working WPCOM connection.
+	 *
+	 * Required for onboarding step completion that depends on the WPCOM connection step.
+	 */
+	private function mock_working_wpcom_connection(): void {
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8610,6 +8610,134 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should complete the post-disable bookkeeping for a test-drive account even if a concurrent request re-acquires the onboarding lock during the unlocked Phase 2 window.
+	 */
+	public function test_disable_test_account_completes_bookkeeping_when_lock_reacquired_during_phase_2_for_test_drive(): void {
+		$location = 'US';
+
+		$account_exists = true;
+		$this->mock_account_state( $account_exists );
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		// Simulate a concurrent onboarding request acquiring the shared lock during the unlocked
+		// Phase 2 window: the internal disable mutation commits, but by the time Core runs its
+		// post-disable bookkeeping the lock is held again. Because the mutation has already
+		// happened, the bookkeeping must not re-check the lock (which would throw onboarding_locked
+		// after a successful mutation) and must not stomp the concurrent request's lock.
+		$current_time = $this->current_time;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$lock_value, $current_time ) {
+						if ( '/wc/v3/payments/onboarding/test_drive_account/disable' === $endpoint ) {
+							// A concurrent request grabs the lock after Core released it for Phase 2.
+							$lock_value = $current_time;
+
+							return array(
+								'success' => true,
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'The disable should succeed even though the lock was re-acquired before the bookkeeping ran.' );
+		// The committed mutation's bookkeeping must run to completion instead of throwing an onboarding-locked error.
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT );
+		// Core must only set and release its own preflight lock; the post-disable bookkeeping must
+		// not write the lock at all, so the concurrent request's lock is left intact (not stomped to 0).
+		$this->assertSame(
+			array( $current_time, 0 ),
+			$lock_changes,
+			'Only the preflight set and release should be written; the post-disable bookkeeping must not write the lock.'
+		);
+		$this->assertSame(
+			$current_time,
+			$lock_value,
+			"The concurrent request's onboarding lock must remain intact after the bookkeeping completes."
+		);
+	}
+
+	/**
+	 * @testdox Should complete the post-reset bookkeeping for a sandbox account even if a concurrent request re-acquires the onboarding lock during the unlocked Phase 2 window.
+	 */
+	public function test_disable_test_account_completes_bookkeeping_when_lock_reacquired_during_phase_2_for_sandbox(): void {
+		$location = 'US';
+
+		// A connected account that is neither a test-drive nor a live account is a sandbox account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
+		$this->mock_account_service
+			->expects( $this->any() )
+			->method( 'get_account_status_data' )
+			->willReturn(
+				array(
+					'status'           => 'complete',
+					'testDrive'        => false,
+					'isLive'           => false,
+					'paymentsEnabled'  => true,
+					'detailsSubmitted' => true,
+				)
+			);
+		$this->mock_working_wpcom_connection();
+
+		$lock_value      = 0;
+		$lock_changes    = array();
+		$updated_profile = array();
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
+
+		// Same race as the test-drive path, but for the sandbox reset endpoint.
+		$current_time = $this->current_time;
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$lock_value, $current_time ) {
+						if ( '/wc/v3/payments/onboarding/reset' === $endpoint ) {
+							// A concurrent request grabs the lock after Core released it for Phase 2.
+							$lock_value = $current_time;
+
+							return array(
+								'success' => true,
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		$result = $this->sut->disable_test_account( $location, 'test-from', 'test-source' );
+
+		$this->assertSame( array( 'success' => true ), $result, 'The reset should succeed even though the lock was re-acquired before the bookkeeping ran.' );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS );
+		$this->assert_onboarding_step_completed( $updated_profile, $location, WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT );
+		$this->assertSame(
+			array( $current_time, 0 ),
+			$lock_changes,
+			'Only the preflight set and release should be written; the post-reset bookkeeping must not write the lock.'
+		);
+		$this->assertSame(
+			$current_time,
+			$lock_value,
+			"The concurrent request's onboarding lock must remain intact after the bookkeeping completes."
+		);
+	}
+
+	/**
 	 * Test get_onboarding_kyc_session throws exception when extension is not active.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8125,35 +8125,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$lock_changes    = array();
 		$stored_profile  = array();
 		$updated_profile = array();
-		$this->mockable_proxy->register_function_mocks(
-			array(
-				'get_option'    => function ( $option_name, $default_value = null ) use ( &$lock_value, &$updated_profile, $stored_profile ) {
-					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
-						return $lock_value ?? $default_value;
-					}
-					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
-						return ! empty( $updated_profile ) ? $updated_profile : $stored_profile;
-					}
-
-					return $default_value;
-				},
-				'update_option' => function ( $option_name, $value ) use ( &$lock_value, &$lock_changes, &$updated_profile ) {
-					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
-						$lock_value     = $value;
-						$lock_changes[] = $value;
-
-						return true;
-					}
-					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
-						$updated_profile = $value;
-
-						return true;
-					}
-
-					return true;
-				},
-			)
-		);
+		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile, $stored_profile );
 
 		$requests_made = array();
 		$this->mockable_proxy->register_static_mocks(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8413,11 +8413,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
 
 		$requested_endpoints = array();
+		$requested_params    = array();
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$requested_endpoints ) {
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( &$requested_endpoints, &$requested_params ) {
 						$requested_endpoints[] = $endpoint;
+						$requested_params[]    = $params;
 
 						return array(
 							'success' => true,
@@ -8435,6 +8437,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			$requested_endpoints,
 			'A sandbox account should be disabled via the onboarding reset endpoint, not the test-drive disable endpoint.'
 		);
+		// The Phase 2 payload must carry the caller's "from" and the validated source so a regression that
+		// routes correctly but drops or swaps these fails. "test-source" is not whitelisted, so the service
+		// normalizes it to the default via validate_onboarding_source().
+		$this->assertSame( 'test-from', $requested_params[0]['from'] ?? null, 'The reset request should forward the caller "from".' );
+		$this->assertSame( WooPaymentsService::SESSION_ENTRY_DEFAULT, $requested_params[0]['source'] ?? null, 'The reset request should carry the validated onboarding source.' );
 		$this->assertSame(
 			array( $this->current_time, 0 ),
 			$lock_changes,
@@ -8510,11 +8517,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mock_disable_test_account_option_state( $lock_value, $lock_changes, $updated_profile );
 
 		$requested_endpoints = array();
+		$requested_params    = array();
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'rest_endpoint_post_request' => function ( string $endpoint ) use ( &$requested_endpoints ) {
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( &$requested_endpoints, &$requested_params ) {
 						$requested_endpoints[] = $endpoint;
+						$requested_params[]    = $params;
 
 						return array(
 							'success' => true,
@@ -8532,6 +8541,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			$requested_endpoints,
 			'A test-drive account should be disabled via the test-drive disable endpoint, not the onboarding reset endpoint.'
 		);
+		// The Phase 2 payload must carry the caller's "from" and the validated source so a regression that
+		// routes correctly but drops or swaps these fails. "test-source" is not whitelisted, so the service
+		// normalizes it to the default via validate_onboarding_source().
+		$this->assertSame( 'test-from', $requested_params[0]['from'] ?? null, 'The disable request should forward the caller "from".' );
+		$this->assertSame( WooPaymentsService::SESSION_ENTRY_DEFAULT, $requested_params[0]['source'] ?? null, 'The disable request should carry the validated onboarding source.' );
 		$this->assertSame(
 			array( $this->current_time, 0 ),
 			$lock_changes,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooPayments test-drive activation can return a stale onboarding-lock error when Core calls the internal WooPayments test-account disable endpoint while holding the shared NOX lock. This mitigates the first-click failure by releasing Core's shared lock before the internal WCPay account mutation, avoiding an unconditional Phase-2 lock clear that could clear a concurrent request's lock, and preserving internal failures as failures instead of converting a lock-shaped error into success.

This is a narrow Core-side mitigation. The wider shared-lock contract between WooCommerce Core and WooPayments should be handled separately.

Because the internal disable call now runs after the lock is released, it is no longer mutually exclusive with a concurrent request. This was checked against the WooPayments client (`disable_test_drive_account` in `class-wc-payments-onboarding-service.php`): the endpoint is not idempotent, but it is **guarded against re-deleting the account** — it overwrites its account cache before the delete, so a duplicate concurrent call short-circuits on `is_stripe_connected() === false`. Note that the second concurrent caller does not get a silent no-op: the guard throws upstream, so Core surfaces it as a hard `ApiException( FAILED_DEPENDENCY )` (via the `is_wp_error()` check, since `rest_endpoint_post_request()` returns a `WP_Error` rather than throwing). Request-scoped locking for that residual window is left to the broader shared-lock work. The two phases' identical exception-to-`WP_Error` handling is also extracted into a shared private helper.

Following review, `clear_onboarding_lock()` now carries a docblock warning that it writes `0` with no ownership check and must not be called after work that runs unlocked. The test suite also gained explicit coverage for the test-drive disable success path and a guard for the Phase 2 no-lock-write invariant (a re-introduced unconditional Phase 2 clear appends a third lock write and fails the test).

Two further follow-ups landed after a deeper review pass. First, the shared exception-to-`WP_Error` helper is now reused by the four sibling onboarding handlers that previously duplicated it (`onboarding_test_account_init`, `get_onboarding_kyc_session`, `finish_onboarding_kyc_session`, `reset_onboarding`). Second, the helper no longer stores the exception stack trace in the error data. This matters beyond the disable endpoint: on the init/KYC paths that error data is persisted to the NOX profile option, so dropping the trace stops stack frames — whose arguments can carry file paths, tokens, and other sensitive values — from being written to `wp_options`. The trace was never read by any consumer, so no observability is lost. The full `WooPaymentsServiceTest` suite (313 tests) passes unchanged.

A later review pass flagged one remaining race in the success path. After Phase 2 releases the lock, the post-disable bookkeeping called `mark_onboarding_step_completed()`, which re-runs the full onboarding acceptance checks — including the shared lock check. A concurrent request that acquired the lock during the unlocked Phase 2 window could therefore turn an already-committed account mutation into an onboarding-locked (409) error during cleanup, re-creating the first-click failure from the bookkeeping side. This is now fixed by extracting the post-check body of `mark_onboarding_step_completed()` into a private `record_onboarding_step_completed()` that records the step without re-checking whether a new onboarding action is allowed; the post-disable bookkeeping uses it, since the mutation has already committed (mirroring `mark_onboarding_step_failed()`/`mark_onboarding_step_blocked()`, which already skip those checks). Two regression tests (test-drive and sandbox) simulate the lock being re-acquired during Phase 2 and assert the disable still succeeds without a 409 and without stomping the concurrent request's lock. The full `WooPaymentsServiceTest` suite is now 315 tests. This was also verified end to end on a Jurassic Ninja site: with a mu-plugin injecting the lock during Phase 2, the real "Activate payments" flow returned HTTP 200 and advanced to the business-verification screen instead of erroring.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Manual fresh Jurassic Ninja validation

1. Spin up a new JurassicNinja store with the WC on this PR's branch, WC Beta Tester (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-beta-tester&branches.woocommerce=agent/wooprd-3553))
1. Go to the site's dashboard, click on WooCommerce, and skip the profiler by setting the store country to US.
1. Navigate to **WooCommerce > Settings > Payments**
1. Install and activate WooPayments
1. Complete the payment methods and Jetpack connection steps.
1. On the activate payments step, click **Test payments**.
![image](https://github.com/user-attachments/assets/88c90ee3-8f72-4ed4-864f-5e68e9b1fd69)
1. Wait until the test account setup completes and the site redirects with `nox=test_account_created`.
1. Go to WooPayments settings:

    ```text
    /wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
    ```

1. Confirm the settings page shows the test-account notice with an **Activate payments** link.
1. Click the WooPayments settings **Activate payments** link.
![image](https://github.com/user-attachments/assets/bc7eb940-081d-449f-adad-ec240dac67ce)
1. In the WooPayments confirmation modal, click **Activate payments**.
1. In the NOX modal, confirm the **Start accepting real payments** screen is shown.
1. Click the NOX **Activate payments** button once.
![image](https://github.com/user-attachments/assets/e48bc610-bc9b-4c89-9721-a8a3369c9704)
1. Confirm the request to this endpoint returns HTTP 200 with `{"success":true}`:

    ```text
    /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/business_verification/test_account/disable
    ```

1. Confirm the UI advances to the business details form with the heading "Let's get your store ready to accept payments".
![image](https://github.com/user-attachments/assets/3c7a31ef-20e6-406b-b7e2-817d78329f9b)
1. Confirm the flow did not require a second click.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Red check: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "WooPaymentsServiceTest::test_disable_test_account_preserves_internal_lock_failure_after_account_delete"` failed before the production change with `Expected ApiException not thrown`.
- Green check: the same focused test passed after removing the stale-lock success fallback with `OK (1 test, 6 assertions)`.
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "WooPaymentsServiceTest::test_disable_test_account"` passed with `OK (9 tests, 46 assertions)`.
- Following review, the `disable_test_account` suite was tightened: the internal-failure mock now returns the realistic `bad_request` / HTTP 400 the WooPayments client actually sends (not an unreachable `onboarding_locked` / 409), the account-state test helper is pass-by-value, and the success-path tests assert the specific completed steps (`payment_methods` and `test_account`) rather than a non-empty profile.
- `php -l plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php` passed.
- `php -l plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `composer exec -- phpstan analyse src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php --memory-limit=2G` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.
- `git diff --check` passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-woopayments-activate-payments-lock`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)






