### PR TITLE
Fix adding to cart variable products with an 'Any' attribute from the Add to Cart + Options block when in legacy mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-any-attribute-legacy-mode
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-any-attribute-legacy-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix adding to cart variable products with an 'Any' attribute from the Add to Cart + Options block when in legacy mode

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -37,7 +37,6 @@ type VariationOptionItem = {
 
 type Context = AddToCartWithOptionsStoreContext & {
 	name: string;
-	attributeSlug?: string;
 	selectedValue: string | null;
 	variationAttributeOptions: VariationOptionItem[];
 	autoselect: boolean;
@@ -184,7 +183,6 @@ export type VariableProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		state: {
 			selectedAttributes: SelectedAttributes[];
-			formAttributeValue: string;
 			selectableItems: readonly SelectableItem< {
 				visual?: VisualAttributeTerm;
 			} >[];
@@ -218,36 +216,6 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return [];
 				}
 				return context.selectedAttributes || [];
-			},
-			get formAttributeValue(): string {
-				const context = getContext< Context >();
-				if ( ! context ) {
-					return '';
-				}
-
-				const { attributeSlug, name, selectedValue } = context;
-				const { selectedAttributes } = state;
-
-				if ( Array.isArray( selectedAttributes ) ) {
-					const match = selectedAttributes.find(
-						( selectedAttribute ) =>
-							( attributeSlug &&
-								attributeNamesMatch(
-									selectedAttribute.attribute,
-									attributeSlug
-								) ) ||
-							attributeNamesMatch(
-								selectedAttribute.attribute,
-								name
-							)
-					);
-
-					if ( match?.value ) {
-						return match.value;
-					}
-				}
-
-				return selectedValue ?? '';
 			},
 			get selectableItems(): readonly SelectableItem< {
 				visual?: VisualAttributeTerm;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -37,6 +37,7 @@ type VariationOptionItem = {
 
 type Context = AddToCartWithOptionsStoreContext & {
 	name: string;
+	attributeSlug?: string;
 	selectedValue: string | null;
 	variationAttributeOptions: VariationOptionItem[];
 	autoselect: boolean;
@@ -183,6 +184,7 @@ export type VariableProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		state: {
 			selectedAttributes: SelectedAttributes[];
+			formAttributeValue: string;
 			selectableItems: readonly SelectableItem< {
 				visual?: VisualAttributeTerm;
 			} >[];
@@ -216,6 +218,36 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 					return [];
 				}
 				return context.selectedAttributes || [];
+			},
+			get formAttributeValue(): string {
+				const context = getContext< Context >();
+				if ( ! context ) {
+					return '';
+				}
+
+				const { attributeSlug, name, selectedValue } = context;
+				const { selectedAttributes } = state;
+
+				if ( Array.isArray( selectedAttributes ) ) {
+					const match = selectedAttributes.find(
+						( selectedAttribute ) =>
+							( attributeSlug &&
+								attributeNamesMatch(
+									selectedAttribute.attribute,
+									attributeSlug
+								) ) ||
+							attributeNamesMatch(
+								selectedAttribute.attribute,
+								name
+							)
+					);
+
+					if ( match?.value ) {
+						return match.value;
+					}
+				}
+
+				return selectedValue ?? '';
 			},
 			get selectableItems(): readonly SelectableItem< {
 				visual?: VisualAttributeTerm;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -121,6 +121,7 @@ class VariationSelectorAttribute extends AbstractBlock {
 
 		$interactive_context = array(
 			'name'                      => $attribute_label,
+			'attributeSlug'             => $attribute_slug,
 			'variationAttributeOptions' => $variation_items,
 			'selectedValue'             => $default_selected,
 			'autoselect'                => $attributes['autoselect'] ?? false,
@@ -132,11 +133,20 @@ class VariationSelectorAttribute extends AbstractBlock {
 			'data-wp-init'        => 'callbacks.setDefaultSelectedAttribute',
 		);
 
+		// Hidden input for legacy form POST submissions (page refresh). Chips and
+		// dropdown UI elements do not include name="attribute_*" fields.
+		$hidden_attribute_input = sprintf(
+			'<input type="hidden" name="%1$s" value="%2$s" data-wp-bind--value="state.formAttributeValue" />',
+			esc_attr( $attribute_slug ),
+			esc_attr( $default_selected ?? '' )
+		);
+
 		return sprintf(
-			'<div %s %s>%s</div>',
+			'<div %s %s>%s%s</div>',
 			get_block_wrapper_attributes( $interactive_attributes ),
 			wp_interactivity_data_wp_context( $interactive_context ),
-			$inner_html
+			$inner_html,
+			$hidden_attribute_input
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttribute.php
@@ -121,7 +121,6 @@ class VariationSelectorAttribute extends AbstractBlock {
 
 		$interactive_context = array(
 			'name'                      => $attribute_label,
-			'attributeSlug'             => $attribute_slug,
 			'variationAttributeOptions' => $variation_items,
 			'selectedValue'             => $default_selected,
 			'autoselect'                => $attributes['autoselect'] ?? false,
@@ -136,7 +135,7 @@ class VariationSelectorAttribute extends AbstractBlock {
 		// Hidden input for legacy form POST submissions (page refresh). Chips and
 		// dropdown UI elements do not include name="attribute_*" fields.
 		$hidden_attribute_input = sprintf(
-			'<input type="hidden" name="%1$s" value="%2$s" data-wp-bind--value="state.formAttributeValue" />',
+			'<input type="hidden" name="%1$s" value="%2$s" data-wp-bind--value="context.selectedValue" />',
 			esc_attr( $attribute_slug ),
 			esc_attr( $default_selected ?? '' )
 		);

--- a/plugins/woocommerce/tests/e2e/tests/blocks/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1226,7 +1226,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
-		await page.goto( '/product/hoodie' );
+		// We intentionally test the V-Neck T-Shirt because it has variations
+		// using 'any' as a variation attribute.
+		await page.goto( '/product/v-neck-t-shirt/' );
 
 		const addToCartBlock = page.locator(
 			'.wp-block-add-to-cart-with-options'
@@ -1234,12 +1236,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 		const colorBlueOption = addToCartBlock
 			.getByRole( 'radiogroup', { name: 'Color' } )
 			.getByRole( 'radio', { name: 'Blue', exact: true } );
-		const logoYesOption = addToCartBlock
-			.getByRole( 'radiogroup', { name: 'Logo' } )
-			.getByRole( 'radio', { name: 'Yes', exact: true } );
+		const sizeLargeOption = addToCartBlock
+			.getByRole( 'radiogroup', { name: 'Size' } )
+			.getByRole( 'radio', { name: 'Large', exact: true } );
 
 		await colorBlueOption.click();
-		await logoYesOption.click();
+		await sizeLargeOption.click();
 
 		const addToCartButton = page.getByRole( 'button', {
 			name: 'Add to cart',
@@ -1248,7 +1250,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await addToCartButton.click();
 
 		await expect(
-			page.getByLabel( 'Quantity of Hoodie in your cart.' )
+			page.getByLabel( 'Quantity of V-Neck T-Shirt in your cart.' )
 		).toHaveValue( '1' );
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a regression in WC 10.9.

When the Add to cart + Options block was rendering the 'legacy mode' form (which happens when an extension is installed or the 'Redirect to cart after successful addition' setting is enabled) and the shopper tried to add to the cart a variation with at least one attribute set to 'Any', the addition would error.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/64887.

In the previous implementation, the `<select>` and the pills (which were radio inputs) had the attribute slug as a `name` attribute, so submitting the form would send their data with the request. Since we migrated to using the inner blocks from Product Filters, they no longer include the attribute slug in the `name`, which means attribute data isn't included in the request.

This PR implements a more explicit fix by simply appending an input to the form that has the selected attribute data. It also updates the e2e tests so new regressions like this are caught in the future.

### How to test the changes in this Pull Request:

1. Make sure you have at least one product with a variation that has one attribute set to 'Any' (or you can use the 'V-Neck T-Shirt' product from the sample data).
2. Go to WooCommerce > Settings > Products and enable _Redirect to the cart page after successful addition_.
3. Go to the frontend of the product and try adding to cart (assuming it's using the _Add to Cart + Options_ block).
4. Verify the product was added to cart:

Before | After
--- | ---
<img width="1704" height="1067" alt="imatge" src="https://github.com/user-attachments/assets/823b09a0-9e9a-4cdb-9673-633eacd1e456" /> | <img width="1704" height="887" alt="imatge" src="https://github.com/user-attachments/assets/96891abf-2ffd-465a-a104-eec03b8d4f2e" />

5. Edit the template and switch between _Chips_ and _Dropdown_ styles.
6. Verify in both cases adding to cart works.