### PR TITLE
Keep chunked POS feed generation backward compatible

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/FeedInterface.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/FeedInterface.php
@@ -16,42 +16,12 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Feed;
  */
 interface FeedInterface {
 	/**
-	 * Start a feed, either fresh or by resuming one a previous chunk began.
-	 *
-	 * A feed may be written across separate processes (one Action Scheduler action per chunk), so it
-	 * lives in a stable, shared location identified by the returned value. Pass that identifier back on
-	 * a later chunk to keep appending to the same feed; pass nothing to begin a new one.
-	 *
-	 * @since 10.5.0
-	 * @since 11.0.0 Added the `$resume_identifier` and `$entries_written` parameters.
-	 *
-	 * @param string|null $resume_identifier Identifier of an existing feed to resume, or null to start fresh.
-	 * @param int         $entries_written   The number of entries already written by previous chunks, so
-	 *                                        separators are added correctly when resuming.
-	 * @return string The identifier of the feed that was started, to be passed back by later chunks.
-	 */
-	public function start( ?string $resume_identifier = null, int $entries_written = 0 ): string;
-
-	/**
-	 * Persist the current chunk and release the file handle without finalizing the feed.
-	 *
-	 * Called at the end of a chunk that is not the last one, so a later chunk can resume.
-	 *
-	 * @since 11.0.0
+	 * Start the feed.
+	 * This can create an empty file, eventually put something in it, or add a database entry.
 	 *
 	 * @return void
 	 */
-	public function flush(): void;
-
-	/**
-	 * Delete a feed (e.g. a partial feed left by an abandoned chunked generation).
-	 *
-	 * @since 11.0.0
-	 *
-	 * @param string $identifier The identifier returned by {@see start()}.
-	 * @return void
-	 */
-	public function delete( string $identifier ): void;
+	public function start(): void;
 
 	/**
 	 * Add an entry to the feed.
@@ -62,7 +32,7 @@ interface FeedInterface {
 	public function add_entry( array $entry ): void;
 
 	/**
-	 * End the feed, marking it complete and ready to be served.
+	 * End the feed.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductWalker.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ProductWalker.php
@@ -195,6 +195,26 @@ class ProductWalker {
 	}
 
 	/**
+	 * Walks through every remaining product in one go, managing the feed lifecycle.
+	 *
+	 * This is the simple, single-process entry point: it starts the feed, walks every batch, ends the
+	 * feed and returns the number of products processed. Callers that need to write a feed across
+	 * several processes should own the feed lifecycle themselves and use {@see walk_batches()} instead.
+	 *
+	 * @since 10.5.0
+	 *
+	 * @param callable|null $callback The callback to call after each batch of products is processed.
+	 * @return int The number of products processed.
+	 */
+	public function walk( ?callable $callback = null ): int {
+		$this->feed->start();
+		$progress = $this->walk_batches( $callback );
+		$this->feed->end();
+
+		return $progress->processed_items;
+	}
+
+	/**
 	 * Walks through products, optionally limited to a bounded number of batches.
 	 *
 	 * The walker does not own the feed lifecycle: the caller is responsible for starting, flushing
@@ -204,7 +224,7 @@ class ProductWalker {
 	 * Called with the defaults it walks every remaining page in one go; pass `$start_page` and
 	 * `$max_batches` to process a bounded slice and resume later from `processed_batches`.
 	 *
-	 * @since 10.5.0
+	 * @since 11.0.0
 	 *
 	 * @param callable|null $callback    The callback to call after each batch of products is processed.
 	 * @param int           $start_page  The 1-based page (batch) to start at.
@@ -212,7 +232,7 @@ class ProductWalker {
 	 * @return WalkerProgress Items/batches processed here, plus the overall total_count and
 	 *                        total_batch_count so the caller knows whether the feed is complete.
 	 */
-	public function walk( ?callable $callback = null, int $start_page = 1, int $max_batches = PHP_INT_MAX ): WalkerProgress {
+	public function walk_batches( ?callable $callback = null, int $start_page = 1, int $max_batches = PHP_INT_MAX ): WalkerProgress {
 		if ( $start_page < 1 ) {
 			$start_page = 1;
 		}

--- a/plugins/woocommerce/src/Internal/ProductFeed/Feed/ResumableFeedInterface.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Feed/ResumableFeedInterface.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Resumable Feed Interface.
+ *
+ * @package Automattic\WooCommerce\Internal\ProductFeed
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFeed\Feed;
+
+/**
+ * Contract for feeds that can be written across multiple processes (chunked generation).
+ *
+ * This is deliberately kept separate from {@see FeedInterface}: a feed backend opts into chunked,
+ * resumable generation by implementing this interface *in addition to* FeedInterface. Existing
+ * FeedInterface implementations (including those provided by third-party integrations) remain
+ * valid and are unaffected, so adding this contract is a backwards-compatible change.
+ *
+ * @since 11.0.0
+ */
+interface ResumableFeedInterface extends FeedInterface {
+	/**
+	 * Start a feed fresh, or resume one that a previous chunk began.
+	 *
+	 * A feed may be written across separate processes (one Action Scheduler action per chunk), so it
+	 * lives in a stable, shared location identified by the returned value. Pass that identifier back on
+	 * a later chunk to keep appending to the same feed; pass nothing to begin a new one.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string|null $resume_identifier Identifier of an existing feed to resume, or null to start fresh.
+	 * @param int         $entries_written   The number of entries already written by previous chunks, so
+	 *                                        separators are added correctly when resuming.
+	 * @return string The identifier of the feed that was started, to be passed back by later chunks.
+	 */
+	public function open( ?string $resume_identifier = null, int $entries_written = 0 ): string;
+
+	/**
+	 * Persist the current chunk and release the file handle without finalizing the feed.
+	 *
+	 * Called at the end of a chunk that is not the last one, so a later chunk can resume.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return void
+	 */
+	public function flush(): void;
+
+	/**
+	 * Delete a feed (e.g. a partial feed left by an abandoned chunked generation).
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string $identifier The identifier returned by {@see open()}.
+	 * @return void
+	 */
+	public function delete( string $identifier ): void;
+
+	/**
+	 * Get the number of entries that have been written to the feed.
+	 *
+	 * This reflects the rows actually written, which may be fewer than the number of products
+	 * iterated, because the validator can silently drop entries before they are added.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @return int Number of entries written to the feed.
+	 */
+	public function get_entry_count(): int;
+}

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -11,8 +11,8 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Integrations\POSCatalog;
 
 use ActionScheduler_AsyncRequest_QueueRunner;
 use ActionScheduler_Store;
-use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\ProductWalker;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ResumableFeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\WalkerProgress;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -224,13 +224,13 @@ class AsyncGenerator {
 			$feed = $this->integration->create_feed();
 
 			if ( $is_first_chunk ) {
-				$status['file_name']       = $feed->start();
+				$status['file_name']       = $feed->open();
 				$status['page']            = 1;
 				$status['processed']       = 0;
 				$status['entries_written'] = 0;
 				update_option( $option_key, $status );
 			} else {
-				$feed->start( (string) $status['file_name'], (int) ( $status['entries_written'] ?? 0 ) );
+				$feed->open( (string) $status['file_name'], (int) ( $status['entries_written'] ?? 0 ) );
 			}
 
 			$walker = ProductWalker::from_integration( $this->integration, $feed );
@@ -241,7 +241,7 @@ class AsyncGenerator {
 
 			$start_page     = max( 1, (int) ( $status['page'] ?? 1 ) );
 			$base_processed = (int) ( $status['processed'] ?? 0 );
-			$progress       = $walker->walk(
+			$progress       = $walker->walk_batches(
 				function ( WalkerProgress $progress ) use ( &$status, $option_key, $base_processed ) {
 					// Refresh progress and the heartbeat after every batch, so polling sees smooth progress
 					// within a chunk rather than a single jump at the chunk boundary.
@@ -293,7 +293,7 @@ class AsyncGenerator {
 			);
 
 			// Release the file handle, if any, so it is not left dangling.
-			if ( $feed instanceof FeedInterface ) {
+			if ( $feed instanceof ResumableFeedInterface ) {
 				$feed->flush();
 			}
 
@@ -510,8 +510,8 @@ class AsyncGenerator {
 	 */
 	private function discard_feed( array $status ): void {
 		// A completed feed exposes a full path; an in-progress chunked feed only tracks a file name.
-		// Reduce either to a plain identifier and let FeedInterface::delete() validate it and confine the
-		// deletion to the feed directory, so a tampered path read back from the option can never escape it.
+		// Reduce either to a plain identifier and let ResumableFeedInterface::delete() validate it and confine
+		// the deletion to the feed directory, so a tampered path read back from the option can never escape it.
 		$identifier = ! empty( $status['file_name'] )
 			? (string) $status['file_name']
 			: ( ! empty( $status['path'] ) ? wp_basename( (string) $status['path'] ) : '' );

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -252,7 +252,7 @@ class AsyncGenerator {
 				$this->get_chunk_batch_count( $option_key )
 			);
 
-			// The feed's entry count is already cumulative across chunks (start() seeds it with the running
+			// The feed's entry count is already cumulative across chunks (open() seeds it with the running
 			// total when resuming), so store it as-is rather than adding to the previous total.
 			$status                    = $this->update_progress( $status, $base_processed + $progress->processed_items, $progress->total_count );
 			$status['entries_written'] = $feed->get_entry_count();

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/POSIntegration.php
@@ -12,6 +12,7 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Integrations\POSCatalog;
 use Automattic\WooCommerce\Container;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedValidatorInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ResumableFeedInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Integrations\IntegrationInterface;
 use Automattic\WooCommerce\Internal\ProductFeed\Storage\JsonFileFeed;
 
@@ -102,8 +103,15 @@ class POSIntegration implements IntegrationInterface {
 
 	/**
 	 * {@inheritdoc}
+	 *
+	 * POS catalog feeds are generated in chunks across multiple processes, so this returns a feed that
+	 * supports the resumable lifecycle. Narrowing the return type (a covariant override of the base
+	 * {@see FeedInterface} contract) guarantees that at the language level for callers such as
+	 * {@see AsyncGenerator}, instead of relying on a PHPDoc hint or a runtime check.
+	 *
+	 * @return ResumableFeedInterface
 	 */
-	public function create_feed(): FeedInterface {
+	public function create_feed(): ResumableFeedInterface {
 		return new JsonFileFeed( 'pos-catalog-feed' );
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Internal\ProductFeed\Storage;
 
 use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
 use Automattic\WooCommerce\Internal\ProductFeed\Feed\FeedInterface;
+use Automattic\WooCommerce\Internal\ProductFeed\Feed\ResumableFeedInterface;
 use Exception;
 
 // This file works directly with local files. That's fine.
@@ -23,7 +24,7 @@ use Exception;
  *
  * @since 10.5.0
  */
-class JsonFileFeed implements FeedInterface {
+class JsonFileFeed implements FeedInterface, ResumableFeedInterface {
 	public const UPLOAD_DIR = 'product-feeds';
 
 	/**
@@ -96,6 +97,20 @@ class JsonFileFeed implements FeedInterface {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Simple one-shot entry point for non-resumable generation. This is a thin adapter over the
+	 * resumable {@see open()}: it starts a fresh feed and discards the returned identifier. It exists
+	 * to honor the base {@see FeedInterface} contract; chunked callers use {@see open()} directly.
+	 *
+	 * @return void
+	 * @throws Exception If the feed directory or file cannot be created/opened.
+	 */
+	public function start(): void {
+		$this->open();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * A feed can be written across separate processes (and possibly servers), so it is created
 	 * directly in the shared upload directory rather than a per-request temp directory.
 	 *
@@ -104,7 +119,7 @@ class JsonFileFeed implements FeedInterface {
 	 * @return string The identifier of the feed that was started.
 	 * @throws Exception If the feed directory or file cannot be created/opened, or a resumed feed is missing.
 	 */
-	public function start( ?string $resume_identifier = null, int $entries_written = 0 ): string {
+	public function open( ?string $resume_identifier = null, int $entries_written = 0 ): string {
 		$upload_dir = $this->get_upload_dir();
 
 		$this->file_completed = false;
@@ -195,14 +210,7 @@ class JsonFileFeed implements FeedInterface {
 	}
 
 	/**
-	 * Get the number of entries that have been added to the feed.
-	 *
-	 * This reflects the rows actually written to the feed, which may be fewer
-	 * than the number of products iterated by `ProductWalker` because the
-	 * validator can silently drop entries before they reach `add_entry()`.
-	 *
-	 * @since 10.9.0
-	 * @return int Number of entries added to the feed.
+	 * {@inheritDoc}
 	 */
 	public function flush(): void {
 		if ( is_resource( $this->file_handle ) ) {
@@ -214,7 +222,7 @@ class JsonFileFeed implements FeedInterface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param string $identifier The identifier returned by start().
+	 * @param string $identifier The identifier returned by open().
 	 * @return void
 	 */
 	public function delete( string $identifier ): void {

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -24,7 +24,7 @@ use Exception;
  *
  * @since 10.5.0
  */
-class JsonFileFeed implements FeedInterface, ResumableFeedInterface {
+class JsonFileFeed implements ResumableFeedInterface {
 	public const UPLOAD_DIR = 'product-feeds';
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductWalkerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Feed/ProductWalkerTest.php
@@ -206,10 +206,9 @@ class ProductWalkerTest extends \WC_Unit_Test_Case {
 				}
 			);
 
-		// The walker does not own the feed lifecycle (the caller starts/ends the feed); it only adds
-		// entries.
-		$mock_feed->expects( $this->never() )->method( 'start' );
-		$mock_feed->expects( $this->never() )->method( 'end' );
+		// walk() owns the feed lifecycle: it starts the feed once, adds entries, and ends it once.
+		$mock_feed->expects( $this->once() )->method( 'start' );
+		$mock_feed->expects( $this->once() )->method( 'end' );
 		$mock_feed->expects( $this->exactly( $number_of_products - $validation_compensation ) )
 			->method( 'add_entry' )
 			->with( $this->isType( 'array' ) );
@@ -331,14 +330,14 @@ class ProductWalkerTest extends \WC_Unit_Test_Case {
 		$walker->set_batch_size( $batch_size );
 
 		// First chunk: pages 1-2 (allotment of 2 batches reached).
-		$progress = $walker->walk( null, 1, 2 );
+		$progress = $walker->walk_batches( null, 1, 2 );
 		$this->assertSame( $total, $progress->total_count );
 		$this->assertSame( $total_pages, $progress->total_batch_count );
 		$this->assertSame( 2, $progress->processed_batches );
 		$this->assertSame( 4, $progress->processed_items );
 
 		// Final chunk: resumes at page 3 and stops at the last page even though 2 batches were allowed.
-		$progress = $walker->walk( null, 3, 2 );
+		$progress = $walker->walk_batches( null, 3, 2 );
 		$this->assertSame( 1, $progress->processed_batches );
 		$this->assertSame( 2, $progress->processed_items );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -108,6 +108,11 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 			->method( 'get_product_mapper' )
 			->willReturn( $mock_mapper );
 
+		// The integration produces a real (resumable) feed so generation runs end to end.
+		$this->mock_integration->method( 'create_feed' )->willReturnCallback(
+			fn() => new JsonFileFeed( 'pos-catalog-feed-test' )
+		);
+
 		// Trigger the action.
 		$this->sut->feed_generation_action( self::OPTION_KEY );
 
@@ -177,7 +182,7 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 
 		// A real partial feed file the failed status points at, so we can prove it is discarded.
 		$partial    = new JsonFileFeed( 'pos-catalog-feed-test' );
-		$identifier = $partial->start();
+		$identifier = $partial->open();
 		$partial->flush();
 		$partial_path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;
 		$this->assertTrue( file_exists( $partial_path ) );
@@ -545,7 +550,7 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 
 		// A real partial feed left behind by the stuck (first, single-pass) attempt.
 		$partial    = new JsonFileFeed( 'pos-catalog-feed-test' );
-		$identifier = $partial->start();
+		$identifier = $partial->open();
 		$partial->flush();
 		$partial_path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;
 		$this->assertTrue( file_exists( $partial_path ) );
@@ -614,7 +619,7 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 
 		// A real partial feed file that force should discard.
 		$partial    = new JsonFileFeed( 'pos-catalog-feed-test' );
-		$identifier = $partial->start();
+		$identifier = $partial->open();
 		$partial->flush();
 		$partial_path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;
 		$this->assertTrue( file_exists( $partial_path ) );
@@ -715,6 +720,11 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 		$mock_mapper->method( 'map_product' )->willReturn( array() );
 		$this->mock_integration->method( 'get_product_mapper' )->willReturn( $mock_mapper );
 
+		// The integration produces a real (resumable) feed so generation runs end to end.
+		$this->mock_integration->method( 'create_feed' )->willReturnCallback(
+			fn() => new JsonFileFeed( 'pos-catalog-feed-test' )
+		);
+
 		$this->sut->feed_generation_action( self::OPTION_KEY );
 
 		$updated_status = get_option( self::OPTION_KEY );
@@ -754,7 +764,7 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 		);
 
 		$partial    = new JsonFileFeed( 'pos-catalog-feed-test' );
-		$identifier = $partial->start();
+		$identifier = $partial->open();
 		$partial->flush();
 
 		$path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -98,7 +98,7 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 
 		// First chunk: start the feed and write some entries, then flush (do not end).
 		$feed       = new JsonFileFeed( 'test-feed' );
-		$identifier = $feed->start();
+		$identifier = $feed->open();
 		foreach ( $chunk_one as $entry ) {
 			$feed->add_entry( $entry );
 		}
@@ -108,7 +108,7 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 		// Second (final) chunk: a fresh instance resumes the same feed and ends it, mirroring how a
 		// subsequent Action Scheduler action would run in its own process.
 		$feed_two = new JsonFileFeed( 'test-feed' );
-		$feed_two->start( $identifier, $entries_written );
+		$feed_two->open( $identifier, $entries_written );
 		foreach ( $chunk_two as $entry ) {
 			$feed_two->add_entry( $entry );
 		}
@@ -127,11 +127,11 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_chunked_feed_handles_empty_first_chunk() {
 		$feed       = new JsonFileFeed( 'test-feed' );
-		$identifier = $feed->start();
+		$identifier = $feed->open();
 		$feed->flush();
 
 		$feed_two = new JsonFileFeed( 'test-feed' );
-		$feed_two->start( $identifier, 0 );
+		$feed_two->open( $identifier, 0 );
 		$feed_two->add_entry( array( 'name' => 'Only' ) );
 		$feed_two->end();
 
@@ -142,22 +142,22 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that start() resumes an existing partial feed by reusing its identifier, and throws when the
+	 * Test that open() resumes an existing partial feed by reusing its identifier, and throws when the
 	 * partial file is missing rather than appending to a non-existent file.
 	 */
-	public function test_start_resumes_existing_feed_and_throws_when_missing() {
+	public function test_open_resumes_existing_feed_and_throws_when_missing() {
 		// Resuming a just-created feed reuses the same identifier.
 		$feed       = new JsonFileFeed( 'test-feed' );
-		$identifier = $feed->start();
+		$identifier = $feed->open();
 		$feed->flush();
 
 		$feed_two = new JsonFileFeed( 'test-feed' );
-		$this->assertSame( $identifier, $feed_two->start( $identifier ) );
+		$this->assertSame( $identifier, $feed_two->open( $identifier ) );
 		$feed_two->flush();
 
 		// Resuming a feed that no longer exists throws.
 		$this->expectException( \Exception::class );
-		( new JsonFileFeed( 'test-feed' ) )->start( 'does-not-exist.json' );
+		( new JsonFileFeed( 'test-feed' ) )->open( 'does-not-exist.json' );
 	}
 
 	/**
@@ -165,7 +165,7 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_delete_removes_partial_feed_file() {
 		$feed       = new JsonFileFeed( 'test-feed' );
-		$identifier = $feed->start();
+		$identifier = $feed->open();
 		$feed->flush();
 
 		$path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;
@@ -179,9 +179,9 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	 * Test that resuming with an identifier that is actually a path (traversal attempt) is rejected
 	 * rather than opening a file outside the feed directory.
 	 */
-	public function test_start_rejects_resume_identifier_with_path() {
+	public function test_open_rejects_resume_identifier_with_path() {
 		$this->expectException( \Exception::class );
-		( new JsonFileFeed( 'test-feed' ) )->start( '../escape.json' );
+		( new JsonFileFeed( 'test-feed' ) )->open( '../escape.json' );
 	}
 
 	/**
@@ -190,7 +190,7 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_delete_ignores_identifier_with_path() {
 		$feed       = new JsonFileFeed( 'test-feed' );
-		$identifier = $feed->start();
+		$identifier = $feed->open();
 		$feed->flush();
 
 		$path = wp_upload_dir()['basedir'] . '/' . JsonFileFeed::UPLOAD_DIR . '/' . $identifier;


### PR DESCRIPTION
Stacked on [feature/pos-catalog-chunked-generation](https://github.com/woocommerce/woocommerce/pull/65860) — merge this into that branch, not `trunk`.

That branch made three backward-incompatible changes to the released `FeedInterface` — changed `start()`'s signature and added required `flush()`/`delete()` — even though it's an internal class, it has external implementers like the WooCommerce Stripe Gateway (the same class of break that reverted 10.9.0). This PR keeps the chunked-generation feature backward compatible:

- `FeedInterface` reverted to its released 10.5.0 shape.
- New additive `ResumableFeedInterface` (`open`/`flush`/`delete`/`get_entry_count`), implemented by `JsonFileFeed`.
- `ProductWalker::walk(): int` restored (lifecycle-owning); the bounded variant moves to `walk_batches(): WalkerProgress`.
- `POSIntegration::create_feed()` covariantly narrows its return to `ResumableFeedInterface`.

**Backward compatibility:** Restores it — external `FeedInterface` implementers are unaffected; the resumable lifecycle is a new additive interface.

**Testing:** PHPStan + phpcs clean on the changed files; 98/98 ProductFeed PHPUnit tests pass.
