### PR TITLE
Decouple blocks reformat-files script from .eslintignore

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6930-prettier-ignore-decouple
+++ b/plugins/woocommerce/changelog/wooplug-6930-prettier-ignore-decouple
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Decouple the blocks reformat-files script from .eslintignore by using a dedicated .prettierignore.

--- a/plugins/woocommerce/client/blocks/.prettierignore
+++ b/plugins/woocommerce/client/blocks/.prettierignore
@@ -1,2 +1,15 @@
 *.json
 *.yml
+
+build
+build-module
+coverage
+languages
+node_modules
+vendor
+legacy
+reports
+tests/e2e-jest/specs/backend/__fixtures__
+tests/e2e-jest/specs/backend/__snapshots__
+storybook/dist
+assets/js/interactivity

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -67,7 +67,7 @@
 		"lint:js-fix": "eslint assets/js --ext=js,jsx,ts,tsx --fix",
 		"lint:md:docs": "wp-scripts lint-md-docs",
 		"pre-commit": "lint-staged",
-		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,ts,tsx,css,scss}\"",
+		"reformat-files": "prettier --write \"**/*.{js,jsx,ts,tsx,css,scss}\"",
 		"rimraf": "./node_modules/rimraf/bin.js",
 		"start": "rimraf ../../assets/client/blocks/* && BABEL_ENV=default CHECK_CIRCULAR_DEPS=true webpack --watch",
 		"storybook": "pnpm watch:build:storybook",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The blocks `reformat-files` script reused `.eslintignore` via Prettier's `--ignore-path`. The upcoming ESLint v9/v10 flat-config migration removes `.eslintignore`, which would silently break that ignore list. This decouples the two ahead of time: the Prettier-relevant directory ignores are copied into `.prettierignore`, and `reformat-files` now uses Prettier's default ignore file. Behavior is unchanged for the script's target file types (`js,jsx,ts,tsx,css,scss`). `.eslintignore` is intentionally left in place for ESLint 8.

Part of #66078. This is the first prep PR of that ESLint v9/v10 flat-config migration.

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce/client/blocks`, place a deliberately misformatted JS file inside an ignored directory (e.g. `coverage/`) and an identical one at the package root.
2. Run `pnpm exec prettier --check coverage/<file>.js <file>.js`.
3. Confirm the file under `coverage/` is ignored (reported clean) and the root file is flagged with a code-style warning — i.e. the `.prettierignore` patterns migrated from `.eslintignore` are honored.
4. Run `pnpm --filter=@woocommerce/block-library run reformat-files` and confirm no files under `build`, `node_modules`, `vendor`, etc. are reformatted.

### Testing that has already taken place:

- Verified with `prettier --check` (wp-prettier 2.8.5) that a misformatted file in a migrated ignore dir (`coverage/`) is skipped while the same content at the package root is flagged.
- Confirmed `.eslintrc.js` is not ignored by Prettier before or after (the dropped `!.eslintrc.js` negation has no effect on Prettier).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually. Internal dev tooling change, not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
