### PR TITLE
Replace payment method notice with WordPress UI

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3212-wp-ui-payment-method-notice
+++ b/plugins/woocommerce/changelog/wooprd-3212-wp-ui-payment-method-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use the standard WordPress UI Notice for payment method eligibility notices in WooPayments onboarding.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/list-item.tsx
@@ -3,10 +3,9 @@
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { type RecommendedPaymentMethod } from '@woocommerce/data';
-import { ExternalLink, Icon, ToggleControl } from '@wordpress/components';
-import { info as infoIcon } from '@wordpress/icons';
-import { useEffect, useRef } from '@wordpress/element';
-import { speak } from '@wordpress/a11y';
+import { ToggleControl } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
+import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -81,14 +80,6 @@ export const PaymentMethodListItem = ( {
 			: shouldRenderInMainListRef.current ?? false;
 
 	const shouldRender = isExpanded || baseVisibility;
-
-	// Announce notice to screen readers when the method is toggled on.
-	const isEnabled = paymentMethodsState[ method.id ] ?? false;
-	useEffect( () => {
-		if ( isEnabled && method.notice?.message ) {
-			speak( method.notice.message, 'polite' );
-		}
-	}, [ isEnabled, method.notice?.message ] );
 
 	if ( ! shouldRender ) {
 		return null;
@@ -209,26 +200,31 @@ export const PaymentMethodListItem = ( {
 			</div>
 			{ method.notice?.message &&
 				( paymentMethodsState[ method.id ] ?? false ) && (
-					<div
+					<Notice.Root
 						className="woocommerce-list__item-notice-info"
 						data-testid="payment-method-notice-info"
+						intent="info"
+						spokenMessage={ decodeEntities(
+							method.notice.message
+						) }
 					>
-						<Icon icon={ infoIcon } size={ 24 } />
-						<p>
-							{ method.notice.message }
-							{ method.notice.link_url &&
-								method.notice.link_text && (
-									<>
-										{ ' ' }
-										<ExternalLink
-											href={ method.notice.link_url }
-										>
-											{ method.notice.link_text }
-										</ExternalLink>
-									</>
-								) }
-						</p>
-					</div>
+						<Notice.Description>
+							{ decodeEntities( method.notice.message ) }
+						</Notice.Description>
+						{ method.notice.link_url && method.notice.link_text && (
+							<Notice.Actions>
+								<Notice.ActionLink
+									href={ method.notice.link_url }
+									openInNewTab
+									rel="noopener noreferrer"
+								>
+									{ decodeEntities(
+										method.notice.link_text
+									) }
+								</Notice.ActionLink>
+							</Notice.Actions>
+						) }
+					</Notice.Root>
 				) }
 		</div>
 	);

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -260,26 +260,5 @@
 
 .woocommerce-list__item-notice-info {
 	flex-basis: 100%;
-	display: flex;
-	gap: 4px;
-	align-items: flex-start;
 	margin: 20px 0 0;
-	padding: 12px;
-	background-color: #f5f9fd;
-	border: 1px solid #9fbcdd;
-	border-radius: 8px;
-
-	svg {
-		flex-shrink: 0;
-		fill: #006cd8;
-	}
-
-	p {
-		margin: 0;
-		padding: 2px 0;
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 20px;
-		color: #001758;
-	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/test/list-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/test/list-item.test.tsx
@@ -3,10 +3,65 @@
  */
 import { render, screen } from '@testing-library/react';
 import { type RecommendedPaymentMethod } from '@woocommerce/data';
+import { type ReactNode } from 'react';
 
-const mockSpeak = jest.fn();
-jest.mock( '@wordpress/a11y', () => ( {
-	speak: ( ...args: unknown[] ) => mockSpeak( ...args ),
+type MockComponentProps = {
+	children?: ReactNode;
+	className?: string;
+	href?: string;
+	intent?: string;
+	openInNewTab?: boolean;
+	rel?: string;
+	spokenMessage?: string;
+	'data-testid'?: string;
+};
+
+jest.mock( '@wordpress/components', () => ( {
+	ToggleControl: ( { checked }: { checked?: boolean } ) => (
+		<input type="checkbox" checked={ checked } readOnly />
+	),
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	Notice: {
+		Root: ( {
+			children,
+			className,
+			intent,
+			spokenMessage,
+			'data-testid': testId,
+		}: MockComponentProps ) => (
+			<div
+				className={ className }
+				data-intent={ intent }
+				data-spoken-message={ spokenMessage }
+				data-testid={ testId }
+			>
+				{ children }
+			</div>
+		),
+		Description: ( { children }: MockComponentProps ) => (
+			<span>{ children }</span>
+		),
+		Actions: ( { children }: MockComponentProps ) => (
+			<div>{ children }</div>
+		),
+		ActionLink: ( {
+			children,
+			href,
+			openInNewTab,
+			rel,
+		}: MockComponentProps ) => (
+			// eslint-disable-next-line react/jsx-no-target-blank -- The mock forwards rel so tests can assert the component contract.
+			<a
+				href={ href }
+				rel={ rel }
+				target={ openInNewTab ? '_blank' : undefined }
+			>
+				{ children }
+			</a>
+		),
+	},
 } ) );
 
 /**
@@ -93,14 +148,14 @@ describe( 'PaymentMethodListItem', () => {
 		} );
 	} );
 
-	describe( 'Warning notice', () => {
-		it( 'renders a warning notice when method is enabled and notice.message is set', () => {
+	describe( 'Payment method notice', () => {
+		it( 'renders a notice when method is enabled and notice.message is set', () => {
 			const method = createMethod( {
 				id: 'p24',
 				notice: {
 					badge: 'Verification required',
-					message: 'Strict requirements apply.',
-					link_text: 'Review requirements',
+					message: 'Strict requirements &amp; eligibility apply.',
+					link_text: 'Review requirements &amp; terms',
 					link_url: 'https://example.com/docs',
 				},
 			} );
@@ -113,15 +168,30 @@ describe( 'PaymentMethodListItem', () => {
 				/>
 			);
 
-			expect(
-				screen.getByText( 'Strict requirements apply.' )
-			).toBeInTheDocument();
-			expect(
-				screen.getByRole( 'link', { name: /review requirements/i } )
-			).toHaveAttribute( 'href', 'https://example.com/docs' );
+			const notice = screen.getByTestId( 'payment-method-notice-info' );
+			expect( notice ).toHaveAttribute( 'data-intent', 'info' );
+			expect( notice ).toHaveAttribute(
+				'data-spoken-message',
+				'Strict requirements & eligibility apply.'
+			);
+			expect( notice ).toHaveTextContent(
+				'Strict requirements & eligibility apply.'
+			);
+			const requirementsLink = screen.getByRole( 'link', {
+				name: /review requirements & terms/i,
+			} );
+			expect( requirementsLink ).toHaveAttribute(
+				'href',
+				'https://example.com/docs'
+			);
+			expect( requirementsLink ).toHaveAttribute( 'target', '_blank' );
+			expect( requirementsLink ).toHaveAttribute(
+				'rel',
+				'noopener noreferrer'
+			);
 		} );
 
-		it( 'does not render a warning notice when method is disabled', () => {
+		it( 'does not render a notice when method is disabled', () => {
 			const method = createMethod( {
 				id: 'p24',
 				notice: {
@@ -145,7 +215,7 @@ describe( 'PaymentMethodListItem', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'does not render a warning notice when notice.message is empty', () => {
+		it( 'does not render a notice when notice.message is empty', () => {
 			const method = createMethod( {
 				notice: {
 					badge: 'Verification required',

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -100,6 +100,7 @@
 		"@wordpress/plugins": "catalog:wp-min",
 		"@wordpress/primitives": "catalog:wp-min",
 		"@wordpress/router": "0.7.0",
+		"@wordpress/ui": "catalog:wp-bundled",
 		"@wordpress/url": "catalog:wp-min",
 		"@wordpress/viewport": "catalog:wp-min",
 		"@wordpress/warning": "catalog:wp-min",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@wordpress/interface':
       specifier: 9.18.5
       version: 9.18.5
+    '@wordpress/ui':
+      specifier: 0.15.1
+      version: 0.15.1
   wp-min:
     '@types/wordpress__block-editor':
       specifier: 15.0.6
@@ -2966,6 +2969,9 @@ importers:
       '@wordpress/router':
         specifier: 0.7.0
         version: 0.7.0(react@18.3.1)
+      '@wordpress/ui':
+        specifier: catalog:wp-bundled
+        version: 0.15.1(@date-fns/tz@1.4.1)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/url':
         specifier: catalog:wp-min
         version: 4.33.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,6 +63,7 @@ catalogs:
         '@wordpress/fields': 0.25.11
         '@wordpress/icons': 11.0.1
         '@wordpress/interface': 9.18.5
+        '@wordpress/ui': 0.15.1
         '@wordpress/undo-manager': 1.33.1
         '@wordpress/views': 1.0.8
         '@wordpress/base-styles': 6.9.1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPRD-3212.

The WooPayments onboarding payment-method eligibility notice was using a custom wrapper, icon, and styles while WordPress UI now provides a standard Notice component. This replaces the custom notice with `@wordpress/ui`'s Notice primitives and removes local visual styling so the notice adheres to the shared design-system treatment.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before:

<img width="2564" height="606" alt="CleanShot 2026-06-25 at 12 10 48@2x" src="https://github.com/user-attachments/assets/549bd168-49c9-43c2-a364-f1cc393a97af" />

After:

<img width="2510" height="518" alt="CleanShot 2026-06-25 at 12 21 04@2x" src="https://github.com/user-attachments/assets/cb5e8b04-193e-493a-9bea-32230c1da024" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start WooCommerce locally and make sure WooPayments is installed.
2. In WooCommerce > Settings > Payments, select Poland as a country, and then open the WooPayments onboarding flow.
3. Enable Przelewy24 and confirm the eligibility notice appears with the standard Notice styling and the Review requirements link.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter='@woocommerce/admin-library' test:js -- client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/test/list-item.test.tsx --runInBand`
- `pnpm --filter='@woocommerce/admin-library' exec eslint client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/list-item.tsx client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/test/list-item.test.tsx`
- `pnpm --filter='@woocommerce/admin-library' exec stylelint client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm syncpack list-mismatches`
- Confirmed the local wp-env site responds after restoring package directories affected by an interrupted dependency install.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
