### PR TITLE
Add signature-change backward-compatibility check to CodeRabbit config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -22,7 +22,9 @@ reviews:
         this is a backwards-incompatible change because existing implementers fatal on load (e.g. WooCommerce 10.9.0 was
         reverted on WP Cloud after a required method was added to `FeedInterface`). Suggest a non-breaking alternative
         such as adding the method to a concrete class, introducing a new interface, or providing a default via an
-        abstract base class.
+        abstract base class. For renames or removals of existing public symbols, follow the deprecate-don't-rename
+        policy: keep the original symbol with an `@deprecated` notice pointing to the replacement, rather than changing
+        it in place.
         When making any changes to code that deletes or modifies orders/products/customer data, make sure that there are
         sufficient checks in place to prevent accidental data loss. As an example, if deleting a draft order, check that
         the order status is indeed `draft` or `checkout-draft`. Also think about whether race conditions could occur and

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -15,6 +15,14 @@ reviews:
         - Is backwards compatible.
         - Is readable and intuitive.
         - Has unit or E2E tests where applicable.
+        Treat any change to a public or externally exposed class, interface, function, or method signature as high-risk,
+        regardless of whether it lives in the `Internal` namespace — third-party code implements and consumes some of
+        these contracts in practice. Flag such changes and ask the author to state the backwards-compatibility impact in
+        the PR description. Call out explicitly when a method is added to an interface that external code can implement:
+        this is a backwards-incompatible change because existing implementers fatal on load (e.g. WooCommerce 10.9.0 was
+        reverted on WP Cloud after a required method was added to `FeedInterface`). Suggest a non-breaking alternative
+        such as adding the method to a concrete class, introducing a new interface, or providing a default via an
+        abstract base class.
         When making any changes to code that deletes or modifies orders/products/customer data, make sure that there are
         sufficient checks in place to prevent accidental data loss. As an example, if deleting a draft order, check that
         the order status is indeed `draft` or `checkout-draft`. Also think about whether race conditions could occur and


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Extends the PHP/JS `path_instructions` in `.coderabbit.yml` so CodeRabbit treats public/exposed signature changes as high-risk and explicitly flags adding a method to an implementable interface, mirroring the AGENTS.md rule.

**Background:** WooCommerce 10.9.0 was reverted on WP Cloud because PR #64394 added a required `get_entry_count(): int` method to `FeedInterface` (in the `Internal\ProductFeed\Feed` namespace). Third-party code implements that interface (e.g. the WooCommerce Stripe Gateway), so adding a required method was a backward-incompatible change and older Stripe versions fataled on load. Fixed by PR #65965, backported via #65972. This PR is part of the agreed guardrail follow-up.

Closes #65981.
Part of #65984.

### How to test the changes in this Pull Request:

Confirm `.coderabbit.yml` parses as valid YAML (`ruby -ryaml -e "YAML.load_file('.coderabbit.yml')"`). The new guidance appears under the existing `**/*.{php,js,ts,jsx,tsx}` path instructions.

### Testing that has already taken place:

Confirm `.coderabbit.yml` parses as valid YAML (`ruby -ryaml -e "YAML.load_file('.coderabbit.yml')"`). The new guidance appears under the existing `**/*.{php,js,ts,jsx,tsx}` path instructions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Repository tooling/CI configuration only (no shipping package code changed); no changelog entry required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)