### PR TITLE
Fix Cart Contents conditional field example to control visibility

### DIFF
--- a/docs/block-development/tutorials/how-to-conditional-additional-fields.md
+++ b/docs/block-development/tutorials/how-to-conditional-additional-fields.md
@@ -102,6 +102,19 @@ woocommerce_register_additional_checkout_field(
 					]
 				]
 			]
+		],
+		'hidden' => [
+			'cart' => [
+				'properties' => [
+					'items' => [
+						'not' => [
+							'contains' => [
+								'enum' => [2766, 456, 789] // Hide unless a fragile item is in the cart
+							]
+						]
+					]
+				]
+			]
 		]
 	)
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The "Show Fields Based on Cart Contents" doc example only set a `required` condition, so the field always rendered instead of showing only when specific products are in the cart ([forum report](https://wordpress.org/support/topic/conditional-fields-for-the-block-checkout-show-fields-based-on-cart-contents/)). Added a `hidden` key with the inverse `not`/`contains` condition. (The related comment issue was already fixed in #65546.)

### How to test the changes in this Pull Request:

1. Open `docs/block-development/tutorials/how-to-conditional-additional-fields.md`, "Show Fields Based on Cart Contents" section.
2. Confirm the example now has both `required` and `hidden` keys, with `hidden` using `not` → `contains`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Documentation-only change under `docs/`; not shipped in the plugin.

</details>
