### PR TITLE
Fix My Account endpoint titles with a non-empty cart in block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-endpoint-title-cart
+++ b/plugins/woocommerce/changelog/fix-orders-endpoint-title-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix My Account endpoint page titles showing the page title instead of the endpoint heading (e.g. "Orders") in block themes when the cart is not empty.

--- a/plugins/woocommerce/includes/wc-page-functions.php
+++ b/plugins/woocommerce/includes/wc-page-functions.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Replace a page title with the endpoint title.
  *
  * @param  string $title   Post title.
- * @param  int    $post_id Optional. The post ID the title belongs to. Passed by the `the_title` filter.
+ * @param  int    $post_id Optional. The post ID the title belongs to. Passed by the `the_title` filter. Defaults to 0 for backwards compatibility with callers that pass only the title, in which case the queried-object check is skipped (matching the original single-argument behaviour).
  * @return string
  */
 function wc_page_endpoint_title( $title, $post_id = 0 ) {

--- a/plugins/woocommerce/includes/wc-page-functions.php
+++ b/plugins/woocommerce/includes/wc-page-functions.php
@@ -13,13 +13,18 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Replace a page title with the endpoint title.
  *
- * @param  string $title Post title.
+ * @param  string $title   Post title.
+ * @param  int    $post_id Optional. The post ID the title belongs to. Passed by the `the_title` filter.
  * @return string
  */
-function wc_page_endpoint_title( $title ) {
+function wc_page_endpoint_title( $title, $post_id = 0 ) {
 	global $wp_query;
 
-	if ( ! is_null( $wp_query ) && ! is_admin() && is_main_query() && in_the_loop() && is_page() && is_wc_endpoint_url() ) {
+	// In block themes the whole template (header, footer, content) renders inside the main
+	// loop, so `the_title` fires for any post title rendered on the page (e.g. a product in a
+	// server-rendered mini-cart) - not just the page's own heading. Only replace the title of
+	// the queried page so an earlier title doesn't consume this one-shot filter.
+	if ( ! is_null( $wp_query ) && ! is_admin() && is_main_query() && in_the_loop() && is_page() && is_wc_endpoint_url() && ( ! $post_id || get_queried_object_id() === $post_id ) ) {
 		$endpoint       = WC()->query->get_current_endpoint();
 		$action         = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
 		$endpoint_title = WC()->query->get_endpoint_title( $endpoint, $action );
@@ -31,7 +36,7 @@ function wc_page_endpoint_title( $title ) {
 	return $title;
 }
 
-add_filter( 'the_title', 'wc_page_endpoint_title' );
+add_filter( 'the_title', 'wc_page_endpoint_title', 10, 2 );
 
 /**
  * Replace the title part of the document title.

--- a/plugins/woocommerce/tests/legacy/unit-tests/page-functions/class-wc-tests-page-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/page-functions/class-wc-tests-page-functions.php
@@ -43,4 +43,76 @@ class WC_Tests_Page_Functions extends WC_Unit_Test_Case {
 		$url = wc_get_endpoint_url( 'customer-logout', '', 'https://' . WP_TESTS_DOMAIN . '/' );
 		$this->assertEquals( 'https://' . WP_TESTS_DOMAIN . '/customer-logout', $url );
 	}
+
+	/**
+	 * Reset the query globals mutated by the endpoint-title tests and restore the filter
+	 * that wc_page_endpoint_title() removes from `the_title` once it matches.
+	 */
+	public function tearDown(): void {
+		global $wp, $wp_query, $wp_the_query, $post;
+		$wp           = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query     = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_the_query = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post         = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		delete_option( 'woocommerce_myaccount_page_id' );
+		add_filter( 'the_title', 'wc_page_endpoint_title', 10, 2 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Set up the globals for a My Account "orders" endpoint request rendered inside the main
+	 * loop, so the conditional tags wc_page_endpoint_title() relies on are all genuinely true.
+	 *
+	 * @return int The My Account page ID, which is also the queried object.
+	 */
+	private function set_up_orders_endpoint_in_loop() {
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'My account',
+				'post_name'   => 'my-account',
+			)
+		);
+		update_option( 'woocommerce_myaccount_page_id', $page_id );
+
+		global $post, $wp, $wp_query, $wp_the_query;
+		$post = get_post( $page_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$wp             = new stdClass(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp->query_vars = array( 'orders' => '' );
+
+		$wp_query                    = new WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query->is_page           = true;
+		$wp_query->in_the_loop       = true;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $page_id;
+		$wp_the_query                = $wp_query; // is_main_query() compares against this. phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $page_id;
+	}
+
+	/**
+	 * @testdox wc_page_endpoint_title() replaces the queried page's title with the endpoint title.
+	 */
+	public function test_wc_page_endpoint_title_replaces_queried_page_title() {
+		$page_id = $this->set_up_orders_endpoint_in_loop();
+
+		$this->assertSame( 'Orders', wc_page_endpoint_title( 'My account', $page_id ) );
+	}
+
+	/**
+	 * @testdox wc_page_endpoint_title() leaves titles of other posts untouched so an earlier title does not consume the one-shot the_title filter before the page heading renders.
+	 */
+	public function test_wc_page_endpoint_title_ignores_non_queried_titles() {
+		$this->set_up_orders_endpoint_in_loop();
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->assertSame(
+			$product->get_name(),
+			wc_page_endpoint_title( $product->get_name(), $product->get_id() ),
+			'A title belonging to another post (e.g. a product in a server-rendered mini-cart) must not be replaced with the endpoint title.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/page-functions/class-wc-tests-page-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/page-functions/class-wc-tests-page-functions.php
@@ -88,7 +88,7 @@ class WC_Tests_Page_Functions extends WC_Unit_Test_Case {
 		$wp_query->in_the_loop       = true;
 		$wp_query->queried_object    = $post;
 		$wp_query->queried_object_id = $page_id;
-		$wp_the_query                = $wp_query; // is_main_query() compares against this. phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_the_query                = $wp_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- is_main_query() compares against this.
 
 		return $page_id;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Found in my own testing. 

In block themes WordPress renders the whole template (header, content, footer) inside the main loop, so the `the_title` filter that swaps in My Account endpoint headings (Orders, Downloads, etc.) fires for *every* title on the page — not just the page's own heading. 

When the cart isn't empty, a product title rendered before the heading (e.g. a server-rendered mini-cart line) consumes the one-off heading filter. So My Account headings are no longer changed.

This PR makes the filter more specific by comparing post IDs to avoid trying to change other titles.

### How to test the changes in this Pull Request:

1. While logged in with no items in the cart, go to the My Account page.
2. Navigate between Dashboard / Orders / Downloads and confirm the page heading updates for each endpoint.
3. Add something to the cart and repeat step 2. Confirm the headings still update correctly.

### Testing that has already taken place:

Reproduced and verified the fix locally on a block theme (Twenty Twenty-Three): with an item in the cart the Orders heading rendered as "My account" before the fix and correctly as "Orders" after, while the non-endpoint Dashboard page still shows "My account". PHPStan passes on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)