### PR TITLE
Spike: iAPI powered cart shortcode

### DIFF
--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -6,6 +6,7 @@
 		"product-data-views": false,
 		"experimental-blocks": false,
 		"experimental-iapi-mini-cart": true,
+		"experimental-iapi-cart": false,
 		"coupons": true,
 		"core-profiler": true,
 		"customize-store": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -6,6 +6,7 @@
 		"product-data-views": false,
 		"experimental-blocks": true,
 		"experimental-iapi-mini-cart": true,
+		"experimental-iapi-cart": true,
 		"coupons": true,
 		"core-profiler": true,
 		"customize-store": true,

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -288,6 +288,16 @@ const { actions } = store< Store >(
 		},
 		actions: {
 			*removeCartItem( key: string ): AsyncAction< void > {
+				// Idempotency guard: if the item is already gone from cart state
+				// (e.g. a re-entrant remove of the same key while the first is
+				// still settling, or after it optimistically removed the item),
+				// there's nothing to do. Skipping avoids sending a remove for a
+				// key the server has already dropped, which fails with
+				// "Cart item no longer exists or is invalid".
+				if ( ! state.cart.items.some( ( item ) => item.key === key ) ) {
+					return;
+				}
+
 				// Track what changes we're making for the sync event.
 				const quantityChanges: QuantityChanges = {
 					cartItemsPendingDelete: [ key ],

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -79,6 +79,16 @@ export type Store = {
 	};
 	actions: {
 		removeCartItem: ( key: string ) => Promise< void >;
+		applyCoupon: ( code: string ) => Promise< void >;
+		removeCoupon: ( code: string ) => Promise< void >;
+		selectShippingRate: ( args: {
+			packageId: number;
+			rateId: string;
+		} ) => Promise< void >;
+		updateCustomer: ( data: {
+			billing_address?: Record< string, string >;
+			shipping_address?: Record< string, string >;
+		} ) => Promise< void >;
 		addCartItem: (
 			args: ClientCartItem,
 			options?: CartUpdateOptions
@@ -332,6 +342,63 @@ const { actions } = store< Store >(
 							true
 						);
 					}
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
+				}
+			},
+
+			*applyCoupon( code: string ): AsyncAction< void > {
+				try {
+					yield sendCartRequest( state, {
+						path: '/wc/store/v1/cart/apply-coupon',
+						method: 'POST',
+						body: { code },
+					} );
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
+				}
+			},
+
+			*removeCoupon( code: string ): AsyncAction< void > {
+				try {
+					yield sendCartRequest( state, {
+						path: '/wc/store/v1/cart/remove-coupon',
+						method: 'POST',
+						body: { code },
+					} );
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
+				}
+			},
+
+			*selectShippingRate( {
+				packageId,
+				rateId,
+			}: {
+				packageId: number;
+				rateId: string;
+			} ): AsyncAction< void > {
+				try {
+					yield sendCartRequest( state, {
+						path: '/wc/store/v1/cart/select-shipping-rate',
+						method: 'POST',
+						body: { package_id: packageId, rate_id: rateId },
+					} );
+				} catch ( error ) {
+					actions.showNoticeError( error as Error );
+				}
+			},
+
+			*updateCustomer( data: {
+				billing_address?: Record< string, string >;
+				shipping_address?: Record< string, string >;
+			} ): AsyncAction< void > {
+				try {
+					yield sendCartRequest( state, {
+						path: '/wc/store/v1/cart/update-customer',
+						method: 'POST',
+						body: data,
+					} );
 				} catch ( error ) {
 					actions.showNoticeError( error as Error );
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -81,14 +81,6 @@ export type Store = {
 		removeCartItem: ( key: string ) => Promise< void >;
 		applyCoupon: ( code: string ) => Promise< void >;
 		removeCoupon: ( code: string ) => Promise< void >;
-		selectShippingRate: ( args: {
-			packageId: number;
-			rateId: string;
-		} ) => Promise< void >;
-		updateCustomer: ( data: {
-			billing_address?: Record< string, string >;
-			shipping_address?: Record< string, string >;
-		} ) => Promise< void >;
 		addCartItem: (
 			args: ClientCartItem,
 			options?: CartUpdateOptions
@@ -365,39 +357,6 @@ const { actions } = store< Store >(
 						path: '/wc/store/v1/cart/remove-coupon',
 						method: 'POST',
 						body: { code },
-					} );
-				} catch ( error ) {
-					actions.showNoticeError( error as Error );
-				}
-			},
-
-			*selectShippingRate( {
-				packageId,
-				rateId,
-			}: {
-				packageId: number;
-				rateId: string;
-			} ): AsyncAction< void > {
-				try {
-					yield sendCartRequest( state, {
-						path: '/wc/store/v1/cart/select-shipping-rate',
-						method: 'POST',
-						body: { package_id: packageId, rate_id: rateId },
-					} );
-				} catch ( error ) {
-					actions.showNoticeError( error as Error );
-				}
-			},
-
-			*updateCustomer( data: {
-				billing_address?: Record< string, string >;
-				shipping_address?: Record< string, string >;
-			} ): AsyncAction< void > {
-				try {
-					yield sendCartRequest( state, {
-						path: '/wc/store/v1/cart/update-customer',
-						method: 'POST',
-						body: data,
 					} );
 				} catch ( error ) {
 					actions.showNoticeError( error as Error );

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -4,9 +4,8 @@
  * Enabled by the `experimental-iapi-cart` feature flag. The cart stays
  * PHP-rendered and hook-driven; this module only replaces the legacy jQuery
  * interaction layer (assets/js/frontend/cart.js):
- *   - mutations go through the shared Mini-Cart `woocommerce` store (optimistic
- *     + Store API), or directly to Store API for coupons/shipping which the
- *     shared store does not (yet) expose;
+ *   - mutations go through the shared `woocommerce` store (Store API, optimistic
+ *     where applicable);
  *   - after a mutation settles we re-render the server HTML via the
  *     Interactivity Router so every PHP hook/filter fires again, then move
  *     focus to any notice for screen-reader parity with the legacy script;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -1,19 +1,19 @@
 /**
  * Interactivity API frontend for the classic cart shortcode.
  *
- * WIP SPIKE SCAFFOLD — not yet wired into the script-module build
- * (interactivity-blocks-frontend-assets) or registered via AssetsController,
- * and not type-checked/linted in this environment. See
- * docs/internal-developers/iapi-classic-cart-migration/migration-plan.md.
- *
- * Approach: the cart stays PHP-rendered and hook-driven. This module only
- * replaces the legacy jQuery interaction layer (assets/js/frontend/cart.js):
+ * Enabled by the `experimental-iapi-cart` feature flag. The cart stays
+ * PHP-rendered and hook-driven; this module only replaces the legacy jQuery
+ * interaction layer (assets/js/frontend/cart.js):
  *   - mutations go through the shared Mini-Cart `woocommerce` store (optimistic
  *     + Store API), or directly to Store API for coupons/shipping which the
  *     shared store does not (yet) expose;
  *   - after a mutation settles we re-render the server HTML via the
- *     Interactivity Router so every PHP hook/filter fires again;
+ *     Interactivity Router so every PHP hook/filter fires again, then move
+ *     focus to any notice for screen-reader parity with the legacy script;
+ *   - a global `isProcessing` flag drives a busy state on the wrapper;
  *   - legacy jQuery events are bridged in and re-emitted for back-compat.
+ *
+ * See docs/internal-developers/iapi-classic-cart-migration/migration-plan.md.
  *
  * TODO: the new mutation actions (applyCoupon/removeCoupon/selectShippingRate/
  * updateCustomer/restoreItem) should ultimately live in the shared `woocommerce`
@@ -37,6 +37,12 @@ interface WooCartState {
 	nonce: string;
 }
 
+// Lock for our own private classic-cart store, so its state is mutable from
+// actions. The shared `woocommerce` store is accessed without a lock (its
+// public actions are reachable that way).
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
 const { state: wooState, actions: wooActions } = store< {
 	state: WooCartState;
 	actions: {
@@ -50,6 +56,34 @@ const { state: wooState, actions: wooActions } = store< {
 	};
 } >( 'woocommerce' );
 
+// Declare the classic-cart store's own state up front (locked, since we own
+// this store) so the actions defined below can reference and mutate it. This
+// "declare beforehand" step mirrors the Mini-Cart store; without it (or without
+// the matching lock) the state mutation silently fails.
+const { state } = store< { state: { isProcessing: boolean } } >(
+	'woocommerce/classic-cart',
+	{},
+	{ lock: universalLock }
+);
+
+/**
+ * Move focus to the first notice after a re-render so screen readers announce
+ * it, matching what the legacy cart script did with scroll_to_notices.
+ */
+function focusNotices(): void {
+	const notice = document.querySelector(
+		'.woocommerce-notices-wrapper .woocommerce-message, ' +
+			'.woocommerce-notices-wrapper .woocommerce-error, ' +
+			'.woocommerce-notices-wrapper .woocommerce-info'
+	);
+	if ( notice instanceof HTMLElement ) {
+		if ( ! notice.hasAttribute( 'tabindex' ) ) {
+			notice.setAttribute( 'tabindex', '-1' );
+		}
+		notice.focus();
+	}
+}
+
 /**
  * Re-render the server-rendered cart region, preserving all PHP hooks/filters.
  * The router fetches the current URL; the server re-renders cart.php /
@@ -58,6 +92,7 @@ const { state: wooState, actions: wooActions } = store< {
  */
 function* rerenderCart(): Generator< unknown > {
 	yield router.navigate( window.location.href, { force: true } );
+	focusNotices();
 }
 
 /**
@@ -97,126 +132,181 @@ async function storeApiPost(
 	return response.json();
 }
 
-const { actions } = store( 'woocommerce/classic-cart', {
-	state: {
-		// UI-only state lives in element context (e.g. shipping calculator
-		// open/closed); nothing global needed for the spike yet.
-	},
-	actions: {
-		// Quantity changed on a cart row -> update via shared store, re-render.
-		*changeQuantity(): Generator< unknown > {
-			const { cartItemKey } = getContext< ClassicCartContext >();
-			const { ref } = getElement();
-			const quantity = parseInt( ( ref as HTMLInputElement ).value, 10 );
-			yield wooActions.addCartItem( { key: cartItemKey, quantity } );
-			yield* rerenderCart();
-		},
+const { actions } = store(
+	'woocommerce/classic-cart',
+	{
+		state: { isProcessing: false },
+		actions: {
+			// Quantity changed on a cart row -> update via shared store, re-render.
+			*changeQuantity(): Generator< unknown > {
+				const { cartItemKey } = getContext< ClassicCartContext >();
+				const { ref } = getElement();
+				const quantity = parseInt(
+					( ref as HTMLInputElement ).value,
+					10
+				);
+				state.isProcessing = true;
+				try {
+					yield wooActions.addCartItem( {
+						key: cartItemKey,
+						quantity,
+					} );
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		// Remove item link.
-		*removeItem( event: Event ): Generator< unknown > {
-			event.preventDefault();
-			const { cartItemKey } = getContext< ClassicCartContext >();
-			yield wooActions.removeCartItem( cartItemKey );
-			emitLegacyEvent( 'item_removed_from_classic_cart' );
-			yield* rerenderCart();
-		},
+			// Remove item link.
+			*removeItem( event: Event ): Generator< unknown > {
+				event.preventDefault();
+				const { cartItemKey } = getContext< ClassicCartContext >();
+				state.isProcessing = true;
+				try {
+					yield wooActions.removeCartItem( cartItemKey );
+					emitLegacyEvent( 'item_removed_from_classic_cart' );
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		// Undo / restore a removed item.
-		// OPEN QUESTION: Store API has no "restore" endpoint. For the spike we
-		// fall back to the server restore URL on the link, then re-render.
-		*restoreItem( event: Event ): Generator< unknown > {
-			event.preventDefault();
-			const { ref } = getElement();
-			const href = ( ref as HTMLAnchorElement ).href;
-			yield fetch( href, { credentials: 'same-origin' } );
-			yield wooActions.refreshCartItems();
-			yield* rerenderCart();
-		},
+			// Undo / restore a removed item.
+			// OPEN QUESTION: Store API has no "restore" endpoint. For the spike we
+			// fall back to the server restore URL on the link, then re-render.
+			*restoreItem( event: Event ): Generator< unknown > {
+				event.preventDefault();
+				const { ref } = getElement();
+				const href = ( ref as HTMLAnchorElement ).href;
+				state.isProcessing = true;
+				try {
+					yield fetch( href, { credentials: 'same-origin' } );
+					yield wooActions.refreshCartItems();
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		*applyCoupon( event: Event ): Generator< unknown > {
-			event.preventDefault();
-			const input = document.getElementById(
-				'coupon_code'
-			) as HTMLInputElement | null;
-			const code = input?.value?.trim();
-			if ( ! code ) {
-				return;
-			}
-			yield storeApiPost( 'cart/apply-coupon', { code } );
-			yield wooActions.refreshCartItems();
-			emitLegacyEvent( 'applied_coupon', code );
-			yield* rerenderCart();
-		},
+			*applyCoupon( event: Event ): Generator< unknown > {
+				event.preventDefault();
+				const input = document.getElementById(
+					'coupon_code'
+				) as HTMLInputElement | null;
+				const code = input?.value?.trim();
+				if ( ! code ) {
+					return;
+				}
+				state.isProcessing = true;
+				try {
+					yield storeApiPost( 'cart/apply-coupon', { code } );
+					yield wooActions.refreshCartItems();
+					emitLegacyEvent( 'applied_coupon', code );
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		*removeCoupon( event: Event ): Generator< unknown > {
-			event.preventDefault();
-			const { coupon } = getContext< ClassicCartContext >();
-			yield storeApiPost( 'cart/remove-coupon', { code: coupon } );
-			yield wooActions.refreshCartItems();
-			emitLegacyEvent( 'removed_coupon', coupon );
-			yield* rerenderCart();
-		},
+			*removeCoupon( event: Event ): Generator< unknown > {
+				event.preventDefault();
+				const { coupon } = getContext< ClassicCartContext >();
+				state.isProcessing = true;
+				try {
+					yield storeApiPost( 'cart/remove-coupon', {
+						code: coupon,
+					} );
+					yield wooActions.refreshCartItems();
+					emitLegacyEvent( 'removed_coupon', coupon );
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		*selectShippingRate(): Generator< unknown > {
-			const { ref } = getElement();
-			const rateId = ( ref as HTMLInputElement ).value;
-			// `index` maps to the shipping package on the classic markup.
-			const packageId = parseInt(
-				( ref as HTMLElement ).dataset.index ?? '0',
-				10
-			);
-			yield storeApiPost( 'cart/select-shipping-rate', {
-				package_id: packageId,
-				rate_id: rateId,
-			} );
-			yield wooActions.refreshCartItems();
-			emitLegacyEvent( 'updated_shipping_method' );
-			yield* rerenderCart();
-		},
+			*selectShippingRate(): Generator< unknown > {
+				const { ref } = getElement();
+				const rateId = ( ref as HTMLInputElement ).value;
+				// `index` maps to the shipping package on the classic markup.
+				const packageId = parseInt(
+					( ref as HTMLElement ).dataset.index ?? '0',
+					10
+				);
+				state.isProcessing = true;
+				try {
+					yield storeApiPost( 'cart/select-shipping-rate', {
+						package_id: packageId,
+						rate_id: rateId,
+					} );
+					yield wooActions.refreshCartItems();
+					emitLegacyEvent( 'updated_shipping_method' );
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		// Shipping calculator submit -> set customer address, re-render.
-		*calculateShipping( event: Event ): Generator< unknown > {
-			event.preventDefault();
-			const form = getElement().ref as HTMLFormElement;
-			const data = new FormData( form );
-			yield storeApiPost( 'cart/update-customer', {
-				shipping_address: {
-					country: data.get( 'calc_shipping_country' ) ?? '',
-					state: data.get( 'calc_shipping_state' ) ?? '',
-					city: data.get( 'calc_shipping_city' ) ?? '',
-					postcode: data.get( 'calc_shipping_postcode' ) ?? '',
-				},
-			} );
-			yield wooActions.refreshCartItems();
-			yield* rerenderCart();
-		},
+			// Shipping calculator submit -> set customer address, re-render.
+			*calculateShipping( event: Event ): Generator< unknown > {
+				event.preventDefault();
+				const form = getElement().ref as HTMLFormElement;
+				const data = new FormData( form );
+				state.isProcessing = true;
+				try {
+					yield storeApiPost( 'cart/update-customer', {
+						shipping_address: {
+							country: data.get( 'calc_shipping_country' ) ?? '',
+							state: data.get( 'calc_shipping_state' ) ?? '',
+							city: data.get( 'calc_shipping_city' ) ?? '',
+							postcode:
+								data.get( 'calc_shipping_postcode' ) ?? '',
+						},
+					} );
+					yield wooActions.refreshCartItems();
+					yield* rerenderCart();
+				} finally {
+					state.isProcessing = false;
+				}
+			},
 
-		// Pure-UI: toggle the shipping calculator panel.
-		toggleShippingCalculator(): void {
-			const context = getContext< { shippingCalculatorOpen: boolean } >();
-			context.shippingCalculatorOpen = ! context.shippingCalculatorOpen;
+			// Pure-UI: toggle the shipping calculator panel.
+			toggleShippingCalculator(): void {
+				const context = getContext< {
+					shippingCalculatorOpen: boolean;
+				} >();
+				context.shippingCalculatorOpen =
+					! context.shippingCalculatorOpen;
+			},
+
+			// With JS active, quantities apply on change so the full-form POST is
+			// redundant. Prevent it; without JS the native submit still posts to the
+			// legacy WC_Form_Handler::update_cart_action handler.
+			preventFormSubmit( event: Event ): void {
+				event.preventDefault();
+			},
 		},
-	},
-	callbacks: {
-		// Bridge inbound legacy events so add-to-cart elsewhere refreshes us.
-		setupLegacyBridge(): void {
-			const w = window as unknown as {
-				jQuery?: ( t: unknown ) => {
-					on: ( e: string, cb: () => void ) => void;
+		callbacks: {
+			// Bridge inbound legacy events so add-to-cart elsewhere refreshes us.
+			setupLegacyBridge(): void {
+				const w = window as unknown as {
+					jQuery?: ( t: unknown ) => {
+						on: ( e: string, cb: () => void ) => void;
+					};
 				};
-			};
-			if ( ! w.jQuery ) {
-				return;
-			}
-			w.jQuery( document ).on( 'added_to_cart wc_update_cart', () => {
-				void wooActions
-					.refreshCartItems()
-					.then( () =>
-						router.navigate( window.location.href, { force: true } )
+				if ( ! w.jQuery ) {
+					return;
+				}
+				w.jQuery( document ).on( 'added_to_cart wc_update_cart', () => {
+					void wooActions.refreshCartItems().then( () =>
+						router.navigate( window.location.href, {
+							force: true,
+						} )
 					);
-			} );
+				} );
+			},
 		},
 	},
-} );
+	{ lock: universalLock }
+);
 
 export type ClassicCartStore = typeof actions;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -298,23 +298,68 @@ const { actions } = store(
 			},
 		},
 		callbacks: {
-			// Bridge inbound legacy events so add-to-cart elsewhere refreshes us.
-			setupLegacyBridge(): void {
-				const w = window as unknown as {
-					jQuery?: ( t: unknown ) => {
-						on: ( e: string, cb: () => void ) => void;
-					};
-				};
-				if ( ! w.jQuery ) {
-					return;
-				}
-				w.jQuery( document ).on( 'added_to_cart wc_update_cart', () => {
+			// Refresh + re-render when the cart is mutated by ANY source on the
+			// page. Other iAPI blocks (wishlist "move to cart", Mini-Cart,
+			// add-to-cart) fire the native `wc-blocks_added_to_cart` /
+			// `wc-blocks_removed_from_cart` events on document; classic
+			// add-to-cart + extensions fire the jQuery `added_to_cart` /
+			// `wc_update_cart` events. We listen to both.
+			//
+			// Returns a cleanup so listeners aren't duplicated across re-renders.
+			setupCartSyncBridge(): () => void {
+				const syncFromCart = () => {
+					// Our own actions already re-render (and also fire these
+					// events via the shared store) — skip while one is in flight
+					// to avoid a double navigate.
+					if ( state.isProcessing ) {
+						return;
+					}
 					void wooActions.refreshCartItems().then( () =>
 						router.navigate( window.location.href, {
 							force: true,
 						} )
 					);
-				} );
+				};
+
+				document.addEventListener(
+					'wc-blocks_added_to_cart',
+					syncFromCart
+				);
+				document.addEventListener(
+					'wc-blocks_removed_from_cart',
+					syncFromCart
+				);
+
+				const w = window as unknown as {
+					jQuery?: ( t: unknown ) => {
+						on: ( e: string, cb: () => void ) => void;
+						off: ( e: string, cb: () => void ) => void;
+					};
+				};
+				const jq = w.jQuery;
+				if ( jq ) {
+					jq( document ).on(
+						'added_to_cart wc_update_cart',
+						syncFromCart
+					);
+				}
+
+				return () => {
+					document.removeEventListener(
+						'wc-blocks_added_to_cart',
+						syncFromCart
+					);
+					document.removeEventListener(
+						'wc-blocks_removed_from_cart',
+						syncFromCart
+					);
+					if ( jq ) {
+						jq( document ).off(
+							'added_to_cart wc_update_cart',
+							syncFromCart
+						);
+					}
+				};
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -179,8 +179,8 @@ const { actions } = store(
 			},
 
 			// Undo / restore a removed item.
-			// OPEN QUESTION: Store API has no "restore" endpoint. For the spike we
-			// fall back to the server restore URL on the link, then re-render.
+			// OPEN QUESTION: Store API has no "restore" endpoint, so we fall back
+			// to the legacy server restore URL on the link, then re-render.
 			*restoreItem( event: Event ): Generator< unknown > {
 				event.preventDefault();
 				const { ref } = getElement();

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -15,9 +15,11 @@
  *
  * See docs/internal-developers/iapi-classic-cart-migration/migration-plan.md.
  *
- * TODO: the new mutation actions (applyCoupon/removeCoupon/selectShippingRate/
- * updateCustomer/restoreItem) should ultimately live in the shared `woocommerce`
- * store (owned by Billow), not here.
+ * All cart mutations (add/remove item, coupons, shipping) live in the shared
+ * `woocommerce` store. This module's actions are thin classic-cart glue: read
+ * the server-rendered markup, call the shared mutation, then re-render. The
+ * exception is `restoreItem`, which has no Store API equivalent and falls back
+ * to the legacy server URL.
  */
 
 /**
@@ -32,19 +34,15 @@ type ClassicCartContext = {
 	coupon: string;
 };
 
-interface WooCartState {
-	restUrl: string;
-	nonce: string;
-}
-
 // Lock for our own private classic-cart store, so its state is mutable from
 // actions. The shared `woocommerce` store is accessed without a lock (its
 // public actions are reachable that way).
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
-const { state: wooState, actions: wooActions } = store< {
-	state: WooCartState;
+// All cart mutations live in the shared `woocommerce` store; this module only
+// reads the classic markup and calls those actions, then re-renders.
+const { actions: wooActions } = store< {
 	actions: {
 		addCartItem: ( args: {
 			key?: string;
@@ -53,6 +51,15 @@ const { state: wooState, actions: wooActions } = store< {
 		} ) => Promise< unknown >;
 		removeCartItem: ( key: string ) => Promise< unknown >;
 		refreshCartItems: () => Promise< unknown >;
+		applyCoupon: ( code: string ) => Promise< unknown >;
+		removeCoupon: ( code: string ) => Promise< unknown >;
+		selectShippingRate: ( args: {
+			packageId: number;
+			rateId: string;
+		} ) => Promise< unknown >;
+		updateCustomer: ( data: {
+			shipping_address?: Record< string, string >;
+		} ) => Promise< unknown >;
 	};
 } >( 'woocommerce' );
 
@@ -108,28 +115,6 @@ function emitLegacyEvent( name: string, ...args: unknown[] ): void {
 	if ( w.jQuery ) {
 		w.jQuery( document.body ).trigger( name, args );
 	}
-}
-
-/**
- * Minimal Store API POST helper. Mirrors what the shared store does internally;
- * kept local for the spike for the endpoints the shared store does not expose.
- */
-async function storeApiPost(
-	path: string,
-	data: Record< string, unknown >
-): Promise< unknown > {
-	const response = await fetch(
-		`${ wooState.restUrl }wc/store/v1/${ path }`,
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Nonce: wooState.nonce,
-			},
-			body: JSON.stringify( data ),
-		}
-	);
-	return response.json();
 }
 
 const { actions } = store(
@@ -199,8 +184,7 @@ const { actions } = store(
 				}
 				state.isProcessing = true;
 				try {
-					yield storeApiPost( 'cart/apply-coupon', { code } );
-					yield wooActions.refreshCartItems();
+					yield wooActions.applyCoupon( code );
 					emitLegacyEvent( 'applied_coupon', code );
 					yield* rerenderCart();
 				} finally {
@@ -213,10 +197,7 @@ const { actions } = store(
 				const { coupon } = getContext< ClassicCartContext >();
 				state.isProcessing = true;
 				try {
-					yield storeApiPost( 'cart/remove-coupon', {
-						code: coupon,
-					} );
-					yield wooActions.refreshCartItems();
+					yield wooActions.removeCoupon( coupon );
 					emitLegacyEvent( 'removed_coupon', coupon );
 					yield* rerenderCart();
 				} finally {
@@ -234,11 +215,10 @@ const { actions } = store(
 				);
 				state.isProcessing = true;
 				try {
-					yield storeApiPost( 'cart/select-shipping-rate', {
-						package_id: packageId,
-						rate_id: rateId,
+					yield wooActions.selectShippingRate( {
+						packageId,
+						rateId,
 					} );
-					yield wooActions.refreshCartItems();
 					emitLegacyEvent( 'updated_shipping_method' );
 					yield* rerenderCart();
 				} finally {
@@ -253,16 +233,22 @@ const { actions } = store(
 				const data = new FormData( form );
 				state.isProcessing = true;
 				try {
-					yield storeApiPost( 'cart/update-customer', {
+					yield wooActions.updateCustomer( {
 						shipping_address: {
-							country: data.get( 'calc_shipping_country' ) ?? '',
-							state: data.get( 'calc_shipping_state' ) ?? '',
-							city: data.get( 'calc_shipping_city' ) ?? '',
-							postcode:
-								data.get( 'calc_shipping_postcode' ) ?? '',
+							country: String(
+								data.get( 'calc_shipping_country' ) ?? ''
+							),
+							state: String(
+								data.get( 'calc_shipping_state' ) ?? ''
+							),
+							city: String(
+								data.get( 'calc_shipping_city' ) ?? ''
+							),
+							postcode: String(
+								data.get( 'calc_shipping_postcode' ) ?? ''
+							),
 						},
 					} );
-					yield wooActions.refreshCartItems();
 					yield* rerenderCart();
 				} finally {
 					state.isProcessing = false;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -146,6 +146,18 @@ const { actions } = store(
 		actions: {
 			// Quantity changed on a cart row -> update via shared store, re-render.
 			*changeQuantity(): Generator< unknown > {
+				// Reentrancy guard: drop repeat activations while a mutation is in
+				// flight. The re-render is slow (Store API mutation + the navigate
+				// round-trip), so the row stays on screen and clickable; a second
+				// activation would POST against an already-mutated/removed key and
+				// surface "Cart item no longer exists". The busy class
+				// (`is-cart-updating` -> `pointer-events:none`) is applied
+				// reactively a tick later, so a fast second click can slip past it;
+				// this synchronous guard is the reliable block. Mirrors the legacy
+				// cart.js behaviour of blocking the cart during a request.
+				if ( state.isProcessing ) {
+					return;
+				}
 				const { cartItemKey } = getContext< ClassicCartContext >();
 				const { ref } = getElement();
 				const quantity = parseInt(
@@ -167,6 +179,9 @@ const { actions } = store(
 			// Remove item link.
 			*removeItem( event: Event ): Generator< unknown > {
 				event.preventDefault();
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const { cartItemKey } = getContext< ClassicCartContext >();
 				state.isProcessing = true;
 				try {
@@ -183,6 +198,9 @@ const { actions } = store(
 			// to the legacy server restore URL on the link, then re-render.
 			*restoreItem( event: Event ): Generator< unknown > {
 				event.preventDefault();
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const { ref } = getElement();
 				const href = ( ref as HTMLAnchorElement ).href;
 				state.isProcessing = true;
@@ -197,6 +215,9 @@ const { actions } = store(
 
 			*applyCoupon( event: Event ): Generator< unknown > {
 				event.preventDefault();
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const input = document.getElementById(
 					'coupon_code'
 				) as HTMLInputElement | null;
@@ -216,6 +237,9 @@ const { actions } = store(
 
 			*removeCoupon( event: Event ): Generator< unknown > {
 				event.preventDefault();
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const { coupon } = getContext< ClassicCartContext >();
 				state.isProcessing = true;
 				try {
@@ -228,6 +252,9 @@ const { actions } = store(
 			},
 
 			*selectShippingRate(): Generator< unknown > {
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const { ref } = getElement();
 				const rateId = ( ref as HTMLInputElement ).value;
 				// `index` maps to the shipping package on the classic markup.
@@ -253,6 +280,9 @@ const { actions } = store(
 			// Shipping calculator submit -> set customer address, re-render.
 			*calculateShipping( event: Event ): Generator< unknown > {
 				event.preventDefault();
+				if ( state.isProcessing ) {
+					return; // Reentrancy guard; see changeQuantity.
+				}
 				const form = getElement().ref as HTMLFormElement;
 				const data = new FormData( form );
 				state.isProcessing = true;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -14,11 +14,12 @@
  *
  * See docs/internal-developers/iapi-classic-cart-migration/migration-plan.md.
  *
- * All cart mutations (add/remove item, coupons, shipping) live in the shared
- * `woocommerce` store. This module's actions are thin classic-cart glue: read
- * the server-rendered markup, call the shared mutation, then re-render. The
- * exception is `restoreItem`, which has no Store API equivalent and falls back
- * to the legacy server URL.
+ * Cart-domain mutations shared with the Cart/Mini-Cart blocks (add/remove item,
+ * coupons) live in the shared `woocommerce` store; this module's handlers read
+ * the server-rendered markup, call the shared mutation, then re-render.
+ * Classic-cart-only mutations stay local here: shipping rate + customer address
+ * (not used by those blocks) hit Store API directly, and `restoreItem` (no Store
+ * API equivalent) falls back to the legacy server URL.
  */
 
 /**
@@ -33,15 +34,21 @@ type ClassicCartContext = {
 	coupon: string;
 };
 
-// Lock for our own private classic-cart store, so its state is mutable from
-// actions. The shared `woocommerce` store is accessed without a lock (its
-// public actions are reachable that way).
+// Lock for the private iAPI stores. Required to read the shared `woocommerce`
+// store's locked state and to make our own classic-cart store's state mutable.
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
 
-// All cart mutations live in the shared `woocommerce` store; this module only
-// reads the classic markup and calls those actions, then re-renders.
-const { actions: wooActions } = store< {
+// Cart-domain mutations shared with the Cart/Mini-Cart blocks live in the shared
+// `woocommerce` store. Shipping rate + customer-address mutations are NOT used by
+// those blocks, so they stay local to this module (see selectShippingRate /
+// calculateShipping below) and hit Store API directly via `restUrl`/`nonce`.
+//
+// Access the shared store WITH the lock (like the Mini-Cart): reading its locked
+// `state` (restUrl/nonce) requires the lock — without it the cart mutations
+// silently break.
+const { state: wooState, actions: wooActions } = store< {
+	state: { restUrl: string; nonce: string };
 	actions: {
 		addCartItem: ( args: {
 			key?: string;
@@ -52,15 +59,8 @@ const { actions: wooActions } = store< {
 		refreshCartItems: () => Promise< unknown >;
 		applyCoupon: ( code: string ) => Promise< unknown >;
 		removeCoupon: ( code: string ) => Promise< unknown >;
-		selectShippingRate: ( args: {
-			packageId: number;
-			rateId: string;
-		} ) => Promise< unknown >;
-		updateCustomer: ( data: {
-			shipping_address?: Record< string, string >;
-		} ) => Promise< unknown >;
 	};
-} >( 'woocommerce' );
+} >( 'woocommerce', {}, { lock: universalLock } );
 
 // Declare the classic-cart store's own state up front (locked, since we own
 // this store) so the actions defined below can reference and mutate it. This
@@ -114,6 +114,29 @@ function emitLegacyEvent( name: string, ...args: unknown[] ): void {
 	if ( w.jQuery ) {
 		w.jQuery( document.body ).trigger( name, args );
 	}
+}
+
+/**
+ * Store API POST for the shipping endpoints that the shared store doesn't expose
+ * (select-shipping-rate, update-customer). Kept local to the classic cart since
+ * the Cart/Mini-Cart blocks don't use these actions.
+ */
+async function storeApiPost(
+	path: string,
+	data: Record< string, unknown >
+): Promise< unknown > {
+	const response = await fetch(
+		`${ wooState.restUrl }wc/store/v1/${ path }`,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Nonce: wooState.nonce,
+			},
+			body: JSON.stringify( data ),
+		}
+	);
+	return response.json();
 }
 
 const { actions } = store(
@@ -214,10 +237,12 @@ const { actions } = store(
 				);
 				state.isProcessing = true;
 				try {
-					yield wooActions.selectShippingRate( {
-						packageId,
-						rateId,
+					yield storeApiPost( 'cart/select-shipping-rate', {
+						package_id: packageId,
+						rate_id: rateId,
 					} );
+					// Sync the shared store so the Mini-Cart reflects new totals.
+					yield wooActions.refreshCartItems();
 					emitLegacyEvent( 'updated_shipping_method' );
 					yield* rerenderCart();
 				} finally {
@@ -232,7 +257,7 @@ const { actions } = store(
 				const data = new FormData( form );
 				state.isProcessing = true;
 				try {
-					yield wooActions.updateCustomer( {
+					yield storeApiPost( 'cart/update-customer', {
 						shipping_address: {
 							country: String(
 								data.get( 'calc_shipping_country' ) ?? ''
@@ -248,6 +273,8 @@ const { actions } = store(
 							),
 						},
 					} );
+					// Sync the shared store so the Mini-Cart reflects new totals.
+					yield wooActions.refreshCartItems();
 					yield* rerenderCart();
 				} finally {
 					state.isProcessing = false;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -1,0 +1,219 @@
+/**
+ * Interactivity API frontend for the classic cart shortcode.
+ *
+ * WIP SPIKE SCAFFOLD — not yet wired into the script-module build
+ * (interactivity-blocks-frontend-assets) or registered via AssetsController,
+ * and not type-checked/linted in this environment. See
+ * docs/internal-developers/iapi-classic-cart-migration/migration-plan.md.
+ *
+ * Approach: the cart stays PHP-rendered and hook-driven. This module only
+ * replaces the legacy jQuery interaction layer (assets/js/frontend/cart.js):
+ *   - mutations go through the shared Mini-Cart `woocommerce` store (optimistic
+ *     + Store API), or directly to Store API for coupons/shipping which the
+ *     shared store does not (yet) expose;
+ *   - after a mutation settles we re-render the server HTML via the
+ *     Interactivity Router so every PHP hook/filter fires again;
+ *   - legacy jQuery events are bridged in and re-emitted for back-compat.
+ *
+ * TODO: the new mutation actions (applyCoupon/removeCoupon/selectShippingRate/
+ * updateCustomer/restoreItem) should ultimately live in the shared `woocommerce`
+ * store (owned by Billow), not here.
+ */
+
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import { actions as router } from '@wordpress/interactivity-router';
+
+// Register/extend the shared Mini-Cart store (namespace `woocommerce`).
+import '@woocommerce/stores/woocommerce/cart';
+
+type ClassicCartContext = {
+	cartItemKey: string;
+	coupon: string;
+};
+
+interface WooCartState {
+	restUrl: string;
+	nonce: string;
+}
+
+const { state: wooState, actions: wooActions } = store< {
+	state: WooCartState;
+	actions: {
+		addCartItem: ( args: {
+			key?: string;
+			id?: number;
+			quantity: number;
+		} ) => Promise< unknown >;
+		removeCartItem: ( key: string ) => Promise< unknown >;
+		refreshCartItems: () => Promise< unknown >;
+	};
+} >( 'woocommerce' );
+
+/**
+ * Re-render the server-rendered cart region, preserving all PHP hooks/filters.
+ * The router fetches the current URL; the server re-renders cart.php /
+ * cart-totals.php (and the directive injection runs again), then the
+ * `data-wp-router-region` is morphed in place.
+ */
+function* rerenderCart(): Generator< unknown > {
+	yield router.navigate( window.location.href, { force: true } );
+}
+
+/**
+ * Emit a legacy jQuery event so cart-fragments.js and existing extensions keep
+ * working. No-op when jQuery is absent.
+ */
+function emitLegacyEvent( name: string, ...args: unknown[] ): void {
+	const w = window as unknown as { jQuery?: ( target: unknown ) => {
+		trigger: ( n: string, a?: unknown[] ) => void;
+	}; };
+	if ( w.jQuery ) {
+		w.jQuery( document.body ).trigger( name, args );
+	}
+}
+
+/**
+ * Minimal Store API POST helper. Mirrors what the shared store does internally;
+ * kept local for the spike for the endpoints the shared store does not expose.
+ */
+async function storeApiPost(
+	path: string,
+	data: Record< string, unknown >
+): Promise< unknown > {
+	const response = await fetch( `${ wooState.restUrl }wc/store/v1/${ path }`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Nonce: wooState.nonce,
+		},
+		body: JSON.stringify( data ),
+	} );
+	return response.json();
+}
+
+const { actions } = store( 'woocommerce/classic-cart', {
+	state: {
+		// UI-only state lives in element context (e.g. shipping calculator
+		// open/closed); nothing global needed for the spike yet.
+	},
+	actions: {
+		// Quantity changed on a cart row -> update via shared store, re-render.
+		*changeQuantity(): Generator< unknown > {
+			const { cartItemKey } = getContext< ClassicCartContext >();
+			const { ref } = getElement();
+			const quantity = parseInt(
+				( ref as HTMLInputElement ).value,
+				10
+			);
+			yield wooActions.addCartItem( { key: cartItemKey, quantity } );
+			yield* rerenderCart();
+		},
+
+		// Remove item link.
+		*removeItem( event: Event ): Generator< unknown > {
+			event.preventDefault();
+			const { cartItemKey } = getContext< ClassicCartContext >();
+			yield wooActions.removeCartItem( cartItemKey );
+			emitLegacyEvent( 'item_removed_from_classic_cart' );
+			yield* rerenderCart();
+		},
+
+		// Undo / restore a removed item.
+		// OPEN QUESTION: Store API has no "restore" endpoint. For the spike we
+		// fall back to the server restore URL on the link, then re-render.
+		*restoreItem( event: Event ): Generator< unknown > {
+			event.preventDefault();
+			const { ref } = getElement();
+			const href = ( ref as HTMLAnchorElement ).href;
+			yield fetch( href, { credentials: 'same-origin' } );
+			yield wooActions.refreshCartItems();
+			yield* rerenderCart();
+		},
+
+		*applyCoupon( event: Event ): Generator< unknown > {
+			event.preventDefault();
+			const input = document.getElementById(
+				'coupon_code'
+			) as HTMLInputElement | null;
+			const code = input?.value?.trim();
+			if ( ! code ) {
+				return;
+			}
+			yield storeApiPost( 'cart/apply-coupon', { code } );
+			yield wooActions.refreshCartItems();
+			emitLegacyEvent( 'applied_coupon', code );
+			yield* rerenderCart();
+		},
+
+		*removeCoupon( event: Event ): Generator< unknown > {
+			event.preventDefault();
+			const { coupon } = getContext< ClassicCartContext >();
+			yield storeApiPost( 'cart/remove-coupon', { code: coupon } );
+			yield wooActions.refreshCartItems();
+			emitLegacyEvent( 'removed_coupon', coupon );
+			yield* rerenderCart();
+		},
+
+		*selectShippingRate(): Generator< unknown > {
+			const { ref } = getElement();
+			const rateId = ( ref as HTMLInputElement ).value;
+			// `index` maps to the shipping package on the classic markup.
+			const packageId = parseInt(
+				( ref as HTMLElement ).dataset.index ?? '0',
+				10
+			);
+			yield storeApiPost( 'cart/select-shipping-rate', {
+				package_id: packageId,
+				rate_id: rateId,
+			} );
+			yield wooActions.refreshCartItems();
+			emitLegacyEvent( 'updated_shipping_method' );
+			yield* rerenderCart();
+		},
+
+		// Shipping calculator submit -> set customer address, re-render.
+		*calculateShipping( event: Event ): Generator< unknown > {
+			event.preventDefault();
+			const form = ( getElement().ref as HTMLFormElement );
+			const data = new FormData( form );
+			yield storeApiPost( 'cart/update-customer', {
+				shipping_address: {
+					country: data.get( 'calc_shipping_country' ) ?? '',
+					state: data.get( 'calc_shipping_state' ) ?? '',
+					city: data.get( 'calc_shipping_city' ) ?? '',
+					postcode: data.get( 'calc_shipping_postcode' ) ?? '',
+				},
+			} );
+			yield wooActions.refreshCartItems();
+			yield* rerenderCart();
+		},
+
+		// Pure-UI: toggle the shipping calculator panel.
+		toggleShippingCalculator(): void {
+			const context = getContext< { shippingCalculatorOpen: boolean } >();
+			context.shippingCalculatorOpen = ! context.shippingCalculatorOpen;
+		},
+	},
+	callbacks: {
+		// Bridge inbound legacy events so add-to-cart elsewhere refreshes us.
+		setupLegacyBridge(): void {
+			const w = window as unknown as {
+				jQuery?: ( t: unknown ) => {
+					on: ( e: string, cb: () => void ) => void;
+				};
+			};
+			if ( ! w.jQuery ) {
+				return;
+			}
+			w.jQuery( document ).on( 'added_to_cart wc_update_cart', () => {
+				void wooActions
+					.refreshCartItems()
+					.then( () =>
+						router.navigate( window.location.href, { force: true } )
+					);
+			} );
+		},
+	},
+} );
+
+export type ClassicCartStore = typeof actions;

--- a/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/classic-cart/frontend.ts
@@ -20,11 +20,12 @@
  * store (owned by Billow), not here.
  */
 
+/**
+ * External dependencies
+ */
 import { store, getContext, getElement } from '@wordpress/interactivity';
 import { actions as router } from '@wordpress/interactivity-router';
-
-// Register/extend the shared Mini-Cart store (namespace `woocommerce`).
-import '@woocommerce/stores/woocommerce/cart';
+import '@woocommerce/stores/woocommerce/cart'; // Side-effect: registers shared store.
 
 type ClassicCartContext = {
 	cartItemKey: string;
@@ -64,9 +65,11 @@ function* rerenderCart(): Generator< unknown > {
  * working. No-op when jQuery is absent.
  */
 function emitLegacyEvent( name: string, ...args: unknown[] ): void {
-	const w = window as unknown as { jQuery?: ( target: unknown ) => {
-		trigger: ( n: string, a?: unknown[] ) => void;
-	}; };
+	const w = window as unknown as {
+		jQuery?: ( target: unknown ) => {
+			trigger: ( n: string, a?: unknown[] ) => void;
+		};
+	};
 	if ( w.jQuery ) {
 		w.jQuery( document.body ).trigger( name, args );
 	}
@@ -80,14 +83,17 @@ async function storeApiPost(
 	path: string,
 	data: Record< string, unknown >
 ): Promise< unknown > {
-	const response = await fetch( `${ wooState.restUrl }wc/store/v1/${ path }`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			Nonce: wooState.nonce,
-		},
-		body: JSON.stringify( data ),
-	} );
+	const response = await fetch(
+		`${ wooState.restUrl }wc/store/v1/${ path }`,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Nonce: wooState.nonce,
+			},
+			body: JSON.stringify( data ),
+		}
+	);
 	return response.json();
 }
 
@@ -101,10 +107,7 @@ const { actions } = store( 'woocommerce/classic-cart', {
 		*changeQuantity(): Generator< unknown > {
 			const { cartItemKey } = getContext< ClassicCartContext >();
 			const { ref } = getElement();
-			const quantity = parseInt(
-				( ref as HTMLInputElement ).value,
-				10
-			);
+			const quantity = parseInt( ( ref as HTMLInputElement ).value, 10 );
 			yield wooActions.addCartItem( { key: cartItemKey, quantity } );
 			yield* rerenderCart();
 		},
@@ -174,7 +177,7 @@ const { actions } = store( 'woocommerce/classic-cart', {
 		// Shipping calculator submit -> set customer address, re-render.
 		*calculateShipping( event: Event ): Generator< unknown > {
 			event.preventDefault();
-			const form = ( getElement().ref as HTMLFormElement );
+			const form = getElement().ref as HTMLFormElement;
 			const data = new FormData( form );
 			yield storeApiPost( 'cart/update-customer', {
 				shipping_address: {

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -43,6 +43,10 @@ const entries = {
 	// Experimental mini cart frontend modules, only enqueued when experimental-iapi-mini-cart feature flag is enabled.
 	'woocommerce/mini-cart': './assets/js/blocks/mini-cart/iapi-frontend.ts',
 
+	// Experimental classic cart frontend module, only enqueued when the
+	// experimental-iapi-cart feature flag is enabled.
+	'woocommerce/classic-cart': './assets/js/classic-cart/frontend.ts',
+
 	// Product elements frontend module. Share by several blocks.
 	'woocommerce/product-elements':
 		'./assets/js/atomic/blocks/product-elements/frontend.ts',

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
@@ -55,8 +55,8 @@ Status legend:
 | --- | --- | --- | --- |
 | `toggle_shipping` | Slide the calculator panel, set `aria-expanded` | iAPI UI: context bool + `data-wp-class` / `data-wp-bind--aria-expanded` | Covered |
 | `country_to_state_changed` | Triggered select2 re-init | Re-emit the event after morph for select2-based fields | Covered (note) — verify with a select2 country field |
-| `shipping_method_selected` | AJAX `update_shipping_method`, totals refresh, focus restore, `updated_shipping_method` | `selectShippingRate` (NEW) → `navigate()`; restore focus; event re-emitted | Covered (note) — new store action |
-| `shipping_calculator_submit` | `calc_shipping` POST, full refresh | `updateCustomer` (NEW) → `navigate()` | Covered (note) — new store action |
+| `shipping_method_selected` | AJAX `update_shipping_method`, totals refresh, focus restore, `updated_shipping_method` | `selectShippingRate` (local classic-cart action; direct Store API + `refreshCartItems`) → `navigate()`; event re-emitted | Covered (note) — local action (blocks don't use it) |
+| `shipping_calculator_submit` | `calc_shipping` POST, full refresh | `updateCustomer` (local classic-cart action; direct Store API + `refreshCartItems`) → `navigate()` | Covered (note) — local action (blocks don't use it) |
 
 ## 2. `wc_cart_params` + AJAX nonces
 
@@ -86,9 +86,16 @@ These are unused by the iAPI path but stay registered, so dependent code keeps w
 
 Status as of the 2026-06-21 spike pass (verified live against the Studio site):
 
-1. **Busy-state visual parity** — DONE. Reactive `state.isProcessing` on the locked
-   classic-cart store toggles `aria-busy` + an `is-cart-updating` class (inline CSS), replacing
-   the blockUI overlay.
+1. **Busy-state overlay** — DONE (corrected). Reactive `state.isProcessing` on the locked
+   classic-cart store toggles `aria-busy` + an `is-cart-updating` class on the `.woocommerce`
+   wrapper, dimming the cart and blocking pointer events while a mutation is in flight (replacing the
+   blockUI overlay). NOTE: the original inline CSS used a descendant selector
+   (`.woocommerce .is-cart-updating`) while the class lands on the `.woocommerce` element itself, so
+   it never matched and the cart did not visibly disable — fixed to the compound
+   `.woocommerce.is-cart-updating`. We deliberately kept this coarse overlay rather than disabling
+   each control in place (`data-wp-bind--disabled` / `aria-disabled` per element): in-place disabling
+   is the nicer end state, but polishing the pending-state UX is out of spike scope. See the
+   double-round-trip finding below.
 2. **`wc_cart_params` consumers** — DONE (documented in `dequeue_legacy_cart()` and the plan).
 3. **No-JS form-submit prevention** — DONE. `preventFormSubmit` on the cart form (verified
    `defaultPrevented`); the native POST still works without JS.
@@ -109,28 +116,71 @@ live:
   not appear (error messages from the Store API response would still need surfacing). `focusNotices`
   therefore usually has nothing to focus.
 
-This is the single biggest open question for the interactivity-only path: decide how cart notices
-are produced once mutations are JSON/Store-API driven rather than PHP-handler driven.
+This is one of the two biggest open questions for the interactivity-only path: decide how cart
+notices are produced once mutations are JSON/Store-API driven rather than PHP-handler driven.
+
+### Key finding: the double round-trip makes the cart slow and rapid interaction error-prone
+
+Every change is two server trips — the Store API mutation, then a full `navigate()` re-render of the
+PHP cart so the hooks/filters re-run. That is the cost of keeping the hooks, but it makes the cart
+noticeably slower than the block cart (which updates reactively), and it makes rapid interaction
+error-prone: clicking remove several times before the slow re-render lands fired duplicate requests
+against an already-removed item, surfacing "Cart item no longer exists or is invalid" (logged by the
+shared store's `showNoticeError`).
+
+Mitigations applied during the spike:
+
+- a **synchronous reentrancy guard** at the top of each mutating action in the classic-cart store
+  (`if ( state.isProcessing ) return;`), since the reactive busy class lands a tick late;
+- a **busy overlay** over the cart while a mutation is pending (the busy-state item above; a coarse
+  overlay, not in-place per-control disabling, which is out of spike scope);
+- making the shared store's **`removeCartItem` idempotent** (no-op when the key is already gone from
+  `state.cart.items`) — split out as its own trunk PR, since it also benefits the Cart block and
+  Mini-Cart.
+
+These stop the error, not the slowness. The root cost — re-rendering server HTML on every change —
+remains. Resolving it means avoiding the navigate (a Store-API-rendered cart fragment, or selective
+reactive updates) and offering iAPI extensibility points so extensions can move off the PHP hooks;
+that is real follow-up work and the other main blocker alongside notices.
 
 ### Implementation note (store locking)
 
 The classic-cart store must be registered **with a lock** (`{ lock: universalLock }`) for its own
-`state` to be mutable from actions (mirrors the Mini-Cart). The shared `woocommerce` store is
-accessed **without** a lock — passing one there breaks access to its public actions.
+`state` to be mutable from actions (mirrors the Mini-Cart). The shared `woocommerce` store is also
+accessed **with** the lock — that's required to read its locked `state` (`restUrl` / `nonce`), which
+the local shipping actions use; reading locked state without the lock silently breaks the mutations.
+(Destructuring only `actions` works without a lock, but reading `state` does not.)
+
+## E2e results (flag ON)
+
+Ran `tests/e2e-pw/tests/cart/cart.spec.ts` against wp-env with `experimental-iapi-cart` enabled
+(twice, same outcome): **3 passed, 2 failed, 1 skipped.**
+
+- ✓ blocks-cart add/remove/quantity/checkout flow.
+- ✘ classic-cart **"undo product removal"** — fails at "verify undo link appears". This is the notice
+  gap above: Store API `removeCartItem` emits no "item removed / Undo" notice, so there's no link.
+- ✘ classic-cart **add/remove/quantity/checkout** — fails at "can remove the last product"
+  (empty-cart state not reached in time). Reproducible in a clean wp-env, but the same flow passes
+  in manual testing, so it reads as a removal re-render timing issue under Playwright, not a flat
+  break. Needs a look (distinct from the notice gap).
+
+Both failures are on the **removal** path; non-removal classic-cart flows pass. To re-run: stop the
+Studio site (wp-env dev needs port 8888), then `pnpm env:start` and
+`pnpm test:e2e:default --project=e2e tests/cart/cart.spec.ts` (node 24).
 
 ## Manual verification checklist (spike acceptance)
 
 Run each with the flag **on**, then repeat with it **off** to confirm identical outcomes.
 
 - [ ] Change a quantity → totals + Mini-Cart update; no full reload.
-- [ ] Remove an item → row goes, totals update, undo notice appears.
-- [ ] Undo a removed item → item restored.
+- [ ] Remove an item → row goes, totals update. (Undo notice does NOT appear — notice gap; e2e ✘.)
+- [ ] Undo a removed item → item restored. (Blocked by the notice gap: no undo link is rendered.)
 - [ ] Apply a valid coupon → discount row + success notice.
 - [ ] Apply an invalid coupon → coupon error shown under the field, announced.
 - [ ] Remove a coupon → discount row gone.
 - [ ] Select a shipping method → totals update.
 - [ ] Submit the shipping calculator → totals update.
-- [ ] Empty the cart (remove last item) → empty-cart view renders.
+- [ ] Empty the cart (remove last item) → empty-cart view renders. (Passes manually; e2e ✘ — timing.)
 - [x] Add to cart from another block on the page → classic cart refreshes (verified: Wishlist
   "move to cart" → classic cart updates via the native `wc-blocks_added_to_cart` event bridge).
 - [ ] A theme/extension listening on `updated_wc_div` / `updated_cart_totals` still reacts.

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
@@ -131,7 +131,8 @@ Run each with the flag **on**, then repeat with it **off** to confirm identical 
 - [ ] Select a shipping method → totals update.
 - [ ] Submit the shipping calculator → totals update.
 - [ ] Empty the cart (remove last item) → empty-cart view renders.
-- [ ] Add to cart from another block on the page → cart + Mini-Cart refresh.
+- [x] Add to cart from another block on the page → classic cart refreshes (verified: Wishlist
+  "move to cart" → classic cart updates via the native `wc-blocks_added_to_cart` event bridge).
 - [ ] A theme/extension listening on `updated_wc_div` / `updated_cart_totals` still reacts.
 - [ ] `cart-fragments.js` still refreshes the classic Mini-Cart.
 - [ ] No-JS (disable JS): form POST update, coupon, shipping calc all still work.

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
@@ -84,10 +84,39 @@ These are unused by the iAPI path but stay registered, so dependent code keeps w
 
 ## Open gaps to resolve before flag-on
 
-1. **Undo / restore item** — no Store API restore endpoint (see row in §1).
-2. **Busy-state visual parity** — replace blockUI overlay with an equivalent iAPI loading state.
-3. **a11y after morph** — focus management + `role="alert"` announcement that cart.js does today.
-4. **`wc_cart_params` consumers** — document the removal for extensions that read it on the cart page.
+Status as of the 2026-06-21 spike pass (verified live against the Studio site):
+
+1. **Busy-state visual parity** — DONE. Reactive `state.isProcessing` on the locked
+   classic-cart store toggles `aria-busy` + an `is-cart-updating` class (inline CSS), replacing
+   the blockUI overlay.
+2. **`wc_cart_params` consumers** — DONE (documented in `dequeue_legacy_cart()` and the plan).
+3. **No-JS form-submit prevention** — DONE. `preventFormSubmit` on the cart form (verified
+   `defaultPrevented`); the native POST still works without JS.
+4. **a11y after morph** — PARTIAL. `focusNotices()` moves focus to a server notice after each
+   re-render, but see the key finding below.
+
+### Key finding: Store API mutations bypass the legacy WC notice/undo system
+
+Routing mutations through Store API (`removeCartItem`, `apply-coupon`, …) does **not** emit the
+classic `wc_add_notice` messages that the legacy form/GET handlers produce. Consequences observed
+live:
+
+- **Undo / restore** — removing an item via Store API produces **no "item removed / Undo"
+  notice**, so the `restore-item` link is never rendered. The `restoreItem` action + directive are
+  in place but unreachable on this path. To keep undo: either replicate the notice + restore link
+  server-side after a Store API removal, or keep using the legacy GET remove URL for removals.
+- **Coupon / status messages** — "Coupon applied successfully", "Shipping costs updated", etc. do
+  not appear (error messages from the Store API response would still need surfacing). `focusNotices`
+  therefore usually has nothing to focus.
+
+This is the single biggest open question for the interactivity-only path: decide how cart notices
+are produced once mutations are JSON/Store-API driven rather than PHP-handler driven.
+
+### Implementation note (store locking)
+
+The classic-cart store must be registered **with a lock** (`{ lock: universalLock }`) for its own
+`state` to be mutable from actions (mirrors the Mini-Cart). The shared `woocommerce` store is
+accessed **without** a lock — passing one there breaks access to its public actions.
 
 ## Manual verification checklist (spike acceptance)
 

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/legacy-mechanism-audit.md
@@ -1,0 +1,110 @@
+# Legacy mechanism audit — no functionality lost
+
+This audit walks every behaviour in the mechanisms we stop loading when
+`experimental-iapi-cart` is on, and records where that behaviour is handled in the iAPI design.
+It is the safety net for "we removed X — is X still covered?".
+
+Status legend:
+
+- **Covered** — a direct equivalent exists in the iAPI design.
+- **Covered (note)** — covered, but with a behavioural difference or extra work to confirm.
+- **Gap** — must be resolved before the flag can ship on.
+
+## 1. `cart.js` (`client/legacy/js/frontend/cart.js`)
+
+### Infrastructure helpers
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `get_url(endpoint)` | Built `wc-ajax` URLs from `wc_cart_params.wc_ajax_url` | Store API `restUrl` + nonce from `BlocksSharedState::load_cart_state()` hydration | Covered |
+| `is_blocked` / `block` / `unblock` | jQuery blockUI overlay + `.processing` class during requests | iAPI pending state bound with `data-wp-class--is-loading` driven by the store's in-flight/optimistic state; CSS replaces blockUI | Covered (note) — confirm visual parity of the busy state |
+| `remove_duplicate_notices` | De-duped notice nodes before showing | Notices come from the server re-render (`woocommerce_output_all_notices`), which already de-dupes; plus `store-notices` | Covered |
+| `show_notice` / `show_coupon_error` | Injected notice / coupon-error HTML client-side | Server re-render emits notices after `navigate()`; coupon errors render in the coupon area server-side | Covered (note) — verify coupon error placement + `role="alert"` after morph |
+
+### Re-render (HTML swap)
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `update_wc_div` — replace form + totals | Parsed response, swapped `.woocommerce-cart-form` and `.cart_totals` | `router.navigate(currentUrl)` morphs the `data-wp-router-region` | Covered |
+| `update_wc_div` — empty cart transition | Replaced `.woocommerce` with the empty-cart markup, fired `wc_cart_emptied` | `navigate()` renders `cart-empty.php` (shortcode branch); `wc_cart_emptied` re-emitted | Covered (note) — confirm region wraps both filled + empty states |
+| `update_wc_div` — checkout on same page | Reloaded / fired `update_checkout` | After morph, re-emit `update_checkout`; reload fallback if a `.woocommerce-checkout` is present | Covered (note) — exercise cart+checkout-on-one-page |
+| `update_wc_div` — preserve coupon error/value | Restored `#coupon_code` value + error after swap | Server re-render returns the entered value + error; verify it round-trips | Covered (note) |
+| `update_cart_totals_div` | Swapped `.cart_totals`, fired `updated_cart_totals` | `navigate()` morph; `updated_cart_totals` re-emitted | Covered |
+| `$.scroll_to_notices` | Scrolled to `[role="alert"]` after a change | a11y step: after morph, move focus / scroll to the notice region | Covered (note) — implement in the morph callback |
+
+### Cart interactions
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `init` delegated bindings | `$(document).on(...)` for all controls | Per-element iAPI directives injected into the markup (no delegation in iAPI) | Covered (note) — every interactive element must receive a directive |
+| `input_changed` | Enabled the "Update cart" button | Qty applies on change → button is no-JS-only | Covered (note) — behaviour change, confirm acceptable |
+| `input_keypress` (ENTER) | ENTER in qty submitted update | `data-wp-on--keydown` on the qty input (or form submit handler) | Covered |
+| `submit_click` / `cart_submit` | Tracked which submit was clicked, routed update vs coupon | Separate directives per control; routing no longer needed | Covered |
+| `update_cart` / `quantity_update` | Serialized form, POSTed, swapped HTML | `addCartItem` update path per changed row → `navigate()` | Covered |
+| `update_cart_totals` (`get_cart_totals`) | Totals-only refresh | `navigate()` morph | Covered |
+| `apply_coupon` | AJAX apply, notice, `applied_coupon`, then full refresh | `applyCoupon` (NEW) → `navigate()`; `applied_coupon` re-emitted | Covered (note) — new store action |
+| `remove_coupon_clicked` | AJAX remove, notice, `removed_coupon`, clear field, refresh | `removeCoupon` (NEW) → `navigate()`; `removed_coupon` re-emitted | Covered (note) — new store action |
+| `remove_coupon_error` | Cleared coupon error styling on input | Server re-render clears it; optional iAPI clear on input | Covered |
+| `item_remove_clicked` | AJAX GET remove URL, refresh, `item_removed_from_classic_cart` | `removeCartItem` (exists) → `navigate()`; event re-emitted | Covered |
+| `item_restore_clicked` (undo) | AJAX GET restore URL, refresh | No Store API restore endpoint — `restoreCartItem` re-add, or call the server URL then `navigate()` | **Gap** — decide approach |
+| `on_keydown_remove_coupon` / `on_keydown_remove_item` | Space key activates `role="button"` links | `data-wp-on--keydown` directives, or convert to real `<button>` | Covered (note) — preserve keyboard a11y |
+
+### Shipping
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `toggle_shipping` | Slide the calculator panel, set `aria-expanded` | iAPI UI: context bool + `data-wp-class` / `data-wp-bind--aria-expanded` | Covered |
+| `country_to_state_changed` | Triggered select2 re-init | Re-emit the event after morph for select2-based fields | Covered (note) — verify with a select2 country field |
+| `shipping_method_selected` | AJAX `update_shipping_method`, totals refresh, focus restore, `updated_shipping_method` | `selectShippingRate` (NEW) → `navigate()`; restore focus; event re-emitted | Covered (note) — new store action |
+| `shipping_calculator_submit` | `calc_shipping` POST, full refresh | `updateCustomer` (NEW) → `navigate()` | Covered (note) — new store action |
+
+## 2. `wc_cart_params` + AJAX nonces
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `wc_cart_params` config object | ajax_url, wc_ajax_url, coupon/shipping nonces for cart.js | Not enqueued when flag on; iAPI uses store `restUrl` + nonce | Covered (note) — extensions reading `wc_cart_params` on the cart page lose it; document |
+
+## 3. Endpoints kept registered (back-compat — no loss)
+
+These are unused by the iAPI path but stay registered, so dependent code keeps working.
+
+| Mechanism | Status |
+| --- | --- |
+| `wc-ajax` `apply_coupon` / `remove_coupon` / `update_shipping_method` / `get_cart_totals` (`includes/class-wc-ajax.php`) | Retained — no loss |
+| Their AJAX nonces | Retained — no loss |
+| `<form>` POST → `WC_Form_Handler::update_cart_action()` | Retained as no-JS fallback — no loss |
+| `woocommerce-cart-nonce`, `cart[{key}][qty]` serialization | Retained for no-JS — no loss |
+| `calc_shipping` POST → `WC_Shortcode_Cart::calculate_shipping()` | Retained for no-JS — no loss |
+
+## 4. Cart fragments
+
+| Behaviour | What it did | Handled by | Status |
+| --- | --- | --- | --- |
+| `cart-fragments.js` + `get_refreshed_fragments` + `woocommerce_add_to_cart_fragments` + `woocommerce_cart_hash` cookie | Live-updated the classic Mini-Cart widget site-wide | Not used by the cart page (router re-render + store). Kept enqueued while the classic Mini-Cart coexists; retired once the iAPI Mini-Cart is on | Covered (note) — retained transitionally |
+
+## Open gaps to resolve before flag-on
+
+1. **Undo / restore item** — no Store API restore endpoint (see row in §1).
+2. **Busy-state visual parity** — replace blockUI overlay with an equivalent iAPI loading state.
+3. **a11y after morph** — focus management + `role="alert"` announcement that cart.js does today.
+4. **`wc_cart_params` consumers** — document the removal for extensions that read it on the cart page.
+
+## Manual verification checklist (spike acceptance)
+
+Run each with the flag **on**, then repeat with it **off** to confirm identical outcomes.
+
+- [ ] Change a quantity → totals + Mini-Cart update; no full reload.
+- [ ] Remove an item → row goes, totals update, undo notice appears.
+- [ ] Undo a removed item → item restored.
+- [ ] Apply a valid coupon → discount row + success notice.
+- [ ] Apply an invalid coupon → coupon error shown under the field, announced.
+- [ ] Remove a coupon → discount row gone.
+- [ ] Select a shipping method → totals update.
+- [ ] Submit the shipping calculator → totals update.
+- [ ] Empty the cart (remove last item) → empty-cart view renders.
+- [ ] Add to cart from another block on the page → cart + Mini-Cart refresh.
+- [ ] A theme/extension listening on `updated_wc_div` / `updated_cart_totals` still reacts.
+- [ ] `cart-fragments.js` still refreshes the classic Mini-Cart.
+- [ ] No-JS (disable JS): form POST update, coupon, shipping calc all still work.
+- [ ] Keyboard: remove item/coupon via Space/Enter; focus lands sensibly after each change.
+- [ ] Cart + Checkout on the same page behaves correctly.

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
@@ -18,6 +18,24 @@ This mirrors the Mini-Cart precedent — **with one deliberate difference**:
 > store JSON). We do **not** do that. We reuse the Mini-Cart store's **mutation actions and
 > event bridge**, but keep PHP as the renderer and re-render server HTML after each change.
 
+## Success criteria
+
+What "good enough to pursue" means, grouped by who it has to be true for. (`[open]` = not met yet.)
+
+1. **Shoppers don't notice (experience & performance)** — no UX downgrade; same flows and markup;
+   cart performance kept with no visible slowdown.
+2. **Extenders & themes keep working (extensibility & parity)** — feature parity with the legacy
+   cart; all PHP hooks and filters keep firing; templates not edited (no version bumps, theme
+   overrides keep working); accessibility kept; legacy cart jQuery events keep firing for
+   extensions/analytics (**[open]** — `updated_wc_div`, `updated_cart_totals`, `wc_cart_emptied`
+   still to do); PHP notices still surface (**[open]** — `wc_add_notice` is bypassed by Store API
+   mutations); no-JS not regressed.
+3. **Fits the iAPI architecture (engineering)** — reuse the shared `woocommerce` store for shared
+   cart-domain mutations; keep classic-cart-only behavior in a thin `woocommerce/classic-cart`
+   store; stay in sync with other iAPI blocks; flag-gated and reversible; no new cart variant.
+4. **We can prove it (verification)** — cart e2e passes with the flag on (**[partly]** — removal
+   tests fail; see the audit); phpcs, phpstan, eslint clean; module builds.
+
 ## Architecture
 
 Three moving parts:
@@ -61,19 +79,30 @@ Source: `client/legacy/js/frontend/cart.js`.
 | --- | --- | --- | --- |
 | `quantity_update` / `update_cart` | `data-wp-on--change` on qty input → update item, then `navigate()` | `addCartItem` (update path, exists) | `POST cart/update-item` |
 | `input_changed` (enable "Update cart") | qty applies on change; "Update cart" becomes no-JS fallback | — | — |
-| `apply_coupon` | `data-wp-on--submit` → action | `applyCoupon` (NEW) | `POST cart/apply-coupon` |
-| `remove_coupon_clicked` | `data-wp-on--click` on remove-coupon link | `removeCoupon` (NEW) | `POST cart/remove-coupon` |
-| `item_remove_clicked` | `data-wp-on--click` on `.product-remove > a` | `removeCartItem` (exists) | `POST cart/remove-item` |
-| `item_restore_clicked` (undo) | `data-wp-on--click` (open question — no Store API restore) | `restoreCartItem` (NEW, TBD) | re-add via `add-item`, or keep server URL + `navigate()` |
-| `shipping_method_selected` | `data-wp-on--change` on shipping radios | `selectShippingRate` (NEW) | `POST cart/select-shipping-rate` |
-| `shipping_calculator_submit` | `data-wp-on--submit` on calculator form | `updateCustomer` (NEW) | `POST cart/update-customer` |
+| `apply_coupon` | `data-wp-on--click` → action | `applyCoupon` (shared store, via batch queue) | `POST cart/apply-coupon` |
+| `remove_coupon_clicked` | `data-wp-on--click` on remove-coupon link | `removeCoupon` (shared store, via batch queue) | `POST cart/remove-coupon` |
+| `item_remove_clicked` | `data-wp-on--click` on `.product-remove > a` | `removeCartItem` (shared store) | `POST cart/remove-item` |
+| `item_restore_clicked` (undo) | `data-wp-on--click` (open question — no Store API restore) | `restoreItem` (local; falls back to the legacy server URL + `navigate()`) | — |
+| `shipping_method_selected` | `data-wp-on--change` on shipping radios | `selectShippingRate` (local classic-cart store; direct Store API) | `POST cart/select-shipping-rate` |
+| `shipping_calculator_submit` | `data-wp-on--submit` on calculator form | `updateCustomer` (local classic-cart store; direct Store API) | `POST cart/update-customer` |
 | `toggle_shipping` (slide panel) | pure UI: `data-wp-on--click` toggles context + `data-wp-class` | — | — |
 | `update_wc_div` / `update_cart_totals_div` (HTML swap) | replaced by `router.navigate()` morph | — | — |
 | listens `added_to_cart`, `wc_update_cart` | `setupCartSyncBridge` listens on document for native `wc-blocks_added_to_cart`/`wc-blocks_removed_from_cart` (other iAPI blocks) **and** jQuery `added_to_cart`/`wc_update_cart` → `refreshCartItems` + `navigate()` | `refreshCartItems` (exists) | `GET cart` |
 | emits `updated_wc_div`, `updated_cart_totals`, `applied_coupon`, `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`, `item_removed_from_classic_cart` | re-emitted from iAPI actions via the legacy-events bridge | — | — |
 
-Store work = add `applyCoupon`, `removeCoupon`, `selectShippingRate`, `updateCustomer`,
-`restoreCartItem` to the shared store. Items / refresh already exist.
+**Store split (decided during the spike).** Cart-domain mutations that the Cart/Mini-Cart blocks
+*also* use live in the shared `woocommerce` store: `applyCoupon` + `removeCoupon` were added there
+(alongside the existing `addCartItem` / `removeCartItem` / `refreshCartItems`), routed through its
+batch queue. Mutations the blocks *don't* use stay **local** to the `woocommerce/classic-cart`
+store — `selectShippingRate` + `updateCustomer` call Store API directly, and `restoreItem` falls back
+to the legacy server URL (no Store API restore endpoint). Rule of thumb: shared = what the blocks
+share; local = classic-cart-only glue (the directive handlers, the re-render, busy state, the event
+bridge).
+
+The classic-cart store accesses the shared store **with** the lock
+(`store('woocommerce', {}, { lock: universalLock })`) because it reads the shared store's locked
+state (`restUrl` / `nonce`) for the direct shipping calls; reading locked state without the lock
+silently breaks the mutations. Its own state is likewise locked so it stays mutable from actions.
 
 ## Legacy mechanisms removed / retained
 
@@ -184,9 +213,11 @@ is rendering the cart through a block `render_callback`.
   `state.isProcessing` so the cart's own mutations (which also fire the native events via the shared
   store) don't double-navigate, and it returns a cleanup so listeners aren't duplicated across
   re-renders. Lesson: iAPI↔iAPI cart sync flows through the native `wc-blocks_*` events, not jQuery.
-- **Re-emit outbound jQuery events** (`updated_wc_div`, `updated_cart_totals`, `applied_coupon`,
-  `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`) from the iAPI actions so
-  analytics, themes and `cart-fragments.js` keep working.
+- **Re-emit outbound jQuery events** from the iAPI actions so analytics and themes that listen on
+  them keep working. Done so far: `applied_coupon`, `removed_coupon`, `updated_shipping_method`,
+  and `item_removed_from_classic_cart`. Still to do: `updated_wc_div`, `updated_cart_totals`, and
+  `wc_cart_emptied` (these were tied to the legacy HTML-swap mechanism, so they need firing after
+  the router re-render / on the empty-cart transition).
 - **Fragments** — the store already calls `triggerAddedToCartEvent`; keep `cart-fragments.js`
   enqueued so the Mini-Cart hash/cookie refresh path is preserved.
 
@@ -209,9 +240,57 @@ is rendering the cart through a block `render_callback`.
 
 ## Open questions / risks
 
-- **Undo/restore** — no Store API "restore last removed" endpoint; decide re-add vs keep-server-URL.
-- **Double round-trip** — mutation (Store API) then `navigate()` (page GET). Acceptable for the
-  spike; optimize later via a Store-API-rendered cart fragment or selective `data-wp-text`.
+### Decisions to make before flag-on
+
+**Notices.** The main one. Cart notices fall in a gap between two systems, and our re-render
+conflicts with both:
+
+- PHP session notices (`wc_add_notice` → `woocommerce_output_all_notices`) are what the classic cart
+  and extensions use. Our `navigate()` re-render runs `woocommerce_output_all_notices`, so a notice
+  already in the session does show. The problem: Store API mutations don't add the transactional
+  ones ("coupon applied", "item removed / Undo"); the Store API `NoticeHandler` only forwards
+  *error* notices. So there's nothing to render.
+- iAPI store-notices (`woocommerce/store-notices`) render notices client-side from a `notices` array
+  held in a store-notices region's context. To use them in the classic cart we'd render that region
+  and `addNotice` into it. But `navigate()` morphs the cart region from fresh server HTML, so a
+  notice added client-side is wiped on the next re-render: the notice is there, then the navigate
+  replaces the region and it's gone.
+
+So the server doesn't create the transactional notices, and client-added ones don't survive the
+re-render. What it would take: produce the notices server-side so the re-render includes them (the
+mutation adds the `wc_add_notice`, or keep the legacy server endpoints for the notice-bearing flows
+like undo); or render the store-notices region **outside** the router re-render region so the morph
+doesn't wipe it, and drive it from the store; or extend the Store API `NoticeHandler` to carry
+success/info notices and surface them through that persistent region. Undo/restore depends on this
+(the Undo link rides on the "item removed" notice).
+
+**Slower interface, and the double round-trip.** A main blocker. Every change is two server trips:
+the Store API mutation, then a full `navigate()` re-render of the PHP cart. That's what preserves
+extensibility (the hooks/filters re-run), but it trades away the iAPI benefit (re-fetch + morph
+instead of reactive updates) and makes the cart noticeably slower than the block cart. It's also
+error-prone under that latency: repeat clicks before the slow re-render lands fire duplicate requests
+against an already-mutated item ("Cart item no longer exists"). Mitigations applied: a synchronous
+reentrancy guard per action (classic-cart store), a busy overlay over the cart while a mutation is
+pending (a coarse `.is-cart-updating` overlay — we kept this rather than disabling each control in
+place, since polishing the pending-state UX is out of spike scope), and making the shared store's
+`removeCartItem` idempotent (split out as a separate trunk PR, #66051). The root cost remains. Open question:
+is the double round-trip the right trade for the cart, or do we invest in avoiding the navigate
+(Store-API-rendered fragment, or selective `data-wp-text`) and offering iAPI extensibility points so
+extensions move off the PHP hooks over time? Avoiding the navigate is real work and changes the
+extensibility story.
+
+**Extension surface and risk.** The cart has a large hook/filter surface and this approach keeps all
+of it; we've only tested on a clean store. We still need to see how it behaves on a store with many
+extensions, where the risk is higher (conflicting hooks, markup assumptions, notices).
+
+**Where the classic-cart behavior lives.** Some functionality the classic cart needs is missing from
+the shared `woocommerce` store (shipping rate, customer address, undo/restore); we kept it in a
+separate `woocommerce/classic-cart` store. Decision: keep a separate store for the legacy surface,
+or fold these into the shared store as core features? The block is the default cart, so the shared
+store is the canonical one; adding classic-only actions there has a cost.
+
+### Finer risks
+
 - **Directive injection brittleness** under heavy theme/template customization → long-term move
   to a block `render_callback`.
 - **Two carts mutating state** — ensure cart.js is fully dequeued when the flag is on.

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
@@ -279,9 +279,17 @@ is the double round-trip the right trade for the cart, or do we invest in avoidi
 extensions move off the PHP hooks over time? Avoiding the navigate is real work and changes the
 extensibility story.
 
-**Extension surface and risk.** The cart has a large hook/filter surface and this approach keeps all
-of it; we've only tested on a clean store. We still need to see how it behaves on a store with many
-extensions, where the risk is higher (conflicting hooks, markup assumptions, notices).
+Note on the hook surface: dropping the PHP refetch means we'd have to account for far more hooks than
+the Cart/Checkout blocks support today — re-supporting every existing cart hook at the
+iAPI level is a large effort. Team Billow has started scoping a **curated list of extensibility
+points** instead; that's a smaller, more tractable scope than blanket hook support, and it's the path
+that would let us drop the refetch without trying to preserve the full hook surface. This direction
+looks more promising than re-rendering server HTML on every change.
+
+**Extension surface and risk (not fully tested).** The cart has a large hook/filter surface and this
+approach keeps all of it. The impact on extensions was not fully tested: only basic interaction
+(Points and Rewards) on an otherwise clean store. We still need extensive testing on a store with
+many extensions, where the risk is higher (conflicting hooks, markup assumptions, notices).
 
 **Where the classic-cart behavior lives.** Some functionality the classic cart needs is missing from
 the shared `woocommerce` store (shipping rate, customer address, undo/restore); we kept it in a

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
@@ -69,7 +69,7 @@ Source: `client/legacy/js/frontend/cart.js`.
 | `shipping_calculator_submit` | `data-wp-on--submit` on calculator form | `updateCustomer` (NEW) | `POST cart/update-customer` |
 | `toggle_shipping` (slide panel) | pure UI: `data-wp-on--click` toggles context + `data-wp-class` | — | — |
 | `update_wc_div` / `update_cart_totals_div` (HTML swap) | replaced by `router.navigate()` morph | — | — |
-| listens `added_to_cart`, `wc_update_cart` | `data-wp-on-document--wc-blocks_added_to_cart` → `refreshCartItems` + `navigate()` | `refreshCartItems` (exists) | `GET cart` |
+| listens `added_to_cart`, `wc_update_cart` | `setupCartSyncBridge` listens on document for native `wc-blocks_added_to_cart`/`wc-blocks_removed_from_cart` (other iAPI blocks) **and** jQuery `added_to_cart`/`wc_update_cart` → `refreshCartItems` + `navigate()` | `refreshCartItems` (exists) | `GET cart` |
 | emits `updated_wc_div`, `updated_cart_totals`, `applied_coupon`, `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`, `item_removed_from_classic_cart` | re-emitted from iAPI actions via the legacy-events bridge | — | — |
 
 Store work = add `applyCoupon`, `removeCoupon`, `selectShippingRate`, `updateCustomer`,
@@ -171,11 +171,19 @@ iAPI has no event delegation, so directives sit on each element. Recommended ord
 Avoid editing template files directly (version bumps + theme-override drift). The long-term fix
 is rendering the cart through a block `render_callback`.
 
-## Backward-compat bridge
+## Backward-compat + cross-block sync bridge
 
-- **jQuery → native** for inbound events with the existing helper
-  (`client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts`) — bridge `added_to_cart`
-  / `removed_from_cart` to `wc-blocks_*` and refresh, like the Mini-Cart `setupJQueryEventBridge`.
+- **Inbound cart-sync (DONE, verified)** — `setupCartSyncBridge` (a `data-wp-init` callback on the
+  wrapper) listens on `document` for **both**:
+    - the native iAPI events `wc-blocks_added_to_cart` / `wc-blocks_removed_from_cart` — what other
+      iAPI blocks emit via the shared store (e.g. Wishlist "move to cart", Mini-Cart, add-to-cart);
+      this is what makes a mutation in another block refresh the classic cart;
+    - the legacy jQuery `added_to_cart` / `wc_update_cart` events — classic add-to-cart + extensions.
+
+  On either, it runs `refreshCartItems()` + router `navigate()`. It's guarded by
+  `state.isProcessing` so the cart's own mutations (which also fire the native events via the shared
+  store) don't double-navigate, and it returns a cleanup so listeners aren't duplicated across
+  re-renders. Lesson: iAPI↔iAPI cart sync flows through the native `wc-blocks_*` events, not jQuery.
 - **Re-emit outbound jQuery events** (`updated_wc_div`, `updated_cart_totals`, `applied_coupon`,
   `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`) from the iAPI actions so
   analytics, themes and `cart-fragments.js` keep working.

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/migration-plan.md
@@ -1,0 +1,223 @@
+# Classic cart shortcode → Interactivity API migration (spike plan)
+
+## Goal
+
+Migrate the classic cart shortcode (`[woocommerce_cart]`) to the Interactivity API (iAPI)
+using the **interactivity-only** approach:
+
+- The cart stays **PHP-templated and hook-driven**. `cart.php` / `cart-totals.php` remain the
+  renderer, so every `do_action` / `apply_filters` keeps firing.
+- We replace only the **interaction + refresh layer** (today: jQuery + Ajax HTML swap in
+  `cart.js`) with iAPI.
+- A **feature flag** (`experimental-iapi-cart`) lets the legacy and iAPI implementations live
+  side by side, exactly like `experimental-iapi-mini-cart`.
+
+This mirrors the Mini-Cart precedent — **with one deliberate difference**:
+
+> The Mini-Cart blockified its rendering (items/totals are rendered client-side by iAPI from
+> store JSON). We do **not** do that. We reuse the Mini-Cart store's **mutation actions and
+> event bridge**, but keep PHP as the renderer and re-render server HTML after each change.
+
+## Architecture
+
+Three moving parts:
+
+1. **Mutations → the shared `woocommerce` store**
+   (`client/blocks/assets/js/base/stores/woocommerce/cart.ts`, namespace `woocommerce`).
+   It already exposes `addCartItem`, `removeCartItem`, `batchAddCartItems`, `refreshCartItems`
+   backed by Store API (`/wc/store/v1/cart/*`) with optimistic updates and mutation batching.
+   This gives instant Mini-Cart sync and a single source of truth.
+
+2. **Re-render → the Interactivity Router**
+   (`@wordpress/interactivity-router`). Wrap the cart in a `data-wp-router-region`; after a
+   mutation settles, call `navigate(currentUrl)`. The server re-renders the templates (hooks +
+   filters fire, notices included) and the router morphs the region in place. This is how we
+   keep "PHP-templated and hook-driven".
+
+3. **Interaction → iAPI directives** injected onto the server-rendered markup. iAPI has no event
+   delegation, so each interactive element needs its own directive (see "Directive injection").
+
+Flow for any change:
+
+```text
+user acts
+  → optimistic store update (Mini-Cart badge moves instantly)
+  → Store API mutation
+  → on settle: router.navigate(currentUrl)
+  → fresh server HTML morphs in
+  → legacy jQuery events re-emitted for back-compat
+```
+
+Why re-render instead of reactive client bindings: per-item subtotal, the whole totals table,
+coupon / fee / tax rows and every injected hook block are **filter-generated formatted HTML**.
+Rebinding them to store state client-side means re-implementing those filters in JS — the
+extensibility loss we are explicitly avoiding. Re-rendering keeps them server-authoritative.
+
+## Where iAPI takes over (cart.js → iAPI map)
+
+Source: `client/legacy/js/frontend/cart.js`.
+
+| Today (cart.js) | iAPI replacement | Store action | Store API endpoint |
+| --- | --- | --- | --- |
+| `quantity_update` / `update_cart` | `data-wp-on--change` on qty input → update item, then `navigate()` | `addCartItem` (update path, exists) | `POST cart/update-item` |
+| `input_changed` (enable "Update cart") | qty applies on change; "Update cart" becomes no-JS fallback | — | — |
+| `apply_coupon` | `data-wp-on--submit` → action | `applyCoupon` (NEW) | `POST cart/apply-coupon` |
+| `remove_coupon_clicked` | `data-wp-on--click` on remove-coupon link | `removeCoupon` (NEW) | `POST cart/remove-coupon` |
+| `item_remove_clicked` | `data-wp-on--click` on `.product-remove > a` | `removeCartItem` (exists) | `POST cart/remove-item` |
+| `item_restore_clicked` (undo) | `data-wp-on--click` (open question — no Store API restore) | `restoreCartItem` (NEW, TBD) | re-add via `add-item`, or keep server URL + `navigate()` |
+| `shipping_method_selected` | `data-wp-on--change` on shipping radios | `selectShippingRate` (NEW) | `POST cart/select-shipping-rate` |
+| `shipping_calculator_submit` | `data-wp-on--submit` on calculator form | `updateCustomer` (NEW) | `POST cart/update-customer` |
+| `toggle_shipping` (slide panel) | pure UI: `data-wp-on--click` toggles context + `data-wp-class` | — | — |
+| `update_wc_div` / `update_cart_totals_div` (HTML swap) | replaced by `router.navigate()` morph | — | — |
+| listens `added_to_cart`, `wc_update_cart` | `data-wp-on-document--wc-blocks_added_to_cart` → `refreshCartItems` + `navigate()` | `refreshCartItems` (exists) | `GET cart` |
+| emits `updated_wc_div`, `updated_cart_totals`, `applied_coupon`, `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`, `item_removed_from_classic_cart` | re-emitted from iAPI actions via the legacy-events bridge | — | — |
+
+Store work = add `applyCoupon`, `removeCoupon`, `selectShippingRate`, `updateCustomer`,
+`restoreCartItem` to the shared store. Items / refresh already exist.
+
+## Legacy mechanisms removed / retained
+
+When the flag is on, the classic cart's own JS machinery is no longer needed. Three buckets.
+
+### A. Fully replaced — not loaded when the flag is on
+
+- **`cart.js` in its entirety** (`client/legacy/js/frontend/cart.js`):
+    - the HTML-swap re-render (`update_wc_div` / `update_cart_totals_div`),
+    - blockUI overlays (`$.block` / `$.unblock`, the `.processing` class),
+    - client-side notice handling (`show_notice`, `remove_duplicate_notices`,
+      `show_coupon_error`, `$.scroll_to_notices`),
+    - the `clicked`-attribute submit detection and the ENTER-key qty handling.
+- **`wc_cart_params`** (ajax_url + the apply/remove-coupon and update-shipping-method nonces) —
+  iAPI uses the store's `restUrl` / nonce from hydration.
+- The cart's **jQuery + blockUI** dependency for its own operation.
+- The **`get_cart_totals` totals-only refresh** path.
+
+### B. Replaced for the JS path, kept as the no-JS fallback
+
+iAPI intercepts these with `event.preventDefault()` when JS is on; they still work without JS.
+
+- The `<form class="woocommerce-cart-form">` POST and
+  `WC_Form_Handler::update_cart_action()`.
+- The `woocommerce-cart-nonce` field and the `cart[{key}][qty]` serialization.
+- The shipping-calculator `calc_shipping` POST → `WC_Shortcode_Cart::calculate_shipping()`.
+- The "Update cart" button (demoted to no-JS only).
+
+### C. Unused by our path, but kept registered (back-compat)
+
+Third parties call these directly, so we cannot remove them:
+
+- The HTML-returning `wc-ajax` endpoints `apply_coupon`, `remove_coupon`,
+  `update_shipping_method`, `get_cart_totals` (`includes/class-wc-ajax.php`).
+- Their AJAX nonces.
+
+### D. Cart fragments (special case)
+
+`cart-fragments.js` + the `get_refreshed_fragments` AJAX + the
+`woocommerce_add_to_cart_fragments` filter + the sessionStorage cache keyed by the
+`woocommerce_cart_hash` cookie exist to live-update the **classic Mini-Cart widget** across the
+whole site.
+
+- Our cart-page work does **not** use them — the page re-renders via the router and state syncs
+  through the store + Store API + events.
+- They become fully redundant once the **iAPI Mini-Cart** is also enabled.
+- Keep them enqueued while the classic / React Mini-Cart can still coexist on the page — that
+  widget has no other update path.
+
+See `legacy-mechanism-audit.md` for the per-mechanism coverage proof.
+
+## Feature flag
+
+Add `experimental-iapi-cart` next to `experimental-iapi-mini-cart` in
+`client/admin/config/core.json` and `client/admin/config/development.json`, then it surfaces in
+the generated feature config and is read with the same `Features::is_enabled()` gate the
+Mini-Cart uses.
+
+Force-off filter for parity:
+
+```php
+add_filter(
+    'woocommerce_admin_get_feature_config',
+    function ( $config ) {
+        $config['experimental-iapi-cart'] = false;
+        return $config;
+    }
+);
+```
+
+Gate points (all default to current `cart.js` behaviour when off):
+
+- `WC_Shortcode_Cart::output()` — when on: inject directives, enqueue the iAPI module, seed
+  store state.
+- Script enqueue — when on: dequeue `wc-cart` (cart.js); keep `wc-cart-fragments`; enqueue
+  `@wordpress/interactivity`, `@wordpress/interactivity-router`, and the new `woocommerce/cart`
+  script module (registered through `AssetsController::register_script_modules()`).
+- State hydration — when on: `BlocksSharedState::load_cart_state()` seeds the `woocommerce`
+  store server-side.
+- `WC_Form_Handler::update_cart_action()` — left intact as the no-JS POST fallback.
+
+## Directive injection (templates stay untouched)
+
+iAPI has no event delegation, so directives sit on each element. Recommended order:
+
+1. **Output-buffer + `WP_HTML_Tag_Processor`** in `output()`: render the template normally, then
+   post-process the HTML to add `data-wp-interactive="woocommerce"` + `data-wp-router-region` on
+   the wrapper and bind directives on known selectors (`input.qty`, `.product-remove > a`,
+   `button[name=apply_coupon]`, `a.woocommerce-remove-coupon`,
+   `:input[name^=shipping_method]`, `form.woocommerce-shipping-calculator`). Survives theme
+   template overrides as long as standard classes exist; touches zero template files.
+2. **Complement with existing filters** where cleaner: `woocommerce_cart_item_quantity` and
+   `woocommerce_cart_item_remove_link` already let us decorate per-row elements without parsing.
+
+Avoid editing template files directly (version bumps + theme-override drift). The long-term fix
+is rendering the cart through a block `render_callback`.
+
+## Backward-compat bridge
+
+- **jQuery → native** for inbound events with the existing helper
+  (`client/blocks/assets/js/base/stores/woocommerce/legacy-events.ts`) — bridge `added_to_cart`
+  / `removed_from_cart` to `wc-blocks_*` and refresh, like the Mini-Cart `setupJQueryEventBridge`.
+- **Re-emit outbound jQuery events** (`updated_wc_div`, `updated_cart_totals`, `applied_coupon`,
+  `removed_coupon`, `updated_shipping_method`, `wc_cart_emptied`) from the iAPI actions so
+  analytics, themes and `cart-fragments.js` keep working.
+- **Fragments** — the store already calls `triggerAddedToCartEvent`; keep `cart-fragments.js`
+  enqueued so the Mini-Cart hash/cookie refresh path is preserved.
+
+## Phased plan
+
+1. **Scaffold flag + module** — add `experimental-iapi-cart`, register an empty `woocommerce/cart`
+   script module, gate enqueue/dequeue. Flag-off = unchanged; flag-on = cart.js gone + module
+   loads.
+2. **Wrapper + router** — inject `data-wp-interactive` + `data-wp-router-region`, seed store
+   state, get `navigate()` re-rendering the region. Prove hooks/notices survive a re-render.
+3. **Read-only sync** — wire the document `added_to_cart` listener → `refreshCartItems` +
+   `navigate()`. Mini-Cart and cart page stay in sync.
+4. **Mutations** — quantity, remove item (existing actions), then coupons, shipping method,
+   shipping calculator. Restore/undo last.
+5. **BC bridge** — re-emit all legacy events; verify cart-fragments + a sample extension react.
+6. **Edge cases** — empty-cart transition, coupon error display, no-JS fallback, a11y
+   (focus / `role=alert` after morph), checkout-on-same-page.
+7. **Verdict writeup** — pros/cons/blockers + the BC-layer cost, feeding the team's "decide final
+   approach" step.
+
+## Open questions / risks
+
+- **Undo/restore** — no Store API "restore last removed" endpoint; decide re-add vs keep-server-URL.
+- **Double round-trip** — mutation (Store API) then `navigate()` (page GET). Acceptable for the
+  spike; optimize later via a Store-API-rendered cart fragment or selective `data-wp-text`.
+- **Directive injection brittleness** under heavy theme/template customization → long-term move
+  to a block `render_callback`.
+- **Two carts mutating state** — ensure cart.js is fully dequeued when the flag is on.
+- **a11y after morph** — re-apply focus + `role="alert"` that cart.js handles today.
+- **Quantity UX change** — applying qty on change (no "Update cart" click) is a behaviour change;
+  confirm acceptable.
+
+## iAPI primitives used
+
+- `data-wp-interactive="woocommerce"` + `wp_interactivity_state()` — bind region to the store.
+- `data-wp-router-region` + `@wordpress/interactivity-router` `navigate(url)` — hook-preserving
+  re-render.
+- `data-wp-on--change|click|submit`, `data-wp-on-document--<event>` — interactions.
+- `data-wp-context`, `getContext()`, `getElement()` — per-row keys (cart item key, coupon code).
+- `data-wp-bind--*`, `data-wp-class--*`, `data-wp-text` — small UI state.
+- `data-wp-init` / `data-wp-watch` — set up the jQuery bridge and side effects.
+- Async actions are generators (`function*`), `yield` the Store API call.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -410,6 +410,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\PushNotifications\PushNotifications::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Interactivity\ClassicCartInteractivity::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -239,13 +239,21 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 		// has run.
 		wp_enqueue_script_module( self::STORE_NAMESPACE );
 
-		// Busy-state styling for the wrapper while a mutation is in flight.
-		// Inline-only style (no src), toggled by data-wp-class--is-cart-updating.
+		// Busy-state styling while a mutation is in flight: a single overlay over
+		// the whole cart (dim + block pointer events), replacing the legacy
+		// blockUI overlay. Note: is-cart-updating is added to the .woocommerce
+		// element itself, so the selector is compound (.woocommerce.is-cart-updating),
+		// not descendant. Inline-only style (no src).
+		//
+		// We deliberately keep this coarse overlay rather than disabling each
+		// control in place (data-wp-bind--disabled / aria-disabled per element):
+		// the spike is about testing feasibility, not polishing the pending-state
+		// UX. In-place disabling is the nicer end state but out of scope here.
 		wp_register_style( self::STYLE_HANDLE, false, array(), \WC_VERSION );
 		wp_enqueue_style( self::STYLE_HANDLE );
 		wp_add_inline_style(
 			self::STYLE_HANDLE,
-			'.woocommerce .is-cart-updating{opacity:.6;pointer-events:none;}'
+			'.woocommerce.is-cart-updating{opacity:.6;pointer-events:none;}'
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -49,6 +49,13 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 	private const STORE_NAMESPACE = 'woocommerce/classic-cart';
 
 	/**
+	 * Style handle for the inline busy-state CSS.
+	 *
+	 * @var string
+	 */
+	private const STYLE_HANDLE = 'wc-classic-cart-iapi';
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
@@ -75,6 +82,10 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 		if ( ! $this->is_iapi_cart_active() ) {
 			return;
 		}
+		// Removing 'wc-cart' also removes its localized `wc_cart_params` object.
+		// Extensions that read `wc_cart_params` on the cart page will not find it
+		// under the iAPI cart; this is a documented breaking change (see the
+		// migration plan's "Legacy mechanisms" section).
 		wp_dequeue_script( self::LEGACY_CART_SCRIPT_HANDLE );
 	}
 
@@ -101,6 +112,9 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 			$processor->set_attribute( 'data-wp-interactive', self::STORE_NAMESPACE );
 			$processor->set_attribute( 'data-wp-router-region', 'woocommerce-cart' );
 			$processor->set_attribute( 'data-wp-init', 'callbacks.setupLegacyBridge' );
+			// Busy state during a mutation (replaces the legacy blockUI overlay).
+			$processor->set_attribute( 'data-wp-bind--aria-busy', 'state.isProcessing' );
+			$processor->set_attribute( 'data-wp-class--is-cart-updating', 'state.isProcessing' );
 		}
 
 		// Decorate the remaining interactive controls.
@@ -121,6 +135,19 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 
 			if ( 'A' === $tag_name && $processor->has_class( 'shipping-calculator-button' ) ) {
 				$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.toggleShippingCalculator' );
+				continue;
+			}
+
+			// Undo/restore link shown in the "item removed" notice.
+			if ( 'A' === $tag_name && $processor->has_class( 'restore-item' ) ) {
+				$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.restoreItem' );
+				continue;
+			}
+
+			// Prevent the full-form POST when JS is active (quantities apply on
+			// change); the native submit still works without JS.
+			if ( 'FORM' === $tag_name && $processor->has_class( 'woocommerce-cart-form' ) ) {
+				$processor->set_attribute( 'data-wp-on--submit', self::STORE_NAMESPACE . '::actions.preventFormSubmit' );
 				continue;
 			}
 
@@ -211,6 +238,15 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 		// file. Enqueuing before registration is a safe no-op until the build
 		// has run.
 		wp_enqueue_script_module( self::STORE_NAMESPACE );
+
+		// Busy-state styling for the wrapper while a mutation is in flight.
+		// Inline-only style (no src), toggled by data-wp-class--is-cart-updating.
+		wp_register_style( self::STYLE_HANDLE, false, array(), \WC_VERSION );
+		wp_enqueue_style( self::STYLE_HANDLE );
+		wp_add_inline_style(
+			self::STYLE_HANDLE,
+			'.woocommerce .is-cart-updating{opacity:.6;pointer-events:none;}'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -111,7 +111,7 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 		if ( $processor->next_tag( array( 'class_name' => 'woocommerce' ) ) ) {
 			$processor->set_attribute( 'data-wp-interactive', self::STORE_NAMESPACE );
 			$processor->set_attribute( 'data-wp-router-region', 'woocommerce-cart' );
-			$processor->set_attribute( 'data-wp-init', 'callbacks.setupLegacyBridge' );
+			$processor->set_attribute( 'data-wp-init', 'callbacks.setupCartSyncBridge' );
 			// Busy state during a mutation (replaces the legacy blockUI overlay).
 			$processor->set_attribute( 'data-wp-bind--aria-busy', 'state.isProcessing' );
 			$processor->set_attribute( 'data-wp-class--is-cart-updating', 'state.isProcessing' );

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Interactivity;
 
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use WP_HTML_Tag_Processor;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -14,13 +16,19 @@ defined( 'ABSPATH' ) || exit;
  * When the 'experimental-iapi-cart' feature is enabled, the classic cart is
  * driven by the Interactivity API instead of the legacy jQuery layer
  * (assets/js/frontend/cart.js, enqueued as 'wc-cart'). This controller is the
- * single switch point: it removes the legacy script and will enqueue the iAPI
- * module + hydrate the shared cart store.
+ * single switch point. It:
  *
- * The legacy implementation is left fully intact so the two can run side by
- * side; only the feature flag decides which one is active. The cart fragments
- * script ('wc-cart-fragments') is intentionally NOT dequeued, since the classic
- * Mini-Cart widget still relies on it.
+ *   - removes the legacy 'wc-cart' script;
+ *   - hydrates the shared 'woocommerce' cart store server-side;
+ *   - injects Interactivity directives onto the server-rendered cart markup
+ *     (without editing the templates) so the existing PHP hooks/filters keep
+ *     producing the HTML;
+ *   - (TODO) enqueues the 'woocommerce/classic-cart' script module once it is
+ *     registered through the script-module build / AssetsController.
+ *
+ * The legacy implementation is left fully intact so the two run side by side;
+ * only the feature flag decides which is active. 'wc-cart-fragments' is NOT
+ * dequeued, since the classic Mini-Cart widget still relies on it.
  *
  * @since 11.0.0
  */
@@ -34,45 +42,176 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 	private const LEGACY_CART_SCRIPT_HANDLE = 'wc-cart';
 
 	/**
+	 * Interactivity store namespace for the classic cart.
+	 *
+	 * @var string
+	 */
+	private const STORE_NAMESPACE = 'woocommerce/classic-cart';
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
 	 */
 	public function register() {
-		// Runs after WC_Frontend_Scripts::load_scripts() (default priority) has
-		// enqueued 'wc-cart', so the handle exists to be dequeued.
-		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_take_over_cart' ), 100 );
+		// Runs after WC_Frontend_Scripts::load_scripts() has enqueued 'wc-cart'.
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_legacy_cart' ), 100 );
+
+		// Inject directives into the rendered shortcode + per-row elements.
+		add_filter( 'do_shortcode_tag', array( $this, 'inject_wrapper_directives' ), 10, 2 );
+		add_filter( 'woocommerce_cart_item_quantity', array( $this, 'inject_quantity_directives' ), 10, 3 );
+		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'inject_remove_directives' ), 10, 2 );
 	}
 
 	/**
-	 * Swap the legacy cart scripts for the Interactivity API implementation.
+	 * Remove the legacy jQuery cart script when the iAPI cart is active.
+	 *
+	 * The server-side fallbacks (form POST handler, wc-ajax endpoints) stay
+	 * registered for no-JS and back-compat.
 	 *
 	 * @return void
 	 */
-	public function maybe_take_over_cart(): void {
+	public function dequeue_legacy_cart(): void {
 		if ( ! $this->is_iapi_cart_active() ) {
 			return;
 		}
-
-		// Remove the legacy jQuery interaction layer. Its server-side fallbacks
-		// (form POST handler, wc-ajax endpoints) stay registered for no-JS and
-		// back-compat.
 		wp_dequeue_script( self::LEGACY_CART_SCRIPT_HANDLE );
+	}
+
+	/**
+	 * Inject store + router directives onto the rendered cart shortcode, and
+	 * decorate the global interactive controls (coupon, shipping).
+	 *
+	 * @param string $output The shortcode output.
+	 * @param string $tag    The shortcode tag.
+	 * @return string
+	 */
+	public function inject_wrapper_directives( $output, $tag ): string {
+		if ( 'woocommerce_cart' !== $tag || ! $this->is_iapi_cart_active() ) {
+			return (string) $output;
+		}
+
+		$this->hydrate_and_enqueue();
+
+		$processor = new WP_HTML_Tag_Processor( (string) $output );
+
+		// Outer wrapper: bind to the store, mark as the router re-render region,
+		// and set up the legacy event bridge on init.
+		if ( $processor->next_tag( array( 'class_name' => 'woocommerce' ) ) ) {
+			$processor->set_attribute( 'data-wp-interactive', self::STORE_NAMESPACE );
+			$processor->set_attribute( 'data-wp-router-region', 'woocommerce-cart' );
+			$processor->set_attribute( 'data-wp-init', 'callbacks.setupLegacyBridge' );
+		}
+
+		// Decorate the remaining interactive controls.
+		while ( $processor->next_tag() ) {
+			$tag_name = $processor->get_tag();
+
+			if ( 'BUTTON' === $tag_name && 'apply_coupon' === $processor->get_attribute( 'name' ) ) {
+				$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.applyCoupon' );
+				continue;
+			}
+
+			if ( 'A' === $tag_name && $processor->has_class( 'woocommerce-remove-coupon' ) ) {
+				$coupon = (string) $processor->get_attribute( 'data-coupon' );
+				$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.removeCoupon' );
+				$processor->set_attribute( 'data-wp-context', (string) wp_json_encode( array( 'coupon' => $coupon ) ) );
+				continue;
+			}
+
+			if ( 'A' === $tag_name && $processor->has_class( 'shipping-calculator-button' ) ) {
+				$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.toggleShippingCalculator' );
+				continue;
+			}
+
+			if ( 'FORM' === $tag_name && $processor->has_class( 'woocommerce-shipping-calculator' ) ) {
+				$processor->set_attribute( 'data-wp-on--submit', self::STORE_NAMESPACE . '::actions.calculateShipping' );
+				continue;
+			}
+
+			// Shipping method radios/hidden inputs (name^="shipping_method") and
+			// the select variant.
+			$name = (string) $processor->get_attribute( 'name' );
+			if (
+				( 'INPUT' === $tag_name && 0 === strpos( $name, 'shipping_method' ) ) ||
+				( 'SELECT' === $tag_name && $processor->has_class( 'shipping_method' ) )
+			) {
+				$processor->set_attribute( 'data-wp-on--change', self::STORE_NAMESPACE . '::actions.selectShippingRate' );
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Add the quantity-change directive + per-row context to a cart row's
+	 * quantity input. Uses the cart item key available in this filter.
+	 *
+	 * @param string $product_quantity The quantity input HTML.
+	 * @param string $cart_item_key    The cart item key.
+	 * @param array  $cart_item        The cart item (unused).
+	 * @return string
+	 */
+	public function inject_quantity_directives( $product_quantity, $cart_item_key, $cart_item ): string {
+		unset( $cart_item );
+		if ( ! $this->is_iapi_cart_active() ) {
+			return (string) $product_quantity;
+		}
+
+		$processor = new WP_HTML_Tag_Processor( (string) $product_quantity );
+		if ( $processor->next_tag( array( 'tag_name' => 'INPUT', 'class_name' => 'qty' ) ) ) {
+			$processor->set_attribute( 'data-wp-on--change', self::STORE_NAMESPACE . '::actions.changeQuantity' );
+			$processor->set_attribute( 'data-wp-context', (string) wp_json_encode( array( 'cartItemKey' => $cart_item_key ) ) );
+		}
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Add the remove-item directive + per-row context to a cart row's remove
+	 * link.
+	 *
+	 * @param string $link          The remove link HTML.
+	 * @param string $cart_item_key The cart item key.
+	 * @return string
+	 */
+	public function inject_remove_directives( $link, $cart_item_key ): string {
+		if ( ! $this->is_iapi_cart_active() ) {
+			return (string) $link;
+		}
+
+		$processor = new WP_HTML_Tag_Processor( (string) $link );
+		if ( $processor->next_tag( array( 'tag_name' => 'A' ) ) ) {
+			$processor->set_attribute( 'data-wp-on--click', self::STORE_NAMESPACE . '::actions.removeItem' );
+			$processor->set_attribute( 'data-wp-context', (string) wp_json_encode( array( 'cartItemKey' => $cart_item_key ) ) );
+		}
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Hydrate the shared 'woocommerce' store server-side and enqueue the iAPI
+	 * module.
+	 *
+	 * @return void
+	 */
+	private function hydrate_and_enqueue(): void {
+		if ( class_exists( BlocksSharedState::class ) ) {
+			$consent = 'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WooCommerce';
+			BlocksSharedState::load_cart_state( $consent );
+			BlocksSharedState::load_store_config( $consent );
+		}
 
 		/*
-		 * TODO (Phase 2): enqueue the 'woocommerce/cart' iAPI script module and
-		 * hydrate the shared 'woocommerce' store via BlocksSharedState, then
-		 * inject the iAPI directives onto the rendered cart markup. Until that
-		 * lands, enabling the flag yields a non-interactive cart, which is why
-		 * the flag ships off in core.json.
+		 * TODO (Phase 2 build wiring): register the 'woocommerce/classic-cart'
+		 * script module via AssetsController + the interactivity script-module
+		 * build, then enqueue it here:
+		 *   wp_enqueue_script_module( self::STORE_NAMESPACE );
+		 * Until the module is registered, enqueuing would warn, so it is left
+		 * out. The directive injection above is already build-independent.
 		 */
 	}
 
 	/**
 	 * Whether the Interactivity API cart should take over on the current request.
-	 *
-	 * Mirrors the condition used to enqueue 'wc-cart' (the cart page), gated by
-	 * the experimental feature flag.
 	 *
 	 * @return bool
 	 */

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -1,0 +1,82 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Interactivity;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Gates the Interactivity API takeover of the classic cart shortcode.
+ *
+ * When the 'experimental-iapi-cart' feature is enabled, the classic cart is
+ * driven by the Interactivity API instead of the legacy jQuery layer
+ * (assets/js/frontend/cart.js, enqueued as 'wc-cart'). This controller is the
+ * single switch point: it removes the legacy script and will enqueue the iAPI
+ * module + hydrate the shared cart store.
+ *
+ * The legacy implementation is left fully intact so the two can run side by
+ * side; only the feature flag decides which one is active. The cart fragments
+ * script ('wc-cart-fragments') is intentionally NOT dequeued, since the classic
+ * Mini-Cart widget still relies on it.
+ *
+ * @since 11.0.0
+ */
+class ClassicCartInteractivity implements RegisterHooksInterface {
+
+	/**
+	 * Script handle of the legacy cart frontend (assets/js/frontend/cart.js).
+	 *
+	 * @var string
+	 */
+	private const LEGACY_CART_SCRIPT_HANDLE = 'wc-cart';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Runs after WC_Frontend_Scripts::load_scripts() (default priority) has
+		// enqueued 'wc-cart', so the handle exists to be dequeued.
+		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_take_over_cart' ), 100 );
+	}
+
+	/**
+	 * Swap the legacy cart scripts for the Interactivity API implementation.
+	 *
+	 * @return void
+	 */
+	public function maybe_take_over_cart(): void {
+		if ( ! $this->is_iapi_cart_active() ) {
+			return;
+		}
+
+		// Remove the legacy jQuery interaction layer. Its server-side fallbacks
+		// (form POST handler, wc-ajax endpoints) stay registered for no-JS and
+		// back-compat.
+		wp_dequeue_script( self::LEGACY_CART_SCRIPT_HANDLE );
+
+		/*
+		 * TODO (Phase 2): enqueue the 'woocommerce/cart' iAPI script module and
+		 * hydrate the shared 'woocommerce' store via BlocksSharedState, then
+		 * inject the iAPI directives onto the rendered cart markup. Until that
+		 * lands, enabling the flag yields a non-interactive cart, which is why
+		 * the flag ships off in core.json.
+		 */
+	}
+
+	/**
+	 * Whether the Interactivity API cart should take over on the current request.
+	 *
+	 * Mirrors the condition used to enqueue 'wc-cart' (the cart page), gated by
+	 * the experimental feature flag.
+	 *
+	 * @return bool
+	 */
+	private function is_iapi_cart_active(): bool {
+		return is_cart() && Features::is_enabled( 'experimental-iapi-cart' );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -23,8 +23,8 @@ defined( 'ABSPATH' ) || exit;
  *   - injects Interactivity directives onto the server-rendered cart markup
  *     (without editing the templates) so the existing PHP hooks/filters keep
  *     producing the HTML;
- *   - (TODO) enqueues the 'woocommerce/classic-cart' script module once it is
- *     registered through the script-module build / AssetsController.
+ *   - enqueues the 'woocommerce/classic-cart' script module (registered through
+ *     the script-module build / AssetsController).
  *
  * The legacy implementation is left fully intact so the two run side by side;
  * only the feature flag decides which is active. 'wc-cart-fragments' is NOT
@@ -159,7 +159,12 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 		}
 
 		$processor = new WP_HTML_Tag_Processor( (string) $product_quantity );
-		if ( $processor->next_tag( array( 'tag_name' => 'INPUT', 'class_name' => 'qty' ) ) ) {
+		if ( $processor->next_tag(
+			array(
+				'tag_name'   => 'INPUT',
+				'class_name' => 'qty',
+			)
+		) ) {
 			$processor->set_attribute( 'data-wp-on--change', self::STORE_NAMESPACE . '::actions.changeQuantity' );
 			$processor->set_attribute( 'data-wp-context', (string) wp_json_encode( array( 'cartItemKey' => $cart_item_key ) ) );
 		}

--- a/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
+++ b/plugins/woocommerce/src/Internal/Interactivity/ClassicCartInteractivity.php
@@ -200,14 +200,12 @@ class ClassicCartInteractivity implements RegisterHooksInterface {
 			BlocksSharedState::load_store_config( $consent );
 		}
 
-		/*
-		 * TODO (Phase 2 build wiring): register the 'woocommerce/classic-cart'
-		 * script module via AssetsController + the interactivity script-module
-		 * build, then enqueue it here:
-		 *   wp_enqueue_script_module( self::STORE_NAMESPACE );
-		 * Until the module is registered, enqueuing would warn, so it is left
-		 * out. The directive injection above is already build-independent.
-		 */
+		// The module is built from client/blocks/assets/js/classic-cart/frontend.ts
+		// (see webpack-config-interactive-blocks.js) and auto-registered by
+		// AssetsController::register_script_modules() from the combined asset
+		// file. Enqueuing before registration is a safe no-op until the build
+		// has run.
+		wp_enqueue_script_module( self::STORE_NAMESPACE );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

**Spike (draft, not for merge as-is):** explore migrating the classic cart shortcode (`[woocommerce_cart]`) to the Interactivity API (iAPI) *without* blockifying it.

The approach is **interactivity-only** and **flag-gated** (`experimental-iapi-cart`, off by default):

- The cart stays PHP-templated and hook-driven — `cart.php` / `cart-totals.php` keep rendering, so every `do_action` / `apply_filters` still fires and theme overrides keep working.
- iAPI replaces only the legacy jQuery/Ajax interaction layer (`cart.js`). Mutations go through the shared `woocommerce` store (Store API); a thin `woocommerce/classic-cart` store holds classic-only behavior (shipping rate, customer address, undo, plus the glue).
- Directives are injected onto the already-rendered markup with `WP_HTML_Tag_Processor` (no template edits, no version bumps), and the cart re-renders after each change via the Interactivity Router so the hooks re-run.

Also adds a migration plan and a legacy-mechanism parity audit under `plugins/woocommerce/client/blocks/docs/internal-developers/iapi-classic-cart-migration/`.

**Split out from this spike:** #66051 — makes the shared cart store's `removeCartItem` idempotent. It's a pre-existing bug in the shared store (not introduced here) that this spike surfaced, so it ships as its own PR against `trunk` and benefits the Cart block and Mini-Cart too. Independent of this draft; no hard dependency.

⚠️ Main open item: Store API mutations bypass the legacy `wc_add_notice` notice/undo system. See the audit + plan for the full status and open decisions.

### How to test the changes in this Pull Request:

1. Set the Cart page content to the `[woocommerce_cart]` shortcode (the default page uses the Cart block).
2. Enable the `experimental-iapi-cart` feature flag (on by default in `development.json`).
3. With items in the cart: change a quantity, apply/remove a coupon, use the shipping calculator, and empty the cart — each updates without a full page reload, with `cart.js` dequeued and no console errors.
4. Add a product from another block on the page (Wishlist "move to cart" / Product Collection) and confirm the classic cart refreshes.
5. Turn the flag off and confirm the legacy cart behaves exactly as before.

### Testing that has already taken place:

Verified live on a Studio site with the flag on: quantity, apply/remove coupon, shipping calculator, empty-cart transition, and cross-block add-to-cart (Wishlist + Product Collection), with no console errors and `cart.js` fully dequeued. Static checks (phpcs, phpstan, eslint) are clean and the module builds. `tests/e2e-pw/tests/cart/cart.spec.ts` with the flag on: non-removal flows pass; two removal tests fail (the notice/undo gap above, and a Playwright re-render timing issue that passes manually) — both documented in the audit.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Exploratory spike behind the experimental, off-by-default `experimental-iapi-cart` flag; no shipped behavior change. A changelog entry will be added if/when this graduates from a spike.

</details>

