### PR TITLE
Fix Analytics "tz is not a function" crash from a moment.js plugin conflict

### DIFF
--- a/packages/js/date/changelog/fix-64020-moment-tz-clobber
+++ b/packages/js/date/changelog/fix-64020-moment-tz-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve the store timezone offset via date-fns-tz instead of moment-timezone's .tz() so Analytics no longer crashes with "tz is not a function" when a plugin replaces the global window.moment (#64020).

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -41,8 +41,8 @@
 		"@types/d3-time-format": "^2.3.4",
 		"@wordpress/date": "catalog:wp-min",
 		"@wordpress/i18n": "catalog:wp-min",
+		"date-fns-tz": "^3.2.0",
 		"moment": "^2.29.4",
-		"moment-timezone": "^0.5.43",
 		"qs": "^6.11.2"
 	},
 	"devDependencies": {

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -168,13 +168,21 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 }
 
 /**
+ * Reads the configured store time zone from `wcSettings`.
+ *
+ * @return {string | undefined} - IANA zone name or `±HH:mm` offset, if set.
+ */
+function getStoreTimeZoneSetting() {
+	return window.wcSettings?.timeZone || window.wcSettings?.admin?.timeZone;
+}
+
+/**
  * Gets the current time in the store time zone if set.
  *
  * @return {moment.Moment} - Moment object in the store time zone.
  */
 export function getStoreTimeZoneMoment() {
-	const timeZone =
-		window.wcSettings?.timeZone || window.wcSettings?.admin?.timeZone;
+	const timeZone = getStoreTimeZoneSetting();
 
 	if ( typeof timeZone !== 'string' || timeZone.length === 0 ) {
 		return moment();
@@ -196,6 +204,52 @@ export function getStoreTimeZoneMoment() {
 	}
 
 	return moment().utcOffset( offsetInMinutes );
+}
+
+/**
+ * Re-applies the store time zone's UTC offset for a moment's own date, keeping
+ * its wall-clock time. `getStoreTimeZoneMoment` resolves a named IANA zone's
+ * offset for "now", so a range boundary in a different DST period (e.g. last
+ * year/quarter) would otherwise be an hour off; this corrects each boundary
+ * against its own date. Fixed `±HH:mm` offsets and the no-zone case are
+ * returned unchanged (#64020).
+ *
+ * @param {moment.Moment} date - The moment to anchor.
+ * @return {moment.Moment} - The anchored moment.
+ */
+function anchorToStoreTimeZone( date: moment.Moment ) {
+	const timeZone = getStoreTimeZoneSetting();
+
+	if (
+		typeof timeZone !== 'string' ||
+		timeZone.length === 0 ||
+		[ '+', '-' ].includes( timeZone.charAt( 0 ) )
+	) {
+		return date;
+	}
+
+	const offsetInMinutes =
+		getTimezoneOffset( timeZone, date.toDate() ) / 60000;
+
+	return Number.isNaN( offsetInMinutes )
+		? date
+		: date.utcOffset( offsetInMinutes, true );
+}
+
+/**
+ * Anchors every boundary of a date range to the store time zone.
+ * See {@link anchorToStoreTimeZone}.
+ *
+ * @param {DateValue} range - The computed range.
+ * @return {DateValue} - The range with each boundary anchored.
+ */
+function anchorRangeToStoreTimeZone( range: DateValue ): DateValue {
+	return {
+		primaryStart: anchorToStoreTimeZone( range.primaryStart ),
+		primaryEnd: anchorToStoreTimeZone( range.primaryEnd ),
+		secondaryStart: anchorToStoreTimeZone( range.secondaryStart ),
+		secondaryEnd: anchorToStoreTimeZone( range.secondaryEnd ),
+	};
 }
 
 /**
@@ -241,12 +295,12 @@ export function getLastPeriod(
 		secondaryEnd = secondaryEnd.clone().endOf( 'month' );
 	}
 
-	return {
+	return anchorRangeToStoreTimeZone( {
 		primaryStart,
 		primaryEnd,
 		secondaryStart,
 		secondaryEnd,
-	};
+	} );
 }
 
 /**
@@ -279,12 +333,12 @@ export function getCurrentPeriod(
 			.add( daysSoFar + 1, 'days' )
 			.subtract( 1, 'seconds' );
 	}
-	return {
+	return anchorRangeToStoreTimeZone( {
 		primaryStart,
 		primaryEnd,
 		secondaryStart,
 		secondaryEnd,
-	};
+	} );
 }
 
 /**

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -173,6 +173,12 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
  * @return {string | undefined} - IANA zone name or `±HH:mm` offset, if set.
  */
 function getStoreTimeZoneSetting() {
+	// Optional chaining does not protect the free `window` reference, so guard
+	// it for non-browser environments before falling back to the local moment.
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
 	return window.wcSettings?.timeZone || window.wcSettings?.admin?.timeZone;
 }
 

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import momentTz from 'moment-timezone';
+import { getTimezoneOffset } from 'date-fns-tz';
 import { find, memoize } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { parse } from 'qs';
@@ -170,7 +170,7 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 /**
  * Gets the current time in the store time zone if set.
  *
- * @return {string} - Datetime string.
+ * @return {moment.Moment} - Moment object in the store time zone.
  */
 export function getStoreTimeZoneMoment() {
 	const timeZone =
@@ -184,7 +184,18 @@ export function getStoreTimeZoneMoment() {
 		return moment().utcOffset( timeZone );
 	}
 
-	return momentTz.tz( timeZone );
+	// Named IANA zone (e.g. `America/New_York`). Resolve the current UTC
+	// offset with `date-fns-tz` (which uses the browser `Intl` API) rather
+	// than `moment-timezone`'s `.tz()`: the admin build externalises
+	// `moment-timezone` to the global `window.moment`, so a plugin replacing
+	// `window.moment` strips `.tz` and crashes Analytics (#64020).
+	const offsetInMinutes = getTimezoneOffset( timeZone ) / 60000;
+
+	if ( Number.isNaN( offsetInMinutes ) ) {
+		return moment();
+	}
+
+	return moment().utcOffset( offsetInMinutes );
 }
 
 /**

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1137,6 +1137,29 @@ describe( 'getStoreTimeZoneMoment', () => {
 			momentProtoWithTz.tz = originalProtoTz;
 		}
 	} );
+
+	it( 'keeps named-zone range boundaries DST-correct across a transition (#64020)', () => {
+		// "Now" is summer (EDT, UTC-4); the previous-year range lands in
+		// winter (EST, UTC-5). A single "now" offset would leave the boundary
+		// an hour off, so each boundary is re-anchored against its own date.
+		jest.useFakeTimers().setSystemTime(
+			new Date( '2026-07-15T12:00:00Z' )
+		);
+		global.window.wcSettings = { timeZone: 'America/New_York' };
+
+		try {
+			const { primaryStart } = getLastPeriod( 'year', 'previous_period' );
+
+			// January is EST (-300) even though the current offset is EDT.
+			expect( primaryStart.utcOffset() ).toBe( -300 );
+			// Wall-clock midnight is preserved; only the offset is corrected.
+			expect( primaryStart.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2025-01-01T00:00:00'
+			);
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
 } );
 
 describe( 'getDateFormatsForIntervalPhp', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1148,14 +1148,61 @@ describe( 'getStoreTimeZoneMoment', () => {
 		global.window.wcSettings = { timeZone: 'America/New_York' };
 
 		try {
-			const { primaryStart } = getLastPeriod( 'year', 'previous_period' );
+			const { primaryStart, primaryEnd, secondaryStart, secondaryEnd } =
+				getLastPeriod( 'year', 'previous_period' );
 
-			// January is EST (-300) even though the current offset is EDT.
+			// Every boundary lands in winter (EST, -300) even though the
+			// current offset is EDT, and each is anchored against its own date
+			// (not "now"), with its wall-clock preserved.
 			expect( primaryStart.utcOffset() ).toBe( -300 );
-			// Wall-clock midnight is preserved; only the offset is corrected.
 			expect( primaryStart.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
 				'2025-01-01T00:00:00'
 			);
+			expect( primaryEnd.utcOffset() ).toBe( -300 );
+			expect( primaryEnd.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2025-12-31T23:59:59'
+			);
+			expect( secondaryStart.utcOffset() ).toBe( -300 );
+			expect( secondaryStart.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2024-01-01T00:00:00'
+			);
+			expect( secondaryEnd.utcOffset() ).toBe( -300 );
+			expect( secondaryEnd.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2024-12-31T23:59:59'
+			);
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'anchors getCurrentPeriod boundaries to their own dates across a DST transition (#64020)', () => {
+		// "Now" is summer (EDT, -240); the year-to-date range opens in winter
+		// (EST, -300). Each boundary must resolve its own date's offset, so a
+		// single "now" offset is not reused across the range. This also covers
+		// getCurrentPeriod, whose boundary math differs from getLastPeriod.
+		jest.useFakeTimers().setSystemTime(
+			new Date( '2026-07-15T12:00:00Z' )
+		);
+		global.window.wcSettings = { timeZone: 'America/New_York' };
+
+		try {
+			const { primaryStart, primaryEnd, secondaryStart, secondaryEnd } =
+				getCurrentPeriod( 'year', 'previous_year' );
+
+			// January is EST (-300); "now" in July is EDT (-240).
+			expect( primaryStart.utcOffset() ).toBe( -300 );
+			expect( primaryStart.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2026-01-01T00:00:00'
+			);
+			expect( primaryEnd.utcOffset() ).toBe( -240 );
+
+			// The previous-year comparison opens in winter and ends in summer,
+			// so its boundaries carry different offsets too.
+			expect( secondaryStart.utcOffset() ).toBe( -300 );
+			expect( secondaryStart.format( 'YYYY-MM-DDTHH:mm:ss' ) ).toBe(
+				'2025-01-01T00:00:00'
+			);
+			expect( secondaryEnd.utcOffset() ).toBe( -240 );
 		} finally {
 			jest.useRealTimers();
 		}

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1024,8 +1024,13 @@ describe( 'getChartTypeForQuery', () => {
 } );
 
 describe( 'getStoreTimeZoneMoment', () => {
+	const previousWcSettings = global.window.wcSettings;
+
 	afterEach( () => {
 		jest.restoreAllMocks();
+		// These tests mutate the global store settings; restore them so a
+		// leaked time zone cannot make later tests order-dependent.
+		global.window.wcSettings = previousWcSettings;
 	} );
 
 	it( 'should return the default moment when no timezone exists', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import moment from 'moment';
-import momentTz from 'moment-timezone';
 import { format as formatDate } from '@wordpress/date';
 import { timeFormat as d3TimeFormat } from 'd3-time-format';
 /**
@@ -40,13 +39,6 @@ declare global {
 		};
 	}
 }
-
-jest.mock( 'moment', () => {
-	const m = jest.requireActual( 'moment' );
-	m.prototype.tz = jest.fn().mockImplementation( () => m() );
-
-	return m;
-} );
 
 describe( 'appendTimestamp', () => {
 	it( 'should append `start` timestamp', () => {
@@ -1032,49 +1024,36 @@ describe( 'getChartTypeForQuery', () => {
 } );
 
 describe( 'getStoreTimeZoneMoment', () => {
-	let mockTz: jest.SpyInstance;
-	let utcOffset: jest.SpyInstance;
-
 	afterEach( () => {
-		mockTz?.mockRestore();
-		utcOffset?.mockRestore();
+		jest.restoreAllMocks();
 	} );
 
 	it( 'should return the default moment when no timezone exists', () => {
-		mockTz = jest.spyOn( momentTz, 'tz' );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
+		const utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
 
 		expect( getStoreTimeZoneMoment() ).toHaveProperty( '_isAMomentObject' );
 
-		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should use the timezone string when one is set', () => {
+	it( 'should resolve the offset for a named timezone', () => {
 		global.window.wcSettings = {
 			timeZone: 'Asia/Taipei',
 		};
 
-		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
-
-		getStoreTimeZoneMoment();
-
-		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
-		expect( utcOffset ).not.toHaveBeenCalled();
+		// Taipei is a fixed UTC+8 (no DST) => +480 minutes.
+		expect( getStoreTimeZoneMoment().utcOffset() ).toBe( 480 );
 	} );
 
 	it( 'should use the utc offset when it is set', () => {
+		const utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
+
 		global.window.wcSettings = {
 			timeZone: '+06:00',
 		};
 
-		mockTz = jest.spyOn( momentTz, 'tz' );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
-
 		getStoreTimeZoneMoment();
 
-		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '+06:00' );
 
 		global.window.wcSettings = {
@@ -1083,7 +1062,6 @@ describe( 'getStoreTimeZoneMoment', () => {
 
 		getStoreTimeZoneMoment();
 
-		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
 	} );
 
@@ -1094,72 +1072,69 @@ describe( 'getStoreTimeZoneMoment', () => {
 			},
 		};
 
-		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
-
-		getStoreTimeZoneMoment();
-
-		expect( mockTz ).toHaveBeenCalledWith( 'America/New_York' );
-		expect( utcOffset ).not.toHaveBeenCalled();
+		// New York is UTC-5 (EST) or UTC-4 (EDT) depending on the date.
+		expect( [ -300, -240 ] ).toContain(
+			getStoreTimeZoneMoment().utcOffset()
+		);
 	} );
 
 	it( 'should use wcSettings.admin.timeZone utc offset when wcSettings.timeZone is not set', () => {
+		const utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
+
 		global.window.wcSettings = {
 			admin: {
 				timeZone: '+05:00',
 			},
 		};
 
-		mockTz = jest.spyOn( momentTz, 'tz' );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
-
 		getStoreTimeZoneMoment();
 
-		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '+05:00' );
 	} );
 
 	it( 'should prefer wcSettings.timeZone over wcSettings.admin.timeZone', () => {
 		global.window.wcSettings = {
-			timeZone: 'Europe/London',
+			timeZone: 'Asia/Taipei',
 			admin: {
 				timeZone: 'America/New_York',
 			},
 		};
 
-		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
-		utcOffset = jest.spyOn( moment.prototype, 'utcOffset' );
-
-		getStoreTimeZoneMoment();
-
-		expect( mockTz ).toHaveBeenCalledWith( 'Europe/London' );
-		expect( utcOffset ).not.toHaveBeenCalled();
+		// Resolves Taipei (+480), not New York.
+		expect( getStoreTimeZoneMoment().utcOffset() ).toBe( 480 );
 	} );
 
-	it( 'should use momentTz.tz() static function, not moment().tz() instance method', () => {
-		// Regression test for plugin conflict where a third-party plugin
-		// clobbers window.moment, removing .tz() from new instances.
-		// The fix uses the bundled momentTz.tz() static function which
-		// operates on moment-timezone's closure reference, unaffected
-		// by the global being replaced.
+	it( 'should not rely on the clobberable window.moment.tz (regression for #64020)', () => {
+		// A third-party plugin can replace window.moment with a build that
+		// has no timezone data, removing the `.tz` method. Because the admin
+		// build externalises moment-timezone to window.moment, this used to
+		// crash getStoreTimeZoneMoment with `TypeError: tz is not a function`.
+		// The offset is now resolved via the browser Intl API, so the
+		// missing `.tz` no longer matters.
 		global.window.wcSettings = {
-			timeZone: 'Asia/Taipei',
+			timeZone: 'America/New_York',
 		};
 
-		// Remove .tz from prototype to simulate clobbered moment instances.
-		const originalTz = moment.prototype.tz;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- need to delete typed property to simulate clobbering
-		delete ( moment.prototype as any ).tz;
-
-		// Mock momentTz.tz since its internals also use the shared prototype in tests.
-		// In production, momentTz's closure holds the original moment with .tz intact.
-		mockTz = jest.spyOn( momentTz, 'tz' ).mockReturnValue( moment() );
+		const momentWithTz = moment as unknown as { tz?: unknown };
+		const momentProtoWithTz = moment.prototype as unknown as {
+			tz?: unknown;
+		};
+		const originalStaticTz = momentWithTz.tz;
+		const originalProtoTz = momentProtoWithTz.tz;
+		delete momentWithTz.tz;
+		delete momentProtoWithTz.tz;
 
 		try {
-			expect( () => getStoreTimeZoneMoment() ).not.toThrow();
-			expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
+			let result: moment.Moment | undefined;
+
+			expect( () => {
+				result = getStoreTimeZoneMoment();
+			} ).not.toThrow();
+
+			expect( [ -300, -240 ] ).toContain( result?.utcOffset() );
 		} finally {
-			moment.prototype.tz = originalTz;
+			momentWithTz.tz = originalStaticTz;
+			momentProtoWithTz.tz = originalProtoTz;
 		}
 	} );
 } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,15 +1013,15 @@ importers:
       '@wordpress/i18n':
         specifier: catalog:wp-min
         version: 6.6.1
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       lodash:
         specifier: ^4.17.0
         version: 4.17.21
       moment:
         specifier: ^2.29.4
         version: 2.30.1
-      moment-timezone:
-        specifier: ^0.5.43
-        version: 0.5.48
       qs:
         specifier: ^6.11.2
         version: 6.15.1
@@ -13647,6 +13647,11 @@ packages:
 
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==, tarball: https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==, tarball: https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz}
@@ -40647,6 +40652,10 @@ snapshots:
   dataloader@2.2.2: {}
 
   date-fns-jalali@4.1.0-0: {}
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
 
   date-fns@2.30.0:
     dependencies:


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Context:** Analytics crashes with `TypeError: tz is not a function` when a third-party plugin replaces the global `window.moment` after WooCommerce loads, stripping the `.tz()` method that `moment-timezone` adds.

**Why the previous fix stopped working:** #64021 fixed this by relying on a bundled `moment-timezone`. Two days later #64201 externalised `moment-timezone` to `window.moment` (to fix unrelated console warnings) — undoing that protection, so `getStoreTimeZoneMoment()` again depended on the clobberable global and the crash returned.

**This change:** resolves a named time zone's current UTC offset via `date-fns-tz`'s `getTimezoneOffset()` (browser `Intl` API) and applies it with `moment().utcOffset()`, so the offset no longer depends on `window.moment`. `moment-timezone` is dropped from `@woocommerce/date`; offset/UTC-string paths are unchanged.

**Why `date-fns-tz` rather than re-bundling `moment-timezone`?** We only need the current offset for a named zone, which `Intl` (via `date-fns-tz`) provides — so this removes the dependency instead of re-introducing it. Re-bundling a private `moment-timezone` would re-add ~140 KB and can destroy `@wordpress/date`'s synthetic `WP` zone ([Gutenberg #27159](https://github.com/WordPress/gutenberg/issues/27159) — the issue #64201 was fixing), whereas the tree-shaken `getTimezoneOffset` adds only ~0.7 KB gzipped. It also nudges us toward retiring `moment`/`moment-timezone` long-term (a direction WooCommerce/WP have wanted on bundle-size grounds) by shrinking that surface rather than growing it.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #64020.

(For Bug Fixes) Bug introduced in PR #64201.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


| Before | After |
| :----- | :---- |
| ![Before](https://github.com/user-attachments/assets/997c9e90-4be5-4880-b17d-0b633571857a) | ![After](https://github.com/user-attachments/assets/8b403887-5315-43d9-b0c4-dda8d40037be) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set a named time zone (e.g. `America/New_York`) in **Settings → General**.
2. Go to **Analytics → Overview** and confirm it loads normally.
3. Open the DevTools console and simulate a conflicting plugin stripping moment-timezone's static method, then call the store-time-zone helper:
   ```js
   delete window.moment.tz;
   window.wc.date.getStoreTimeZoneMoment().format();
   ```
   - On `trunk`: throws `TypeError: tz is not a function`.
   - With this PR: returns the current time in the store time zone (e.g. `2026-06-24T...-04:00`) with the correct offset.
4. Confirm Analytics dates/ranges still reflect the store time zone, not the browser's.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- All 95 unit tests in `@woocommerce/date` pass; ESLint and `tsc` are clean.
- Added a regression test that removes `window.moment.tz` / `moment.prototype.tz` and asserts `getStoreTimeZoneMoment()` no longer throws and returns the correct offset.
- Verified on a local site: reproduced the crash on `trunk` (deleting `window.moment.tz` → `TypeError`), then confirmed the fixed build returns a correct DST-aware offset (`Europe/Amsterdam` → +120 in June) under the same condition.
- Bundle impact measured: the `date` chunk grows by ~0.7 KB gzipped (`date-fns-tz`'s tree-shaken `getTimezoneOffset`); no net change vs. re-bundling `moment-timezone`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `packages/js/date/changelog/fix-64020-moment-tz-clobber`.

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
