### PR TITLE
Remove stale Mini-Cart cleanup leftovers

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { getSetting } from '@woocommerce/settings';
-import { isObject } from '@woocommerce/types';
 
 type Variant = 'text' | 'contained' | 'outlined';
 
@@ -19,22 +18,6 @@ export const getVariant = (
 	}
 
 	return defaultVariant;
-};
-
-/**
- * Checks if there are any children that are blocks.
- */
-export const hasChildren = ( children: JSX.Element[] | undefined ): boolean => {
-	if ( ! children ) {
-		return false;
-	}
-
-	return children.some( ( child ) => {
-		if ( Array.isArray( child ) ) {
-			return hasChildren( child );
-		}
-		return isObject( child ) && child.key !== null;
-	} );
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/types.ts
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { CartResponseTotals } from '@woocommerce/types';
-
 export type IconType = 'cart' | 'bag' | 'bag-alt' | undefined;
 export type productCountVisibilityType =
 	| 'always'
@@ -15,20 +10,4 @@ export interface ColorItem {
 	name?: string;
 	slug?: string;
 	class?: string;
-}
-export interface BlockAttributes {
-	initialCartItemsCount?: number;
-	initialCartTotals?: CartResponseTotals;
-	isInitiallyOpen?: boolean;
-	colorClassNames?: string;
-	style?: Record< string, Record< string, string > >;
-	contents: string;
-	miniCartIcon?: IconType;
-	addToCartBehaviour: string;
-	onCartClickBehaviour: string;
-	hasHiddenPrice: boolean;
-	priceColor: ColorItem;
-	iconColor: ColorItem;
-	productCountColor: ColorItem;
-	productCountVisibility?: productCountVisibilityType;
 }

--- a/plugins/woocommerce/client/blocks/docs/contributors/block-assets.md
+++ b/plugins/woocommerce/client/blocks/docs/contributors/block-assets.md
@@ -11,7 +11,7 @@
     -   [AbstractBlock::enqueue_data](#abstractblockenqueue_data)
 -   [woocommerce_shared_settings deprecated filter](#woocommerce_shared_settings-deprecated-filter)
 
-[Block Types](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/Blocks/BlockTypes) are often responsible for enqueuing script assets that make blocks functional on both the front-end and within the editor. Additionally, some block scripts require extra data from the server and thus have extra dependencies that need to be loaded.
+[Block Types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/BlockTypes) are often responsible for enqueuing script assets that make blocks functional on both the front-end and within the editor. Additionally, some block scripts require extra data from the server and thus have extra dependencies that need to be loaded.
 
 For performance reasons the blocks plugin ensures assets and asset data is made available only as needed.
 
@@ -19,7 +19,7 @@ For performance reasons the blocks plugin ensures assets and asset data is made 
 
 Assets are needed when we know a block will be rendered.
 
-In the context of [Block Types](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/Blocks/BlockTypes), assets and asset data is enqueued within the block `render()` method.
+In the context of [Block Types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/BlockTypes), assets and asset data is enqueued within the block `render()` method.
 
 In an admin editor context we must also ensure asset _data_ is available when the `enqueue_block_editor_assets` hook is fired. That is because block scripts are enqueued ready for the Block Inserter, but the block may not be rendered.
 
@@ -44,7 +44,7 @@ These rules also apply to styles.
 
 ## Using the `AbstractBlock` class
 
-The [`AbstractBlock` class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php) has some helper methods to make asset management easier. Most Block Types in this plugin extend this class.
+The [`AbstractBlock` class](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/AbstractBlock.php) has some helper methods to make asset management easier. Most Block Types in this plugin extend this class.
 
 ### AbstractBlock::render
 
@@ -98,3 +98,4 @@ wc.wcSettings.getSetting( 'key' );
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=type%3A+documentation&template=suggestion-for-documentation-improvement-correction.md&title=Feedback%20on%20./docs/contributors/block-assets.md)
 
 <!-- /FEEDBACK -->
+

--- a/plugins/woocommerce/client/blocks/docs/contributors/block-assets.md
+++ b/plugins/woocommerce/client/blocks/docs/contributors/block-assets.md
@@ -11,7 +11,7 @@
     -   [AbstractBlock::enqueue_data](#abstractblockenqueue_data)
 -   [woocommerce_shared_settings deprecated filter](#woocommerce_shared_settings-deprecated-filter)
 
-[Block Types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/BlockTypes) are often responsible for enqueuing script assets that make blocks functional on both the front-end and within the editor. Additionally, some block scripts require extra data from the server and thus have extra dependencies that need to be loaded.
+[Block Types](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/Blocks/BlockTypes) are often responsible for enqueuing script assets that make blocks functional on both the front-end and within the editor. Additionally, some block scripts require extra data from the server and thus have extra dependencies that need to be loaded.
 
 For performance reasons the blocks plugin ensures assets and asset data is made available only as needed.
 
@@ -19,7 +19,7 @@ For performance reasons the blocks plugin ensures assets and asset data is made 
 
 Assets are needed when we know a block will be rendered.
 
-In the context of [Block Types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/BlockTypes), assets and asset data is enqueued within the block `render()` method.
+In the context of [Block Types](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/Blocks/BlockTypes), assets and asset data is enqueued within the block `render()` method.
 
 In an admin editor context we must also ensure asset _data_ is available when the `enqueue_block_editor_assets` hook is fired. That is because block scripts are enqueued ready for the Block Inserter, but the block may not be rendered.
 
@@ -44,7 +44,7 @@ These rules also apply to styles.
 
 ## Using the `AbstractBlock` class
 
-The [`AbstractBlock` class](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/AbstractBlock.php) has some helper methods to make asset management easier. Most Block Types in this plugin extend this class.
+The [`AbstractBlock` class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php) has some helper methods to make asset management easier. Most Block Types in this plugin extend this class.
 
 ### AbstractBlock::render
 
@@ -98,4 +98,3 @@ wc.wcSettings.getSetting( 'key' );
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=type%3A+documentation&template=suggestion-for-documentation-improvement-correction.md&title=Feedback%20on%20./docs/contributors/block-assets.md)
 
 <!-- /FEEDBACK -->
-

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-for-lazy-loaded-components.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-for-lazy-loaded-components.md
@@ -1,6 +1,6 @@
 # Translations for lazy-loaded components
 
-The inner blocks of the Cart and Checkout blocks are lazy-loaded. To lazy-load them, the translation chunks need to be registered. This takes place in `/src/BlockTypes/AbstractBlock.php`:
+The inner blocks of the Cart and Checkout blocks are lazy-loaded. To lazy-load them, the translation chunks need to be registered. This takes place in `src/Blocks/BlockTypes/AbstractBlock.php`:
 
 ```php
 /**
@@ -26,7 +26,7 @@ protected function register_chunk_translations( $chunks ) {
 
 ## Lazy-loaded translations of the Cart block
 
-The translations of the inner blocks of the Cart block are loaded in this function in `src/BlockTypes/Cart.php`:
+The translations of the inner blocks of the Cart block are loaded in this function in `src/Blocks/BlockTypes/Cart.php`:
 
 ```php
 /**
@@ -45,7 +45,7 @@ protected function register_block_type_assets() {
 
 ## Lazy-loaded translations of the Checkout block
 
-The translations of the inner blocks of the Cart block are loaded in this function in `src/BlockTypes/Checkout.php`:
+The translations of the inner blocks of the Checkout block are loaded in this function in `src/Blocks/BlockTypes/Checkout.php`:
 
 ```php
 /**

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-for-lazy-loaded-components.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-for-lazy-loaded-components.md
@@ -1,6 +1,6 @@
 # Translations for lazy-loaded components
 
-The Mini-Cart block as well as inner blocks of the Cart and the Checkout blocks are lazy-loaded. To lazy-load them, the translation chunks needs to be registered. This takes place in `/src/BlockTypes/AbstractBlock.php`:
+The inner blocks of the Cart and Checkout blocks are lazy-loaded. To lazy-load them, the translation chunks need to be registered. This takes place in `/src/BlockTypes/AbstractBlock.php`:
 
 ```php
 /**

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-in-FSE-templates.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/translations/translations-in-FSE-templates.md
@@ -73,7 +73,7 @@ We then replace this code with the following code:
 <!-- wp:pattern {"slug":"woocommerce/mini-cart-empty-cart-message"} /-->
 ```
 
-In the file, that holds the logic for this FSE-template, in this case `src/BlockTypes/MiniCart.php`, we then register this placeholder as a block pattern:
+In the file, that holds the logic for this FSE-template, in this case `src/Blocks/BlockTypes/MiniCart.php`, we then register this placeholder as a block pattern:
 
 ```php
 /**
@@ -83,9 +83,9 @@ public function register_empty_cart_message_block_pattern() {
     register_block_pattern(
         'woocommerce/mini-cart-empty-cart-message',
         array(
-            'title'    => __( 'Empty Mini-Cart Message', 'woo-gutenberg-products-block' ),
+            'title'    => __( 'Empty Mini-Cart Message', 'woocommerce' ),
             'inserter' => false,
-            'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</strong></p><!-- /wp:paragraph -->',
+            'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woocommerce' ) . '</strong></p><!-- /wp:paragraph -->',
         )
     );
 }

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -28,7 +28,6 @@
 		"./assets/js/blocks/cart/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/cart/inner-blocks/register-components.ts",
 		"./assets/js/base/components/**/*.{tsx,ts}",
-		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts",
 		"./assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx",
 		"./assets/js/blocks/cart-checkout-shared/view-switcher/index.tsx",

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -28,7 +28,6 @@
 		"./assets/js/blocks/cart/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/cart/inner-blocks/register-components.ts",
 		"./assets/js/base/components/**/*.{tsx,ts}",
-		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts",
 		"./assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx",
 		"./assets/js/blocks/cart-checkout-shared/view-switcher/index.tsx",
 		"./assets/js/blocks/filter-wrapper/register-components.ts",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This follows up on the Mini-Cart cleanup by removing a few stale leftovers that are no longer needed. It drops the obsolete `sideEffects` entry for Mini-Cart inner block entrypoints, removes unused Mini-Cart type/helper exports, and updates related developer docs that still referenced old Mini-Cart or WooCommerce Blocks paths.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable. This removes unused code, build metadata, and stale documentation references only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/block-library exec eslint assets/js/blocks/mini-cart/types.ts assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts`.
2. Run `pnpm run lint:md:docs docs/contributors/block-assets.md docs/internal-developers/translations/translations-for-lazy-loaded-components.md docs/internal-developers/translations/translations-in-FSE-templates.md` from `plugins/woocommerce/client/blocks`.
3. Confirm both commands complete successfully.
4. Review the diff and confirm the removed `sideEffects` entry, unused Mini-Cart exports, and stale documentation references are no longer present.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran `pnpm --filter=@woocommerce/block-library exec eslint assets/js/blocks/mini-cart/types.ts assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/utils.ts`.
- Ran `pnpm run lint:md:docs docs/internal-developers/translations/translations-for-lazy-loaded-components.md`.
- Ran `pnpm run lint:md:docs docs/contributors/block-assets.md docs/internal-developers/translations/translations-for-lazy-loaded-components.md docs/internal-developers/translations/translations-in-FSE-templates.md`.
- Ran `git diff --check`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove stale Mini-Cart block cleanup leftovers.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Developer cleanup and documentation updates only; no merchant-facing behavior change.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
