### PR TITLE
e2e tests: fix unstable create-product-attributes test

### DIFF
--- a/plugins/woocommerce/changelog/testops-199-fix-flaky-create-product-attributes-e2e
+++ b/plugins/woocommerce/changelog/testops-199-fix-flaky-create-product-attributes-e2e
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: E2E test only change.

--- a/plugins/woocommerce/tests/e2e/tests/product/create-product-attributes.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/create-product-attributes.spec.ts
@@ -68,7 +68,13 @@ async function goToAttributesTab( page: Page ) {
 			.locator( '.attribute_tab' )
 			.getByRole( 'link', { name: 'Attributes' } );
 
-		await attributesTab.click();
+		// On a freshly reloaded edit page the tab click can fire before the
+		// metabox JS binds its handlers, silently leaving the General panel
+		// active. Retry the click until the Attributes panel is really shown.
+		await expect( async () => {
+			await attributesTab.click();
+			await expect( page.locator( '#product_attributes' ) ).toBeVisible();
+		} ).toPass();
 	} );
 }
 async function addAttribute(
@@ -92,17 +98,20 @@ async function addAttribute(
 	}
 
 	await test.step( `Type "${ attributeName }" in the "Attribute name" input field.`, async () => {
+		// Use pressSequentially (not fill): the "Save attributes" button is
+		// enabled by a `keyup` handler on these inputs (see meta-boxes.js).
+		// fill() only fires `input`, leaving the button disabled.
 		await page
 			.getByPlaceholder( 'e.g. length or weight' )
 			.last()
-			.type( attributeName );
+			.pressSequentially( attributeName );
 	} );
 
 	await test.step( `Type the attribute values "${ attributeValues }".`, async () => {
 		await page
 			.getByPlaceholder( 'Enter options for customers to choose from' )
 			.last()
-			.type( attributeValues );
+			.pressSequentially( attributeValues );
 	} );
 
 	await test.step( `Expect "Visible on the product page" checkbox to be checked by default`, async () => {


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Closes TESTOPS-199.

Fixes intermittent failures of the `can add custom product attributes` test in `tests/e2e/tests/product/create-product-attributes.spec.ts`.

Two distinct issues were addressed:

1. **Attributes tab navigation race.** `goToAttributesTab()` clicked the **Attributes** tab without confirming the panel actually switched. On a freshly reloaded "Edit product" page, the click could land before the product-data metabox JS had bound its tab handlers, leaving the **General** panel active. The subsequent attribute-heading interactions then timed out (the reported failure was a `locator.click` timeout on `getByRole('heading', { name: 'Colour' })`). The tab click is now wrapped in `expect(...).toPass()` so it re-clicks until `#product_attributes` is visible.

2. **`Save attributes` button stayed disabled.** The attribute name/value inputs were filled with `.type()`. The **Save attributes** button is enabled by a `keyup` handler on those inputs (`client/legacy/js/admin/meta-boxes.js`). The inputs now use `.pressSequentially()` — the non-deprecated equivalent of `.type()` that still dispatches `keyup`. (`.fill()` was deliberately **not** used here, since it only fires `input` and would leave the button disabled.)

### How to test the changes in this Pull Request:

1. Run the product E2E suite locally and confirm the spec passes:
   `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:core-parallel tests/product`
2. Optionally run it repeatedly (e.g. 10×) to confirm the flake is gone.

### Testing that has already taken place:

- Reproduced the original failure locally and captured the root cause from the trace/screenshot (`Save attributes` button `aria-disabled="true"`, panel left on **General**).
- Ran the **product** suite in parallel (`--workers=4`) **10 consecutive times** → 10/10 green, the previously-flaky spec passing every time.
- Ran the **full `core-parallel` suite 3 times**. The target spec passed in all 3 runs.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->