### PR TITLE
Migrate MiniCart, MiniCartContents, CartLink blocks to block.json-declared assets and EnableBlockJsonAssetsTrait

### DIFF
--- a/plugins/woocommerce/changelog/feat-issue-65929
+++ b/plugins/woocommerce/changelog/feat-issue-65929
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate MiniCart, MiniCartContents, CartLink, and their inner blocks to declare assets in block.json and adopt EnableBlockJsonAssetsTrait, removing legacy PHP-side asset override methods. Fix AbstractInnerBlock::register_block_type() to conditionally pass editor_style so block.json takes effect for migrated inner blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-link/block.json
@@ -39,6 +39,8 @@
 			"default": null
 		}
 	},
+	"style": [ "wc-blocks-style", "wc-blocks-style-cart-link" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json
@@ -67,6 +67,8 @@
 			"default": "greater_than_zero"
 		}
 	},
+	"style": [ "wc-blocks-style", "wc-blocks-style-mini-cart", "wc-blocks-packages-style" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
@@ -34,6 +34,8 @@
 			"default": "480px"
 		}
 	},
+	"style": [ "wc-blocks-style", "wc-blocks-style-mini-cart-contents", "wc-blocks-packages-style" ],
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.json
@@ -24,6 +24,7 @@
 	},
 	"parent": [ "woocommerce/mini-cart-contents" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.json
@@ -24,6 +24,7 @@
 	},
 	"parent": [ "woocommerce/mini-cart-contents" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.json
@@ -44,6 +44,7 @@
 	],
 	"parent": [ "woocommerce/mini-cart-footer-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.json
@@ -44,6 +44,7 @@
 	],
 	"parent": [ "woocommerce/mini-cart-footer-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
@@ -24,6 +24,7 @@
 	},
 	"parent": [ "woocommerce/filled-mini-cart-contents-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-items-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-items-block/block.json
@@ -26,6 +26,7 @@
 	},
 	"parent": [ "woocommerce/filled-mini-cart-contents-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
@@ -24,6 +24,7 @@
 	},
 	"parent": [ "woocommerce/mini-cart-items-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -44,6 +44,7 @@
 	],
 	"parent": [ "woocommerce/empty-mini-cart-contents-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -33,6 +33,7 @@
 	},
 	"parent": [ "woocommerce/filled-mini-cart-contents-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-items-counter-block/block.json
@@ -25,6 +25,7 @@
 	},
 	"parent": [ "woocommerce/mini-cart-title-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/block.json
@@ -33,6 +33,7 @@
 	},
 	"parent": [ "woocommerce/mini-cart-title-block" ],
 	"textdomain": "woocommerce",
+	"editorStyle": "wc-blocks-editor-style",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -50164,12 +50164,6 @@ parameters:
 			path: src/Blocks/BlockTypes/AbstractInnerBlock.php
 
 		-
-			message: '#^Parameter \#2 \$args of function register_block_type_from_metadata expects array\{api_version\?\: string, title\?\: string, category\?\: string\|null, parent\?\: array\<string\>\|null, ancestor\?\: array\<string\>\|null, allowed_blocks\?\: array\<string\>\|null, icon\?\: string\|null, description\?\: string, \.\.\.\}, array\{render_callback\: mixed, editor_style\: string\|null, style\: null, api_version\?\: int\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/BlockTypes/AbstractInnerBlock.php
-
-		-
 			message: '#^@param Automattic\\WooCommerce\\Blocks\\BlockTypes\\WC_Product \$product does not accept actual type of parameter\: WC_Product\.$#'
 			identifier: parameter.phpDocType
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
@@ -22,12 +22,12 @@ abstract class AbstractInnerBlock extends AbstractBlock {
 	protected function register_block_type() {
 		$block_settings = [
 			'render_callback' => $this->get_block_type_render_callback(),
-			'editor_style'    => $this->get_block_type_editor_style(),
-			'style'           => $this->get_block_type_style(),
 		];
 
-		if ( isset( $this->api_version ) ) {
-			$block_settings['api_version'] = intval( $this->api_version );
+		// Only override editor_style when PHP provides one — let block.json take effect otherwise.
+		$block_type_editor_style = $this->get_block_type_editor_style();
+		if ( $block_type_editor_style ) {
+			$block_settings['editor_style'] = $block_type_editor_style;
 		}
 
 		$metadata_path = $this->asset_api->get_block_metadata_path( $this->block_name, 'inner-blocks/' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CartLink.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CartLink.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Blocks\Utils\MiniCartUtils;
  * CartLink class.
  */
 class CartLink extends AbstractBlock {
+	use EnableBlockJsonAssetsTrait;
 
 	/**
 	 * Block name.
@@ -44,14 +45,5 @@ class CartLink extends AbstractBlock {
 			$text,
 			$aria_label
 		);
-	}
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * EmptyMiniCartContentsBlock class.
  */
 class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
  * FilledMiniCartContentsBlock class.
  */
 class FilledMiniCartContentsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -26,6 +26,7 @@ use Automattic\Block_Delimiter;
  */
 class MiniCart extends AbstractBlock {
 	use BlockHooksTrait;
+	use EnableBlockJsonAssetsTrait;
 
 	/**
 	 * Block name.
@@ -114,6 +115,8 @@ class MiniCart extends AbstractBlock {
 	 * - Register the block with WordPress.
 	 */
 	protected function initialize() {
+		// Register the per-block style handle so block.json can reference it by name.
+		$this->asset_api->register_style( 'wc-blocks-style-mini-cart', $this->asset_api->get_block_asset_build_path( 'mini-cart', 'css' ), [], 'all', true );
 		parent::initialize();
 		add_action( 'wp_loaded', array( $this, 'register_empty_cart_message_block_pattern' ) );
 		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 2 );
@@ -198,15 +201,6 @@ class MiniCart extends AbstractBlock {
 			'dependencies' => array(),
 		);
 		return $key ? $script[ $key ] : $script;
-	}
-
-	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return string[]
-	 */
-	protected function get_block_type_style() {
-		return array_merge( parent::get_block_type_style(), array( 'wc-blocks-packages-style' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartCartButtonBlock class.
  */
 class MiniCartCartButtonBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartCheckoutButtonBlock class.
  */
 class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -10,12 +10,26 @@ use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
  * @internal
  */
 class MiniCartContents extends AbstractBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'mini-cart-contents';
+
+	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize(): void {
+		// Register the per-block style handle so block.json can reference it by name.
+		$this->asset_api->register_style( 'wc-blocks-style-mini-cart-contents', $this->asset_api->get_block_asset_build_path( 'mini-cart-contents', 'css' ), [], 'all', true );
+		parent::initialize();
+	}
 
 	/**
 	 * Get the editor script handle for this block type.
@@ -44,15 +58,6 @@ class MiniCartContents extends AbstractBlock {
 		// The frontend script is a dependency of the Mini-Cart block so it's
 		// already lazy-loaded.
 		return null;
-	}
-
-	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return string[]
-	 */
-	protected function get_block_type_style() {
-		return array_merge( parent::get_block_type_style(), [ 'wc-blocks-packages-style' ] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\Enums\TaxDisplayMode;
  * MiniCartFooterBlock class.
  */
 class MiniCartFooterBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartItemsBlock class.
  */
 class MiniCartItemsBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  * MiniCartProductsTableBlock class.
  */
 class MiniCartProductsTableBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 
 	/**
 	 * Block name.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartShoppingButtonBlock class.
  */
 class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartTitleBlock class.
  */
 class MiniCartTitleBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartTitleItemsCounterBlock class.
  */
 class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * MiniCartTitleLabelBlock class.
  */
 class MiniCartTitleLabelBlock extends AbstractInnerBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

First family-sized PR in the #65929 migration series. Follows the established pattern (already applied to `AddToCartForm`, `SingleProduct`, `ProductGallery`, `Checkout` etc.) to move the MiniCart block family and CartLink off the legacy PHP-side style/script registration path onto `block.json`-declared assets.

**`AbstractInnerBlock.php`:**
- Rewrote `register_block_type()` to conditionally include `editor_style` only when non-null, matching `AbstractBlock`'s existing pattern. Previously it unconditionally passed both `style` and `editor_style` as explicit args, meaning a `null` value would override any `style`/`editorStyle` declared in block.json. This is a prerequisite for all inner block migrations.
- Removed the dead `style` branch (inner blocks never provide a PHP-side style — `get_block_type_style()` always returns `null`).
- Removed the dead `api_version` conditional (no inner block subclass sets `$api_version`; block.json already declares `"apiVersion": 3`).
- Removed the now-resolved PHPStan baseline entry covering the old array shape `{style: null, api_version?: int}`.

Note: this same change appears in draft PR #65103 (Checkout-only migration). If that PR lands first, this diff will conflict on `AbstractInnerBlock.php` and should be rebased.

**`MiniCart.php`:**
- Added `use EnableBlockJsonAssetsTrait;` so `get_block_type_style()` and `get_block_type_editor_style()` return `null`, letting block.json take effect.
- Moved the `register_style('wc-blocks-style-mini-cart', ...)` call into `initialize()` — previously a side-effect of `get_block_type_style()`. The handle must still be registered before WordPress reads it from block.json.
- Removed `get_block_type_style()` override.
- `get_block_type_script()` is preserved — class methods take precedence over trait methods in PHP, so the conditional skip logic for cart/checkout pages and the `experimental-iapi-mini-cart` feature flag is unaffected.

**`plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.json`:**
- Declared `"style": ["wc-blocks-style", "wc-blocks-style-mini-cart", "wc-blocks-packages-style"]` and `"editorStyle": "wc-blocks-editor-style"`, replicating the handles previously returned from PHP.

**`MiniCartContents.php`:**
- Same pattern as MiniCart above: added trait, moved `register_style('wc-blocks-style-mini-cart-contents', ...)` into `initialize()`, removed `get_block_type_style()`. Script override is preserved (it nulls the script because the frontend script is a lazy-loaded dependency of the MiniCart block itself).
- Added `: void` return type to the new `initialize()` method to satisfy PHPStan.

**`mini-cart/mini-cart-contents/block.json`:**
- Declared `style` and `editorStyle` handles matching what was previously returned from PHP.

**11 MiniCart AbstractInnerBlock classes** (`MiniCartCartButtonBlock`, `MiniCartCheckoutButtonBlock`, `MiniCartFooterBlock`, `MiniCartItemsBlock`, `MiniCartProductsTableBlock`, `MiniCartShoppingButtonBlock`, `MiniCartTitleBlock`, `MiniCartTitleItemsCounterBlock`, `MiniCartTitleLabelBlock`, `EmptyMiniCartContentsBlock`, `FilledMiniCartContentsBlock`):
- Added `use EnableBlockJsonAssetsTrait;` to each class. This makes `get_block_type_editor_style()` return `null`, so the fixed `AbstractInnerBlock::register_block_type()` no longer passes it as a PHP override and block.json's `editorStyle` takes effect.

**11 MiniCart inner-block `block.json` files:**
- Added `"editorStyle": "wc-blocks-editor-style"` to each. No `style` field needed — inner blocks have no frontend CSS of their own.

**`CartLink.php`:**
- Added `use EnableBlockJsonAssetsTrait;` and removed the explicit `get_block_type_script() { return null; }` override (the trait provides the same behavior).

**`cart-link/block.json`:**
- Declared `"style": ["wc-blocks-style", "wc-blocks-style-cart-link"]` and `"editorStyle": "wc-blocks-editor-style"`.

Closes #65929 (partial — this covers MiniCart + CartLink families; Cart, Checkout, Filters, and remaining families follow in subsequent PRs).

### Screenshots or screen recordings:

Not applicable — no visual changes; this is a pure asset-registration path change. Functionality and output are unchanged.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with a block theme (e.g., Twenty Twenty-Four).
2. Add the Mini-Cart block to the site header via the Site Editor.
3. Open DevTools → Network tab, filter by `.css`. On any frontend page containing the Mini-Cart block, confirm all expected style handles are loaded:
   - `wc-blocks-style`
   - `wc-blocks-style-mini-cart`
   - `wc-blocks-packages-style`
4. Confirm the Mini-Cart renders correctly on the frontend — icon, price, badge, and drawer open/close all work.
5. Open the Site Editor and inspect the Mini-Cart block in the editor. Confirm `wc-blocks-editor-style` is loaded and the block renders with correct editor styles.
6. Add the Cart Link block to a page. Confirm it renders on the frontend and in the editor.
7. Open the Mini-Cart drawer on the frontend — verify all inner blocks (products table, footer, buttons, title) render and style correctly.
8. Check the browser console for any CSS 404 errors or JS warnings.

### Testing that has already taken place:

- PHP linting (`phpcs-changed` via `lint:php:changes`) passes with no errors.
- Branch-level PHP and JS lint (`lint:changes:branch`) passes clean.
- PHPStan analysis on all 15 modified PHP files reports no errors.
- A previously baselined PHPStan error for `AbstractInnerBlock` covering the old array shape `{style: null, api_version?: int}` has been removed from the baseline since that code path no longer exists.
- The migration follows the identical pattern already in production for `AddToCartForm`, `SingleProduct`, `CatalogSorting`, `ProductGallery`, and 14 other blocks.

### Milestone

- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [x] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Migrate MiniCart, MiniCartContents, CartLink, and their inner blocks to declare assets in block.json and adopt EnableBlockJsonAssetsTrait, removing legacy PHP-side asset override methods.

</details>