### PR TITLE
Fix Store API cart merge on token (JWT) login

### DIFF
--- a/plugins/woocommerce/changelog/55653-fix-store-api-cart-merge-on-token-login
+++ b/plugins/woocommerce/changelog/55653-fix-store-api-cart-merge-on-token-login
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Store API: merge a guest cart token into the logged-in user's cart on first authenticated request, so headless/token logins (JWT, OAuth) get the same cart merge that cookie logins do.

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -113,14 +113,18 @@ final class SessionHandler extends WC_Session {
 			return;
 		}
 
-		// Consume the guest session so a repeated, stale token cannot merge again.
-		$this->delete_session( $guest_id );
-
 		// Fold the saved cart and the active guest cart into the user's session. Later entries
 		// win on key collision, so the active guest cart takes precedence over saved items.
 		$saved_cart = $this->get_persistent_cart_contents( (int) $user_id );
 		$user_cart  = (array) $this->get( 'cart', array() );
 		$this->set( 'cart', array_merge( $saved_cart, $user_cart, $guest_cart ) );
+
+		// Persist the merged user cart before consuming the guest session. delete_session()
+		// writes immediately but set() only flushes on shutdown, so saving first ensures a
+		// fatal between the two can't leave the guest session gone and the merge unsaved. A
+		// stale guest token still can't re-merge: it loads an empty cart next time.
+		$this->save_data();
+		$this->delete_session( $guest_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -136,7 +136,12 @@ final class SessionHandler extends WC_Session {
 	 * @return array
 	 */
 	private function get_persistent_cart_contents( int $user_id ): array {
-		/** This filter is documented in includes/class-wc-cart-session.php */
+		/**
+		 * Filters whether the persistent cart is enabled.
+		 *
+		 * @since 3.4.0
+		 * @param bool $enabled Whether the persistent cart is enabled. Default true.
+		 */
 		if ( ! apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
 			return array();
 		}

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -65,6 +65,89 @@ final class SessionHandler extends WC_Session {
 		$this->_customer_id       = $payload['user_id'];
 		$this->session_expiration = $payload['exp'];
 		$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
+
+		$this->maybe_merge_guest_cart_on_login();
+	}
+
+	/**
+	 * Merge a guest cart token into the logged-in user's session on first authenticated load.
+	 *
+	 * Token-based logins (JWT, OAuth, etc.) never fire the `wp_login` hook, so the
+	 * `_woocommerce_load_saved_cart_after_login` flag the cookie session flow relies on to
+	 * merge carts is never set. When an authenticated request arrives carrying a guest cart
+	 * token, fold the guest cart into the user's session once and switch the session to the
+	 * user, so the response returns a user-scoped cart token (see
+	 * AbstractCartRoute::get_cart_token()).
+	 *
+	 * The guest session is consumed (deleted) as part of the merge. A repeated, stale guest
+	 * token therefore loads an empty cart and cannot merge again, keeping the operation
+	 * one-shot and preventing removed items from reappearing.
+	 *
+	 * @since 11.0.0
+	 */
+	protected function maybe_merge_guest_cart_on_login(): void {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$guest_id = (string) $this->get_customer_id();
+
+		// Only merge a genuine guest session token (t_...). A user-scoped token — the current
+		// user's own, or another user's — must never be treated as a guest cart. This matches
+		// WC_Session_Handler::is_customer_guest() and also covers an empty/absent token.
+		if ( 't_' !== substr( $guest_id, 0, 2 ) ) {
+			return;
+		}
+
+		$user_id    = (string) get_current_user_id();
+		$guest_cart = (array) $this->get( 'cart', array() );
+
+		// Switch this request to the user's own session.
+		$this->_customer_id = $user_id;
+		$this->_data        = (array) $this->get_session( $user_id, array() );
+
+		// Nothing to merge when the guest session has no cart (it may not even exist), so leave
+		// it untouched. get_cart_from_session() loads the saved cart on its own when the user's
+		// session is empty.
+		if ( empty( $guest_cart ) ) {
+			return;
+		}
+
+		// Consume the guest session so a repeated, stale token cannot merge again.
+		$this->delete_session( $guest_id );
+
+		// Fold the saved cart and the active guest cart into the user's session. Later entries
+		// win on key collision, so the active guest cart takes precedence over saved items.
+		$saved_cart = $this->get_persistent_cart_contents( (int) $user_id );
+		$user_cart  = (array) $this->get( 'cart', array() );
+		$this->set( 'cart', array_merge( $saved_cart, $user_cart, $guest_cart ) );
+	}
+
+	/**
+	 * Read the user's saved (persistent) cart contents.
+	 *
+	 * Mirrors the private WC_Cart_Session::get_saved_cart() so the merge can fold the
+	 * persistent cart in directly, without depending on the wp_login-era
+	 * `_woocommerce_load_saved_cart_after_login` flag being consumed elsewhere.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param int $user_id User ID.
+	 * @return array
+	 */
+	private function get_persistent_cart_contents( int $user_id ): array {
+		/** This filter is documented in includes/class-wc-cart-session.php */
+		if ( ! apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+			return array();
+		}
+
+		$saved_cart_meta = get_user_meta( $user_id, '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
+
+		if ( is_array( $saved_cart_meta ) && isset( $saved_cart_meta['cart'] ) ) {
+			return array_filter( (array) $saved_cart_meta['cart'] );
+		}
+
+		return array();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/StoreApi/CartMergeTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/CartMergeTest.php
@@ -1,0 +1,307 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi;
+
+use Automattic\WooCommerce\StoreApi\SessionHandler;
+use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
+use WC_Cart_Session;
+use WC_Helper_Product;
+use WC_Session;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for guest/saved cart merge behaviour on login.
+ *
+ * The classic cookie flow (WC_Cart_Session::get_cart_from_session) merges carts via the
+ * _woocommerce_load_saved_cart_after_login user meta set by the wp_login hook. Headless/token
+ * logins (JWT, OAuth, custom) never fire wp_login, so SessionHandler merges the guest cart
+ * token into the user's session itself. See https://github.com/woocommerce/woocommerce/issues/55653.
+ *
+ * The `test_classic_*` tests pin the canonical one-shot semantics; the `test_store_api_*` tests
+ * cover the equivalent behaviour for the Store API token flow.
+ */
+class CartMergeTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Session handler in place before the test swapped it.
+	 *
+	 * @var WC_Session
+	 */
+	private $original_session;
+
+	/**
+	 * Logged-in user used across the merge scenarios.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Product stored in the user's saved (persistent) cart.
+	 *
+	 * @var \WC_Product
+	 */
+	private $saved_product;
+
+	/**
+	 * Product stored in the guest session cart.
+	 *
+	 * @var \WC_Product
+	 */
+	private $guest_product;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_session = WC()->session;
+		$this->user_id          = $this->factory->user->create( array( 'role' => 'customer' ) );
+		$this->saved_product    = WC_Helper_Product::create_simple_product();
+		$this->guest_product    = WC_Helper_Product::create_simple_product();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		WC()->cart->empty_cart();
+		WC()->session = $this->original_session;
+		unset( $_SERVER['HTTP_CART_TOKEN'] );
+		wp_set_current_user( 0 );
+		delete_user_meta( $this->user_id, '_woocommerce_load_saved_cart_after_login' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Classic login merges the guest cart and the saved cart into one cart.
+	 */
+	public function test_classic_login_merges_guest_and_saved_cart(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+		WC()->session->set( 'cart', $this->build_cart_array( array( $this->guest_product->get_id() => 1 ) ) );
+
+		$this->log_in_via_wp_login();
+
+		$contents = $this->load_cart();
+
+		$this->assertArrayHasKey( $this->saved_product->get_id(), $contents, 'Saved cart item should be merged in after login.' );
+		$this->assertArrayHasKey( $this->guest_product->get_id(), $contents, 'Guest cart item should survive the merge.' );
+	}
+
+	/**
+	 * @testdox Classic merge is one-shot and does not resurrect a removed item on the next load.
+	 */
+	public function test_classic_merge_is_one_shot(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+		WC()->session->set( 'cart', $this->build_cart_array( array( $this->guest_product->get_id() => 1 ) ) );
+		$this->log_in_via_wp_login();
+
+		$merged = $this->load_cart();
+		$this->assertArrayHasKey( $this->saved_product->get_id(), $merged, 'Saved cart item should be merged in on first load.' );
+
+		// User removes the item that came from the saved cart, then a second request loads the cart again.
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $this->guest_product->get_id(), 1 );
+		WC()->session->set( 'cart', ( new WC_Cart_Session( WC()->cart ) )->get_cart_for_session() );
+
+		$contents = $this->load_cart();
+
+		$this->assertArrayNotHasKey( $this->saved_product->get_id(), $contents, 'Removed saved-cart item must not reappear on reload (merge is one-shot).' );
+		$this->assertArrayHasKey( $this->guest_product->get_id(), $contents, 'Guest cart item should remain after reload.' );
+	}
+
+	/**
+	 * @testdox When the same product is in both carts the session quantity wins rather than summing.
+	 */
+	public function test_classic_merge_session_quantity_wins_on_collision(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+		WC()->session->set( 'cart', $this->build_cart_array( array( $this->saved_product->get_id() => 3 ) ) );
+		$this->log_in_via_wp_login();
+
+		$contents = $this->load_cart();
+
+		$this->assertArrayHasKey( $this->saved_product->get_id(), $contents, 'Product present in both carts should appear once.' );
+		$this->assertSame( 3, $contents[ $this->saved_product->get_id() ], 'Session quantity should win on collision, not be summed with the saved quantity.' );
+	}
+
+	/**
+	 * @testdox Token login merges the guest cart token into the user's saved cart (issue #55653).
+	 */
+	public function test_store_api_token_login_merges_guest_and_saved_cart(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+		$this->start_store_api_guest_request( array( $this->guest_product->get_id() => 1 ) );
+
+		// Authenticated as the user via a token (e.g. JWT determine_current_user) — wp_login never fires.
+		wp_set_current_user( $this->user_id );
+		$this->dispatch_store_api_request();
+
+		$contents = $this->load_cart();
+
+		$this->assertArrayHasKey( $this->saved_product->get_id(), $contents, 'Saved cart item should be merged in for a token login.' );
+		$this->assertArrayHasKey( $this->guest_product->get_id(), $contents, 'Guest cart token item should survive the merge.' );
+	}
+
+	/**
+	 * @testdox Token-login merge is one-shot and does not resurrect a removed item on the next load.
+	 */
+	public function test_store_api_token_merge_is_one_shot(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+		$this->start_store_api_guest_request( array( $this->guest_product->get_id() => 1 ) );
+		wp_set_current_user( $this->user_id );
+
+		$this->dispatch_store_api_request();
+		$merged = $this->load_cart();
+		$this->assertArrayHasKey( $this->saved_product->get_id(), $merged, 'Saved cart item should be merged in on first load for a token login.' );
+
+		// User removes the merged-in saved item, leaving just the guest item, and the session is persisted.
+		WC()->session->set( 'cart', $this->build_cart_array( array( $this->guest_product->get_id() => 1 ) ) );
+		WC()->session->save_data();
+
+		// A second request still carries the now-stale guest token.
+		$this->dispatch_store_api_request();
+		$contents = $this->load_cart();
+
+		$this->assertArrayNotHasKey( $this->saved_product->get_id(), $contents, 'Removed saved-cart item must not reappear on reload for token logins.' );
+		$this->assertArrayHasKey( $this->guest_product->get_id(), $contents, 'Guest cart token item should remain after reload.' );
+	}
+
+	/**
+	 * @testdox A user-scoped cart token from another user is never treated as a guest cart.
+	 */
+	public function test_store_api_ignores_a_user_scoped_token_for_merge(): void {
+		$this->save_persistent_cart( array( $this->saved_product->get_id() => 1 ) );
+
+		// A token scoped to a different user (a numeric id, not a t_ guest session).
+		$other_user_id = (string) $this->factory->user->create( array( 'role' => 'customer' ) );
+		$this->seed_session( $other_user_id, array( $this->guest_product->get_id() => 1 ) );
+		$_SERVER['HTTP_CART_TOKEN'] = CartTokenUtils::get_cart_token( $other_user_id );
+
+		// Authenticated as our user, presenting the other user's token.
+		wp_set_current_user( $this->user_id );
+		$this->dispatch_store_api_request();
+		$this->load_cart();
+
+		$foreign_session = ( new SessionHandler() )->get_session( $other_user_id, array() );
+		$this->assertNotEmpty( $foreign_session, 'A user-scoped token must not be consumed (deleted) as if it were a guest cart.' );
+		$this->assertEmpty(
+			get_user_meta( (int) $this->user_id, '_woocommerce_load_saved_cart_after_login', true ),
+			'No saved-cart merge should be triggered for a user-scoped token.'
+		);
+	}
+
+	/**
+	 * Persist the given items as the user's saved (persistent) cart.
+	 *
+	 * @param array<int,int> $items Map of product ID to quantity.
+	 */
+	private function save_persistent_cart( array $items ): void {
+		// Write the persistent-cart meta directly in the same shape persistent_cart_update() stores.
+		// Going via the cart + empty_cart() would trigger the persistent-cart-destroy hook and wipe it.
+		update_user_meta(
+			$this->user_id,
+			'_woocommerce_persistent_cart_' . get_current_blog_id(),
+			array( 'cart' => $this->build_cart_array( $items ) )
+		);
+	}
+
+	/**
+	 * Build a session-format cart array for the given items.
+	 *
+	 * @param array<int,int> $items Map of product ID to quantity.
+	 * @return array
+	 */
+	private function build_cart_array( array $items ): array {
+		// Build while logged out so empty_cart() cannot fire the persistent-cart-destroy hook
+		// and wipe a saved cart belonging to the current user.
+		$previous = get_current_user_id();
+		wp_set_current_user( 0 );
+
+		WC()->cart->empty_cart();
+		foreach ( $items as $product_id => $quantity ) {
+			WC()->cart->add_to_cart( $product_id, $quantity );
+		}
+		$cart_array = ( new WC_Cart_Session( WC()->cart ) )->get_cart_for_session();
+		WC()->cart->empty_cart();
+
+		wp_set_current_user( $previous );
+
+		return $cart_array;
+	}
+
+	/**
+	 * Persist a guest Store API session in the DB and set the matching Cart-Token header.
+	 *
+	 * @param array<int,int> $items Map of product ID to quantity for the guest cart.
+	 */
+	private function start_store_api_guest_request( array $items ): void {
+		// Session keys are stored in a char(32) column, so keep the guest id within 32 chars
+		// or the truncated stored key won't match the id carried in the token.
+		$guest_id = substr( 't_' . wc_rand_hash(), 0, 32 );
+
+		$this->seed_session( $guest_id, $items );
+		$_SERVER['HTTP_CART_TOKEN'] = CartTokenUtils::get_cart_token( $guest_id );
+	}
+
+	/**
+	 * Persist a Store API session row in the DB under the given key with the given cart.
+	 *
+	 * @param string         $session_id Session key (guest t_... id or user id).
+	 * @param array<int,int> $items      Map of product ID to quantity.
+	 */
+	private function seed_session( string $session_id, array $items ): void {
+		$handler = new SessionHandler();
+		$this->set_protected_property( $handler, '_customer_id', $session_id );
+		$this->set_protected_property( $handler, 'session_expiration', time() + DAY_IN_SECONDS );
+		$handler->set( 'cart', $this->build_cart_array( $items ) );
+		$handler->save_data();
+	}
+
+	/**
+	 * Boot a fresh Store API SessionHandler for the current Cart-Token header, as a request would.
+	 */
+	private function dispatch_store_api_request(): void {
+		WC()->session = new SessionHandler();
+		WC()->session->init();
+	}
+
+	/**
+	 * Set a protected property on an object via reflection.
+	 *
+	 * @param object $object Target object.
+	 * @param string $name   Property name.
+	 * @param mixed  $value  Value to set.
+	 */
+	private function set_protected_property( object $object, string $name, $value ): void {
+		$property = new \ReflectionProperty( $object, $name );
+		$property->setAccessible( true );
+		$property->setValue( $object, $value );
+	}
+
+	/**
+	 * Simulate a classic login by setting the current user and the merge flag wp_login would set.
+	 */
+	private function log_in_via_wp_login(): void {
+		wp_set_current_user( $this->user_id );
+		update_user_meta( $this->user_id, '_woocommerce_load_saved_cart_after_login', 1 );
+	}
+
+	/**
+	 * Load the cart from the session and return a map of product ID to total quantity.
+	 *
+	 * @return array<int,int>
+	 */
+	private function load_cart(): array {
+		// Note: do not empty_cart() here — that also clears the session 'cart' key we are loading from.
+		( new WC_Cart_Session( WC()->cart ) )->get_cart_from_session();
+
+		$contents = array();
+		foreach ( WC()->cart->get_cart_contents() as $item ) {
+			$contents[ $item['product_id'] ] = ( $contents[ $item['product_id'] ] ?? 0 ) + $item['quantity'];
+		}
+
+		return $contents;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/StoreApi/CartMergeTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/CartMergeTest.php
@@ -270,14 +270,14 @@ class CartMergeTest extends WC_Unit_Test_Case {
 	/**
 	 * Set a protected property on an object via reflection.
 	 *
-	 * @param object $object Target object.
-	 * @param string $name   Property name.
-	 * @param mixed  $value  Value to set.
+	 * @param object $instance Target object.
+	 * @param string $name     Property name.
+	 * @param mixed  $value    Value to set.
 	 */
-	private function set_protected_property( object $object, string $name, $value ): void {
-		$property = new \ReflectionProperty( $object, $name );
+	private function set_protected_property( object $instance, string $name, $value ): void {
+		$property = new \ReflectionProperty( $instance, $name );
 		$property->setAccessible( true );
-		$property->setValue( $object, $value );
+		$property->setValue( $instance, $value );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Cart merging on login leans on the `wp_login` hook. It sets the `_woocommerce_load_saved_cart_after_login` user meta that `WC_Cart_Session::get_cart_from_session()` reads to fold a guest cart into the customer's saved cart. Headless and token logins (JWT, OAuth, custom) authenticate through `determine_current_user` and never fire `wp_login`, so on the Store API that flag is never set. A guest `Cart-Token` then overrides the customer's saved cart instead of merging with it. That's the behaviour reported in #55653.

I've moved the merge into `SessionHandler` so it no longer depends on `wp_login`. When an authenticated request arrives carrying a guest cart token, it folds the guest cart and the customer's saved (persistent) cart into the user's session, switches to a user-scoped session (so the response `Cart-Token` rotates to the user), and deletes the guest session. Deleting the guest session is what makes this one-shot. A repeated or stale guest token loads an empty cart and can't merge again, so items the customer removed don't reappear. Only genuine guest tokens (`t_…`) are merged. A user-scoped token, whether the current user's own or another user's, is never treated as a guest cart.

Closes #55653.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install JWT Authentication for WP-API plugin and set up the key
2. You can also add `add_filter("woocommerce_store_api_disable_nonce_check", "__return_true");` to wp-config.php to simplify requests.
3. Logged in, in your browser add a product to the cart (Product A). Then log out. This will set persistent cart.
4. POST `{"id": 67, "quantity": 1}` to `/wp-json/wc/store/v1/cart/add-item` and add an item to cart. Get the CART TOKEN from header response.
5. Get a JWT token for the previous logged in user POST username nad password to `wp-json/jwt-auth/v1/token`
6. Now GET the cart using both tokens. GET `wp-json/wc/store/v1/cart` with 2 headers.  `Cart-Token` set to the cart token of the guest. And `Authorization` Bearer using the JWT token.
7. Check the response has all items from both carts and the user ID header matches the user you're using the JWT token for.

<!-- End testing instructions -->

### Testing that has already taken place:

-   PHPUnit: `CartMergeTest`, 6 tests / 14 assertions, green under wp-env (PHP 8.1, WP 6.x).
-   PHPStan: clean on `SessionHandler.php`.
-   `phpcs-changed` couldn't run locally, so WPCS will be verified by CI.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually (`plugins/woocommerce/changelog/55653-fix-store-api-cart-merge-on-token-login`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
