### PR TITLE
Add --force to env:restart wp-env destroy

### DIFF
--- a/plugins/woocommerce/changelog/env-restart-force-destroy
+++ b/plugins/woocommerce/changelog/env-restart-force-destroy
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add --force to the env:restart script so wp-env destroy skips the interactive confirmation prompt.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -30,7 +30,7 @@
 		"env:dev": "pnpm wp-env start --update",
 		"env:down": "pnpm wp-env stop",
 		"env:performance-init": "./tests/performance/bin/init-environment.sh",
-		"env:restart": "pnpm wp-env destroy && pnpm wp-env start --update",
+		"env:restart": "pnpm wp-env destroy --force && pnpm wp-env start --update",
 		"env:start": "pnpm wp-env start",
 		"env:start:blocks": "pnpm wp-env start && bash ./tests/e2e-pw/bin/blocks/test-env-setup.sh && pnpm playwright install chromium",
 		"env:stop": "pnpm wp-env stop",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds `--force` to the `wp-env destroy` call in the `env:restart` script. `wp-env destroy` otherwise prompts for an interactive `y/N` confirmation, which stalls `pnpm env:restart` until a human answers. With `--force` the script runs unattended.

```diff
- "env:restart": "pnpm wp-env destroy && pnpm wp-env start --update",
+ "env:restart": "pnpm wp-env destroy --force && pnpm wp-env start --update",
```

### How to test the changes in this Pull Request:

1. Check out this branch and ensure a wp-env environment exists (`pnpm --filter=@woocommerce/plugin-woocommerce env:start`).
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce env:restart`.
3. Confirm the command destroys and restarts the environment without pausing for a `Are you sure?` confirmation prompt.

### Testing that has already taken place:

Ran `pnpm env:restart` locally and confirmed the destroy step no longer blocks on the interactive prompt.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
