### PR TITLE
Fix express payment methods wrongly flagged as incompatible in editor

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md
@@ -71,7 +71,7 @@ const options = {
 | `content` | ReactNode | React node output in the express payment method area when the block is rendered in the frontend. Receives props from the checkout payment method interface. | Yes |
 | `edit` | ReactNode | React node output in the express payment method area when the block is rendered in the editor. Receives props from the payment method interface to checkout (with preview data). | Yes |
 | `canMakePayment` | Function | Callback to determine whether the payment method should be available for the shopper. | Yes |
-| `paymentMethodId` | String | Identifier accompanying the checkout processing request to the server. Used to identify the payment method gateway class for processing the payment. | No |
+| `paymentMethodId` | String | Identifier accompanying the checkout processing request to the server. Used to identify the payment method gateway class for processing the payment. Should match the gateway's server-side ID, as it is also used to detect whether the gateway is compatible with the Checkout block in the editor. Defaults to the value of `name` when omitted. | No |
 | `supports:features` | Array | Array of payment features supported by the gateway. Used to crosscheck if the payment method can be used for the cart content. Defaults to `['products']` if no value is provided. | No |
 | `supports:style` | Array | This is an array of style variations supported by the express payment method. These are styles that are applied across all the active express payment buttons and can be controlled from the express payment block in the editor. Supported values for these are one of `['height', 'borderRadius']`. | No |
 

--- a/plugins/woocommerce/changelog/wooplug-6248-express-payment-incompatible-notice
+++ b/plugins/woocommerce/changelog/wooplug-6248-express-payment-incompatible-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix false "incompatible extension" notice shown in the block editor for express payment methods whose client-side `name` differs from their server-side gateway ID. The compatibility check now matches on `paymentMethodId` (falling back to `name`).

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/selectors.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/selectors.ts
@@ -131,14 +131,17 @@ export const getIncompatiblePaymentMethods = createSelector(
 			return {};
 		}
 
+		// Match express methods on `paymentMethodId` (falling back to `name`) rather
+		// than their store key, so a distinct client-side `name` isn't flagged.
+		const availableExpressPaymentMethodIds = Object.values(
+			availableExpressPaymentMethods
+		).map( ( method ) => method.paymentMethodId ?? method.name );
+
 		return Object.fromEntries(
-			Object.entries( globalPaymentMethods ).filter( ( [ k ] ) => {
+			Object.entries( globalPaymentMethods ).filter( ( [ id ] ) => {
 				return ! (
-					k in
-					{
-						...availablePaymentMethods,
-						...availableExpressPaymentMethods,
-					}
+					id in availablePaymentMethods ||
+					availableExpressPaymentMethodIds.includes( id )
 				);
 			} )
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/test/selectors.js
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/test/selectors.js
@@ -26,7 +26,10 @@ import {
 	SavedPaymentMethodOptions,
 } from '../../../blocks/cart-checkout-shared/payment-methods';
 import { defaultCartState } from '../../cart/default-state';
-import { getRegisteredExpressPaymentMethods } from '../selectors';
+import {
+	getRegisteredExpressPaymentMethods,
+	getIncompatiblePaymentMethods,
+} from '../selectors';
 
 jest.mock( '@wordpress/data', () => {
 	const originalModule = jest.requireActual( '@wordpress/data' );
@@ -75,6 +78,15 @@ jest.mock( '@woocommerce/settings', () => {
 						},
 					],
 				};
+			}
+			if ( setting === 'globalPaymentMethods' ) {
+				return [
+					{
+						id: 'woo-payment-gateway',
+						title: 'Woo Payment Gateway',
+					},
+					{ id: 'stripe', title: 'Stripe' },
+				];
 			}
 			return originalModule.getSetting( setting, ...rest );
 		},
@@ -499,6 +511,102 @@ describe( 'Payment Selectors Unit Tests', () => {
 				description: 'Pay with Apple Pay',
 				gatewayId: 'apple-pay',
 				supportsStyle: [ 'height' ],
+			} );
+		} );
+	} );
+
+	describe( 'getIncompatiblePaymentMethods', () => {
+		// The mocked `globalPaymentMethods` setting (see jest.mock above) exposes
+		// two server-side gateways: `woo-payment-gateway` and `stripe`.
+		const buildState = ( {
+			availablePaymentMethods = {},
+			availableExpressPaymentMethods = {},
+		} ) => ( {
+			status: 'idle',
+			activePaymentMethod: '',
+			availablePaymentMethods,
+			availableExpressPaymentMethods,
+			registeredExpressPaymentMethods: {},
+			savedPaymentMethods: {},
+			paymentMethodData: {},
+			paymentResult: null,
+			paymentMethodsInitialized: true,
+			expressPaymentMethodsInitialized: true,
+			shouldSavePaymentMethod: false,
+		} );
+
+		it( 'does not flag an express method whose client-side name differs from its gateway id', () => {
+			const state = buildState( {
+				// Keyed by the client-side `name`, which differs from the
+				// server-side gateway id. The match must happen via
+				// `paymentMethodId`, not the key.
+				availableExpressPaymentMethods: {
+					woo_express: {
+						name: 'woo_express',
+						title: 'Woo Express',
+						description: '',
+						gatewayId: 'woo-payment-gateway',
+						paymentMethodId: 'woo-payment-gateway',
+						supportsStyle: [],
+					},
+				},
+				availablePaymentMethods: {
+					stripe: {
+						name: 'stripe',
+						title: 'Stripe',
+						description: '',
+						gatewayId: 'stripe',
+						supportsStyle: [],
+					},
+				},
+			} );
+
+			expect( getIncompatiblePaymentMethods( state ) ).toEqual( {} );
+		} );
+
+		it( 'falls back to `name` when an express method has no paymentMethodId', () => {
+			const state = buildState( {
+				availableExpressPaymentMethods: {
+					stripe: {
+						name: 'stripe',
+						title: 'Stripe',
+						description: '',
+						gatewayId: 'stripe',
+						// No paymentMethodId — should fall back to `name`.
+						paymentMethodId: undefined,
+						supportsStyle: [],
+					},
+				},
+				availablePaymentMethods: {
+					'woo-payment-gateway': {
+						name: 'woo-payment-gateway',
+						title: 'Woo Payment Gateway',
+						description: '',
+						gatewayId: 'woo-payment-gateway',
+						supportsStyle: [],
+					},
+				},
+			} );
+
+			expect( getIncompatiblePaymentMethods( state ) ).toEqual( {} );
+		} );
+
+		it( 'still flags a server gateway that has no matching available method', () => {
+			const state = buildState( {
+				availablePaymentMethods: {
+					stripe: {
+						name: 'stripe',
+						title: 'Stripe',
+						description: '',
+						gatewayId: 'stripe',
+						supportsStyle: [],
+					},
+				},
+				availableExpressPaymentMethods: {},
+			} );
+
+			expect( getIncompatiblePaymentMethods( state ) ).toEqual( {
+				'woo-payment-gateway': 'Woo Payment Gateway',
 			} );
 		} );
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/utils/check-payment-methods.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/utils/check-payment-methods.ts
@@ -177,8 +177,14 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 			| ExpressPaymentMethodConfigInstance
 	) => {
 		if ( express ) {
-			const { name, title, description, gatewayId, supports } =
-				paymentMethod as ExpressPaymentMethodConfigInstance;
+			const {
+				name,
+				title,
+				description,
+				gatewayId,
+				supports,
+				paymentMethodId,
+			} = paymentMethod as ExpressPaymentMethodConfigInstance;
 
 			availablePaymentMethods = {
 				...availablePaymentMethods,
@@ -187,6 +193,7 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 					title,
 					description,
 					gatewayId,
+					paymentMethodId: paymentMethodId ?? name,
 					supportsStyle: supports?.style,
 				},
 			};

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/payments.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/payments.ts
@@ -166,9 +166,15 @@ export type PlainPaymentMethods = Record<
 >;
 
 /**
- * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
+ * Like `PlainPaymentMethods`, but express methods may also carry a `paymentMethodId`
+ * (the server-side gateway id, defaulting to `name`) for matching registered gateways.
  */
-export type PlainExpressPaymentMethods = PlainPaymentMethods;
+export type PlainExpressPaymentMethods = Record<
+	string,
+	PlainPaymentMethods[ string ] & {
+		paymentMethodId?: string;
+	}
+>;
 
 export type ExpressPaymentMethods =
 	| Record< string, ExpressPaymentMethodConfigInstance >


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Express payment methods are stored in the editor's payment data store keyed by their client-side `name`, but the incompatible-gateway check compared those keys against server-side gateway IDs — so any gateway whose `name` differs from its gateway ID was wrongly shown as an "incompatible extension" in the Checkout block editor (while working fine on the frontend). The check now matches on the documented `paymentMethodId` (falling back to `name`), which required threading `paymentMethodId` through the stored express payment-method shape.

Closes #63124.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. With only WooCommerce active, install [woo-payment-gateway](https://wordpress.org/plugins/woo-payment-gateway/) (registers an express method whose `name` differs from its gateway ID).
2. Add a Checkout block to a page — confirm no "incompatible extension" notice appears for it.
3. Run `pnpm --filter @woocommerce/block-library test:js -- data/payment/test/selectors.js` — the `getIncompatiblePaymentMethods` cases pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Unit tests added (3 `getIncompatiblePaymentMethods` cases) and passing; verified no new TypeScript errors against the trunk baseline; ESLint clean on changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>