### PR TITLE
fix(logging): delete all expired log files, not just the first 20

### DIFF
--- a/plugins/woocommerce/changelog/fix-log-cleanup-20-file-cap
+++ b/plugins/woocommerce/changelog/fix-log-cleanup-20-file-cap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the daily log cleanup so it deletes all expired log files, not just the first 20.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -57097,17 +57097,6 @@ parameters:
 			count: 1
 			path: src/Internal/Admin/Logging/LogHandlerFileV2.php
 
-		-
-			message: '#^Parameter \#1 \$input of function array_filter expects array, array\<Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File\>\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Logging/LogHandlerFileV2.php
-
-		-
-			message: '#^Parameter \#1 \$var of function count expects array\|Countable, array\<Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File\>\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/Admin/Logging/LogHandlerFileV2.php
 
 		-
 			message: '#^Call to protected method prepare_column_headers\(\) of class WC_Admin_Log_Table_List\.$#'

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -235,6 +235,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		}
 
 		$deleted = 0;
+		$skipped = 0;
 
 		// Fetch and delete in batches so that sites with more than the default
 		// per-page of log files don't leave expired files behind.
@@ -245,6 +246,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 					'date_start'  => 1,
 					'date_end'    => $timestamp,
 					'per_page'    => self::DELETE_BATCH_SIZE,
+					'offset'      => $skipped,
 				)
 			);
 
@@ -271,22 +273,23 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				}
 			);
 
-			$file_count = count( $files );
-			if ( $file_count < 1 ) {
-				break;
+			$file_count       = count( $files );
+			$vetoed_count     = $fetched_count - $file_count;
+			$deleted_in_batch = 0;
+			if ( $file_count > 0 ) {
+				$file_ids = array_map(
+					fn( $file ) => $file->get_file_id(),
+					$files
+				);
+
+				$deleted_in_batch = $this->file_controller->delete_files( $file_ids );
+				$deleted         += $deleted_in_batch;
 			}
 
-			$file_ids = array_map(
-				fn( $file ) => $file->get_file_id(),
-				$files
-			);
-
-			$deleted_in_batch = $this->file_controller->delete_files( $file_ids );
-			if ( $deleted_in_batch < 1 ) {
-				break;
-			}
-
-			$deleted += $deleted_in_batch;
+			// Deleted files disappear from the directory, so only vetoed files
+			// need to be skipped. If no progress was made, skip the full page to
+			// avoid retrying a permanently vetoed or undeletable batch forever.
+			$skipped += $deleted_in_batch > 0 ? $vetoed_count : $fetched_count;
 		} while ( self::DELETE_BATCH_SIZE === $fetched_count );
 
 		if ( $deleted > 0 ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -11,6 +11,13 @@ use WC_Log_Handler;
  */
 class LogHandlerFileV2 extends WC_Log_Handler {
 	/**
+	 * Maximum number of expired log files to delete in one loop iteration.
+	 *
+	 * @var int
+	 */
+	private const DELETE_BATCH_SIZE = 100;
+
+	/**
 	 * Instance of the FileController class.
 	 *
 	 * @var FileController
@@ -18,18 +25,10 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 	private $file_controller;
 
 	/**
-	 * Instance of the Settings class.
-	 *
-	 * @var Settings
-	 */
-	private $settings;
-
-	/**
 	 * LogHandlerFileV2 class.
 	 */
 	public function __construct() {
 		$this->file_controller = wc_get_container()->get( FileController::class );
-		$this->settings        = wc_get_container()->get( Settings::class );
 	}
 
 	/**
@@ -235,47 +234,60 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 			return 0;
 		}
 
-		$files = $this->file_controller->get_files(
-			array(
-				'date_filter' => 'created',
-				'date_start'  => 1,
-				'date_end'    => $timestamp,
-			)
-		);
+		$deleted = 0;
 
-		if ( is_wp_error( $files ) ) {
-			return 0;
-		}
+		// Fetch and delete in batches so that sites with more than the default
+		// per-page of log files don't leave expired files behind.
+		do {
+			$files = $this->file_controller->get_files(
+				array(
+					'date_filter' => 'created',
+					'date_start'  => 1,
+					'date_end'    => $timestamp,
+					'per_page'    => self::DELETE_BATCH_SIZE,
+				)
+			);
 
-		$files = array_filter(
-			$files,
-			function ( $file ) use ( $timestamp ) {
-				/**
-				 * Allows preventing an expired log file from being deleted.
-				 *
-				 * @param bool $delete    True to delete the file.
-				 * @param File $file      The log file object.
-				 * @param int  $timestamp The expiration threshold.
-				 *
-				 * @since 8.7.0
-				 */
-				$delete = apply_filters( 'woocommerce_logger_delete_expired_file', true, $file, $timestamp );
-
-				return boolval( $delete );
+			if ( is_wp_error( $files ) || ! is_array( $files ) ) {
+				break;
 			}
-		);
 
-		if ( count( $files ) < 1 ) {
-			return 0;
-		}
+			$fetched_count = count( $files );
+			$files         = array_filter(
+				$files,
+				function ( $file ) use ( $timestamp ) {
+					/**
+					 * Allows preventing an expired log file from being deleted.
+					 *
+					 * @param bool $delete    True to delete the file.
+					 * @param File $file      The log file object.
+					 * @param int  $timestamp The expiration threshold.
+					 *
+					 * @since 8.7.0
+					 */
+					$delete = apply_filters( 'woocommerce_logger_delete_expired_file', true, $file, $timestamp );
 
-		$file_ids = array_map(
-			fn( $file ) => $file->get_file_id(),
-			$files
-		);
+					return boolval( $delete );
+				}
+			);
 
-		$deleted        = $this->file_controller->delete_files( $file_ids );
-		$retention_days = $this->settings->get_retention_period();
+			$file_count = count( $files );
+			if ( $file_count < 1 ) {
+				break;
+			}
+
+			$file_ids = array_map(
+				fn( $file ) => $file->get_file_id(),
+				$files
+			);
+
+			$deleted_in_batch = $this->file_controller->delete_files( $file_ids );
+			if ( $deleted_in_batch < 1 ) {
+				break;
+			}
+
+			$deleted += $deleted_in_batch;
+		} while ( self::DELETE_BATCH_SIZE === $fetched_count );
 
 		if ( $deleted > 0 ) {
 			$this->handle(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -181,7 +181,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 			)
 		);
 
-		if ( is_wp_error( $files ) || count( $files ) < 1 ) {
+		if ( is_wp_error( $files ) || ! is_array( $files ) || count( $files ) < 1 ) {
 			return 0;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\{ LogHandlerFileV2, Settings };
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
+use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
 use WC_Unit_Test_Case;
 
 /**
@@ -422,13 +423,22 @@ MESSAGE;
 		$current_time = time();
 		$past_time    = strtotime( '-5 days' );
 
-		// Create 101 expired files. Only the last one should be deletable.
-		$expired_count = 101;
+		// Create 100 vetoed files, then the single allowed file. Files are sorted
+		// by modified time descending, so the 100 vetoed files normally land on the
+		// first 100-file page. Touch the allowed file to an older mtime so it is
+		// guaranteed to fall on the next page and forces pagination to advance past
+		// a fully vetoed batch.
+		$expired_count = 100;
 		foreach ( range( 1, $expired_count ) as $suffix ) {
 			$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => "source-{$suffix}" ) );
 		}
+		$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source-101' ) );
 
-		// Allow only the last file to be deleted.
+		$allowed_paths = glob( Settings::get_log_directory() . '*source-101*.log' );
+		$this->assertCount( 1, $allowed_paths );
+		FilesystemUtil::get_wp_filesystem()->touch( reset( $allowed_paths ), $past_time - 1 );
+
+		// Allow only the older file to be deleted.
 		$filter = function ( $delete, $file ) {
 			unset( $delete );
 			$basename = basename( $file->get_path() );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -380,6 +380,42 @@ MESSAGE;
 	}
 
 	/**
+	 * @testdox Check that delete_logs_before_timestamp deletes more than 20 expired log files in one run.
+	 */
+	public function test_delete_logs_before_timestamp_deletes_more_than_default_per_page() {
+		$current_time = time();
+		$past_time    = strtotime( '-5 days' );
+
+		// Create more expired files than a single delete batch can remove (batch size is 100).
+		$expired_count = 101;
+		foreach ( range( 1, $expired_count ) as $suffix ) {
+			$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => "source-{$suffix}" ) );
+		}
+
+		// Add a couple of non-expired files as well.
+		$this->sut->handle( $current_time, 'debug', 'new!', array( 'source' => 'fresh1' ) );
+		$this->sut->handle( $current_time, 'debug', 'new!', array( 'source' => 'fresh2' ) );
+
+		$paths = glob( Settings::get_log_directory() . '*.log' );
+		$this->assertCount( $expired_count + 2, $paths );
+
+		$result = $this->sut->delete_logs_before_timestamp( strtotime( '-3 days' ) );
+		$this->assertEquals( $expired_count, $result );
+
+		$paths = glob( Settings::get_log_directory() . '*.log' );
+		// wc_logger plus two fresh files.
+		$this->assertCount( 3, $paths );
+
+		$paths = glob( Settings::get_log_directory() . 'wc_logger*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content  = file_get_contents( reset( $paths ) );
+		$expected_string = '101 expired log files were deleted.';
+		$this->assertStringContainsString( $expected_string, $actual_content );
+	}
+
+	/**
 	 * @testdox Check that the handle method does not throw an error when passed a non-array context.
 	 */
 	public function test_handle_context_does_not_throw_error_non_array_contexts() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -416,6 +416,48 @@ MESSAGE;
 	}
 
 	/**
+	 * @testdox Check that delete_logs_before_timestamp advances past a fully vetoed batch.
+	 */
+	public function test_delete_logs_before_timestamp_advances_past_vetoed_batch() {
+		$current_time = time();
+		$past_time    = strtotime( '-5 days' );
+
+		// Create 101 expired files. Only the last one should be deletable.
+		$expired_count = 101;
+		foreach ( range( 1, $expired_count ) as $suffix ) {
+			$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => "source-{$suffix}" ) );
+		}
+
+		// Allow only the last file to be deleted.
+		$filter = function ( $delete, $file ) {
+			unset( $delete );
+			$basename = basename( $file->get_path() );
+			return false !== strpos( $basename, 'source-101' );
+		};
+		add_filter( 'woocommerce_logger_delete_expired_file', $filter, 10, 2 );
+
+		try {
+			$result = $this->sut->delete_logs_before_timestamp( strtotime( '-3 days' ) );
+		} finally {
+			remove_filter( 'woocommerce_logger_delete_expired_file', $filter, 10 );
+		}
+
+		$this->assertEquals( 1, $result );
+
+		$paths = glob( Settings::get_log_directory() . '*.log' );
+		// 100 vetoed files, 1 wc_logger summary file.
+		$this->assertCount( 101, $paths );
+
+		$paths = glob( Settings::get_log_directory() . 'wc_logger*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content  = file_get_contents( reset( $paths ) );
+		$expected_string = '1 expired log file was deleted.';
+		$this->assertStringContainsString( $expected_string, $actual_content );
+	}
+
+	/**
 	 * @testdox Check that the handle method does not throw an error when passed a non-array context.
 	 */
 	public function test_handle_context_does_not_throw_error_non_array_contexts() {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren\'t other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #66071.

`LogHandlerFileV2::delete_logs_before_timestamp()` used `FileController::get_files()` without setting `per_page`, so it inherited the default UI pagination value of 20. When the daily `woocommerce_cleanup_logs` action ran on sites with more than 20 distinct expired log sources, it deleted only 20 files and left the rest behind.

This change fetches expired log files in batches of 100 and deletes them until no more expired files remain. A no-progress guard stops the loop if a batch cannot be deleted.

### Screenshots or screen recordings:

No UI changes.

### How to test the changes in this Pull Request:

1. Create more than 20 distinct expired log files, e.g. with WP-CLI:
   ```php
   <?php
    = wc_get_logger();
   foreach ( range( \'a\', \'z\' ) as  ) {
       ->info( \'hello world\', array( \'source\' => \'hello-logger-\' .  ) );
   }
   ```
   Backdate the generated `hello-logger-*.log` files in `wp-content/uploads/wc-logs/` so they are older than the retention period.
2. Run the cleanup action manually:
   ```sh
   wp eval \'do_action( "woocommerce_cleanup_logs" );\'
   ```
3. Check `wp-content/uploads/wc-logs/` — all `hello-logger-*.log` files should be gone, and the `wc_logger` log should report the actual number deleted (e.g. `26 expired log files were deleted.`).

### Testing that has already taken place:

- Automated tests added in `LogHandlerFileV2Test.php` covering 101 expired files deleted across batches and a fully vetoed first batch.
- Made the vetoed-batch test deterministic by forcing the allowed file to an older mtime so it falls on the second page.
- PHPUnit: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter LogHandlerFileV2Test` — OK (22 tests, 65 assertions).
- PHPCS: `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Branch-level lint: `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean.
- PHPStan: `composer exec -- phpstan analyse src/Internal/Admin/Logging/LogHandlerFileV2.php --memory-limit=2G` — no errors.
- CodeRabbit review: passed with no actionable findings after resolving the nondeterministic vetoed-batch test thread.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Comment required below)

**Changelog Entry Details**

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix the daily log cleanup so it deletes all expired log files, not just the first 20.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
