### PR TITLE
[Performance] Centralize wp_count_posts invocations towards products (p2)

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -852,7 +852,7 @@ class WC_Install {
 		return is_null( get_option( 'woocommerce_version', null ) )
 			|| (
 				-1 === wc_get_page_id( 'shop' )
-				&& 0 === array_sum( ProductUtil::get_counts_for_type( 'product' ) )
+				&& 0 === array_sum( wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' ) )
 			);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -490,7 +490,7 @@ class WC_Tracker {
 	 * @return array
 	 */
 	public static function get_product_counts() {
-		$product_count_data = ProductUtil::get_counts_for_type( 'product' );
+		$product_count_data = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 		$product_count      = array( 'total' => $product_count_data[ ProductStatus::PUBLISH ] ?? 0 );
 
 		$product_statuses = get_terms( 'product_type', array( 'hide_empty' => 0 ) );

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -513,7 +513,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Template contents.
 	 */
 	private static function get_homepage_template( $post_id ) {
-		$products = ProductUtil::get_counts_for_type( 'product' );
+		$products = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 		if ( ( $products[ ProductStatus::PUBLISH ] ?? 0 ) >= 4 ) {
 			$images   = self::sideload_homepage_images( $post_id, 1 );
 			$image_1  = ! empty( $images[0] ) ? $images[0] : '';

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -340,7 +340,7 @@ class Products extends Task {
 	public function maybe_redirect_to_add_product_tasklist() {
 		$screen = get_current_screen();
 		if ( $screen && 'edit' === $screen->base && 'product' === $screen->post_type ) {
-			$counts = ProductUtil::get_counts_for_type( 'product' );
+			$counts = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 			$count  = array_sum( $counts ) - ( $counts[ ProductStatus::AUTO_DRAFT ] ?? 0 );
 			if ( $count > 0 ) {
 				return;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -444,7 +444,7 @@ abstract class AbstractBlock {
 				'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 			];
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
-				$product_counts     = ProductUtil::get_counts_for_type( 'product' );
+				$product_counts     = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 				$published_products = $product_counts[ ProductStatus::PUBLISH ] ?? 0;
 				$wc_blocks_config   = array_merge(
 					$wc_blocks_config,

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -682,7 +682,7 @@ class SiteHealth {
 			return false;
 		}
 
-		$product_count = ProductUtil::get_counts_for_type( 'product' );
+		$product_count = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 
 		return ( $product_count[ ProductStatus::PUBLISH ] ?? 0 ) > 0 && 0 === wc_get_shipping_method_count();
 	}

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/CLIRunner.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/CLIRunner.php
@@ -384,7 +384,7 @@ class CLIRunner {
 
 		$was_enabled = 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' );
 
-		$products_count = ProductUtil::get_counts_for_type( 'product' );
+		$products_count = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 		$products_count = ( $products_count[ ProductStatus::PUBLISH ] ?? 0 ) + ( $products_count[ ProductStatus::PENDING ] ?? 0 ) + ( $products_count[ ProductStatus::DRAFT ] ?? 0 );
 
 		if ( ! $this->lookup_data_store->regeneration_is_in_progress() || array_key_exists( 'from-scratch', $assoc_args ) ) {

--- a/plugins/woocommerce/src/Internal/Utilities/ProductUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/ProductUtil.php
@@ -136,7 +136,7 @@ class ProductUtil {
 	 * @param string $post_type Post type (e.g. 'product', 'product_variation').
 	 * @return array<string,int>
 	 */
-	public static function get_counts_for_type( string $post_type ): array {
+	public function get_counts_for_type( string $post_type ): array {
 		// Performance note: integration point for upcoming persistent counters solution.
 		return array_map( 'intval', (array) wp_count_posts( $post_type ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/ProductUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/ProductUtilTest.php
@@ -16,13 +16,13 @@ class ProductUtilTest extends \WC_Unit_Test_Case {
 	 * @testdox `get_counts_for_type` returns per-status counts for the given post type.
 	 */
 	public function test_get_counts_for_type_returns_per_status_counts(): void {
-		$before = ProductUtil::get_counts_for_type( 'product' );
+		$before = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 
 		$published = \WC_Helper_Product::create_simple_product();
 		$draft     = \WC_Helper_Product::create_simple_product( true, array( 'status' => ProductStatus::DRAFT ) );
 		$pending   = \WC_Helper_Product::create_simple_product( true, array( 'status' => ProductStatus::PENDING ) );
 
-		$after = ProductUtil::get_counts_for_type( 'product' );
+		$after = wc_get_container()->get( ProductUtil::class )->get_counts_for_type( 'product' );
 
 		$this->assertSame( ( $before[ ProductStatus::PUBLISH ] ?? 0 ) + 1, $after[ ProductStatus::PUBLISH ] );
 		$this->assertSame( ( $before[ ProductStatus::DRAFT ] ?? 0 ) + 1, $after[ ProductStatus::DRAFT ] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follows up on https://github.com/woocommerce/woocommerce/pull/65894

Refactor the new utility method declaration (remove `static`) to align with the rest of the class methods.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- (optional) Smoke tests: visit admin pages such as `Products -> All Products` and `Tools -> Site health`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
The relevant changelog is part of https://github.com/woocommerce/woocommerce/pull/65894

</details>