### PR TITLE
Fix false 'unsaved changes' warning when editing orders with customer notes

### DIFF
--- a/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
+++ b/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Message: Fix false "unsaved changes" warning when editing orders with customer notes

--- a/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
+++ b/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
@@ -1,3 +1,4 @@
 Significance: patch
 Type: fix
-Message: Fix false "unsaved changes" warning when editing orders with customer notes
+
+Fix false "unsaved changes" warning when editing orders with customer notes

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -663,7 +663,7 @@ class WC_Meta_Box_Order_Data {
 								?>
 								<p class="form-field form-field-wide">
 									<label for="customer_note"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
-									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array( 'br' => array() ) ); ?></textarea>
+									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="customer_note" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array( 'br' => array() ) ); ?></textarea>
 								</p>
 							<?php endif; ?>
 						</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #65424.

The "Customer provided note" textarea in the order data meta box uses `id="excerpt"`, which collides with WordPress core's post excerpt field. WordPress tracks `#excerpt` in its `beforeunload` dirty-state handler (`wp-admin/js/common.js`). When the textarea is pre-filled with the existing customer note on page load, WordPress treats it as an unsaved excerpt change and fires the "Changes that you made may not be saved" popup when the user clicks Update. The save still proceeds after dismissing the popup, so the warning is spurious.

**Repro (before the fix):**
1. Create an order with a customer note and save it.
2. Reopen the order in the admin edit screen.
3. Click "Update" without touching any field.
4. Result: the "Changes that you made may not be saved" popup appears, even though nothing changed.

**Fix:** Change `id="excerpt"` to `id="customer_note"` on the textarea in `class-wc-meta-box-order-data.php`. The field still saves via its `name="customer_note"` attribute, so behavior is unchanged. A repo-wide search confirms no WooCommerce admin JavaScript or CSS targets the `#excerpt` selector in the order edit context, so the rename is safe.

### How to test the changes in this Pull Request:

1. Create a new order and add a customer note (e.g. "Test note"). Save the order.
2. Reopen the order in the admin edit screen (WooCommerce → Orders → Edit).
3. Click the "Update" button without changing anything.
4. Confirm no "Changes that you made may not be saved" popup appears.
5. Edit the customer note, then click Update. Confirm the note saves correctly and no popup appears.
6. Edit other order fields (status, billing, items), click Update. Confirm the normal save flow still works.

### Testing that has already taken place:

- Manual verification of the repro steps above before and after the change (popup before, no popup after).
- Confirmed the textarea renders with `id="customer_note"` after the change.
- Repo-wide grep confirms no WooCommerce admin JS/CSS targets `#excerpt` in the order edit context (the remaining `#excerpt` references are for the product excerpt field in product-create/tour code, unrelated to orders).
- PHPCS linting passed on the modified file.
- PHPStan analysis passed on the modified file.
- Environment: WordPress trunk, WooCommerce trunk.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>