### PR TITLE
Fix stock reservation default duration

### DIFF
--- a/plugins/woocommerce/changelog/fix-30612-stock-reservation-default
+++ b/plugins/woocommerce/changelog/fix-30612-stock-reservation-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the checkout hold stock setting only for core checkout stock reservations.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -453,7 +453,7 @@ function wc_reserve_stock_for_order( $order ) {
 
 	if ( $order ) {
 		$reserve_stock = new ReserveStock();
-		$reserve_stock->reserve_stock_for_order( $order );
+		$reserve_stock->reserve_stock_for_order( $order, (int) get_option( 'woocommerce_hold_stock_minutes', 60 ) );
 	}
 }
 add_action( 'woocommerce_checkout_order_created', 'wc_reserve_stock_for_order' );

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -68,14 +68,13 @@ final class ReserveStock {
 	 * @throws ReserveStockException If stock cannot be reserved.
 	 *
 	 * @param \WC_Order $order Order object.
-	 * @param int       $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
+	 * @param int       $minutes How long to reserve stock in minutes. Defaults to 60.
 	 */
-	public function reserve_stock_for_order( $order, $minutes = 0 ) {
+	public function reserve_stock_for_order( $order, $minutes = 60 ) {
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
-		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
 		/**
 		 * Filters the number of minutes an order should reserve stock for.
 		 *
@@ -83,7 +82,7 @@ final class ReserveStock {
 		 *
 		 * @since 8.8.0
 		 *
-		 * @param int       $minutes How long to reserve stock for the order in minutes. Defaults to woocommerce_hold_stock_minutes or 10 if block checkout entry.
+		 * @param int       $minutes How long to reserve stock for the order in minutes.
 		 * @param \WC_Order $order Order object.
 		 */
 		$minutes = (int) apply_filters( 'woocommerce_order_hold_stock_minutes', $minutes, $order );

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Tests\Functions\Stock
  */
 
+use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 
 /**
@@ -68,6 +69,71 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$order->set_status( $status );
 		$order->save();
 		return $order;
+	}
+
+	/**
+	 * Run a callback with stock reservation enabled and the configured hold duration.
+	 *
+	 * @param string   $hold_stock_minutes Configured hold stock duration.
+	 * @param callable $callback Callback to run.
+	 * @return mixed
+	 */
+	private function with_stock_reservation_options( $hold_stock_minutes, $callback ) {
+		$option_names         = array(
+			'woocommerce_hold_stock_minutes',
+			'woocommerce_manage_stock',
+			'woocommerce_schema_version',
+		);
+		$missing_option_value = new stdClass();
+		$original_options     = array();
+
+		foreach ( $option_names as $option_name ) {
+			$option_value                     = get_option( $option_name, $missing_option_value );
+			$original_options[ $option_name ] = array(
+				'exists' => $missing_option_value !== $option_value,
+				'value'  => $option_value,
+			);
+		}
+
+		update_option( 'woocommerce_hold_stock_minutes', $hold_stock_minutes );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		update_option( 'woocommerce_schema_version', 430 );
+
+		try {
+			return $callback();
+		} finally {
+			foreach ( $original_options as $option_name => $option_data ) {
+				if ( $option_data['exists'] ) {
+					update_option( $option_name, $option_data['value'] );
+				} else {
+					delete_option( $option_name );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Capture stock reservation minutes observed by the stock hold filter.
+	 *
+	 * @param callable $reserve_stock_callback Callback that attempts to reserve stock.
+	 * @return int|null
+	 */
+	private function get_captured_order_hold_stock_minutes( $reserve_stock_callback ) {
+		$captured_minutes = null;
+		$capture_minutes  = function ( $minutes ) use ( &$captured_minutes ) {
+			$captured_minutes = $minutes;
+			return 0;
+		};
+
+		add_filter( 'woocommerce_order_hold_stock_minutes', $capture_minutes );
+
+		try {
+			$reserve_stock_callback();
+		} finally {
+			remove_filter( 'woocommerce_order_hold_stock_minutes', $capture_minutes );
+		}
+
+		return $captured_minutes;
 	}
 
 	/**
@@ -211,6 +277,55 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	private function assertIsIntAndEquals( $expected, $actual ) {
 		$this->assertEquals( $expected, $actual );
 		self::assertIsInteger( $actual );
+	}
+
+	/**
+	 * @testdox reserve_stock_for_order defaults to 60 minutes when no duration is provided.
+	 */
+	public function test_reserve_stock_for_order_defaults_to_60_minutes() {
+		$minutes = $this->with_stock_reservation_options(
+			'15',
+			function () {
+				$order         = wc_create_order();
+				$reserve_stock = new ReserveStock();
+
+				return $this->get_captured_order_hold_stock_minutes(
+					function () use ( $reserve_stock, $order ) {
+						$reserve_stock->reserve_stock_for_order( $order );
+					}
+				);
+			}
+		);
+
+		$this->assertSame(
+			60,
+			$minutes,
+			'Direct stock reservation calls should use the explicit default duration.'
+		);
+	}
+
+	/**
+	 * @testdox wc_reserve_stock_for_order passes the configured checkout stock hold duration.
+	 */
+	public function test_wc_reserve_stock_for_order_passes_configured_checkout_hold_duration() {
+		$minutes = $this->with_stock_reservation_options(
+			'15',
+			function () {
+				$order = wc_create_order();
+
+				return $this->get_captured_order_hold_stock_minutes(
+					function () use ( $order ) {
+						wc_reserve_stock_for_order( $order );
+					}
+				);
+			}
+		);
+
+		$this->assertSame(
+			15,
+			$minutes,
+			'Core checkout stock reservation should use the configured hold duration.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`ReserveStock::reserve_stock_for_order()` no longer reads `woocommerce_hold_stock_minutes` when callers omit `$minutes`; it now uses a predictable 60-minute default. Core checkout still honors the store setting because `wc_reserve_stock_for_order()` passes it explicitly.

Small behavior change: direct callers that relied on the implicit store setting should now pass their desired duration explicitly.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #30612.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm test:php:env -- --filter 'WC_Stock_Functions_Tests::test_(reserve_stock_for_order_defaults_to_60_minutes|wc_reserve_stock_for_order_passes_configured_checkout_hold_duration)'`.
2. Confirm both tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHP syntax checks passed for the touched files.
- Targeted PHPUnit passed: `OK (2 tests, 2 assertions)`.
- PHPStan passed for the touched production files.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
