### PR TITLE
Mark grouped products add to cart table as presentational

### DIFF
--- a/plugins/woocommerce/changelog/fix-65094-grouped-product-a11y
+++ b/plugins/woocommerce/changelog/fix-65094-grouped-product-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mark grouped products add to cart table as presentational

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.2.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -22,7 +22,7 @@ global $product, $post;
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 <form class="cart grouped_form" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
-	<table cellspacing="0" class="woocommerce-grouped-product-list group_table">
+	<table cellspacing="0" class="woocommerce-grouped-product-list group_table" role="presentation">
 		<tbody>
 			<?php
 			$quantites_required      = false;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/65094.
Closes WOOPLUG-6707.

This PR adds `role="presentation"` to the grouped products add to cart table.

### How to test the changes in this Pull Request:

1. Go to the frontend of a grouped product.
2. Inspect the table that lists the child products.
3. Verifty the table has `role="presentation"`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
