### PR TITLE
fix: hoist `uuid` and `memize` so admin build and JS tests resolve them

### DIFF
--- a/plugins/woocommerce/changelog/dev-hoist-uuid-memize-for-dataviews
+++ b/plugins/woocommerce/changelog/dev-hoist-uuid-memize-for-dataviews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Hoist uuid and memize in pnpm publicHoistPattern so the admin client build and JS tests resolve these @wordpress/dataviews and jest-preset phantom imports.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,9 +83,10 @@ packages:
 # pnpm 10 emptied public-hoist-pattern (was ['*eslint*', '*prettier*']).
 # Also hoist react/react-dom so phantom deps in @wordpress/* packages resolve
 # (e.g. @wordpress/dataviews imports react-dom/client without declaring it).
-# uuid/memize are the same kind of phantom import: @wordpress/dataviews pulls in
-# uuid (admin client bundle), and @woocommerce/internal-js-tests' jest preset
-# require.resolve()s uuid + memize — none of them declare these, so hoist to root.
+# uuid/memize are the same kind of phantom import: @wordpress/dataviews's
+# bundle imports both, and @woocommerce/internal-js-tests' jest preset resolves
+# them via require.resolve(). None of those packages declare uuid or memize as a
+# dependency, so we hoist them to the repo root where every consumer can find them.
 publicHoistPattern:
     - '*eslint*'
     - '*prettier*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,12 +83,17 @@ packages:
 # pnpm 10 emptied public-hoist-pattern (was ['*eslint*', '*prettier*']).
 # Also hoist react/react-dom so phantom deps in @wordpress/* packages resolve
 # (e.g. @wordpress/dataviews imports react-dom/client without declaring it).
+# uuid/memize are the same kind of phantom import: @wordpress/dataviews pulls in
+# uuid (admin client bundle), and @woocommerce/internal-js-tests' jest preset
+# require.resolve()s uuid + memize — none of them declare these, so hoist to root.
 publicHoistPattern:
     - '*eslint*'
     - '*prettier*'
     - 'react'
     - 'react-dom'
     - '@use-gesture/react'
+    - 'uuid'
+    - 'memize'
 
 # Quality of life tweaks (migrated from .npmrc)
 childConcurrency: 8        # 5 by default


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds `uuid` and `memize` to `publicHoistPattern` in `pnpm-workspace.yaml` so they are hoisted into the repo-root `node_modules`.

#### The problem

Both `uuid` and `memize` are **phantom dependencies** in this monorepo — they are imported at runtime but never declared in the `package.json` of the code that imports them:

1. **Admin client build** — `@wordpress/dataviews` (bundled by the admin client through its `@wordpress/dataviews/wp` → `build-wp` entry, used in `client/settings-email/*` and `client/wp-admin-scripts/settings-embed/*`) imports **both `uuid` and `memize`** in its `build-wp` bundle (`import * as uuid from "uuid"` and `import memoize from "memize"`) but declares **neither** as a dependency. (Verified in the bundled `@wordpress/dataviews@14.2.0`; the lockfile also carries `4.22.0`/`10.3.0`, which phantom-import these the same way.)
2. **JS unit tests** — `@woocommerce/internal-js-tests`'s `jest-preset.js` calls `require.resolve( 'uuid' )` and `require.resolve( 'memize' )` to build its `moduleNameMapper`, but the package only declares `lib0` (which is why `lib0` resolves and these two don't).

pnpm 10 emptied the default `public-hoist-pattern`. This repo restores a curated set via `publicHoistPattern` (`*eslint*`, `*prettier*`, `react`, `react-dom`, `@use-gesture/react`) precisely so that undeclared `@wordpress/*` imports keep resolving — the comment directly above the list already documents this for `@wordpress/dataviews` importing `react-dom/client`. **`uuid` and `memize` are the same class of phantom import, but were never added to the list.**

Under pnpm 10's strict `node_modules` layout, an undeclared dependency has nowhere valid to resolve from. The result:

- **Admin client webpack build fails:** `Module not found: Error: Can't resolve 'uuid' in .../@wordpress/dataviews/build-wp`.
- **JS unit tests fail to start:** the jest preset throws `Cannot find module 'uuid'` at config-load time, before any test runs.

#### Why this is intermittent / "it worked before"

The failure only appears on a **clean** dependency graph. A `node_modules` that has accumulated cruft from earlier installs (or from switching between branches with different dependency sets) often leaves `uuid`/`memize` sitting somewhere resolvable, so the build and tests appear to work. Anything that re-resolves and prunes the tree from scratch — a fresh clone, CI, `pnpm install --force`, or installing a branch that changes the lockfile (e.g. reviewing #65835) and switching back — removes that leftover and exposes the latent gap. This is what makes it confusing: the same checkout can build one day and fail the next with no source change.

Confirmed locally that `pnpm install` / `pnpm install --force` does **not** fix it — the locked state genuinely has no place to resolve these from. Only declaring or hoisting them does.

#### Why `publicHoistPattern` (and not other fixes)

- It mirrors the **existing precedent** in the same file (`react`/`react-dom` were added for the identical undeclared-`@wordpress/*`-import problem), so it's the consistent, idiomatic fix here.
- It's a single root-config line per package and **does not touch `pnpm-lock.yaml`** (it only affects the `node_modules` linking layer, not dependency resolution), so it can't drift the lockfile or break `--frozen-lockfile`.
- Declaring `uuid` in every consumer (and `uuid`/`memize` in `internal-js-tests`) would be more invasive and still wouldn't cleanly cover the third-party `@wordpress/dataviews` phantom import that lands in the bundle — hoisting handles all consumers at once, exactly as it already does for `react-dom`.

#### Relationship to #65835

#65835 ("Standardize WordPress bundled dependency versions", currently open) reworks the `wp-bundled` catalog and bumps `@wordpress/dataviews` (e.g. to `10.1.7`). It is **not** a substitute for this change:

- It does not modify `publicHoistPattern`, does not declare `uuid`/`memize` anywhere, and does not touch `@woocommerce/internal-js-tests` — so it leaves the JS-test resolution gap untouched entirely.
- The dataviews version it pins (`10.1.7`) still phantom-imports `uuid` the same way `4.22.0` does; its green build relies on incidental lockfile re-resolution rather than addressing the phantom import.

This PR is independent and complementary: it fixes the root cause for both the build and the tests, regardless of which dataviews version is in use.

### How to test the changes in this Pull Request:

1. Check out this branch and run a clean install: `pnpm install` (or `pnpm install --frozen-lockfile`).
2. Confirm both are now hoisted to the repo root: `ls -l node_modules/uuid node_modules/memize` — each should symlink into `.pnpm` (`uuid@9.0.1`, `memize@1.1.0`).
3. Build the admin client: `pnpm --filter=@woocommerce/plugin-woocommerce build:admin` (or `pnpm build`). The `admin-js` bundle should compile successfully — no `Can't resolve 'uuid'`.
4. Run a package's JS unit tests, e.g. `pnpm --filter=@woocommerce/settings-ui test:js` — the suite should run (the jest preset loads).
5. *Regression reference:* on `trunk`, after a clean install (which prunes any leftover hoisted `uuid`/`memize`), steps 3–4 fail on `uuid`/`memize` resolution.

### Testing that has already taken place:

- Reproduced the failure locally: `pnpm build` failed with `Can't resolve 'uuid' in .../@wordpress+dataviews@4.22.0/.../build-wp`, and `pnpm --filter=@woocommerce/settings-ui test:js` failed at jest-preset load (`Cannot find module 'uuid'`). Confirmed `pnpm install --force` did **not** fix it.
- Verified the root cause: `@wordpress/dataviews@4.22.0` and `@woocommerce/internal-js-tests` both reference `uuid`/`memize` without declaring them; neither is in `publicHoistPattern`; the gap is present on `trunk`.
- Applied this change in an isolated checkout off `trunk` and ran a clean `pnpm install`: it hoisted `uuid@9.0.1` and `memize@1.1.0` into root `node_modules`, and left `pnpm-lock.yaml` unchanged.
- With those hoisted, a full `pnpm build` completed successfully (exit 0, admin bundle `compiled successfully`, no module-resolution errors) and `@woocommerce/settings-ui` jest passed **34/34**.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry has been **added manually** in this PR (`plugins/woocommerce/changelog/dev-hoist-uuid-memize-for-dataviews`).

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Dev - Development related task

#### Message
Hoist uuid and memize in pnpm publicHoistPattern so the admin client build and JS tests resolve these @wordpress/dataviews and jest-preset phantom imports.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

