### PR TITLE
Fix oversized heading on offline payment settings pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooprd-3552-offline-payments-header-font-size
+++ b/plugins/woocommerce/changelog/fix-wooprd-3552-offline-payments-header-font-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix oversized heading on the offline payment settings pages by setting the header font size explicitly instead of relying on the floating-header-scoped rule.

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -531,8 +531,18 @@
 
 		h1 {
 			padding-left: $gap-smaller * 2;
-			// This is the same as the Payments settings header.
-			// This is used to keep the UI consistent across when navigating to the offline payments settings page.
+			// This title renders as an inline
+			// <h1.woocommerce-layout__header-heading> in the page content,
+			// outside the floating header, so the shared
+			// `.woocommerce-layout__header .woocommerce-layout__header-heading`
+			// rule (which scopes heading typography to the floating header) no
+			// longer reaches it. Restore the 16px / 500 size explicitly;
+			// otherwise the heading falls back to the default wp-admin h1 (23px)
+			// and its 9px top padding, so also trim padding-top to 4px to
+			// vertically center it against the back button.
+			padding-top: 4px;
+			font-size: 16px;
+			font-weight: 500;
 			line-height: 38px;
 			color: #3c434a;
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -531,20 +531,18 @@
 
 		h1 {
 			padding-left: $gap-smaller * 2;
-			// This title renders as an inline
-			// <h1.woocommerce-layout__header-heading> in the page content,
-			// outside the floating header, so the shared
-			// `.woocommerce-layout__header .woocommerce-layout__header-heading`
-			// rule (which scopes heading typography to the floating header) no
-			// longer reaches it. Restore the 16px / 500 size explicitly;
-			// otherwise the heading falls back to the default wp-admin h1 (23px)
-			// and its 9px top padding, so also trim padding-top to 4px to
-			// vertically center it against the back button.
+			// This heading renders outside the floating header, so the shared
+			// header typography doesn't reach it — restate it to match the other
+			// settings headers. padding-top trims wp-admin's default h1 padding
+			// so the title centers against the back button.
 			padding-top: 4px;
-			font-size: 16px;
+			font-size: 15px;
 			font-weight: 500;
-			line-height: 38px;
-			color: #3c434a;
+			color: $gray-900;
+
+			.woocommerce-settings-payments-header__title {
+				line-height: 24px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

On **WooCommerce → Settings → Payments** offline payment pages, the page-title heading ("Take offline payments", and each gateway's title such as "Direct bank transfer") rendered oversized — at the default wp-admin `h1` size (23px) instead of the intended 15px.

The offline header is rendered as an inline `<h1 class="woocommerce-layout__header-heading …">` in the page content, outside the floating header. PR #64885 consolidated heading typography into the `.woocommerce-layout__header`-scoped rule and dropped the per-page size overrides, so this inline title stopped matching any size rule and fell back to the default. This sets `font-size`/`font-weight` explicitly on `.settings-payments-offline__header h1`, restoring 15px/500 on both the offline methods list and each gateway's settings page.

(For Bug Fixes) Bug introduced in PR #64885.

### Screenshots or screen recordings:

Offline payment page heading (`…&tab=checkout&path=/offline` and `…/offline/bacs`):

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/7bde0cc5-ffd6-4b51-9d33-dd546139348d) | ![image](https://github.com/user-attachments/assets/b50bad6c-e65e-47c0-9cf8-5060e12a9809) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Spin up a new JurassicNinja store with the WC on this PR's branch, WC Beta Tester (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-beta-tester&branches.woocommerce=fix/wooprd-3552-offline-payments-header-font-size))
1. Go to the site's dashboard, click on WooCommerce, and skip the profiler by setting the store country to US.
1. Go to **WooCommerce → Settings → Payments**.
1. Click **Take offline payments** (or navigate to `…&tab=checkout&path=/offline`).
1. Confirm the **"Take offline payments"** page heading is the normal small heading size (15px), consistent with the other settings-tab headers — not the oversized default.
1. Open an individual offline method (e.g. **Direct bank transfer**, `…&tab=checkout&path=/offline/bacs`).
1. Confirm that gateway's page heading is likewise the normal size.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified on a fresh site running this branch built from current `trunk`:
- Before: the offline page heading computed to `font-size: 23px; font-weight: 400` (falling back to the default wp-admin `h1`).
- After: `font-size: 15px; font-weight: 500` on both the offline methods list and the per-gateway pages.
- `stylelint` passes on the changed file; the production bundle build confirms the compiled CSS carries the rule (LTR + RTL).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix oversized heading on the offline payment settings pages.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry was added manually in `plugins/woocommerce/changelog/fix-wooprd-3552-offline-payments-header-font-size`.

</details>

### Release Communication

<!-- release-communication-section -->

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)