### PR TITLE
Fix misleading get_unpaid_orders() docblock (says after, queries before)

### DIFF
--- a/plugins/woocommerce/changelog/fix-get-unpaid-orders-docblock
+++ b/plugins/woocommerce/changelog/fix-get-unpaid-orders-docblock
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Correct the WC_Order_Data_Store_CPT::get_unpaid_orders() docblock to reflect that it returns orders last updated before the specified date, matching the query and the HPOS data store.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -544,7 +544,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
-	 * Get unpaid orders after a certain date,
+	 * Get unpaid orders last updated before the specified date.
 	 *
 	 * @param  int $date Timestamp.
 	 * @return array


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The docblock for `WC_Order_Data_Store_CPT::get_unpaid_orders()` claimed it returns orders "after a certain date", but the query uses `post_modified < %s` and intentionally returns orders last updated *before* the cutoff — the behavior the `woocommerce_cancel_unpaid_orders` cron depends on to cancel stale pending orders. Issue #35675 reported this as a bug and suggested flipping the operator to `>`; doing so would actually break order auto-cancellation. The SQL is correct by design, and only the comment was misleading.

This corrects the docblock to match the query and to harmonize with `OrdersTableDataStore::get_unpaid_orders()` (HPOS), which already documents the "before" behavior — exactly the harmonization requested in the issue thread.

Closes #35675.

### How to test the changes in this Pull Request:

N/A

### Testing that has already taken place:

Comment-only change. Confirmed the corrected docblock now matches both the query (`post_modified < %s`) and the HPOS data store's documented behavior. No runtime behavior changes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (`Type: dev`, `Significance: patch`) in `plugins/woocommerce/changelog/fix-get-unpaid-orders-docblock`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>