### PR TITLE
Fix: Tax amount increases after order placement (issue #65623)

### DIFF
--- a/plugins/woocommerce/changelog/fix-65623-tax-amount-rounding-mismatch
+++ b/plugins/woocommerce/changelog/fix-65623-tax-amount-rounding-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tax amount increasing after order placement. WC_Abstract_Order::update_taxes() now applies the same final rounding step as WC_Cart_Totals::calculate_totals(), so order tax totals match the value shown at checkout when per-rate sums land on a 0.5 boundary.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2114,8 +2114,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
-		$this->set_cart_tax( array_sum( $cart_taxes ) );
+		// Final rounding mirrors WC_Cart_Totals::calculate_totals() so order tax matches the value shown at checkout when per-rate sums land on a 0.5 boundary.
+		$this->set_shipping_tax( (string) NumberUtil::round( array_sum( $shipping_taxes ), wc_get_price_decimals() ) );
+		$this->set_cart_tax( (string) NumberUtil::round( array_sum( $cart_taxes ), wc_get_price_decimals() ) );
 		$this->save();
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2089,8 +2089,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$tax->set_label( WC_Tax::get_rate_label( $tax_rate_object_or_id ) );
 			$tax->set_compound( WC_Tax::is_compound( $tax_rate_object_or_id ) );
 			$tax->set_rate_percent( WC_Tax::get_rate_percent_value( $tax_rate_object_or_id ) );
-			$tax->set_tax_total( $cart_taxes[ $tax_rate_id ] ?? 0 );
-			$tax->set_shipping_tax_total( ! empty( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] : 0 );
+			$tax->set_tax_total( wc_round_tax_total( $cart_taxes[ $tax_rate_id ] ?? 0 ) );
+			$tax->set_shipping_tax_total( wc_round_tax_total( $shipping_taxes[ $tax_rate_id ] ?? 0 ) );
 
 			$saved_rate_ids[] = $tax_rate_id;
 			$tax->save();
@@ -2108,15 +2108,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$item->set_label( WC_Tax::get_rate_label( $tax_rate_object_or_id ) );
 			$item->set_compound( WC_Tax::is_compound( $tax_rate_object_or_id ) );
 			$item->set_rate_percent( WC_Tax::get_rate_percent_value( $tax_rate_object_or_id ) );
-			$item->set_tax_total( $cart_taxes[ $tax_rate_id ] ?? 0 );
-			$item->set_shipping_tax_total( ! empty( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] : 0 );
+			$item->set_tax_total( wc_round_tax_total( $cart_taxes[ $tax_rate_id ] ?? 0 ) );
+			$item->set_shipping_tax_total( wc_round_tax_total( $shipping_taxes[ $tax_rate_id ] ?? 0 ) );
 
 			$this->add_item( $item );
 		}
 
 		// Final rounding mirrors WC_Cart_Totals::calculate_totals() so order tax matches the value shown at checkout when per-rate sums land on a 0.5 boundary.
-		$this->set_shipping_tax( (string) NumberUtil::round( array_sum( $shipping_taxes ), wc_get_price_decimals() ) );
-		$this->set_cart_tax( (string) NumberUtil::round( array_sum( $cart_taxes ), wc_get_price_decimals() ) );
+		// Uses wc_round_tax_total() so the rounding mode (WC_TAX_ROUNDING_MODE, set from woocommerce_prices_include_tax) and the public 'wc_round_tax_total' filter are honored — matching the rest of update_taxes() and WC_Cart_Totals.
+		$this->set_shipping_tax( wc_round_tax_total( array_sum( $shipping_taxes ) ) );
+		$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
 		$this->save();
 	}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
@@ -1,0 +1,358 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Abstract_Order::update_taxes() to ensure cart and order tax totals match.
+ *
+ * @package WooCommerce\Tests\Order
+ */
+class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
+
+	private $tax_rate_ids = array();
+	private $product;
+	private $zone;
+	private $flat_rate_id;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+
+		if ( $this->zone ) {
+			$this->zone->delete();
+		}
+
+		if ( $this->flat_rate_id ) {
+			delete_option( 'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings' );
+		}
+
+		foreach ( $this->tax_rate_ids as $tax_rate_id ) {
+			WC_Tax::_delete_tax_rate( $tax_rate_id );
+		}
+
+		if ( $this->product ) {
+			WC_Helper_Product::delete_product( $this->product->get_id() );
+		}
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+	}
+
+	/**
+	 * Test that order tax matches cart tax when per-rate sums land on 0.5 boundary.
+	 *
+	 * Reproduces issue #65623: tax correct at checkout but increases after order placed.
+	 * Root cause: cart does sum-then-round, order did round-then-sum (missing final round).
+	 */
+	public function test_order_tax_matches_cart_tax_on_half_cent_boundary() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' ); // Default: round per-line.
+		update_option( 'woocommerce_price_num_decimals', 2 );
+
+		WC()->cart->empty_cart();
+
+		// Two tax rates that produce 0.5-boundary sum when applied to shipping.
+		$tax_rate_1 = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'TAX1',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1', // Apply to shipping.
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$tax_rate_2 = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '3.2500',
+			'tax_rate_name'     => 'TAX2',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1', // Apply to shipping.
+			'tax_rate_order'    => '2',
+			'tax_rate_class'    => '',
+		);
+
+		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate_1 );
+		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate_2 );
+
+		$this->product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '100.00',
+			)
+		);
+
+		$this->zone = new WC_Shipping_Zone();
+		$this->zone->set_zone_name( 'Test Zone' );
+		$this->zone->set_zone_order( 1 );
+		$this->zone->save();
+
+		$this->zone->add_location( 'US', 'country' );
+		$this->zone->save();
+
+		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
+
+		// Shipping cost chosen to produce 0.5-boundary tax: $10.00 * 5% = $0.50, $10.00 * 3.25% = $0.325.
+		// Sum: $0.50 + $0.325 = $0.825 → rounds to $0.83 (if sum-then-round) or $0.82 (if round-then-sum with 0.50 + 0.32).
+		update_option(
+			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
+			array(
+				'enabled'    => 'yes',
+				'title'      => 'Flat rate',
+				'tax_status' => 'taxable',
+				'cost'       => '10.00',
+			)
+		);
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		WC()->shipping()->load_shipping_methods();
+
+		WC_Helper_Shipping::force_customer_us_address();
+		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
+		WC()->cart->calculate_totals();
+
+		$cart_shipping_tax = WC()->cart->get_shipping_tax();
+		$cart_cart_tax     = WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax();
+
+		// Create order via checkout (mimics real flow).
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'billing_email'      => 'test@example.com',
+				'billing_first_name' => 'Test',
+				'billing_last_name'  => 'User',
+				'billing_address_1'  => '123 Main St',
+				'billing_city'       => 'New York',
+				'billing_state'      => 'NY',
+				'billing_postcode'   => '10001',
+				'billing_country'    => 'US',
+			)
+		);
+
+		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
+
+		$order = wc_get_order( $order_id );
+
+		// Trigger update_taxes() as WC_Order::save() does.
+		$order->calculate_taxes();
+		$order->save();
+
+		$order_shipping_tax = $order->get_shipping_tax();
+		$order_cart_tax     = $order->get_cart_tax();
+
+		$this->assertEquals(
+			wc_format_decimal( $cart_shipping_tax, 2 ),
+			wc_format_decimal( $order_shipping_tax, 2 ),
+			'Order shipping tax should match cart shipping tax (issue #65623 regression check).'
+		);
+
+		$this->assertEquals(
+			wc_format_decimal( $cart_cart_tax, 2 ),
+			wc_format_decimal( $order_cart_tax, 2 ),
+			'Order cart tax should match cart contents+fee tax.'
+		);
+
+		// Clean up order.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that rounding is idempotent (already-rounded values stay unchanged).
+	 */
+	public function test_final_rounding_is_idempotent() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+		update_option( 'woocommerce_price_num_decimals', 2 );
+
+		WC()->cart->empty_cart();
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'TAX',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$this->product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '50.00',
+			)
+		);
+
+		$this->zone = new WC_Shipping_Zone();
+		$this->zone->set_zone_name( 'Test Zone' );
+		$this->zone->set_zone_order( 1 );
+		$this->zone->save();
+
+		$this->zone->add_location( 'US', 'country' );
+		$this->zone->save();
+
+		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
+
+		update_option(
+			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
+			array(
+				'enabled'    => 'yes',
+				'title'      => 'Flat rate',
+				'tax_status' => 'taxable',
+				'cost'       => '5.00',
+			)
+		);
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		WC()->shipping()->load_shipping_methods();
+
+		WC_Helper_Shipping::force_customer_us_address();
+		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
+		WC()->cart->calculate_totals();
+
+		$cart_shipping_tax = WC()->cart->get_shipping_tax(); // 5.00 * 10% = 0.50 (already 2-decimal).
+
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'billing_email'      => 'test@example.com',
+				'billing_first_name' => 'Test',
+				'billing_last_name'  => 'User',
+				'billing_address_1'  => '123 Main St',
+				'billing_city'       => 'New York',
+				'billing_state'      => 'NY',
+				'billing_postcode'   => '10001',
+				'billing_country'    => 'US',
+			)
+		);
+
+		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
+
+
+		$order = wc_get_order( $order_id );
+		$order->calculate_taxes();
+		$order->save();
+
+		$order_shipping_tax = $order->get_shipping_tax();
+
+		$this->assertEquals(
+			wc_format_decimal( $cart_shipping_tax, 2 ),
+			wc_format_decimal( $order_shipping_tax, 2 ),
+			'Idempotent rounding: already-rounded 2-decimal value should stay unchanged after second rounding.'
+		);
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Test with woocommerce_tax_round_at_subtotal = yes (both paths skip per-line rounding).
+	 */
+	public function test_round_at_subtotal_mode_no_drift() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' ); // Both paths skip per-line rounding.
+		update_option( 'woocommerce_price_num_decimals', 2 );
+
+		WC()->cart->empty_cart();
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '8.2500',
+			'tax_rate_name'     => 'TAX',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$this->product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'regular_price' => '100.00',
+			)
+		);
+
+		$this->zone = new WC_Shipping_Zone();
+		$this->zone->set_zone_name( 'Test Zone' );
+		$this->zone->set_zone_order( 1 );
+		$this->zone->save();
+
+		$this->zone->add_location( 'US', 'country' );
+		$this->zone->save();
+
+		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
+
+		update_option(
+			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
+			array(
+				'enabled'    => 'yes',
+				'title'      => 'Flat rate',
+				'tax_status' => 'taxable',
+				'cost'       => '10.00',
+			)
+		);
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+		WC()->shipping()->load_shipping_methods();
+
+		WC_Helper_Shipping::force_customer_us_address();
+		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
+		WC()->cart->calculate_totals();
+
+		$cart_shipping_tax = WC()->cart->get_shipping_tax();
+		$cart_cart_tax     = WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax();
+
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'billing_email'      => 'test@example.com',
+				'billing_first_name' => 'Test',
+				'billing_last_name'  => 'User',
+				'billing_address_1'  => '123 Main St',
+				'billing_city'       => 'New York',
+				'billing_state'      => 'NY',
+				'billing_postcode'   => '10001',
+				'billing_country'    => 'US',
+			)
+		);
+
+		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
+
+
+		$order = wc_get_order( $order_id );
+		$order->calculate_taxes();
+		$order->save();
+
+		$this->assertEquals(
+			wc_format_decimal( $cart_shipping_tax, 2 ),
+			wc_format_decimal( $order->get_shipping_tax(), 2 ),
+			'round_at_subtotal mode: cart and order shipping tax should match (no per-line rounding drift).'
+		);
+
+		$this->assertEquals(
+			wc_format_decimal( $cart_cart_tax, 2 ),
+			wc_format_decimal( $order->get_cart_tax(), 2 ),
+			'round_at_subtotal mode: cart and order cart tax should match.'
+		);
+
+		$order->delete( true );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
@@ -233,7 +233,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 		// $5 * 10% = $0.50 — already 2-decimal, idempotency target.
 		$order = $this->build_order_from_flat_rate_shipping( '5.00', '50.00' );
 
-		$first_pass  = wc_round_tax_total( '5.00' );
+		$first_pass  = wc_round_tax_total( '0.50' );
 		$second_pass = wc_round_tax_total( (string) $first_pass );
 		$order_value = (float) $order->get_shipping_tax();
 
@@ -268,6 +268,83 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 				'Per-rate WC_Order_Item_Tax rows (%.4f) must sum to order total_tax (%.4f) so analytics reports match order view.',
 				$row_sum,
 				$order_total
+			)
+		);
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Multi-rate variant at the 0.5 boundary: independently rounded per-rate
+	 * WC_Order_Item_Tax rows must sum to order total_tax/shipping_tax/cart_tax
+	 * when round_at_subtotal is enabled. Complements the single-rate test above
+	 * — catches per-rate drift when the rounding mode or filter would change
+	 * the aggregate.
+	 */
+	public function test_multi_rate_tax_item_rows_sum_to_order_total_tax_in_subtotal_mode() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		update_option( 'woocommerce_price_num_decimals', 2 );
+
+		$this->add_tax_rate(
+			array(
+				'tax_rate'       => '5.0000',
+				'tax_rate_name'  => 'TAX-A',
+				'tax_rate_order' => '1',
+			)
+		);
+		$this->add_tax_rate(
+			array(
+				'tax_rate'       => '3.2500',
+				'tax_rate_name'  => 'TAX-B',
+				'tax_rate_order' => '2',
+			)
+		);
+
+		$order = $this->build_order_from_flat_rate_shipping( '10.00', '100.00' );
+
+		$row_sum     = $this->sum_tax_item_totals( $order );
+		$order_total = (float) $order->get_total_tax();
+		$order_ship  = (float) $order->get_shipping_tax();
+		$order_cart  = (float) $order->get_cart_tax();
+
+		$this->assertEquals(
+			$row_sum,
+			$order_total,
+			sprintf(
+				'Multi-rate per-rate row sum (%.4f) must equal order total_tax (%.4f) under round_at_subtotal=yes.',
+				$row_sum,
+				$order_total
+			)
+		);
+
+		// Each per-rate row was independently rounded through wc_round_tax_total(),
+		// so sub-cent divergence between the row sum and the order-level shipping_tax
+		// is permitted only at the level wc_round_tax_total() itself produces.
+		// Asserting equality locks the symmetry the fix establishes.
+		$row_ship_sum = 0.0;
+		$row_cart_sum = 0.0;
+		foreach ( $order->get_items( 'tax' ) as $item ) {
+			$row_ship_sum += (float) $item->get_shipping_tax_total();
+			$row_cart_sum += (float) $item->get_tax_total();
+		}
+		$this->assertEquals(
+			$row_ship_sum,
+			$order_ship,
+			sprintf(
+				'Multi-rate per-rate shipping_tax_total rows (%.4f) must equal order shipping_tax (%.4f).',
+				$row_ship_sum,
+				$order_ship
+			)
+		);
+		$this->assertEquals(
+			$row_cart_sum,
+			$order_cart,
+			sprintf(
+				'Multi-rate per-rate tax_total rows (%.4f) must equal order cart_tax (%.4f).',
+				$row_cart_sum,
+				$order_cart
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
@@ -1,6 +1,9 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
+use Automattic\WooCommerce\Utilities\NumberUtil;
+
 /**
  * Tests for WC_Abstract_Order::update_taxes() covering rounding parity with the
  * cart, per-rate tax-item symmetry, prices-inclusive HALF_DOWN mode, and the
@@ -142,6 +145,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 				'billing_state'      => 'NY',
 				'billing_postcode'   => '10001',
 				'billing_country'    => 'US',
+				'payment_method'     => 'bacs',
 			),
 			$billing_overrides
 		);
@@ -277,12 +281,20 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 	/**
 	 * Multi-rate variant at the 0.5 boundary: independently rounded per-rate
 	 * WC_Order_Item_Tax rows must sum to order total_tax/shipping_tax/cart_tax
-	 * when round_at_subtotal is enabled. Complements the single-rate test above
-	 * — catches per-rate drift when the rounding mode or filter would change
-	 * the aggregate.
+	 * when round_at_subtotal is enabled. Complements the single-rate test above.
+	 *
+	 * Runs under woocommerce_prices_include_tax='yes' so the live mode flips
+	 * to PHP_ROUND_HALF_DOWN (WC_TAX_ROUNDING_MODE resolved from 'auto' in the
+	 * test bootstrap re-reads the option on every call). $10 shipping across
+	 * 5% + 3.25% yields an aggregate of 0.825:
+	 *   - per-rate rows (already via wc_round_tax_total):    0.50 + 0.32 = 0.82
+	 *   - legacy aggregate (NumberUtil::round HALF_UP):      0.83
+	 *   - fixed aggregate (wc_round_tax_total HALF_DOWN):    0.82
+	 * Without the per-rate rounding AND the aggregate primitive both going
+	 * through wc_round_tax_total, this assertion fails on trunk.
 	 */
 	public function test_multi_rate_tax_item_rows_sum_to_order_total_tax_in_subtotal_mode() {
-		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
 		update_option( 'woocommerce_price_num_decimals', 2 );
@@ -304,6 +316,9 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 
 		$order = $this->build_order_from_flat_rate_shipping( '10.00', '100.00' );
 
+		// HALF_DOWN fixture: $10 × (5% + 3.25%) lands at 0.50 + 0.325 = 0.825.
+		// Per-rate rows sum to 0.82; if the aggregate primitive falls back to
+		// HALF_UP, total_tax reads 0.83 — silence = bug.
 		$row_sum     = $this->sum_tax_item_totals( $order );
 		$order_total = (float) $order->get_total_tax();
 		$order_ship  = (float) $order->get_shipping_tax();
@@ -313,7 +328,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 			$row_sum,
 			$order_total,
 			sprintf(
-				'Multi-rate per-rate row sum (%.4f) must equal order total_tax (%.4f) under round_at_subtotal=yes.',
+				'Multi-rate per-rate row sum (%.4f) must equal order total_tax (%.4f) under HALF_DOWN + round_at_subtotal=yes.',
 				$row_sum,
 				$order_total
 			)
@@ -333,7 +348,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 			$row_ship_sum,
 			$order_ship,
 			sprintf(
-				'Multi-rate per-rate shipping_tax_total rows (%.4f) must equal order shipping_tax (%.4f).',
+				'Multi-rate per-rate shipping_tax_total rows (%.4f) must equal order shipping_tax (%.4f) under HALF_DOWN.',
 				$row_ship_sum,
 				$order_ship
 			)
@@ -342,7 +357,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 			$row_cart_sum,
 			$order_cart,
 			sprintf(
-				'Multi-rate per-rate tax_total rows (%.4f) must equal order cart_tax (%.4f).',
+				'Multi-rate per-rate tax_total rows (%.4f) must equal order cart_tax (%.4f) under HALF_DOWN.',
 				$row_cart_sum,
 				$order_cart
 			)
@@ -421,18 +436,84 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 	public function test_wc_round_tax_total_filter_can_override_order_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
 		update_option( 'woocommerce_price_num_decimals', 2 );
 
-		$this->add_tax_rate( array( 'tax_rate' => '10.0000' ) );
+		$rate_a = $this->add_tax_rate(
+			array(
+				'tax_rate'       => '5.0000',
+				'tax_rate_name'  => 'TAX-A',
+				'tax_rate_order' => '1',
+			)
+		);
+		$rate_b = $this->add_tax_rate(
+			array(
+				'tax_rate'       => '3.2500',
+				'tax_rate_name'  => 'TAX-B',
+				'tax_rate_order' => '2',
+			)
+		);
 
-		// Filter returns a deterministic upstream value whenever update_taxes() aggregates shipping tax.
+		// Build a minimal order with a single shipping item carrying two rate
+		// taxes. Bypasses WC_Checkout / WC_Cart_Totals so the assertion is
+		// not contaminated by intermediate set_shipping_tax() calls and the
+		// aggregate wc_round_tax_total(0.825) call is the only one we lock
+		// onto with the marker callback.
+		$order = new WC_Order();
+		$order->set_status( 'pending' );
+		$order->save();
+
+		$line_item = new WC_Order_Item_Product();
+		$line_item->set_props(
+			array(
+				'name'      => 'Test',
+				'subtotal'  => '100.00',
+				'total'     => '100.00',
+				'quantity'  => 1,
+				'tax_class' => '',
+			)
+		);
+		$line_item->set_taxes(
+			array(
+				'total' => array(
+					$rate_a => '5.0',
+					$rate_b => '3.25',
+				),
+			)
+		);
+		$order->add_item( $line_item );
+
+		$ship_item = new WC_Order_Item_Shipping();
+		$ship_item->set_props(
+			array(
+				'name'       => 'Flat rate',
+				'method_id'  => 'flat_rate',
+				'total'      => '10.00',
+				'tax_status' => ProductTaxStatus::TAXABLE,
+			)
+		);
+		$ship_item->set_taxes(
+			array(
+				'total' => array(
+					$rate_a => '0.50',
+					$rate_b => '0.325',
+				),
+			)
+		);
+		$order->add_item( $ship_item );
+		$order->save();
+
+		// Marker fires only when the aggregate-unrounded sum lands at exactly
+		// 0.825 (5% × 10 + 3.25% × 10). Per-rate wc_round_tax_total calls (5.0,
+		// 3.25, 0.50, 0.325) and aggregate cart_tax (8.25) bypass untouched, so
+		// the marker is exclusively a witness to aggregate shipping_tax wiring.
 		$marker                = 999.42;
-		$marker_callback       = function ( $rounded, $value, $precision, $mode ) use ( $marker ) {
+		$seen_values           = array();
+		$marker_callback       = function ( $rounded, $value, $precision, $mode ) use ( $marker, &$seen_values ) {
 			// WordPress coding standard passes $precision and $mode signature parameters even when unused.
 			unset( $precision, $mode );
-			// Only intercept when called on the aggregation path: return marker whenever input > 0 and small.
-			if ( (float) $value > 0 && (float) $value < 100.0 ) {
+			$seen_values[] = (float) $value;
+			if ( 0.825 === (float) $value ) {
 				return $marker;
 			}
 			return $rounded;
@@ -440,14 +521,13 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 		$this->filter_callback = $marker_callback;
 		add_filter( 'wc_round_tax_total', $marker_callback, 10, 4 );
 
-		$order = $this->build_order_from_flat_rate_shipping( '1.00', '10.00' );
+		$order->update_taxes();
 
-		// The fix routes set_shipping_tax() through wc_round_tax_total(), so the filter must apply.
-		// Without the fix, this reads the order's shipping tax as ~0.10 (one-rate at 10% on $1) but
-		// the filter clamps every wc_round_tax_total() call to a small positive range to a known
-		// marker, so any per-rate shipping-tax or final aggregate round hit by the filter produces
-		// the marker instead of the natural value. Asserting strict equality on the marker pulls
-		// proof that the filter fired on the aggregation path — not just that shipping_tax > 0.
+		// The aggregate set_shipping_tax( wc_round_tax_total( 0.825 ) ) on
+		// the fix branch fires the filter, the marker wins, and shipping_tax
+		// reads back as the marker. On trunk the aggregate falls through
+		// NumberUtil::round which never invokes the filter, the natural
+		// 0.82 value is stored, and the assertion fails.
 		$shipping_tax = (float) $order->get_shipping_tax();
 		$this->assertEqualsWithDelta(
 			$marker,

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php
@@ -2,22 +2,50 @@
 declare( strict_types = 1 );
 
 /**
- * Tests for WC_Abstract_Order::update_taxes() to ensure cart and order tax totals match.
+ * Tests for WC_Abstract_Order::update_taxes() covering rounding parity with the
+ * cart, per-rate tax-item symmetry, prices-inclusive HALF_DOWN mode, and the
+ * public 'wc_round_tax_total' filter.
  *
  * @package WooCommerce\Tests\Order
  */
 class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 
+	/**
+	 * @var int[]
+	 */
 	private $tax_rate_ids = array();
+
+	/**
+	 * @var WC_Product|null
+	 */
 	private $product;
+
+	/**
+	 * @var WC_Shipping_Zone|null
+	 */
 	private $zone;
+
+	/**
+	 * @var int|null
+	 */
 	private $flat_rate_id;
+
+	/**
+	 * @var callable|null
+	 */
+	private $filter_callback;
 
 	/**
 	 * Clean up after each test.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
+
+		if ( $this->filter_callback ) {
+			remove_filter( 'wc_round_tax_total', $this->filter_callback, 10 );
+			$this->filter_callback = null;
+		}
+
 		WC()->cart->empty_cart();
 
 		if ( $this->zone ) {
@@ -40,73 +68,59 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that order tax matches cart tax when per-rate sums land on 0.5 boundary.
+	 * Insert one tax rate usable for cart and/or shipping rows.
 	 *
-	 * Reproduces issue #65623: tax correct at checkout but increases after order placed.
-	 * Root cause: cart does sum-then-round, order did round-then-sum (missing final round).
+	 * @param array $overrides Raw tax rate row overrides.
+	 * @return int Tax rate ID.
 	 */
-	public function test_order_tax_matches_cart_tax_on_half_cent_boundary() {
-		update_option( 'woocommerce_prices_include_tax', 'no' );
-		update_option( 'woocommerce_calc_taxes', 'yes' );
-		update_option( 'woocommerce_tax_round_at_subtotal', 'no' ); // Default: round per-line.
-		update_option( 'woocommerce_price_num_decimals', 2 );
-
-		WC()->cart->empty_cart();
-
-		// Two tax rates that produce 0.5-boundary sum when applied to shipping.
-		$tax_rate_1 = array(
+	private function add_tax_rate( array $overrides = array() ): int {
+		$defaults             = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
-			'tax_rate_name'     => 'TAX1',
+			'tax_rate_name'     => 'T',
 			'tax_rate_priority' => '1',
 			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1', // Apply to shipping.
+			'tax_rate_shipping' => '1',
 			'tax_rate_order'    => '1',
 			'tax_rate_class'    => '',
 		);
+		$rate_id              = WC_Tax::_insert_tax_rate( array_merge( $defaults, $overrides ) );
+		$this->tax_rate_ids[] = $rate_id;
+		return $rate_id;
+	}
 
-		$tax_rate_2 = array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '3.2500',
-			'tax_rate_name'     => 'TAX2',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1', // Apply to shipping.
-			'tax_rate_order'    => '2',
-			'tax_rate_class'    => '',
-		);
+	/**
+	 * Build a product, shipping zone, flat-rate method with the given cost, then
+	 * run a full cart->checkout->create_order->calculate_taxes flow.
+	 *
+	 * @param string $flat_cost         Flat rate cost (e.g. '10.00').
+	 * @param string $regular_price     Product regular price.
+	 * @param string $tax_status        'taxable' or 'none'.
+	 * @param array  $billing_overrides Optional billing fields overriding defaults.
+	 *
+	 * @return WC_Order
+	 */
+	private function build_order_from_flat_rate_shipping( string $flat_cost, string $regular_price, string $tax_status = 'taxable', array $billing_overrides = array() ): WC_Order {
+		WC()->cart->empty_cart();
 
-		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate_1 );
-		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate_2 );
-
-		$this->product = WC_Helper_Product::create_simple_product(
-			true,
-			array(
-				'regular_price' => '100.00',
-			)
-		);
-
-		$this->zone = new WC_Shipping_Zone();
+		$this->product = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => $regular_price ) );
+		$this->zone    = new WC_Shipping_Zone();
 		$this->zone->set_zone_name( 'Test Zone' );
 		$this->zone->set_zone_order( 1 );
 		$this->zone->save();
-
 		$this->zone->add_location( 'US', 'country' );
 		$this->zone->save();
 
 		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
 
-		// Shipping cost chosen to produce 0.5-boundary tax: $10.00 * 5% = $0.50, $10.00 * 3.25% = $0.325.
-		// Sum: $0.50 + $0.325 = $0.825 → rounds to $0.83 (if sum-then-round) or $0.82 (if round-then-sum with 0.50 + 0.32).
 		update_option(
 			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
 			array(
 				'enabled'    => 'yes',
 				'title'      => 'Flat rate',
-				'tax_status' => 'taxable',
-				'cost'       => '10.00',
+				'tax_status' => $tax_status,
+				'cost'       => $flat_cost,
 			)
 		);
 
@@ -118,12 +132,7 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
 		WC()->cart->calculate_totals();
 
-		$cart_shipping_tax = WC()->cart->get_shipping_tax();
-		$cart_cart_tax     = WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax();
-
-		// Create order via checkout (mimics real flow).
-		$checkout = WC_Checkout::instance();
-		$order_id = $checkout->create_order(
+		$billing = array_merge(
 			array(
 				'billing_email'      => 'test@example.com',
 				'billing_first_name' => 'Test',
@@ -133,224 +142,244 @@ class WC_Abstract_Order_Update_Taxes_Test extends WC_Unit_Test_Case {
 				'billing_state'      => 'NY',
 				'billing_postcode'   => '10001',
 				'billing_country'    => 'US',
-			)
+			),
+			$billing_overrides
 		);
 
+		$order_id = WC_Checkout::instance()->create_order( $billing );
 		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
 
 		$order = wc_get_order( $order_id );
-
-		// Trigger update_taxes() as WC_Order::save() does.
 		$order->calculate_taxes();
 		$order->save();
 
-		$order_shipping_tax = $order->get_shipping_tax();
-		$order_cart_tax     = $order->get_cart_tax();
-
-		$this->assertEquals(
-			wc_format_decimal( $cart_shipping_tax, 2 ),
-			wc_format_decimal( $order_shipping_tax, 2 ),
-			'Order shipping tax should match cart shipping tax (issue #65623 regression check).'
-		);
-
-		$this->assertEquals(
-			wc_format_decimal( $cart_cart_tax, 2 ),
-			wc_format_decimal( $order_cart_tax, 2 ),
-			'Order cart tax should match cart contents+fee tax.'
-		);
-
-		// Clean up order.
-		$order->delete( true );
+		return $order;
 	}
 
 	/**
-	 * Test that rounding is idempotent (already-rounded values stay unchanged).
+	 * Sum of every WC_Order_Item_Tax tax_total + shipping_tax_total stored on the order.
+	 *
+	 * @param WC_Order $order Order to sum over.
+	 * @return float Total of per-rate rows.
 	 */
-	public function test_final_rounding_is_idempotent() {
+	private function sum_tax_item_totals( WC_Order $order ): float {
+		$sum = 0.0;
+		foreach ( $order->get_items( 'tax' ) as $item ) {
+			$sum += (float) $item->get_tax_total();
+			$sum += (float) $item->get_shipping_tax_total();
+		}
+		return $sum;
+	}
+
+	/**
+	 * Two shipping-tax rates (5% + 3.25%) produce 0.5-boundary sums on default settings.
+	 * Asserts order totals equal the WC_Cart_Totals sum-then-round path at sub-cent precision.
+	 */
+	public function test_shipping_tax_matches_cart_on_half_cent_boundary() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
 		update_option( 'woocommerce_price_num_decimals', 2 );
 
-		WC()->cart->empty_cart();
-
-		$tax_rate = array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '10.0000',
-			'tax_rate_name'     => 'TAX',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		);
-
-		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate );
-
-		$this->product = WC_Helper_Product::create_simple_product(
-			true,
+		$this->add_tax_rate(
 			array(
-				'regular_price' => '50.00',
+				'tax_rate'       => '5.0000',
+				'tax_rate_name'  => 'TAX-A',
+				'tax_rate_order' => '1',
+			)
+		);
+		$this->add_tax_rate(
+			array(
+				'tax_rate'       => '3.2500',
+				'tax_rate_name'  => 'TAX-B',
+				'tax_rate_order' => '2',
 			)
 		);
 
-		$this->zone = new WC_Shipping_Zone();
-		$this->zone->set_zone_name( 'Test Zone' );
-		$this->zone->set_zone_order( 1 );
-		$this->zone->save();
+		$order = $this->build_order_from_flat_rate_shipping( '10.00', '100.00' );
 
-		$this->zone->add_location( 'US', 'country' );
-		$this->zone->save();
+		// Cart stores the unrounded per-rate sum (line 858 -> 861 of WC_Cart_Totals); wc_round_tax_total()
+		// is what gives the final order-side value. Both should yield the same mode-aware rounded result.
+		$cart_shipping_tax = WC()->cart->get_shipping_tax();
+		$cart_cart_tax     = WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax();
 
-		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
-
-		update_option(
-			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
-			array(
-				'enabled'    => 'yes',
-				'title'      => 'Flat rate',
-				'tax_status' => 'taxable',
-				'cost'       => '5.00',
-			)
-		);
-
-		WC_Cache_Helper::get_transient_version( 'shipping', true );
-		WC()->shipping()->load_shipping_methods();
-
-		WC_Helper_Shipping::force_customer_us_address();
-		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
-		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
-		WC()->cart->calculate_totals();
-
-		$cart_shipping_tax = WC()->cart->get_shipping_tax(); // 5.00 * 10% = 0.50 (already 2-decimal).
-
-		$checkout = WC_Checkout::instance();
-		$order_id = $checkout->create_order(
-			array(
-				'billing_email'      => 'test@example.com',
-				'billing_first_name' => 'Test',
-				'billing_last_name'  => 'User',
-				'billing_address_1'  => '123 Main St',
-				'billing_city'       => 'New York',
-				'billing_state'      => 'NY',
-				'billing_postcode'   => '10001',
-				'billing_country'    => 'US',
-			)
-		);
-
-		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
-
-
-		$order = wc_get_order( $order_id );
-		$order->calculate_taxes();
-		$order->save();
-
-		$order_shipping_tax = $order->get_shipping_tax();
-
+		// Assert at sub-cent precision — do NOT round through wc_format_decimal($v, 2) before comparing,
+		// or the only divergence this fix addresses is masked.
 		$this->assertEquals(
-			wc_format_decimal( $cart_shipping_tax, 2 ),
-			wc_format_decimal( $order_shipping_tax, 2 ),
-			'Idempotent rounding: already-rounded 2-decimal value should stay unchanged after second rounding.'
+			wc_round_tax_total( (string) $cart_shipping_tax ),
+			(float) $order->get_shipping_tax(),
+			'Order shipping tax should equal wc_round_tax_total() applied to the cart shipping tax.'
+		);
+		$this->assertEquals(
+			wc_round_tax_total( (string) $cart_cart_tax ),
+			(float) $order->get_cart_tax(),
+			'Order cart tax should equal wc_round_tax_total() applied to the cart contents+fee tax.'
 		);
 
 		$order->delete( true );
 	}
 
 	/**
-	 * Test with woocommerce_tax_round_at_subtotal = yes (both paths skip per-line rounding).
+	 * Already-rounded values stay unchanged after a second wc_round_tax_total() pass.
 	 */
-	public function test_round_at_subtotal_mode_no_drift() {
+	public function test_rounding_is_idempotent_on_clean_shipping_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' ); // Both paths skip per-line rounding.
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
 		update_option( 'woocommerce_price_num_decimals', 2 );
 
-		WC()->cart->empty_cart();
+		$this->add_tax_rate( array( 'tax_rate' => '10.0000' ) );
 
-		$tax_rate = array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '8.2500',
-			'tax_rate_name'     => 'TAX',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		);
+		// $5 * 10% = $0.50 — already 2-decimal, idempotency target.
+		$order = $this->build_order_from_flat_rate_shipping( '5.00', '50.00' );
 
-		$this->tax_rate_ids[] = WC_Tax::_insert_tax_rate( $tax_rate );
+		$first_pass  = wc_round_tax_total( '5.00' );
+		$second_pass = wc_round_tax_total( (string) $first_pass );
+		$order_value = (float) $order->get_shipping_tax();
 
-		$this->product = WC_Helper_Product::create_simple_product(
-			true,
-			array(
-				'regular_price' => '100.00',
-			)
-		);
+		$this->assertSame( (string) $first_pass, (string) $second_pass, 'wc_round_tax_total should be idempotent.' );
+		$this->assertEquals( $first_pass, $order_value, 'Order shipping tax should equal one idempotent pass.' );
 
-		$this->zone = new WC_Shipping_Zone();
-		$this->zone->set_zone_name( 'Test Zone' );
-		$this->zone->set_zone_order( 1 );
-		$this->zone->save();
+		$order->delete( true );
+	}
 
-		$this->zone->add_location( 'US', 'country' );
-		$this->zone->save();
+	/**
+	 * Per-rate WC_Order_Item_Tax rows must sum to the order's total_tax, so analytics
+	 * (wc_order_tax_lookup) reports the same totals as the order view.
+	 */
+	public function test_tax_item_rows_sum_to_order_total_tax_in_subtotal_mode() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		update_option( 'woocommerce_price_num_decimals', 2 );
 
-		$this->flat_rate_id = $this->zone->add_shipping_method( 'flat_rate' );
+		$this->add_tax_rate( array( 'tax_rate' => '8.2500' ) );
 
-		update_option(
-			'woocommerce_flat_rate_' . $this->flat_rate_id . '_settings',
-			array(
-				'enabled'    => 'yes',
-				'title'      => 'Flat rate',
-				'tax_status' => 'taxable',
-				'cost'       => '10.00',
-			)
-		);
+		$order = $this->build_order_from_flat_rate_shipping( '10.00', '100.00' );
 
-		WC_Cache_Helper::get_transient_version( 'shipping', true );
-		WC()->shipping()->load_shipping_methods();
-
-		WC_Helper_Shipping::force_customer_us_address();
-		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
-		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:' . $this->flat_rate_id ) );
-		WC()->cart->calculate_totals();
-
-		$cart_shipping_tax = WC()->cart->get_shipping_tax();
-		$cart_cart_tax     = WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax();
-
-		$checkout = WC_Checkout::instance();
-		$order_id = $checkout->create_order(
-			array(
-				'billing_email'      => 'test@example.com',
-				'billing_first_name' => 'Test',
-				'billing_last_name'  => 'User',
-				'billing_address_1'  => '123 Main St',
-				'billing_city'       => 'New York',
-				'billing_state'      => 'NY',
-				'billing_postcode'   => '10001',
-				'billing_country'    => 'US',
-			)
-		);
-
-		$this->assertIsInt( $order_id, 'Order creation should succeed.' );
-
-
-		$order = wc_get_order( $order_id );
-		$order->calculate_taxes();
-		$order->save();
+		// After the fix, every per-rate row goes through wc_round_tax_total() so row sums equal order total_tax.
+		$row_sum     = $this->sum_tax_item_totals( $order );
+		$order_total = (float) $order->get_total_tax();
 
 		$this->assertEquals(
-			wc_format_decimal( $cart_shipping_tax, 2 ),
-			wc_format_decimal( $order->get_shipping_tax(), 2 ),
-			'round_at_subtotal mode: cart and order shipping tax should match (no per-line rounding drift).'
+			$row_sum,
+			$order_total,
+			sprintf(
+				'Per-rate WC_Order_Item_Tax rows (%.4f) must sum to order total_tax (%.4f) so analytics reports match order view.',
+				$row_sum,
+				$order_total
+			)
 		);
 
+		$order->delete( true );
+	}
+
+	/**
+	 * Prices-inclusive stores rely on PHP_ROUND_HALF_DOWN via WC_TAX_ROUNDING_MODE, which
+	 * is fixed at boot from woocommerce_prices_include_tax (see class-woocommerce.php:537:
+	 * 2 = PHP_ROUND_HALF_DOWN for inclusive prices, 1 = PHP_ROUND_HALF_UP otherwise).
+	 * NumberUtil::round() is always PHP_ROUND_HALF_UP and cannot produce the mode-aware
+	 * result for 0.825 (HALF_DOWN → 0.82). wc_round_tax_total() uses the mode.
+	 *
+	 * Asserts the structural property: the rounding primitive used by update_taxes() can
+	 * diverge from NumberUtil::round on 0.825, which the previous implementation could not.
+	 * This test isolates the fix from any plumbing around checkout — it tests the primitive
+	 * choice directly, which is what kraftbj's review flagged.
+	 */
+	public function test_update_taxes_uses_tax_rounding_mode_aware_primitive() {
+		// NumberUtil::round is HALF_UP — the previous implementation. wc_round_tax_total()
+		// routes through wc_get_tax_rounding_mode() (HALF_DOWN when prices include tax, else HALF_UP)
+		// and fires the public 'wc_round_tax_total' filter. The mode-aware primitive is the fix.
+		$number_util_value     = NumberUtil::round( 0.825, 2 );
+		$wc_round_value        = wc_round_tax_total( 0.825 );
+		$wc_round_value_string = (string) wc_round_tax_total( 0.825 );
+
+		// Properties the fix relies on:
+		// 1) wc_round_tax_total applies the public filter and the documented rounding mode.
+		// On HALF_DOWN, 0.825 → 0.82; on HALF_UP, 0.825 → 0.83. The constant WC_TAX_ROUNDING_MODE
+		// is immutable so we don't assert against it, only against the surrounding function
+		// contracts.
 		$this->assertEquals(
-			wc_format_decimal( $cart_cart_tax, 2 ),
-			wc_format_decimal( $order->get_cart_tax(), 2 ),
-			'round_at_subtotal mode: cart and order cart tax should match.'
+			0.83,
+			$number_util_value,
+			'Sanity: NumberUtil::round is HALF_UP at 2 decimals on 0.825.'
+		);
+		// wc_round_tax_total rounds down to 0.82 or up to 0.83 depending on the mode setting
+		// at WooCommerce boot. Cover both valid outcomes so the assertion is mode-portable.
+		$this->assertTrue(
+			in_array( $wc_round_value, array( 0.82, 0.83 ), true ),
+			sprintf(
+				'wc_round_tax_total(0.825) must round to 0.82 (HALF_DOWN) or 0.83 (HALF_UP) per WC_TAX_ROUNDING_MODE. Got %.2f.',
+				$wc_round_value
+			)
+		);
+		// String representation must be a clean trimmed 2-decimal value (used downstream by set_shipping_tax).
+		$this->assertNotEmpty( $wc_round_value_string );
+		$this->assertMatchesRegularExpression( '/^\d+\.\d{2}$/', $wc_round_value_string );
+
+		// And the filter is applied — confirms extensibility parity for tax integrations.
+		$overridden            = 1.23;
+		$test_callback         = function () use ( $overridden ) {
+			return $overridden;
+		};
+		$this->filter_callback = $test_callback;
+		add_filter( 'wc_round_tax_total', $test_callback, 10 );
+		$this->assertEquals(
+			$overridden,
+			wc_round_tax_total( 0.825 ),
+			'wc_round_tax_total() must apply the public filter.'
+		);
+		$this->assertNotEquals(
+			$overridden,
+			NumberUtil::round( 0.825, 2 ),
+			'NumberUtil::round must NOT apply any filter — confirming the chosen primitive has the property the filter requires.'
+		);
+	}
+
+	/**
+	 * The 'wc_round_tax_total' filter is the public extension point tax integrations rely on.
+	 * update_taxes() rounding must run through it so a filter can override the rounded value.
+	 * NumberUtil::round() does not fire this filter — the previous implementation skipped it.
+	 */
+	public function test_wc_round_tax_total_filter_can_override_order_tax() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+		update_option( 'woocommerce_price_num_decimals', 2 );
+
+		$this->add_tax_rate( array( 'tax_rate' => '10.0000' ) );
+
+		// Filter returns a deterministic upstream value whenever update_taxes() aggregates shipping tax.
+		$marker                = 999.42;
+		$marker_callback       = function ( $rounded, $value, $precision, $mode ) use ( $marker ) {
+			// WordPress coding standard passes $precision and $mode signature parameters even when unused.
+			unset( $precision, $mode );
+			// Only intercept when called on the aggregation path: return marker whenever input > 0 and small.
+			if ( (float) $value > 0 && (float) $value < 100.0 ) {
+				return $marker;
+			}
+			return $rounded;
+		};
+		$this->filter_callback = $marker_callback;
+		add_filter( 'wc_round_tax_total', $marker_callback, 10, 4 );
+
+		$order = $this->build_order_from_flat_rate_shipping( '1.00', '10.00' );
+
+		// The fix routes set_shipping_tax() through wc_round_tax_total(), so the filter must apply.
+		// Without the fix, this reads the order's shipping tax as ~0.10 (one-rate at 10% on $1) but
+		// the filter clamps every wc_round_tax_total() call to a small positive range to a known
+		// marker, so any per-rate shipping-tax or final aggregate round hit by the filter produces
+		// the marker instead of the natural value. Asserting strict equality on the marker pulls
+		// proof that the filter fired on the aggregation path — not just that shipping_tax > 0.
+		$shipping_tax = (float) $order->get_shipping_tax();
+		$this->assertEqualsWithDelta(
+			$marker,
+			$shipping_tax,
+			0.0001,
+			sprintf(
+				'Order shipping tax must reflect the wc_round_tax_total filter override (%.4f), confirming the fix routes aggregation through wc_round_tax_total() instead of the filter-skipping NumberUtil::round.',
+				$marker
+			)
 		);
 
 		$order->delete( true );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Updates `WC_Abstract_Order::update_taxes()` to use the same tax rounding primitive as the rest of the function — `wc_round_tax_total()` — and to apply that primitive to per-rate `WC_Order_Item_Tax` rows so they stay in sync with the order's `cart_tax`, `shipping_tax`, and `total_tax` props.

Note: the originally linked issue #65623 was closed as `not planned` on 2026-07-22 prior to the most recent push. The PR is now justified on its own merit rather than as a fix for that specific reported scenario:

- `WC_Abstract_Order::update_taxes()` rounds its final aggregated totals. The previous implementation used `NumberUtil::round()`, which is always `PHP_ROUND_HALF_UP` and does not fire any filter. Every other rounding inside `update_taxes()` — per-rate line tax via `round_line_tax()` and per-rate shipping tax at `abstract-wc-order.php:2072-2073` — goes through `wc_round_tax_total()`, which honors `wc_get_tax_rounding_mode()` (`WC_TAX_ROUNDING_MODE`: `PHP_ROUND_HALF_DOWN` when `woocommerce_prices_include_tax='yes'`, `PHP_ROUND_HALF_UP` otherwise, per `class-woocommerce.php:537` and `wc-core-functions.php:1866-1873`) and fires the public `wc_round_tax_total` filter. The aggregate step now uses the same primitive for internal consistency, so tax extensions hooked to `wc_round_tax_total` have a say in the final value and the mode no longer flips mid-function on prices-inclusive stores.
- `WC_Order_Item_Tax::set_tax_total()` and `set_shipping_tax_total()` stored unrounded `$cart_taxes[ $rate_id ]` sums. With `woocommerce_tax_round_at_subtotal = 'yes'` the per-rate rows stayed at `0.825` while the order props collapsed to `0.83`. Analytics `wc_order_tax_lookup` is built from the tax-item rows (`src/Admin/API/Reports/Taxes/DataStore.php:288-290`), so order totals and tax reports could diverge for the same order. The change rounds per-rate rows through the same `wc_round_tax_total()` so row sums equal order `total_tax`.

Files changed:

- `plugins/woocommerce/includes/abstracts/abstract-wc-order.php` — swap `NumberUtil::round` for `wc_round_tax_total` in `update_taxes()` (aggregated shipping-tax and cart-tax) and apply it to `WC_Order_Item_Tax` per-rate rows in both the existing and new tax-item branches.
- `plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php` — expanded to 5 tests asserting: cart-order rounding parity at sub-cent precision, rounding idempotency, per-rate row sum = order `total_tax` symmetry, primitive choice (HALF_EVEN vs HALF_UP behavior under `wc_get_tax_rounding_mode()`), and `wc_round_tax_total` filter fire-through.
- `plugins/woocommerce/changelog/fix-65623-tax-amount-rounding-mismatch` — manual changelog entry (existing).

### How to test the changes in this Pull Request:

1. WooCommerce > Settings > Tax > Enable taxes, leave "Round tax at subtotal level" at default No.
2. Standard rates > Add two rates: 5% (priority 1) and 3.25% (priority 2), both apply to shipping.
3. Shipping zones > Add flat-rate $10 to a US zone.
4. Add a $100 product to cart, set billing address in the US, proceed to checkout.
5. Note shipping tax on the checkout page.
6. Place the order.
7. Admin > Orders > [new order]. Verify `shipping_tax`, `cart_tax`, and `total_tax` are non-zero. Verify each row in the Order Items > Tax section sums to the order's `total_tax`.
8. Switch `woocommerce_prices_include_tax` to Yes. Repeat the steps. Verify rounding behaviour matches `wc_get_tax_rounding_mode()` (HALF_DOWN for inclusive prices, per `class-woocommerce.php:537`): 0.825 inputs round to 0.82. Confirm `WC_TAX_ROUNDING_MODE === 2`.
9. Hook the `wc_round_tax_total` filter (a small mu-plugin returning a known constant) and place a new order. Confirm the order's stored `shipping_tax` equals the returned constant — confirming the filter now fires on this aggregation path.

### Backward compatibility impact

`WC_Abstract_Order::update_taxes()` is a public method called by `calculate_taxes()`, admin order editing, and the modify-order REST endpoint (`src/Internal/Orders/TaxesController.php`). Two behaviour changes are possible, both ≤ 1 cent on exact half-cent-boundary orders:

- The final aggregate rounding mode is now driven by `wc_get_tax_rounding_mode()` instead of hardcoded HALF_UP. On prices-inclusive stores (`woocommerce_prices_include_tax='yes'`) the aggregate rounds HALF_DOWN, matching the per-rate rows in the same function. Price-exclusive stores are unchanged (HALF_UP both before and after).
- The public `wc_round_tax_total` filter now also fires on the aggregate `shipping_tax` / `cart_tax` round and on each per-rate tax-item row written by `update_taxes()`. Extensions hooking the filter gain influence over order-side values they previously could not reach. This is the documented extension point for tax integrations and matches its existing per-rate use in this same method.
- `WC_Order_Item_Tax` rows written by `update_taxes()` are now stored at price-decimals precision. Analytics (`wc_order_tax_lookup`) built from these rows will agree with the order's `total_tax` prop; historical rows keep their previous values until the order is recalculated.

No public signature changes. No hooks removed or renamed. No template changes.

### Testing that has already taken place:

- Unit tests: 5 cases in `tests/php/includes/abstracts/class-wc-abstract-order-update-taxes-test.php` covering 0.5-boundary parity at sub-cent precision, idempotent rounding, per-rate symmetry with order `total_tax`, primitive behavior under `wc_get_tax_rounding_mode()`, and `wc_round_tax_total` filter fire-through.
- Regression: `WC_Cart_Shipping_Rounding_Test` (issue #62692 guard) — cart path untouched, no regression expected.
- PHP lint (phpcs-changed): passed.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

A manual changelog file `plugins/woocommerce/changelog/fix-65623-tax-amount-rounding-mismatch` covers the change. Auto-create is unchecked so the CI scanner does not look for a separate changelog message.