### PR TITLE
e2e tests: fix unstable customer-list and create-order tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-core-parallel-customer-order-flakiness
+++ b/plugins/woocommerce/changelog/fix-e2e-core-parallel-customer-order-flakiness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize two e2e specs in the core-parallel pool against concurrent-worker pollution: customer-list (pin the customers report page size on the URL so the list assertions and CSV download stay deterministic regardless of how many customers other workers create) and create-order (wait for the line item to render before saving so the order is never persisted with a 0-quantity line).

--- a/plugins/woocommerce/tests/e2e/tests/customer/customer-list.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/customer/customer-list.spec.ts
@@ -110,8 +110,13 @@ test.describe( 'Merchant > Customer List', () => {
 			const responsePromise = page.waitForResponse(
 				'**/wp-json/wc-analytics/reports/customers?orderby**'
 			);
+			// Pin the page size to 100 so every customer this test created shows
+			// on a single page regardless of how many customers other parallel
+			// workers have created. This keeps the list assertions and the CSV
+			// download (which only streams in-browser when all rows are loaded,
+			// otherwise the report is emailed) deterministic.
 			await page.goto(
-				'wp-admin/admin.php?page=wc-admin&path=%2Fcustomers'
+				'wp-admin/admin.php?page=wc-admin&path=%2Fcustomers&per_page=100'
 			);
 			await responsePromise;
 		} );
@@ -237,8 +242,9 @@ test.describe( 'Merchant > Customer List', () => {
 			// around a midnight boundary. Assert the filename structure with a
 			// YYYY-MM-DD date rather than pinning an exact local date, which is
 			// what this step actually verifies (the orderby/order/path encoding).
+			// The page size we pinned on the report URL is encoded too.
 			const filenamePattern =
-				/^customers_\d{4}-\d{2}-\d{2}_orderby-date-last-active_order-desc_page-wc-admin_path--customers\.csv$/;
+				/^customers_\d{4}-\d{2}-\d{2}_orderby-date-last-active_order-desc_page-wc-admin_path--customers_per-page-100\.csv$/;
 
 			expect( download.suggestedFilename() ).toMatch( filenamePattern );
 		} );

--- a/plugins/woocommerce/tests/e2e/tests/order/create-order.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/create-order.spec.ts
@@ -58,12 +58,26 @@ async function addProductToOrder( page: Page, product, quantity: number ) {
 	await page.getByText( 'Search for a product…' ).click();
 	await page.locator( 'span > .select2-search__field' ).fill( product.name );
 	await page.getByRole( 'option', { name: product.name } ).first().click();
-	await page
+
+	const quantityField = page
 		.locator( 'tr' )
 		.filter( { hasText: product.name } )
-		.getByPlaceholder( '1' )
-		.fill( quantity.toString() );
+		.getByPlaceholder( '1' );
+	await quantityField.fill( quantity.toString() );
+	// Confirm the quantity stuck before committing, so the line item is never
+	// added with a stale/empty value.
+	await expect( quantityField ).toHaveValue( quantity.toString() );
+
 	await page.locator( '#btn-ok' ).click();
+
+	// Adding the product fires an AJAX request that inserts the line item and
+	// recalculates the order totals. Wait for the item row to render before
+	// returning; otherwise a subsequent "Create"/save can persist the order
+	// before the line item is fully applied, saving a 0-quantity / $0 line
+	// (observed intermittently under parallel load).
+	await expect(
+		page.locator( 'td.name > a' ).filter( { hasText: product.name } )
+	).toBeVisible();
 }
 
 const test = baseTest.extend( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Two specs in the `core-parallel` Playwright project (`tests/e2e`) flaked intermittently because they assert against **store-wide state that other parallel workers concurrently mutate**. Both are fixed in place — they stay in the parallel pool.

**`tests/customer/customer-list.spec.ts` — "Merchant can view a list of all customers, filter and download"**

The customers report defaults to 25 rows per page, and other parallel workers continuously create customers. That single fact caused two distinct failures:

- The unfiltered "customers are displayed in the list" check failed when concurrent customers pushed this test's three customers onto page 2.
- The Download step timed out: WC Admin only streams a CSV download in-browser (the event the test waits for) when every row is loaded client-side; once the report spans multiple pages it switches to an emailed export and no download event fires.

Rather than react to whichever state happens to render, the fix **controls the state deterministically**: the report is opened with the page size pinned on the URL (`&per_page=100`), so every customer this test created is always on a single page regardless of how many other workers' customers exist. Both the list assertion and the CSV download then behave deterministically, and the picker-interaction workaround is removed. The download filename assertion is updated for the pinned page size it now encodes.

**`tests/order/create-order.spec.ts` — "can create a simple guest order"**

The `addProductToOrder` helper clicked the modal's OK button and returned immediately. Under load, the test then clicked "Create" before the add-line-item AJAX had finished, persisting the order with a **0-quantity / \$0 line** (subtotal already \$200). The helper now waits for the line item to render (`td.name > a`) and confirms the quantity stuck before continuing.

### How to test the changes in this Pull Request:

1. Ensure the local e2e environment is running.
2. Run the core-parallel suite under load: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:core-parallel --workers=4`.
3. Repeat several times — `customer/customer-list.spec.ts` and `order/create-order.spec.ts` should pass consistently.

### Testing that has already taken place:

- Reproduced both failures locally by running `core-parallel --workers=4` in a loop (~1 in 7 runs failed): customer-list (pagination + emailed-export download) and create-order (0-qty line).
- After the fixes: multiple consecutive full `core-parallel --workers=4` runs pass (195 passed, 0 failures), and `customer/customer-list.spec.ts` passes both in isolation (single-page store) and under full parallel load (multi-page store) — confirming the pinned page size is honored from the URL in both cases.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

> A changelog entry (`Significance: patch`, `Type: dev`) is already included in the branch at `plugins/woocommerce/changelog/fix-e2e-core-parallel-customer-order-flakiness`, since these are test-only changes.