### PR TITLE
Always enable push notifications by deprecating the feature flag

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -336,6 +336,9 @@ class WC_Install {
 		'10.9.0'   => array(
 			'wc_update_1090_remove_task_list_reminder_bar_hidden_option',
 		),
+		'10.9.2'   => array(
+			'wc_update_10902_remove_deprecated_push_notifications_option',
+		),
 		'11.0.0'   => array(
 			'wc_update_1100_enable_point_of_sale_feature',
 		),

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3551,6 +3551,23 @@ function wc_update_1090_remove_task_list_reminder_bar_hidden_option() {
 }
 
 /**
+ * Remove the deprecated push_notifications feature option from the database.
+ *
+ * The push_notifications feature flag was deprecated in 10.9.2 and is now always enabled.
+ * The option is no longer needed as FeaturesUtil::feature_is_enabled('push_notifications')
+ * returns the deprecated_value directly without reading from the database. Removing it also
+ * clears the stale "no" value that wc_update_1050_enable_autoload_options() persisted for
+ * stores upgrading across the 10.5.0 boundary.
+ *
+ * @since 10.9.2
+ *
+ * @return void
+ */
+function wc_update_10902_remove_deprecated_push_notifications_option(): void {
+	delete_option( 'woocommerce_feature_push_notifications_enabled' );
+}
+
+/**
  * Set the stored value of the point_of_sale feature flag to enabled.
  *
  * The feature is deprecated as of 11.0.0 and always enabled in core, but the WooCommerce

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -632,11 +632,13 @@ class FeaturesController {
 					'Enable push notifications for the WooCommerce mobile apps to receive order notifications and store updates.',
 					'woocommerce'
 				),
+				'is_experimental'              => false,
 				'enabled_by_default'           => true,
-				'is_experimental'              => true,
 				'disable_ui'                   => true,
-				'skip_compatibility_checks'    => false,
+				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+				'deprecated_since'             => '10.9.2',
+				'deprecated_value'             => true,
 			),
 			'rest_api_caching'                   => array(
 				'name'                         => __( 'REST API Caching', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -126,12 +126,24 @@ class PushNotifications {
 	 * Push notifications require Jetpack to be connected. Memoize the value so
 	 * we only check once per request.
 	 *
+	 * The feature is deprecated and always enabled by default, but an explicit
+	 * 'no' in the (now-removed) feature option is still honoured as a manual
+	 * kill switch, so a store can force a fallback if needed. The option is read
+	 * directly rather than through FeaturesUtil to avoid emitting a deprecation
+	 * notice on every request, and to avoid returning only the deprecated
+	 * value of `true`.
+	 *
 	 * @return bool
 	 *
 	 * @since 10.4.0
 	 */
 	public function should_be_enabled(): bool {
 		if ( null !== $this->enabled ) {
+			return $this->enabled;
+		}
+
+		if ( 'no' === get_option( 'woocommerce_feature_push_notifications_enabled' ) ) {
+			$this->enabled = false;
 			return $this->enabled;
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -135,20 +135,22 @@ class PushNotifications {
 			return $this->enabled;
 		}
 
-		/**
-		 * Filters whether enhanced push notifications should be disabled.
-		 *
-		 * The feature was previously controlled by a now-deprecated feature
-		 * flag. It is now enabled by default for all compatible users, but this
-		 * filter lets a store force it off (e.g. to fall back to Jetpack Sync
-		 * if something isn't working). The feature also requires a Jetpack
-		 * connection, which is checked separately below.
-		 *
-		 * @since 10.9.2
-		 *
-		 * @param bool $disabled Whether enhanced push notifications are disabled. Defaults to false.
-		 */
-		$feature_disabled = apply_filters( 'woocommerce_enhanced_push_notifications_disabled', false );
+		$feature_disabled = wc_string_to_bool(
+			/**
+			 * Filters whether enhanced push notifications should be disabled.
+			 *
+			 * The feature was previously controlled by a now-deprecated feature
+			 * flag. It is now enabled by default for all compatible users, but this
+			 * filter lets a store force it off (e.g. to fall back to Jetpack Sync
+			 * if something isn't working). The feature also requires a Jetpack
+			 * connection, which is checked separately below.
+			 *
+			 * @since 10.9.2
+			 *
+			 * @param bool $disabled Whether enhanced push notifications are disabled. Defaults to false.
+			 */
+			apply_filters( 'woocommerce_enhanced_push_notifications_disabled', false )
+		);
 
 		if ( $feature_disabled ) {
 			$this->enabled = false;

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -19,7 +19,6 @@ use Automattic\WooCommerce\Internal\PushNotifications\Triggers\NewReviewNotifica
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\StockNotificationRecoveryHandler;
 use Automattic\WooCommerce\Internal\PushNotifications\Triggers\StockNotificationTrigger;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Logger;
 use Exception;
 
@@ -124,9 +123,8 @@ class PushNotifications {
 
 	/**
 	 * Determines if local push notification functionality should be enabled.
-	 * Push notifications require both the feature flag to be enabled and
-	 * Jetpack to be connected. Memoize the value so we only check once per
-	 * request.
+	 * Push notifications require Jetpack to be connected. Memoize the value so
+	 * we only check once per request.
 	 *
 	 * @return bool
 	 *
@@ -134,11 +132,6 @@ class PushNotifications {
 	 */
 	public function should_be_enabled(): bool {
 		if ( null !== $this->enabled ) {
-			return $this->enabled;
-		}
-
-		if ( ! FeaturesUtil::feature_is_enabled( self::FEATURE_NAME ) ) {
-			$this->enabled = false;
 			return $this->enabled;
 		}
 

--- a/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/PushNotifications.php
@@ -126,13 +126,6 @@ class PushNotifications {
 	 * Push notifications require Jetpack to be connected. Memoize the value so
 	 * we only check once per request.
 	 *
-	 * The feature is deprecated and always enabled by default, but an explicit
-	 * 'no' in the (now-removed) feature option is still honoured as a manual
-	 * kill switch, so a store can force a fallback if needed. The option is read
-	 * directly rather than through FeaturesUtil to avoid emitting a deprecation
-	 * notice on every request, and to avoid returning only the deprecated
-	 * value of `true`.
-	 *
 	 * @return bool
 	 *
 	 * @since 10.4.0
@@ -142,7 +135,22 @@ class PushNotifications {
 			return $this->enabled;
 		}
 
-		if ( 'no' === get_option( 'woocommerce_feature_push_notifications_enabled' ) ) {
+		/**
+		 * Filters whether enhanced push notifications should be disabled.
+		 *
+		 * The feature was previously controlled by a now-deprecated feature
+		 * flag. It is now enabled by default for all compatible users, but this
+		 * filter lets a store force it off (e.g. to fall back to Jetpack Sync
+		 * if something isn't working). The feature also requires a Jetpack
+		 * connection, which is checked separately below.
+		 *
+		 * @since 10.9.2
+		 *
+		 * @param bool $disabled Whether enhanced push notifications are disabled. Defaults to false.
+		 */
+		$feature_disabled = apply_filters( 'woocommerce_enhanced_push_notifications_disabled', false );
+
+		if ( $feature_disabled ) {
 			$this->enabled = false;
 			return $this->enabled;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -43,7 +43,6 @@ class NotificationPreferencesRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->set_up_features_controller_mock();
 		$this->reset_push_notifications_cache();
 
 		$this->user_id       = $this->factory->user->create( array( 'role' => 'shop_manager' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -62,7 +62,6 @@ class PushTokenRestControllerTest extends WC_REST_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->set_up_features_controller_mock();
 		$this->reset_push_notifications_cache();
 
 		( new PushTokenRestController() )->register_routes();

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Helpers/PushNotificationsTestTrait.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications\Helpers;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -14,10 +13,9 @@ use ReflectionClass;
 /**
  * Shared test helpers for the PushNotifications module.
  *
- * Mocks the Jetpack connection state, the FeaturesController, and resets the
- * memoized enablement flag on the container's `PushNotifications` instance —
- * the three things every push-notifications-related controller test needs in
- * setUp.
+ * Mocks the Jetpack connection state and resets the memoized enablement flag on
+ * the container's `PushNotifications` instance — the two things every
+ * push-notifications-related controller test needs in setUp.
  *
  * @package WooCommerce\Tests\PushNotifications
  */
@@ -26,11 +24,6 @@ trait PushNotificationsTestTrait {
 	 * @var JetpackConnectionManager|MockObject|null
 	 */
 	protected $jetpack_connection_manager_mock;
-
-	/**
-	 * @var FeaturesController|MockObject|null
-	 */
-	protected $features_controller_mock;
 
 	/**
 	 * Mocks the JetpackConnectionManager so its `is_connected()` returns the
@@ -56,28 +49,6 @@ trait PushNotificationsTestTrait {
 			->willReturn( $is_connected );
 
 		$this->reset_push_notifications_cache();
-	}
-
-	/**
-	 * Sets up the FeaturesController mock so the `push_notifications` feature
-	 * reports as enabled (and only that feature).
-	 */
-	protected function set_up_features_controller_mock() {
-		$this->features_controller_mock = $this
-			->getMockBuilder( FeaturesController::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'feature_is_enabled' ) )
-			->getMock();
-
-		$this->features_controller_mock
-			->method( 'feature_is_enabled' )
-			->willReturnCallback(
-				function ( $feature_id ) {
-					return PushNotifications::FEATURE_NAME === $feature_id;
-				}
-			);
-
-		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -76,20 +76,23 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests the functionality can be manually disabled via the feature option,
-	 * short-circuiting the Jetpack connection check.
+	 * @testdox Tests the functionality can be manually disabled via the
+	 * woocommerce_enhanced_push_notifications_disabled filter, skipping the Jetpack connection check.
 	 */
-	public function test_it_can_tell_push_notifications_should_not_be_enabled_when_manually_disabled_via_option() {
-		update_option( 'woocommerce_feature_push_notifications_enabled', 'no' );
+	public function test_it_can_tell_push_notifications_should_not_be_enabled_when_disabled_via_filter() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
 		$this->jetpack_connection_manager_mock
 			->expects( $this->never() )
 			->method( 'is_connected' );
 
+		add_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
+
 		$push_notifications = new PushNotifications();
 
 		$this->assertFalse( $push_notifications->should_be_enabled() );
+
+		remove_filter( 'woocommerce_enhanced_push_notifications_disabled', '__return_true' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Internal\PushNotifications;
 
 use Automattic\Jetpack\Connection\Manager as JetpackConnectionManager;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -26,20 +25,6 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	private $jetpack_connection_manager_mock;
 
 	/**
-	 * @var FeaturesController|MockObject
-	 */
-	private $features_controller_mock;
-
-	/**
-	 * Set up the test case.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		$this->set_up_features_controller_mock();
-	}
-
-	/**
 	 * Tear down the test case.
 	 */
 	public function tearDown(): void {
@@ -58,25 +43,7 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests the functionality is disabled if the feature flag is
-	 * disabled.
-	 */
-	public function test_it_can_tell_push_notifications_should_not_be_enabled_if_feature_is_disabled() {
-		$this->set_up_features_controller_mock( false );
-		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
-
-		$this->jetpack_connection_manager_mock
-			->expects( $this->never() )
-			->method( 'is_connected' );
-
-		$push_notifications = new PushNotifications();
-
-		$this->assertFalse( $push_notifications->should_be_enabled() );
-	}
-
-	/**
-	 * @testdox Tests the functionality is enabled if feature flag is enabled
-	 * and Jetpack is connected.
+	 * @testdox Tests the functionality is enabled when Jetpack is connected.
 	 */
 	public function test_it_can_tell_push_notifications_should_be_enabled_if_jetpack_is_connected() {
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
@@ -122,7 +89,6 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 			);
 
 		$this->register_legacy_proxy_function_mocks( array( 'wc_get_logger' => fn () => $logger_mock ) );
-		$this->set_up_features_controller_mock( true );
 		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
 
 		$this->jetpack_connection_manager_mock
@@ -218,10 +184,15 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests that on_init does not register post types when disabled.
+	 * @testdox Tests that on_init does not register post types when Jetpack is not connected.
 	 */
 	public function test_on_init_does_not_register_post_types_when_disabled() {
-		$this->set_up_features_controller_mock( false );
+		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
 
 		$push_notifications = new PushNotifications();
 		$push_notifications->on_init();
@@ -230,29 +201,6 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 			post_type_exists( PushToken::POST_TYPE ),
 			'Push token post type should not be registered when disabled'
 		);
-	}
-
-	/**
-	 * Sets up the FeaturesController mock.
-	 *
-	 * @param bool $feature_enabled Whether the push_notifications feature should be enabled.
-	 */
-	private function set_up_features_controller_mock( bool $feature_enabled = true ) {
-		$this->features_controller_mock = $this
-			->getMockBuilder( FeaturesController::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'feature_is_enabled' ) )
-			->getMock();
-
-		$this->features_controller_mock
-			->method( 'feature_is_enabled' )
-			->willReturnCallback(
-				function ( $feature_id ) use ( $feature_enabled ) {
-					return PushNotifications::FEATURE_NAME === $feature_id ? $feature_enabled : false;
-				}
-			);
-
-		wc_get_container()->replace( FeaturesController::class, $this->features_controller_mock );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/PushNotificationsTest.php
@@ -76,6 +76,23 @@ class PushNotificationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Tests the functionality can be manually disabled via the feature option,
+	 * short-circuiting the Jetpack connection check.
+	 */
+	public function test_it_can_tell_push_notifications_should_not_be_enabled_when_manually_disabled_via_option() {
+		update_option( 'woocommerce_feature_push_notifications_enabled', 'no' );
+		$this->set_up_jetpack_connection_manager_mock( array( 'is_connected' ) );
+
+		$this->jetpack_connection_manager_mock
+			->expects( $this->never() )
+			->method( 'is_connected' );
+
+		$push_notifications = new PushNotifications();
+
+		$this->assertFalse( $push_notifications->should_be_enabled() );
+	}
+
+	/**
 	 * @testdox Tests that errors are logged when exception is thrown during
 	 * enablement check.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Context

Apps Infra + Kiwi have been working on a feature which allows Woo to trigger its own push notifications via direct request to WPCOM, rather than via the Jetpack Sync process. This was originally controlled via a feature flag with `'enabled_by_default' = false`, which was flipped to `true` in 10.9.0. This was supposed to implicitly enable the feature for all users, however users who have run any version between `10.5.0`-`10.9.0` will currently have the feature flag set to `false` in the database, overriding the default.

### Changes proposed in this Pull Request:

Deprecates the push notifications feature flag, and removes calls referencing it, ensuring all installs have the feature **enabled**. This addresses a bug where falsey feature flag values baked into options in version 10.5.0 results in the push notifications feature being disabled despite the default feature flag value being flipped to `true`.

Bug introduced in PR #65572.

Closes AINFRA-2580.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set up a https://jurassic.ninja/ site without Woo installed
2. Install [Woo version 10.4.0](https://github.com/woocommerce/woocommerce/releases/tag/10.4.0) and set up your store
3. Install [Woo version 10.6.0](https://github.com/woocommerce/woocommerce/releases/tag/10.6.0) and allow migrations to run
4. Assert `/wp-json/wc-push-notifications/push-tokens` gives a 404
5. Install Woo from this PR and allow migrations to run
6. Assert `/wp-json/wc-push-notifications/push-tokens` gives a 401, **not** a 404 (401 is expected as this endpoint is only accessible via WPCOM)

<!-- End testing instructions -->

### Testing that has already taken place:

I have run through the testing steps above on a fresh JN site. There are also automated tests that cover this area.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Internal-only change

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>