### PR TITLE
fix: make cart store removeCartItem idempotent

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-store-remove-item-idempotent
+++ b/plugins/woocommerce/changelog/fix-cart-store-remove-item-idempotent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the cart Interactivity store's removeCartItem idempotent so re-entrant removals of the same item no longer error with "Cart item no longer exists or is invalid".

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -286,6 +286,16 @@ const { actions } = store< Store >(
 		},
 		actions: {
 			*removeCartItem( key: string ): AsyncAction< void > {
+				// Idempotency guard: if the item is already gone from cart state
+				// (e.g. a re-entrant remove of the same key while the first is
+				// still settling, or after it optimistically removed the item),
+				// there's nothing to do. Skipping avoids sending a remove for a
+				// key the server has already dropped, which fails with
+				// "Cart item no longer exists or is invalid".
+				if ( ! state.cart.items.some( ( item ) => item.key === key ) ) {
+					return;
+				}
+
 				// Track what changes we're making for the sync event.
 				const quantityChanges: QuantityChanges = {
 					cartItemsPendingDelete: [ key ],


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Makes `removeCartItem` in the shared cart Interactivity store idempotent.

The action removes the item from `state.cart.items` optimistically and only catches and logs errors. So clicking remove repeatedly on the same item, especially under slow latency, fires a second remove for a key the server already dropped; that fails with "Cart item no longer exists or is invalid". The fix adds a guard at the top of the action: if the item is already gone from cart state, it returns early, so repeat removals no-op silently.

The store is shared, so this helps the Cart block and the Mini-Cart. I surfaced it while spiking the classic cart shortcode ([#66040](https://github.com/woocommerce/woocommerce/pull/66040)); it's a pre-existing gap in the shared store, not introduced by a specific PR.

### How to test the changes in this Pull Request:

1. Add a few items to the cart and open the Cart block (or the Mini-Cart / cart shortcode).
2. Throttle the network to a slow profile in devtools.
3. Click an item's remove control several times quickly.
4. Before: the console logs "Cart item no longer exists or is invalid" and an error notice shows. After: the item removes once, the repeat clicks do nothing, and no error appears.

### Testing that has already taken place:

- Verified live on the cart shortcode: the "Cart item no longer exists or is invalid" error stops on rapid repeat removals.
- I didn't re-run eslint / ts:check here; this fresh trunk worktree has no `node_modules`.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry was added manually at `plugins/woocommerce/changelog/fix-cart-store-remove-item-idempotent` (Significance: patch, Type: fix), so the automatic options below are left unchecked.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)
