### PR TITLE
Add cart checkout template guidance

### DIFF
--- a/docs/theming/block-theme-development/cart-and-checkout.md
+++ b/docs/theming/block-theme-development/cart-and-checkout.md
@@ -9,6 +9,7 @@ sidebar_label: Cart and Checkout blocks theming
 > [!IMPORTANT]
 > We strongly discourage writing CSS code based on existing block class names and prioritize using global styles when possible. We especially discourage writing CSS selectors that rely on a specific block being a descendant of another one, as users can move blocks around freely, so they are prone to breaking. Similar to WordPress itself, we consider the HTML structure within components, blocks, and block templates to be "private", and subject to further change in the future, so using CSS to target the internals of a block or a block template is _not recommended or supported_.
 
+If your theme overrides `page-cart.html` or `page-checkout.html`, keep the Cart and Checkout blocks in the assigned page content and render that content from the template with `core/post-content`. See [Cart and Checkout page templates](/docs/theming/block-theme-development/theming-woo-blocks#cart-and-checkout-page-templates) for the recommended template structure.
 
 ## Buttons
 
@@ -81,6 +82,3 @@ By default, it uses a combination of black and white borders and shadows so it h
 ```
 
 ![Order summary screenshot with custom styles for the item quantity badge](https://user-images.githubusercontent.com/3616980/83863109-2e421c80-a723-11ea-9bf7-2033a96cf5b2.png)
-
-
-

--- a/docs/theming/block-theme-development/theming-woo-blocks.md
+++ b/docs/theming/block-theme-development/theming-woo-blocks.md
@@ -42,13 +42,27 @@ Block themes can customize those templates in the following ways:
 
 The `page-cart.html` and `page-checkout.html` templates should render the content from the assigned Cart and Checkout pages. Add layout, headers, footers, and other template-level content around the page content, but keep the Cart and Checkout blocks in the corresponding page content.
 
-WooCommerce's default templates use the `woocommerce/page-content-wrapper` block with `core/post-content` inside it:
+WooCommerce's default `page-cart.html` template uses the `woocommerce/page-content-wrapper` block with `woocommerce/store-notices`, `core/post-title`, and `core/post-content` inside it:
 
 ```html
 <!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-    <!-- wp:post-title {"align":"wide","level":1} /-->
+    <!-- wp:woocommerce/store-notices /-->
+    <!-- wp:post-title {"align":"wide", "level":1} /-->
+    <!-- wp:post-content {"align":"wide"} /-->
+</main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->
+```
+
+The default `page-checkout.html` template uses the same wrapper and store notices, but renders page content without a page title:
+
+```html
+<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:woocommerce/store-notices /-->
     <!-- wp:post-content {"align":"wide"} /-->
 </main>
 <!-- /wp:group -->

--- a/docs/theming/block-theme-development/theming-woo-blocks.md
+++ b/docs/theming/block-theme-development/theming-woo-blocks.md
@@ -38,6 +38,25 @@ Block themes can customize those templates in the following ways:
 - It's possible to create templates for specific products and taxonomies. For example, if the theme provides a template with file name of `single-product-cap.html`, that template will be used when rendering the product with slug `cap`. Similarly, themes can provide specific taxonomy templates: `taxonomy-product_cat-clothing.html` would be used in the product category with slug `clothing`.
 - Always keep in mind users can make modifications to the templates provided by the theme via the Site Editor.
 
+#### Cart and Checkout page templates
+
+The `page-cart.html` and `page-checkout.html` templates should render the content from the assigned Cart and Checkout pages. Add layout, headers, footers, and other template-level content around the page content, but keep the Cart and Checkout blocks in the corresponding page content.
+
+WooCommerce's default templates use the `woocommerce/page-content-wrapper` block with `core/post-content` inside it:
+
+```html
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:post-title {"align":"wide","level":1} /-->
+    <!-- wp:post-content {"align":"wide"} /-->
+</main>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->
+```
+
+Use the same pattern when overriding `page-cart.html` or `page-checkout.html` in a theme. Avoid placing `woocommerce/cart` or `woocommerce/checkout` directly in these template files as a replacement for `core/post-content`. If the template bypasses page content, the page editor can become out of sync with what shoppers see, and WooCommerce features that inspect the assigned page content may not detect the Cart or Checkout block correctly.
+
 ### Block template parts
 
 WooCommerce also comes with two specific [block template parts](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/templates/parts):


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds block theme documentation for overriding Cart and Checkout page templates.

It documents that themes with `page-cart.html` or `page-checkout.html` should keep the Cart and Checkout blocks in the assigned page content and render that content from the template with `core/post-content`, matching WooCommerce's default template structure.

It also links to that guidance from the Cart and Checkout blocks theming page.

Related: https://github.com/woocommerce/woocommerce/issues/65846

### Screenshots or screen recordings:

Not applicable. This is a documentation-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open `docs/theming/block-theme-development/theming-woo-blocks.md`.
2. Confirm the "Cart and Checkout page templates" section recommends rendering assigned page content with `core/post-content`.
3. Open `docs/theming/block-theme-development/cart-and-checkout.md` and confirm the link points to `/docs/theming/block-theme-development/theming-woo-blocks#cart-and-checkout-page-templates`.

<!-- End testing instructions -->

### Testing that has already taken place:

-   Ran `markdownlint --fix docs/theming/block-theme-development/theming-woo-blocks.md docs/theming/block-theme-development/cart-and-checkout.md`.
-   Ran `markdownlint docs/theming/block-theme-development/theming-woo-blocks.md docs/theming/block-theme-development/cart-and-checkout.md`.
-   Ran `git diff --check -- docs/theming/block-theme-development/theming-woo-blocks.md docs/theming/block-theme-development/cart-and-checkout.md`.
-   Ran `pnpm build` from `docs/_docu-tools`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details open>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation-only change; not shipped to merchants as a plugin/package change.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
