### PR TITLE
fix(checkout): re-validate ValidatedTextInput when required prop changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-63002-gb-state-validation
+++ b/plugins/woocommerce/changelog/fix-63002-gb-state-validation
@@ -1,5 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Fix block checkout showing a required state/county validation error on first visit for countries where the state field is optional, such as the UK.
 
-
+Fix block checkout showing a required state/county validation error on first visit for countries where the state field is optional, such as the UK.

--- a/plugins/woocommerce/changelog/fix-63002-gb-state-validation
+++ b/plugins/woocommerce/changelog/fix-63002-gb-state-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix block checkout showing a required state/county validation error on first visit for countries where the state field is optional, such as the UK.
+
+

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/test/validated-text-input.tsx
@@ -466,5 +466,54 @@ describe( 'ValidatedTextInput', () => {
 			await expect( textInputElement ).toHaveFocus();
 			await expect( setValidationErrors ).not.toHaveBeenCalled();
 		} );
+		it( 'clears stale validation error when required changes from true to false', async () => {
+			const setValidationErrors = jest.fn();
+			const clearValidationError = jest.fn();
+			mockUseDispatch.mockImplementation(
+				( store: string | { name: string } ) => {
+					if ( store === validationStore ) {
+						return {
+							...jest
+								.requireActual( '@wordpress/data' )
+								.useDispatch( store ),
+							setValidationErrors,
+							clearValidationError,
+						};
+					}
+					return jest
+						.requireActual( '@wordpress/data' )
+						.useDispatch( store );
+				}
+			);
+
+			const TestComponent = ( { isRequired = true } ) => {
+				const [ inputValue, setInputValue ] = useState( '' );
+				return (
+					<ValidatedTextInput
+						instanceId={ '7' }
+						id={ 'test-input' }
+						onChange={ ( value ) => setInputValue( value ) }
+						value={ inputValue }
+						label={ 'Test Input' }
+						required={ isRequired }
+						focusOnMount={ false }
+					/>
+				);
+			};
+			const { rerender } = await render( <TestComponent /> );
+			await expect( setValidationErrors ).toHaveBeenCalledWith( {
+				'test-input': {
+					message: 'Please enter a valid test input',
+					hidden: true,
+				},
+			} );
+			setValidationErrors.mockClear();
+
+			await rerender( <TestComponent isRequired={ false } /> );
+			await expect( clearValidationError ).toHaveBeenCalledWith(
+				'test-input'
+			);
+			await expect( setValidationErrors ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/text-input/validated-text-input.tsx
@@ -60,6 +60,7 @@ const ValidatedTextInput = forwardRef<
 			validateOnMount = true,
 			instanceId: preferredInstanceId = '',
 			icon = null,
+			required,
 			...rest
 		},
 		forwardedRef
@@ -67,8 +68,9 @@ const ValidatedTextInput = forwardRef<
 		// True on mount.
 		const [ isPristine, setIsPristine ] = useState( true );
 
-		// Track incoming value.
+		// Track incoming value and required prop.
 		const previousValue = usePrevious( value );
+		const previousRequired = usePrevious( required );
 
 		// Ref for the input element.
 		const inputRef = useRef< HTMLInputElement >( null );
@@ -246,6 +248,22 @@ const ValidatedTextInput = forwardRef<
 			validateInput,
 		] );
 
+		/**
+		 * Re-validate when the required prop changes.
+		 *
+		 * This clears stale validation errors that were set while the input was
+		 * required (e.g. during the initial empty-country cart state) but should no
+		 * longer apply once the field becomes optional (e.g. after the country locale
+		 * is resolved). The effect is gated on isPristine and previousRequired so it
+		 * does not duplicate the mount validation effect.
+		 */
+		useEffect( () => {
+			if ( isPristine || previousRequired === required ) {
+				return;
+			}
+			validateInput( true );
+		}, [ isPristine, previousRequired, required, validateInput ] );
+
 		// Remove validation errors when unmounted.
 		useEffect( () => {
 			return () => {
@@ -285,6 +303,7 @@ const ValidatedTextInput = forwardRef<
 						feedback
 					)
 				}
+				required={ required }
 				ref={ inputRef }
 				onChange={ ( newValue ) => {
 					// Hide errors while typing.


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#63002.

The block checkout state/county field shows "Please enter a valid state/county" on first checkout visit for countries where state is optional (e.g. UK), when multiple shipping zones are configured. This happens because the cart store hydrates asynchronously: the `ValidatedTextInput` mounts with `required=true` (default locale, country empty), validates and sets a hidden error. When the async cart response sets the shipping country to GB, the locale merge flips state to `required=false`, but the validation error persists because the component never re-validates when the `required` prop changes.

The fix adds a `useEffect` to `ValidatedTextInput` that triggers re-validation when the `required` prop changes, clearing stale errors.

### How to test the changes in this Pull Request:

1. Set store location to UK, sell to UK only
2. Configure two UK shipping zones: Scotland (postcode AB\*) with Free Shipping, England with Free Shipping
3. Add a product to cart, go to checkout
4. Expected: no "Please enter a valid state/county" error for the County field
5. Add another product to basket and return to checkout
6. Expected: still no validation error

### Testing that has already taken place:

* Unit test: "clears stale validation error when required changes from true to false" (13/13 passing)
* Regression: form tests (6/6), address utils (8/8), checkout address block tests (16/16)
* Environment: macOS, WP 6.9, WC 11.0-dev

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [X] Patch
- [ ] Minor
- [ ] Major

#### Type

- [X] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix block checkout showing a required state/county validation error on first visit for countries where the state field is optional, such as the UK.

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
