### PR TITLE
Fix custom place order button never submitting on shortcode checkout

### DIFF
--- a/plugins/woocommerce/changelog/woopmnt-6250-custom-place-order-button
+++ b/plugins/woocommerce/changelog/woopmnt-6250-custom-place-order-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix custom place order button (shortcode checkout) never submitting the order when a shipping address block is present. Client-side validation now only counts visible invalid fields, so the collapsed "Ship to a different address?" shipping fields no longer block submission.

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -43,8 +43,14 @@ jQuery( function ( $ ) {
 					// Trigger field-level validation (which adds `.woocommerce-invalid` to invalid fields)
 					$form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' );
 
-					// Check for validation errors (from validate_field handler)
-					if ( $form.find( '.woocommerce-invalid' ).length > 0 ) {
+					// Check for validation errors (from validate_field handler).
+					// Only consider visible fields: `validate_field` flags any empty
+					// required field regardless of visibility, so hidden fields (e.g.
+					// the collapsed "Ship to a different address?" shipping fields)
+					// would otherwise block submission even when the visible form is
+					// valid. The `.woocommerce-invalid` class lives on the `.form-row`,
+					// which is hidden when its section is collapsed.
+					if ( $form.find( '.woocommerce-invalid:visible' ).length > 0 ) {
 						hasError = true;
 					}
 
@@ -79,7 +85,7 @@ jQuery( function ( $ ) {
 
 					// Scroll to the first invalid field in DOM order
 					if ( hasError ) {
-						var $firstInvalidField = $form.find( '.woocommerce-invalid' ).first();
+						var $firstInvalidField = $form.find( '.woocommerce-invalid:visible' ).first();
 						if ( $firstInvalidField.length ) {
 							$( 'html, body' ).animate(
 								{

--- a/plugins/woocommerce/client/legacy/js/frontend/test/checkout-place-order-api.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/checkout-place-order-api.js
@@ -7,9 +7,17 @@ describe( 'createCheckoutPlaceOrderApi', () => {
 	let $termsCheckbox;
 	let $termsRow;
 	let capturedApi;
+	// Set the number of invalid `.form-row` elements that are hidden (e.g. the
+	// collapsed "Ship to a different address?" shipping fields). These must never
+	// block submission, so `validate()` should only count visible invalid fields.
+	let setHiddenInvalidCount;
 
 	beforeEach( () => {
 		capturedApi = null;
+		let hiddenInvalidCount = 0;
+		setHiddenInvalidCount = ( count ) => {
+			hiddenInvalidCount = count;
+		};
 
 		// used to track whether terms checkbox is checked
 		let termsChecked = false;
@@ -61,11 +69,26 @@ describe( 'createCheckoutPlaceOrderApi', () => {
 				if ( selector === '.input-text, select, input:checkbox' ) {
 					return { trigger: jest.fn() };
 				}
-				if ( selector === '.woocommerce-invalid' ) {
+				if ( selector === '.woocommerce-invalid:visible' ) {
+					// Visible invalid fields only (e.g. the terms row). Hidden
+					// invalid fields are deliberately excluded.
 					return {
 						length: formInvalidElements.size,
 						first: jest.fn( () => ( {
 							length: formInvalidElements.size > 0 ? 1 : 0,
+							offset: jest.fn( () => ( { top: 100 } ) ),
+						} ) ),
+					};
+				}
+				if ( selector === '.woocommerce-invalid' ) {
+					// Unfiltered query (includes hidden fields). The implementation
+					// must NOT use this to gate submission; counting hidden invalid
+					// fields here is the regression these tests guard against.
+					const total = formInvalidElements.size + hiddenInvalidCount;
+					return {
+						length: total,
+						first: jest.fn( () => ( {
+							length: total > 0 ? 1 : 0,
 							offset: jest.fn( () => ( { top: 100 } ) ),
 						} ) ),
 					};
@@ -268,6 +291,34 @@ describe( 'createCheckoutPlaceOrderApi', () => {
 			// Second attempt: should pass on first try (not require double-click)
 			const secondResult = await capturedApi.validate();
 			expect( secondResult.hasError ).toBe( false );
+		} );
+	} );
+
+	describe( 'Hidden field validation', () => {
+		test( 'should ignore invalid fields that are hidden (e.g. collapsed shipping address)', async () => {
+			// A shippable cart renders the "Ship to a different address?" block,
+			// whose required shipping fields are present but hidden when the option
+			// is unchecked. Field-level validation flags them as invalid regardless
+			// of visibility, so validate() must only count *visible* invalid fields
+			// or the order is never submitted even when the visible form is valid.
+			$termsCheckbox.setChecked( true );
+			setHiddenInvalidCount( 5 );
+
+			const result = await capturedApi.validate();
+
+			expect( result.hasError ).toBe( false );
+		} );
+
+		test( 'should only count visible invalid fields', async () => {
+			$termsCheckbox.setChecked( true );
+			setHiddenInvalidCount( 5 );
+
+			await capturedApi.validate();
+
+			expect( $form.find ).toHaveBeenCalledWith(
+				'.woocommerce-invalid:visible'
+			);
+			expect( $form.find ).not.toHaveBeenCalledWith( '.woocommerce-invalid' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the classic (shortcode) checkout, a payment gateway using a custom place order button (`wc.customPlaceOrderButton`) never submitted the order whenever the cart needed shipping. Because the cart needs shipping, the collapsed "Ship to a different address?" block renders its required shipping fields hidden and empty; the button's client-side `validate()` counted **all** `.woocommerce-invalid` fields regardless of visibility, so those hidden rows set `hasError = true` and submission was silently skipped with no error notice.

This gates submission (and the scroll-to-first-error target) on `.woocommerce-invalid:visible`, matching the `:visible` filter already used by the sibling required-field check in the same function. `:visible` correctly excludes the collapsed shipping rows while still catching genuinely-visible invalid fields, including select2-enhanced country/state inputs whose `.form-row` wrapper stays visible.

(For Bug Fixes) Bug introduced in PR #62509.

### How to test the changes in this Pull Request:

1. Configure the store with a shippable (physical) product and at least one shipping method (e.g. Free shipping on the default zone) so the cart "needs shipping".
2. Enable a payment gateway that uses a custom place order button on the classic/shortcode checkout (e.g. the `test-custom-button` gateway used in E2E, or any gateway using `has_custom_place_order_button`).
3. Add the product to the cart and go to the classic (shortcode) checkout.
4. Fill in all required **billing** fields, leaving "Ship to a different address?" unchecked.
5. Select the custom-place-order-button gateway and click its button.
6. **Expected:** the order is submitted and you land on the order-received / thank-you page (before this fix, nothing happened and no error notice appeared).

### Testing that has already taken place:

- Added Jest unit tests in `client/legacy/js/frontend/test/checkout-place-order-api.js` that model hidden invalid fields; they fail against the pre-fix code and pass after the fix. Full suite: 6/6 pass (`pnpm --filter=@woocommerce/classic-assets test:js -- checkout-place-order-api`).
- ESLint on changed files: 0 errors (only pre-existing `console` warnings unrelated to this change).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.