### PR TITLE
Fix filename rewrite for non-downloadable product uploads

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6192-incorrect-conditional-causes-filename-change-for-non
+++ b/plugins/woocommerce/changelog/wooplug-6192-incorrect-conditional-causes-filename-change-for-non
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect conditional that could cause filenames to be rewritten for non-downloadable product uploads.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-upload-downloadable-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-upload-downloadable-product.php
@@ -64,7 +64,7 @@ class WC_Admin_Upload_Downloadable_Product {
 	 */
 	public function update_filename( $full_filename, $ext, $dir ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		if ( ! isset( $_POST['type'] ) || ! 'downloadable_product' === $_POST['type'] ) {
+		if ( ! isset( $_POST['type'] ) || 'downloadable_product' !== $_POST['type'] ) {
 			return $full_filename;
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/post-types-admin.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/post-types-admin.php
@@ -27,6 +27,14 @@ class WC_Test_Admin_Post_Types extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tear down. Clean up the upload type left in the request superglobal.
+	 */
+	public function tearDown(): void {
+		unset( $_POST['type'] );
+		parent::tearDown();
+	}
+
+	/**
 	 * Check if filename is extended and extension is preserved.
 	 */
 	public function test_unique_filename() {
@@ -47,5 +55,45 @@ class WC_Test_Admin_Post_Types extends WC_Unit_Test_Case {
 		$unique_filename = $this->wc_cpt->unique_filename( $full_filename, $ext );
 		$this->assertEquals( 254, strlen( $unique_filename ) );
 		$this->assertEquals( $ext, substr( $unique_filename, - 4 ) );
+	}
+
+	/**
+	 * @testdox Should not modify the filename when the upload type is not a downloadable product.
+	 */
+	public function test_update_filename_skips_non_downloadable_type() {
+		$_POST['type'] = 'image';
+		update_option( 'woocommerce_downloads_add_hash_to_filename', 'yes' );
+
+		$full_filename = 'dummy_filename.csv';
+		$result        = $this->wc_cpt->update_filename( $full_filename, '.csv', '/uploads/woocommerce_uploads' );
+
+		$this->assertEquals( $full_filename, $result, 'Non-downloadable uploads should keep their original filename.' );
+	}
+
+	/**
+	 * @testdox Should not modify the filename when the upload type is absent.
+	 */
+	public function test_update_filename_returns_original_when_type_missing() {
+		unset( $_POST['type'] );
+		update_option( 'woocommerce_downloads_add_hash_to_filename', 'yes' );
+
+		$full_filename = 'dummy_filename.csv';
+		$result        = $this->wc_cpt->update_filename( $full_filename, '.csv', '/uploads/woocommerce_uploads' );
+
+		$this->assertEquals( $full_filename, $result, 'Uploads without a type should keep their original filename.' );
+	}
+
+	/**
+	 * @testdox Should prepend a unique hash to the filename for downloadable product uploads.
+	 */
+	public function test_update_filename_hashes_downloadable_product() {
+		$_POST['type'] = 'downloadable_product';
+		update_option( 'woocommerce_downloads_add_hash_to_filename', 'yes' );
+
+		$full_filename = 'dummy_filename.csv';
+		$result        = $this->wc_cpt->update_filename( $full_filename, '.csv', '/uploads/woocommerce_uploads' );
+
+		$this->assertNotEquals( $full_filename, $result, 'Downloadable product uploads should be hashed.' );
+		$this->assertEquals( strlen( $full_filename ) + 6 + 1, strlen( $result ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

`WC_Admin_Upload_Downloadable_Product::update_filename()` is meant to skip non-downloadable uploads, but an operator-precedence mistake broke the guard. PHP evaluates `! 'downloadable_product' === $_POST['type']` as `( ! 'downloadable_product' ) === $_POST['type']`, i.e. `false === $_POST['type']`, which is always `false`. The condition therefore collapsed to "is `type` set at all", letting the unique-hash filename rewrite run for any upload that included a `type` field (the only remaining protection being the `woocommerce_uploads` directory check).

This switches the check to a strict `!==` comparison — matching the sibling `upload_dir()` method — so filenames are only rewritten for genuine `downloadable_product` uploads, and adds regression tests covering the guard.

Closes #62983.

Bug introduced in PR #42702.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. With this branch checked out and the dev environment running, run the affected unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Test_Admin_Post_Types`. Confirm all tests pass, including `test_update_filename_skips_non_downloadable_type`.
2. In WP Admin, go to **WooCommerce → Settings → Products → Downloadable products** and enable **Append a unique string to filename for security**.
3. Edit a product, open the **Downloadable files** section, and upload a file. Confirm the stored filename gets a `-XXXXXX` hash suffix (expected — it is a downloadable-product upload).
4. Upload a regular image through the **Media Library** (type ≠ `downloadable_product`) and confirm its filename is **not** given the hash suffix.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Added three regression tests to `WC_Test_Admin_Post_Types`; the full class passes (5 tests, 8 assertions) on PHP 8.1 via `wp-env`.
- Confirmed `test_update_filename_skips_non_downloadable_type` fails against the old conditional (the filename was hashed to `dummy_filename-XXXXXX.csv`) and passes with the fix — verifying it genuinely locks in the bug.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` is clean, and PHPStan on the modified file reports no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The changelog entry was added manually in this PR (`plugins/woocommerce/changelog/wooplug-6192-incorrect-conditional-causes-filename-change-for-non`, Significance: patch, Type: fix), so the automatic changelog job is not required.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
