### PR TITLE
Add as_has_scheduled_action fallback in batch processing and transient files

### DIFF
--- a/plugins/woocommerce/changelog/52745-fix-as-has-scheduled-action-fallback
+++ b/plugins/woocommerce/changelog/52745-fix-as-has-scheduled-action-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a fallback for the remaining `as_has_scheduled_action()` calls (batch processing watchdog/scheduling and transient files cleanup) so a very old bundled Action Scheduler from another plugin can no longer cause a fatal "undefined function" error.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -140,7 +140,11 @@ class BatchProcessingController {
 			$time += apply_filters( 'woocommerce_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );
 		}
 
-		if ( ! as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
+		if ( ! call_user_func( $has_scheduled_action, self::WATCHDOG_ACTION_NAME ) ) {
 			as_schedule_single_action(
 				$time,
 				self::WATCHDOG_ACTION_NAME,
@@ -326,7 +330,11 @@ class BatchProcessingController {
 	 * @return bool True if a batch processing action is already scheduled for the processor.
 	 */
 	public function is_scheduled( string $processor_class_name ): bool {
-		return as_has_scheduled_action( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
+		return (bool) call_user_func( $has_scheduled_action, self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -140,8 +140,7 @@ class BatchProcessingController {
 			$time += apply_filters( 'woocommerce_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );
 		}
 
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		// Prefer as_has_scheduled_action() (Action Scheduler 3.3.0+); fall back if an older bundled copy is loaded.
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
 
 		if ( ! call_user_func( $has_scheduled_action, self::WATCHDOG_ACTION_NAME ) ) {
@@ -330,8 +329,7 @@ class BatchProcessingController {
 	 * @return bool True if a batch processing action is already scheduled for the processor.
 	 */
 	public function is_scheduled( string $processor_class_name ): bool {
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		// Prefer as_has_scheduled_action() (Action Scheduler 3.3.0+); fall back if an older bundled copy is loaded.
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
 
 		return (bool) call_user_func( $has_scheduled_action, self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -311,7 +311,11 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 * @return bool True if the expired files cleanup action is currently scheduled, false otherwise.
 	 */
 	public function expired_files_cleanup_is_scheduled(): bool {
-		return as_has_scheduled_action( self::CLEANUP_ACTION_NAME, array(), self::CLEANUP_ACTION_GROUP );
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
+		return (bool) call_user_func( $has_scheduled_action, self::CLEANUP_ACTION_NAME, array(), self::CLEANUP_ACTION_GROUP );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -311,8 +311,7 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 * @return bool True if the expired files cleanup action is currently scheduled, false otherwise.
 	 */
 	public function expired_files_cleanup_is_scheduled(): bool {
-		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
-		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		// Prefer as_has_scheduled_action() (Action Scheduler 3.3.0+); fall back if an older bundled copy is loaded.
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
 
 		return (bool) call_user_func( $has_scheduled_action, self::CLEANUP_ACTION_NAME, array(), self::CLEANUP_ACTION_GROUP );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #52745.

`as_has_scheduled_action()` was added in **Action Scheduler 3.3.0** (2021-09-15) as a performant way to test for an existing action. WooCommerce assumes it is present, but Action Scheduler is a bundled library: many plugins ship their own copy, and while the highest registered version normally wins, a plugin that loads its copy non-standardly/too early can leave an **older (pre-3.3.0)** Action Scheduler active on an otherwise-modern WooCommerce site. When that happens, `as_has_scheduled_action()` is undefined and any unguarded call fatals.

PR #52725 added a `function_exists()` fallback for this in the PTK pattern store. Issue #52745 noted three remaining call sites without the same protection. This PR applies the established fallback to all three:

- `BatchProcessingController::schedule_watchdog_action()` (watchdog scheduling guard)
- `BatchProcessingController::is_scheduled()`
- `TransientFilesEngine::expired_files_cleanup_is_scheduled()`

Each now resolves to `as_next_scheduled_action()` when `as_has_scheduled_action()` is unavailable, via the same `function_exists()` + `call_user_func()` pattern already used elsewhere in the codebase (e.g. `BlockPatterns.php`, `DraftOrders.php`, and `BatchProcessingController` itself around line 575). The two `: bool` return sites cast the result, since `as_next_scheduled_action()` returns an integer timestamp rather than a boolean.

This prevents the fatal reported in the issue:
`Call to undefined function Automattic\WooCommerce\Internal\BatchProcessing\as_has_scheduled_action()`

### How to test the changes in this Pull Request:

**Normal path (function is present — the common case):**

1. On any standard WooCommerce install (Action Scheduler 3.3.0+, which modern WooCommerce bundles), confirm scheduling still works: batch processing and expired-transient-files cleanup schedule and report `is_scheduled()` / `expired_files_cleanup_is_scheduled()` correctly. Existing unit tests in `BatchProcessingControllerTests.php` cover this path.

**Fallback path (function is missing):**

To reach the fallback you need a site where an older Action Scheduler (< 3.3.0) is the loaded copy. Two ways to reproduce:

- *Quick / deterministic:* temporarily simulate the missing function so the fallback branch is taken, e.g. add `if ( ! function_exists( 'as_has_scheduled_action' ) ) { … }` locally, or run the changed methods under a bootstrap where Action Scheduler < 3.3.0 is loaded. Confirm no fatal is raised and `as_next_scheduled_action()` is used instead, with the same scheduled/not-scheduled result.
- *Realistic scenario:* this is the situation described in the [WooCommerce 8.8.1 advisory](https://developer.woocommerce.com/2024/04/15/woocommerce-8-8-1-advisory/) — a plugin such as **WP Mail SMTP 2.8.0** (and other pre-Feb-2022 releases) loaded an old bundled Action Scheduler in a way that won the version resolution, so `as_has_scheduled_action()` was undefined and every wp-admin request fataled. Installing such a plugin alongside modern WooCommerce reproduces the undefined-function condition that this fallback guards against.

Before this change, the fallback branch didn't exist and the call at each of the three sites would fatal in that scenario; after it, the methods degrade to `as_next_scheduled_action()`.

### Testing that has already taken place:

- The three changed call sites are consistent with the existing, already-merged `function_exists()` fallback pattern (`BlockPatterns.php`, `DraftOrders.php`, and `BatchProcessingController` ~line 575), so behavior under the normal path is unchanged.
- No new tests added, consistent with #52725: the "function undefined" condition can't be reproduced in the standard test environment where Action Scheduler is always loaded. Existing `is_scheduled()` coverage guards the normal path.
- References: `as_has_scheduled_action()` was introduced in [Action Scheduler 3.3.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.3.0) and is [documented API](https://actionscheduler.org/api/).
- Analysis assisted by an LLM (Claude Code): I reviewed every change, traced each call site's return-type contract, verified the Action Scheduler version facts against the changelog and official docs, and confirmed the pattern matches the merged precedent.
