### PR TITLE
Fix hierarchical selection and expansion in SearchListControl for multi-level categories

### DIFF
--- a/plugins/woocommerce/changelog/add-search-list-control-depth-fixes
+++ b/plugins/woocommerce/changelog/add-search-list-control-depth-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix hierarchical selection and expansion in SearchListControl for multi-level categories

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
@@ -24,11 +24,11 @@ const ExpandableSearchListItem = ( {
 			<SearchListItem
 				{ ...rest }
 				key={ item.id }
-				className={ className }
+				{ ...( className && { className } ) }
 				isSelected={ isSelected }
 				item={ item }
 				onSelect={ onSelect }
-				disabled={ disabled }
+				{ ...( disabled && { disabled } ) }
 			/>
 			{ isSelected && isLoading && (
 				<div

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
@@ -11,7 +11,7 @@ interface ExpandableSearchListItemProps extends RenderItemArgs {
 }
 
 const ExpandableSearchListItem = ( {
-	className = '',
+	className,
 	item,
 	isSelected,
 	isLoading,

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx
@@ -11,7 +11,7 @@ interface ExpandableSearchListItemProps extends RenderItemArgs {
 }
 
 const ExpandableSearchListItem = ( {
-	className,
+	className = '',
 	item,
 	isSelected,
 	isLoading,

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
@@ -73,6 +73,7 @@ const ProductAttributeTermControl = ( {
 					className={ clsx( classes ) }
 					item={ item }
 					isLoading={ isLoadingAttributes }
+					isSelectable={ false }
 					disabled={ item.count === 0 }
 					name={ `attributes-${ instanceId }` }
 					countLabel={ sprintf(

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-attribute-term-control/index.tsx
@@ -18,6 +18,7 @@ import {
 	SearchListItem as SearchListItemProps,
 } from '@woocommerce/editor-components/search-list-control/types';
 import { convertAttributeObjectToSearchItem } from '@woocommerce/utils';
+import type { AttributeObject, AttributeTerm } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -40,6 +41,26 @@ interface Props
 	 */
 	selected: { id: number }[];
 }
+
+/**
+ * Attribute rows use negative IDs so they do not collide with term IDs in the
+ * flat list consumed by SearchListControl (keys, expansion, buildTermsTree).
+ */
+const toAttributeListItem = (
+	attribute: AttributeObject
+): SearchListItemProps => ( {
+	...convertAttributeObjectToSearchItem( attribute ),
+	id: -attribute.id,
+	parent: 0,
+} );
+
+const toTermListItem = (
+	term: AttributeTerm,
+	attributeId: number
+): SearchListItemProps => ( {
+	...convertAttributeObjectToSearchItem( term ),
+	parent: -attributeId,
+} );
 
 const ProductAttributeTermControl = ( {
 	onChange,
@@ -124,12 +145,12 @@ const ProductAttributeTermControl = ( {
 	};
 
 	const list = productsAttributes.reduce( ( acc, curr ) => {
-		const { terms, ...props } = curr;
+		const { terms, ...attribute } = curr;
 
 		return [
 			...acc,
-			convertAttributeObjectToSearchItem( props ),
-			...terms.map( convertAttributeObjectToSearchItem ),
+			toAttributeListItem( attribute ),
+			...terms.map( ( term ) => toTermListItem( term, attribute.id ) ),
 		];
 	}, [] as SearchListItemProps[] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-control/index.tsx
@@ -32,6 +32,7 @@ import ExpandableSearchListItem from '@woocommerce/editor-components/expandable-
  * Internal dependencies
  */
 import './style.scss';
+import { isExpandedOrDescendantIsExpanded } from '../search-list-control/utils';
 
 interface ProductControlProps {
 	/**
@@ -116,7 +117,23 @@ const ProductControl = (
 	const renderItemWithVariations = (
 		args: RenderItemArgs< ProductResponseItem >
 	) => {
-		const { item, search, depth = 0, isSelected, onSelect } = args;
+		const {
+			item,
+			search,
+			depth = 0,
+			isSelected,
+			onSelect,
+			useExpandedPanelId,
+		} = args;
+		const [ expandedPanelId, setExpandedPanelId ] = useExpandedPanelId ?? [
+			null,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			() => {},
+		];
+		const isExpanded = isExpandedOrDescendantIsExpanded(
+			item,
+			expandedPanelId
+		);
 		const variationsCount =
 			item.details?.variations && Array.isArray( item.details.variations )
 				? item.details.variations.length
@@ -149,6 +166,9 @@ const ProductControl = (
 					onSelect={ () => {
 						return () => {
 							onSelect( item )();
+							if ( ! isExpanded ) {
+								setExpandedPanelId( item.id );
+							}
 						};
 					} }
 					isLoading={ isLoading || variationsLoading }

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/product-control/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/product-control/style.scss
@@ -39,7 +39,7 @@
 		background-size: contain;
 	}
 
-	&.depth-0.is-variable.is-selected::after {
+	&.depth-0.is-variable.is-expanded::after {
 		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" fill="#{encode-color($gray-700)}" /></svg>');
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -217,7 +217,6 @@ export const SearchListItem = < T extends object = object >( {
 								)();
 							}
 						} }
-						onClick={ ( e ) => e.stopPropagation() }
 						__nextHasNoMarginBottom={ true }
 					/>
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -234,7 +234,10 @@ export const SearchListItem = < T extends object = object >( {
 			) }
 		</div>
 	) : (
-		<div className={ classes }>
+		// Items can be enabled via the radios and checkboxes. But we make the
+		// whole row clickable for convenience.
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div className={ classes } onClick={ onSelect( item ) }>
 			{ isSingle ? (
 				<>
 					<input
@@ -246,6 +249,7 @@ export const SearchListItem = < T extends object = object >( {
 						onChange={ onSelect( item ) }
 						checked={ isSelected }
 						className="woocommerce-search-list__item-input"
+						onClick={ ( e ) => e.stopPropagation() }
 					/>
 
 					<label htmlFor={ id }>
@@ -266,6 +270,7 @@ export const SearchListItem = < T extends object = object >( {
 					onChange={ onSelect( item ) }
 					checked={ isSelected }
 					__nextHasNoMarginBottom={ true }
+					onClick={ ( e ) => e.stopPropagation() }
 				/>
 			) }
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -31,8 +31,11 @@ const getItemDescendants = (
 
 const isExpandedOrDescendantIsExpanded = (
 	item: SearchListItemProps,
-	expandedPanelId: number
+	expandedPanelId: number | null
 ): boolean => {
+	if ( expandedPanelId === null ) {
+		return false;
+	}
 	if ( item.id === expandedPanelId ) {
 		return true;
 	}
@@ -142,7 +145,7 @@ export const SearchListItem = < T extends object = object >( {
 			setExpandedPanelId( Number( item.parent ) );
 			return;
 		}
-		setExpandedPanelId( -1 );
+		setExpandedPanelId( null );
 	}, [ isExpanded, item.id, item.parent, setExpandedPanelId ] );
 
 	// Non-selectable items (like Product Attributes) should look selecteed when

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -126,12 +126,12 @@ export const SearchListItem = < T extends object = object >( {
 	const id = `${ name }-${ item.id }`;
 
 	const togglePanel = useCallback( () => {
-		if ( ! isExpanded ) {
-			setExpandedPanelId( Number( item.id ) );
+		if ( ! isExpanded && typeof item.id === 'number' && item.id ) {
+			setExpandedPanelId( item.id );
 			return;
 		}
-		if ( item.parent ) {
-			setExpandedPanelId( Number( item.parent ) );
+		if ( typeof item.parent === 'number' && item.parent ) {
+			setExpandedPanelId( item.parent );
 			return;
 		}
 		setExpandedPanelId( null );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -3,7 +3,7 @@
  */
 import clsx from 'clsx';
 import { CheckboxControl } from '@wordpress/components';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { arrayDifferenceBy, arrayUnionBy } from '@woocommerce/utils';
 import { decodeEntities } from '@wordpress/html-entities';
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -16,6 +16,46 @@ import type {
 } from './types';
 import { getHighlightedName, getBreadcrumbsForDisplay } from './utils';
 
+const isExpandedOrDescendantIsExpanded = (
+	item: SearchListItemProps,
+	expandedPanelId: number
+): boolean => {
+	if ( item.id === expandedPanelId ) {
+		return true;
+	}
+	if ( Array.isArray( item.children ) && item.children.length > 0 ) {
+		return item.children.some( ( child ) =>
+			isExpandedOrDescendantIsExpanded( child, expandedPanelId )
+		);
+	}
+	return false;
+};
+
+const isSomeChildrenSelected = (
+	item: SearchListItemProps,
+	selected: SearchListItemProps[]
+): boolean => {
+	return ( item.children as SearchListItemProps[] ).some( ( child ) =>
+		selected.find(
+			( selectedItem ) =>
+				selectedItem.id === child.id ||
+				isSomeChildrenSelected( child, selected )
+		)
+	);
+};
+
+const getItemWithDescendants = (
+	item: SearchListItemProps
+): SearchListItemProps[] => {
+	const descendants = item.children?.map( ( child ) =>
+		getItemWithDescendants( child )
+	);
+	if ( ! descendants ) {
+		return [ item ];
+	}
+	return [ item, ...descendants.flat() ];
+};
+
 const Count = ( { label }: { label: string | React.ReactNode | number } ) => {
 	return (
 		<span className="woocommerce-search-list__item-count">{ label }</span>
@@ -62,7 +102,10 @@ export const SearchListItem = < T extends object = object >( {
 		item.count !== null;
 	const hasBreadcrumbs = !! item.breadcrumbs?.length;
 	const hasChildren = !! item.children?.length;
-	const isExpanded = expandedPanelId === item.id;
+	const isExpanded = isExpandedOrDescendantIsExpanded(
+		item,
+		expandedPanelId
+	);
 	const classes = clsx(
 		[ 'woocommerce-search-list__item', `depth-${ depth }`, className ],
 		{
@@ -84,7 +127,15 @@ export const SearchListItem = < T extends object = object >( {
 	const id = `${ name }-${ item.id }`;
 
 	const togglePanel = useCallback( () => {
-		setExpandedPanelId( isExpanded ? -1 : Number( item.id ) );
+		if ( ! isExpanded ) {
+			setExpandedPanelId( Number( item.id ) );
+			return;
+		}
+		if ( item.parent ) {
+			setExpandedPanelId( Number( item.parent ) );
+			return;
+		}
+		setExpandedPanelId( -1 );
 	}, [ isExpanded, item.id, setExpandedPanelId ] );
 
 	return hasChildren ? (
@@ -122,28 +173,22 @@ export const SearchListItem = < T extends object = object >( {
 					<CheckboxControl
 						className="woocommerce-search-list__item-input"
 						checked={ isSelected }
-						{ ...( ! isSelected &&
-						// We know that `item.children` is not `undefined` because
-						// we are here only if `hasChildren` is `true`.
-						( item.children as SearchListItemProps[] ).some(
-							( child ) =>
-								selected.find(
-									( selectedItem ) =>
-										selectedItem.id === child.id
-								)
-						)
-							? { indeterminate: true }
-							: {} ) }
+						indeterminate={
+							! isSelected &&
+							isSomeChildrenSelected( item, selected )
+						}
 						label={ getHighlightedName(
 							decodeEntities( item.name ),
 							search
 						) }
 						onChange={ () => {
+							const itemWithDescendants =
+								getItemWithDescendants( item );
 							if ( isSelected ) {
 								onSelect(
 									arrayDifferenceBy(
 										selected,
-										item.children as SearchListItemProps[],
+										itemWithDescendants,
 										'id'
 									)
 								)();
@@ -151,7 +196,7 @@ export const SearchListItem = < T extends object = object >( {
 								onSelect(
 									arrayUnionBy(
 										selected,
-										item.children as SearchListItemProps[],
+										itemWithDescendants,
 										'id'
 									)
 								)();

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -136,7 +136,7 @@ export const SearchListItem = < T extends object = object >( {
 			return;
 		}
 		setExpandedPanelId( -1 );
-	}, [ isExpanded, item.id, setExpandedPanelId ] );
+	}, [ isExpanded, item.id, item.parent, setExpandedPanelId ] );
 
 	return hasChildren ? (
 		<div
@@ -203,6 +203,7 @@ export const SearchListItem = < T extends object = object >( {
 							}
 						} }
 						onClick={ ( e ) => e.stopPropagation() }
+						__nextHasNoMarginBottom={ true }
 					/>
 
 					{ showCount ? (
@@ -212,7 +213,7 @@ export const SearchListItem = < T extends object = object >( {
 			) }
 		</div>
 	) : (
-		<label htmlFor={ id } className={ classes }>
+		<div className={ classes }>
 			{ isSingle ? (
 				<>
 					<input
@@ -224,9 +225,11 @@ export const SearchListItem = < T extends object = object >( {
 						onChange={ onSelect( item ) }
 						checked={ isSelected }
 						className="woocommerce-search-list__item-input"
-					></input>
+					/>
 
-					<ItemLabel item={ item } search={ search } />
+					<label htmlFor={ id }>
+						<ItemLabel item={ item } search={ search } />
+					</label>
 				</>
 			) : (
 				<CheckboxControl
@@ -241,11 +244,12 @@ export const SearchListItem = < T extends object = object >( {
 					) }
 					onChange={ onSelect( item ) }
 					checked={ isSelected }
+					__nextHasNoMarginBottom={ true }
 				/>
 			) }
 
 			{ showCount ? <Count label={ countLabel || item.count } /> : null }
-		</label>
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -44,16 +44,30 @@ const isSomeChildrenSelected = (
 	);
 };
 
-const getItemWithDescendants = (
+const areAllDescendantsSelected = (
+	item: SearchListItemProps,
+	selected: SearchListItemProps[]
+): boolean => {
+	return ( item.children as SearchListItemProps[] ).every( ( child ) =>
+		selected.find(
+			( selectedItem ) =>
+				selectedItem.id === child.id ||
+				areAllDescendantsSelected( child, selected )
+		)
+	);
+};
+
+const getItemDescendants = (
 	item: SearchListItemProps
 ): SearchListItemProps[] => {
-	const descendants = item.children?.map( ( child ) =>
-		getItemWithDescendants( child )
-	);
+	const descendants = item.children?.map( ( child ) => [
+		child,
+		...getItemDescendants( child ),
+	] );
 	if ( ! descendants ) {
-		return [ item ];
+		return [];
 	}
-	return [ item, ...descendants.flat() ];
+	return descendants.flat();
 };
 
 const Count = ( { label }: { label: string | React.ReactNode | number } ) => {
@@ -87,6 +101,7 @@ export const SearchListItem = < T extends object = object >( {
 	controlId = '',
 	item,
 	isSelected,
+	isSelectable = true,
 	isSingle,
 	onSelect,
 	search = '',
@@ -182,13 +197,20 @@ export const SearchListItem = < T extends object = object >( {
 							search
 						) }
 						onChange={ () => {
-							const itemWithDescendants =
-								getItemWithDescendants( item );
-							if ( isSelected ) {
+							const descendants = getItemDescendants( item );
+							const itemsToToggle = isSelectable
+								? [ item, ...descendants ]
+								: [ ...descendants ];
+							const allDescendantsAreSelected =
+								areAllDescendantsSelected( item, selected );
+							if (
+								( isSelectable && isSelected ) ||
+								( ! isSelectable && allDescendantsAreSelected )
+							) {
 								onSelect(
 									arrayDifferenceBy(
 										selected,
-										itemWithDescendants,
+										itemsToToggle,
 										'id'
 									)
 								)();
@@ -196,7 +218,7 @@ export const SearchListItem = < T extends object = object >( {
 								onSelect(
 									arrayUnionBy(
 										selected,
-										itemWithDescendants,
+										itemsToToggle,
 										'id'
 									)
 								)();

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -145,6 +145,13 @@ export const SearchListItem = < T extends object = object >( {
 		setExpandedPanelId( -1 );
 	}, [ isExpanded, item.id, item.parent, setExpandedPanelId ] );
 
+	// Non-selectable items (like Product Attributes) should look selecteed when
+	// all their descendants are selected, but look indeterminate when only some
+	// are selected.
+	const looksSelected =
+		isSelected ||
+		( ! isSelectable && areAllDescendantsSelected( item, selected ) );
+
 	return hasChildren ? (
 		<div
 			className={ classes }
@@ -179,9 +186,9 @@ export const SearchListItem = < T extends object = object >( {
 				<>
 					<CheckboxControl
 						className="woocommerce-search-list__item-input"
-						checked={ isSelected }
+						checked={ looksSelected }
 						indeterminate={
-							! isSelected &&
+							! looksSelected &&
 							areSomeDescendantsSelected( item, selected )
 						}
 						label={ getHighlightedName(

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -16,47 +16,6 @@ import type {
 } from './types';
 import { getHighlightedName, getBreadcrumbsForDisplay } from './utils';
 
-const isExpandedOrDescendantIsExpanded = (
-	item: SearchListItemProps,
-	expandedPanelId: number
-): boolean => {
-	if ( item.id === expandedPanelId ) {
-		return true;
-	}
-	if ( Array.isArray( item.children ) && item.children.length > 0 ) {
-		return item.children.some( ( child ) =>
-			isExpandedOrDescendantIsExpanded( child, expandedPanelId )
-		);
-	}
-	return false;
-};
-
-const isSomeChildrenSelected = (
-	item: SearchListItemProps,
-	selected: SearchListItemProps[]
-): boolean => {
-	return ( item.children as SearchListItemProps[] ).some( ( child ) =>
-		selected.find(
-			( selectedItem ) =>
-				selectedItem.id === child.id ||
-				isSomeChildrenSelected( child, selected )
-		)
-	);
-};
-
-const areAllDescendantsSelected = (
-	item: SearchListItemProps,
-	selected: SearchListItemProps[]
-): boolean => {
-	return ( item.children as SearchListItemProps[] ).every( ( child ) =>
-		selected.find(
-			( selectedItem ) =>
-				selectedItem.id === child.id ||
-				areAllDescendantsSelected( child, selected )
-		)
-	);
-};
-
 const getItemDescendants = (
 	item: SearchListItemProps
 ): SearchListItemProps[] => {
@@ -68,6 +27,39 @@ const getItemDescendants = (
 		return [];
 	}
 	return descendants.flat();
+};
+
+const isExpandedOrDescendantIsExpanded = (
+	item: SearchListItemProps,
+	expandedPanelId: number
+): boolean => {
+	if ( item.id === expandedPanelId ) {
+		return true;
+	}
+	const descendants = getItemDescendants( item );
+	return descendants.some(
+		( descendant ) => descendant.id === expandedPanelId
+	);
+};
+
+const areSomeDescendantsSelected = (
+	item: SearchListItemProps,
+	selected: SearchListItemProps[]
+): boolean => {
+	const descendants = getItemDescendants( item );
+	return descendants.some( ( descendant ) =>
+		selected.find( ( selectedItem ) => selectedItem.id === descendant.id )
+	);
+};
+
+const areAllDescendantsSelected = (
+	item: SearchListItemProps,
+	selected: SearchListItemProps[]
+): boolean => {
+	const descendants = getItemDescendants( item );
+	return descendants.every( ( descendant ) =>
+		selected.find( ( selectedItem ) => selectedItem.id === descendant.id )
+	);
 };
 
 const Count = ( { label }: { label: string | React.ReactNode | number } ) => {
@@ -190,7 +182,7 @@ export const SearchListItem = < T extends object = object >( {
 						checked={ isSelected }
 						indeterminate={
 							! isSelected &&
-							isSomeChildrenSelected( item, selected )
+							areSomeDescendantsSelected( item, selected )
 						}
 						label={ getHighlightedName(
 							decodeEntities( item.name ),

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -162,7 +162,12 @@ export const SearchListItem = < T extends object = object >( {
 						id={ id }
 						name={ name }
 						value={ item.value }
-						onChange={ onSelect( item ) }
+						onChange={ () => {
+							onSelect( item )();
+							if ( ! isExpanded ) {
+								setExpandedPanelId( item.id );
+							}
+						} }
 						onClick={ ( e ) => e.stopPropagation() }
 						checked={ isSelected }
 						disabled={ disabled }
@@ -219,6 +224,9 @@ export const SearchListItem = < T extends object = object >( {
 										'id'
 									)
 								)();
+								if ( ! isExpanded ) {
+									setExpandedPanelId( item.id );
+								}
 							}
 						} }
 						__nextHasNoMarginBottom={ true }
@@ -268,7 +276,12 @@ export const SearchListItem = < T extends object = object >( {
 						decodeEntities( item.name ),
 						search
 					) }
-					onChange={ onSelect( item ) }
+					onChange={ () => {
+						onSelect( item )();
+						if ( ! isExpanded ) {
+							setExpandedPanelId( item.id );
+						}
+					} }
 					checked={ isSelected }
 					disabled={ disabled }
 					__nextHasNoMarginBottom={ true }

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -116,12 +116,6 @@ export const SearchListItem = < T extends object = object >( {
 		}
 	);
 
-	useEffect( () => {
-		if ( hasChildren && isSelected ) {
-			setExpandedPanelId( item.id as number );
-		}
-	}, [ item, hasChildren, isSelected, setExpandedPanelId ] );
-
 	const name = props.name || `search-list-item-${ controlId }`;
 	const id = `${ name }-${ item.id }`;
 
@@ -141,8 +135,8 @@ export const SearchListItem = < T extends object = object >( {
 	// all their descendants are selected, but look indeterminate when only some
 	// are selected.
 	const looksSelected =
-		isSelected ||
-		( ! isSelectable && areAllDescendantsSelected( item, selected ) );
+		( isSelected || ! isSelectable ) &&
+		areAllDescendantsSelected( item, selected );
 
 	return hasChildren ? (
 		<div
@@ -183,12 +177,14 @@ export const SearchListItem = < T extends object = object >( {
 						disabled={ disabled }
 						indeterminate={
 							! looksSelected &&
-							areSomeDescendantsSelected( item, selected )
+							( isSelected ||
+								areSomeDescendantsSelected( item, selected ) )
 						}
 						label={ getHighlightedName(
 							decodeEntities( item.name ),
 							search
 						) }
+						onClick={ ( e ) => e.stopPropagation() }
 						onChange={ () => {
 							const descendants = getItemDescendants( item );
 							const itemsToToggle = isSelectable

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -120,11 +120,18 @@ export const SearchListItem = < T extends object = object >( {
 	const id = `${ name }-${ item.id }`;
 
 	const togglePanel = useCallback( () => {
-		if ( ! isExpanded && typeof item.id === 'number' && item.id ) {
+		if (
+			! isExpanded &&
+			( typeof item.id === 'number' || typeof item.id === 'string' )
+		) {
 			setExpandedPanelId( item.id );
 			return;
 		}
-		if ( typeof item.parent === 'number' && item.parent ) {
+		if (
+			item.parent &&
+			( typeof item.parent === 'number' ||
+				typeof item.parent === 'string' )
+		) {
 			setExpandedPanelId( item.parent );
 			return;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -185,6 +185,7 @@ export const SearchListItem = < T extends object = object >( {
 							search
 						) }
 						onClick={ ( e ) => e.stopPropagation() }
+						onKeyDown={ ( e ) => e.stopPropagation() }
 						onChange={ () => {
 							const descendants = getItemDescendants( item );
 							const itemsToToggle = isSelectable

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/item.tsx
@@ -14,7 +14,11 @@ import type {
 	RenderItemArgs,
 	SearchListItem as SearchListItemProps,
 } from './types';
-import { getHighlightedName, getBreadcrumbsForDisplay } from './utils';
+import {
+	getHighlightedName,
+	getBreadcrumbsForDisplay,
+	isExpandedOrDescendantIsExpanded,
+} from './utils';
 
 const getItemDescendants = (
 	item: SearchListItemProps
@@ -27,22 +31,6 @@ const getItemDescendants = (
 		return [];
 	}
 	return descendants.flat();
-};
-
-const isExpandedOrDescendantIsExpanded = (
-	item: SearchListItemProps,
-	expandedPanelId: number | null
-): boolean => {
-	if ( expandedPanelId === null ) {
-		return false;
-	}
-	if ( item.id === expandedPanelId ) {
-		return true;
-	}
-	const descendants = getItemDescendants( item );
-	return descendants.some(
-		( descendant ) => descendant.id === expandedPanelId
-	);
 };
 
 const areSomeDescendantsSelected = (
@@ -94,6 +82,7 @@ export const SearchListItem = < T extends object = object >( {
 	className,
 	depth = 0,
 	controlId = '',
+	disabled = false,
 	item,
 	isSelected,
 	isSelectable = true,
@@ -148,7 +137,7 @@ export const SearchListItem = < T extends object = object >( {
 		setExpandedPanelId( null );
 	}, [ isExpanded, item.id, item.parent, setExpandedPanelId ] );
 
-	// Non-selectable items (like Product Attributes) should look selecteed when
+	// Non-selectable items (like Product Attributes) should look selected when
 	// all their descendants are selected, but look indeterminate when only some
 	// are selected.
 	const looksSelected =
@@ -175,6 +164,7 @@ export const SearchListItem = < T extends object = object >( {
 						onChange={ onSelect( item ) }
 						onClick={ ( e ) => e.stopPropagation() }
 						checked={ isSelected }
+						disabled={ disabled }
 						className="woocommerce-search-list__item-input"
 						{ ...props }
 					/>
@@ -190,6 +180,7 @@ export const SearchListItem = < T extends object = object >( {
 					<CheckboxControl
 						className="woocommerce-search-list__item-input"
 						checked={ looksSelected }
+						disabled={ disabled }
 						indeterminate={
 							! looksSelected &&
 							areSomeDescendantsSelected( item, selected )
@@ -240,7 +231,10 @@ export const SearchListItem = < T extends object = object >( {
 		// Items can be enabled via the radios and checkboxes. But we make the
 		// whole row clickable for convenience.
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-		<div className={ classes } onClick={ onSelect( item ) }>
+		<div
+			className={ classes }
+			onClick={ disabled ? undefined : onSelect( item ) }
+		>
 			{ isSingle ? (
 				<>
 					<input
@@ -251,6 +245,7 @@ export const SearchListItem = < T extends object = object >( {
 						value={ item.value }
 						onChange={ onSelect( item ) }
 						checked={ isSelected }
+						disabled={ disabled }
 						className="woocommerce-search-list__item-input"
 						onClick={ ( e ) => e.stopPropagation() }
 					/>
@@ -272,6 +267,7 @@ export const SearchListItem = < T extends object = object >( {
 					) }
 					onChange={ onSelect( item ) }
 					checked={ isSelected }
+					disabled={ disabled }
 					__nextHasNoMarginBottom={ true }
 					onClick={ ( e ) => e.stopPropagation() }
 				/>

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -23,7 +23,11 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { getFilteredList, defaultMessages } from './utils';
+import {
+	getFilteredList,
+	defaultMessages,
+	isExpandedOrDescendantIsExpanded,
+} from './utils';
 import SearchListItem from './item';
 import Tag from '../tag';
 import type {
@@ -35,24 +39,6 @@ import type {
 	SearchListItemsContainerProps,
 } from './types';
 import './style.scss';
-
-const isExpandedOrDescendantIsExpanded = (
-	item: SearchListItemProps,
-	expandedPanelId: number | null
-): boolean => {
-	if ( expandedPanelId === null ) {
-		return false;
-	}
-	if ( item.id === expandedPanelId ) {
-		return true;
-	}
-	if ( Array.isArray( item.children ) && item.children.length > 0 ) {
-		return item.children.some( ( child ) =>
-			isExpandedOrDescendantIsExpanded( child, expandedPanelId )
-		);
-	}
-	return false;
-};
 
 const defaultRenderListItem = ( args: RenderItemArgs ): JSX.Element => {
 	return <SearchListItem { ...args } />;

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -36,6 +36,21 @@ import type {
 } from './types';
 import './style.scss';
 
+const isExpandedOrDescendantIsExpanded = (
+	item: SearchListItemProps,
+	expandedPanelId: number
+): boolean => {
+	if ( item.id === expandedPanelId ) {
+		return true;
+	}
+	if ( Array.isArray( item.children ) && item.children.length > 0 ) {
+		return item.children.some( ( child ) =>
+			isExpandedOrDescendantIsExpanded( child, expandedPanelId )
+		);
+	}
+	return false;
+};
+
 const defaultRenderListItem = ( args: RenderItemArgs ): JSX.Element => {
 	return <SearchListItem { ...args } />;
 };
@@ -65,15 +80,13 @@ const ListItems = ( props: ListItemsProps ): JSX.Element | null => {
 		<>
 			{ list.map( ( item ) => {
 				const childrenCount = item.children?.length ?? 0;
-				const isSelected =
-					childrenCount && ! isSingle
-						? item.children?.every( ( { id } ) =>
-								selected.find(
-									( selectedItem ) => selectedItem.id === id
-								)
-						  )
-						: !! selected.find( ( { id } ) => id === item.id );
-				const isExpanded = childrenCount && expandedPanelId === item.id;
+				const isSelected = !! selected.find(
+					( { id } ) => id === item.id
+				);
+				const isExpanded = isExpandedOrDescendantIsExpanded(
+					item,
+					expandedPanelId
+				);
 				const totalChildrenForItem = totalChildren?.[ item.id ];
 				const hasMoreChildren =
 					typeof totalChildrenForItem === 'number' &&

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -38,8 +38,11 @@ import './style.scss';
 
 const isExpandedOrDescendantIsExpanded = (
 	item: SearchListItemProps,
-	expandedPanelId: number
+	expandedPanelId: number | null
 ): boolean => {
+	if ( expandedPanelId === null ) {
+		return false;
+	}
 	if ( item.id === expandedPanelId ) {
 		return true;
 	}
@@ -265,7 +268,7 @@ export const SearchListControl = < T extends object = object >(
 	} = props;
 
 	const [ search, setSearch ] = useState( '' );
-	const useExpandedPanelId = useState< number >( -1 );
+	const useExpandedPanelId = useState< number | null >( null );
 	const instanceId = useInstanceId( SearchListControl );
 	const messages = useMemo(
 		() => ( { ...defaultMessages, ...customMessages } ),

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -254,7 +254,7 @@ export const SearchListControl = < T extends object = object >(
 	} = props;
 
 	const [ search, setSearch ] = useState( '' );
-	const useExpandedPanelId = useState< number | null >( null );
+	const useExpandedPanelId = useState< string | number | null >( null );
 	const instanceId = useInstanceId( SearchListControl );
 	const messages = useMemo(
 		() => ( { ...defaultMessages, ...customMessages } ),

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/style.scss
@@ -211,6 +211,10 @@
 			margin: 0;
 		}
 
+		> label:has(.woocommerce-search-list__item-label) {
+			display: contents;
+		}
+		
 		.woocommerce-search-list__item-label {
 			display: flex;
 			flex: 1;

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
@@ -109,9 +109,8 @@ exports[`SearchListControl should render a search box and list of hierarchical o
             </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-11-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -144,12 +143,11 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-11-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -182,7 +180,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -269,9 +267,8 @@ exports[`SearchListControl should render a search box and list of hierarchical o
           </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-11-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -304,12 +301,11 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-11-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -342,7 +338,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -472,9 +468,8 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -507,12 +502,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -545,12 +539,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -583,12 +576,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -621,12 +613,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -659,12 +650,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-0-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -697,7 +687,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -746,9 +736,8 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -781,12 +770,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -819,12 +807,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -857,12 +844,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -895,12 +881,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -933,12 +918,11 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-0-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -971,7 +955,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -1101,9 +1085,8 @@ exports[`SearchListControl should render a search box and list of options with a
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1136,12 +1119,11 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1174,12 +1156,11 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1212,12 +1193,11 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1250,12 +1230,11 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1288,12 +1267,11 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-1-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1326,7 +1304,7 @@ exports[`SearchListControl should render a search box and list of options with a
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -1375,9 +1353,8 @@ exports[`SearchListControl should render a search box and list of options with a
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1410,12 +1387,11 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1448,12 +1424,11 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1486,12 +1461,11 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1524,12 +1498,11 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1562,12 +1535,11 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-1-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -1600,7 +1572,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -1975,9 +1947,8 @@ exports[`SearchListControl should render a search box and list of options, with 
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2010,12 +1981,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2048,12 +2018,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2086,12 +2055,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2124,12 +2092,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2162,12 +2129,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-9-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2200,7 +2166,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -2249,9 +2215,8 @@ exports[`SearchListControl should render a search box and list of options, with 
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2284,12 +2249,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2322,12 +2286,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2360,12 +2323,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2398,12 +2360,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2436,12 +2397,11 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-9-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2474,7 +2434,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -2825,9 +2785,8 @@ exports[`SearchListControl should render a search box with a search term, and no
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2860,12 +2819,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2898,12 +2856,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2936,12 +2893,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -2974,12 +2930,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3012,12 +2967,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-8-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3050,7 +3004,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -3099,9 +3053,8 @@ exports[`SearchListControl should render a search box with a search term, and no
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3134,12 +3087,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3172,12 +3124,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3210,12 +3161,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3248,12 +3198,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3286,12 +3235,11 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-8-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3324,7 +3272,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -3454,9 +3402,8 @@ exports[`SearchListControl should render a search box with a search term, and on
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3489,12 +3436,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3527,12 +3473,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3565,12 +3510,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3603,12 +3547,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3641,12 +3584,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-5-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3679,7 +3621,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -3728,9 +3670,8 @@ exports[`SearchListControl should render a search box with a search term, and on
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3763,12 +3704,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3801,12 +3741,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3839,12 +3778,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3877,12 +3815,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3915,12 +3852,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-5-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -3953,7 +3889,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -4083,9 +4019,8 @@ exports[`SearchListControl should render a search box with a search term, and on
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-6-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4121,12 +4056,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-6-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4162,7 +4096,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -4211,9 +4145,8 @@ exports[`SearchListControl should render a search box with a search term, and on
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-6-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4249,12 +4182,11 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-6-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4290,7 +4222,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -4471,9 +4403,8 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4506,12 +4437,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4559,12 +4489,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4597,12 +4526,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4635,12 +4563,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4673,12 +4600,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-2-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4711,7 +4637,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -4811,9 +4737,8 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4846,12 +4771,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4899,12 +4823,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4937,12 +4860,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -4975,12 +4897,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5013,12 +4934,11 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-2-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5051,7 +4971,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>
@@ -5274,9 +5194,8 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
           class="woocommerce-search-list__list"
         >
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-1"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5309,12 +5228,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-2"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5362,12 +5280,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-3"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5400,12 +5317,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-4"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5453,12 +5369,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-5"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5491,12 +5406,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
           <li>
-            <label
+            <div
               class="woocommerce-search-list__item depth-0"
-              for="search-list-item-3-6"
             >
               <div
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5529,7 +5443,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                   </div>
                 </div>
               </div>
-            </label>
+            </div>
           </li>
         </ul>
       </div>
@@ -5671,9 +5585,8 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         class="woocommerce-search-list__list"
       >
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-1"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5706,12 +5619,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-2"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5759,12 +5671,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-3"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5797,12 +5708,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-4"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5850,12 +5760,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-5"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5888,12 +5797,11 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
         <li>
-          <label
+          <div
             class="woocommerce-search-list__item depth-0"
-            for="search-list-item-3-6"
           >
             <div
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
@@ -5926,7 +5834,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 </div>
               </div>
             </div>
-          </label>
+          </div>
         </li>
       </ul>
     </div>

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
@@ -80,7 +80,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -116,7 +116,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -153,7 +153,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -238,7 +238,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -274,7 +274,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -311,7 +311,7 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -475,7 +475,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -512,7 +512,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -549,7 +549,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -586,7 +586,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -623,7 +623,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -660,7 +660,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -743,7 +743,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -780,7 +780,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -817,7 +817,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -854,7 +854,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -891,7 +891,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -928,7 +928,7 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1092,7 +1092,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1129,7 +1129,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1166,7 +1166,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1203,7 +1203,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1240,7 +1240,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1277,7 +1277,7 @@ exports[`SearchListControl should render a search box and list of options with a
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1360,7 +1360,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1397,7 +1397,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1434,7 +1434,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1471,7 +1471,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1508,7 +1508,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1545,7 +1545,7 @@ exports[`SearchListControl should render a search box and list of options with a
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1954,7 +1954,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -1991,7 +1991,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2028,7 +2028,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2065,7 +2065,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2102,7 +2102,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2139,7 +2139,7 @@ exports[`SearchListControl should render a search box and list of options, with 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2222,7 +2222,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2259,7 +2259,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2296,7 +2296,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2333,7 +2333,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2370,7 +2370,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2407,7 +2407,7 @@ exports[`SearchListControl should render a search box and list of options, with 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2792,7 +2792,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2829,7 +2829,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2866,7 +2866,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2903,7 +2903,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2940,7 +2940,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -2977,7 +2977,7 @@ exports[`SearchListControl should render a search box with a search term, and no
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3060,7 +3060,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3097,7 +3097,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3134,7 +3134,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3171,7 +3171,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3208,7 +3208,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3245,7 +3245,7 @@ exports[`SearchListControl should render a search box with a search term, and no
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3409,7 +3409,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3446,7 +3446,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3483,7 +3483,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3520,7 +3520,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3557,7 +3557,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3594,7 +3594,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3677,7 +3677,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3714,7 +3714,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3751,7 +3751,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3788,7 +3788,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3825,7 +3825,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -3862,7 +3862,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4026,7 +4026,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4066,7 +4066,7 @@ exports[`SearchListControl should render a search box with a search term, and on
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4152,7 +4152,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4192,7 +4192,7 @@ exports[`SearchListControl should render a search box with a search term, and on
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4410,7 +4410,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4447,7 +4447,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4499,7 +4499,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4536,7 +4536,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4573,7 +4573,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4610,7 +4610,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4744,7 +4744,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4781,7 +4781,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4833,7 +4833,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4870,7 +4870,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4907,7 +4907,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -4944,7 +4944,7 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5201,7 +5201,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5238,7 +5238,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5290,7 +5290,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5327,7 +5327,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5379,7 +5379,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5416,7 +5416,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
               >
                 <div
-                  class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                  class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
                 >
                   <div
                     class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5592,7 +5592,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5629,7 +5629,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5681,7 +5681,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5718,7 +5718,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5770,7 +5770,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
@@ -5807,7 +5807,7 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               class="components-base-control components-checkbox-control woocommerce-search-list__item-input css-1ymh5rp-Wrapper-boxSizingReset ej5x27r4"
             >
               <div
-                class="components-base-control__field css-1s74ogk-StyledField-deprecatedMarginField ej5x27r3"
+                class="components-base-control__field css-sa9iwi-StyledField ej5x27r3"
               >
                 <div
                   class="components-flex components-h-stack css-56qjkt-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
@@ -96,6 +96,21 @@ describe( 'SearchListControl hierarchy interactions', () => {
 		expect( selectedIds ).toEqual( [ 1, 2, 3, 4 ] );
 	} );
 
+	test( 'does not collapse an expanded parent when its checkbox is clicked', () => {
+		const { container } = renderHierarchicalControl();
+
+		expandCategory( container, 'Apricots' );
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Elderberry' } )
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Apricots' } ) );
+
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Elderberry' } )
+		).toBeInTheDocument();
+	} );
+
 	test( 'deselects a parent category and all descendants when its checkbox is unchecked', () => {
 		const onChange = jest.fn();
 		const selected = hierarchicalList.filter( ( { id } ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
@@ -6,8 +6,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { SearchListControl } from '..';
-import type { SearchListItem } from '../types';
+import { SearchListControl, SearchListItem } from '..';
+import type {
+	RenderItemArgs,
+	SearchListItem as SearchListItemType,
+} from '../types';
 
 const hierarchicalList = [
 	{ id: 1, name: 'Apricots', parent: 0, value: 'apricots' },
@@ -16,11 +19,18 @@ const hierarchicalList = [
 	{ id: 4, name: 'Guava', parent: 3, value: 'guava' },
 	{ id: 5, name: 'Lychee', parent: 0, value: 'lychee' },
 	{ id: 6, name: 'Mulberry', parent: 0, value: 'mulberry' },
-] as SearchListItem[];
+] as SearchListItemType[];
+
+const renderNonSelectableParentItem = ( args: RenderItemArgs ) => (
+	<SearchListItem { ...args } isSelectable={ ! args.item.children?.length } />
+);
 
 const renderHierarchicalControl = ( {
-	selected = [] as SearchListItem[],
+	selected = [] as SearchListItemType[],
 	onChange = jest.fn(),
+	renderItem = undefined as
+		| ( ( args: RenderItemArgs ) => JSX.Element )
+		| undefined,
 } = {} ) =>
 	render(
 		<SearchListControl
@@ -30,6 +40,7 @@ const renderHierarchicalControl = ( {
 			list={ hierarchicalList }
 			selected={ selected }
 			onChange={ onChange }
+			renderItem={ renderItem }
 		/>
 	);
 
@@ -80,7 +91,7 @@ describe( 'SearchListControl hierarchy interactions', () => {
 		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Apricots' } ) );
 
 		const selectedIds = onChange.mock.calls[ 0 ][ 0 ].map(
-			( item: SearchListItem ) => item.id
+			( item: SearchListItemType ) => item.id
 		);
 		expect( selectedIds ).toEqual( [ 1, 2, 3, 4 ] );
 	} );
@@ -119,5 +130,101 @@ describe( 'SearchListControl hierarchy interactions', () => {
 
 		expect( apricotsCheckbox ).toBePartiallyChecked();
 		expect( elderberryCheckbox ).toBePartiallyChecked();
+	} );
+
+	describe( 'isSelectable', () => {
+		test( 'shows a non-selectable parent as checked when all descendants are selected', () => {
+			const { container } = renderHierarchicalControl( {
+				selected: hierarchicalList.filter( ( { id } ) =>
+					[ 2, 3, 4 ].includes( Number( id ) )
+				),
+				renderItem: renderNonSelectableParentItem,
+			} );
+
+			expandCategory( container, 'Apricots' );
+
+			expect(
+				screen.getByRole( 'checkbox', { name: 'Apricots' } )
+			).toBeChecked();
+		} );
+
+		test( 'shows a non-selectable parent as indeterminate when only some descendants are selected', () => {
+			const { container } = renderHierarchicalControl( {
+				selected: hierarchicalList.filter(
+					( { id } ) => Number( id ) === 4
+				),
+				renderItem: renderNonSelectableParentItem,
+			} );
+
+			expandCategory( container, 'Apricots' );
+
+			expect(
+				screen.getByRole( 'checkbox', { name: 'Apricots' } )
+			).toBePartiallyChecked();
+			expect(
+				screen.getByRole( 'checkbox', { name: 'Elderberry' } )
+			).toBeChecked();
+		} );
+
+		test( 'selects only descendants when a non-selectable parent checkbox is checked', () => {
+			const onChange = jest.fn();
+			const { container } = renderHierarchicalControl( {
+				onChange,
+				renderItem: renderNonSelectableParentItem,
+			} );
+
+			expandCategory( container, 'Apricots' );
+			fireEvent.click(
+				screen.getByRole( 'checkbox', { name: 'Apricots' } )
+			);
+
+			const selectedIds = onChange.mock.calls[ 0 ][ 0 ].map(
+				( item: SearchListItemType ) => item.id
+			);
+			expect( selectedIds ).toEqual( [ 2, 3, 4 ] );
+			expect( selectedIds ).not.toContain( 1 );
+		} );
+
+		test( 'deselects only descendants when a non-selectable parent checkbox is unchecked', () => {
+			const onChange = jest.fn();
+			const selected = hierarchicalList.filter( ( { id } ) =>
+				[ 2, 3, 4 ].includes( Number( id ) )
+			);
+			const { container } = renderHierarchicalControl( {
+				onChange,
+				selected,
+				renderItem: renderNonSelectableParentItem,
+			} );
+
+			expandCategory( container, 'Apricots' );
+			fireEvent.click(
+				screen.getByRole( 'checkbox', { name: 'Apricots' } )
+			);
+
+			expect( onChange ).toHaveBeenCalledWith( [] );
+		} );
+
+		test( 'selects remaining descendants when a partially selected non-selectable parent is checked', () => {
+			const onChange = jest.fn();
+			const selected = hierarchicalList.filter(
+				( { id } ) => Number( id ) === 4
+			);
+			const { container } = renderHierarchicalControl( {
+				onChange,
+				selected,
+				renderItem: renderNonSelectableParentItem,
+			} );
+
+			expandCategory( container, 'Apricots' );
+			fireEvent.click(
+				screen.getByRole( 'checkbox', { name: 'Apricots' } )
+			);
+
+			const selectedIds = onChange.mock.calls[ 0 ][ 0 ].map(
+				( item: SearchListItemType ) => item.id
+			);
+			expect( selectedIds ).toEqual( [ 4, 2, 3 ] );
+			expect( selectedIds ).not.toContain( 1 );
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/hierarchy-interaction.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { SearchListControl } from '..';
+import type { SearchListItem } from '../types';
+
+const hierarchicalList = [
+	{ id: 1, name: 'Apricots', parent: 0, value: 'apricots' },
+	{ id: 2, name: 'Clementine', parent: 1, value: 'clementine' },
+	{ id: 3, name: 'Elderberry', parent: 1, value: 'elderberry' },
+	{ id: 4, name: 'Guava', parent: 3, value: 'guava' },
+	{ id: 5, name: 'Lychee', parent: 0, value: 'lychee' },
+	{ id: 6, name: 'Mulberry', parent: 0, value: 'mulberry' },
+] as SearchListItem[];
+
+const renderHierarchicalControl = ( {
+	selected = [] as SearchListItem[],
+	onChange = jest.fn(),
+} = {} ) =>
+	render(
+		<SearchListControl
+			isHierarchical
+			isSingle={ false }
+			isCompact
+			list={ hierarchicalList }
+			selected={ selected }
+			onChange={ onChange }
+		/>
+	);
+
+const getTreeItemByName = ( container: HTMLElement, name: string ) =>
+	Array.from( container.querySelectorAll( '[role="treeitem"]' ) ).find(
+		( element ) => element.textContent.includes( name )
+	);
+
+const expandCategory = ( container: HTMLElement, name: string ) => {
+	const treeItem = getTreeItemByName( container, name );
+	if ( treeItem ) {
+		fireEvent.click( treeItem );
+	}
+};
+
+describe( 'SearchListControl hierarchy interactions', () => {
+	test( 'keeps ancestor branches open when expanding nested categories', () => {
+		const { container } = renderHierarchicalControl();
+
+		expandCategory( container, 'Apricots' );
+		expandCategory( container, 'Elderberry' );
+
+		expect(
+			screen.getByRole( 'checkbox', { name: 'Guava' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'selects a leaf category at depth greater than one', () => {
+		const onChange = jest.fn();
+		const { container } = renderHierarchicalControl( { onChange } );
+
+		expandCategory( container, 'Apricots' );
+		expandCategory( container, 'Elderberry' );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Guava' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 4, name: 'Guava' } ),
+			] )
+		);
+	} );
+
+	test( 'selects a parent category and all descendants when its checkbox is checked', () => {
+		const onChange = jest.fn();
+		const { container } = renderHierarchicalControl( { onChange } );
+
+		expandCategory( container, 'Apricots' );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Apricots' } ) );
+
+		const selectedIds = onChange.mock.calls[ 0 ][ 0 ].map(
+			( item: SearchListItem ) => item.id
+		);
+		expect( selectedIds ).toEqual( [ 1, 2, 3, 4 ] );
+	} );
+
+	test( 'deselects a parent category and all descendants when its checkbox is unchecked', () => {
+		const onChange = jest.fn();
+		const selected = hierarchicalList.filter( ( { id } ) =>
+			[ 1, 2, 3, 4 ].includes( Number( id ) )
+		);
+		const { container } = renderHierarchicalControl( {
+			onChange,
+			selected,
+		} );
+
+		expandCategory( container, 'Apricots' );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Apricots' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( [] );
+	} );
+
+	test( 'shows an indeterminate parent when only a descendant is selected', () => {
+		const { container } = renderHierarchicalControl( {
+			selected: hierarchicalList.filter(
+				( { id } ) => Number( id ) === 4
+			),
+		} );
+
+		expandCategory( container, 'Apricots' );
+
+		const apricotsCheckbox = screen.getByRole( 'checkbox', {
+			name: 'Apricots',
+		} );
+		const elderberryCheckbox = screen.getByRole( 'checkbox', {
+			name: 'Elderberry',
+		} );
+
+		expect( apricotsCheckbox ).toBePartiallyChecked();
+		expect( elderberryCheckbox ).toBePartiallyChecked();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/index.js
@@ -44,10 +44,6 @@ describe( 'SearchListControl', () => {
 			/>
 		);
 		expect( component ).toMatchSnapshot();
-
-		// wp-6.8: upstream @wordpress/* deprecation warnings that we cannot
-		// opt out of without changing the visual output.
-		expect( console ).toHaveWarned();
 	} );
 
 	test( 'should render a search box and list of options with a custom className', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
@@ -86,13 +86,13 @@ export interface RenderItemArgs< T extends object = object >
 			>
 		> {
 	// Additional CSS classes.
-	className?: string | undefined;
+	className?: string;
 	// Unique id of the parent control.
 	controlId: string | number;
 	// Label to display in the count bubble. Takes preference over `item.count`.
 	countLabel?: ReactNode;
 	// Whether the item is disabled.
-	disabled?: boolean | undefined;
+	disabled?: boolean;
 	// Current item to display.
 	item: SearchListItem< T >;
 	// Whether this item is selected.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
@@ -86,13 +86,13 @@ export interface RenderItemArgs< T extends object = object >
 			>
 		> {
 	// Additional CSS classes.
-	className?: string;
+	className?: string | undefined;
 	// Unique id of the parent control.
 	controlId: string | number;
 	// Label to display in the count bubble. Takes preference over `item.count`.
 	countLabel?: ReactNode;
 	// Whether the item is disabled.
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 	// Current item to display.
 	item: SearchListItem< T >;
 	// Whether this item is selected.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
@@ -21,8 +21,8 @@ interface ItemProps< T extends object = object > {
 	// Search string, used to highlight the substring in the item name.
 	search: string;
 	useExpandedPanelId: [
-		number,
-		React.Dispatch< React.SetStateAction< number > >
+		number | null,
+		React.Dispatch< React.SetStateAction< number | null > >
 	];
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
@@ -97,6 +97,8 @@ export interface RenderItemArgs< T extends object = object >
 	item: SearchListItem< T >;
 	// Whether this item is selected.
 	isSelected: boolean;
+	// Whether this item is selectable.
+	isSelectable?: boolean;
 	// Whether this should only display a single item (controls radio vs checkbox icon).
 	isSingle: boolean;
 	// The list of currently selected items.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/types.ts
@@ -21,8 +21,8 @@ interface ItemProps< T extends object = object > {
 	// Search string, used to highlight the substring in the item name.
 	search: string;
 	useExpandedPanelId: [
-		number | null,
-		React.Dispatch< React.SetStateAction< number | null > >
+		string | number | null,
+		React.Dispatch< React.SetStateAction< string | number | null > >
 	];
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/utils.tsx
@@ -31,7 +31,7 @@ export const defaultMessages = {
  */
 export const isExpandedOrDescendantIsExpanded = (
 	item: SearchListItem,
-	expandedPanelId: number | null
+	expandedPanelId: string | number | null
 ): boolean => {
 	if ( expandedPanelId === null ) {
 		return false;

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/utils.tsx
@@ -26,6 +26,28 @@ export const defaultMessages = {
 };
 
 /**
+ * Whether a tree item should show as expanded: it matches expandedPanelId or
+ * contains a descendant that does.
+ */
+export const isExpandedOrDescendantIsExpanded = (
+	item: SearchListItem,
+	expandedPanelId: number | null
+): boolean => {
+	if ( expandedPanelId === null ) {
+		return false;
+	}
+	if ( item.id === expandedPanelId ) {
+		return true;
+	}
+	if ( Array.isArray( item.children ) && item.children.length > 0 ) {
+		return item.children.some( ( child ) =>
+			isExpandedOrDescendantIsExpanded( child, expandedPanelId )
+		);
+	}
+	return false;
+};
+
+/**
  * Returns terms in a tree form.
  *
  * @param {Array} filteredList Array of terms, possibly a subset of all terms, in flat format.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/handpicked-products/handpicked-products.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/handpicked-products/handpicked-products.block_theme.spec.ts
@@ -17,7 +17,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: blockData.slug } );
 		const blockLocator = await editor.getBlockByName( blockData.slug );
-		await blockLocator.getByText( 'Album' ).click();
+		await blockLocator
+			.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+			.click();
 		await blockLocator.getByText( 'Done' ).click();
 		await editor.publishAndVisitPost();
 		const blockLocatorFrontend = await frontendUtils.getBlockByName(

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-category/product-category.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-category/product-category.block_theme.spec.ts
@@ -17,7 +17,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: blockData.slug } );
 		const blockLocator = await editor.getBlockByName( blockData.slug );
-		await blockLocator.getByText( 'Accessories' ).click();
+		await blockLocator
+			.getByRole( 'checkbox', { name: 'Accessories' } )
+			.click();
 		await blockLocator.getByText( 'Done' ).click();
 		await expect( blockLocator.getByRole( 'listitem' ) ).toHaveCount( 5 );
 		await editor.publishAndVisitPost();

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/collection-pickers.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/collection-pickers.block_theme.spec.ts
@@ -77,13 +77,17 @@ test.describe( 'Product Collection: Collection Pickers', () => {
 			await expect( doneButton ).toBeDisabled();
 
 			// Select first product
-			await productPicker.getByText( 'Album (woo-album)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+				.click();
 
 			// Done button should now be enabled
 			await expect( doneButton ).toBeEnabled();
 
 			// Select second product
-			await productPicker.getByText( 'Beanie (woo-beanie)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Beanie (woo-beanie)' } )
+				.click();
 
 			// Click Done
 			await doneButton.click();
@@ -108,7 +112,9 @@ test.describe( 'Product Collection: Collection Pickers', () => {
 			const productPicker = editor.canvas.locator(
 				SELECTORS.productPicker
 			);
-			await productPicker.getByText( 'Album (woo-album)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+				.click();
 			await productPicker.locator( SELECTORS.pickerDoneButton ).click();
 
 			// Save and refresh
@@ -146,8 +152,12 @@ test.describe( 'Product Collection: Collection Pickers', () => {
 			const productPicker = editor.canvas.locator(
 				SELECTORS.productPicker
 			);
-			await productPicker.getByText( 'Album (woo-album)' ).click();
-			await productPicker.getByText( 'Beanie (woo-beanie)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+				.click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Beanie (woo-beanie)' } )
+				.click();
 			await productPicker.locator( SELECTORS.pickerDoneButton ).click();
 
 			await pageObject.refreshLocators( 'editor' );
@@ -239,7 +249,9 @@ test.describe( 'Product Collection: Collection Pickers', () => {
 			const productPicker = editor.canvas.locator(
 				SELECTORS.productPicker
 			);
-			await productPicker.getByText( 'Album (woo-album)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+				.click();
 			await productPicker.locator( SELECTORS.pickerDoneButton ).click();
 
 			// Switch to Products by Category using toolbar
@@ -267,7 +279,9 @@ test.describe( 'Product Collection: Collection Pickers', () => {
 			const productPicker = editor.canvas.locator(
 				SELECTORS.productPicker
 			);
-			await productPicker.getByText( 'Album (woo-album)' ).click();
+			await productPicker
+				.getByRole( 'checkbox', { name: 'Album (woo-album)' } )
+				.click();
 			await productPicker.locator( SELECTORS.pickerDoneButton ).click();
 
 			// Switch to Featured Products (no picker needed)

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
@@ -136,7 +136,7 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 
 		await pageObject.addFilter( 'Show product categories' );
 		await pageObject.checkTaxonomyTerm( 'categories', 'Clothing' );
-		await expect( pageObject.products ).toHaveCount( 8 );
+		await expect( pageObject.products ).toHaveCount( 9 );
 
 		// Switch to Accessories
 		await pageObject.uncheckTaxonomyTerm( 'categories', 'Clothing' );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
@@ -691,10 +691,12 @@ class ProductCollectionPage {
 			`.woocommerce-product-${ taxonomy }`
 		);
 		await taxonomyContainer.waitFor();
-		await taxonomyContainer
+		const checkbox = taxonomyContainer
 			.getByRole( 'checkbox', { name: term } )
-			.first()
-			.click();
+			.first();
+		if ( ! ( await checkbox.isChecked() ) ) {
+			await checkbox.click();
+		}
 		await this.refreshLocators( 'editor' );
 	}
 
@@ -711,10 +713,12 @@ class ProductCollectionPage {
 		);
 		await taxonomyContainer.waitFor();
 
-		await taxonomyContainer
+		const checkbox = taxonomyContainer
 			.getByRole( 'checkbox', { name: term } )
-			.first()
-			.click();
+			.first();
+		if ( await checkbox.isChecked() ) {
+			await checkbox.click();
+		}
 		await this.refreshLocators( 'editor' );
 	}
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
@@ -691,7 +691,10 @@ class ProductCollectionPage {
 			`.woocommerce-product-${ taxonomy }`
 		);
 		await taxonomyContainer.waitFor();
-		await taxonomyContainer.getByText( term, { exact: true } ).check();
+		await taxonomyContainer
+			.getByRole( 'checkbox', { name: term } )
+			.first()
+			.click();
 		await this.refreshLocators( 'editor' );
 	}
 
@@ -707,7 +710,11 @@ class ProductCollectionPage {
 			`.woocommerce-product-${ taxonomy }`
 		);
 		await taxonomyContainer.waitFor();
-		await taxonomyContainer.getByText( term, { exact: true } ).uncheck();
+
+		await taxonomyContainer
+			.getByRole( 'checkbox', { name: term } )
+			.first()
+			.click();
 		await this.refreshLocators( 'editor' );
 	}
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-tag/product-tag.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-tag/product-tag.block_theme.spec.ts
@@ -17,7 +17,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: blockData.slug } );
 		const blockLocator = await editor.getBlockByName( blockData.slug );
-		await blockLocator.getByText( 'Recommended' ).click();
+		await blockLocator
+			.getByRole( 'checkbox', { name: 'Recommended' } )
+			.check();
 		await blockLocator.getByText( 'Done' ).click();
 		await expect( blockLocator.getByRole( 'listitem' ) ).toHaveCount( 2 );
 		await editor.publishAndVisitPost();

--- a/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
@@ -30,12 +30,14 @@ test.describe( `${ BLOCK_NAME } Block`, () => {
 		page,
 		editor,
 	} ) => {
-		const categoryCheckbox = editor.canvas.getByRole( 'checkbox', {
+		const blockLocator = await editor.getBlockByName( BLOCK_NAME );
+		const categoryCheckbox = blockLocator.getByRole( 'checkbox', {
 			name: 'Clothing',
+			exact: true,
 		} );
 		await categoryCheckbox.check();
 		await expect( categoryCheckbox ).toBeChecked();
-		const doneButton = editor.canvas.getByRole( 'button', {
+		const doneButton = blockLocator.getByRole( 'button', {
 			name: 'Done',
 		} );
 		await doneButton.click();

--- a/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
@@ -30,7 +30,9 @@ test.describe( `${ BLOCK_NAME } Block`, () => {
 		page,
 		editor,
 	} ) => {
-		const categoryCheckbox = editor.canvas.getByLabel( 'Clothing' ).first();
+		const categoryCheckbox = editor.canvas.getByRole( 'checkbox', {
+			name: 'Clothing',
+		} );
 		await categoryCheckbox.check();
 		await expect( categoryCheckbox ).toBeChecked();
 		const doneButton = editor.canvas.getByRole( 'button', {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While reviewing https://github.com/woocommerce/woocommerce/pull/65799, I noticed the `<SearchListControl>` component was very buggy in cases there were more than 1 level of depth, which might happen when a category is inside another category that is inside a third one.

This PR tries to fix all the oddities I could find. I also tried to make the 'selected' and 'indeterminate' state in the checkboxes easier to understand and making click on the checkboxes more predictable.

### How to test the changes in this Pull Request:

1. Edit your product categories so there are at least 3 nested levels.
2. Add the _Product Collection_ block to a post or page and select _Products by Category_. You can test with other blocks if you prefer, like _Reviews by Category_.
3. Interact with the category selector component and try to break it: select a parent category, a child one, unselect them, expand and collapse parents, etc.

https://github.com/user-attachments/assets/8c1be980-bf75-463f-8ee8-ce885657a3e8

4. Now, add the _Product Attributes_ filter to the _Product Collection_ block. Select and unselect some terms and some attributes. Verify the checked, unchecked and undeterminate states are correct.

https://github.com/user-attachments/assets/c4b525dd-af8b-4ffd-af8f-db7064b2a4ce

5. Test other blocks like _Featured Product_, _Featured Category_, etc. They also use the `<SearchListControl>` component but without multiple selection or without nesting, so simply test that there are no regressions.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
