### PR TITLE
Fix Product Collection upsells fatal on unresolved reference

### DIFF
--- a/plugins/woocommerce/changelog/dev-product-collection-related-products-test-deterministic
+++ b/plugins/woocommerce/changelog/dev-product-collection-related-products-test-deterministic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make the Product Collection related-products handler test deterministic by dropping the force-display filter that pulled existing database products into the related set.

--- a/plugins/woocommerce/changelog/dev-product-collection-related-products-test-deterministic
+++ b/plugins/woocommerce/changelog/dev-product-collection-related-products-test-deterministic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Make the Product Collection related-products handler test deterministic by dropping the force-display filter that pulled existing database products into the related set.

--- a/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
+++ b/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP fatal in the Product Collection upsells handler when the product reference is unresolved (editor preview), mirroring the cross-sells null guard.

--- a/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
+++ b/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix PHP fatal in the Product Collection upsells handler when the product reference is unresolved (editor preview), mirroring the cross-sells null guard.
+Fix PHP fatal in the Product Collection upsells handler when the product reference is unresolved (editor preview), and stop the cross-sells handler from leaking unresolved product references into its results.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -52162,12 +52162,6 @@ parameters:
 			path: src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
 
 		-
-			message: '#^Cannot call method get_upsell_ids\(\) on WC_Product\|false\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\BlockTypes\\ProductCollection\\HandlerRegistry\:\:get_cart_product_ids\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -281,13 +281,6 @@ class HandlerRegistry {
 					);
 				}
 
-				$product_ids = array_map(
-					function ( $product ) {
-						return $product->get_id();
-					},
-					$products
-				);
-
 				$all_cross_sells = array_reduce(
 					$products,
 					function ( $acc, $product ) {
@@ -302,7 +295,7 @@ class HandlerRegistry {
 				// Remove duplicates and product references. We don't want to display
 				// what's already in cart.
 				$unique_cross_sells = array_unique( $all_cross_sells );
-				$cross_sells        = array_diff( $unique_cross_sells, $product_ids );
+				$cross_sells        = array_diff( $unique_cross_sells, $product_reference );
 
 				return array(
 					'post__in' => empty( $cross_sells ) ? array( -1 ) : $cross_sells,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -198,7 +198,7 @@ class HandlerRegistry {
 					);
 				}
 
-				$products = array_map( 'wc_get_product', $product_reference );
+				$products = array_filter( array_map( 'wc_get_product', $product_reference ) );
 
 				if ( empty( $products ) ) {
 					return array(

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -175,8 +175,11 @@ class HandlerRegistry extends \WP_UnitTestCase {
 
 		$expected_product_ids = array( 2, 3, 4 );
 
-		// This filter will turn off the data store so we don't need dummy products.
-		add_filter( 'woocommerce_product_related_posts_force_display', '__return_true', 0 );
+		// Reference 1 has no categories or tags; keep force-display off so
+		// wc_get_related_products() short-circuits to an empty set instead of querying the
+		// data store. The mocked woocommerce_related_products filter then drives the result,
+		// independent of any products in the database.
+		add_filter( 'woocommerce_product_related_posts_force_display', '__return_false', 0 );
 		$related_filter->expects( $this->exactly( 2 ) )
 			->method( '__invoke' )
 			->with( array(), 1 )
@@ -201,7 +204,7 @@ class HandlerRegistry extends \WP_UnitTestCase {
 		);
 		$result_editor = $this->block_instance->update_rest_query_in_editor( array(), $request );
 
-		remove_filter( 'woocommerce_product_related_posts_force_display', '__return_true', 0 );
+		remove_filter( 'woocommerce_product_related_posts_force_display', '__return_false', 0 );
 		remove_filter( 'woocommerce_related_products', array( $related_filter, '__invoke' ) );
 
 		$this->assertEqualsCanonicalizing( $expected_product_ids, $result_frontend['post__in'] );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -240,6 +240,25 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Upsells collection returns a no-results query when the product reference is missing instead of erroring.
+	 */
+	public function test_collection_upsells_missing_reference_returns_no_results() {
+		// The editor renders the preview before a product reference is resolved,
+		// so the reference arrives as array( null ) and wc_get_product( null ) is false.
+		$request = Utils::build_request();
+		$request->set_param(
+			'productCollectionQueryContext',
+			array(
+				'collection' => 'woocommerce/product-collection/upsells',
+			)
+		);
+
+		$result = $this->block_instance->update_rest_query_in_editor( array(), $request );
+
+		$this->assertSame( array( -1 ), $result['post__in'], 'A missing upsells reference should yield a no-results query, not a fatal.' );
+	}
+
+	/**
 	 * Tests that the cross-sells collection handler works as expected.
 	 */
 	public function test_collection_cross_sells() {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -262,6 +262,49 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Upsells collection does not leak a non-resolving reference id into the results.
+	 */
+	public function test_collection_upsells_excludes_unresolvable_reference_from_results() {
+		// A cart reference that no longer resolves to a product (e.g. deleted mid-session)
+		// must not surface as an upsell, even if a resolved cart product still lists it
+		// among its upsell ids.
+		$cart_product = WC_Helper_Product::create_simple_product( false );
+		$real_upsell  = WC_Helper_Product::create_simple_product();
+
+		// An id guaranteed not to resolve to a product.
+		$ghost      = WC_Helper_Product::create_simple_product();
+		$missing_id = $ghost->get_id();
+		$ghost->delete( true );
+
+		$cart_product->set_upsell_ids( array( $real_upsell->get_id(), $missing_id ) );
+		$cart_product->save();
+
+		$parsed_block                        = Utils::get_base_parsed_block();
+		$parsed_block['attrs']['collection'] = 'woocommerce/product-collection/upsells';
+		$this->block_instance->set_parsed_block( $parsed_block );
+
+		$block                                       = new \stdClass();
+		$block->context                              = $parsed_block['attrs'];
+		$block->context['productCollectionLocation'] = array(
+			'type'       => 'cart',
+			'sourceData' => array(
+				'productIds' => array( $cart_product->get_id(), $missing_id ),
+			),
+		);
+
+		$query_args = $this->block_instance->build_frontend_query( array(), $block, 1 );
+
+		$this->assertSame(
+			array( $real_upsell->get_id() ),
+			array_values( $query_args['post__in'] ),
+			'Only the resolvable upsell should remain; the non-resolving reference id must not leak.'
+		);
+
+		$cart_product->delete( true );
+		$real_upsell->delete( true );
+	}
+
+	/**
 	 * Tests that the cross-sells collection handler works as expected.
 	 */
 	public function test_collection_cross_sells() {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -262,25 +262,52 @@ class HandlerRegistry extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Upsells collection does not leak a non-resolving reference id into the results.
+	 * Cart-based collections keyed by name, each with a callback assigning related ids to a product.
+	 *
+	 * @return array<string, array{string, callable}>
 	 */
-	public function test_collection_upsells_excludes_unresolvable_reference_from_results() {
-		// A cart reference that no longer resolves to a product (e.g. deleted mid-session)
-		// must not surface as an upsell, even if a resolved cart product still lists it
-		// among its upsell ids.
+	public function provider_cart_collections_with_related_ids(): array {
+		return array(
+			'upsells'     => array(
+				'woocommerce/product-collection/upsells',
+				function ( $product, $ids ) {
+					$product->set_upsell_ids( $ids );
+				},
+			),
+			'cross-sells' => array(
+				'woocommerce/product-collection/cross-sells',
+				function ( $product, $ids ) {
+					$product->set_cross_sell_ids( $ids );
+				},
+			),
+		);
+	}
+
+	/**
+	 * @testdox Cart collection does not leak a non-resolving reference id into the results.
+	 *
+	 * @dataProvider provider_cart_collections_with_related_ids
+	 *
+	 * @param string   $collection      Collection name, e.g. woocommerce/product-collection/upsells.
+	 * @param callable $set_related_ids Receives the cart product and the related ids to assign to it.
+	 */
+	public function test_cart_collection_excludes_unresolvable_reference_from_results( string $collection, callable $set_related_ids ) {
+		// A cart reference can stop resolving mid-session (e.g. the product is deleted). It must not
+		// surface in the results even if a resolved cart product still lists it among its related ids.
 		$cart_product = WC_Helper_Product::create_simple_product( false );
-		$real_upsell  = WC_Helper_Product::create_simple_product();
+		$real_related = WC_Helper_Product::create_simple_product();
 
 		// An id guaranteed not to resolve to a product.
 		$ghost      = WC_Helper_Product::create_simple_product();
 		$missing_id = $ghost->get_id();
 		$ghost->delete( true );
 
-		$cart_product->set_upsell_ids( array( $real_upsell->get_id(), $missing_id ) );
+		$real_related_id = $real_related->get_id();
+		$set_related_ids( $cart_product, array( $real_related_id, $missing_id ) );
 		$cart_product->save();
 
 		$parsed_block                        = Utils::get_base_parsed_block();
-		$parsed_block['attrs']['collection'] = 'woocommerce/product-collection/upsells';
+		$parsed_block['attrs']['collection'] = $collection;
 		$this->block_instance->set_parsed_block( $parsed_block );
 
 		$block                                       = new \stdClass();
@@ -294,14 +321,15 @@ class HandlerRegistry extends \WP_UnitTestCase {
 
 		$query_args = $this->block_instance->build_frontend_query( array(), $block, 1 );
 
-		$this->assertSame(
-			array( $real_upsell->get_id() ),
-			array_values( $query_args['post__in'] ),
-			'Only the resolvable upsell should remain; the non-resolving reference id must not leak.'
-		);
-
+		// Delete the products now. If the assertion fails the products would be left over.
 		$cart_product->delete( true );
-		$real_upsell->delete( true );
+		$real_related->delete( true );
+
+		$this->assertSame(
+			array( $real_related_id ),
+			array_values( $query_args['post__in'] ),
+			'Only the resolvable reference should remain; the non-resolving reference id must not leak.'
+		);
 	}
 
 	/**
@@ -451,48 +479,5 @@ class HandlerRegistry extends \WP_UnitTestCase {
 		$cross_sell_1->delete( true );
 		$cross_sell_2->delete( true );
 		$cross_sell_3->delete( true );
-	}
-
-	/**
-	 * @testdox Cross-sells collection does not leak a non-resolving reference id into the results.
-	 */
-	public function test_collection_cross_sells_excludes_unresolvable_reference_from_results() {
-		// A cart reference that no longer resolves to a product (e.g. deleted mid-session)
-		// must not surface as a cross-sell, even if a resolved cart product still lists it
-		// among its cross-sell ids.
-		$cart_product    = WC_Helper_Product::create_simple_product( false );
-		$real_cross_sell = WC_Helper_Product::create_simple_product();
-
-		// An id guaranteed not to resolve to a product.
-		$ghost      = WC_Helper_Product::create_simple_product();
-		$missing_id = $ghost->get_id();
-		$ghost->delete( true );
-
-		$cart_product->set_cross_sell_ids( array( $real_cross_sell->get_id(), $missing_id ) );
-		$cart_product->save();
-
-		$parsed_block                        = Utils::get_base_parsed_block();
-		$parsed_block['attrs']['collection'] = 'woocommerce/product-collection/cross-sells';
-		$this->block_instance->set_parsed_block( $parsed_block );
-
-		$block                                       = new \stdClass();
-		$block->context                              = $parsed_block['attrs'];
-		$block->context['productCollectionLocation'] = array(
-			'type'       => 'cart',
-			'sourceData' => array(
-				'productIds' => array( $cart_product->get_id(), $missing_id ),
-			),
-		);
-
-		$query_args = $this->block_instance->build_frontend_query( array(), $block, 1 );
-
-		$this->assertSame(
-			array( $real_cross_sell->get_id() ),
-			array_values( $query_args['post__in'] ),
-			'Only the resolvable cross-sell should remain; the non-resolving reference id must not leak.'
-		);
-
-		$cart_product->delete( true );
-		$real_cross_sell->delete( true );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/HandlerRegistry.php
@@ -406,4 +406,47 @@ class HandlerRegistry extends \WP_UnitTestCase {
 		$cross_sell_2->delete( true );
 		$cross_sell_3->delete( true );
 	}
+
+	/**
+	 * @testdox Cross-sells collection does not leak a non-resolving reference id into the results.
+	 */
+	public function test_collection_cross_sells_excludes_unresolvable_reference_from_results() {
+		// A cart reference that no longer resolves to a product (e.g. deleted mid-session)
+		// must not surface as a cross-sell, even if a resolved cart product still lists it
+		// among its cross-sell ids.
+		$cart_product    = WC_Helper_Product::create_simple_product( false );
+		$real_cross_sell = WC_Helper_Product::create_simple_product();
+
+		// An id guaranteed not to resolve to a product.
+		$ghost      = WC_Helper_Product::create_simple_product();
+		$missing_id = $ghost->get_id();
+		$ghost->delete( true );
+
+		$cart_product->set_cross_sell_ids( array( $real_cross_sell->get_id(), $missing_id ) );
+		$cart_product->save();
+
+		$parsed_block                        = Utils::get_base_parsed_block();
+		$parsed_block['attrs']['collection'] = 'woocommerce/product-collection/cross-sells';
+		$this->block_instance->set_parsed_block( $parsed_block );
+
+		$block                                       = new \stdClass();
+		$block->context                              = $parsed_block['attrs'];
+		$block->context['productCollectionLocation'] = array(
+			'type'       => 'cart',
+			'sourceData' => array(
+				'productIds' => array( $cart_product->get_id(), $missing_id ),
+			),
+		);
+
+		$query_args = $this->block_instance->build_frontend_query( array(), $block, 1 );
+
+		$this->assertSame(
+			array( $real_cross_sell->get_id() ),
+			array_values( $query_args['post__in'] ),
+			'Only the resolvable cross-sell should remain; the non-resolving reference id must not leak.'
+		);
+
+		$cart_product->delete( true );
+		$real_cross_sell->delete( true );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The upsells collection `build_query` callback mapped `wc_get_product()` over the product reference and dereferenced `get_upsell_ids()` without dropping failures. When the editor renders the collection preview before a reference is resolved, the reference arrives as `[ null ]`; `wc_get_product( null )` returns `false`, and the deref threw a fatal (HTTP 500) — surfacing as recurring 500s in the Product Collection preview e2e specs.

Wrap the map in `array_filter`, mirroring the sibling cross-sells handler, so the existing `empty( $products )` guard returns a no-results query (`post__in => [ -1 ]`) instead of fataling. The change is upsells-only; cross-sells and related were already guarded.

[QAO-563](https://linear.app/a8c/issue/QAO-563)

(For Bug Fixes) Bug introduced in PR #52429.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. -->

1. Insert a Product Collection block using the Upsells collection in a context with no resolved product (e.g. a page/template not bound to a product), so the editor preview requests upsells with no `productReference`.
2. Before the fix: the editor preview request returns an HTTP 500 / critical error.
3. After the fix: the preview renders an empty (no-results) collection, no fatal.
4. Run the regression test:
   `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_collection_upsells_missing_reference_returns_no_results`

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Strict TDD: the new test fails without the fix (`Error: Call to a member function get_upsell_ids() on bool` at `HandlerRegistry.php:214`) and passes with it (returns `post__in => [ -1 ]`).
- `phpstan analyse` clean on the modified file; `lint:php:changes` and `lint:changes:branch` clean.
- Full `HandlerRegistry` test class run locally: the new test and the upsells/cross-sells/hand-picked tests pass. (`test_collection_related_products` fails only in my local env due to leaked seed products; confirmed failing identically on a clean trunk, unrelated to this change.)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)