### PR TITLE
Prevent double-escaping in PlanRepository queries

### DIFF
--- a/packages/php/woocommerce-subscriptions-engine/changelog/fix-double-escaping-in-plan-repository
+++ b/packages/php/woocommerce-subscriptions-engine/changelog/fix-double-escaping-in-plan-repository
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent double-escaping for incoming queries

--- a/packages/php/woocommerce-subscriptions-engine/src/Integration/Storage/PlanRepository.php
+++ b/packages/php/woocommerce-subscriptions-engine/src/Integration/Storage/PlanRepository.php
@@ -134,15 +134,20 @@ final class PlanRepository {
 		global $wpdb;
 
 		$table  = SchemaInstaller::get_table_name( SchemaInstaller::TABLE_PLANS );
-		$where  = $this->build_where_clauses( $args );
 		$order  = $this->build_order_clause( $args );
 		$limit  = max( 1, self::coerce_int( $args['limit'] ?? null, 50 ) );
 		$offset = max( 0, self::coerce_int( $args['offset'] ?? null, 0 ) );
 
-		$sql = "SELECT * FROM {$table}{$where} {$order} LIMIT %d OFFSET %d";
+		// phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+		[
+			'sql'    => $where_sql,
+			'params' => $where_params,
+		] = $this->build_where_clause( $args );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
-		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $limit, $offset ), ARRAY_A );
+		$params = array( ...$where_params, $limit, $offset );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table}{$where_sql} {$order} LIMIT %d OFFSET %d", $params ), ARRAY_A );
 		if ( ! is_array( $rows ) ) {
 			return array();
 		}
@@ -169,10 +174,22 @@ final class PlanRepository {
 		global $wpdb;
 
 		$table = SchemaInstaller::get_table_name( SchemaInstaller::TABLE_PLANS );
-		$where = $this->build_where_clauses( $args );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}{$where}" );
+		// phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+		[
+			'sql'    => $where_sql,
+			'params' => $where_params,
+		] = $this->build_where_clause( $args );
+
+		if ( array() === $where_params ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$result = $wpdb->get_var( "SELECT COUNT(*) FROM {$table}{$where_sql}" );
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table}{$where_sql}", $where_params ) );
+		}
+
+		return (int) $result;
 	}
 
 	/**
@@ -307,23 +324,27 @@ final class PlanRepository {
 	}
 
 	/**
-	 * Build SQL WHERE clauses from supported query args.
+	 * Build SQL WHERE clauses and params from supported query args.
 	 *
 	 * @param array<string, mixed> $args Query args.
+	 * @return array{sql: string, params: array<int, mixed>}
 	 */
-	private function build_where_clauses( array $args ): string {
+	private function build_where_clause( array $args ): array {
 		global $wpdb;
 
 		$clauses = array();
+		$params  = array();
 
 		$status = self::coerce_string( $args['status'] ?? null );
 		if ( '' !== $status ) {
-			$clauses[] = $wpdb->prepare( 'status = %s', $status );
+			$clauses[] = 'status = %s';
+			$params[]  = $status;
 		}
 
 		if ( array_key_exists( 'extension_slug', $args ) ) {
 			if ( self::is_valid_extension_slug( $args['extension_slug'] ) ) {
-				$clauses[] = $wpdb->prepare( 'extension_slug = %s', $args['extension_slug'] );
+				$clauses[] = 'extension_slug = %s';
+				$params[]  = $args['extension_slug'];
 			} else {
 				$clauses[] = '0 = 1';
 			}
@@ -349,7 +370,8 @@ final class PlanRepository {
 						$are_extension_slugs_valid = true;
 
 						$extension_slugs = array_values( $valid_slugs );
-						$clauses[]       = $wpdb->prepare( 'extension_slug IN (' . implode( ',', array_fill( 0, count( $extension_slugs ), '%s' ) ) . ')', $extension_slugs );
+						$clauses[]       = 'extension_slug IN (' . implode( ',', array_fill( 0, count( $extension_slugs ), '%s' ) ) . ')';
+						$params          = array_merge( $params, $extension_slugs );
 					}
 				}
 			}
@@ -362,14 +384,22 @@ final class PlanRepository {
 		$search = self::coerce_string( $args['search'] ?? null );
 		if ( '' !== $search ) {
 			$like      = '%' . $wpdb->esc_like( $search ) . '%';
-			$clauses[] = $wpdb->prepare( '(name LIKE %s OR description LIKE %s)', $like, $like );
+			$clauses[] = '(name LIKE %s OR description LIKE %s)';
+			$params[]  = $like;
+			$params[]  = $like;
 		}
 
 		if ( empty( $clauses ) ) {
-			return '';
+			return array(
+				'sql'    => '',
+				'params' => array(),
+			);
 		}
 
-		return ' WHERE ' . implode( ' AND ', $clauses );
+		return array(
+			'sql'    => ' WHERE ' . implode( ' AND ', $clauses ),
+			'params' => $params,
+		);
 	}
 
 	/**

--- a/packages/php/woocommerce-subscriptions-engine/tests/integration/Integration/Storage/PlanRepositoryTest.php
+++ b/packages/php/woocommerce-subscriptions-engine/tests/integration/Integration/Storage/PlanRepositoryTest.php
@@ -278,6 +278,50 @@ class PlanRepositoryTest extends EngineIntegrationTestCase {
 		$this->assertSame( array( $second_id, $archived_id, $first_id ), array_map( static fn ( Plan $plan ): ?int => $plan->get_id(), $ordered ) );
 	}
 
+	/**
+	 * Search terms that previously looked like placeholders after LIKE wildcards.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function prepare_specifier_search_terms_provider(): array {
+		return array(
+			'starts with s' => array( 'status-specifier-regression' ),
+			'starts with d' => array( 'daily-specifier-regression' ),
+			'starts with f' => array( 'fixed-specifier-regression' ),
+			'starts with F' => array( 'Featured-specifier-regression' ),
+			'starts with i' => array( 'intro-specifier-regression' ),
+		);
+	}
+
+	/**
+	 * @dataProvider prepare_specifier_search_terms_provider
+	 *
+	 * @param string $search Search term.
+	 */
+	public function test_query_search_terms_starting_with_prepare_specifiers( string $search ): void {
+		$group_id = $this->make_group();
+		$repo     = new PlanRepository();
+
+		$this->make_plan( $repo, $group_id, 'Unrelated prepare regression plan', 'lite' );
+		$expected_id = $this->make_plan( $repo, $group_id, $search . ' plan', 'lite' );
+
+		$query_args = array(
+			'extension_slug' => 'lite',
+			'status'         => Plan::STATUS_ACTIVE,
+			'search'         => $search,
+			'orderby'        => 'id',
+			'order'          => 'asc',
+			'limit'          => 10,
+			'offset'         => 0,
+		);
+		$plans      = $repo->query( $query_args );
+
+		$this->assertCount( 1, $plans );
+		$this->assertSame( $expected_id, $plans[0]->get_id() );
+
+		$this->assertSame( 1, $repo->count( $query_args ) );
+	}
+
 	public function test_invalid_extension_scopes_do_not_return_unscoped_results(): void {
 		$group_id = $this->make_group();
 		$repo     = new PlanRepository();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR addresses a double-escaping issue with the `woocommerce-subscriptions-engine` code by ensuring that we call `$wpdb->prepare()` only once for incoming queries.

Closes https://github.com/woocommerce/woocommerce/issues/66055.

Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/65958.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Testing should be covered by the unit and integration tests suites run via CI, as this PR includes a regression test to ensure that we're handling search queries with `%` values correctly.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
Local unit and integration test runs are passing.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
