### PR TITLE
Fix 'current-menu-item' class not being added to the Shop page in the Page List block

### DIFF
--- a/plugins/woocommerce/changelog/fix-34827-shop-page-queried_object
+++ b/plugins/woocommerce/changelog/fix-34827-shop-page-queried_object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 'current-menu-item' class not being added to the Shop page in the Page List block

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -374,8 +374,11 @@ class WC_Query {
 			$q->is_comment_feed = false;
 		}
 
+		$shop_page      = null;
+		$shop_page_id   = wc_get_page_id( 'shop' );
+
 		// Special check for shops with the PRODUCT POST TYPE ARCHIVE on front.
-		if ( wc_current_theme_supports_woocommerce_or_fse() && $q->is_page() && 'page' === get_option( 'show_on_front' ) && absint( $q->get( 'page_id' ) ) === wc_get_page_id( 'shop' ) ) {
+		if ( wc_current_theme_supports_woocommerce_or_fse() && $q->is_page() && 'page' === get_option( 'show_on_front' ) && absint( $q->get( 'page_id' ) ) === $shop_page_id ) {
 			// This is a front-page shop.
 			$q->set( 'post_type', 'product' );
 			$q->set( 'page_id', '' );
@@ -391,7 +394,7 @@ class WC_Query {
 			// This is hacky but works. Awaiting https://core.trac.wordpress.org/ticket/21096.
 			global $wp_post_types;
 
-			$shop_page = get_post( wc_get_page_id( 'shop' ) );
+			$shop_page = get_post( $shop_page_id );
 
 			$wp_post_types['product']->ID         = $shop_page->ID;
 			$wp_post_types['product']->post_title = $shop_page->post_title;
@@ -413,6 +416,9 @@ class WC_Query {
 				add_filter( 'wpseo_metadesc', array( $this, 'wpseo_metadesc' ) );
 				add_filter( 'wpseo_metakey', array( $this, 'wpseo_metakey' ) );
 			}
+		} elseif ( $q->is_post_type_archive( 'product' ) && ! $q->is_tax() && $shop_page_id > 0 ) {
+			// This is a regular shop page (product archive).
+			$shop_page = get_post( $shop_page_id );
 		} elseif ( ! $q->is_post_type_archive( 'product' ) && ! $q->is_tax( get_object_taxonomies( 'product' ) ) ) {
 			// Only apply to product categories, the product post archive, the shop page, product tags, and product attribute taxonomies.
 			if ( $q->is_search() ) {
@@ -435,6 +441,12 @@ class WC_Query {
 				}
 			}
 			return;
+		}
+
+		// Set queried object for any shop page scenario.
+		if ( $shop_page ) {
+			$q->queried_object    = $shop_page;
+			$q->queried_object_id = $shop_page->ID;
 		}
 
 		$this->product_query( $q );

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -374,8 +374,8 @@ class WC_Query {
 			$q->is_comment_feed = false;
 		}
 
-		$shop_page      = null;
-		$shop_page_id   = wc_get_page_id( 'shop' );
+		$shop_page    = null;
+		$shop_page_id = wc_get_page_id( 'shop' );
 
 		// Special check for shops with the PRODUCT POST TYPE ARCHIVE on front.
 		if ( wc_current_theme_supports_woocommerce_or_fse() && $q->is_page() && 'page' === get_option( 'show_on_front' ) && absint( $q->get( 'page_id' ) ) === $shop_page_id ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -85,8 +85,6 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 	 * @testdox Product archive queries set queried_object to the Shop page.
 	 */
 	public function test_shop_page_sets_queried_object_on_product_archive(): void {
-		switch_theme( 'twentytwentyfour' );
-
 		$shop_page_id         = wp_insert_post(
 			array(
 				'post_type'   => 'page',
@@ -97,7 +95,15 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		$default_shop_page_id = get_option( 'woocommerce_shop_page_id' );
 		update_option( 'woocommerce_shop_page_id', $shop_page_id );
 
-		$query = new WP_Query();
+		$query                       = new WP_Query(
+			array(
+				'post_type' => 'product',
+			)
+		);
+		$query->is_post_type_archive = true;
+		$query->is_archive           = true;
+		$query->is_tax               = false;
+		$query->is_home              = false;
 
 		global $wp_the_query, $wp_query;
 		$previous_wp_the_query = $wp_the_query;
@@ -105,13 +111,7 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_query              = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$query->query_vars['post_type'] = 'product';
-		$query->is_post_type_archive    = true;
-		$query->is_archive              = true;
-		$query->is_tax                  = false;
-		$query->is_home                 = false;
-
-		WC()->query->pre_get_posts( $query );
+		$query->get_posts();
 
 		$this->assert_shop_page_queried_object( $query, $shop_page_id );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -71,6 +71,7 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		$query->get_posts();
 
 		$this->assertTrue( defined( 'SHOP_IS_ON_FRONT' ) && SHOP_IS_ON_FRONT );
+		$this->assert_shop_page_queried_object( $query, $shop_page_id );
 
 		// Reset main query, options and delete the page we created.
 		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -78,6 +79,58 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		update_option( 'show_on_front', $default_show_on_front );
 		update_option( 'page_on_front', $default_page_on_front );
 		wp_delete_post( $shop_page_id, true );
+	}
+
+	/**
+	 * @testdox Product archive queries set queried_object to the Shop page.
+	 */
+	public function test_shop_page_sets_queried_object_on_product_archive(): void {
+		switch_theme( 'twentytwentyfour' );
+
+		$shop_page_id         = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Shop',
+			)
+		);
+		$default_shop_page_id = get_option( 'woocommerce_shop_page_id' );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		$query = new WP_Query();
+
+		global $wp_the_query, $wp_query;
+		$previous_wp_the_query = $wp_the_query;
+		$previous_wp_query     = $wp_query;
+		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query              = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$query->query_vars['post_type'] = 'product';
+		$query->is_post_type_archive    = true;
+		$query->is_archive              = true;
+		$query->is_tax                  = false;
+		$query->is_home                 = false;
+
+		WC()->query->pre_get_posts( $query );
+
+		$this->assert_shop_page_queried_object( $query, $shop_page_id );
+
+		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query     = $previous_wp_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		update_option( 'woocommerce_shop_page_id', $default_shop_page_id );
+		wp_delete_post( $shop_page_id, true );
+	}
+
+	/**
+	 * Assert that a query's queried object matches the configured Shop page.
+	 *
+	 * @param WP_Query $query        The query to inspect.
+	 * @param int      $shop_page_id The expected Shop page ID.
+	 */
+	private function assert_shop_page_queried_object( WP_Query $query, int $shop_page_id ): void {
+		$this->assertInstanceOf( WP_Post::class, $query->queried_object, 'queried_object should be a WP_Post instance.' );
+		$this->assertSame( $shop_page_id, $query->queried_object->ID, 'queried_object ID should match the Shop page ID.' );
+		$this->assertSame( $shop_page_id, $query->queried_object_id, 'queried_object_id should match the Shop page ID.' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #34827.

This fix is inspired by https://github.com/woocommerce/woocommerce/pull/63207/. I don't have a preference between that PR or this one, but this one keeps the changes smaller, only focused on fixing https://github.com/woocommerce/woocommerce/issues/34827.

### How to test the changes in this Pull Request:

**Test the fix:**

1. Make sure your header has the _Page List_ block.
2. Go to the Shop page.
3. Verify the `<li>` around the _Shop_ link inside the _Page List_ block has the `current-menu-item` class.

**Test the are not regressions:**

(Copied from https://github.com/woocommerce/woocommerce/pull/63202)

1. Install Divi (see p1770650490840659/1770607333.478699-slack-C01DT6U03HC).
2. Go to Pages > Shop and click on Edit With Divi. If that doesn't work, click on Edit and inside the editor, click on Edit With Divi Builder.
3. Add the Woo Products block and save.
4. Visit the page in the frontend.
5. Verify products are listed as expected.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->