### PR TITLE
fix: prevent Brand Nav widget from poisoning shared subcategory cache

### DIFF
--- a/plugins/woocommerce/changelog/fix-65832-brand-nav-cache-poisoning
+++ b/plugins/woocommerce/changelog/fix-65832-brand-nav-cache-poisoning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent Brand Nav widget from poisoning shared product subcategory cache.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3118,7 +3118,7 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 			/**
 			 * Filters the arguments used to retrieve product subcategories.
 			 *
-			 * @since 11.0.0
+			 * @since 11.1.0
 			 *
 			 * @param array $args Array of arguments for get_categories().
 			 */

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3135,7 +3135,7 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 
 			$product_categories = get_categories( $args );
 
-			if ( $cache_key && ! empty( $args['taxonomy'] ) ) {
+			if ( $cache_key && is_array( $args ) && ! empty( $args['taxonomy'] ) ) {
 				wp_cache_set( $cache_key, $product_categories, 'product_cat' );
 			}
 		}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3115,20 +3115,27 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 
 		if ( false === $product_categories ) {
 			// NOTE: using child_of instead of parent - this is not ideal but due to a WP bug ( https://core.trac.wordpress.org/ticket/15626 ) pad_counts won't work.
-			$product_categories = get_categories(
-				apply_filters(
-					'woocommerce_product_subcategories_args',
-					array(
-						'parent'       => $parent_id,
-						'hide_empty'   => 0,
-						'hierarchical' => 1,
-						'taxonomy'     => 'product_cat',
-						'pad_counts'   => 1,
-					)
+			/**
+			 * Filters the arguments used to retrieve product subcategories.
+			 *
+			 * @since 11.0.0
+			 *
+			 * @param array $args Array of arguments for get_categories().
+			 */
+			$args = apply_filters(
+				'woocommerce_product_subcategories_args',
+				array(
+					'parent'       => $parent_id,
+					'hide_empty'   => 0,
+					'hierarchical' => 1,
+					'taxonomy'     => 'product_cat',
+					'pad_counts'   => 1,
 				)
 			);
 
-			if ( $cache_key ) {
+			$product_categories = get_categories( $args );
+
+			if ( $cache_key && ! empty( $args['taxonomy'] ) ) {
 				wp_cache_set( $cache_key, $product_categories, 'product_cat' );
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -15,6 +15,9 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 	 */
 	private function create_category_tree(): int {
 		$parent = wp_insert_term( 'Test Parent', 'product_cat' );
+		if ( is_wp_error( $parent ) ) {
+			throw new \RuntimeException( esc_html( $parent->get_error_message() ) );
+		}
 		$parent_id = $parent['term_id'];
 
 		update_term_meta( $parent_id, 'display_type', 'both' );
@@ -25,6 +28,9 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 				'product_cat',
 				array( 'parent' => $parent_id )
 			);
+			if ( is_wp_error( $child ) ) {
+				throw new \RuntimeException( esc_html( $child->get_error_message() ) );
+			}
 
 			$product = \WC_Helper_Product::create_simple_product();
 			$product->set_category_ids( array( $child['term_id'] ) );
@@ -79,13 +85,11 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$parent_id = $this->create_category_tree();
 		$cache_key = 'product-category-hierarchy-' . $parent_id;
 
-		add_filter(
-			'woocommerce_product_subcategories_args',
-			function ( $args ) {
-				$args['taxonomy'] = '';
-				return $args;
-			}
-		);
+		$filter = function ( $args ) {
+			$args['taxonomy'] = '';
+			return $args;
+		};
+		add_filter( 'woocommerce_product_subcategories_args', $filter );
 
 		$result = woocommerce_get_product_subcategories( $parent_id );
 
@@ -93,6 +97,8 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
 		// Result should be empty too (query with empty taxonomy returns nothing).
 		$this->assertEmpty( $result );
+
+		remove_filter( 'woocommerce_product_subcategories_args', $filter );
 	}
 
 	/**
@@ -102,18 +108,18 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$parent_id = $this->create_category_tree();
 		$cache_key = 'product-category-hierarchy-' . $parent_id;
 
-		add_filter(
-			'woocommerce_product_subcategories_args',
-			function ( $args ) {
-				unset( $args['taxonomy'] );
-				return $args;
-			}
-		);
+		$filter = function ( $args ) {
+			unset( $args['taxonomy'] );
+			return $args;
+		};
+		add_filter( 'woocommerce_product_subcategories_args', $filter );
 
 		woocommerce_get_product_subcategories( $parent_id );
 
 		// Cache should remain empty because taxonomy was removed.
 		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
+
+		remove_filter( 'woocommerce_product_subcategories_args', $filter );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -1,0 +1,142 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for wc-template-functions.php.
+ *
+ * @package WooCommerce\Tests\Includes
+ */
+class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
+
+	/**
+	 * Helper: create a parent product category with child categories and products.
+	 *
+	 * @return int Parent category term ID.
+	 */
+	private function create_category_tree(): int {
+		$parent = wp_insert_term( 'Test Parent', 'product_cat' );
+		$parent_id = $parent['term_id'];
+
+		update_term_meta( $parent_id, 'display_type', 'both' );
+
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$child = wp_insert_term(
+				"Test Child $i",
+				'product_cat',
+				array( 'parent' => $parent_id )
+			);
+
+			$product = \WC_Helper_Product::create_simple_product();
+			$product->set_category_ids( array( $child['term_id'] ) );
+			$product->save();
+		}
+
+		wp_update_term_count_now(
+			get_terms(
+				array(
+					'taxonomy'   => 'product_cat',
+					'fields'     => 'ids',
+					'hide_empty' => 0,
+				)
+			),
+			'product_cat'
+		);
+
+		return $parent_id;
+	}
+
+	/**
+	 * Clean up cache between tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		wp_cache_flush();
+	}
+
+	/**
+	 * @testdox woocommerce_get_product_subcategories caches results under the expected key.
+	 */
+	public function test_subcategories_are_cached_under_expected_key(): void {
+		$parent_id = $this->create_category_tree();
+		$cache_key = 'product-category-hierarchy-' . $parent_id;
+
+		// Cache should be empty before the call.
+		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
+
+		$result = woocommerce_get_product_subcategories( $parent_id );
+
+		// Cache should be populated after the call.
+		$cached = wp_cache_get( $cache_key, 'product_cat' );
+		$this->assertNotFalse( $cached );
+		$this->assertCount( 3, $cached );
+		$this->assertSame( $result, $cached );
+	}
+
+	/**
+	 * @testdox woocommerce_get_product_subcategories does not cache when taxonomy is cleared by filter.
+	 */
+	public function test_cache_is_skipped_when_taxonomy_is_cleared(): void {
+		$parent_id = $this->create_category_tree();
+		$cache_key = 'product-category-hierarchy-' . $parent_id;
+
+		add_filter(
+			'woocommerce_product_subcategories_args',
+			function ( $args ) {
+				$args['taxonomy'] = '';
+				return $args;
+			}
+		);
+
+		$result = woocommerce_get_product_subcategories( $parent_id );
+
+		// Cache should remain empty because taxonomy was cleared.
+		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
+		// Result should be empty too (query with empty taxonomy returns nothing).
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * @testdox woocommerce_get_product_subcategories does not cache when taxonomy is missing after filter.
+	 */
+	public function test_cache_is_skipped_when_taxonomy_is_missing(): void {
+		$parent_id = $this->create_category_tree();
+		$cache_key = 'product-category-hierarchy-' . $parent_id;
+
+		add_filter(
+			'woocommerce_product_subcategories_args',
+			function ( $args ) {
+				unset( $args['taxonomy'] );
+				return $args;
+			}
+		);
+
+		woocommerce_get_product_subcategories( $parent_id );
+
+		// Cache should remain empty because taxonomy was removed.
+		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
+	}
+
+	/**
+	 * @testdox woocommerce_get_product_subcategories caches normally after filter is removed.
+	 */
+	public function test_cache_works_normally_after_filter_removed(): void {
+		$parent_id = $this->create_category_tree();
+		$cache_key = 'product-category-hierarchy-' . $parent_id;
+
+		// First call with filter that clears taxonomy.
+		$filter = function ( $args ) {
+			$args['taxonomy'] = '';
+			return $args;
+		};
+		add_filter( 'woocommerce_product_subcategories_args', $filter );
+		woocommerce_get_product_subcategories( $parent_id );
+		$this->assertFalse( wp_cache_get( $cache_key, 'product_cat' ) );
+		remove_filter( 'woocommerce_product_subcategories_args', $filter );
+
+		// Second call without filter should cache normally.
+		$result = woocommerce_get_product_subcategories( $parent_id );
+		$cached = wp_cache_get( $cache_key, 'product_cat' );
+		$this->assertNotFalse( $cached );
+		$this->assertCount( 3, $cached );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #65832.

Bug introduced in PR #50165 (Brands merge into core).

`WC_Widget_Brand_Nav::filter_out_cats()` hooks `woocommerce_product_subcategories_args` and returns `array( 'taxonomy' => '' )` when `filter_product_brand` is in the URL. The empty-taxonomy query returns zero rows, and those zero rows get cached under the same key used by non-brand-filtered requests. Every subsequent visitor to that category archive — with or without the brand filter — reads the poisoned cache and sees no subcategories.

The fix: only cache when taxonomy is non-empty. An empty taxonomy query never produces a meaningful result, so storing it poisons the shared cache for no benefit.

To reproduce before the fix:

```bash
wp eval '
  $p = wp_insert_term("Parent", "product_cat");
  update_term_meta($p["term_id"], "display_type", "both");
  for ($i = 1; $i <= 4; $i++) {
    $c = wp_insert_term("Sub $i", "product_cat", ["parent" => $p["term_id"]]);
    $pid = wp_insert_post(["post_title" => "p-$i", "post_status" => "publish", "post_type" => "product"]);
    wp_set_object_terms($pid, [$c["term_id"]], "product_cat");
  }
  wp_update_term_count_now(get_terms(["taxonomy" => "product_cat", "fields" => "ids", "hide_empty" => 0]), "product_cat");
  update_option("wc_bug_parent_id", $p["term_id"]);
'

wp cache flush
# Visit /product-category/parent/?filter_product_brand= (triggers the poisoned cache write)
wp eval 'var_export(wp_cache_get("product-category-hierarchy-" . get_option("wc_bug_parent_id"), "product_cat"));'
# → array () — poisoned

# Visit /product-category/parent/ (no brand filter)
# → Subcategories hidden despite existing in DB
```

### Screenshots or screen recordings:

N/A — no UI changes.

### How to test the changes in this Pull Request:

1. Create a product category with subcategories that have products attached.
2. Visit that category archive with `?filter_product_brand=` in the URL (as the Brand Nav widget would produce).
3. Check the cache key `product-category-hierarchy-{parent_id}` — it should remain empty.
4. Visit the same category archive without the brand filter — subcategories should display normally.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Template_Functions_Tests` — the new test should pass.

### Testing that has already taken place:

- PHP lint (phpcs-changed): clean
- PHPStan: no errors
- Added 4 PHPUnit test methods covering baseline caching, cache skip with empty taxonomy, cache skip with missing taxonomy, and cache recovery after filter is removed

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

**Changelog Entry Details**

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Prevent Brand Nav widget from poisoning shared product subcategory cache.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
