### PR TITLE
Avoid update-time fatals in 10.9 settings paths

### DIFF
--- a/plugins/woocommerce/changelog/fix-66031-update-time-settings-fatals
+++ b/plugins/woocommerce/changelog/fix-66031-update-time-settings-fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent update-time fatal errors by guarding new settings SDK classes and preserving the removed legacy settings API controller as a no-op compatibility stub.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -257,12 +257,20 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * Settings section registry instance, or null when the modern settings SDK is unavailable.
 		 *
 		 * The class can be missing mid-update: a 10.9 copy of this file may load before the autoloader
-		 * class map knows the new registry, so a direct call would fatal with "class not found".
+		 * class map can safely resolve the new registry, so a direct call would fatal.
 		 *
 		 * @return SettingsSectionRegistry|null
 		 */
 		protected function get_settings_section_registry() {
-			return class_exists( SettingsSectionRegistry::class ) ? SettingsSectionRegistry::get_instance() : null;
+			try {
+				if ( ! class_exists( SettingsSectionRegistry::class ) ) {
+					return null;
+				}
+
+				return SettingsSectionRegistry::get_instance();
+			} catch ( \Throwable $e ) {
+				return null;
+			}
 		}
 
 		/**
@@ -272,7 +280,15 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @return SettingsUIRequestContext|null
 		 */
 		protected function get_settings_ui_request_context( $section ) {
-			return class_exists( SettingsUIRequestContext::class ) ? SettingsUIRequestContext::for_settings_page( $this, $section ) : null;
+			try {
+				if ( ! class_exists( SettingsUIRequestContext::class ) ) {
+					return null;
+				}
+
+				return SettingsUIRequestContext::for_settings_page( $this, $section );
+			} catch ( \Throwable $e ) {
+				return null;
+			}
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -139,9 +139,9 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			}
 
 			$section = is_string( $current_section ) ? $current_section : '';
-			$context = SettingsUIRequestContext::for_settings_page( $this, $section );
+			$context = $this->get_settings_ui_request_context( $section );
 
-			if ( ! $context->is_rendering_enabled() ) {
+			if ( ! $context || ! $context->is_rendering_enabled() ) {
 				return $classes;
 			}
 
@@ -254,6 +254,28 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		}
 
 		/**
+		 * Settings section registry instance, or null when the modern settings SDK is unavailable.
+		 *
+		 * The class can be missing mid-update: a 10.9 copy of this file may load before the autoloader
+		 * class map knows the new registry, so a direct call would fatal with "class not found".
+		 *
+		 * @return SettingsSectionRegistry|null
+		 */
+		protected function get_settings_section_registry() {
+			return class_exists( SettingsSectionRegistry::class ) ? SettingsSectionRegistry::get_instance() : null;
+		}
+
+		/**
+		 * Settings UI request context, or null when the modern settings SDK is unavailable.
+		 *
+		 * @param string $section Section id.
+		 * @return SettingsUIRequestContext|null
+		 */
+		protected function get_settings_ui_request_context( $section ) {
+			return class_exists( SettingsUIRequestContext::class ) ? SettingsUIRequestContext::for_settings_page( $this, $section ) : null;
+		}
+
+		/**
 		 * Get the settings for a given section.
 		 * This method is invoked from 'get_settings_for_section' when no 'get_settings_for_{current_section}_section'
 		 * method exists in the class.
@@ -266,7 +288,8 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @return array Settings array, each item being an associative array representing a setting.
 		 */
 		protected function get_settings_for_section_core( $section_id ) {
-			$registered_section = SettingsSectionRegistry::get_instance()->get_registered( $this->id, (string) $section_id );
+			$registry           = $this->get_settings_section_registry();
+			$registered_section = $registry ? $registry->get_registered( $this->id, (string) $section_id ) : null;
 
 			return $registered_section ? $registered_section->get_settings( $this ) : array();
 		}
@@ -278,7 +301,8 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 */
 		public function get_sections() {
 			$sections            = $this->get_own_sections();
-			$registered_sections = SettingsSectionRegistry::get_instance()->get_sections_for_page( $this->id );
+			$registry            = $this->get_settings_section_registry();
+			$registered_sections = $registry ? $registry->get_sections_for_page( $this->id ) : array();
 
 			foreach ( $registered_sections as $section_id => $section_label ) {
 				// Preserve sections declared by the settings page when a registered section uses the same id.
@@ -349,9 +373,9 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			global $current_section;
 
 			$section = is_string( $current_section ) ? $current_section : '';
-			$context = SettingsUIRequestContext::for_settings_page( $this, $section );
+			$context = $this->get_settings_ui_request_context( $section );
 
-			if ( $context->is_rendering_enabled() ) {
+			if ( $context && $context->is_rendering_enabled() ) {
 				$settings_ui_page = $context->get_settings_ui_page();
 				assert( $settings_ui_page instanceof SettingsUIPageInterface );
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -240,7 +240,9 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 			return false;
 		}
 
-		return null !== SettingsSectionRegistry::get_instance()->get_registered( self::TAB_NAME, (string) $section );
+		$registry = $this->get_settings_section_registry();
+
+		return null !== $registry && null !== $registry->get_registered( self::TAB_NAME, (string) $section );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Settings.php
+++ b/plugins/woocommerce/src/Admin/API/Settings.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * REST API Settings Controller (compatibility stub).
+ *
+ * @package WooCommerce\Admin\API
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Settings controller.
+ *
+ * The real controller was removed in 10.9 with the settings editor. This empty stub stays so an
+ * in-memory 10.8 controller list, still naming this class while the files are swapped to 10.9
+ * during an update, can instantiate it instead of fataling on the deleted file. It registers
+ * nothing.
+ *
+ * @deprecated 10.9.0
+ */
+class Settings {
+
+	/**
+	 * Register routes. Intentionally a no-op.
+	 */
+	public function register_routes(): void {}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -409,7 +409,16 @@ class Settings {
 	 * @return array
 	 */
 	private function add_settings_ui_schema( array $settings ): array {
-		$context = SettingsUIRequestContext::get_current();
+		try {
+			if ( ! class_exists( SettingsUIRequestContext::class ) ) {
+				return $settings;
+			}
+
+			$context = SettingsUIRequestContext::get_current();
+		} catch ( \Throwable $e ) {
+			return $settings;
+		}
+
 		if ( ! $context ) {
 			return $settings;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -344,7 +344,11 @@ class SettingsUIRequestContext {
 	 * @return SettingsUIPageInterface|null
 	 */
 	private static function resolve_settings_ui_page( \WC_Settings_Page $settings_page, string $section ): ?SettingsUIPageInterface {
-		$registered_section = SettingsSectionRegistry::get_instance()->get_registered( $settings_page->get_id(), $section );
+		try {
+			$registered_section = SettingsSectionRegistry::get_instance()->get_registered( $settings_page->get_id(), $section );
+		} catch ( \Throwable $e ) {
+			$registered_section = null;
+		}
 
 		if ( $registered_section ) {
 			return new RegisteredSettingsSectionAdapter( $settings_page, $registered_section );

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -456,7 +456,16 @@ class WCAdminAssets {
 	 * @return array
 	 */
 	private function get_settings_ui_script_dependencies(): array {
-		$context = SettingsUIRequestContext::get_current();
+		try {
+			if ( ! class_exists( SettingsUIRequestContext::class ) ) {
+				return array();
+			}
+
+			$context = SettingsUIRequestContext::get_current();
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
 		if ( ! $context ) {
 			return array();
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This fixes update-time fatals reported after updating WooCommerce 10.8.x to 10.9.x by making the 10.9 settings migration paths tolerant of mixed in-memory/file-system state during an in-place update.

The PR:

- guards legacy `WC_Settings_Page` settings SDK lookups so missing/stale autoload entries for `SettingsSectionRegistry` or `SettingsUIRequestContext` fall back gracefully instead of fataling;
- guards the Payments settings registered-section lookup through the same compatibility path;
- guards other settings UI bootstrap paths that can resolve `SettingsUIRequestContext::get_current()` during settings-page asset/schema setup;
- catches transient autoloader failures from `SettingsUIRequestContext` when `SettingsSectionRegistry` cannot be resolved;
- restores `Automattic\WooCommerce\Admin\API\Settings` as a no-op compatibility stub so a stale 10.8 REST controller list can instantiate it during an update without re-registering the removed legacy settings endpoint.

Closes #66031.

(For Bug Fixes) Bug introduced in PRs #65316 and #65813.

### Screenshots or screen recordings:

N/A — this is an update-time compatibility fix for fatal errors.

### How to test the changes in this Pull Request:

1. Start from a WooCommerce 10.8.x site and update to a build from this branch.
2. Visit `/wp-admin/` and WooCommerce → Settings, including the Payments tab.
3. Confirm wp-admin and WooCommerce settings pages load without fatal errors.
4. Confirm registered settings sections still render normally when the settings SDK classes are available.
5. To simulate a stale autoload/classmap window, temporarily make the new settings SDK class files unavailable, clear opcode cache if applicable, and reload WooCommerce admin/settings pages. Confirm the pages degrade instead of fataling, then restore the files.
6. Confirm `Automattic\WooCommerce\Admin\API\Settings` can still be instantiated and `register_routes()` can be called without registering the removed legacy endpoint.

### Testing that has already taken place:

Local environment: existing WooCommerce/WooPayments Docker site at `http://localhost:8082`, WordPress 7.0, PHP 8.1.34, WooCommerce symlinked to this checkout.

- `pnpm install --frozen-lockfile` — passed.
- `php -l` on all changed PHP files — passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — passed.
- `composer exec -- phpstan analyse includes/admin/settings/class-wc-settings-page.php src/Internal/Admin/Settings/SettingsUIRequestContext.php src/Internal/Admin/WCAdminAssets.php src/Internal/Admin/Settings.php --memory-limit=2G` — passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — passed with existing JS warnings for branch-vs-trunk ignored/unresolved e2e files.
- Authenticated smoke requests returned HTTP 200 and no fatal/critical-error output for:
  - `/wp-admin/`
  - `/wp-admin/admin.php?page=wc-admin`
  - `/wp-admin/admin.php?page=wc-settings`
  - `/wp-admin/admin.php?page=wc-settings&tab=checkout`
  - `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=offline`
- Simulated stale autoloader/missing-file windows by temporarily renaming:
  - `src/Admin/Settings/SettingsSectionRegistry.php`
  - `src/Internal/Admin/Settings/SettingsUIRequestContext.php`
  - both files at once

  In each simulation, authenticated requests to WooCommerce admin/settings pages returned HTTP 200 without the reported `SettingsSectionRegistry` / `SettingsUIRequestContext` fatal.
- Verified the compatibility stub with WP-CLI:
  - `Automattic\WooCommerce\Admin\API\Settings` exists.
  - It can be instantiated.
  - Calling `register_routes()` returns without fataling.

Build note: `pnpm build` was attempted and failed in the existing admin bundle dependency graph while resolving `react-dom/client` and `uuid` from `@wordpress/dataviews`. This PR is PHP-only; the targeted PHP checks and runtime smoke tests above passed.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> Point-release PR targeting `release/10.9`; please assign the appropriate 10.9.x milestone manually if needed.

### Changelog entry

Changelog file added manually: `plugins/woocommerce/changelog/fix-66031-update-time-settings-fatals`.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
