### PR TITLE
Fix Settings UI save-and-continue navigation

### DIFF
--- a/packages/js/settings-ui/changelog/fix-save-and-continue-navigation
+++ b/packages/js/settings-ui/changelog/fix-save-and-continue-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve Settings UI pending navigation after form-post saves.

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -49,6 +49,8 @@ type PendingNavigation = {
 	href: string;
 };
 
+const FORM_POST_REDIRECT_INPUT_NAME = 'wc_settings_ui_redirect_to';
+
 const normalizeSection = ( section?: string ) =>
 	section === 'default' ? '' : section;
 
@@ -115,6 +117,21 @@ const getSaveStrategy = ( schema: SettingsUISchema ): SettingsUISaveStrategy =>
 
 const clearLegacyFormPrompt = () => {
 	window.onbeforeunload = null;
+};
+
+const setFormPostRedirectInput = ( form: HTMLFormElement, href: string ) => {
+	let redirectInput = form.querySelector< HTMLInputElement >(
+		`input[name="${ FORM_POST_REDIRECT_INPUT_NAME }"]`
+	);
+
+	if ( ! redirectInput ) {
+		redirectInput = document.createElement( 'input' );
+		redirectInput.type = 'hidden';
+		redirectInput.name = FORM_POST_REDIRECT_INPUT_NAME;
+		form.appendChild( redirectInput );
+	}
+
+	redirectInput.value = href;
 };
 
 const shouldPromptForNavigation = ( event: MouseEvent ) => {
@@ -562,27 +579,31 @@ export const SettingsUIPage = ( {
 		clearLegacyFormPrompt();
 	}, [] );
 
-	const submitSettingsForm = useCallback( () => {
-		const form = document.getElementById( 'mainform' );
+	const submitSettingsForm = useCallback(
+		( redirectTo?: string ) => {
+			const form = document.getElementById( 'mainform' );
 
-		if ( ! ( form instanceof HTMLFormElement ) ) {
-			return;
-		}
+			if ( ! ( form instanceof HTMLFormElement ) ) {
+				return;
+			}
 
-		allowNavigation();
+			if ( typeof redirectTo === 'string' && redirectTo ) {
+				setFormPostRedirectInput( form, redirectTo );
+			}
 
-		const saveButton = document.querySelector( '.woocommerce-save-button' );
+			allowNavigation();
 
-		if (
-			saveButton instanceof HTMLButtonElement &&
-			saveButton.form === form
-		) {
-			form.requestSubmit( saveButton );
-			return;
-		}
+			const saveButton = form.querySelector( '.woocommerce-save-button' );
 
-		form.requestSubmit();
-	}, [ allowNavigation ] );
+			if ( saveButton instanceof HTMLButtonElement ) {
+				form.requestSubmit( saveButton );
+				return;
+			}
+
+			form.requestSubmit();
+		},
+		[ allowNavigation ]
+	);
 
 	const setValues = useCallback(
 		( nextValues: Partial< SettingsValues > ) => {
@@ -736,7 +757,7 @@ export const SettingsUIPage = ( {
 		}
 
 		if ( saveStrategy.adapter === 'form_post' ) {
-			submitSettingsForm();
+			submitSettingsForm( pendingNavigation.href );
 			return;
 		}
 

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -8,12 +8,19 @@ import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/admin-ui', () => ( {
 	Page: ( {
+		actions,
 		children,
 		className,
 	}: {
+		actions?: ReactNode;
 		children: ReactNode;
 		className?: string;
-	} ) => <div className={ className }>{ children }</div>,
+	} ) => (
+		<div className={ className }>
+			{ actions }
+			{ children }
+		</div>
+	),
 } ) );
 
 /**
@@ -38,6 +45,54 @@ const renderElement = ( element: JSX.Element ) => {
 	} );
 
 	return { container, root };
+};
+
+const renderElementInMainForm = ( element: JSX.Element ) => {
+	const form = document.createElement( 'form' );
+	form.id = 'mainform';
+	document.body.appendChild( form );
+
+	const container = document.createElement( 'div' );
+	form.appendChild( container );
+	const root = createRoot( container );
+
+	act( () => {
+		root.render( element );
+	} );
+
+	return { container, form, root };
+};
+
+const changeTextInput = ( input: HTMLInputElement, value: string ) => {
+	const valueSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		'value'
+	)?.set;
+
+	if ( ! valueSetter ) {
+		throw new Error( 'Expected HTMLInputElement value setter.' );
+	}
+
+	valueSetter.call( input, value );
+	input.dispatchEvent(
+		new Event( 'input', { bubbles: true, cancelable: true } )
+	);
+};
+
+const getUnsavedChangesActionButton = ( label: string ): HTMLButtonElement => {
+	const button = Array.from(
+		document.body.querySelectorAll< HTMLButtonElement >(
+			'.wc-settings-ui__unsaved-changes-actions button'
+		)
+	).find( ( candidate ) => candidate.textContent?.trim() === label );
+
+	if ( ! ( button instanceof HTMLButtonElement ) ) {
+		throw new Error(
+			`Expected unsaved changes action button "${ label }".`
+		);
+	}
+
+	return button;
 };
 
 const expectUnsafeMarkupRemoved = ( container: HTMLElement ) => {
@@ -302,6 +357,98 @@ describe( 'settings HTML rendering', () => {
 		container.remove();
 	} );
 
+	it( 'submits form-post saves with the pending destination', () => {
+		const requestSubmit = jest
+			.spyOn( HTMLFormElement.prototype, 'requestSubmit' )
+			.mockImplementation( () => undefined );
+
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'form_post' },
+			shell: {
+				navigation: [
+					{
+						id: 'next-page',
+						label: 'Next page',
+						href: 'https://example.com/next',
+					},
+				],
+			},
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'test_field',
+							label: 'Test field',
+							type: 'text',
+							value: 'Initial value',
+						},
+					],
+				},
+			},
+		};
+
+		const { container, form, root } = renderElementInMainForm(
+			<SettingsUIPage schema={ schema } />
+		);
+
+		try {
+			const input = container.querySelector( 'input[type="text"]' );
+			const link = container.querySelector(
+				'a[href="https://example.com/next"]'
+			);
+
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			expect( link ).not.toBeNull();
+
+			act( () => {
+				changeTextInput( input as HTMLInputElement, 'Changed value' );
+			} );
+
+			act( () => {
+				link?.dispatchEvent(
+					new MouseEvent( 'click', {
+						bubbles: true,
+						cancelable: true,
+						button: 0,
+					} )
+				);
+			} );
+
+			const saveButton = getUnsavedChangesActionButton( 'Save' );
+
+			act( () => {
+				saveButton.dispatchEvent(
+					new MouseEvent( 'click', {
+						bubbles: true,
+						cancelable: true,
+						button: 0,
+					} )
+				);
+			} );
+
+			const redirectInput = form.querySelector(
+				'input[name="wc_settings_ui_redirect_to"]'
+			);
+
+			expect( redirectInput ).toBeInstanceOf( HTMLInputElement );
+			expect( redirectInput ).toHaveAttribute(
+				'value',
+				'https://example.com/next'
+			);
+			expect( requestSubmit ).toHaveBeenCalledWith(
+				container.querySelector( '.woocommerce-save-button' )
+			);
+		} finally {
+			act( () => root.unmount() );
+			form.remove();
+			requestSubmit.mockRestore();
+		}
+	} );
+
 	it( 'keeps unload protection when custom save before navigation fails', async () => {
 		const saveHandler = jest
 			.fn()
@@ -376,14 +523,10 @@ describe( 'settings HTML rendering', () => {
 			);
 		} );
 
-		const saveButton = Array.from(
-			document.body.querySelectorAll(
-				'.wc-settings-ui__unsaved-changes-actions button'
-			)
-		).find( ( button ) => button.textContent === 'Save' );
+		const saveButton = getUnsavedChangesActionButton( 'Save' );
 
 		await act( async () => {
-			saveButton?.dispatchEvent(
+			saveButton.dispatchEvent(
 				new MouseEvent( 'click', {
 					bubbles: true,
 					cancelable: true,

--- a/plugins/woocommerce/changelog/fix-settings-ui-save-and-continue
+++ b/plugins/woocommerce/changelog/fix-settings-ui-save-and-continue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve Settings UI pending navigation after form-post saves.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -106,6 +106,33 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 			WC()->query->add_endpoints();
 
 			do_action( 'woocommerce_settings_saved' );
+
+			self::maybe_redirect_after_settings_ui_save();
+		}
+
+		/**
+		 * Redirect to the requested Settings UI destination after a form-post save.
+		 */
+		private static function maybe_redirect_after_settings_ui_save(): void {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- The settings nonce is verified before this method is called.
+			if ( empty( $_POST['wc_settings_ui_redirect_to'] ) ) {
+				return;
+			}
+
+			$redirect_to = wp_validate_redirect(
+				esc_url_raw(
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- The settings nonce is verified before this method is called.
+					wp_unslash( $_POST['wc_settings_ui_redirect_to'] )
+				),
+				''
+			);
+
+			if ( '' === $redirect_to ) {
+				return;
+			}
+
+			wp_safe_redirect( $redirect_to );
+			exit;
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -23,6 +23,9 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 			delete_option( $option_name );
 		}
 		$this->option_names_to_clean = array();
+		unset( $_POST['_wpnonce'], $_POST['save'], $_POST['wc_settings_ui_redirect_to'], $_REQUEST['_wpnonce'] );
+		unset( $GLOBALS['current_tab'] );
+		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 
@@ -218,5 +221,94 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 		WC_Admin_Settings::save_fields( $options, $data );
 
 		$this->assertSame( 'bold text', get_option( $option_name ), 'Text fields should still go through wc_clean' );
+	}
+
+	/**
+	 * @testdox Should redirect to the requested Settings UI destination after saving.
+	 */
+	public function test_save_redirects_to_settings_ui_destination(): void {
+		$redirect_to = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=bacs' );
+		$this->prepare_settings_save_request( $redirect_to );
+
+		$intercept_redirect = function ( string $location ) use ( $redirect_to ): string {
+			$this->assertSame( $redirect_to, $location );
+			throw new RuntimeException( 'wp_redirect intercepted.' );
+		};
+		add_filter( 'wp_redirect', $intercept_redirect );
+
+		try {
+			$this->expectException( RuntimeException::class );
+			$this->expectExceptionMessage( 'wp_redirect intercepted.' );
+
+			WC_Admin_Settings::save();
+		} finally {
+			remove_filter( 'wp_redirect', $intercept_redirect );
+		}
+	}
+
+	/**
+	 * @testdox Should not redirect after a standard settings save without a Settings UI destination.
+	 */
+	public function test_save_does_not_redirect_without_settings_ui_destination(): void {
+		$this->prepare_settings_save_request();
+
+		$redirect_attempted = false;
+		$intercept_redirect = function ( string $location ) use ( &$redirect_attempted ): string {
+			$redirect_attempted = true;
+			throw new RuntimeException( 'Unexpected redirect to ' . esc_url_raw( $location ) . '.' );
+		};
+		add_filter( 'wp_redirect', $intercept_redirect );
+
+		try {
+			WC_Admin_Settings::save();
+		} finally {
+			remove_filter( 'wp_redirect', $intercept_redirect );
+		}
+
+		$this->assertFalse( $redirect_attempted );
+	}
+
+	/**
+	 * @testdox Should ignore unsafe Settings UI redirect destinations after saving.
+	 */
+	public function test_save_ignores_unsafe_settings_ui_destination(): void {
+		$this->prepare_settings_save_request( 'https://example.invalid/wp-admin/admin.php?page=wc-settings' );
+
+		$redirect_attempted = false;
+		$intercept_redirect = function ( string $location ) use ( &$redirect_attempted ): string {
+			$redirect_attempted = true;
+			throw new RuntimeException( 'Unexpected redirect to ' . esc_url_raw( $location ) . '.' );
+		};
+		add_filter( 'wp_redirect', $intercept_redirect );
+
+		try {
+			WC_Admin_Settings::save();
+		} finally {
+			remove_filter( 'wp_redirect', $intercept_redirect );
+		}
+
+		$this->assertFalse( $redirect_attempted );
+	}
+
+	/**
+	 * Prepare globals used by WC_Admin_Settings::save().
+	 *
+	 * @param string|null $redirect_to Requested redirect target, or null to omit the Settings UI redirect field.
+	 */
+	private function prepare_settings_save_request( ?string $redirect_to = null ): void {
+		global $current_tab;
+
+		$current_tab = 'settings_ui_redirect_test';
+		$this->login_as_administrator();
+
+		$nonce = wp_create_nonce( 'woocommerce-settings' );
+
+		$_POST['_wpnonce']    = $nonce;
+		$_POST['save']        = 'Save changes';
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		if ( null !== $redirect_to ) {
+			$_POST['wc_settings_ui_redirect_to'] = $redirect_to;
+		}
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-6201

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

For Settings UI pages that still save through the legacy form POST flow, choosing **Save** from the unsaved-changes modal now saves the current settings and continues to the destination the user originally clicked.

This PR:

- Adds a hidden `wc_settings_ui_redirect_to` input before submitting form-post saves from the unsaved-changes modal.
- Redirects to that destination after `WC_Admin_Settings::save()` completes, using WordPress safe redirect validation.
- Keeps custom-save behavior unchanged: navigation only continues after a successful async save.
- Adds JS and PHP regression coverage.

(For Bug Fixes) Bug introduced in PR #65557.

### Screenshots or screen recordings:

No visual changes.

### How to test the changes in this Pull Request:

#### Manual smoke with temporary Settings UI sections

1. Build assets for your local WooCommerce checkout.

   ```sh
   pnpm install --frozen-lockfile
   pnpm build
   ```

2. Add this temporary MU plugin to your local test site at `wp-content/mu-plugins/wc-settings-ui-save-continue-smoke.php`.

   ```php
   <?php
   /**
    * Plugin Name: WC Settings UI Save Continue Smoke
    */

   use Automattic\WooCommerce\Admin\Settings\SettingsSection;
   use Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry;

   add_action(
       'woocommerce_settings_sections_registration',
       function ( SettingsSectionRegistry $registry ) {
           foreach ( array( 'one' => 'Smoke One', 'two' => 'Smoke Two' ) as $suffix => $label ) {
               $registry->register(
                   new class( $suffix, $label ) extends SettingsSection {
                       private string $suffix;
                       private string $label;

                       public function __construct( string $suffix, string $label ) {
                           $this->suffix = $suffix;
                           $this->label  = $label;
                       }

                       public function get_parent_page_id(): string {
                           return 'products';
                       }

                       public function get_id(): string {
                           return 'smoke_' . $this->suffix;
                       }

                       public function get_label(): string {
                           return $this->label;
                       }

                       public function get_settings( WC_Settings_Page $parent_page ): array {
                           return array(
                               array(
                                   'title' => $this->label,
                                   'type'  => 'title',
                                   'id'    => 'smoke_' . $this->suffix . '_section',
                               ),
                               array(
                                   'title'   => 'Smoke value',
                                   'id'      => 'wc_settings_ui_smoke_' . $this->suffix,
                                   'type'    => 'text',
                                   'default' => '',
                               ),
                               array(
                                   'type' => 'sectionend',
                                   'id'   => 'smoke_' . $this->suffix . '_section',
                               ),
                           );
                       }
                   }
               );
           }
       }
   );
   ```

3. In wp-admin, open:

   ```text
   WooCommerce > Settings > Products > Smoke One
   ```

   Direct URL:

   ```text
   /wp-admin/admin.php?page=wc-settings&tab=products&section=smoke_one
   ```

4. Enter a value in **Smoke value**.
5. Click the **Smoke Two** section navigation link.
6. Confirm the unsaved-changes modal appears.
7. Click **Save** in the modal.
8. Confirm the browser navigates to `section=smoke_two`.
9. Confirm the value from step 4 was saved, for example with WP-CLI:

   ```sh
   wp option get wc_settings_ui_smoke_one
   ```

10. Clean up the temporary MU plugin and smoke option when finished.

    ```sh
    rm wp-content/mu-plugins/wc-settings-ui-save-continue-smoke.php
    wp option delete wc_settings_ui_smoke_one
    wp option delete wc_settings_ui_smoke_two
    ```

#### Regression check

- Repeat the unsaved-changes flow on a Settings UI page that uses a custom async save handler, if available, and confirm navigation only continues after the async save succeeds.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/settings-ui test:js -- src/test/html-rendering.test.tsx --runInBand`
- `pnpm --filter=@woocommerce/settings-ui lint`
- `pnpm --filter=@woocommerce/settings-ui build`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Admin_Settings_Test`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `composer exec -- phpstan analyse includes/admin/class-wc-admin-settings.php --memory-limit=2G`
- `pnpm --filter=@woocommerce/plugin-woocommerce changelog validate` (passes with existing PHP 8.4 deprecation notices from `wikimedia/at-ease`)
- Local browser smoke on `http://localhost:8082` using the temporary MU plugin above:
  - Changed **Smoke One**.
  - Clicked **Smoke Two**.
  - Clicked **Save** in the unsaved-changes modal.
  - Confirmed the browser landed on `section=smoke_two`.
  - Confirmed `wc_settings_ui_smoke_one` was persisted via WP-CLI.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Manual changelog entries added for `@woocommerce/plugin-woocommerce` and `@woocommerce/settings-ui`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Preserve Settings UI pending navigation after form-post saves.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
