### PR TITLE
e2e tests: fix product-reviews "can delete a product review" e2e flake

### DIFF
--- a/plugins/woocommerce/changelog/testops-189-product-reviews-delete-flake
+++ b/plugins/woocommerce/changelog/testops-189-product-reviews-delete-flake
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix product-reviews "can delete a product review" E2E flake by waiting for the trash AJAX to commit before navigating to the Trash view.

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.ts
@@ -338,6 +338,11 @@ test.describe( 'Product Reviews', () => {
 					trashNoticeText2?.includes( trashMessageSmart )
 			).toBeTruthy();
 
+			// The trash notice renders optimistically, before the trash AJAX
+			// commits. Wait for the row to actually leave the approved list so
+			// navigating to the Trash view does not abort the in-flight request.
+			await expect( reviewRow ).toBeHidden();
+
 			await page.click( 'a[href*="comment_status=trash"]' );
 
 			await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes an intermittent failure in `product-reviews.spec.ts` › **"can delete a product review"** under parallel load.

The test's delete flow clicks **Trash**, asserts the "Undo" trash notice, then immediately clicks the trash-status link to navigate to the Trash view. WordPress renders the "Undo" notice **optimistically**, before the `admin-ajax.php` trash request commits. Navigating away aborts that in-flight request, so the comment stays approved (`All (2)` / `Trash (0)`) and the review row is never found in the Trash view.

This adds a state assertion that only resolves once the trash AJAX has committed (the review row leaves the approved list) before navigating.

Fixes TESTOPS-189.

### How to test the changes in this Pull Request:

Run the target test:

```
pnpm --filter=@woocommerce/plugin-woocommerce test:e2e product-reviews.spec.ts
```

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->