### PR TITLE
Fix extension cart update shipping mode sync

### DIFF
--- a/plugins/woocommerce/changelog/66014-fix-extension-cart-update-shipping-mode-sync
+++ b/plugins/woocommerce/changelog/66014-fix-extension-cart-update-shipping-mode-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Checkout block shipping method UI after extension cart updates change the selected shipping rate.

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/thunks.ts
@@ -13,9 +13,20 @@ import {
 } from '../thunks';
 import { apiFetchWithHeaders } from '../../shared-controls';
 import { getIsCustomerDataDirty } from '../utils';
+import { store as checkoutStore } from '../../checkout';
 
 jest.mock( '../../shared-controls', () => ( {
 	apiFetchWithHeaders: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/base-utils', () => ( {
+	...jest.requireActual( '@woocommerce/base-utils' ),
+	hasCollectableRate: jest.fn( ( chosenRates ) => {
+		if ( Array.isArray( chosenRates ) ) {
+			return chosenRates.includes( 'pickup_location' );
+		}
+		return chosenRates === 'pickup_location';
+	} ),
 } ) );
 
 jest.mock( '../notify-quantity-changes', () => ( {
@@ -28,6 +39,7 @@ jest.mock( '../notify-errors', () => ( {
 
 jest.mock( '../utils', () => ( {
 	getIsCustomerDataDirty: jest.fn( () => false ),
+	getTriggerStoreSyncEvent: jest.fn( () => false ),
 	setIsCustomerDataDirty: jest.fn(),
 	setTriggerStoreSyncEvent: jest.fn(),
 } ) );
@@ -397,6 +409,15 @@ describe( 'applyExtensionCartUpdate', () => {
 		receiveCart: jest.fn(),
 		receiveError: jest.fn(),
 	} );
+	const createMockRegistry = () => {
+		const setPrefersCollection = jest.fn();
+		return {
+			registry: {
+				dispatch: jest.fn( () => ( { setPrefersCollection } ) ),
+			},
+			setPrefersCollection,
+		};
+	};
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -415,6 +436,64 @@ describe( 'applyExtensionCartUpdate', () => {
 		} )( { dispatch } as never );
 
 		expect( dispatch.receiveCart ).toHaveBeenCalledWith( mockResponse );
+	} );
+
+	it( 'should set prefersCollection true when the extension response selects local pickup', async () => {
+		const dispatch = createMockDispatch();
+		const { registry, setPrefersCollection } = createMockRegistry();
+		mockApiFetchWithHeaders.mockResolvedValue( {
+			response: {
+				...mockResponse,
+				shipping_rates: [
+					{
+						package_id: 0,
+						shipping_rates: [
+							{
+								method_id: 'pickup_location',
+								selected: true,
+							},
+						],
+					},
+				],
+			},
+		} );
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+		} )( { dispatch, registry } as never );
+
+		expect( registry.dispatch ).toHaveBeenCalledWith( checkoutStore );
+		expect( setPrefersCollection ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should set prefersCollection false when the extension response selects shipping', async () => {
+		const dispatch = createMockDispatch();
+		const { registry, setPrefersCollection } = createMockRegistry();
+		mockApiFetchWithHeaders.mockResolvedValue( {
+			response: {
+				...mockResponse,
+				shipping_rates: [
+					{
+						package_id: 0,
+						shipping_rates: [
+							{
+								method_id: 'flat_rate',
+								selected: true,
+							},
+						],
+					},
+				],
+			},
+		} );
+
+		await applyExtensionCartUpdate( {
+			namespace: 'test',
+			data: {},
+		} )( { dispatch, registry } as never );
+
+		expect( registry.dispatch ).toHaveBeenCalledWith( checkoutStore );
+		expect( setPrefersCollection ).toHaveBeenCalledWith( false );
 	} );
 
 	it( 'should strip both addresses when customer data is dirty and no overwrite specified', async () => {

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -13,6 +13,7 @@ import {
 } from '@woocommerce/types';
 import {
 	camelCaseKeys,
+	hasCollectableRate,
 	triggerAddedToCartEvent,
 	triggerAddingToCartEvent,
 } from '@woocommerce/base-utils';
@@ -20,6 +21,7 @@ import {
 	type CurriedSelectorsOf,
 	type ConfigOf,
 	type ActionCreatorsOf,
+	type DispatchFunction,
 } from '@wordpress/data/build-types/types';
 import { __ } from '@wordpress/i18n';
 import { cartStore } from '@woocommerce/block-data';
@@ -40,9 +42,11 @@ import {
 	setTriggerStoreSyncEvent,
 } from './utils';
 import { isEditor } from '../utils';
+import { store as checkoutStore } from '../checkout';
 interface CartThunkArgs {
 	select: CurriedSelectorsOf< typeof cartStore >;
 	dispatch: ActionCreatorsOf< ConfigOf< typeof cartStore > >;
+	registry?: { dispatch: DispatchFunction };
 }
 
 /**
@@ -125,13 +129,40 @@ export const receiveError =
 	};
 
 /**
+ * Updates the checkout store with the shopper's collection preference based on
+ * the selected shipping rates in the cart.
+ *
+ * @param {CartResponse} response
+ * @param {CartThunkArgs['registry']} registry
+ */
+const syncPrefersCollectionFromSelectedShippingRates = (
+	response: CartResponse,
+	registry?: CartThunkArgs[ 'registry' ]
+) => {
+	if ( ! registry ) {
+		return;
+	}
+
+	const selectedMethodIds = response.shipping_rates
+		?.flatMap( ( shippingPackage ) => shippingPackage.shipping_rates )
+		.filter( ( rate ) => rate.selected )
+		.map( ( rate ) => rate.method_id );
+
+	if ( selectedMethodIds?.length ) {
+		registry
+			.dispatch( checkoutStore )
+			.setPrefersCollection( hasCollectableRate( selectedMethodIds ) );
+	}
+};
+
+/**
  * POSTs to the /cart/extensions endpoint with the data supplied by the extension.
  *
  * @param {Object} args The data to be posted to the endpoint
  */
 export const applyExtensionCartUpdate =
 	( args: ExtensionCartUpdateArgs ) =>
-	async ( { dispatch }: CartThunkArgs ) => {
+	async ( { dispatch, registry }: CartThunkArgs ) => {
 		try {
 			const { response } = await apiFetchWithHeaders< {
 				response: CartResponse;
@@ -178,9 +209,14 @@ export const applyExtensionCartUpdate =
 				}
 
 				dispatch.receiveCart( cartToReceive );
+				syncPrefersCollectionFromSelectedShippingRates(
+					response,
+					registry
+				);
 				return response;
 			}
 			dispatch.receiveCart( response );
+			syncPrefersCollectionFromSelectedShippingRates( response, registry );
 			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -217,7 +217,10 @@ export const applyExtensionCartUpdate =
 				return response;
 			}
 			dispatch.receiveCart( response );
-			syncPrefersCollectionFromSelectedShippingRates( response, registry );
+			syncPrefersCollectionFromSelectedShippingRates(
+				response,
+				registry
+			);
 			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -43,6 +43,7 @@ import {
 } from './utils';
 import { isEditor } from '../utils';
 import { store as checkoutStore } from '../checkout';
+
 interface CartThunkArgs {
 	select: CurriedSelectorsOf< typeof cartStore >;
 	dispatch: ActionCreatorsOf< ConfigOf< typeof cartStore > >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58740.

Plugins can change the selected shipping rates programmatically on the server but this data isn't represented in the UI when it's returned to the client. This adds some logic to the `applyExtensionCartUpdate` thunk to determine whether the user has selected collection or not.

An example scenario would be Local Pickup is selected, and a plugin programmatically updates shipping to be a flat rate option. Prices are updated in the order summary, but in the UI Local Pickup is still active.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; this is a behavior fix with no visual design changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Install the plugin referenced [in the issue](https://github.com/woocommerce/woocommerce/issues/58740#issue-3137329867).
2. Prepare a store with at least one regular shipping method and local pickup enabled.
3. Add a product to the cart and proceed to the Checkout block.
4. Select the local pickup tab
5. Click the "Click me" button in the order summary
6. Confirm the order totals update, the shipping method selector switches back to shipping, and the selected shipping rate radio option matches the server-selected rate.

<!-- End testing instructions -->

### Testing that has already taken place:

1. The above testing steps
2. Unit test coverage

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Checkout block shipping method UI after extension cart updates change the selected shipping rate.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>