### PR TITLE
Fix oversized headings in cart/checkout product short descriptions

### DIFF
--- a/plugins/woocommerce/changelog/61018-cart-short-desc-format
+++ b/plugins/woocommerce/changelog/61018-cart-short-desc-format
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Normalize heading formatting in Cart and Checkout product short descriptions so an H1-styled short description no longer renders oversized.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -4,7 +4,20 @@
 	flex-direction: column;
 	gap: $gap-smallest;
 
-	.wc-block-components-product-metadata__description > p,
+	.wc-block-components-product-metadata__description {
+		> p,
+		> h1,
+		> h2,
+		> h3,
+		> h4,
+		> h5,
+		> h6 {
+			margin: 0;
+			color: inherit;
+			@include font-x-small-locked;
+		}
+	}
+
 	.wc-block-components-product-metadata__variation-data {
 		margin: 0;
 		@include font-x-small-locked;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

A product short description formatted as a heading (e.g. H1) rendered oversized in the Cart and Checkout product metadata, dominating the line item. The block only size-locked `> p` elements, so headings fell back to theme heading sizes.

This normalizes all heading levels (`h1`–`h6`) in the short description to the same locked font size as paragraphs, with `margin: 0` and `color: inherit` — matching how the Product Summary block already normalizes headings on product pages.

Closes #61018.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|   <img width="705" height="566" alt="Screenshot 2026-06-25 at 16 45 25" src="https://github.com/user-attachments/assets/169c6482-0488-4e52-8f47-f832e1761ae8" /> |  <img width="724" height="394" alt="Screenshot 2026-06-25 at 16 44 31" src="https://github.com/user-attachments/assets/debad156-d7e3-4b35-8301-67daa662a8fc" />  |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Edit a product and set its **short description** to a Heading 1 with some bold text.
2. Add the product to the cart and open the Cart and Checkout blocks (works on any theme).
3. Confirm the short description now renders at the same small size as the rest of the product metadata, instead of as an oversized heading.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified locally that headings in the short description render at the locked x-small size in Cart and Checkout, matching the Product Summary block behaviour. Stylelint passes on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)