### PR TITLE
Add signature-change backward-compatibility guardrail to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,14 @@ For detailed test commands, see `woocommerce-dev-cycle` skill.
 - Never create standalone functions (always use class methods)
 - Tests require Docker environment
 
+## Backward Compatibility
+
+Any change to a **public or externally exposed** class, interface, function, or method signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in the `Internal` namespace. The `Internal` namespace is not a guarantee that a symbol is safe to change: third-party code implements and consumes some of these contracts in practice (for example, the WooCommerce Stripe Gateway implements `Internal\ProductFeed\Feed\FeedInterface`).
+
+**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Prefer a non-breaking alternative — add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class — and follow the deprecate-don't-rename policy for existing public symbols.
+
+> This rule exists because WooCommerce 10.9.0 was reverted on WP Cloud: PR #64394 added a required `get_entry_count(): int` method to `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implement it. Fixed in PR #65965.
+
 ## Block Development
 
 ### `block.json` Attribute Defaults

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,11 @@ For detailed test commands, see `woocommerce-dev-cycle` skill.
 
 Any change to a **public or externally exposed** class, interface, function, or method signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in the `Internal` namespace. The `Internal` namespace is not a guarantee that a symbol is safe to change: third-party code implements and consumes some of these contracts in practice (for example, the WooCommerce Stripe Gateway implements `Internal\ProductFeed\Feed\FeedInterface`).
 
-**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Prefer a non-breaking alternative — add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class — and follow the deprecate-don't-rename policy for existing public symbols.
+Treat a symbol as **externally exposed** when it is implemented or consumed outside `plugins/woocommerce/` — by extensions, other plugins, or themes — even if it lives under `Internal`. When in doubt, assume it is exposed and state the BC impact.
+
+**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Likewise, **removing a required method from an interface is breaking** for existing implementers (they carry a now-dead method, which static analysis such as PHPStan will flag). Prefer a non-breaking alternative — add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class.
+
+**Deprecate, don't rename.** For existing public symbols (classes, interfaces, methods, constants, hooks), never rename or remove them in place. Mark the old symbol `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window so external consumers have time to migrate.
 
 > This rule exists because WooCommerce 10.9.0 was reverted on WP Cloud: PR #64394 added a required `get_entry_count(): int` method to `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implement it. Fixed in PR #65965.
 


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Adds a `## Backward Compatibility` section to `AGENTS.md`: any change to a public/exposed class, interface, function, or method signature is high-risk regardless of the `Internal` namespace and must state its BC impact in the PR description. Adding a method to an implementable interface is called out explicitly as backward-incompatible, with non-breaking alternatives.

**Background:** WooCommerce 10.9.0 was reverted on WP Cloud because PR #64394 added a required `get_entry_count(): int` method to `FeedInterface` (in the `Internal\ProductFeed\Feed` namespace). Third-party code implements that interface (e.g. the WooCommerce Stripe Gateway), so adding a required method was a backward-incompatible change and older Stripe versions fataled on load. Fixed by PR #65965, backported via #65972. This PR is part of the agreed guardrail follow-up.

Closes #65980.
Part of #65984.

### How to test the changes in this Pull Request:

Read the new `## Backward Compatibility` section in `AGENTS.md` and confirm it renders correctly. `npx markdownlint-cli2 AGENTS.md` reports 0 errors.

### Testing that has already taken place:

Read the new `## Backward Compatibility` section in `AGENTS.md` and confirm it renders correctly. `npx markdownlint-cli2 AGENTS.md` reports 0 errors.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Repository tooling/CI configuration only (no shipping package code changed); no changelog entry required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)