### PR TITLE
Decode HTML entities in WooCommerce pattern titles

### DIFF
--- a/plugins/woocommerce/changelog/fix-43332-decode-pattern-titles
+++ b/plugins/woocommerce/changelog/fix-43332-decode-pattern-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Decode HTML entities in PTK pattern titles

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -143,7 +143,7 @@ class PatternRegistry {
 		}
 
 		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
-		$pattern_data['title'] = translate_with_gettext_context( html_entity_decode( (string) $pattern_data['title'], ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Pattern title', 'woocommerce' );
+		$pattern_data['title'] = translate_with_gettext_context( wp_strip_all_tags( html_entity_decode( (string) $pattern_data['title'], ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ), 'Pattern title', 'woocommerce' );
 		if ( ! empty( $pattern_data['description'] ) ) {
 			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 			$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'woocommerce' );

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -143,7 +143,7 @@ class PatternRegistry {
 		}
 
 		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
-		$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'woocommerce' );
+		$pattern_data['title'] = translate_with_gettext_context( html_entity_decode( (string) $pattern_data['title'], ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Pattern title', 'woocommerce' );
 		if ( ! empty( $pattern_data['description'] ) ) {
 			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 			$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'woocommerce' );
@@ -174,7 +174,6 @@ class PatternRegistry {
 
 		register_block_pattern( $pattern_data['slug'], $pattern_data );
 	}
-
 
 	/**
 	 * Convert a kebab-case string to capital case.

--- a/plugins/woocommerce/tests/php/src/Blocks/Patterns/PatternRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Patterns/PatternRegistryTest.php
@@ -179,6 +179,25 @@ class PatternRegistryTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test HTML entities are decoded in pattern titles.
+	 */
+	public function test_html_entities_are_decoded_in_pattern_title() {
+		$pattern = [
+			'title'   => 'Featured Products: Fresh &amp; Tasty',
+			'slug'    => 'my-pattern',
+			'content' => '<!-- wp:group {"metadata":{"name":"Sweet Organic Lemons"}} -->
+<div class="wp-block-group"></div>
+<!-- /wp:group -->',
+		];
+
+		$this->pattern_registry->register_block_pattern( 'source', $pattern, [] );
+
+		$registered_pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern['slug'] );
+
+		$this->assertSame( 'Featured Products: Fresh & Tasty', $registered_pattern['title'] );
+	}
+
+	/**
 	 * Enable the feature flag.
 	 *
 	 * @param array $features The features.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #43332.

As mentioned in https://github.com/woocommerce/woocommerce/issues/43332#issuecomment-4784678199, WooCommerce pattern titles weren't properly decoded, showing `&amp;` instead of `&`. This PR fixes that.

### How to test the changes in this Pull Request:

1. Create a post or page.
2. Open the inserter and go to the _Patterns_ tab.
3. Search for _Fresh_.
4. Verify the pattern has `&` instead of `&amp;`.

Before | After
--- | ---
<img width="691" height="590" alt="imatge" src="https://github.com/user-attachments/assets/e7e5c314-3cf4-4348-8691-039cd85fbe2f" /> | <img width="691" height="590" alt="Captura de pantalla de 2026-06-24 11-33-52" src="https://github.com/user-attachments/assets/c84d7ecb-8588-4419-8ae5-4ea7d7d1518e" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->