### PR TITLE
Add Checkout block PO Box address snippet

### DIFF
--- a/docs/code-snippets/prevent-po-box-addresses-in-checkout-block.md
+++ b/docs/code-snippets/prevent-po-box-addresses-in-checkout-block.md
@@ -1,0 +1,40 @@
+---
+post_title: Prevent PO Box addresses in the Checkout block
+sidebar_label: Prevent PO Box addresses in Checkout block
+---
+
+# Prevent PO Box addresses in the Checkout block
+
+The Checkout block uses the Store API checkout flow, so shortcode checkout hooks such as `woocommerce_after_checkout_validation` do not run there. To validate orders submitted through the Checkout block, use the `woocommerce_checkout_validate_order_before_payment` hook.
+
+The following snippet checks the shipping address when one exists, and falls back to billing details when checkout does not include a separate shipping address. Add it with the Code Snippets plugin and set it to run everywhere.
+
+```php
+/**
+ * Prevent Checkout block orders from using PO Box addresses.
+ *
+ * @param WC_Order $order  Checkout order.
+ * @param WP_Error $errors Validation errors.
+ */
+function wc_prevent_checkout_block_po_box_addresses( $order, $errors ) {
+	$address = $order->has_shipping_address()
+		? $order->get_shipping_address_1() . ' ' . $order->get_shipping_address_2()
+		: $order->get_billing_address_1() . ' ' . $order->get_billing_address_2();
+
+	$postcode = $order->has_shipping_address()
+		? $order->get_shipping_postcode()
+		: $order->get_billing_postcode();
+
+	$normalized_address = strtolower( str_replace( array( ' ', '.', ',' ), '', $address . ' ' . $postcode ) );
+
+	if ( false !== strpos( $normalized_address, 'pobox' ) ) {
+		$errors->add(
+			'po_box_address',
+			__( 'Sorry, we cannot ship to PO Box addresses.', 'woocommerce' )
+		);
+	}
+}
+add_action( 'woocommerce_checkout_validate_order_before_payment', 'wc_prevent_checkout_block_po_box_addresses', 10, 2 );
+```
+
+For example, the snippet blocks address formats such as `PO Box 123`, `P.O. Box 123`, and `POBOX 123`.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The existing PO Box restriction snippet is shortcode-checkout specific and does not document the Store API checkout validation hook. This adds a developer docs code snippet for blocking PO Box addresses in the Checkout block using `woocommerce_checkout_validate_order_before_payment`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60452.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; documentation only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Review `docs/code-snippets/prevent-po-box-addresses-in-checkout-block.md`.
2. Confirm the snippet uses `woocommerce_checkout_validate_order_before_payment` and adds validation errors through the provided `WP_Error` object.
3. Confirm the page explains that the snippet applies to the Checkout block / Store API flow.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran `markdownlint --fix docs/code-snippets/prevent-po-box-addresses-in-checkout-block.md --config .markdownlint.json`.
- Ran `markdownlint docs/code-snippets/prevent-po-box-addresses-in-checkout-block.md --config .markdownlint.json`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If this PR doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation only, not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
