### PR TITLE
Fix product attributes lookup table tools failing via REST API

### DIFF
--- a/plugins/woocommerce/changelog/32831-fix-regenerate-attributes-lookup-table-via-rest-api
+++ b/plugins/woocommerce/changelog/32831-fix-regenerate-attributes-lookup-table-via-rest-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow the "Regenerate the product attributes lookup table" tool (and the related abort and resume tools) to run via the REST API instead of failing with an "Invalid nonce" error.

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -367,10 +367,8 @@ class DataRegenerator {
 	/**
 	 * Callback to initiate the regeneration process when the tool is run.
 	 *
-	 * This runs both from the Status - Tools admin page and from the REST API. Authorization is
-	 * enforced by the caller: the admin page verifies the 'debug_action' nonce before dispatching
-	 * the tool (see WC_Admin_Status::status_tools), and the REST controller performs a capability
-	 * check (see WC_REST_System_Status_Tools_V2_Controller::update_item_permissions_check).
+	 * Runs both from the Tools admin page and from the REST API. Authorization is
+	 * enforced by the caller (nonce for the admin page, capability check for the REST endpoint).
 	 *
 	 * @throws \Exception The regeneration is already in progress.
 	 */

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -335,7 +335,7 @@ class DataRegenerator {
 				'desc'             => __( 'This tool will abort the regenerate product attributes lookup table regeneration. After this is done the process can be either started over, or resumed to continue where it stopped.', 'woocommerce' ),
 				'requires_refresh' => true,
 				'callback'         => function () {
-					$this->abort_regeneration( true );
+					$this->abort_regeneration( false );
 					return __( 'Product attributes lookup table regeneration process has been aborted.', 'woocommerce' );
 				},
 				'button'           => __( 'Abort', 'woocommerce' ),
@@ -353,7 +353,7 @@ class DataRegenerator {
 					),
 				'requires_refresh' => true,
 				'callback'         => function () {
-					$this->resume_regeneration( true );
+					$this->resume_regeneration( false );
 					return __( 'Product attributes lookup table regeneration process has been resumed.', 'woocommerce' );
 				},
 				'button'           => __( 'Resume', 'woocommerce' ),
@@ -365,13 +365,16 @@ class DataRegenerator {
 	}
 
 	/**
-	 * Callback to initiate the regeneration process from the Status - Tools page.
+	 * Callback to initiate the regeneration process when the tool is run.
+	 *
+	 * This runs both from the Status - Tools admin page and from the REST API. Authorization is
+	 * enforced by the caller: the admin page verifies the 'debug_action' nonce before dispatching
+	 * the tool (see WC_Admin_Status::status_tools), and the REST controller performs a capability
+	 * check (see WC_REST_System_Status_Tools_V2_Controller::update_item_permissions_check).
 	 *
 	 * @throws \Exception The regeneration is already in progress.
 	 */
 	private function initiate_regeneration_from_tools_page() {
-		$this->verify_tool_execution_nonce();
-
 		//phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['regenerate_product_attribute_lookup_data_product_id'] ) ) {
 			$product_id = (int) $_REQUEST['regenerate_product_attribute_lookup_data_product_id'];

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -321,4 +321,90 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$actual_final_option_value = get_option( 'woocommerce_attribute_lookup_enabled' );
 		$this->assertEquals( $expected_final_option_value, $actual_final_option_value );
 	}
+
+	/**
+	 * @testdox The 'regenerate' tool callback runs without requiring a nonce (e.g. when invoked via the REST API).
+	 */
+	public function test_regenerate_tool_callback_runs_without_a_nonce() {
+		global $wpdb;
+
+		// Simulate a non-admin-page invocation (REST API / WP-CLI), where no 'debug_action' nonce is present.
+		unset( $_REQUEST['_wpnonce'] );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $this->lookup_table_name );
+		$wpdb->query( 'CREATE TABLE ' . $this->lookup_table_name . ' ( foo int );' );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$sut   = $this->get_sut_for_existing_lookup_table();
+		$tools = $sut->add_initiate_regeneration_entry_to_tools_array( array() );
+
+		$message = $tools['regenerate_product_attributes_lookup_table']['callback']();
+
+		$this->assertStringContainsString( 'regenerating', $message, 'The regenerate tool must run without a nonce.' );
+	}
+
+	/**
+	 * @testdox The 'abort' tool callback runs without requiring a nonce (e.g. when invoked via the REST API).
+	 */
+	public function test_abort_tool_callback_runs_without_a_nonce() {
+		// Simulate a non-admin-page invocation (REST API / WP-CLI), where no 'debug_action' nonce is present.
+		unset( $_REQUEST['_wpnonce'] );
+
+		$sut = $this->get_sut_for_existing_lookup_table( true );
+
+		$tools = $sut->add_initiate_regeneration_entry_to_tools_array( array() );
+
+		$message = $tools['abort_product_attributes_lookup_table_regeneration']['callback']();
+
+		$this->assertStringContainsString( 'aborted', $message, 'The abort tool must run without a nonce.' );
+	}
+
+	/**
+	 * @testdox The 'resume' tool callback runs without requiring a nonce (e.g. when invoked via the REST API).
+	 */
+	public function test_resume_tool_callback_runs_without_a_nonce() {
+		// Simulate a non-admin-page invocation (REST API / WP-CLI), where no 'debug_action' nonce is present.
+		unset( $_REQUEST['_wpnonce'] );
+
+		$sut = $this->get_sut_for_existing_lookup_table( false, true );
+
+		$tools = $sut->add_initiate_regeneration_entry_to_tools_array( array() );
+
+		$message = $tools['resume_product_attributes_lookup_table_regeneration']['callback']();
+
+		$this->assertStringContainsString( 'resumed', $message, 'The resume tool must run without a nonce.' );
+	}
+
+	/**
+	 * Build a DataRegenerator whose data store reports that the lookup table exists, so that the
+	 * Status - Tools entries (and their callbacks) get registered. The real existence check relies
+	 * on SHOW TABLES, which doesn't list the temporary tables that PHPUnit creates.
+	 *
+	 * @param bool $regeneration_in_progress Whether to flag a regeneration as currently in progress.
+	 * @param bool $regeneration_aborted     Whether to flag the last regeneration as aborted.
+	 * @return DataRegenerator
+	 */
+	private function get_sut_for_existing_lookup_table( bool $regeneration_in_progress = false, bool $regeneration_aborted = false ): DataRegenerator {
+		// phpcs:disable Squiz.Commenting
+		$data_store = new class() extends LookupDataStore {
+			public function check_lookup_table_exists() {
+				return true;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+		$container->replace( LookupDataStore::class, $data_store );
+
+		if ( $regeneration_in_progress ) {
+			$data_store->set_regeneration_in_progress_flag();
+		}
+		if ( $regeneration_aborted ) {
+			$data_store->set_regeneration_aborted_flag();
+		}
+
+		return $container->get( DataRegenerator::class );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -331,6 +331,9 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		// Simulate a non-admin-page invocation (REST API / WP-CLI), where no 'debug_action' nonce is present.
 		unset( $_REQUEST['_wpnonce'] );
 
+		// Ensure the full-table path is exercised, not the admin product-selector branch.
+		unset( $_REQUEST['regenerate_product_attribute_lookup_data_product_id'] );
+
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $this->lookup_table_name );
 		$wpdb->query( 'CREATE TABLE ' . $this->lookup_table_name . ' ( foo int );' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The "Regenerate the product attributes lookup table" system status tool (and the related "Abort" and "Resume" tools) could not be executed through the REST API (`PUT /wc/v3/system_status/tools/{id}`). The request always failed with:

```
There was an error calling regenerate_product_attributes_lookup_table: Invalid nonce
```

These three tools are registered via the `woocommerce_debug_tools` filter in `DataRegenerator`. Their callbacks called `verify_tool_execution_nonce()`, which checks `$_REQUEST['_wpnonce']` against the `debug_action` nonce. That nonce only exists on the admin **WooCommerce → Status → Tools** page, and that page already verifies it *before* dispatching to `execute_tool()` (`WC_Admin_Status::status_tools()`). So the check inside the callbacks was redundant on the admin path and simply threw when the same tool was invoked via REST, which carries no `debug_action` nonce.

Fix: stop the tool callbacks from performing the redundant nonce verification, so the shared `execute_tool()` path works for REST callers too:

- The abort and resume callbacks now call `abort_regeneration( false )` / `resume_regeneration( false )` (matching what `CLIRunner` already does for WP-CLI).
- The initiate callback no longer calls `verify_tool_execution_nonce()`.

Authorization is unchanged and still enforced on every path:

- **Admin Tools page**: verifies the `debug_action` nonce before dispatching (`WC_Admin_Status::status_tools()`).
- **REST API**: requires the `manage_woocommerce` capability via `WC_REST_System_Status_Tools_V2_Controller::update_item_permissions_check()`.
- **WP-CLI**: runs in an already-authenticated admin context.

Closes #32831.

### How to test the changes in this Pull Request:

1. On a store with at least one product, confirm the product attributes lookup table exists (visit **WooCommerce → Status → Tools** and verify the "Regenerate the product attributes lookup table" tool is listed).
2. Run the tool via an authenticated REST API call (using an Application Password or REST API key with the `manage_woocommerce` capability), for example:

   ```bash
   curl -u "USER:APP_PASSWORD" -X PUT \
     "https://your-store.test/wp-json/wc/v3/system_status/tools/regenerate_product_attributes_lookup_table"
   ```

3. **Before this PR:** the response has `"success": false` and `"message": "There was an error calling regenerate_product_attributes_lookup_table: Invalid nonce"`.
   **After this PR:** the response has `"success": true` and `"message": "Product attributes lookup table data is regenerating"`.
4. While a regeneration is in progress, repeat the call against `.../tools/abort_product_attributes_lookup_table_regeneration` and confirm it succeeds; then against `.../tools/resume_product_attributes_lookup_table_regeneration` and confirm it succeeds.
5. Regression check: on the **WooCommerce → Status → Tools** admin page, click **Regenerate**, **Abort**, and **Resume** and confirm they still work as before.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Release Communication

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
