### PR TITLE
Fix existing order payments clearing active cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-pay-for-order-preserve-cart
+++ b/plugins/woocommerce/changelog/fix-pay-for-order-preserve-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve cart contents when paying for an existing order.

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -410,9 +410,6 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
-		// Remove cart.
-		WC()->cart->empty_cart();
-
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -410,6 +410,11 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
+		// Remove cart if it still matches the order being processed.
+		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+			WC()->cart->empty_cart();
+		}
+
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -411,7 +411,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 		}
 
 		// Remove cart if it still matches the order being processed.
-		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+		if ( $order instanceof WC_Order && WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
 			WC()->cart->empty_cart();
 		}
 

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -161,6 +161,11 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
+		// Remove cart if it still matches the order being processed.
+		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+			WC()->cart->empty_cart();
+		}
+
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -162,7 +162,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 		}
 
 		// Remove cart if it still matches the order being processed.
-		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+		if ( $order instanceof WC_Order && WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
 			WC()->cart->empty_cart();
 		}
 

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -161,9 +161,6 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
-		// Remove cart.
-		WC()->cart->empty_cart();
-
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -326,6 +326,11 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
+		// Remove cart if it still matches the order being processed.
+		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+			WC()->cart->empty_cart();
+		}
+
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -326,9 +326,6 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 			$order->payment_complete();
 		}
 
-		// Remove cart.
-		WC()->cart->empty_cart();
-
 		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -327,7 +327,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 		}
 
 		// Remove cart if it still matches the order being processed.
-		if ( WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+		if ( $order instanceof WC_Order && WC()->cart && $order->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
 			WC()->cart->empty_cart();
 		}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -68,6 +68,10 @@ abstract class WC_Gateway_Paypal_Response {
 		if ( ! $order->has_status( array( OrderStatus::PROCESSING, OrderStatus::COMPLETED ) ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
+
+			if ( isset( WC()->cart ) ) {
+				WC()->cart->empty_cart();
+			}
 		}
 	}
 
@@ -79,5 +83,9 @@ abstract class WC_Gateway_Paypal_Response {
 	 */
 	protected function payment_on_hold( $order, $reason = '' ) {
 		$order->update_status( OrderStatus::ON_HOLD, $reason );
+
+		if ( isset( WC()->cart ) ) {
+			WC()->cart->empty_cart();
+		}
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -68,10 +68,6 @@ abstract class WC_Gateway_Paypal_Response {
 		if ( ! $order->has_status( array( OrderStatus::PROCESSING, OrderStatus::COMPLETED ) ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
-
-			if ( isset( WC()->cart ) ) {
-				WC()->cart->empty_cart();
-			}
 		}
 	}
 
@@ -83,9 +79,5 @@ abstract class WC_Gateway_Paypal_Response {
 	 */
 	protected function payment_on_hold( $order, $reason = '' ) {
 		$order->update_status( OrderStatus::ON_HOLD, $reason );
-
-		if ( isset( WC()->cart ) ) {
-			WC()->cart->empty_cart();
-		}
 	}
 }

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -177,6 +177,7 @@ function wc_clear_cart_after_payment() {
 
 	$should_clear_cart_after_payment = false;
 	$after_payment                   = false;
+	$order                           = null;
 
 	// If the order has been received, clear the cart.
 	if ( ! empty( $wp->query_vars['order-received'] ) ) {
@@ -203,6 +204,37 @@ function wc_clear_cart_after_payment() {
 			$should_clear_cart_after_payment = ! $order->has_status( array( OrderStatus::FAILED, OrderStatus::PENDING, OrderStatus::CANCELLED ) );
 			$after_payment                   = true;
 		}
+	}
+
+	// If the order is different from the cart, don't clear the cart. This can happen if the user has multiple tabs open and completes a different order than the one in the cart.
+	if ( $order instanceof WC_Order && ! WC()->cart->is_empty() ) {
+		$order_products = array();
+		$cart_products  = array();
+
+		foreach ( $order->get_items() as $item ) {
+			$product_id = $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id();
+
+			if ( ! $product_id ) {
+				continue;
+			}
+
+			$order_products[ $product_id ] = ( $order_products[ $product_id ] ?? 0 ) + (int) $item->get_quantity();
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$product_id = ! empty( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : $cart_item['product_id'];
+
+			if ( ! $product_id ) {
+				continue;
+			}
+
+			$cart_products[ $product_id ] = ( $cart_products[ $product_id ] ?? 0 ) + (int) $cart_item['quantity'];
+		}
+
+		ksort( $order_products );
+		ksort( $cart_products );
+
+		$should_clear_cart_after_payment = $order_products === $cart_products;
 	}
 
 	// If it doesn't look like a payment happened, bail early.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -206,37 +206,6 @@ function wc_clear_cart_after_payment() {
 		}
 	}
 
-	// If the order is different from the cart, don't clear the cart. This can happen if the user has multiple tabs open and completes a different order than the one in the cart.
-	if ( $order instanceof WC_Order && ! WC()->cart->is_empty() ) {
-		$order_products = array();
-		$cart_products  = array();
-
-		foreach ( $order->get_items() as $item ) {
-			$product_id = $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id();
-
-			if ( ! $product_id ) {
-				continue;
-			}
-
-			$order_products[ $product_id ] = ( $order_products[ $product_id ] ?? 0 ) + (int) $item->get_quantity();
-		}
-
-		foreach ( WC()->cart->get_cart() as $cart_item ) {
-			$product_id = ! empty( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : $cart_item['product_id'];
-
-			if ( ! $product_id ) {
-				continue;
-			}
-
-			$cart_products[ $product_id ] = ( $cart_products[ $product_id ] ?? 0 ) + (int) $cart_item['quantity'];
-		}
-
-		ksort( $order_products );
-		ksort( $cart_products );
-
-		$should_clear_cart_after_payment = $order_products === $cart_products;
-	}
-
 	// If it doesn't look like a payment happened, bail early.
 	if ( ! $after_payment ) {
 		return;
@@ -249,6 +218,11 @@ function wc_clear_cart_after_payment() {
 	 * @param bool $should_clear_cart_after_payment Whether the cart should be cleared after payment.
 	 */
 	$should_clear_cart_after_payment = apply_filters( 'woocommerce_should_clear_cart_after_payment', $should_clear_cart_after_payment );
+
+	// If the order is different from the cart, don't clear the cart. This can happen if the user has multiple tabs open and completes a different order than the one in the cart.
+	if ( $should_clear_cart_after_payment && $order instanceof WC_Order && ! WC()->cart->is_empty() ) {
+		$should_clear_cart_after_payment = $order->has_cart_hash( WC()->cart->get_cart_hash() );
+	}
 
 	if ( $should_clear_cart_after_payment ) {
 		WC()->cart->empty_cart();

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
@@ -88,6 +88,53 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_clear_cart_after_payment() clears the cart when the order products match the cart products.
+	 */
+	public function test_wc_clear_cart_after_payment_clears_matching_cart() {
+		global $wp;
+
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = WC_Helper_Order::create_order( 1, $product );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 4 );
+
+		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = $order->get_order_key();
+
+		wc_clear_cart_after_payment();
+
+		unset( $wp->query_vars['order-received'], $_GET['key'] );
+
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+	}
+
+	/**
+	 * Test wc_clear_cart_after_payment() preserves the cart when the order products do not match the cart products.
+	 */
+	public function test_wc_clear_cart_after_payment_preserves_different_cart() {
+		global $wp;
+
+		$order_product = WC_Helper_Product::create_simple_product();
+		$cart_product  = WC_Helper_Product::create_simple_product();
+		$order         = WC_Helper_Order::create_order( 1, $order_product );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $cart_product->get_id(), 1 );
+
+		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = $order->get_order_key();
+
+		wc_clear_cart_after_payment();
+
+		unset( $wp->query_vars['order-received'], $_GET['key'] );
+
+		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
+
+		WC()->cart->empty_cart();
+	}
+
+	/**
 	 * Test wc_format_list_of_items().
 	 *
 	 * @since 2.4

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
@@ -88,16 +88,19 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_clear_cart_after_payment() clears the cart when the order products match the cart products.
+	 * Test wc_clear_cart_after_payment() clears the cart when the order cart hash matches the cart hash.
 	 */
-	public function test_wc_clear_cart_after_payment_clears_matching_cart() {
+	public function test_wc_clear_cart_after_payment_clears_matching_cart_hash() {
 		global $wp;
 
 		$product = WC_Helper_Product::create_simple_product();
-		$order   = WC_Helper_Order::create_order( 1, $product );
 
 		WC()->cart->empty_cart();
 		WC()->cart->add_to_cart( $product->get_id(), 4 );
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_cart_hash( WC()->cart->get_cart_hash() );
+		$order->save();
 
 		$wp->query_vars['order-received'] = $order->get_id();
 		$_GET['key']                      = $order->get_order_key();
@@ -110,17 +113,18 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_clear_cart_after_payment() preserves the cart when the order products do not match the cart products.
+	 * Test wc_clear_cart_after_payment() preserves the cart when the order cart hash does not match the cart hash.
 	 */
-	public function test_wc_clear_cart_after_payment_preserves_different_cart() {
+	public function test_wc_clear_cart_after_payment_preserves_different_cart_hash() {
 		global $wp;
 
-		$order_product = WC_Helper_Product::create_simple_product();
-		$cart_product  = WC_Helper_Product::create_simple_product();
-		$order         = WC_Helper_Order::create_order( 1, $order_product );
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = WC_Helper_Order::create_order( 1, $product );
+		$order->set_cart_hash( 'different-cart-hash' );
+		$order->save();
 
 		WC()->cart->empty_cart();
-		WC()->cart->add_to_cart( $cart_product->get_id(), 1 );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		$wp->query_vars['order-received'] = $order->get_id();
 		$_GET['key']                      = $order->get_order_key();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Preserves a shopper's active cart when they pay for an existing order unless the cart and the order hash match. Regular checkout still clears the cart after order confirmation when they land on the confirmation page, however we have to check if the order products are different from the cart products since paying via Orders > Order > Customer Payment Page also redirects to the order confirmation.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56772.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an unpaid order from WP Admin and open its customer payment page link.
2. In the same browser session, add a different product to the cart, then pay the unpaid order from the customer payment page.
3. Confirm the cart still contains the product that was already in the cart.
4. Complete a normal cart checkout and confirm the cart is cleared after order confirmation.
5. Create another unpaid order from WP Admin and open the customer payment page link
6. In the same browser session add a different product to the card, then in the customer payment link page paste the below in your console changing the relevant IDs
7. Verify the cart hasnt been cleared in your other browser session.
8. Finally, complete the typical user payment flow: Add product to cart > Go to Cart > go to checkout > complete order > ensure the cart is cleared

```js
// retrieve `orderId`, `orderKey` from the "Customer payment page" link, retrieve `billingEmail` from the order you created
const orderId = '46';
const orderKey = 'wc_order_R3ua0RyNTj883';
const billingEmail = 'user@email.com';

// getting the order information from the API, just so that we can pass them again when placing the order
const order = await wp.apiFetch({
	method: 'GET',
	path: `/wc/store/v1/order/${orderId}?billing_email=${billingEmail}&key=${orderKey}`,
	parse: false,
});
const orderData = await order.json();
wp.apiFetch({
	method: 'POST',
	path: `/wc/store/v1/checkout/${orderId}`,
	headers: { Nonce: order.headers.get('Nonce') },
	data: {
		key: orderKey,
		billing_email: billingEmail,
		billing_address: orderData.billing_address,
		shipping_address: orderData.shipping_address,
		payment_method: 'cod',
	},
});
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

-   Ran PHP syntax checks for changed files.
-   Ran changed-file PHP linting.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
