### PR TITLE
Stabilize non-UTC refund sales report test

### DIFF
--- a/plugins/woocommerce/changelog/fix-flaky-non-utc-refund-report-test
+++ b/plugins/woocommerce/changelog/fix-flaky-non-utc-refund-report-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stabilize the non-UTC refund sales report unit test so it no longer fails depending on the time of day CI runs; test-only, no changes to shipped code.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller-tests.php
@@ -164,14 +164,13 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * per-row net sales (sales - refunds) wrong.
 	 */
 	public function test_refunds_bucketed_by_local_time_in_non_utc_site(): void {
-		$previous_php_tz = date_default_timezone_get();
-		$previous_wp_tz  = get_option( 'timezone_string' );
+		$previous_wp_tz = get_option( 'timezone_string' );
 
-		// Pacific/Auckland is UTC+12 (or +13 in DST) — large enough that a local-time-of-02:00
-		// is the previous calendar day in UTC, surfacing any date()/gmdate() mismatch.
+		// Pacific/Auckland is UTC+12 (or +13 in DST). Configure the non-UTC site the
+		// way WordPress actually does (via the timezone_string option, leaving PHP's
+		// default timezone at UTC) so the legacy report range math (which assumes the
+		// WordPress UTC invariant) is exercised as it runs in production.
 		update_option( 'timezone_string', 'Pacific/Auckland' );
-		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Need to change the PHP timezone to exercise local-vs-UTC date bucketing.
-		date_default_timezone_set( 'Pacific/Auckland' );
 
 		try {
 			$order = WC_Helper_Order::create_order();
@@ -185,8 +184,10 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 				)
 			);
 
-			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Need local-zone date for the assertion.
-			$local_today     = date( 'Y-m-d' );
+			// Local time of 02:00 is still the previous calendar day in UTC, so the
+			// refund's post_date (local) and post_date_gmt (UTC) land on different days.
+			// Bucketing by UTC instead of local time would put the refund in the wrong row.
+			$local_today     = current_datetime()->format( 'Y-m-d' );
 			$local_post_date = $local_today . ' 02:00:00';
 			wp_update_post(
 				array(
@@ -208,8 +209,6 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 				'Refund must bucket by local time so it lines up with sales/orders in the same row.'
 			);
 		} finally {
-			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Restore the original PHP timezone.
-			date_default_timezone_set( $previous_php_tz );
 			update_option( 'timezone_string', $previous_wp_tz );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stabilizes the flaky unit test `WC_REST_Report_Sales_Controller_Tests::test_refunds_bucketed_by_local_time_in_non_utc_site`, which fails intermittently in CI (for example on the `PHP: 7.4 WP: latest` job) with:

```
Failed asserting that an array has the key '2026-06-30'.
```

**Root cause.** The test configured the non-UTC site by calling `date_default_timezone_set( 'Pacific/Auckland' )`. That breaks an invariant WordPress guarantees at runtime: PHP's default timezone is always `UTC`, and site-local time is derived from the `timezone_string`/`gmt_offset` options. WooCommerce's legacy sales report builds its date range with `date( 'Y-m-d', current_time( 'timestamp' ) )` (`includes/admin/reports/class-wc-admin-report.php`), which relies on that invariant. With PHP's default zone forced to UTC+12, the +12h offset is applied twice, so the report's "today" bucket drifts one calendar day ahead whenever the job runs while UTC is between 00:00 and 12:00. The expected `current_datetime()`-based key then no longer exists in `totals`, and the assertion fails. Jobs that happen to run in the afternoon (UTC) pass, which is why the failure looked intermittent.

**Fix.** Configure the non-UTC site the realistic way (only via `update_option( 'timezone_string', 'Pacific/Auckland' )`, leaving PHP's default timezone at UTC) and compute the expected day with the timezone-aware `current_datetime()->format( 'Y-m-d' )` helper (consistent with the sibling tests in the same file). The now-unnecessary `date_default_timezone_set()` save/restore and three `phpcs:ignore` annotations are removed.

The test still exercises the original regression it was written for: the refund's `post_date` (local 02:00) and `post_date_gmt` (previous-day 14:00 UTC) deliberately fall on different calendar days, so a controller that bucketed refunds by UTC instead of local time would still place the refund in the wrong row and fail the assertion.

This is a test-only change; no production code is modified.

Bug introduced in PR #65467.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run the affected test class:
   ```sh
   cd plugins/woocommerce
   pnpm test:php:env -- --filter WC_REST_Report_Sales_Controller_Tests
   ```
   It should pass: `OK (5 tests, 78 assertions)`.
3. To confirm the time-of-day flakiness is gone, run it (or just the single method) while the machine's clock is inside the old failure window, any UTC time between 00:00 and 12:00:
   ```sh
   pnpm test:php:env -- --filter test_refunds_bucketed_by_local_time_in_non_utc_site
   ```
   The previous (trunk) version of the test fails under that condition; this version passes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Stabilize the non-UTC refund sales report unit test so it no longer fails depending on the time of day CI runs.

</details>
