### PR TITLE
Update Settings UI container radius

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3555-settings-container-radius
+++ b/plugins/woocommerce/changelog/wooprd-3555-settings-container-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update the Settings UI section card border radius to match DataForm styling.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -246,7 +246,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	.wc-settings-ui__section-card {
 		background: #fff;
 		border: 1px solid #e0e0e0;
-		border-radius: 4px;
+		border-radius: 10px;
 		box-sizing: border-box;
 		padding: 24px;
 		width: 100%;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Update the embedded Settings UI section card/container border radius from `4px` to `10px` for consistency with DataForm styling and the Square designs.

Linear: WOOPRD-3555

### Screenshots or screen recordings:

<img width="1359" height="619" alt="Screenshot 2026-06-26 at 12 06 22" src="https://github.com/user-attachments/assets/b4cb5b18-8a02-4bb2-9e90-6a6159307e63" />

### How to test the changes in this Pull Request:

1. Enable the `settings-ui` admin feature.
2. Go to **WooCommerce > Settings > Products**.
3. Confirm the Settings UI section card/container uses a `10px` corner radius.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/admin-library lint:lang:css`
- `pnpm install --frozen-lockfile`
- `pnpm build` — passed with existing autoprefixer/translation-domain warnings.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- Local smoke test on `http://localhost:8082` with a temporary MU plugin enabling `settings-ui`:
  - Opened `wp-admin/admin.php?page=wc-settings&tab=products`.
  - Confirmed `.wc-settings-ui__section-card` computed `border-radius` is `10px`.
  - Removed the temporary MU plugin after testing.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A changelog entry was added manually in `plugins/woocommerce/changelog/wooprd-3555-settings-container-radius`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Update the Settings UI section card border radius to match DataForm styling.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
