### PR TITLE
Fix backslashes stripped from Agentic Checkout buyer and address fields

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6866-fix-backslash-agentic-checkout
+++ b/plugins/woocommerce/changelog/wooplug-6866-fix-backslash-agentic-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix silent backslash corruption in Agentic Checkout buyer/address fields and Store API checkout field validation. Calling wp_unslash() on JSON request body data that is never magic-quoted was stripping real backslashes typed by the buyer.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php
@@ -132,7 +132,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 							}
 						}
 					} else {
-						$customer->{"set_{$function_key}"}( wp_unslash( $data[ $session_key ] ) );
+						$customer->{"set_{$function_key}"}( $data[ $session_key ] );
 					}
 				}
 			}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -277,8 +277,8 @@ class Checkout extends AbstractCartRoute {
 					continue;
 				}
 
-				// Clean the field value to trim whitespace.
-				$field_value = wc_clean( wp_unslash( $field_values[ $field_key ] ?? '' ) );
+				// Clean the field value to trim whitespace. Request body is JSON-decoded and never magic-quoted, so no wp_unslash().
+				$field_value = wc_clean( $field_values[ $field_key ] ?? '' );
 
 				if ( empty( $field_value ) ) {
 					if ( true === $field['required'] ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/AgenticCheckoutUtils.php
@@ -168,26 +168,26 @@ class AgenticCheckoutUtils {
 	 */
 	public static function set_buyer_data( $buyer, $customer ) {
 		if ( isset( $buyer['first_name'] ) ) {
-			$first_name = wc_clean( wp_unslash( $buyer['first_name'] ) );
+			$first_name = wc_clean( $buyer['first_name'] );
 			$customer->set_billing_first_name( $first_name );
 			$customer->set_shipping_first_name( $first_name );
 		}
 
 		if ( isset( $buyer['last_name'] ) ) {
-			$last_name = wc_clean( wp_unslash( $buyer['last_name'] ) );
+			$last_name = wc_clean( $buyer['last_name'] );
 			$customer->set_billing_last_name( $last_name );
 			$customer->set_shipping_last_name( $last_name );
 		}
 
 		if ( isset( $buyer['email'] ) ) {
-			$email = sanitize_email( wp_unslash( $buyer['email'] ) );
+			$email = sanitize_email( $buyer['email'] );
 			if ( is_email( $email ) ) {
 				$customer->set_billing_email( $email );
 			}
 		}
 
 		if ( isset( $buyer['phone_number'] ) ) {
-			$phone = wc_clean( wp_unslash( $buyer['phone_number'] ) );
+			$phone = wc_clean( $buyer['phone_number'] );
 			$customer->set_billing_phone( $phone );
 		}
 
@@ -203,7 +203,7 @@ class AgenticCheckoutUtils {
 	public static function set_fulfillment_address( $address, $customer ) {
 		// Only parse and set name if provided and non-empty.
 		if ( ! empty( $address['name'] ) ) {
-			$name       = wc_clean( wp_unslash( $address['name'] ) );
+			$name       = wc_clean( $address['name'] );
 			$name_parts = explode( ' ', $name, 2 );
 			$first_name = $name_parts[0];
 			$last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
@@ -218,12 +218,12 @@ class AgenticCheckoutUtils {
 		}
 
 		// Sanitize all address fields.
-		$line_one    = wc_clean( wp_unslash( $address['line_one'] ?? '' ) );
-		$line_two    = wc_clean( wp_unslash( $address['line_two'] ?? '' ) );
-		$city        = wc_clean( wp_unslash( $address['city'] ?? '' ) );
-		$state       = wc_clean( wp_unslash( $address['state'] ?? '' ) );
-		$postal_code = wc_clean( wp_unslash( $address['postal_code'] ?? '' ) );
-		$country     = wc_clean( wp_unslash( $address['country'] ?? '' ) );
+		$line_one    = wc_clean( $address['line_one'] ?? '' );
+		$line_two    = wc_clean( $address['line_two'] ?? '' );
+		$city        = wc_clean( $address['city'] ?? '' );
+		$state       = wc_clean( $address['state'] ?? '' );
+		$postal_code = wc_clean( $address['postal_code'] ?? '' );
+		$country     = wc_clean( $address['country'] ?? '' );
 
 		// Set shipping address fields.
 		$customer->set_shipping_address_1( $line_one );
@@ -279,7 +279,7 @@ class AgenticCheckoutUtils {
 	public static function set_billing_address( $address, $customer ) {
 		// Only parse and set name if provided and non-empty.
 		if ( ! empty( $address['name'] ) ) {
-			$name       = wc_clean( wp_unslash( $address['name'] ) );
+			$name       = wc_clean( $address['name'] );
 			$name_parts = explode( ' ', $name, 2 );
 			$first_name = $name_parts[0];
 			$last_name  = isset( $name_parts[1] ) ? $name_parts[1] : '';
@@ -290,12 +290,12 @@ class AgenticCheckoutUtils {
 		}
 
 		// Sanitize all address fields.
-		$line_one    = wc_clean( wp_unslash( $address['line_one'] ?? '' ) );
-		$line_two    = wc_clean( wp_unslash( $address['line_two'] ?? '' ) );
-		$city        = wc_clean( wp_unslash( $address['city'] ?? '' ) );
-		$state       = wc_clean( wp_unslash( $address['state'] ?? '' ) );
-		$postal_code = wc_clean( wp_unslash( $address['postal_code'] ?? '' ) );
-		$country     = wc_clean( wp_unslash( $address['country'] ?? '' ) );
+		$line_one    = wc_clean( $address['line_one'] ?? '' );
+		$line_two    = wc_clean( $address['line_two'] ?? '' );
+		$city        = wc_clean( $address['city'] ?? '' );
+		$state       = wc_clean( $address['state'] ?? '' );
+		$postal_code = wc_clean( $address['postal_code'] ?? '' );
+		$country     = wc_clean( $address['country'] ?? '' );
 
 		// Set billing address fields.
 		$customer->set_billing_address_1( $line_one );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -199,4 +199,34 @@ class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( '', $customer->get_shipping_address_2() );
 	}
+
+	/**
+	 * Ensure backslashes in customer fields survive a session save/read round-trip.
+	 *
+	 * Reproduces the Agentic Checkout flow where one request stores the address in the session and a
+	 * follow-up request reads it back: the session store must not wp_unslash() the data on read, or
+	 * real backslashes the buyer typed get stripped (session data is stored raw, never magic-quoted).
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/pull/65900
+	 */
+	public function test_backslashes_survive_session_round_trip() {
+		WC()->session->init();
+
+		$customer = new WC_Customer();
+		$customer->set_email( 'backslash@example.com' );
+		$customer->set_shipping_address_1( 'Apt 4\\B' );
+		$customer->set_shipping_city( 'C:\\Users' );
+		$customer->save();
+
+		$data_store = new WC_Customer_Data_Store_Session();
+		$data_store->save_to_session( $customer );
+
+		// Overwrite in memory, then read back from the session as the next request would.
+		$customer->set_shipping_address_1( 'overwritten' );
+		$customer->set_shipping_city( 'overwritten' );
+		$data_store->read( $customer );
+
+		$this->assertSame( 'Apt 4\\B', $customer->get_shipping_address_1(), 'Backslashes in the shipping address should survive the session round-trip.' );
+		$this->assertSame( 'C:\\Users', $customer->get_shipping_city(), 'Backslashes in the shipping city should survive the session round-trip.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1568,6 +1568,71 @@ class AdditionalFields extends MockeryTestCase {
 	}
 
 	/**
+	 * Ensures backslashes survive field validation. The request body is JSON-decoded and never
+	 * magic-quoted, so Checkout::validate_callback() must not wp_unslash() the value before validating.
+	 */
+	public function test_placing_order_preserves_backslashes_in_validation() {
+		$id = 'plugin-namespace/backslash-validate';
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => $id,
+				'label'             => 'Backslash Validate',
+				'location'          => 'order',
+				'type'              => 'text',
+				'validate_callback' => function ( $value ) {
+					// Passes only if the real backslash survived; wp_unslash() would have stripped it.
+					return false !== strpos( $value, '\\' );
+				},
+			)
+		);
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'   => (object) array(
+					'first_name'              => 'test',
+					'last_name'               => 'test',
+					'company'                 => '',
+					'address_1'               => 'test',
+					'address_2'               => '',
+					'city'                    => 'test',
+					'state'                   => '',
+					'postcode'                => 'cb241ab',
+					'country'                 => 'GB',
+					'phone'                   => '5555551234',
+					'email'                   => 'testaccount@test.com',
+					'plugin-namespace/gov-id' => 'my-gov-id',
+				),
+				'shipping_address'  => (object) array(
+					'first_name'              => 'test',
+					'last_name'               => 'test',
+					'company'                 => '',
+					'address_1'               => 'test',
+					'address_2'               => '',
+					'city'                    => 'test',
+					'state'                   => '',
+					'postcode'                => 'cb241ab',
+					'country'                 => 'GB',
+					'phone'                   => '5555551234',
+					'plugin-namespace/gov-id' => 'my-gov-id',
+				),
+				'payment_method'    => WC_Gateway_BACS::ID,
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+					$id                             => 'C:\\Users',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
+
+		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
+	}
+
+	/**
 	 * Ensures that the provided validate callback works and prevents an order.
 	 */
 	public function test_placing_order_validate_text() {

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
@@ -231,7 +231,7 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 			$customer
 		);
 
-		$this->assertSame( 'O\\Brien', $customer->get_shipping_first_name(), 'Backslashes in name should be preserved.' );
+		$this->assertSame( 'O\\Brien', $customer->get_shipping_first_name(), 'Backslashes in the parsed first name should be preserved.' );
 		$this->assertSame( 'Apt 4\\B', $customer->get_shipping_address_1(), 'Backslashes in address line should be preserved.' );
 		$this->assertSame( 'Düsseldorf\\Nord', $customer->get_shipping_city(), 'Backslashes in city should be preserved.' );
 	}
@@ -250,7 +250,7 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 			$customer
 		);
 
-		$this->assertSame( 'O\\Brien', $customer->get_billing_first_name(), 'Backslashes in name should be preserved.' );
+		$this->assertSame( 'O\\Brien', $customer->get_billing_first_name(), 'Backslashes in the parsed first name should be preserved.' );
 		$this->assertSame( 'Apt 4\\B', $customer->get_billing_address_1(), 'Backslashes in address line should be preserved.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/AgenticCheckoutUtilsTest.php
@@ -195,4 +195,62 @@ class AgenticCheckoutUtilsTest extends \WC_Unit_Test_Case {
 			$result->get_error_message()
 		);
 	}
+
+	/**
+	 * @testdox Should preserve backslashes in buyer data, which arrives JSON-decoded and is never magic-quoted.
+	 */
+	public function test_set_buyer_data_preserves_backslashes() {
+		$customer = WC()->customer;
+
+		AgenticCheckoutUtils::set_buyer_data(
+			array(
+				'first_name' => 'C:\\Users',
+				'last_name'  => 'O\\Brien',
+			),
+			$customer
+		);
+
+		$this->assertSame( 'C:\\Users', $customer->get_billing_first_name(), 'Backslashes in first name should be preserved.' );
+		$this->assertSame( 'O\\Brien', $customer->get_billing_last_name(), 'Backslashes in last name should be preserved.' );
+	}
+
+	/**
+	 * @testdox Should preserve backslashes in fulfillment address fields.
+	 */
+	public function test_set_fulfillment_address_preserves_backslashes() {
+		$customer = WC()->customer;
+
+		AgenticCheckoutUtils::set_fulfillment_address(
+			array(
+				'name'        => 'O\\Brien Family',
+				'line_one'    => 'Apt 4\\B',
+				'city'        => 'Düsseldorf\\Nord',
+				'country'     => 'US',
+				'postal_code' => '90210',
+			),
+			$customer
+		);
+
+		$this->assertSame( 'O\\Brien', $customer->get_shipping_first_name(), 'Backslashes in name should be preserved.' );
+		$this->assertSame( 'Apt 4\\B', $customer->get_shipping_address_1(), 'Backslashes in address line should be preserved.' );
+		$this->assertSame( 'Düsseldorf\\Nord', $customer->get_shipping_city(), 'Backslashes in city should be preserved.' );
+	}
+
+	/**
+	 * @testdox Should preserve backslashes in billing address fields.
+	 */
+	public function test_set_billing_address_preserves_backslashes() {
+		$customer = WC()->customer;
+
+		AgenticCheckoutUtils::set_billing_address(
+			array(
+				'name'     => 'O\\Brien Family',
+				'line_one' => 'Apt 4\\B',
+			),
+			$customer
+		);
+
+		$this->assertSame( 'O\\Brien', $customer->get_billing_first_name(), 'Backslashes in name should be preserved.' );
+		$this->assertSame( 'Apt 4\\B', $customer->get_billing_address_1(), 'Backslashes in address line should be preserved.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`wp_unslash()` only undoes WordPress magic quotes, which apply solely to the `$_POST`/`$_GET` superglobals. The Agentic Checkout routes and the Store API checkout field validation read their data from the JSON request body, which is never magic-quoted — so unslashing it silently stripped real backslashes a buyer typed into a name or address.

This removes `wp_unslash()` from the buyer/address handling in `AgenticCheckoutUtils` and from the additional-field validation in `Checkout.php`, leaving all other sanitization intact. Same class of bug as #65643, in the spots that PR didn't touch. Adds regression tests for buyer, shipping, and billing fields.

Closes #65748.

(For Bug Fixes) Bug introduced in PR #61216.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run the unit tests: `pnpm test:php:env -- --filter AgenticCheckoutUtilsTest` — all pass.
2. In an agentic checkout session, submit a buyer name or address line containing a backslash (e.g. `Apt 4\B`).
3. Confirm the saved customer billing/shipping field keeps the backslash instead of dropping it.

You can include this snippet to enable the routes:

```
// 1. Turn on the (UI-hidden) feature flag.
add_action( 'init', function () {
	if ( 'yes' !== get_option( 'woocommerce_feature_agentic_checkout_enabled' ) ) {
		update_option( 'woocommerce_feature_agentic_checkout_enabled', 'yes' );
	}
} );

// 2. Drop the blog-token auth on the agentic routes so a plain request gets through.
add_filter( 'rest_endpoints', function ( $endpoints ) {
	foreach ( $endpoints as $route => &$handlers ) {
		if ( 0 !== strpos( ltrim( $route, '/' ), 'wc/agentic/v1' ) ) {
			continue;
		}
		foreach ( $handlers as &$handler ) {
			if ( is_array( $handler ) && isset( $handler['permission_callback'] ) ) {
				$handler['permission_callback'] = '__return_true';
			}
		}
		unset( $handler );
	}
	unset( $handlers );
	return $endpoints;
} );

// 3. Skip the Store API nonce check (covers the session-update route).
add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
```

Then POST to `wp-json/wc/agentic/v1/checkout_sessions`

<!-- End testing instructions -->

### Testing that has already taken place:

- Added and ran PHPUnit coverage for `set_buyer_data`, `set_fulfillment_address`, and `set_billing_address` (10/10 pass).
- phpcs clean on changed files; PHPStan reports no new errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>