### PR TITLE
Add woocommerce_should_resize_image filter to allow excluding images by type

### DIFF
--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -215,7 +215,7 @@ class WC_Regenerate_Images {
 		}
 
 		// List of sizes we want to resize. Ignore others.
-		if ( ! $image || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' ) ), true ) ) {
+		if ( ! $image || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' ) ), true ) || ! apply_filters( 'woocommerce_should_resize_image', true, $image, $attachment_id ) ) {
 			return $image;
 		}
 


### PR DESCRIPTION
## Changes

Adds a new `woocommerce_should_resize_image` filter hook to `WC_Regenerate_Images::maybe_resize_image()`.

### Problem
When uploading SVG images, WooCommerce attempts to resize them which causes PHP notices (SVGs have no width/height dimensions). The existing `woocommerce_resize_images` filter can only disable resizing entirely, which is too broad.

### Solution
Added `woocommerce_should_resize_image` filter that receives `$image` data and `$attachment_id`, allowing developers to conditionally skip resizing for specific images (e.g., based on MIME type or extension):

```php
add_filter( 'woocommerce_should_resize_image', function( $should_resize, $image, $attachment_id ) {
    $mime_type = get_post_mime_type( $attachment_id );
    if ( 'image/svg+xml' === $mime_type ) {
        return false;
    }
    return $should_resize;
}, 10, 3 );
```

### Files Changed
- `plugins/woocommerce/includes/class-wc-regenerate-images.php` — 1 line addition

### How to test the changes
1. Upload an SVG image to the WordPress media library
2. Assign the image to a WooCommerce product
3. Verify that no PHP notices about missing width/height are triggered
4. Use the `woocommerce_should_resize_image` filter to conditionally skip resizing

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry
- [x] This Pull Request does not require a changelog entry. (Minor filter addition, no user-facing change)

Closes #33729