### PR TITLE
Performance: snapshot cart contents at calculation time

### DIFF
--- a/plugins/woocommerce/changelog/add-cart-contents-snapshot-cache
+++ b/plugins/woocommerce/changelog/add-cart-contents-snapshot-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Cache the filtered cart contents at totals-calculation time so the woocommerce_get_cart_contents filter is not re-run on every read. Adds a woocommerce_cache_cart_contents filter to opt out and restore per-read execution.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1489,7 +1489,14 @@ class WC_Cart extends WC_Legacy_Cart {
 			} else {
 				$cart_item_key = $cart_id;
 
-				// Add item after merging with $cart_item_data - hook to allow plugins to modify cart item.
+				/**
+				 * Filter a cart item immediately before it is added to the cart, after merging with $cart_item_data.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param array  $cart_item     The cart item data being added.
+				 * @param string $cart_item_key The cart item key.
+				 */
 				$cart_item = apply_filters(
 					'woocommerce_add_cart_item',
 					array_merge(

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -53,6 +53,18 @@ class WC_Cart extends WC_Legacy_Cart {
 	public $removed_cart_contents = array();
 
 	/**
+	 * Filtered cart contents captured at calculate_totals() time and reused by
+	 * get_cart_contents() until the next mutation or recalculation. Null when not
+	 * primed, in which case reads run the woocommerce_get_cart_contents filter live
+	 * (the historical behaviour). This gives cart contents the same freshness
+	 * contract as cart totals: both are settled by calculate_totals() and frozen
+	 * together until the cart changes again.
+	 *
+	 * @var array|null
+	 */
+	protected $cart_contents_cache = null;
+
+	/**
 	 * Contains an array of coupon codes applied to the cart.
 	 *
 	 * @var array
@@ -168,6 +180,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array of cart items
 	 */
 	public function get_cart_contents() {
+		if ( null !== $this->cart_contents_cache ) {
+			return $this->cart_contents_cache;
+		}
 		return apply_filters( 'woocommerce_get_cart_contents', (array) $this->cart_contents );
 	}
 
@@ -415,6 +430,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_cart_contents( $value ) {
 		$this->cart_contents = (array) $value;
+		$this->reset_cart_contents_cache();
 	}
 
 	/**
@@ -426,6 +442,69 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_removed_cart_contents( $value = array() ) {
 		$this->removed_cart_contents = (array) $value;
+	}
+
+	/**
+	 * Invalidate the cached cart contents snapshot. Called on every mutation so the
+	 * next read either recalculates (re-priming the snapshot) or runs the filter live.
+	 *
+	 * @return void
+	 */
+	protected function reset_cart_contents_cache() {
+		$this->cart_contents_cache = null;
+	}
+
+	/**
+	 * Set or replace a single cart item and invalidate the contents snapshot.
+	 *
+	 * All element-level writes to $this->cart_contents should go through this method (or
+	 * unset_cart_item()/set_cart_contents()) so that invalidation can never be forgotten.
+	 *
+	 * @since 11.0.0
+	 * @param string $cart_item_key Cart item key.
+	 * @param array  $item          Cart item data.
+	 * @return void
+	 */
+	protected function set_cart_item( $cart_item_key, $item ) {
+		$this->cart_contents[ $cart_item_key ] = $item;
+		$this->reset_cart_contents_cache();
+	}
+
+	/**
+	 * Remove a single cart item and invalidate the contents snapshot.
+	 *
+	 * @since 11.0.0
+	 * @param string $cart_item_key Cart item key.
+	 * @return void
+	 */
+	protected function unset_cart_item( $cart_item_key ) {
+		unset( $this->cart_contents[ $cart_item_key ] );
+		$this->reset_cart_contents_cache();
+	}
+
+	/**
+	 * Capture the filtered cart contents as a snapshot reused by get_cart_contents()
+	 * until the next mutation or recalculation. Honours an opt-out for the rare
+	 * extension whose woocommerce_get_cart_contents filter must run on every read.
+	 *
+	 * @return void
+	 */
+	protected function prime_cart_contents_cache() {
+		/**
+		 * Filters whether cart contents are snapshotted at calculation time.
+		 *
+		 * Return false to force woocommerce_get_cart_contents to run on every read,
+		 * matching the historical behaviour for filters that depend on state changing
+		 * within a calculated window.
+		 *
+		 * @since 11.0.0
+		 * @param bool $enabled Whether to cache the filtered cart contents snapshot.
+		 */
+		if ( apply_filters( 'woocommerce_cache_cart_contents', true ) ) {
+			// Cache is null here (invalidated at the start of calculate_totals()), so the getter runs the
+			// woocommerce_get_cart_contents filter live and we store its result as the snapshot.
+			$this->cart_contents_cache = $this->get_cart_contents();
+		}
 	}
 
 	/**
@@ -703,7 +782,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		 */
 		do_action( 'woocommerce_before_cart_emptied', $clear_persistent_cart );
 
-		$this->cart_contents              = array();
+		$this->set_cart_contents( array() );
 		$this->removed_cart_contents      = array();
 		$this->shipping_methods           = array();
 		$this->coupon_discount_totals     = array();
@@ -863,7 +942,9 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			if ( $product_to_check->is_sold_individually() && $values['quantity'] > 1 ) {
 				// Re-fetch and overwrite to reflect product changes made after item was added to cart.
-				$this->cart_contents[ $cart_item_key ]['data'] = $product_to_check;
+				$cart_item         = $this->cart_contents[ $cart_item_key ];
+				$cart_item['data'] = $product_to_check;
+				$this->set_cart_item( $cart_item_key, $cart_item );
 				$this->set_quantity( $cart_item_key, 1, false );
 				/* translators: %s: product name */
 				$errors->add( 'sold-individually', sprintf( __( 'You can only have 1 %s in your cart.', 'woocommerce' ), $product_to_check->get_name() ) );
@@ -1409,7 +1490,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				$cart_item_key = $cart_id;
 
 				// Add item after merging with $cart_item_data - hook to allow plugins to modify cart item.
-				$this->cart_contents[ $cart_item_key ] = apply_filters(
+				$cart_item = apply_filters(
 					'woocommerce_add_cart_item',
 					array_merge(
 						$cart_item_data,
@@ -1425,9 +1506,11 @@ class WC_Cart extends WC_Legacy_Cart {
 					),
 					$cart_item_key
 				);
+				$this->set_cart_item( $cart_item_key, $cart_item );
 			}
 
 			$this->cart_contents = apply_filters( 'woocommerce_cart_contents_changed', $this->cart_contents );
+			$this->reset_cart_contents_cache();
 
 			do_action( 'woocommerce_add_to_cart', $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data );
 
@@ -1456,7 +1539,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			do_action( 'woocommerce_remove_cart_item', $cart_item_key, $this );
 
-			unset( $this->cart_contents[ $cart_item_key ] );
+			$this->unset_cart_item( $cart_item_key );
 
 			do_action( 'woocommerce_cart_item_removed', $cart_item_key, $this );
 
@@ -1473,9 +1556,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function restore_cart_item( $cart_item_key ) {
 		if ( isset( $this->removed_cart_contents[ $cart_item_key ] ) ) {
-			$restore_item                                  = $this->removed_cart_contents[ $cart_item_key ];
-			$this->cart_contents[ $cart_item_key ]         = $restore_item;
-			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
+			$restore_item         = $this->removed_cart_contents[ $cart_item_key ];
+			$restore_item['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
+			$this->set_cart_item( $cart_item_key, $restore_item );
 
 			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this );
 
@@ -1504,8 +1587,10 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		// Update qty.
-		$old_quantity                                      = $this->cart_contents[ $cart_item_key ]['quantity'];
-		$this->cart_contents[ $cart_item_key ]['quantity'] = $quantity;
+		$cart_item             = $this->cart_contents[ $cart_item_key ];
+		$old_quantity          = $cart_item['quantity'];
+		$cart_item['quantity'] = $quantity;
+		$this->set_cart_item( $cart_item_key, $cart_item );
 
 		do_action( 'woocommerce_after_cart_item_quantity_update', $cart_item_key, $quantity, $old_quantity, $this );
 
@@ -1543,10 +1628,13 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return void
 	 */
 	public function calculate_totals() {
+		// Invalidate the snapshot so reads during calculation run live against the settling cart.
+		$this->reset_cart_contents_cache();
 		$this->reset_totals();
 
 		if ( $this->is_empty() ) {
 			$this->session->set_session();
+			$this->prime_cart_contents_cache();
 			return;
 		}
 
@@ -1555,6 +1643,9 @@ class WC_Cart extends WC_Legacy_Cart {
 		new WC_Cart_Totals( $this );
 
 		do_action( 'woocommerce_after_calculate_totals', $this );
+
+		// Freeze the final settled contents so subsequent reads reuse them instead of re-running the filter.
+		$this->prime_cart_contents_cache();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -30,6 +30,122 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 		WC()->customer->set_is_vat_exempt( false );
 		WC()->session->set( 'wc_notices', null );
+		remove_all_filters( 'woocommerce_get_cart_contents' );
+		remove_all_filters( 'woocommerce_cache_cart_contents' );
+	}
+
+	/**
+	 * @testdox woocommerce_get_cart_contents runs once per calculate_totals(), not on every read.
+	 */
+	public function test_get_cart_contents_filter_runs_once_after_calculate_totals() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$calls    = 0;
+		$callback = function ( $contents ) use ( &$calls ) {
+			++$calls;
+			return $contents;
+		};
+
+		WC()->cart->add_to_cart( $product->get_id() );
+		add_filter( 'woocommerce_get_cart_contents', $callback );
+		WC()->cart->calculate_totals();
+
+		$calls = 0;
+		for ( $i = 0; $i < 5; $i++ ) {
+			WC()->cart->get_cart_contents();
+			WC()->cart->get_cart();
+			WC()->cart->is_empty();
+		}
+
+		$this->assertSame( 0, $calls, 'Filter should not run on reads served from the snapshot.' );
+
+		remove_filter( 'woocommerce_get_cart_contents', $callback );
+	}
+
+	/**
+	 * @testdox woocommerce_get_cart_contents re-runs after a cart mutation invalidates the snapshot.
+	 */
+	public function test_get_cart_contents_filter_reruns_after_mutation() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$calls    = 0;
+		$callback = function ( $contents ) use ( &$calls ) {
+			++$calls;
+			return $contents;
+		};
+
+		$key = WC()->cart->add_to_cart( $product->get_id() );
+		add_filter( 'woocommerce_get_cart_contents', $callback );
+		WC()->cart->calculate_totals();
+
+		$calls = 0;
+		WC()->cart->get_cart_contents();
+		$this->assertSame( 0, $calls, 'Read before mutation should be served from the snapshot.' );
+
+		WC()->cart->set_quantity( $key, 3, false );
+
+		$calls = 0;
+		WC()->cart->get_cart_contents();
+		$this->assertSame( 1, $calls, 'Filter should run again once a mutation invalidates the snapshot.' );
+
+		remove_filter( 'woocommerce_get_cart_contents', $callback );
+	}
+
+	/**
+	 * @testdox Modifications made by woocommerce_get_cart_contents persist across cached reads.
+	 */
+	public function test_get_cart_contents_filter_modifications_persist_in_snapshot() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$callback = function ( $contents ) {
+			foreach ( $contents as $key => $item ) {
+				$contents[ $key ]['snapshot_test_field'] = 'applied';
+			}
+			return $contents;
+		};
+
+		WC()->cart->add_to_cart( $product->get_id() );
+		add_filter( 'woocommerce_get_cart_contents', $callback );
+		WC()->cart->calculate_totals();
+
+		$first = WC()->cart->get_cart_contents();
+		$this->assertNotEmpty( $first, 'Cart should contain the added product.' );
+		foreach ( $first as $item ) {
+			$this->assertArrayHasKey( 'snapshot_test_field', $item, 'Filter-added field should be present on snapshot reads.' );
+			$this->assertSame( 'applied', $item['snapshot_test_field'], 'Filter-added value should be preserved.' );
+		}
+
+		$this->assertEquals( $first, WC()->cart->get_cart_contents(), 'Repeated cached reads should return identical contents.' );
+
+		remove_filter( 'woocommerce_get_cart_contents', $callback );
+	}
+
+	/**
+	 * @testdox Disabling woocommerce_cache_cart_contents restores per-read filter execution.
+	 */
+	public function test_cache_cart_contents_opt_out_runs_filter_per_read() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$calls    = 0;
+		$callback = function ( $contents ) use ( &$calls ) {
+			++$calls;
+			return $contents;
+		};
+
+		add_filter( 'woocommerce_cache_cart_contents', '__return_false' );
+		WC()->cart->add_to_cart( $product->get_id() );
+		add_filter( 'woocommerce_get_cart_contents', $callback );
+		WC()->cart->calculate_totals();
+
+		$calls = 0;
+		for ( $i = 0; $i < 3; $i++ ) {
+			WC()->cart->get_cart_contents();
+		}
+
+		$this->assertSame( 3, $calls, 'With caching disabled, the filter should run on every read.' );
+
+		remove_filter( 'woocommerce_get_cart_contents', $callback );
+		remove_filter( 'woocommerce_cache_cart_contents', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Caches the filtered cart contents at `calculate_totals()` time and reuses the snapshot until the next mutation/recalculation, so `woocommerce_get_cart_contents` no longer re-runs on every cart read (a hot path — see #48053). Cart contents now share the same freshness contract as cart totals.

-   All `cart_contents` writes are funnelled through `set_cart_contents` / `set_cart_item` / `unset_cart_item`, which invalidate the snapshot — so invalidation can't be missed.
-   New `woocommerce_cache_cart_contents` filter (default `true`) opts out and restores per-read execution for filters that depend on state changing within a calculated window.
-   Surveyed 10 marketplace extensions hooking this filter; all remain compatible (transform and idempotent side-effect patterns).

Relates to #48053.

> **Note:** Exploratory branch raised as a draft to run CI and gather feedback.

### How to test the changes in this Pull Request:

1.  With Query Monitor active, add products to the cart and load the cart/shop pages; confirm `woocommerce_get_cart_contents` callbacks fire ~once per `calculate_totals()` rather than per read.
2.  Change quantities / add / remove items and confirm cart contents and totals stay correct.
3.  Add `add_filter( 'woocommerce_cache_cart_contents', '__return_false' );` and confirm the filter runs on every read again.

### Testing that has already taken place:

-   New PHPUnit tests in `WC_Cart_Test` cover: filter runs once per `calculate_totals()`, re-runs after a mutation, modifications persist across cached reads, and the opt-out restores per-read execution.
-   `php -l`, PHPStan, and PHPCS (zero error-count delta vs trunk) clean locally; relying on CI for the full PHPUnit run.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually at `plugins/woocommerce/changelog/add-cart-contents-snapshot-cache` (Significance: minor, Type: performance).
