### PR TITLE
fix(abilities): suppress vendor abilities-api REST hook on WP 6.9+

### DIFF
--- a/plugins/woocommerce/changelog/63302-fix-vendor-abilities-rest-stale-opcache
+++ b/plugins/woocommerce/changelog/63302-fix-vendor-abilities-rest-stale-opcache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error on WordPress 6.9+ caused by stale PHP opcache from an updated wordpress/abilities-api vendor package. Suppress the redundant vendor REST endpoint registration when WordPress core already provides the same abilities REST routes.

--- a/plugins/woocommerce/src/Internal/Abilities/AbilitiesLoader.php
+++ b/plugins/woocommerce/src/Internal/Abilities/AbilitiesLoader.php
@@ -71,6 +71,8 @@ class AbilitiesLoader {
 			return;
 		}
 
+		self::maybe_suppress_vendor_rest_routes();
+
 		/*
 		 * Register abilities when Abilities API is ready.
 		 * Support both old (pre-6.9) and new (6.9+) action names.
@@ -163,6 +165,34 @@ class AbilitiesLoader {
 				'definition_class' => $class_name,
 				'reserved_prefix'  => 'woocommerce/',
 			)
+		);
+	}
+
+	/**
+	 * Suppress the vendor abilities-api REST route registration on WordPress 6.9+.
+	 *
+	 * WordPress 6.9+ includes the abilities REST endpoints in core. The vendored
+	 * wordpress/abilities-api package registers the same routes at rest_api_init
+	 * priority 11. When PHP opcache serves stale v0.3.0 bytecode after an update,
+	 * that vendor init class requires a file renamed in v0.4.0 and causes a fatal
+	 * error. Removing only the vendor REST hook prevents the fatal while leaving
+	 * asset loading and ability registration intact.
+	 *
+	 * @internal
+	 *
+	 * @since 11.0.0
+	 */
+	private static function maybe_suppress_vendor_rest_routes(): void {
+		global $wp_version;
+
+		if ( ! isset( $wp_version ) || version_compare( $wp_version, '6.9', '<' ) ) {
+			return;
+		}
+
+		remove_action(
+			'rest_api_init',
+			array( 'WP_REST_Abilities_Init', 'register_routes' ),
+			11
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/AbilitiesLoaderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/AbilitiesLoaderTest.php
@@ -167,6 +167,9 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 
 		wp_set_current_user( 0 );
 
+		add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ), 11 );
+		$this->reset_abilities_loader_initialized();
+
 		parent::tearDown();
 	}
 
@@ -539,6 +542,78 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		foreach ( self::CANONICAL_ABILITY_IDS as $ability_id ) {
 			$this->assertNotNull( wp_get_ability( $ability_id ), "{$ability_id} should remain registered." );
 		}
+	}
+
+	/**
+	 * @testdox Should remove the vendor abilities-api REST init hook on WordPress 6.9+.
+	 */
+	public function test_vendor_rest_init_hook_removed_on_wp_69_plus(): void {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '6.9', '<' ) ) {
+			$this->markTestSkipped( 'Requires WordPress 6.9+.' );
+		}
+
+		$this->reset_abilities_loader_initialized();
+
+		$vendor_callback = array( 'WP_REST_Abilities_Init', 'register_routes' );
+		add_action( 'rest_api_init', $vendor_callback, 11 );
+
+		$this->assertNotFalse( has_action( 'rest_api_init', $vendor_callback ), 'Vendor rest_api_init hook should be present before init.' );
+
+		AbilitiesLoader::init();
+
+		$this->assertFalse( has_action( 'rest_api_init', $vendor_callback ), 'Vendor rest_api_init hook should be removed on WordPress 6.9+.' );
+	}
+
+	/**
+	 * @testdox Should preserve the vendor abilities-api REST init hook on WordPress 6.8 and earlier.
+	 */
+	public function test_vendor_rest_init_hook_preserved_before_wp_69(): void {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '6.9', '>=' ) ) {
+			$this->markTestSkipped( 'Requires WordPress before 6.9.' );
+		}
+
+		$this->reset_abilities_loader_initialized();
+
+		$vendor_callback = array( 'WP_REST_Abilities_Init', 'register_routes' );
+		add_action( 'rest_api_init', $vendor_callback, 11 );
+
+		$this->assertNotFalse( has_action( 'rest_api_init', $vendor_callback ), 'Vendor rest_api_init hook should be present before init.' );
+
+		AbilitiesLoader::init();
+
+		$this->assertNotFalse( has_action( 'rest_api_init', $vendor_callback ), 'Vendor rest_api_init hook should be preserved on WordPress <6.9.' );
+	}
+
+	/**
+	 * @testdox Should remove only the vendor REST hook and leave other vendor hooks untouched on WordPress 6.9+.
+	 */
+	public function test_vendor_rest_init_hook_removed_without_touching_other_hooks_on_wp_69_plus(): void {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '6.9', '<' ) ) {
+			$this->markTestSkipped( 'Requires WordPress 6.9+.' );
+		}
+
+		$this->reset_abilities_loader_initialized();
+
+		$vendor_callback       = array( 'WP_REST_Abilities_Init', 'register_routes' );
+		$assets_callback       = array( 'WP_Abilities_Assets_Init', 'register_assets' );
+		$admin_assets_callback = array( 'WP_Abilities_Assets_Init', 'admin_enqueue_scripts' );
+
+		add_action( 'rest_api_init', $vendor_callback, 11 );
+
+		$assets_before       = has_action( 'init', $assets_callback );
+		$admin_assets_before = has_action( 'admin_enqueue_scripts', $admin_assets_callback );
+
+		AbilitiesLoader::init();
+
+		$this->assertFalse( has_action( 'rest_api_init', $vendor_callback ), 'Vendor rest_api_init hook should be removed.' );
+		$this->assertSame( $assets_before, has_action( 'init', $assets_callback ), 'Vendor init asset hook should be untouched.' );
+		$this->assertSame( $admin_assets_before, has_action( 'admin_enqueue_scripts', $admin_assets_callback ), 'Vendor admin_enqueue_scripts hook should be untouched.' );
 	}
 
 	/**
@@ -2403,6 +2478,15 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		$this->set_order_modified_date_for_query_test( $order, $date_modified );
 
 		return $order;
+	}
+
+	/**
+	 * Reset the AbilitiesLoader initialized flag so init() can be tested.
+	 */
+	private function reset_abilities_loader_initialized(): void {
+		$reflection = new \ReflectionProperty( AbilitiesLoader::class, 'initialized' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( null, false );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#63302.

On WordPress 6.9+ the wordpress/abilities-api vendor package registers redundant REST routes at `rest_api_init` priority 11. When PHP opcache still serves the v0.3.0 bytecode of `WP_REST_Abilities_Init::register_routes()` after a WooCommerce update, that stale code tries to require `class-wp-rest-abilities-run-controller.php`, which was renamed to `class-wp-rest-abilities-v1-run-controller.php` in v0.4.0, and the site fatal-errors.

This change adds a guard in `AbilitiesLoader::init()` that removes the vendor `rest_api_init` callback on WP 6.9+. Core already provides the same abilities REST routes on those versions, so the vendor registration is unnecessary. Asset loading and ability/category registration are left untouched. On WP <6.9 the guard exits early and the vendor hook remains the only provider.

### Screenshots or screen recordings:

No UI changes.

### How to test the changes in this Pull Request:

1. Install the changed WooCommerce build on a WordPress 6.9+ site with opcache enabled.
2. Add a small snippet during `init` that logs `has_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) )`.
3. Load any admin page. The log should show the vendor callback is no longer registered.
4. On WordPress 6.8 or earlier, the same snippet should show the vendor callback is still registered.
5. Run the automated tests: `pnpm test:php:env -- --filter AbilitiesLoaderTest`.

### Testing that has already taken place:

* Ran `AbilitiesLoaderTest` in the wp-env PHPUnit environment: 107 tests, 428 assertions, 1 skipped (the WP <6.9 branch on a WP 6.9+ test runner).
* Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — no errors.
* Ran `composer exec -- phpstan analyse src/Internal/Abilities/AbilitiesLoader.php --memory-limit=2G` — no errors.
* Ran `coderabbit review --agent` and verified the vendor callback is registered before `AbilitiesLoader::init()` runs.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Prevent fatal error on WordPress 6.9+ caused by stale PHP opcache from an updated wordpress/abilities-api vendor package.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)

