### PR TITLE
Fix e2e flakiness: reload block checkout until login email hydrates

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-checkout-login-email-hydration
+++ b/plugins/woocommerce/changelog/fix-e2e-checkout-login-email-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize the "customer can login at checkout" e2e test: reload the block checkout until the logged-in customer's contact email hydrates from the Store API cart, so a lagged or guest-rendered checkout under parallel load no longer leaves the email empty and blocks the order.

--- a/plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/checkout/checkout.spec.ts
@@ -39,6 +39,21 @@ function isClassicCheckout( page: Page ) {
 	return page.url().includes( CLASSIC_CHECKOUT_PAGE.slug );
 }
 
+// Block checkout hydrates the logged-in customer's contact email asynchronously
+// from the Store API cart; under parallel load that can lag behind navigation,
+// or the page can render in a guest state with an empty contact email that
+// blocks the order. Reload to force a fresh cart fetch with the established
+// session, retrying until the email populates.
+async function reloadUntilCheckoutEmailHydrates( page: Page ) {
+	const contactEmail = page
+		.getByRole( 'textbox', { name: 'Email address' } )
+		.first();
+	await expect( async () => {
+		await page.reload();
+		await expect( contactEmail ).not.toHaveValue( '', { timeout: 5000 } );
+	} ).toPass( { timeout: 30000 } );
+}
+
 async function checkOrderDetails( page: Page, product, qty: number, tax ) {
 	const expectedTotalPrice = (
 		parseFloat( product.price ) *
@@ -382,16 +397,10 @@ checkoutPages.forEach( ( { name, slug } ) => {
 			await page.goto( slug );
 			await expect( page.url() ).toContain( slug );
 
-			// Block checkout hydrates the logged-in customer's contact email
-			// asynchronously from the Store API cart; under parallel load that
-			// can lag behind navigation, leaving the field empty and blocking
-			// the order. Wait for it to populate before placing the order.
+			// Make sure the logged-in customer's email is populated before
+			// placing the order (see helper above).
 			if ( ! isClassicCheckout( page ) ) {
-				await expect(
-					page
-						.getByRole( 'textbox', { name: 'Email address' } )
-						.first()
-				).not.toHaveValue( '' );
+				await reloadUntilCheckoutEmailHydrates( page );
 			}
 
 			await checkOrderDetails( page, product, qty, tax );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`tests/checkout/checkout.spec.ts` — "customer can login at checkout and place the order with a different shipping address" — flaked intermittently in the `core-parallel` pool.

### How to test the changes in this Pull Request:

1. Ensure the local e2e environment is running.
2. Run the checkout spec under load several times: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:default --project=core-parallel tests/checkout/checkout.spec.ts --workers=4`.
3. The "customer can login at checkout…" tests (block + classic) should pass consistently.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

> A changelog entry (`Significance: patch`, `Type: dev`) is included in the branch at `plugins/woocommerce/changelog/fix-e2e-checkout-login-email-hydration`, since this is a test-only change.