### PR TITLE
Remove required nvm dependency from compare-perf tool

### DIFF
--- a/tools/compare-perf/performance.js
+++ b/tools/compare-perf/performance.js
@@ -26,6 +26,29 @@ const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
 
 /**
+ * Wraps a setup/build command so it runs under bash and, when nvm happens to be
+ * installed, aligns Node with the checked-out ref's `.nvmrc`.
+ *
+ * nvm is no longer required: refs built here pin their Node version through
+ * pnpm's `useNodeVersion` setting (pnpm-workspace.yaml), so pnpm provisions and
+ * uses the correct runtime for every pnpm invocation on its own. Sourcing nvm is
+ * kept only as a best-effort fallback for older refs that predate
+ * `useNodeVersion`, and is skipped silently when nvm isn't present so the tool
+ * works without it. The first `npm`/`pnpm` call still needs a base Node on PATH,
+ * which the caller's environment provides (in CI via actions/setup-node).
+ *
+ * @param {string} command Setup/build command to run.
+ *
+ * @return {string} A `bash -c` invocation wrapping the command.
+ */
+function withNodeVersion( command ) {
+	const alignNodeWithNvm =
+		'{ [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh" && nvm install > /dev/null 2>&1; } || true';
+
+	return `bash -c '${ alignNodeWithNvm } && ${ command }'`;
+}
+
+/**
  * @typedef WPPerformanceCommandOptions
  *
  * @property {boolean=} ci               Run on CI.
@@ -187,9 +210,7 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && ${ config.getSetupTestRunner(
-			testRunnerDir
-		) }"`,
+		withNodeVersion( config.getSetupTestRunner( testRunnerDir ) ),
 		testRunnerDir
 	);
 
@@ -230,9 +251,7 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Installing dependencies and building' );
 		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && ${ config.getSetupCommand(
-				buildDir
-			) }"`,
+			withNodeVersion( config.getSetupCommand( buildDir ) ),
 			buildDir
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes #62695.

Completes the remaining work for "Remove NVM Dependency" (acceptance criteria 2 and 3). The documentation updates and the Blocks build admin notice were already handled in PR 65850, so this PR only covers the one code path that still hard-required nvm.

`tools/compare-perf/performance.js` wrapped its per-ref setup/build commands in `bash -c "source $HOME/.nvm/nvm.sh && nvm install && <command>"`. That made nvm a hard requirement: on a machine without nvm, `source $HOME/.nvm/nvm.sh` fails and the whole benchmark setup aborts.

Since pnpm 10.14+, the `useNodeVersion` setting in `pnpm-workspace.yaml` (currently `24.15.0`) makes pnpm auto-provision the pinned Node runtime and prepend it to `$PATH` for every `pnpm` invocation, so aligning Node with `nvm install` before the pnpm setup/build is redundant for any ref that has `useNodeVersion` set.

This PR introduces a small `withNodeVersion()` helper that:

-   Relies on pnpm's `useNodeVersion` to select the correct Node for each benchmarked ref (the modern, default path).
-   Keeps sourcing nvm only as a best-effort fallback for older refs that predate `useNodeVersion` (added 2026-04-15), and **skips it silently when nvm is not installed**, so the tool no longer fails without nvm.
-   Preserves the `bash -c` wrapper, which is still needed because the setup/build commands use bash-specific `&>` redirects that are not portable to `/bin/sh` (dash) on Linux runners.

#### Audit summary

Grepped the whole repo (excluding `node_modules`/`vendor`) for `nvm`, `.nvmrc`, `use-node-version`, `useNodeVersion`, `setup-node`, and `node-version`:

-   **CI `actions/setup-node` with `node-version-file: .nvmrc`** (`ci.yml`, `setup-woocommerce-monorepo/action.yml`, and four release/changelog workflows): **already fine, left unchanged.** These provide the base Node that pnpm bootstraps from and enable Node caching; they do not use nvm.
-   **`tools/compare-perf/performance.js`** (lines 190, 233): **the one offender — fixed here.**
-   Remaining `nvm` references are all in Markdown docs (READMEs, getting-started, e2e/email-editor guides), which are acceptance criterion 4 and out of scope for this PR.

No `package.json` script, `.github/workflows/scripts/*.sh`, or test-env setup script calls `nvm use`/`nvm install` before a pnpm command.

### How to test the changes in this Pull Request:

The compare-perf tool's full-benchmark path runs only locally; CI invokes it with `--skip-benchmarking` (see notes below), so the changed code does not run in CI.

1. **Confirm pnpm provisions the pinned Node regardless of system Node.** With a system Node that differs from the pin on `$PATH`, create a throwaway project:
   ```sh
   mkdir /tmp/pnpm-probe && cd /tmp/pnpm-probe
   printf 'useNodeVersion: 22.14.0\n' > pnpm-workspace.yaml
   printf '{"name":"probe","packageManager":"pnpm@10.33.0","scripts":{"v":"node -v"}}' > package.json
   node -v          # system Node, e.g. v24.15.0
   pnpm run v       # prints v22.14.0 (pnpm fetches/uses the pinned version)
   ```
2. **Confirm the tool no longer requires nvm.** On a machine (or shell) without `$HOME/.nvm/nvm.sh`, run a compare-perf benchmark between two refs:
   ```sh
   pnpm --filter=compare-perf run compare perf <ref-a> <ref-b>
   ```
   The "Installing dependencies and building" steps should complete (previously they aborted with a "No such file or directory" error on `$HOME/.nvm/nvm.sh`). A base Node must be on `$PATH` for the first `npm install -g pnpm` (provided by `actions/setup-node` in CI, or your shell locally).
3. **Confirm the fallback still works when nvm is present:** with nvm installed, the same command sources nvm and runs `nvm install` for older refs that lack `useNodeVersion`, exactly as before.

### Testing that has already taken place:

-   **pnpm `useNodeVersion` behavior:** With system Node `v24.15.0` on `$PATH`, a throwaway project pinned to `useNodeVersion: 22.14.0` ran `pnpm run` under `v22.14.0` — confirming pnpm selects the pinned runtime independent of the system Node. This is the mechanism the tool now relies on.
-   **Generated shell command:** Reproduced the exact string `withNodeVersion()` produces (via `/bin/sh -c "bash -c '…'"`, matching `child_process.exec`) against a command containing both a `&>` redirect and a double-quoted `--filter`. Verified:
    -   nvm **absent** (`HOME` with no `.nvm`): the `{ … } || true` guard skips nvm and the command still runs (exit 0); the `&>` redirect and double quotes survive the single-quoted `bash -c` wrapper.
    -   nvm **present** (stubbed `nvm.sh`): nvm is sourced, `nvm install` runs (suppressed), and the command runs (exit 0).
-   `node --check tools/compare-perf/performance.js` passes (syntax valid). Formatting follows the file's existing tabs / `( x )` / `${ x }` conventions.
-   **Could not run:** a full end-to-end `compare-perf` benchmark — it builds two refs, starts wp-env (Docker), and runs Playwright metrics (tens of minutes); not feasible in this environment. Full `eslint`/`prettier` was not run because root `node_modules` is not installed in this workspace.

#### Residual risk / note for a perf-tool owner

The changed code path runs only in **local full-benchmark** mode. In CI, `test:metrics:ci` → `.github/workflows/scripts/run-metrics.sh` benchmarks inline and calls compare-perf only with `--skip-benchmarking`, which returns early in `runPerformanceTests()` **before** reaching the changed setup/build code. The "Metrics" job is also marked `optional: true` (`plugins/woocommerce/package.json`), so a silent break there would not fail required CI — a green PR is **not** proof this path works. The verifications above target the changed code directly rather than relying on CI. A perf-tool owner who runs local compare-perf benchmarks against older refs is best placed to confirm the fallback behaves as expected on their setup.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Tooling-only change to the internal `tools/compare-perf` performance benchmarking tool. It does not touch any shipped plugin or published package, and `compare-perf` has no changelogger configuration, so no changelog entry is required.

</details>
