### PR TITLE
Make PHP branch lint part of the pre-commit step in agent docs

### DIFF
--- a/.ai/skills/woocommerce-git-commit/SKILL.md
+++ b/.ai/skills/woocommerce-git-commit/SKILL.md
@@ -84,4 +84,4 @@ After all commits, show `git log --oneline -n <number of new commits>` to confir
 - No Co-Authored-By lines or self-attribution
 - Never push to remote
 - Never use `git add -A` or `git add .`
-- Do not run pre-commit lint/test checks — the `woocommerce-dev-cycle` skill handles that. Linting should be run *before* invoking this skill, not after.
+- Do not run pre-commit lint/test checks — the `woocommerce-dev-cycle` skill handles that. Linting should be run *before* invoking this skill, not after. For PHP changes, don't commit until that skill's PHP lint has passed (warnings block CI).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ plugins/woocommerce/
 
 1. Make code changes
 2. Run relevant tests (see `woocommerce-dev-cycle` skill)
-3. Run linting (see `woocommerce-dev-cycle` skill)
+3. Run linting and fix all errors and warnings before committing (see Pre-commit Checks)
 4. Run PHPStan for PHP changes (see below)
 5. Commit only after tests pass and all checks are clean
 6. Create changelog entries for each affected package
@@ -90,27 +90,27 @@ plugins/woocommerce/
 
 ### Pre-commit Checks
 
-**Before committing PHP changes**, run these checks to avoid CI failures:
+**Before committing PHP changes**, run both lint commands and fix what they report:
 
 ```sh
-# Lint changed PHP files
+# Lint the changed PHP files
 pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
 
-# Run PHPStan on modified files (from plugins/woocommerce directory)
+# Lint the full branch diff (phpcs-changed — catches warnings the per-file pass can miss across commits)
+pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
+```
+
+Fix every `phpcs` **error and warning** before committing — the CI **Lint** job treats warnings as failures, so an unaddressed warning turns the check red. If a finding is intentionally suppressed, add a brief inline justification. Re-run `lint:changes:branch` after any commit rewrite, since it compares the whole branch against trunk.
+
+Also run PHPStan on modified PHP files (from the `plugins/woocommerce` directory):
+
+```sh
 composer exec -- phpstan analyse path/to/modified/File.php --memory-limit=2G
 ```
 
 **PHPStan Baseline Policy:** The baseline file (`phpstan-baseline.neon`) must never be added to. It should only shrink over time as existing errors are naturally resolved by code changes. If PHPStan reports a new error, fix it in the code rather than adding it to the baseline. If your fix resolves a previously baselined error, remove the corresponding entry from the baseline.
 
-### Pre-push Checks
-
-**Before pushing**, run the branch-level lint to catch issues across all commits on the branch (e.g. alignment warnings that per-file linting misses):
-
-```sh
-pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
-```
-
-This compares the full branch diff against trunk and runs `phpcs-changed` on it. Fix any warnings before pushing.
+### Changelog Entries
 
 **NEVER create a PR without changelog entries.** Each package modified in the monorepo requires its own changelog entry. Run for each affected package:
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Agent Sandbox PR #65507 was pushed with a PHPCS **warning** that failed the CI **Lint** job — the agent committed without running the branch-level PHP lint. `AGENTS.md` already documented the lint commands, but the branch-diff lint sat in a separate, advisory "Pre-push Checks" section, so an agent linting "before commit" never reached it.

This is a minimal documentation fix:

- **`AGENTS.md`** — folds both lint commands (`lint:php:changes` and `lint:changes:branch`) into a single Pre-commit Checks step, and states plainly that the CI Lint job treats warnings as failures, so a warning turns the check red. PHPStan guidance is preserved; the orphaned changelog block gets its own heading.
- **`.ai/skills/woocommerce-git-commit/SKILL.md`** — the commit skill deliberately defers linting to `woocommerce-dev-cycle` (single-purpose by design), which left a loophole an autonomous agent can fall through. Adds a one-line conditional gate: for PHP changes, don't commit until that skill's PHP lint has passed (warnings block CI). No commands are duplicated — it points at the owning skill.

Closes #65515.

### How to test the changes in this Pull Request:

This is a documentation-only change to agent guidance. To verify:

1. Read the **Pre-commit Checks** section of `AGENTS.md` and confirm both `lint:php:changes` and `lint:changes:branch` appear together as the pre-commit step, with warnings called out as CI-blocking.
2. Read the Constraints section of `.ai/skills/woocommerce-git-commit/SKILL.md` and confirm the conditional PHP lint gate is present without restating commands.
3. Confirm markdownlint passes: `npx --yes markdownlint-cli2 AGENTS.md .ai/skills/woocommerce-git-commit/SKILL.md`.

### Testing that has already taken place:

`markdownlint-cli2` reports 0 errors on both changed files. No code paths changed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation-only change to root-level `AGENTS.md` and a Claude Code skill under `.ai/skills/`. No code in any package (`plugins/woocommerce/` or otherwise) changed, so no changelog entry is required.

</details>
