### PR TITLE
Reports: fix custom date range text colour contrast (WCAG AA)

### DIFF
--- a/plugins/woocommerce/changelog/fix-61682-reports-custom-date-contrast
+++ b/plugins/woocommerce/changelog/fix-61682-reports-custom-date-contrast
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Reports: fix insufficient color contrast on the custom date range text (WCAG AA).

--- a/plugins/woocommerce/changelog/fix-61682-reports-custom-date-contrast
+++ b/plugins/woocommerce/changelog/fix-61682-reports-custom-date-contrast
@@ -1,3 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Reports: fix insufficient color contrast on the custom date range text (WCAG AA).
+
+Improve the color contrast of the active date range tab in legacy Reports.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7150,7 +7150,7 @@ img.ui-datepicker-trigger {
 						box-shadow: 0 4px 0 0 #fff;
 
 						a {
-							color: #777;
+							color: #646970; // Gray 50 (WCAG AA contrast)
 						}
 					}
 
@@ -7168,7 +7168,7 @@ img.ui-datepicker-trigger {
 								margin: 0 10px 0 0;
 								background: transparent;
 								border: 0;
-								color: #777;
+								color: #646970; // Gray 50 (WCAG AA contrast)
 								text-align: center;
 								box-shadow: none;
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7534,7 +7534,7 @@ img.ui-datepicker-trigger {
 						box-shadow: 0 4px 0 0 #fff;
 
 						a {
-							color: #777;
+							color: #646970; // Gray 50 (WCAG AA contrast)
 						}
 					}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7534,7 +7534,7 @@ img.ui-datepicker-trigger {
 						box-shadow: 0 4px 0 0 #fff;
 
 						a {
-							color: #646970; // Gray 50 (WCAG AA contrast)
+							color: $wp-admin-text-gray;
 						}
 					}
 


### PR DESCRIPTION
### What & why

The legacy **WooCommerce → Reports** date-range selector renders the custom date inputs — and the active range-tab label — in `#777`, which fails WCAG AA (1.4.3 Contrast Minimum) for normal text:

- Custom date text: `#777` on the `#f5f5f5` toolbar = **4.1:1** (the reported issue)
- Active range-tab label: `#777` on `#fff` = **4.48:1**

Both are below the 4.5:1 threshold.

This changes both to the WordPress-admin **Gray 50 (`#646970`)** — a value already used elsewhere in `admin.scss` — which clears AA on both backgrounds the component uses:

| | on `#f5f5f5` | on `#fff` |
|---|---|---|
| `#777` (before) | 4.1:1 ❌ | 4.48:1 ❌ |
| `#646970` (after) | **5.1:1** ✅ | **5.6:1** ✅ |

Note: the commonly-used `#767676` / `#757575` greys are *not* sufficient here — they only reach ~4.2:1 against the `#f5f5f5` toolbar, so they'd still fail the reported case.

Closes #61682

### Changes proposed in this Pull Request

- `client/legacy/css/admin.scss` — in the `.stats_range` block, change the text colour of both `li.active a` and `input.range_datepicker` from `#777` to `#646970`. (Same component, same failing value, same root cause.)
- Added a `patch` / `fix` changelog entry.

### How to test

1. With WooCommerce active, go to **WooCommerce → Reports** (legacy reports screen).
2. Pick the **Custom** date range and note the date input text + the active range-tab label.
3. Run a contrast checker (e.g. WebAIM) on that text against its background — it should now be ≥ 4.5:1 (was 4.1:1).
4. Visual sanity check: text is a slightly darker grey; spacing/layout unchanged.

> Note: the compiled `assets/css/admin.css` is build-generated and git-ignored, so only the SCSS source is changed here.
