### PR TITLE
Fix deprecated AssetDataRegistry argument notice

### DIFF
--- a/plugins/woocommerce/changelog/fix-46349-asset-data-registry-deprecated-argument
+++ b/plugins/woocommerce/changelog/fix-46349-asset-data-registry-deprecated-argument
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Warn when deprecated AssetDataRegistry key check arguments are explicitly provided.

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -303,12 +303,15 @@ class AssetDataRegistry {
 	 * @param string  $key              The key used to reference the data being registered. This should use camelCase.
 	 * @param mixed   $data             If not a function, registered to the registry as is. If a function, then the
 	 *                                  callback is invoked right before output to the screen.
-	 * @param boolean $check_key_exists Deprecated. If set to true, duplicate data will be ignored if the key exists.
-	 *                                  If false, duplicate data will cause an exception.
+	 * @param boolean $check_key_exists Deprecated. Duplicate data will be ignored if the key exists.
 	 */
-	public function add( $key, $data, $check_key_exists = false ) {
-		if ( $check_key_exists ) {
-			wc_deprecated_argument( 'Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::add()', '8.9', 'The $check_key_exists parameter is no longer used: all duplicate data will be ignored if the key exists by default' );
+	public function add( $key, $data, $check_key_exists = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Deprecated parameter kept for backwards compatibility.
+		if ( 3 <= func_num_args() ) {
+			wc_deprecated_argument(
+				__METHOD__ . '()',
+				'8.9',
+				'The $check_key_exists parameter is no longer used: all duplicate data will be ignored if the key exists by default'
+			);
 		}
 
 		$this->add_data( $key, $data );
@@ -330,12 +333,19 @@ class AssetDataRegistry {
 	 *
 	 * @param string  $key  The key used to reference the data being registered.
 	 * @param string  $path REST API path to preload.
-	 * @param boolean $check_key_exists If set to true, duplicate data will be ignored if the key exists.
-	 *                                  If false, duplicate data will cause an exception.
+	 * @param boolean $check_key_exists Deprecated. Duplicate data will be ignored if the key exists.
 	 *
 	 * @throws InvalidArgumentException  Only throws when site is in debug mode. Always logs the error.
 	 */
-	public function hydrate_data_from_api_request( $key, $path, $check_key_exists = false ) {
+	public function hydrate_data_from_api_request( $key, $path, $check_key_exists = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Deprecated parameter kept for backwards compatibility.
+		if ( 3 <= func_num_args() ) {
+			wc_deprecated_argument(
+				__METHOD__ . '()',
+				'8.9',
+				'The $check_key_exists parameter is no longer used: all duplicate data will be ignored if the key exists by default'
+			);
+		}
+
 		$this->add(
 			$key,
 			function () use ( $path ) {
@@ -344,8 +354,7 @@ class AssetDataRegistry {
 				}
 				$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( $path );
 				return $response['body'] ?? '';
-			},
-			$check_key_exists
+			}
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
@@ -31,6 +31,33 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 		$this->assertEquals( [ 'test' => 'foo' ], $this->registry->get() );
 	}
 
+	/**
+	 * @testdox Deprecated key check argument triggers deprecation notice for explicit values.
+	 *
+	 * @dataProvider deprecated_key_check_argument_values
+	 *
+	 * @param bool $check_key_exists Deprecated key check argument value.
+	 */
+	public function test_add_data_with_deprecated_key_check_argument_triggers_deprecation( $check_key_exists ) {
+		$this->setExpectedDeprecated( 'Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::add()' );
+
+		$this->registry->add( 'test', 'foo', $check_key_exists );
+
+		$this->assertEquals( [ 'test' => 'foo' ], $this->registry->get() );
+	}
+
+	/**
+	 * Provides explicit deprecated key check argument values.
+	 *
+	 * @return array[]
+	 */
+	public function deprecated_key_check_argument_values() {
+		return [
+			'true'  => [ true ],
+			'false' => [ false ],
+		];
+	}
+
 	public function test_data_exists() {
 		$this->registry->add( 'foo', 'lorem-ipsum' );
 		$this->assertEquals( true, $this->registry->exists( 'foo' ) );
@@ -52,6 +79,26 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 	public function test_invalid_key_on_adding_data() {
 		$this->setExpectedException( 'PHPUnit_Framework_Error_Warning' );
 		$this->registry->add( [ 'some_value' ], 'foo' );
+	}
+
+	/**
+	 * @testdox Hydrating data does not trigger deprecation notice when key check argument is omitted.
+	 */
+	public function test_hydrate_data_from_api_request_without_key_check_argument_does_not_trigger_deprecation() {
+		$this->registry->hydrate_data_from_api_request( 'test', '/wc/store/v1/test' );
+
+		$this->assertEmpty( $this->registry->get() );
+	}
+
+	/**
+	 * @testdox Hydrating data with deprecated key check argument triggers deprecation notice.
+	 */
+	public function test_hydrate_data_from_api_request_with_deprecated_key_check_argument_triggers_deprecation() {
+		$this->setExpectedDeprecated( 'Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::hydrate_data_from_api_request()' );
+
+		$this->registry->hydrate_data_from_api_request( 'test', '/wc/store/v1/test', false );
+
+		$this->assertEmpty( $this->registry->get() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
@@ -17,6 +17,8 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 	private $registry;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->registry = new AssetDataRegistryMock(
 			Package::container()->get( API::class )
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `$check_key_exists` argument on `AssetDataRegistry::add()` is deprecated, but the current notice only fires when callers pass a truthy value. This updates the check to warn whenever the deprecated argument is explicitly provided, including `false`, and avoids forwarding the default argument from `hydrate_data_from_api_request()`.

Original issue suggested using `isset` but that would throw an notice for every case, even is someone doesn't provide argument, because then, argument gets default value `false`.

Closes #46349.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the `AssetDataRegistry` PHPUnit tests.
2. Confirm calling `AssetDataRegistry::add( 'key', 'value' )` does not trigger a deprecation notice.
3. Confirm calling `AssetDataRegistry::add( 'key', 'value', false )` and `AssetDataRegistry::add( 'key', 'value', true )` trigger the `$check_key_exists` deprecation notice.
4. Confirm calling `AssetDataRegistry::hydrate_data_from_api_request( 'key', '/wc/store/v1/test' )` does not trigger a deprecation notice.
5. Confirm calling `AssetDataRegistry::hydrate_data_from_api_request( 'key', '/wc/store/v1/test', false )` triggers the `$check_key_exists` deprecation notice.

<!-- End testing instructions -->

### Testing that has already taken place:

- `php -l plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php`
- `php -l plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- Attempted `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter AssetDataRegistry`, but `wp-env` reported that the `tests-cli` service is not running.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>