### PR TITLE
Fix tax recommendations card not staying dismissed in non-production environments

### DIFF
--- a/plugins/woocommerce/client/admin/client/abandoned-cart-recovery/abandoned-cart-recovery-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/abandoned-cart-recovery/abandoned-cart-recovery-recommendations.tsx
@@ -17,6 +17,7 @@ import {
 	DismissableListHeading,
 } from '../settings-recommendations/dismissable-list';
 import { TrackedLink } from '~/components/tracked-link/tracked-link';
+import { useOptionDismiss } from '~/hooks/use-option-dismiss';
 import { createNoticesFromResponse } from '../lib/notices';
 import AutomateWooItem from './automatewoo-item';
 import MailPoetItem from './mailpoet-item';
@@ -63,49 +64,55 @@ export const AbandonedCartRecoveryRecommendationsList = ( {
 	children,
 }: {
 	children: React.ReactNode;
-} ) => (
-	<DismissableList
-		className="woocommerce-recommended-abandoned-cart-recovery-extensions"
-		dismissOptionName="woocommerce_abandoned_cart_recovery_recommendations_hidden"
-	>
-		<DismissableListHeading>
-			<Text variant="title.small" as="p" size="20" lineHeight="28px">
-				{ __( 'Recover more abandoned carts', 'woocommerce' ) }
-			</Text>
-			<Text
-				className="woocommerce-recommended-abandoned-cart-recovery__header-heading"
-				variant="caption"
-				as="p"
-				size="12"
-				lineHeight="16px"
-			>
-				{ __(
-					'Add multi-step recovery flows, customer segmentation, and ongoing email marketing to win back more shoppers.',
-					'woocommerce'
-				) }
-			</Text>
-		</DismissableListHeading>
-		<ul className="woocommerce-list">
-			{ Children.map( children, ( item ) => (
-				<li className="woocommerce-list__item">{ item }</li>
-			) ) }
-		</ul>
-		<CardFooter>
-			<TrackedLink
-				message={ __(
-					// translators: {{Link}} is a placeholder for a html element.
-					'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more email marketing and customer engagement solutions.',
-					'woocommerce'
-				) }
-				targetUrl={ getAdminLink(
-					'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=marketing'
-				) }
-				linkType="wc-admin"
-				eventName="abandoned_cart_recovery_visit_marketplace_click"
-			/>
-		</CardFooter>
-	</DismissableList>
-);
+} ) => {
+	const { isDismissed, onDismiss } = useOptionDismiss(
+		'woocommerce_abandoned_cart_recovery_recommendations_hidden'
+	);
+
+	return (
+		<DismissableList
+			className="woocommerce-recommended-abandoned-cart-recovery-extensions"
+			isDismissed={ isDismissed }
+		>
+			<DismissableListHeading onDismiss={ onDismiss }>
+				<Text variant="title.small" as="p" size="20" lineHeight="28px">
+					{ __( 'Recover more abandoned carts', 'woocommerce' ) }
+				</Text>
+				<Text
+					className="woocommerce-recommended-abandoned-cart-recovery__header-heading"
+					variant="caption"
+					as="p"
+					size="12"
+					lineHeight="16px"
+				>
+					{ __(
+						'Add multi-step recovery flows, customer segmentation, and ongoing email marketing to win back more shoppers.',
+						'woocommerce'
+					) }
+				</Text>
+			</DismissableListHeading>
+			<ul className="woocommerce-list">
+				{ Children.map( children, ( item ) => (
+					<li className="woocommerce-list__item">{ item }</li>
+				) ) }
+			</ul>
+			<CardFooter>
+				<TrackedLink
+					message={ __(
+						// translators: {{Link}} is a placeholder for a html element.
+						'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more email marketing and customer engagement solutions.',
+						'woocommerce'
+					) }
+					targetUrl={ getAdminLink(
+						'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=marketing'
+					) }
+					linkType="wc-admin"
+					eventName="abandoned_cart_recovery_visit_marketplace_click"
+				/>
+			</CardFooter>
+		</DismissableList>
+	);
+};
 
 const AbandonedCartRecoveryRecommendations = () => {
 	const activePlugins = useSelect(

--- a/plugins/woocommerce/client/admin/client/abandoned-cart-recovery/test/abandoned-cart-recovery-recommendations.test.tsx
+++ b/plugins/woocommerce/client/admin/client/abandoned-cart-recovery/test/abandoned-cart-recovery-recommendations.test.tsx
@@ -22,6 +22,10 @@ jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
 		children,
 } ) );
 
+jest.mock( '~/hooks/use-option-dismiss', () => ( {
+	useOptionDismiss: () => ( { isDismissed: false, onDismiss: jest.fn() } ),
+} ) );
+
 const mockActivePlugins = ( plugins: string[] ) => {
 	( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
 		fn( () => ( {

--- a/plugins/woocommerce/client/admin/client/hooks/test/use-endpoint-dismiss.test.ts
+++ b/plugins/woocommerce/client/admin/client/hooks/test/use-endpoint-dismiss.test.ts
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { useEndpointDismiss } from '../use-endpoint-dismiss';
+import { createNoticesFromResponse } from '../../lib/notices';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../../lib/notices', () => ( {
+	createNoticesFromResponse: jest.fn(),
+} ) );
+
+const PATH = '/wc-admin/tax/recommendations/dismiss';
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'useEndpointDismiss', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'honours the initial dismissal state', () => {
+		const { result } = renderHook( () => useEndpointDismiss( PATH, true ) );
+
+		expect( result.current.isDismissed ).toBe( true );
+	} );
+
+	it( 'optimistically dismisses and POSTs to the endpoint', async () => {
+		mockApiFetch.mockResolvedValueOnce( { dismissed: true } );
+
+		const { result } = renderHook( () =>
+			useEndpointDismiss( PATH, false )
+		);
+
+		await act( async () => {
+			result.current.onDismiss();
+		} );
+
+		expect( result.current.isDismissed ).toBe( true );
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: PATH,
+			method: 'POST',
+		} );
+		expect( createNoticesFromResponse ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rolls back and surfaces a notice when the request fails', async () => {
+		const error = { code: 'fail', message: 'Nope' };
+		mockApiFetch.mockRejectedValueOnce( error );
+
+		const { result } = renderHook( () =>
+			useEndpointDismiss( PATH, false )
+		);
+
+		await act( async () => {
+			result.current.onDismiss();
+		} );
+
+		expect( result.current.isDismissed ).toBe( false );
+		expect( createNoticesFromResponse ).toHaveBeenCalledWith( error );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/hooks/test/use-option-dismiss.test.ts
+++ b/plugins/woocommerce/client/admin/client/hooks/test/use-option-dismiss.test.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useOptionDismiss } from '../use-option-dismiss';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+const OPTION_NAME = 'woocommerce_test_recommendations_hidden';
+
+const mockSelect = ( {
+	option,
+	hasResolved,
+}: {
+	option: string | boolean;
+	hasResolved: boolean;
+} ) => {
+	( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+		fn( () => ( {
+			getOption: () => option,
+			hasFinishedResolution: () => hasResolved,
+		} ) )
+	);
+};
+
+describe( 'useOptionDismiss', () => {
+	let updateOptions: jest.Mock;
+
+	beforeEach( () => {
+		updateOptions = jest.fn();
+		( useDispatch as jest.Mock ).mockReturnValue( { updateOptions } );
+	} );
+
+	it( 'treats an unresolved option as dismissed to avoid flashing the card', () => {
+		mockSelect( { option: false, hasResolved: false } );
+
+		const { result } = renderHook( () => useOptionDismiss( OPTION_NAME ) );
+
+		expect( result.current.isDismissed ).toBe( true );
+	} );
+
+	it( 'is dismissed when the resolved option is "yes"', () => {
+		mockSelect( { option: 'yes', hasResolved: true } );
+
+		const { result } = renderHook( () => useOptionDismiss( OPTION_NAME ) );
+
+		expect( result.current.isDismissed ).toBe( true );
+	} );
+
+	it( 'is not dismissed when the resolved option is not "yes"', () => {
+		mockSelect( { option: false, hasResolved: true } );
+
+		const { result } = renderHook( () => useOptionDismiss( OPTION_NAME ) );
+
+		expect( result.current.isDismissed ).toBe( false );
+	} );
+
+	it( 'persists the dismissal through updateOptions', () => {
+		mockSelect( { option: false, hasResolved: true } );
+
+		const { result } = renderHook( () => useOptionDismiss( OPTION_NAME ) );
+
+		act( () => {
+			result.current.onDismiss();
+		} );
+
+		expect( updateOptions ).toHaveBeenCalledWith( {
+			[ OPTION_NAME ]: 'yes',
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/hooks/use-endpoint-dismiss.ts
+++ b/plugins/woocommerce/client/admin/client/hooks/use-endpoint-dismiss.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { createNoticesFromResponse } from '../lib/notices';
+import type { DismissState } from './use-option-dismiss';
+
+/**
+ * Dismissal state persisted through a dedicated REST endpoint.
+ *
+ * Used when the dismissal cannot ride the (frozen) options REST API and instead
+ * has a purpose-built endpoint. The initial state is supplied by the caller
+ * (typically preloaded into wc-admin settings) so the card renders the correct
+ * visibility without an extra request.
+ *
+ * The dismissal is optimistic: the card hides immediately, then the endpoint is
+ * called. If the request fails the card is restored and an error notice is
+ * surfaced so the failure is not silent.
+ *
+ * @param path    The REST path to POST to in order to persist the dismissal.
+ * @param initial The initial dismissal state (e.g. from preloaded settings).
+ * @return The current dismissal state and a callback to dismiss.
+ */
+export const useEndpointDismiss = (
+	path: string,
+	initial: boolean
+): DismissState => {
+	const [ isDismissed, setIsDismissed ] = useState< boolean >( initial );
+
+	const onDismiss = () => {
+		// Optimistically hide the card, then persist the dismissal site-wide.
+		setIsDismissed( true );
+		apiFetch( { path, method: 'POST' } ).catch( ( response ) => {
+			// Restore the card and surface the failure so the state stays
+			// accurate and the merchant is not left without feedback.
+			setIsDismissed( false );
+			createNoticesFromResponse( response );
+		} );
+	};
+
+	return { isDismissed, onDismiss };
+};

--- a/plugins/woocommerce/client/admin/client/hooks/use-option-dismiss.ts
+++ b/plugins/woocommerce/client/admin/client/hooks/use-option-dismiss.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { optionsStore } from '@woocommerce/data';
+
+export type DismissState = {
+	isDismissed: boolean;
+	onDismiss: () => void;
+};
+
+/**
+ * Dismissal state backed by a WordPress option (via the wc-admin options store).
+ *
+ * The option is treated as a "yes"/"no" flag: a value of `'yes'` means the
+ * related card has been dismissed. While the option is still resolving the card
+ * is treated as dismissed so it does not flash before we know its real state.
+ *
+ * @param optionName The option name used to persist the dismissal.
+ * @return The current dismissal state and a callback to dismiss.
+ */
+export const useOptionDismiss = ( optionName: string ): DismissState => {
+	const isDismissed = useSelect(
+		( select ) => {
+			const { getOption, hasFinishedResolution } = select( optionsStore );
+
+			const hasResolved = hasFinishedResolution( 'getOption', [
+				optionName,
+			] );
+
+			// Treat "not yet resolved" as dismissed so the card does not flash
+			// before the option value is known.
+			return ! hasResolved || getOption( optionName ) === 'yes';
+		},
+		[ optionName ]
+	);
+
+	const { updateOptions } = useDispatch( optionsStore );
+
+	const onDismiss = () => {
+		updateOptions( { [ optionName ]: 'yes' } );
+	};
+
+	return { isDismissed, onDismiss };
+};

--- a/plugins/woocommerce/client/admin/client/hooks/use-option-dismiss.ts
+++ b/plugins/woocommerce/client/admin/client/hooks/use-option-dismiss.ts
@@ -24,13 +24,20 @@ export const useOptionDismiss = ( optionName: string ): DismissState => {
 		( select ) => {
 			const { getOption, hasFinishedResolution } = select( optionsStore );
 
+			// Read the option first so the resolver is always triggered. Calling
+			// `getOption` is what kicks off the fetch; gating it behind the
+			// resolution check (e.g. via `||` short-circuit) would mean it is
+			// never called while unresolved, so resolution would never start and
+			// the card would stay hidden forever.
+			const value = getOption( optionName );
+
 			const hasResolved = hasFinishedResolution( 'getOption', [
 				optionName,
 			] );
 
 			// Treat "not yet resolved" as dismissed so the card does not flash
 			// before the option value is known.
-			return ! hasResolved || getOption( optionName ) === 'yes';
+			return ! hasResolved || value === 'yes';
 		},
 		[ optionName ]
 	);

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { Button, Card, CardHeader } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
 import { EllipsisMenu } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -48,12 +50,18 @@ export const DismissableListHeading = ( {
 };
 
 /**
- * Pure UI wrapper for a dismissable recommendation card. Renders nothing when
+ * Pure UI wrapper for a dismissable recommendation card. Hides the `Card` when
  * `isDismissed` is true, otherwise wraps `children` in a `Card`.
  *
  * This component holds no persistence logic. Callers manage the dismissal state
  * with a hook and pass the resulting `isDismissed` here and `onDismiss` to the
  * nested {@link DismissableListHeading}.
+ *
+ * Dismissing the card unmounts whatever element held focus (the ellipsis menu
+ * button or its popover), which would otherwise drop keyboard and screen reader
+ * users onto `document.body` with no announcement. To keep them oriented, the
+ * surrounding wrapper stays mounted as a focus target: on dismissal we move
+ * focus to it and announce the change with `speak()`.
  */
 export const DismissableList = ( {
 	children,
@@ -63,20 +71,43 @@ export const DismissableList = ( {
 	children: React.ReactNode;
 	className?: string;
 	/**
-	 * Whether the card has been dismissed. When true the component renders null.
+	 * Whether the card has been dismissed. When true the card is hidden.
 	 */
 	isDismissed?: boolean;
 } ) => {
-	if ( isDismissed ) {
-		return null;
-	}
+	const wrapperRef = useRef< HTMLDivElement >( null );
+	// Seed with the initial value so an already-dismissed card on first render
+	// is treated as steady state, not a fresh dismissal.
+	const wasDismissed = useRef( isDismissed );
+
+	useEffect( () => {
+		if ( isDismissed && ! wasDismissed.current ) {
+			speak( __( 'Recommendation hidden.', 'woocommerce' ), 'assertive' );
+			wrapperRef.current?.focus();
+		}
+
+		wasDismissed.current = isDismissed;
+	}, [ isDismissed ] );
 
 	return (
-		<Card
-			size="medium"
-			className={ clsx( 'woocommerce-dismissable-list', className ) }
+		<div
+			ref={ wrapperRef }
+			// Programmatically focusable (not in the tab order) so focus can
+			// land here once the card unmounts on dismissal.
+			tabIndex={ -1 }
+			className="woocommerce-dismissable-list__wrapper"
 		>
-			{ children }
-		</Card>
+			{ ! isDismissed && (
+				<Card
+					size="medium"
+					className={ clsx(
+						'woocommerce-dismissable-list',
+						className
+					) }
+				>
+					{ children }
+				</Card>
+			) }
+		</div>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
@@ -29,9 +29,13 @@ export const DismissableListHeading = ( {
 
 	const handleDismissClick = () => {
 		onDismiss();
-		updateOptions( {
-			[ dismissOptionName ]: 'yes',
-		} );
+		// When no option name is provided the list is controlled by the parent
+		// (e.g. persisted as a user preference), so skip the legacy Options API.
+		if ( dismissOptionName ) {
+			updateOptions( {
+				[ dismissOptionName ]: 'yes',
+			} );
+		}
 	};
 
 	return (
@@ -59,25 +63,41 @@ export const DismissableList = ( {
 	children,
 	className,
 	dismissOptionName,
+	isDismissed,
 }: {
 	children: React.ReactNode;
 	className?: string;
-	dismissOptionName: string;
+	/**
+	 * Legacy Options API option name used to persist the dismissal. Omit when
+	 * the parent controls dismissal (e.g. via a dedicated endpoint) and pass
+	 * `isDismissed` instead.
+	 */
+	dismissOptionName?: string;
+	/**
+	 * Controlled dismissal state. Only used when `dismissOptionName` is omitted.
+	 */
+	isDismissed?: boolean;
 } ) => {
-	const isVisible = useSelect(
+	const optionIsVisible = useSelect(
 		( select ) => {
+			if ( ! dismissOptionName ) {
+				return null;
+			}
+
 			const { getOption, hasFinishedResolution } = select( optionsStore );
 
 			const hasFinishedResolving = hasFinishedResolution( 'getOption', [
 				dismissOptionName,
 			] );
 
-			const isDismissed = getOption( dismissOptionName ) === 'yes';
-
-			return hasFinishedResolving && ! isDismissed;
+			return (
+				hasFinishedResolving && getOption( dismissOptionName ) !== 'yes'
+			);
 		},
 		[ dismissOptionName ]
 	);
+
+	const isVisible = dismissOptionName ? optionIsVisible : ! isDismissed;
 
 	if ( ! isVisible ) {
 		return null;
@@ -88,7 +108,7 @@ export const DismissableList = ( {
 			size="medium"
 			className={ clsx( 'woocommerce-dismissable-list', className ) }
 		>
-			<OptionNameContext.Provider value={ dismissOptionName }>
+			<OptionNameContext.Provider value={ dismissOptionName ?? '' }>
 				{ children }
 			</OptionNameContext.Provider>
 		</Card>

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
@@ -1,12 +1,9 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Card, CardHeader } from '@wordpress/components';
-import { optionsStore } from '@woocommerce/data';
 import { EllipsisMenu } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
-import { createContext, useContext } from '@wordpress/element';
 import clsx from 'clsx';
 
 /**
@@ -14,9 +11,14 @@ import clsx from 'clsx';
  */
 import './dismissable-list.scss';
 
-// using a context provider for the option name so that the option name prop doesn't need to be passed to the `DismissableListHeading` too
-const OptionNameContext = createContext( '' );
-
+/**
+ * Presentational heading for a {@link DismissableList}. Renders the card header
+ * and an ellipsis menu with a "Hide this" action that invokes `onDismiss`.
+ *
+ * Persistence is intentionally not handled here — the parent owns the dismissal
+ * state and supplies `onDismiss` (typically from a dismiss hook such as
+ * `useOptionDismiss` or `useEndpointDismiss`).
+ */
 export const DismissableListHeading = ( {
 	onDismiss = () => null,
 	children,
@@ -24,20 +26,6 @@ export const DismissableListHeading = ( {
 	children: React.ReactNode;
 	onDismiss?: () => void;
 } ) => {
-	const { updateOptions } = useDispatch( optionsStore );
-	const dismissOptionName = useContext( OptionNameContext );
-
-	const handleDismissClick = () => {
-		onDismiss();
-		// Persist via the legacy Options API only in option-backed mode. In
-		// controlled mode (no option name) the parent handles persistence.
-		if ( dismissOptionName ) {
-			updateOptions( {
-				[ dismissOptionName ]: 'yes',
-			} );
-		}
-	};
-
 	return (
 		<CardHeader>
 			<div className="woocommerce-dismissable-list__header">
@@ -48,7 +36,7 @@ export const DismissableListHeading = ( {
 					label={ __( 'Task List Options', 'woocommerce' ) }
 					renderContent={ () => (
 						<div className="woocommerce-dismissable-list__controls">
-							<Button onClick={ handleDismissClick }>
+							<Button onClick={ onDismiss }>
 								{ __( 'Hide this', 'woocommerce' ) }
 							</Button>
 						</div>
@@ -59,47 +47,27 @@ export const DismissableListHeading = ( {
 	);
 };
 
+/**
+ * Pure UI wrapper for a dismissable recommendation card. Renders nothing when
+ * `isDismissed` is true, otherwise wraps `children` in a `Card`.
+ *
+ * This component holds no persistence logic. Callers manage the dismissal state
+ * with a hook and pass the resulting `isDismissed` here and `onDismiss` to the
+ * nested {@link DismissableListHeading}.
+ */
 export const DismissableList = ( {
 	children,
 	className,
-	dismissOptionName,
 	isDismissed,
 }: {
 	children: React.ReactNode;
 	className?: string;
 	/**
-	 * Legacy Options API option name used to persist the dismissal. Omit when
-	 * the parent controls dismissal (e.g. via a dedicated endpoint) and pass
-	 * `isDismissed` instead.
-	 */
-	dismissOptionName?: string;
-	/**
-	 * Controlled dismissal state. Only used when `dismissOptionName` is omitted.
+	 * Whether the card has been dismissed. When true the component renders null.
 	 */
 	isDismissed?: boolean;
 } ) => {
-	const optionIsVisible = useSelect(
-		( select ) => {
-			if ( ! dismissOptionName ) {
-				return null;
-			}
-
-			const { getOption, hasFinishedResolution } = select( optionsStore );
-
-			const hasFinishedResolving = hasFinishedResolution( 'getOption', [
-				dismissOptionName,
-			] );
-
-			return (
-				hasFinishedResolving && getOption( dismissOptionName ) !== 'yes'
-			);
-		},
-		[ dismissOptionName ]
-	);
-
-	const isVisible = dismissOptionName ? optionIsVisible : ! isDismissed;
-
-	if ( ! isVisible ) {
+	if ( isDismissed ) {
 		return null;
 	}
 
@@ -108,9 +76,7 @@ export const DismissableList = ( {
 			size="medium"
 			className={ clsx( 'woocommerce-dismissable-list', className ) }
 		>
-			<OptionNameContext.Provider value={ dismissOptionName ?? '' }>
-				{ children }
-			</OptionNameContext.Provider>
+			{ children }
 		</Card>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
@@ -29,8 +29,8 @@ export const DismissableListHeading = ( {
 
 	const handleDismissClick = () => {
 		onDismiss();
-		// When no option name is provided the list is controlled by the parent
-		// (e.g. persisted as a user preference), so skip the legacy Options API.
+		// Persist via the legacy Options API only in option-backed mode. In
+		// controlled mode (no option name) the parent handles persistence.
 		if ( dismissOptionName ) {
 			updateOptions( {
 				[ dismissOptionName ]: 'yes',

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
@@ -3,11 +3,16 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import { DismissableList, DismissableListHeading } from '../dismissable-list';
+
+jest.mock( '@wordpress/a11y', () => ( {
+	speak: jest.fn(),
+} ) );
 
 describe( 'DismissableList', () => {
 	it( 'renders its children when isDismissed is false', () => {
@@ -44,6 +49,49 @@ describe( 'DismissableList', () => {
 		expect(
 			screen.queryByText( 'dismissible children' )
 		).not.toBeInTheDocument();
+	} );
+
+	describe( 'dismissal accessibility', () => {
+		beforeEach( () => {
+			speak.mockClear();
+		} );
+
+		it( 'announces and moves focus to a stable element when dismissed', () => {
+			const { container, rerender } = render(
+				<DismissableList isDismissed={ false }>
+					<span>dismissible children</span>
+				</DismissableList>
+			);
+
+			const wrapper = container.querySelector(
+				'.woocommerce-dismissable-list__wrapper'
+			);
+
+			rerender(
+				<DismissableList isDismissed={ true }>
+					<span>dismissible children</span>
+				</DismissableList>
+			);
+
+			expect( speak ).toHaveBeenCalledWith(
+				'Recommendation hidden.',
+				'assertive'
+			);
+			// The wrapper stays mounted so focus has somewhere to land.
+			expect( wrapper ).toBeInTheDocument();
+			expect( wrapper ).toHaveFocus();
+		} );
+
+		it( 'does not announce or steal focus when dismissed on first render', () => {
+			render(
+				<DismissableList isDismissed={ true }>
+					<span>dismissible children</span>
+				</DismissableList>
+			);
+
+			expect( speak ).not.toHaveBeenCalled();
+			expect( document.body ).toHaveFocus();
+		} );
 	} );
 } );
 

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
@@ -97,3 +97,55 @@ describe( 'DismissableList', () => {
 		);
 	} );
 } );
+
+describe( 'DismissableList (controlled mode)', () => {
+	beforeEach( () => {
+		// In controlled mode (no dismissOptionName) the visibility selector
+		// short-circuits to null, so the Options API is never consulted.
+		useSelect.mockImplementation( ( fn ) => fn( () => ( {} ) ) );
+		useDispatch.mockReturnValue( { updateOptions: () => null } );
+	} );
+
+	it( 'renders its children when isDismissed is false', () => {
+		render(
+			<DismissableList isDismissed={ false }>
+				<span>controlled children</span>
+			</DismissableList>
+		);
+
+		expect(
+			screen.queryByText( 'controlled children' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not render its children when isDismissed is true', () => {
+		render(
+			<DismissableList isDismissed={ true }>
+				<span>controlled children</span>
+			</DismissableList>
+		);
+
+		expect(
+			screen.queryByText( 'controlled children' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onDismiss without touching the legacy Options API when no option name is provided', () => {
+		const handleDismissMock = jest.fn();
+		const updateOptionsMock = jest.fn();
+		useDispatch.mockReturnValue( { updateOptions: updateOptionsMock } );
+		render(
+			<DismissableList isDismissed={ false }>
+				<DismissableListHeading onDismiss={ handleDismissMock }>
+					controlled heading
+				</DismissableListHeading>
+			</DismissableList>
+		);
+
+		userEvent.click( screen.getByTitle( 'Task List Options' ) );
+		userEvent.click( screen.getByText( 'Hide this' ) );
+
+		expect( handleDismissMock ).toHaveBeenCalled();
+		expect( updateOptionsMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/test/dismissable-list.test.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import { useDispatch, useSelect } from '@wordpress/data';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -10,142 +9,78 @@ import userEvent from '@testing-library/user-event';
  */
 import { DismissableList, DismissableListHeading } from '../dismissable-list';
 
-jest.mock( '@wordpress/data', () => ( {
-	...jest.requireActual( '@wordpress/data' ),
-	useSelect: jest.fn(),
-	useDispatch: jest.fn(),
-} ) );
-
-const DismissableListMock = ( { children } ) => (
-	<DismissableList dismissOptionName="dismissable_option_mock">
-		{ children }
-		<span>dismissible children</span>
-	</DismissableList>
-);
-
 describe( 'DismissableList', () => {
-	beforeEach( () => {
-		useSelect.mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getOption: () => false,
-				hasFinishedResolution: () => true,
-			} ) )
-		);
-		useDispatch.mockReturnValue( { updateOptions: () => null } );
-	} );
-
-	it( 'should not render its children when the option is not resolved', () => {
-		useSelect.mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getOption: () => false,
-				hasFinishedResolution: () => false,
-			} ) )
-		);
-		render( <DismissableListMock /> );
-
-		expect(
-			screen.queryByText( 'dismissible children' )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'should not render its children when the option is dismissed', () => {
-		useSelect.mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getOption: () => 'yes',
-				hasFinishedResolution: () => true,
-			} ) )
-		);
-		render( <DismissableListMock /> );
-
-		expect(
-			screen.queryByText( 'dismissible children' )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'render its children', () => {
-		render( <DismissableListMock /> );
-
-		expect(
-			screen.queryByText( 'dismissible children' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'should allow dismissing the option through the DismissableListHeading component', () => {
-		const handleDismissMock = jest.fn();
-		const updateOptionsMock = jest.fn();
-		useDispatch.mockReturnValue( { updateOptions: updateOptionsMock } );
-		render(
-			<DismissableListMock>
-				<DismissableListHeading onDismiss={ handleDismissMock }>
-					heading content mock
-				</DismissableListHeading>
-			</DismissableListMock>
-		);
-
-		expect(
-			screen.queryByText( 'heading content mock' )
-		).toBeInTheDocument();
-
-		userEvent.click( screen.getByTitle( 'Task List Options' ) );
-		userEvent.click( screen.getByText( 'Hide this' ) );
-
-		expect( handleDismissMock ).toHaveBeenCalled();
-		expect( updateOptionsMock ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				dismissable_option_mock: 'yes',
-			} )
-		);
-	} );
-} );
-
-describe( 'DismissableList (controlled mode)', () => {
-	beforeEach( () => {
-		// In controlled mode (no dismissOptionName) the visibility selector
-		// short-circuits to null, so the Options API is never consulted.
-		useSelect.mockImplementation( ( fn ) => fn( () => ( {} ) ) );
-		useDispatch.mockReturnValue( { updateOptions: () => null } );
-	} );
-
 	it( 'renders its children when isDismissed is false', () => {
 		render(
 			<DismissableList isDismissed={ false }>
-				<span>controlled children</span>
+				<span>dismissible children</span>
 			</DismissableList>
 		);
 
 		expect(
-			screen.queryByText( 'controlled children' )
+			screen.queryByText( 'dismissible children' )
 		).toBeInTheDocument();
 	} );
 
-	it( 'does not render its children when isDismissed is true', () => {
+	it( 'renders its children when isDismissed is omitted', () => {
 		render(
-			<DismissableList isDismissed={ true }>
-				<span>controlled children</span>
+			<DismissableList>
+				<span>dismissible children</span>
 			</DismissableList>
 		);
 
 		expect(
-			screen.queryByText( 'controlled children' )
-		).not.toBeInTheDocument();
+			screen.queryByText( 'dismissible children' )
+		).toBeInTheDocument();
 	} );
 
-	it( 'calls onDismiss without touching the legacy Options API when no option name is provided', () => {
-		const handleDismissMock = jest.fn();
-		const updateOptionsMock = jest.fn();
-		useDispatch.mockReturnValue( { updateOptions: updateOptionsMock } );
+	it( 'renders nothing when isDismissed is true', () => {
 		render(
-			<DismissableList isDismissed={ false }>
-				<DismissableListHeading onDismiss={ handleDismissMock }>
-					controlled heading
-				</DismissableListHeading>
+			<DismissableList isDismissed={ true }>
+				<span>dismissible children</span>
 			</DismissableList>
+		);
+
+		expect(
+			screen.queryByText( 'dismissible children' )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'DismissableListHeading', () => {
+	it( 'renders its children', () => {
+		render(
+			<DismissableListHeading>
+				<span>heading content</span>
+			</DismissableListHeading>
+		);
+
+		expect( screen.queryByText( 'heading content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onDismiss when "Hide this" is clicked', () => {
+		const onDismiss = jest.fn();
+		render(
+			<DismissableListHeading onDismiss={ onDismiss }>
+				heading content
+			</DismissableListHeading>
 		);
 
 		userEvent.click( screen.getByTitle( 'Task List Options' ) );
 		userEvent.click( screen.getByText( 'Hide this' ) );
 
-		expect( handleDismissMock ).toHaveBeenCalled();
-		expect( updateOptionsMock ).not.toHaveBeenCalled();
+		expect( onDismiss ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not throw when "Hide this" is clicked without an onDismiss prop', () => {
+		render(
+			<DismissableListHeading>heading content</DismissableListHeading>
+		);
+
+		userEvent.click( screen.getByTitle( 'Task List Options' ) );
+
+		expect( () =>
+			userEvent.click( screen.getByText( 'Hide this' ) )
+		).not.toThrow();
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
@@ -20,6 +20,7 @@ import {
 import WoocommerceShippingItem from './woocommerce-shipping-item';
 import './shipping-recommendations.scss';
 import { TrackedLink } from '~/components/tracked-link/tracked-link';
+import { useOptionDismiss } from '~/hooks/use-option-dismiss';
 
 export const useInstallPlugin = () => {
 	const [ pluginsBeingSetup, setPluginsBeingSetup ] = useState<
@@ -98,49 +99,55 @@ export const ShippingRecommendationsList = ( {
 	children,
 }: {
 	children: React.ReactNode;
-} ) => (
-	<DismissableList
-		className="woocommerce-recommended-shipping-extensions"
-		dismissOptionName="woocommerce_settings_shipping_recommendations_hidden"
-	>
-		<DismissableListHeading>
-			<Text variant="title.small" as="p" size="20" lineHeight="28px">
-				{ __( 'Recommended shipping solutions', 'woocommerce' ) }
-			</Text>
-			<Text
-				className="woocommerce-recommended-shipping__header-heading"
-				variant="caption"
-				as="p"
-				size="12"
-				lineHeight="16px"
-			>
-				{ __(
-					'We recommend adding one of the following shipping extensions to your store.',
-					'woocommerce'
-				) }
-			</Text>
-		</DismissableListHeading>
-		<ul className="woocommerce-list">
-			{ Children.map( children, ( item ) => (
-				<li className="woocommerce-list__item">{ item }</li>
-			) ) }
-		</ul>
-		<CardFooter>
-			<TrackedLink
-				message={ __(
-					// translators: {{Link}} is a placeholder for a html element.
-					'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more shipping, delivery, and fulfillment solutions.',
-					'woocommerce'
-				) }
-				targetUrl={ getAdminLink(
-					'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=shipping-delivery-and-fulfillment'
-				) }
-				linkType="wc-admin"
-				eventName="settings_shipping_recommendation_visit_marketplace_click"
-			/>
-		</CardFooter>
-	</DismissableList>
-);
+} ) => {
+	const { isDismissed, onDismiss } = useOptionDismiss(
+		'woocommerce_settings_shipping_recommendations_hidden'
+	);
+
+	return (
+		<DismissableList
+			className="woocommerce-recommended-shipping-extensions"
+			isDismissed={ isDismissed }
+		>
+			<DismissableListHeading onDismiss={ onDismiss }>
+				<Text variant="title.small" as="p" size="20" lineHeight="28px">
+					{ __( 'Recommended shipping solutions', 'woocommerce' ) }
+				</Text>
+				<Text
+					className="woocommerce-recommended-shipping__header-heading"
+					variant="caption"
+					as="p"
+					size="12"
+					lineHeight="16px"
+				>
+					{ __(
+						'We recommend adding one of the following shipping extensions to your store.',
+						'woocommerce'
+					) }
+				</Text>
+			</DismissableListHeading>
+			<ul className="woocommerce-list">
+				{ Children.map( children, ( item ) => (
+					<li className="woocommerce-list__item">{ item }</li>
+				) ) }
+			</ul>
+			<CardFooter>
+				<TrackedLink
+					message={ __(
+						// translators: {{Link}} is a placeholder for a html element.
+						'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more shipping, delivery, and fulfillment solutions.',
+						'woocommerce'
+					) }
+					targetUrl={ getAdminLink(
+						'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=shipping-delivery-and-fulfillment'
+					) }
+					linkType="wc-admin"
+					eventName="settings_shipping_recommendation_visit_marketplace_click"
+				/>
+			</CardFooter>
+		</DismissableList>
+	);
+};
 
 const ShippingRecommendations = () => {
 	const [ pluginsBeingSetup, setupPlugin ] = useInstallPlugin();

--- a/plugins/woocommerce/client/admin/client/shipping/test/shipping-recommendations.test.js
+++ b/plugins/woocommerce/client/admin/client/shipping/test/shipping-recommendations.test.js
@@ -22,6 +22,9 @@ jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
 jest.mock( '../../lib/notices', () => ( {
 	createNoticesFromResponse: () => null,
 } ) );
+jest.mock( '~/hooks/use-option-dismiss', () => ( {
+	useOptionDismiss: () => ( { isDismissed: false, onDismiss: jest.fn() } ),
+} ) );
 
 describe( 'ShippingRecommendations', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
@@ -9,7 +9,6 @@ import { Text } from '@woocommerce/experimental';
 import { PluginNames, pluginsStore, settingsStore } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -24,6 +23,7 @@ import { supportsWooCommerceTax } from '../task-lists/fills/tax/utils';
 import { TrackedLink } from '~/components/tracked-link/tracked-link';
 import { getCountryCode } from '~/dashboard/utils';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { useEndpointDismiss } from '~/hooks/use-endpoint-dismiss';
 import './tax-recommendations.scss';
 
 const ANROK_LOGO_URL = 'https://ps.w.org/anrok-tax/assets/icon.svg';
@@ -210,28 +210,17 @@ const TaxRecommendationsList = ( {
 }: {
 	children: React.ReactNode;
 } ) => {
-	const [ isDismissed, setIsDismissed ] = useState< boolean >(
+	const { isDismissed, onDismiss } = useEndpointDismiss(
+		'/wc-admin/tax/recommendations/dismiss',
 		getAdminSetting( 'taxRecommendationsHidden', false )
 	);
-
-	const handleDismiss = () => {
-		// Optimistically hide the card, then persist the dismissal site-wide.
-		setIsDismissed( true );
-		apiFetch( {
-			path: '/wc-admin/tax/recommendations/dismiss',
-			method: 'POST',
-		} ).catch( () => {
-			// Restore the card if the request fails so the state stays accurate.
-			setIsDismissed( false );
-		} );
-	};
 
 	return (
 		<DismissableList
 			className="woocommerce-recommended-tax-extensions"
 			isDismissed={ isDismissed }
 		>
-			<DismissableListHeading onDismiss={ handleDismiss }>
+			<DismissableListHeading onDismiss={ onDismiss }>
 				<Text variant="title.small" as="p" size="20" lineHeight="28px">
 					{ __( 'Recommended tax solutions', 'woocommerce' ) }
 				</Text>

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
@@ -7,7 +7,7 @@ import { Children, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Text } from '@woocommerce/experimental';
 import { PluginNames, pluginsStore, settingsStore } from '@woocommerce/data';
-import { getAdminLink, getSetting } from '@woocommerce/settings';
+import { getAdminLink } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -23,6 +23,7 @@ import {
 import { supportsWooCommerceTax } from '../task-lists/fills/tax/utils';
 import { TrackedLink } from '~/components/tracked-link/tracked-link';
 import { getCountryCode } from '~/dashboard/utils';
+import { getAdminSetting } from '~/utils/admin-settings';
 import './tax-recommendations.scss';
 
 const ANROK_LOGO_URL = 'https://ps.w.org/anrok-tax/assets/icon.svg';
@@ -210,7 +211,7 @@ const TaxRecommendationsList = ( {
 	children: React.ReactNode;
 } ) => {
 	const [ isDismissed, setIsDismissed ] = useState< boolean >(
-		getSetting( 'taxRecommendationsHidden', false )
+		getAdminSetting( 'taxRecommendationsHidden', false )
 	);
 
 	const handleDismiss = () => {

--- a/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/tax-recommendations.tsx
@@ -7,8 +7,9 @@ import { Children, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Text } from '@woocommerce/experimental';
 import { PluginNames, pluginsStore, settingsStore } from '@woocommerce/data';
-import { getAdminLink } from '@woocommerce/settings';
+import { getAdminLink, getSetting } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -207,49 +208,67 @@ const TaxRecommendationsList = ( {
 	children,
 }: {
 	children: React.ReactNode;
-} ) => (
-	<DismissableList
-		className="woocommerce-recommended-tax-extensions"
-		dismissOptionName="woocommerce_settings_tax_recommendations_hidden"
-	>
-		<DismissableListHeading>
-			<Text variant="title.small" as="p" size="20" lineHeight="28px">
-				{ __( 'Recommended tax solutions', 'woocommerce' ) }
-			</Text>
-			<Text
-				className="woocommerce-recommended-tax__header-heading"
-				variant="caption"
-				as="p"
-				size="12"
-				lineHeight="16px"
-			>
-				{ __(
-					'Explore tax extensions that can help automate calculations and compliance for your store.',
-					'woocommerce'
-				) }
-			</Text>
-		</DismissableListHeading>
-		<ul className="woocommerce-list">
-			{ Children.map( children, ( item ) => (
-				<li className="woocommerce-list__item">{ item }</li>
-			) ) }
-		</ul>
-		<CardFooter>
-			<TrackedLink
-				message={ __(
-					// translators: {{Link}} is a placeholder for a html element.
-					'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more tax solutions.',
-					'woocommerce'
-				) }
-				targetUrl={ getAdminLink(
-					'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=operations'
-				) }
-				linkType="wc-admin"
-				eventName="settings_tax_recommendation_visit_marketplace_click"
-			/>
-		</CardFooter>
-	</DismissableList>
-);
+} ) => {
+	const [ isDismissed, setIsDismissed ] = useState< boolean >(
+		getSetting( 'taxRecommendationsHidden', false )
+	);
+
+	const handleDismiss = () => {
+		// Optimistically hide the card, then persist the dismissal site-wide.
+		setIsDismissed( true );
+		apiFetch( {
+			path: '/wc-admin/tax/recommendations/dismiss',
+			method: 'POST',
+		} ).catch( () => {
+			// Restore the card if the request fails so the state stays accurate.
+			setIsDismissed( false );
+		} );
+	};
+
+	return (
+		<DismissableList
+			className="woocommerce-recommended-tax-extensions"
+			isDismissed={ isDismissed }
+		>
+			<DismissableListHeading onDismiss={ handleDismiss }>
+				<Text variant="title.small" as="p" size="20" lineHeight="28px">
+					{ __( 'Recommended tax solutions', 'woocommerce' ) }
+				</Text>
+				<Text
+					className="woocommerce-recommended-tax__header-heading"
+					variant="caption"
+					as="p"
+					size="12"
+					lineHeight="16px"
+				>
+					{ __(
+						'Explore tax extensions that can help automate calculations and compliance for your store.',
+						'woocommerce'
+					) }
+				</Text>
+			</DismissableListHeading>
+			<ul className="woocommerce-list">
+				{ Children.map( children, ( item ) => (
+					<li className="woocommerce-list__item">{ item }</li>
+				) ) }
+			</ul>
+			<CardFooter>
+				<TrackedLink
+					message={ __(
+						// translators: {{Link}} is a placeholder for a html element.
+						'Visit {{Link}}the WooCommerce Marketplace{{/Link}} to find more tax solutions.',
+						'woocommerce'
+					) }
+					targetUrl={ getAdminLink(
+						'admin.php?page=wc-admin&tab=extensions&path=/extensions&category=operations'
+					) }
+					linkType="wc-admin"
+					eventName="settings_tax_recommendation_visit_marketplace_click"
+				/>
+			</CardFooter>
+		</DismissableList>
+	);
+};
 
 const getPluginSlugForAction = (
 	pluginSlugs: string[],

--- a/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
+++ b/plugins/woocommerce/client/admin/client/tax/test/tax-recommendations.test.tsx
@@ -34,6 +34,10 @@ jest.mock( '../../lib/notices', () => ( {
 	createNoticesFromResponse: () => null,
 } ) );
 
+jest.mock( '~/hooks/use-endpoint-dismiss', () => ( {
+	useEndpointDismiss: () => ( { isDismissed: false, onDismiss: jest.fn() } ),
+} ) );
+
 const clickAndFlush = async ( element: Element ) => {
 	await act( async () => {
 		await userEvent.click( element );

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -69,8 +69,8 @@ class Loader {
 		Settings::get_instance();
 		SiteHealth::get_instance();
 		SystemStatusReport::get_instance();
-		TaxSettingsRecommendations::get_instance();
 
+		wc_get_container()->get( TaxSettingsRecommendations::class );
 		wc_get_container()->get( Reviews::class );
 		wc_get_container()->get( ReviewsCommentsOverrides::class );
 

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -69,6 +69,7 @@ class Loader {
 		Settings::get_instance();
 		SiteHealth::get_instance();
 		SystemStatusReport::get_instance();
+		TaxSettingsRecommendations::get_instance();
 
 		wc_get_container()->get( Reviews::class );
 		wc_get_container()->get( ReviewsCommentsOverrides::class );

--- a/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
+++ b/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
@@ -28,28 +28,11 @@ class TaxSettingsRecommendations {
 	const DISMISSED_OPTION_NAME = 'woocommerce_settings_tax_recommendations_hidden';
 
 	/**
-	 * Class instance.
+	 * Class initialization, to be executed when the class is resolved by the container.
 	 *
-	 * @var TaxSettingsRecommendations instance
+	 * @internal
 	 */
-	protected static $instance = null;
-
-	/**
-	 * Get class instance.
-	 *
-	 * @return object Instance.
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	/**
-	 * Hook into WooCommerce.
-	 */
-	public function __construct() {
+	final public function init(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'preload_settings' ) );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
+++ b/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * TaxSettingsRecommendations Class.
+ *
+ * Handles dismissal of the recommended tax solutions card on the Tax settings
+ * screen. The dismissal is stored site-wide in the
+ * `woocommerce_settings_tax_recommendations_hidden` option, but is read and
+ * written through a dedicated REST endpoint instead of the deprecated Options
+ * REST API (whose allowlist is frozen). This keeps the dismissal working in all
+ * environments, including non-production.
+ */
+class TaxSettingsRecommendations {
+
+	/**
+	 * Option name used to persist the dismissal.
+	 *
+	 * @var string
+	 */
+	const DISMISSED_OPTION_NAME = 'woocommerce_settings_tax_recommendations_hidden';
+
+	/**
+	 * Class instance.
+	 *
+	 * @var TaxSettingsRecommendations instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Hook into WooCommerce.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'preload_settings' ) );
+	}
+
+	/**
+	 * Register the REST route used to dismiss the recommended tax solutions card.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			'wc-admin',
+			'/tax/recommendations/dismiss',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'dismiss' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check whether the current user can dismiss the recommendations.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Persist the dismissal of the recommended tax solutions card.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function dismiss() {
+		update_option( self::DISMISSED_OPTION_NAME, 'yes' );
+
+		return new \WP_REST_Response( array( 'dismissed' => true ), 200 );
+	}
+
+	/**
+	 * Preload the dismissal state into the wc-admin settings so the client can
+	 * render the correct initial visibility without an extra request.
+	 *
+	 * @param array $settings Shared settings.
+	 * @return array
+	 */
+	public function preload_settings( $settings ) {
+		$settings['taxRecommendationsHidden'] = 'yes' === get_option( self::DISMISSED_OPTION_NAME );
+
+		return $settings;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
+++ b/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || exit;
  * written through a dedicated REST endpoint instead of the deprecated Options
  * REST API (whose allowlist is frozen). This keeps the dismissal working in all
  * environments, including non-production.
+ *
+ * @internal
  */
 class TaxSettingsRecommendations {
 
@@ -107,6 +109,10 @@ class TaxSettingsRecommendations {
 	 * @return array
 	 */
 	public function preload_settings( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			return $settings;
+		}
+
 		$settings['taxRecommendationsHidden'] = 'yes' === get_option( self::DISMISSED_OPTION_NAME );
 
 		return $settings;

--- a/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
+++ b/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
@@ -76,10 +76,22 @@ class TaxSettingsRecommendations {
 	 * Persist the dismissal of the recommended tax solutions card.
 	 *
 	 * @param \WP_REST_Request<array<string, mixed>> $request Full details about the request.
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function dismiss( \WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, Squiz.Commenting.FunctionComment.IncorrectTypeHint
-		update_option( self::DISMISSED_OPTION_NAME, 'yes' );
+		// Already dismissed: update_option() returns false when the value is
+		// unchanged, which is not a failure, so report success directly.
+		if ( 'yes' === get_option( self::DISMISSED_OPTION_NAME ) ) {
+			return new \WP_REST_Response( array( 'dismissed' => true ), 200 );
+		}
+
+		if ( ! update_option( self::DISMISSED_OPTION_NAME, 'yes' ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_tax_recommendations_dismiss_failed',
+				__( 'The dismissal could not be saved.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
 
 		return new \WP_REST_Response( array( 'dismissed' => true ), 200 );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
+++ b/plugins/woocommerce/src/Internal/Admin/TaxSettingsRecommendations.php
@@ -61,7 +61,7 @@ class TaxSettingsRecommendations {
 			'/tax/recommendations/dismiss',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::EDITABLE,
+					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'dismiss' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
@@ -72,18 +72,28 @@ class TaxSettingsRecommendations {
 	/**
 	 * Check whether the current user can dismiss the recommendations.
 	 *
-	 * @return bool
+	 * @param \WP_REST_Request<array<string, mixed>> $request Full details about the request.
+	 * @return bool|\WP_Error
 	 */
-	public function permissions_check() {
-		return current_user_can( 'manage_woocommerce' );
+	public function permissions_check( \WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, Squiz.Commenting.FunctionComment.IncorrectTypeHint
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_cannot_edit',
+				__( 'Sorry, you are not allowed to dismiss these recommendations.', 'woocommerce' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
 	}
 
 	/**
 	 * Persist the dismissal of the recommended tax solutions card.
 	 *
+	 * @param \WP_REST_Request<array<string, mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response
 	 */
-	public function dismiss() {
+	public function dismiss( \WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, Squiz.Commenting.FunctionComment.IncorrectTypeHint
 		update_option( self::DISMISSED_OPTION_NAME, 'yes' );
 
 		return new \WP_REST_Response( array( 'dismissed' => true ), 200 );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
@@ -25,7 +25,11 @@ class TaxSettingsRecommendationsTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->sut = new TaxSettingsRecommendations();
-		$this->sut->register_routes();
+		$this->sut->init();
+
+		// Routes must register on rest_api_init; firing it runs init()'s callback.
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'rest_api_init' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
@@ -1,0 +1,119 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\TaxSettingsRecommendations;
+use WC_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * Tests for the TaxSettingsRecommendations class.
+ */
+class TaxSettingsRecommendationsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var TaxSettingsRecommendations
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new TaxSettingsRecommendations();
+		$this->sut->register_routes();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		delete_option( TaxSettingsRecommendations::DISMISSED_OPTION_NAME );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Dismissing persists the option and returns a 200 response.
+	 */
+	public function test_dismiss_persists_option_and_returns_200(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$response = rest_do_request( new WP_REST_Request( 'POST', '/wc-admin/tax/recommendations/dismiss' ) );
+
+		$this->assertSame( 200, $response->get_status(), 'A valid dismissal should return HTTP 200.' );
+		$this->assertSame(
+			'yes',
+			get_option( TaxSettingsRecommendations::DISMISSED_OPTION_NAME ),
+			'The dismissal option should be persisted as "yes".'
+		);
+	}
+
+	/**
+	 * @testdox Dismissing twice still returns a 200 response.
+	 */
+	public function test_dismiss_twice_returns_200(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		update_option( TaxSettingsRecommendations::DISMISSED_OPTION_NAME, 'yes' );
+
+		$response = rest_do_request( new WP_REST_Request( 'POST', '/wc-admin/tax/recommendations/dismiss' ) );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'Re-dismissing an already-dismissed card should succeed, not error.'
+		);
+	}
+
+	/**
+	 * @testdox Users without manage_woocommerce cannot dismiss.
+	 */
+	public function test_dismiss_denied_without_capability(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = rest_do_request( new WP_REST_Request( 'POST', '/wc-admin/tax/recommendations/dismiss' ) );
+
+		$this->assertSame(
+			rest_authorization_required_code(),
+			$response->get_status(),
+			'A user lacking manage_woocommerce should be denied.'
+		);
+		$this->assertNotSame(
+			'yes',
+			get_option( TaxSettingsRecommendations::DISMISSED_OPTION_NAME ),
+			'A denied request must not persist the dismissal.'
+		);
+	}
+
+	/**
+	 * @testdox Preload maps the stored option to the taxRecommendationsHidden boolean.
+	 */
+	public function test_preload_settings_maps_option_to_boolean(): void {
+		$this->assertFalse(
+			$this->sut->preload_settings( array() )['taxRecommendationsHidden'],
+			'An unset option should preload as false.'
+		);
+
+		update_option( TaxSettingsRecommendations::DISMISSED_OPTION_NAME, 'yes' );
+
+		$this->assertTrue(
+			$this->sut->preload_settings( array() )['taxRecommendationsHidden'],
+			'A dismissed card should preload as true.'
+		);
+	}
+
+	/**
+	 * @testdox Preload leaves non-array input untouched.
+	 */
+	public function test_preload_settings_ignores_non_array(): void {
+		$this->assertSame(
+			'unchanged',
+			$this->sut->preload_settings( 'unchanged' ),
+			'Non-array settings should be returned as-is.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The "Recommended tax solutions" card on **WooCommerce → Settings → Tax** could not be dismissed in non-production environments. Its dismissal was persisted through the legacy Options REST API (`/wc-admin/options`), whose allowlist is frozen — `woocommerce_settings_tax_recommendations_hidden` is not on it, so `user_has_permission()` returned `false` outside production, the write was silently rejected, and the card reappeared on reload.

The original fix added a dedicated endpoint plus a second, parallel persistence path baked directly into `DismissableList` (an optional `dismissOptionName` prop on one side, a controlled `isDismissed` + `onDismiss` on the other, with the option name threaded through a React context to the heading). That left the shared component with two competing modes and persistence logic split across two components — confusing, and inconsistent across the three cards that use it.

This PR resolves both the bug and the structural debt:

- **`DismissableList` / `DismissableListHeading` are now purely presentational.** `DismissableList` takes `{ children, className, isDismissed }` and renders nothing when dismissed; `DismissableListHeading` takes `{ children, onDismiss }` and just invokes the callback. The `OptionNameContext` and all `@wordpress/data` / `@woocommerce/data` usage are removed from the component.
- **Persistence moves into two small, reusable hooks**, both returning `{ isDismissed, onDismiss }`:
  - `useOptionDismiss( optionName )` — options-store backed (treats "not yet resolved" as dismissed to avoid flashing the card).
  - `useEndpointDismiss( path, initial )` — dedicated-endpoint backed; optimistic hide, rollback **and an error notice** if the request fails.
- **All three recommendation cards now consume the same shape.** Shipping and abandoned-cart use `useOptionDismiss`; tax uses `useEndpointDismiss` with the preloaded `taxRecommendationsHidden` value as its initial state.
- **`TaxSettingsRecommendations::dismiss()` reflects persistence failures.** It returns a `WP_Error` when `update_option()` genuinely fails, while treating an already-dismissed card (`update_option()` returns `false` for an unchanged value) as success.
- New REST endpoint `POST /wc-admin/tax/recommendations/dismiss` (`Internal\Admin\TaxSettingsRecommendations`), gated on `manage_woocommerce`, writes the existing option. The current dismissal state is preloaded into the `wc-admin` shared settings (`taxRecommendationsHidden`) so the client renders correct initial visibility with no extra request.

Closes WOOPLUG-6924

(For Bug Fixes) Bug introduced in PR #65786 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Tax.
2. Ensure that Tax Recommendations are visible.
3. Click on the 3 dots and click to hide them. 
4. Refresh the page and ensure that they remain hidden.
5. Repeat the same test for Shipping Recommendations under WooCommerce > Settings > Shipping.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a follow-up fix for an unreleased feature.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
