### PR TITLE
[Issue- #60455] Make the new Product Gallery Block compatible with Additional Variation Images

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-legacy-variation-images
+++ b/plugins/woocommerce/changelog/fix-product-gallery-legacy-variation-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add fallback compatibility for legacy additional variation images to the Product Gallery block

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -210,9 +210,16 @@ class ProductGalleryUtils {
 		$variation_gallery_ids = array();
 		if ( VariationGalleryPackage::is_enabled() ) {
 			$variation_gallery_ids = array_map( 'intval', $variation->get_gallery_image_ids() );
-			$variation_gallery_ids = array_filter( $variation_gallery_ids, 'wp_attachment_is_image' );
-			$variation_gallery_ids = array_values( $variation_gallery_ids );
+		} else {
+			// Compatibility with the legacy WooCommerce Additional Variation Images extension.
+			$legacy_gallery_image_ids = get_post_meta( $variation_id, '_wc_additional_variation_images', true );
+			if ( ! empty( $legacy_gallery_image_ids ) ) {
+				$variation_gallery_ids = array_map( 'intval', wp_parse_id_list( $legacy_gallery_image_ids ) );
+			}
 		}
+
+		$variation_gallery_ids = array_filter( $variation_gallery_ids, 'wp_attachment_is_image' );
+		$variation_gallery_ids = array_values( $variation_gallery_ids );
 
 		// No images from variation - full parent fallback.
 		if ( ! $featured_valid && empty( $variation_gallery_ids ) ) {
@@ -266,7 +273,17 @@ class ProductGalleryUtils {
 	public static function get_variation_gallery_image_ids( \WC_Product_Variation $variation ) {
 		$image_ids          = array();
 		$variation_image_id = (int) $variation->get_image_id();
-		$gallery_image_ids  = array_map( 'intval', $variation->get_gallery_image_ids() );
+
+		$gallery_image_ids = array();
+		if ( VariationGalleryPackage::is_enabled() ) {
+			$gallery_image_ids = array_map( 'intval', $variation->get_gallery_image_ids() );
+		} else {
+			// Compatibility with the legacy WooCommerce Additional Variation Images extension.
+			$legacy_gallery_image_ids = get_post_meta( $variation->get_id(), '_wc_additional_variation_images', true );
+			if ( ! empty( $legacy_gallery_image_ids ) ) {
+				$gallery_image_ids = array_map( 'intval', wp_parse_id_list( $legacy_gallery_image_ids ) );
+			}
+		}
 
 		if ( $variation_image_id ) {
 			$image_ids[] = $variation_image_id;


### PR DESCRIPTION
This adds backwards compatibility to the Product Gallery block, ensuring it displays variation-specific gallery images for merchants who are still using the legacy WooCommerce Additional Variation Images plugin, even when the new Variation Gallery core feature is disabled.

Fixes #60455

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds backwards compatibility to the new Product Gallery Block for legacy variation images. Specifically, it ensures that if a merchant has the new Variation Gallery core feature disabled (`woocommerce_feature_variation_gallery_v1` is off), but they still have legacy data stored in the `_wc_additional_variation_images` meta field (from the WooCommerce Additional Variation Images extension), the Product Gallery Block will still seamlessly pick up and display those variation-specific gallery images on the frontend. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Switch to a Block Theme (e.g. Twenty Twenty-Four) so the Product Gallery block is used.
2. Ensure you have a Variable Product with at least two variations.
3. For one of the variations (e.g., Variation ID: `34`), attach multiple legacy variation images by manually inserting them into the database or via WP-CLI:
   ```bash
   wp post meta set 34 _wc_additional_variation_images "15,16" # Replace with valid attachment IDs

**Test 1: With the new Variation Gallery feature DISABLED**

- Go to WooCommerce > Settings > Advanced > Features.
- Uncheck "Variation Gallery" and save.
- Go to your variable product on the frontend.
- Select the variation you added the legacy meta to.
- Verify that the Product Gallery Block correctly displays the images (IDs 15, 16) assigned via the legacy _wc_additional_variation_images meta.

**Test 2: With the new Variation Gallery feature ENABLED**

- Go to WooCommerce > Settings > Advanced > Features.
- Check "Variation Gallery" and save.
- Edit the variable product and add some variation images using the standard UI.
- Go to the frontend and select the variation.
- Verify that the standard variation images show up perfectly and the legacy meta logic is safely ignored.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally using wp-env with Twenty Twenty-Four.

- Injected dummy comma-separated IDs into the _wc_additional_variation_images meta for a specific variation.
- Toggled the Variation Gallery feature off under WooCommerce > Settings > Advanced > Features.
- Confirmed the Product Gallery Block correctly parses the string of IDs into an array and serves them to the frontend when the variation is selected.
- Toggled the Variation Gallery feature back on, and confirmed the block gracefully falls back to using the standard $variation->get_gallery_image_ids().

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
