### PR TITLE
Register Add to whislist unconditionally and ship it statically in ATCWO template parts

### DIFF
--- a/plugins/woocommerce/changelog/65979-register-add-to-wishlist-button-unconditionally
+++ b/plugins/woocommerce/changelog/65979-register-add-to-wishlist-button-unconditionally
@@ -1,3 +1,3 @@
 Significance: patch
 Type: dev
-Comment: Register the Add to Wishlist Button block unconditionally and include it statically in the Add to Cart + Options template parts, gating it solely at the block's render layer. No change for shoppers on flag-off stores.
+Comment: Register the Add to Wishlist Button and Wishlist blocks unconditionally, include the button statically in the Add to Cart + Options template parts, and gate both blocks solely at their render layer. No change for shoppers on flag-off stores.

--- a/plugins/woocommerce/changelog/65979-register-add-to-wishlist-button-unconditionally
+++ b/plugins/woocommerce/changelog/65979-register-add-to-wishlist-button-unconditionally
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Register the Add to Wishlist Button block unconditionally and include it statically in the Add to Cart + Options template parts, gating it solely at the block's render layer. No change for shoppers on flag-off stores.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
@@ -9,7 +8,6 @@ import {
 	useInnerBlocksProps,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Icon, starEmpty } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/settings';
 
 /**
@@ -17,40 +15,14 @@ import { getSetting } from '@woocommerce/settings';
  */
 import { Skeleton } from './skeleton';
 
-/**
- * Non-editable preview of the Add to Wishlist Button block, shown as the last
- * child of the template part when the merchant enables the toggle. The button
- * isn't a real inner block here (the template part is loaded separately and we
- * don't want to persist it into the shared template part), so this just mirrors
- * the block's editor markup to show where it'll appear on the frontend.
- */
-const AddToWishlistPreview = () => (
-	<div className="wc-block-add-to-wishlist-button">
-		<button
-			type="button"
-			className="wc-block-add-to-wishlist-button__toggle"
-			disabled
-		>
-			<span className="wc-block-add-to-wishlist-button__icon wc-block-add-to-wishlist-button__icon--empty">
-				<Icon icon={ starEmpty } size={ 24 } />
-			</span>
-			<span className="wc-block-add-to-wishlist-button__label">
-				{ __( 'Add to wishlist', 'woocommerce' ) }
-			</span>
-		</button>
-	</div>
-);
-
 const TemplatePartInnerBlocks = ( {
 	blockProps,
 	productType,
 	templatePartId,
-	showAddToWishlist,
 }: {
 	blockProps: Record< string, unknown >;
 	productType: string;
 	templatePartId: string | undefined;
-	showAddToWishlist: boolean;
 } ) => {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
@@ -94,20 +66,13 @@ const TemplatePartInnerBlocks = ( {
 
 	const { children, ...innerBlocksWrapperProps } = innerBlocksProps;
 
-	return (
-		<div { ...innerBlocksWrapperProps }>
-			{ children }
-			{ showAddToWishlist && <AddToWishlistPreview /> }
-		</div>
-	);
+	return <div { ...innerBlocksWrapperProps }>{ children }</div>;
 };
 
 export const AddToCartWithOptionsEditTemplatePart = ( {
 	productType,
-	showAddToWishlist,
 }: {
 	productType: string;
-	showAddToWishlist: boolean;
 } ) => {
 	const addToCartWithOptionsTemplatePartIds = getSetting(
 		'addToCartWithOptionsTemplatePartIds',
@@ -158,7 +123,6 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 		return (
 			<div { ...blockProps }>
 				<Skeleton productType={ productType } isLoading={ isLoading } />
-				{ showAddToWishlist && <AddToWishlistPreview /> }
 			</div>
 		);
 	}
@@ -168,7 +132,6 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 			blockProps={ blockProps }
 			productType={ productType }
 			templatePartId={ templatePartId }
-			showAddToWishlist={ showAddToWishlist }
 		/>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -8,7 +8,6 @@ import {
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { getSetting } from '@woocommerce/settings';
 import { useProduct } from '@woocommerce/entities';
 
 /**
@@ -25,10 +24,6 @@ import type { Attributes } from '../types';
 const AddToCartOptionsEdit = (
 	props: BlockEditProps< Attributes > & { context?: { postId?: number } }
 ) => {
-	const isWishlistFeatureEnabled = getSetting< boolean >(
-		'wishlistFeatureEnabled',
-		false
-	);
 	const { product } = useProduct( props.context?.postId );
 	const blockProps = useBlockProps( {
 		className: 'wc-block-add-to-cart-with-options',
@@ -66,7 +61,6 @@ const AddToCartOptionsEdit = (
 			{ isCoreProductType ? (
 				<AddToCartWithOptionsEditTemplatePart
 					productType={ productType }
-					showAddToWishlist={ isWishlistFeatureEnabled }
 				/>
 			) : (
 				<div { ...blockProps }>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
-use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
 
 /**
  * AddToCartWithOptions class.
@@ -104,21 +103,7 @@ class AddToCartWithOptions extends AbstractBlock {
 		if ( is_admin() ) {
 			$this->asset_data_registry->add( 'productTypes', wc_get_product_types() );
 			$this->asset_data_registry->add( 'addToCartWithOptionsTemplatePartIds', $this->get_template_part_ids() );
-			$this->asset_data_registry->add( 'wishlistFeatureEnabled', $this->is_wishlist_enabled() );
 		}
-	}
-
-	/**
-	 * Whether the wishlist feature is enabled.
-	 *
-	 * Gates the render-time injection of the Add to Wishlist Button block (and
-	 * its editor preview), so the button only appears while the (experimental,
-	 * feature-flagged) wishlist feature is on.
-	 *
-	 * @return bool True if the wishlist feature flag is enabled, false otherwise.
-	 */
-	private function is_wishlist_enabled(): bool {
-		return wc_get_container()->get( ShopperListsController::class )->is_enabled( 'wishlist' );
 	}
 
 	/**
@@ -524,15 +509,6 @@ class AddToCartWithOptions extends AbstractBlock {
 				do_action( 'woocommerce_after_add_to_cart_form' );
 
 				$hooks_after = ob_get_clean();
-			}
-
-			// Add to Wishlist Button: when the wishlist feature is enabled,
-			// inject the button as the last child of the template part so it
-			// renders inside the form's iAPI scope (where it can read the
-			// selected variation/attributes). The markup is injected at render
-			// time only, never persisted to the shipped template parts.
-			if ( $this->is_wishlist_enabled() ) {
-				$template_part_contents .= "\n<!-- wp:woocommerce/add-to-wishlist-button /-->";
 			}
 
 			// Because we are printing the template part using do_blocks, context from the outside is lost.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToWishlistButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToWishlistButton.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperListRenderer;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
 
 /**
  * Add to Wishlist Button block.
@@ -46,6 +47,15 @@ final class AddToWishlistButton extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		// The block is registered unconditionally and shipped as a static
+		// inner block of the Add to Cart + Options template parts, so this
+		// render layer is the sole feature-flag gate: when the wishlist
+		// feature is off, output nothing and flag-off stores show no
+		// wishlist UI.
+		if ( ! wc_get_container()->get( ShopperListsController::class )->is_enabled( self::LIST_SLUG ) ) {
+			return '';
+		}
+
 		// Guests can't have a wishlist — bail before enqueuing assets or
 		// seeding state.
 		if ( ! is_user_logged_in() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 use Automattic\WooCommerce\Internal\ShopperLists\ShopperListRenderer;
+use Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController;
 
 /**
  * Wishlist block.
@@ -45,6 +46,15 @@ final class Wishlist extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		// The block is registered unconditionally, so this render layer is the
+		// feature-flag gate: when the wishlist feature is off, output nothing.
+		// The My Account endpoint that normally renders this block is itself
+		// flag-gated, but the block can also be merchant-placed on any page,
+		// where this guard keeps flag-off stores free of wishlist UI.
+		if ( ! wc_get_container()->get( ShopperListsController::class )->is_enabled( self::LIST_SLUG ) ) {
+			return '';
+		}
+
 		// Guests have no personal list — bail before enqueuing assets or
 		// seeding state. The My Account endpoint isn't reachable for
 		// guests, but the block can also be placed by a merchant on any

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -560,9 +560,14 @@ final class BlockTypesController {
 			$block_types[] = 'SavedForLater';
 		}
 
+		// Registered unconditionally so it can live as a static inner block of
+		// the Add to Cart + Options template parts. All flag-driven behavior is
+		// gated at the block's render layer (it returns an empty string when the
+		// wishlist feature is off), so flag-off stores render no wishlist UI.
+		$block_types[] = 'AddToWishlistButton';
+
 		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( 'wishlist' ) ) {
 			$block_types[] = 'Wishlist';
-			$block_types[] = 'AddToWishlistButton';
 		}
 
 		if ( wp_is_block_theme() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -560,15 +560,15 @@ final class BlockTypesController {
 			$block_types[] = 'SavedForLater';
 		}
 
-		// Registered unconditionally so it can live as a static inner block of
-		// the Add to Cart + Options template parts. All flag-driven behavior is
-		// gated at the block's render layer (it returns an empty string when the
+		// Wishlist blocks are registered unconditionally. AddToWishlistButton
+		// has to be, since it ships as a static inner block of the Add to Cart
+		// + Options template parts; Wishlist follows the same model so both are
+		// consistently available in the editor. All flag-driven behavior lives
+		// at each block's render layer (both return an empty string when the
 		// wishlist feature is off), so flag-off stores render no wishlist UI.
+		// The My Account wishlist endpoint and Store API routes stay flag-gated.
 		$block_types[] = 'AddToWishlistButton';
-
-		if ( wc_get_container()->get( ShopperListsController::class )->is_enabled( 'wishlist' ) ) {
-			$block_types[] = 'Wishlist';
-		}
+		$block_types[] = 'Wishlist';
 
 		if ( wp_is_block_theme() ) {
 			$block_types[] = 'AddToCartWithOptions\AddToCartWithOptions';

--- a/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
@@ -1,3 +1,4 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+<!-- wp:woocommerce/add-to-wishlist-button /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -29,5 +29,6 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+<!-- wp:woocommerce/add-to-wishlist-button /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,5 +1,6 @@
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
+<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+<!-- wp:woocommerce/add-to-wishlist-button /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -34,5 +34,7 @@
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 
 	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
+
+	<!-- wp:woocommerce/add-to-wishlist-button /-->
 </div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -16,7 +16,6 @@ use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelec
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeNameMock;
 use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 
 /**
  * Tests for the AddToCartWithOptions block type
@@ -520,20 +519,20 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the Add to Wishlist Button is injected as the last child only
-	 * when the `product_wishlist` feature flag is enabled.
+	 * Tests that the Add to Wishlist Button is rendered from the ATCWO template
+	 * part, after the product button.
 	 *
-	 * A lightweight stub stands in for the real `add-to-wishlist-button` block so
-	 * the test isolates the ATCWO injection/gating logic (the button's own
-	 * rendering is covered by AddToWishlistButtonTests).
+	 * The button ships as a static inner block of the per-product-type template
+	 * parts, so ATCWO renders it unconditionally — feature gating now lives in
+	 * the block's own render layer (covered by AddToWishlistButtonTests). A
+	 * lightweight stub stands in for the real `add-to-wishlist-button` block to
+	 * isolate ATCWO's template-part rendering from the button's own output.
 	 *
 	 * @covers \Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\AddToCartWithOptions::render
 	 */
-	public function test_add_to_wishlist_button_injection() {
+	public function test_renders_add_to_wishlist_button_from_template_part() {
 		$marker   = 'wc-block-add-to-wishlist-button-stub';
 		$registry = \WP_Block_Type_Registry::get_instance();
-		$features = wc_get_container()->get( FeaturesController::class );
-		$original = $features->feature_is_enabled( 'product_wishlist' );
 
 		if ( $registry->is_registered( 'woocommerce/add-to-wishlist-button' ) ) {
 			$registry->unregister( 'woocommerce/add-to-wishlist-button' );
@@ -554,27 +553,19 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			$product_id = $product->save();
 			$block      = '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->';
 
-			// Feature on: the button is injected as the last child.
-			$features->change_feature_enable( 'product_wishlist', true );
 			$markup = do_blocks( $block );
 
-			$this->assertStringContainsString( $marker, $markup, 'The Add to Wishlist Button is injected when the wishlist feature is enabled.' );
+			$this->assertStringContainsString( $marker, $markup, 'The Add to Wishlist Button is rendered from the template part.' );
 			// Confirm the product button is present first, so both strpos() calls
 			// below return integers and the position comparison is meaningful.
 			$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The product button is rendered.' );
 			$this->assertGreaterThan(
 				strpos( $markup, 'wp-block-woocommerce-product-button' ),
 				strpos( $markup, $marker ),
-				'The Add to Wishlist Button is injected after the product button (as the last child).'
+				'The Add to Wishlist Button is rendered after the product button.'
 			);
-
-			// Feature off: the button is not injected.
-			$features->change_feature_enable( 'product_wishlist', false );
-			$markup = do_blocks( $block );
-			$this->assertStringNotContainsString( $marker, $markup, 'The Add to Wishlist Button is not injected when the wishlist feature is disabled.' );
 		} finally {
 			$registry->unregister( 'woocommerce/add-to-wishlist-button' );
-			$features->change_feature_enable( 'product_wishlist', $original );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToWishlistButtonTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToWishlistButtonTests.php
@@ -45,6 +45,12 @@ class AddToWishlistButtonTests extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		// The block is registered unconditionally and shipped statically in
+		// the ATCWO template parts, so render() is the sole feature-flag gate.
+		// Turn the feature on so the "renders markup" tests exercise the full
+		// path; the flag-off case is covered explicitly below.
+		update_option( 'woocommerce_product_wishlist_enabled', 'yes' );
+
 		$reflection = new ReflectionClass( AddToWishlistButton::class );
 		$this->sut  = $reflection->newInstanceWithoutConstructor();
 
@@ -64,6 +70,7 @@ class AddToWishlistButtonTests extends WP_UnitTestCase {
 			WP_Block_Supports::$block_to_render = $this->previous_block_to_render;
 			$this->previous_block_to_render     = null;
 		}
+		delete_option( 'woocommerce_product_wishlist_enabled' );
 		parent::tearDown();
 	}
 
@@ -103,6 +110,28 @@ class AddToWishlistButtonTests extends WP_UnitTestCase {
 		$render->setAccessible( true );
 
 		return (string) $render->invoke( $this->sut, $attributes, '', $block );
+	}
+
+	/**
+	 * `render()` returns an empty string when the wishlist feature flag is off,
+	 * even for a logged-in shopper on a valid product. This is the render-layer
+	 * gate that keeps flag-off stores free of wishlist UI now that the block is
+	 * registered unconditionally and ships statically in the ATCWO template
+	 * parts.
+	 */
+	public function test_render_returns_empty_when_feature_disabled(): void {
+		update_option( 'woocommerce_product_wishlist_enabled', 'no' );
+
+		$customer_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		$product = \WC_Helper_Product::create_simple_product();
+
+		$this->assertSame(
+			'',
+			$this->invoke_render( $this->build_block_stub( $product->get_id() ) ),
+			'Flag-off stores must render no wishlist UI.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This replaces the interim runtime injection from #65765 with the durable always-register + static-include model from #65979.

Before, the wishlist button was gated three times over the same flag: conditional registration, a render-time string append in `AddToCartWithOptions::render()`, and a hardcoded editor preview. Three gates that can silently drift apart.

This collapses it to one path:

- Register both `add-to-wishlist-button` and `wishlist` unconditionally. The button has to be, since it ships statically in the ATCWO template parts; the `wishlist` block follows the same model so both stay consistently available in the editor.
- Gate each block only at its render layer; both now return `''` when the `product_wishlist` flag is off.
- Ship the button statically in the four ATCWO template parts, right after the product button, as a plain inner block.
- Drop the render-time append, the `is_wishlist_enabled()` helper, and the editor-side injection. The editor now renders the real block on its own.

The My Account wishlist endpoint and the Store API routes stay flag-gated. `saved-for-later` is left as-is; it's a separate feature flag, out of scope here.

For shoppers on flag-off stores nothing changes; the output is still empty. The win is structural.

One thing worth flagging: the issue assumed `render()` already bailed when the flag was off, but it only bailed for guests and missing products. Since the registration gate is gone, I added the flag check to both blocks' render; without it, flag-off stores would show them.

Closes #65979.

### How to test the changes in this Pull Request:

1. On a block theme, enable **Products → Wishlist** under WooCommerce → Settings → Advanced → Features.
2. As a logged-in shopper, open a single product page (simple, variable, grouped, external) and confirm the Add to wishlist button renders next to Add to cart and toggles.
3. Visit My Account → Wishlist and confirm the wishlist renders.
4. Disable the flag, reload both, and confirm no wishlist UI renders and no console errors.
5. In the Site Editor, confirm the button shows as a regular inner block of the ATCWO template part, and that both wishlist blocks behave consistently in the inserter.
6. Run the PHP tests: `--filter AddToWishlistButtonTests` and `--filter AddToCartWithOptions`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request includes a changelog entry (added manually at `plugins/woocommerce/changelog/65979-register-add-to-wishlist-button-unconditionally`).
