### PR TITLE
fix: guard SettingsSectionRegistry autoload in legacy settings pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-66031-settings-section-registry-autoload-guard
+++ b/plugins/woocommerce/changelog/fix-66031-settings-section-registry-autoload-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error on WooCommerce admin screens when the SettingsSectionRegistry class cannot be autoloaded during an in-place upgrade by guarding the legacy settings section lookups with class_exists().

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -266,6 +266,12 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @return array Settings array, each item being an associative array representing a setting.
 		 */
 		protected function get_settings_for_section_core( $section_id ) {
+			// The registry is autoloaded from src/; during the brief in-place-upgrade window a stale
+			// classmap may not resolve it yet, so guard to degrade gracefully instead of fataling.
+			if ( ! class_exists( SettingsSectionRegistry::class ) ) {
+				return array();
+			}
+
 			$registered_section = SettingsSectionRegistry::get_instance()->get_registered( $this->id, (string) $section_id );
 
 			return $registered_section ? $registered_section->get_settings( $this ) : array();
@@ -277,16 +283,21 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @return array
 		 */
 		public function get_sections() {
-			$sections            = $this->get_own_sections();
-			$registered_sections = SettingsSectionRegistry::get_instance()->get_sections_for_page( $this->id );
+			$sections = $this->get_own_sections();
 
-			foreach ( $registered_sections as $section_id => $section_label ) {
-				// Preserve sections declared by the settings page when a registered section uses the same id.
-				if ( array_key_exists( $section_id, $sections ) ) {
-					continue;
+			// The registry is autoloaded from src/; during the brief in-place-upgrade window a stale
+			// classmap may not resolve it yet, so guard to degrade gracefully instead of fataling.
+			if ( class_exists( SettingsSectionRegistry::class ) ) {
+				$registered_sections = SettingsSectionRegistry::get_instance()->get_sections_for_page( $this->id );
+
+				foreach ( $registered_sections as $section_id => $section_label ) {
+					// Preserve sections declared by the settings page when a registered section uses the same id.
+					if ( array_key_exists( $section_id, $sections ) ) {
+						continue;
+					}
+
+					$sections[ $section_id ] = $section_label;
 				}
-
-				$sections[ $section_id ] = $section_label;
 			}
 
 			/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -139,6 +139,13 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			}
 
 			$section = is_string( $current_section ) ? $current_section : '';
+
+			// The request context (and the registry it resolves) are autoloaded from src/; during the
+			// brief in-place-upgrade window they may not resolve yet, so skip gracefully instead of fataling.
+			if ( ! class_exists( SettingsUIRequestContext::class ) ) {
+				return $classes;
+			}
+
 			$context = SettingsUIRequestContext::for_settings_page( $this, $section );
 
 			if ( ! $context->is_rendering_enabled() ) {
@@ -360,9 +367,15 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			global $current_section;
 
 			$section = is_string( $current_section ) ? $current_section : '';
-			$context = SettingsUIRequestContext::for_settings_page( $this, $section );
 
-			if ( $context->is_rendering_enabled() ) {
+			// The request context (and the registry it resolves) are autoloaded from src/; during the
+			// brief in-place-upgrade window they may not resolve yet. Fall through to legacy rendering
+			// instead of fataling.
+			$context = class_exists( SettingsUIRequestContext::class )
+				? SettingsUIRequestContext::for_settings_page( $this, $section )
+				: null;
+
+			if ( $context && $context->is_rendering_enabled() ) {
 				$settings_ui_page = $context->get_settings_ui_page();
 				assert( $settings_ui_page instanceof SettingsUIPageInterface );
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -236,7 +236,9 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 	 * @return bool
 	 */
 	private function is_registered_settings_section( $section ): bool {
-		if ( '' === (string) $section ) {
+		// The registry is autoloaded from src/; during the brief in-place-upgrade window a stale
+		// classmap may not resolve it yet, so guard to degrade gracefully instead of fataling.
+		if ( '' === (string) $section || ! class_exists( SettingsSectionRegistry::class ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since #65813 (shipped in 10.9.0), the always-loaded legacy `WC_Settings_Page::get_sections()` calls `SettingsSectionRegistry::get_instance()` unconditionally, and that method runs on virtually every wc-admin screen. The registry is autoloaded from `src/`, so when the autoloader classmap is momentarily stale after an in-place upgrade, the class can't be resolved and the call throws `Class "…SettingsSectionRegistry" not found`, fataling wp-admin.

This wraps the three legacy call sites in `class_exists()` so they degrade gracefully (to pre-#65813 behaviour) when the class isn't resolvable:

- `class-wc-settings-page.php` → `get_sections()`
- `class-wc-settings-page.php` → `get_settings_for_section_core()`
- `class-wc-settings-payment-gateways.php` → `is_registered_settings_section()`

Closes #66031

(For Bug Fixes) Bug introduced in PR #65813.

### How to test the changes in this Pull Request:

1. Open WooCommerce → Settings (and the **Payments** tab); confirm pages and all sections render as before.
2. Confirm an extension-registered section still appears in its parent page.
3. Make the class temporarily unresolvable (rename `src/Admin/Settings/SettingsSectionRegistry.php` and clear opcache), then reload wp-admin: with this change the admin loads instead of throwing the fatal. Restore the file afterwards.

### Testing that has already taken place:

`php -l`, `phpcs` (changed lines), `lint:changes:branch`, and PHPStan on both files all pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog file added manually: `plugins/woocommerce/changelog/fix-66031-settings-section-registry-autoload-guard`.

Debugged with Claude and Codex. Code solution mostly generated by Claude.