### PR TITLE
Fix parent review auto-approval when replying to unapproved reviews

### DIFF
--- a/plugins/woocommerce/changelog/65944-fix-36619-review-reply-auto-approve-parent
+++ b/plugins/woocommerce/changelog/65944-fix-36619-review-reply-auto-approve-parent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix parent review auto-approval when replying to an unapproved review from the admin product reviews screen.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -326,7 +326,7 @@ class Reviews {
 		if ( ! empty( $_POST['approve_parent'] ) ) {
 			$parent = get_comment( $comment_parent );
 
-			if ( $parent && '0' === $parent->comment_approved && $parent->comment_post_ID === $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			if ( $parent && '0' === $parent->comment_approved && (int) $parent->comment_post_ID === $comment_post_ID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				if ( ! current_user_can( 'edit_comment', $parent->comment_ID ) ) {
 					wp_die( -1 );
 				}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -10,6 +10,8 @@ use ReflectionException;
 use stdClass;
 use WC_Unit_Test_Case;
 use WP_Comment;
+use WPDieException;
+use WPAjaxDieContinueException;
 
 /**
  * Tests for the admin reviews handler.
@@ -595,6 +597,74 @@ test2</p></div>',
 	 */
 	public function test_get_reviews_page_url() : void {
 		$this->assertSame( 'http://' . WP_TESTS_DOMAIN . '/wp-admin/edit.php?post_type=product&page=product-reviews', Reviews::get_reviews_page_url() );
+	}
+
+	/**
+	 * @testdox `handle_reply_to_review` approves the parent review when replying to an unapproved review.
+	 *
+	 * @covers \Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews::handle_reply_to_review()
+	 *
+	 * @return void
+	 */
+	public function test_handle_reply_to_review_approves_unapproved_parent_review(): void {
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$product_id = $this->factory()->post->create(
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+
+		$parent_review_id = $this->factory()->comment->create(
+			array(
+				'comment_post_ID'  => $product_id,
+				'comment_type'     => 'review',
+				'comment_approved' => '0',
+			)
+		);
+
+		$nonce = wp_create_nonce( 'replyto-comment' );
+
+		$request = array(
+			'action'                      => 'replyto-comment',
+			'mode'                        => 'detail',
+			'_ajax_nonce-replyto-comment' => $nonce,
+			'comment_post_ID'             => $product_id,
+			'comment_ID'                  => $parent_review_id,
+			'content'                     => 'Thank you for your review!',
+			'comment_type'                => 'comment',
+			'approve_parent'              => 1,
+			'_wp_unfiltered_html_comment' => wp_create_nonce( 'unfiltered-html-comment' ),
+		);
+
+		$_POST    = $request;
+		$_REQUEST = array_merge( $_REQUEST, $request ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$reviews = wc_get_container()->get( Reviews::class );
+
+		try {
+			$reviews->handle_reply_to_review();
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		} catch ( WPDieException $e ) {
+			unset( $e );
+		} catch ( \Throwable $e ) {
+			// WP_Ajax_Response::send() may fail when headers are already sent in the test environment.
+			unset( $e );
+		}
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$parent = get_comment( $parent_review_id );
+
+		$this->assertSame( '1', $parent->comment_approved );
+
+		wp_set_current_user( 0 );
+		$_POST = array();
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Replying to an unapproved product review from the admin product reviews screen should also approve the parent review. The parent approval check compared `comment_post_ID` values with strict equality, but WordPress returns the parent comment's post ID as a string while the request value is cast to an integer. The comparison never matched, so the parent review stayed unapproved.

This change casts the parent comment post ID to an integer before comparing it to the request value, matching the intent of the existing approval logic.

Closes #36619.

(For Bug Fixes) Bug introduced in PR #34019.

### Screenshots or screen recordings:

N/A — backend admin AJAX behavior only.

### How to test the changes in this Pull Request:

1. In wp-admin, go to **Products > Reviews**.
2. Find or create an unapproved product review.
3. Reply to that review and submit the reply.
4. Confirm the parent review status changes to **Approved** after the reply is saved.

### Testing that has already taken place:

- PHPUnit: `ReviewsTest::test_handle_reply_to_review_approves_unapproved_parent_review`
- Verified the test fails without the cast and passes with it
- PHP lint on changed files
- PHPStan on `Reviews.php`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix parent review auto-approval when replying to an unapproved review from the admin product reviews screen.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)