### PR TITLE
Remove the flux team from review assignment and code ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-performance-issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-performance-issue-report.yml
@@ -1,7 +1,7 @@
 name: 🔧 Performance issue report
 description: Report a performance issue if something isn't performing well in WooCommerce Core.
 title: "[Performance]: "
-labels: [ "Enhancement", "Performance", "team: Flux"]
+labels: [ "Enhancement", "Performance"]
 projects: ["woocommerce/220"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/3-performance-issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-performance-issue-report.yml
@@ -2,7 +2,6 @@ name: 🔧 Performance issue report
 description: Report a performance issue if something isn't performing well in WooCommerce Core.
 title: "[Performance]: "
 labels: [ "Enhancement", "Performance"]
-projects: ["woocommerce/220"]
 body:
   - type: markdown
     attributes:

--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -17,14 +17,6 @@ when:
         - woo-fse
   - author:
       teamIs:
-        - flux
-      ignore:
-        nameIs:
-    assign:
-      teams:
-        - flux
-  - author:
-      teamIs:
         - ballade
       ignore:
         nameIs:

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,22 +1,22 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
 #
-# TODO: The paths below previously routed community PR reviews to `team: flux`
-# (team removed) and need a replacement reviewer team:
-#   "*"  (catch-all default)
-#   ".github/**/*"
-#   "bin/*"
-#   "packages/js/api/**/*"
-#   "packages/js/dependency-extraction-webpack-plugin/**/*"
-#   "packages/js/eslint-plugin/**/*"
-#   "packages/js/tracks/**/*"
-#   "plugins/woocommerce/**/*"
-#   "plugins/woocommerce-beta-tester/**/*"
-#   "tools/**/*"
-#   "**/composer.json"
-#   "**/package.json"
+# nerrad is the interim reviewer for the paths formerly owned by the flux team
+# (removed), pending a replacement team.
+
+"*":
+  - nerrad
+
+".github/**/*":
+  - nerrad
+
+"bin/*":
+  - nerrad
 
 "docs/**/*":
   - team: developer-advocacy
+
+"packages/js/api/**/*":
+  - nerrad
 
 "packages/js/components/**/*":
   - team: woo-fse
@@ -36,6 +36,12 @@
 "packages/js/date/**/*":
   - team: rubik
 
+"packages/js/dependency-extraction-webpack-plugin/**/*":
+  - nerrad
+
+"packages/js/eslint-plugin/**/*":
+  - nerrad
+
 "packages/js/experimental/**/*":
   - team: woo-fse
 
@@ -51,11 +57,17 @@
 "packages/js/onboarding/**/*":
   - team: rubik
 
+"packages/js/tracks/**/*":
+  - nerrad
+
 "packages/js/email-editor/**/*":
   - team: ballade
 
 "packages/php/email-editor/**/*":
   - team: ballade
+
+"plugins/woocommerce/**/*":
+  - nerrad
 
 "plugins/woocommerce/templates/**/*":
   - team: rubik
@@ -85,8 +97,20 @@
   - team: rubik
   - team: woo-fse
 
+"plugins/woocommerce-beta-tester/**/*":
+  - nerrad
+
 "plugins/woocommerce/src/Internal/EmailEditor/**/*":
   - team: ballade
 
 "plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/**/*":
   - team: ballade
+
+"tools/**/*":
+  - nerrad
+
+'**/composer.json':
+  - nerrad
+
+'**/package.json':
+  - nerrad

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,19 +1,22 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
-
-"*":
-  - team: flux
-
-".github/**/*":
-  - team: flux
-
-"bin/*":
-  - team: flux
+#
+# TODO: The paths below previously routed community PR reviews to `team: flux`
+# (team removed) and need a replacement reviewer team:
+#   "*"  (catch-all default)
+#   ".github/**/*"
+#   "bin/*"
+#   "packages/js/api/**/*"
+#   "packages/js/dependency-extraction-webpack-plugin/**/*"
+#   "packages/js/eslint-plugin/**/*"
+#   "packages/js/tracks/**/*"
+#   "plugins/woocommerce/**/*"
+#   "plugins/woocommerce-beta-tester/**/*"
+#   "tools/**/*"
+#   "**/composer.json"
+#   "**/package.json"
 
 "docs/**/*":
   - team: developer-advocacy
-
-"packages/js/api/**/*":
-  - team: flux
 
 "packages/js/components/**/*":
   - team: woo-fse
@@ -33,12 +36,6 @@
 "packages/js/date/**/*":
   - team: rubik
 
-"packages/js/dependency-extraction-webpack-plugin/**/*":
-  - team: flux
-
-"packages/js/eslint-plugin/**/*":
-  - team: flux
-
 "packages/js/experimental/**/*":
   - team: woo-fse
 
@@ -54,17 +51,11 @@
 "packages/js/onboarding/**/*":
   - team: rubik
 
-"packages/js/tracks/**/*":
-  - team: flux
-
 "packages/js/email-editor/**/*":
   - team: ballade
 
 "packages/php/email-editor/**/*":
   - team: ballade
-
-"plugins/woocommerce/**/*":
-  - team: flux
 
 "plugins/woocommerce/templates/**/*":
   - team: rubik
@@ -94,20 +85,8 @@
   - team: rubik
   - team: woo-fse
 
-"plugins/woocommerce-beta-tester/**/*":
-  - team: flux
-
 "plugins/woocommerce/src/Internal/EmailEditor/**/*":
   - team: ballade
 
 "plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/**/*":
   - team: ballade
-
-"tools/**/*":
-  - team: flux
-
-'**/composer.json':
-  - team: flux
-
-'**/package.json':
-  - team: flux

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,21 @@
 # Monorepo CI and package managers manifests.
-/.github/ @woocommerce/flux
-**/composer.json @woocommerce/flux
-**/package.json @woocommerce/flux
+# TODO: Reassign owner; previously @woocommerce/flux (team removed).
+/.github/
+**/composer.json
+**/package.json
 
 # Monorepo tooling folders.
-/bin/ @woocommerce/flux
-/tools/ @woocommerce/flux
-/packages/js/eslint-plugin/ @woocommerce/flux
-/packages/js/dependency-extraction-webpack-plugin/ @woocommerce/flux
-/packages/js/e2e-utils-playwright/ @woocommerce/flux
+# TODO: Reassign owner; previously @woocommerce/flux (team removed).
+/bin/
+/tools/
+/packages/js/eslint-plugin/
+/packages/js/dependency-extraction-webpack-plugin/
+/packages/js/e2e-utils-playwright/
 
 # Files in root of repository
-/.* @woocommerce/flux
-/*.* @woocommerce/flux
+# TODO: Reassign owner for /.* and /*.*; previously @woocommerce/flux (team removed).
+/.*
+/*.*
 /changelog.txt
 /pnpm-lock.yaml
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,21 +1,18 @@
 # Monorepo CI and package managers manifests.
-# TODO: Reassign owner; previously @woocommerce/flux (team removed).
-/.github/
-**/composer.json
-**/package.json
+/.github/ @nerrad
+**/composer.json @nerrad
+**/package.json @nerrad
 
 # Monorepo tooling folders.
-# TODO: Reassign owner; previously @woocommerce/flux (team removed).
-/bin/
-/tools/
-/packages/js/eslint-plugin/
-/packages/js/dependency-extraction-webpack-plugin/
-/packages/js/e2e-utils-playwright/
+/bin/ @nerrad
+/tools/ @nerrad
+/packages/js/eslint-plugin/ @nerrad
+/packages/js/dependency-extraction-webpack-plugin/ @nerrad
+/packages/js/e2e-utils-playwright/ @nerrad
 
 # Files in root of repository
-# TODO: Reassign owner for /.* and /*.*; previously @woocommerce/flux (team removed).
-/.*
-/*.*
+/.* @nerrad
+/*.* @nerrad
 /changelog.txt
 /pnpm-lock.yaml
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The flux team is being deleted, so every reference that routed reviews, code ownership, or issue triage to it has been updated. The paths flux previously owned now point to `nerrad` (Darren) as the interim owner/reviewer, pending a replacement team.

-   **`CODEOWNERS`** — the CI/manifest, tooling, and root-file patterns formerly owned by flux now list `@nerrad`.
-   **`.github/project-community-pr-assigner.yml`** — the community-PR paths formerly routed to flux (the `"*"` catch-all, `plugins/woocommerce/**`, tooling/manifest paths, etc.) now route to `nerrad`. A header comment notes this is interim.
-   **`.github/automate-team-review-assignment-config.yml`** — the author-based flux self-assignment block is removed (no replacement needed; this rule is keyed on team membership and the team is going away).
-   **`.github/ISSUE_TEMPLATE/3-performance-issue-report.yml`** — the `team: Flux` label is removed from new performance issue reports.

The `nerrad` assignments are an interim stand-in for the removed team. One follow-up remains for a later change (not blocking this PR): deciding the longer-term replacement team for these paths, and whether new performance issues should carry a team label at all.

### How to test the changes in this Pull Request:

1.  Review the diff and confirm every path formerly routed to flux now points to `nerrad`, and no `flux`/`team: Flux` references remain (the only `flux` mention is the explanatory comment in the community assigner).
2.  Confirm `.github/project-community-pr-assigner.yml` and `.github/automate-team-review-assignment-config.yml` remain valid YAML and that every non-flux team mapping is untouched.
3.  Confirm `CODEOWNERS` still parses and the `@nerrad` entries are well-formed.
4.  Confirm `.github/ISSUE_TEMPLATE/3-performance-issue-report.yml` still has valid `labels:` (`Enhancement`, `Performance`).

### Testing that has already taken place:

-   Verified the net diff against `origin/trunk` is limited to flux to nerrad reassignments on the former-flux paths, the author-based block removal, and the issue-template label removal.
-   Verified no `flux`/`team: Flux` references remain in the changed files except the explanatory comment, and the branch carries no unrelated commits.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Repository meta only (`CODEOWNERS`, `.github/` review-assignment config, and an issue template). Nothing is shipped to merchants, so no changelog entry is required.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
