### PR TITLE
Fix WooCommerce templates being flagged as dirty in the Site Editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-48936-templates-dirty-on-open
+++ b/plugins/woocommerce/changelog/fix-48936-templates-dirty-on-open
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooCommerce Cart and Checkout templates/pages being flagged as dirty (Save button enabled) in the Site Editor without any real edit, when opening them, navigating to them, or switching editor views.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/view-switcher/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/view-switcher/utils.ts
@@ -20,8 +20,14 @@ export const selectView = (
 	viewName: string,
 	selectParent = true
 ) => {
-	const { updateBlockAttributes, selectBlock } =
-		dispatch( 'core/block-editor' );
+	const {
+		updateBlockAttributes,
+		selectBlock,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = dispatch( 'core/block-editor' );
+	// `currentView` is an editor-only view toggle. Mark the change as
+	// non-persistent so switching views doesn't create an undo step.
+	__unstableMarkNextChangeAsNotPersistent();
 	updateBlockAttributes( clientId, {
 		currentView: viewName,
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/view-switcher/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/view-switcher/utils.ts
@@ -25,8 +25,6 @@ export const selectView = (
 		selectBlock,
 		__unstableMarkNextChangeAsNotPersistent,
 	} = dispatch( 'core/block-editor' );
-	// `currentView` is an editor-only view toggle. Mark the change as
-	// non-persistent so switching views doesn't create an undo step.
 	__unstableMarkNextChangeAsNotPersistent();
 	updateBlockAttributes( clientId, {
 		currentView: viewName,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -19,7 +19,6 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import ExternalLinkCard from '@woocommerce/editor-components/external-link-card';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -160,16 +159,6 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
-	useEffect( () => {
-		const localPickupTitle = getSetting< string >(
-			'localPickupText',
-			attributes.localPickupText
-		);
-		setAttributes( { localPickupText: localPickupTitle } );
-		// Disable the exhaustive deps rule because we only want to run this on first mount to set the attribute, not
-		// each time the attribute changes.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ setAttributes ] );
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const { prefersCollection } = useSelect( ( select ) => {
 		const checkoutStore = select( checkoutStoreDescriptor );
@@ -177,8 +166,7 @@ export const Edit = ( {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};
 	} );
-	const { showPrice, showIcon, className, localPickupText, shippingText } =
-		attributes;
+	const { showPrice, showIcon, className, shippingText } = attributes;
 	const {
 		shippingRates,
 		needsShipping,
@@ -195,6 +183,14 @@ export const Edit = ( {
 	) {
 		return null;
 	}
+
+	// Read the merchant-configured local pickup title at render (mirroring the
+	// frontend in block.tsx) instead of writing it to the attribute on mount,
+	// which flagged the page dirty on open (#48936).
+	const localPickupText = getSetting< string >(
+		'localPickupText',
+		attributes.localPickupText || defaultLocalPickupText
+	);
 
 	const changeView = ( method: string ) => {
 		if ( method === 'pickup' ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -184,9 +184,8 @@ export const Edit = ( {
 		return null;
 	}
 
-	// Read the merchant-configured local pickup title at render (mirroring the
-	// frontend in block.tsx) instead of writing it to the attribute on mount,
-	// which flagged the page dirty on open (#48936).
+	// Read the local pickup title at render (mirroring the frontend) instead of
+	// writing it to the attribute on mount, which flagged the page dirty (#48936).
 	const localPickupText = getSetting< string >(
 		'localPickupText',
 		attributes.localPickupText || defaultLocalPickupText

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/block.json
@@ -16,10 +16,6 @@
 			"default": ""
 		}
 	},
-	"providesContext": {
-		"postId": "postId",
-		"postType": "postType"
-	},
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
@@ -7,10 +7,13 @@ import {
 	BlockAttributes,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockContextProvider,
+	InnerBlocks,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { page } from '@wordpress/icons';
 import { CHECKOUT_PAGE_ID, CART_PAGE_ID } from '@woocommerce/block-settings';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,13 +21,7 @@ import { useEffect } from '@wordpress/element';
 import metadata from './block.json';
 import './editor.scss';
 
-const Edit = ( {
-	attributes,
-	setAttributes,
-}: {
-	attributes: BlockAttributes;
-	setAttributes: ( attrs: BlockAttributes ) => void;
-} ) => {
+const Edit = ( { attributes }: { attributes: BlockAttributes } ) => {
 	const TEMPLATE: InnerBlockTemplate[] = [
 		[ 'core/post-title', { align: 'wide', level: 1 } ],
 		[ 'core/post-content', { align: 'wide' } ],
@@ -34,27 +31,29 @@ const Edit = ( {
 		className: 'wp-block-woocommerce-page-content-wrapper',
 	} );
 
-	useEffect( () => {
-		if ( ! attributes.postId && attributes.page ) {
-			let postId = 0;
+	// Resolve the page being previewed so the inner post-title/post-content
+	// render the right content in the editor canvas. We provide this as block
+	// context rather than writing it to attributes: mutating attributes on
+	// mount makes the Site Editor flag the template as dirty (#48936). On the
+	// frontend the queried post supplies this context, so it's editor-only.
+	let postId = 0;
+	if ( attributes.page === 'checkout' ) {
+		postId = CHECKOUT_PAGE_ID;
+	} else if ( attributes.page === 'cart' ) {
+		postId = CART_PAGE_ID;
+	}
 
-			if ( attributes.page === 'checkout' ) {
-				postId = CHECKOUT_PAGE_ID;
-			}
-
-			if ( attributes.page === 'cart' ) {
-				postId = CART_PAGE_ID;
-			}
-
-			if ( postId ) {
-				setAttributes( { postId, postType: 'page' } );
-			}
-		}
-	}, [ attributes, setAttributes ] );
+	const innerBlocks = <InnerBlocks template={ TEMPLATE } />;
 
 	return (
 		<div { ...blockProps }>
-			<InnerBlocks template={ TEMPLATE } />
+			{ postId ? (
+				<BlockContextProvider value={ { postId, postType: 'page' } }>
+					{ innerBlocks }
+				</BlockContextProvider>
+			) : (
+				innerBlocks
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/page-content-wrapper/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import { page } from '@wordpress/icons';
 import { CHECKOUT_PAGE_ID, CART_PAGE_ID } from '@woocommerce/block-settings';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,11 +32,9 @@ const Edit = ( { attributes }: { attributes: BlockAttributes } ) => {
 		className: 'wp-block-woocommerce-page-content-wrapper',
 	} );
 
-	// Resolve the page being previewed so the inner post-title/post-content
-	// render the right content in the editor canvas. We provide this as block
-	// context rather than writing it to attributes: mutating attributes on
-	// mount makes the Site Editor flag the template as dirty (#48936). On the
-	// frontend the queried post supplies this context, so it's editor-only.
+	// Provide the previewed page as block context rather than writing it to
+	// attributes on mount, which flagged the template dirty on open (#48936).
+	// On the frontend the queried post supplies this context.
 	let postId = 0;
 	if ( attributes.page === 'checkout' ) {
 		postId = CHECKOUT_PAGE_ID;
@@ -43,17 +42,16 @@ const Edit = ( { attributes }: { attributes: BlockAttributes } ) => {
 		postId = CART_PAGE_ID;
 	}
 
-	const innerBlocks = <InnerBlocks template={ TEMPLATE } />;
+	const context = useMemo(
+		() => ( postId ? { postId, postType: 'page' } : {} ),
+		[ postId ]
+	);
 
 	return (
 		<div { ...blockProps }>
-			{ postId ? (
-				<BlockContextProvider value={ { postId, postType: 'page' } }>
-					{ innerBlocks }
-				</BlockContextProvider>
-			) : (
-				innerBlocks
-			) }
+			<BlockContextProvider value={ context }>
+				<InnerBlocks template={ TEMPLATE } />
+			</BlockContextProvider>
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/block.json
@@ -59,10 +59,6 @@
 		"forcePageReload": {
 			"type": "boolean",
 			"default": false
-		},
-		"__privatePreviewState": {
-			"type": "object",
-			"role": "local"
 		}
 	},
 	"providesContext": {
@@ -72,8 +68,7 @@
 		"dimensions": "dimensions",
 		"queryContextIncludes": "queryContextIncludes",
 		"collection": "collection",
-		"forcePageReload": "forcePageReload",
-		"__privateProductCollectionPreviewState": "__privatePreviewState"
+		"forcePageReload": "forcePageReload"
 	},
 	"usesContext": [ "templateSlug", "postId" ],
 	"supports": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -5,6 +5,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
+	BlockContextProvider,
 } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
@@ -43,14 +44,13 @@ const useQueryId = (
 	// @ts-ignore These selectors aren't getting their types loaded for some reason.
 	const { getBlockParentsByBlockName } = useSelect( blockEditorStore );
 
-	// In order to properly support pagination this block has a queryId attribute that
-	// is initialized to a unique value when the block is first added to the editor.
-	// We use the `instanceId` for this purpose. It is stable across saves as long
-	// as the order of instances of these blocks in the editor does not change.
-	// The block will be re-indexed in that case, however, this won't cause
-	// any problems since the queryid only has to be stable across client
-	// renders.
-	let queryId = instanceId as number;
+	// queryId must be unique per block instance (for pagination) but stable
+	// across re-mounts. Prefer the persisted value so re-mounting an existing
+	// block doesn't rewrite the attribute and flag the entity dirty on open
+	// (#48936); brand-new blocks have no queryId yet and fall back to instanceId.
+	let queryId = Number.isFinite( attributes.queryId )
+		? ( attributes.queryId as number )
+		: ( instanceId as number );
 
 	// We need to take special care when handling instances in a sync pattern
 	// to avoid an infinite loop. When two instances of a pattern are placed
@@ -82,13 +82,23 @@ const ProductCollectionContent = ( {
 
 	const isEmailEditor = useIsEmailEditor();
 
-	useSetPreviewState( {
+	const previewState = useSetPreviewState( {
 		setPreviewState,
-		setAttributes,
+		initialPreviewState,
 		location,
 		attributes,
 		isUsingReferencePreviewMode,
 	} );
+
+	// Provide the preview state to inner blocks (e.g. product-template) via block
+	// context instead of a persisted attribute, so deriving it never marks the
+	// post/template dirty.
+	const previewStateContext = useMemo(
+		() => ( {
+			__privateProductCollectionPreviewState: previewState,
+		} ),
+		[ previewState ]
+	);
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps(
@@ -113,11 +123,6 @@ const ProductCollectionContent = ( {
 		},
 		...( attributes as Partial< ProductCollectionAttributes > ),
 		queryId,
-		// If initialPreviewState is provided, set it as previewState.
-		...( !! attributes.collection &&
-			initialPreviewState && {
-				__privatePreviewState: initialPreviewState,
-			} ),
 	};
 
 	let style = {};
@@ -166,15 +171,13 @@ const ProductCollectionContent = ( {
 
 	return (
 		<div { ...blockProps }>
-			{ attributes.__privatePreviewState?.isPreview &&
+			{ previewState?.isPreview &&
 				( isEmailEditor || props.isSelected ) && (
 					<Button
 						variant="primary"
 						size="small"
 						showTooltip
-						label={
-							attributes.__privatePreviewState?.previewMessage
-						}
+						label={ previewState?.previewMessage }
 						className="wc-block-product-collection__preview-button"
 						data-testid="product-collection-preview-button"
 					>
@@ -185,7 +188,9 @@ const ProductCollectionContent = ( {
 			<InspectorControls { ...props } />
 			<InspectorAdvancedControls { ...props } />
 			<ToolbarControls { ...props } />
-			<div { ...innerBlocksProps } style={ style } />
+			<BlockContextProvider value={ previewStateContext }>
+				<div { ...innerBlocksProps } style={ style } />
+			</BlockContextProvider>
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -45,12 +45,10 @@ const useQueryId = (
 	const { getBlockParentsByBlockName } = useSelect( blockEditorStore );
 
 	// queryId must be unique per block instance (for pagination) but stable
-	// across re-mounts. Prefer the persisted value so re-mounting an existing
-	// block doesn't rewrite the attribute and flag the entity dirty on open
-	// (#48936); brand-new blocks have no queryId yet and fall back to instanceId.
-	let queryId = Number.isFinite( attributes.queryId )
-		? ( attributes.queryId as number )
-		: ( instanceId as number );
+	// across re-mounts. Prefer the persisted value so re-mounting doesn't
+	// rewrite the attribute and flag the entity dirty on open (#48936);
+	// brand-new blocks fall back to instanceId.
+	let queryId = attributes.queryId ?? ( instanceId as number );
 
 	// We need to take special care when handling instances in a sync pattern
 	// to avoid an infinite loop. When two instances of a pattern are placed
@@ -90,9 +88,8 @@ const ProductCollectionContent = ( {
 		isUsingReferencePreviewMode,
 	} );
 
-	// Provide the preview state to inner blocks (e.g. product-template) via block
-	// context instead of a persisted attribute, so deriving it never marks the
-	// post/template dirty.
+	// Provided to inner blocks via context instead of a persisted attribute,
+	// so deriving it never marks the entity dirty.
 	const previewStateContext = useMemo(
 		() => ( {
 			__privateProductCollectionPreviewState: previewState,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/types.ts
@@ -42,8 +42,6 @@ export interface ProductCollectionAttributes {
 	queryContextIncludes: string[];
 	forcePageReload: boolean;
 	filterable: boolean;
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	__privatePreviewState?: PreviewState;
 }
 
 export enum LayoutOptions {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -473,7 +473,13 @@ export const useSetPreviewState = ( {
 			? location.sourceData?.termId
 			: null;
 	useEffect( () => {
-		if ( ! setPreviewState && ! isUsingReferencePreviewMode ) {
+		// Collections that declared a static `initialPreviewState` keep it — the
+		// generic-archive fallback must not overwrite it (#48936 regression).
+		if (
+			! setPreviewState &&
+			! isUsingReferencePreviewMode &&
+			! initialPreviewState
+		) {
 			const isGenericArchiveTemplate =
 				location.type === LocationType.Archive && termId === null;
 
@@ -493,6 +499,7 @@ export const useSetPreviewState = ( {
 		termId,
 		location.type,
 		setPreviewState,
+		initialPreviewState,
 		isUsingReferencePreviewMode,
 	] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -406,21 +406,11 @@ export const useSetPreviewState = ( {
 	usesReference?: string[] | undefined;
 	isUsingReferencePreviewMode: boolean;
 } ): PreviewState | undefined => {
-	// Preview state is editor-only UI — it drives the "Preview" badge and is
-	// passed down to inner blocks via block context. We keep it in local state
-	// rather than a block attribute: writing an attribute marks the entity dirty
-	// (and on navigation even a non-persistent write loses the race), flagging
-	// unsaved changes the merchant never made (#48936 / #51671).
-	const [ previewState, setLocalPreviewState ] = useState<
-		PreviewState | undefined
-	>( initialPreviewState );
-
-	const setState = ( newPreviewState: PreviewState ) => {
-		setLocalPreviewState( ( current ) => ( {
-			...current,
-			...newPreviewState,
-		} ) );
-	};
+	// Preview state is editor-only UI, so keep it in local state rather than a
+	// block attribute — attribute writes mark the entity dirty (#48936).
+	const [ previewState, setState ] = useState< PreviewState | undefined >(
+		initialPreviewState
+	);
 
 	/**
 	 * When usesReference is available on Frontend but not on Editor side,
@@ -432,7 +422,7 @@ export const useSetPreviewState = ( {
 	);
 	useEffect( () => {
 		if ( isUsingReferencePreviewMode ) {
-			setLocalPreviewState( {
+			setState( {
 				isPreview: usesReferencePreviewMessage.length > 0,
 				previewMessage: usesReferencePreviewMessage,
 			} );
@@ -473,8 +463,8 @@ export const useSetPreviewState = ( {
 			? location.sourceData?.termId
 			: null;
 	useEffect( () => {
-		// Collections that declared a static `initialPreviewState` keep it — the
-		// generic-archive fallback must not overwrite it (#48936 regression).
+		// Don't overwrite a collection's static `initialPreviewState` with the
+		// generic archive fallback.
 		if (
 			! setPreviewState &&
 			! isUsingReferencePreviewMode &&
@@ -483,7 +473,7 @@ export const useSetPreviewState = ( {
 			const isGenericArchiveTemplate =
 				location.type === LocationType.Archive && termId === null;
 
-			setLocalPreviewState( {
+			setState( {
 				isPreview: isGenericArchiveTemplate
 					? !! attributes?.query?.inherit
 					: false,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -3,7 +3,7 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
-import { select, useSelect, useDispatch } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import type { BlockEditProps, Block } from '@wordpress/blocks';
 import { CORE_EDITOR_STORE } from '@woocommerce/utils';
@@ -394,31 +394,32 @@ export const useProductCollectionUIState = ( {
 
 export const useSetPreviewState = ( {
 	setPreviewState,
+	initialPreviewState,
 	location,
 	attributes,
-	setAttributes,
 	isUsingReferencePreviewMode,
 }: {
 	setPreviewState?: SetPreviewState | undefined;
+	initialPreviewState?: PreviewState | undefined;
 	location: WooCommerceBlockLocation;
 	attributes: ProductCollectionAttributes;
-	setAttributes: (
-		attributes: Partial< ProductCollectionAttributes >
-	) => void;
 	usesReference?: string[] | undefined;
 	isUsingReferencePreviewMode: boolean;
-} ) => {
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+} ): PreviewState | undefined => {
+	// Preview state is editor-only UI — it drives the "Preview" badge and is
+	// passed down to inner blocks via block context. We keep it in local state
+	// rather than a block attribute: writing an attribute marks the entity dirty
+	// (and on navigation even a non-persistent write loses the race), flagging
+	// unsaved changes the merchant never made (#48936 / #51671).
+	const [ previewState, setLocalPreviewState ] = useState<
+		PreviewState | undefined
+	>( initialPreviewState );
 
 	const setState = ( newPreviewState: PreviewState ) => {
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( {
-			__privatePreviewState: {
-				...attributes.__privatePreviewState,
-				...newPreviewState,
-			},
-		} );
+		setLocalPreviewState( ( current ) => ( {
+			...current,
+			...newPreviewState,
+		} ) );
 	};
 
 	/**
@@ -431,19 +432,12 @@ export const useSetPreviewState = ( {
 	);
 	useEffect( () => {
 		if ( isUsingReferencePreviewMode ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				__privatePreviewState: {
-					isPreview: usesReferencePreviewMessage.length > 0,
-					previewMessage: usesReferencePreviewMessage,
-				},
+			setLocalPreviewState( {
+				isPreview: usesReferencePreviewMessage.length > 0,
+				previewMessage: usesReferencePreviewMessage,
 			} );
 		}
-	}, [
-		setAttributes,
-		usesReferencePreviewMessage,
-		isUsingReferencePreviewMode,
-	] );
+	}, [ usesReferencePreviewMessage, isUsingReferencePreviewMode ] );
 
 	// Running setPreviewState function provided by Collection, if it exists.
 	useLayoutEffect( () => {
@@ -483,17 +477,14 @@ export const useSetPreviewState = ( {
 			const isGenericArchiveTemplate =
 				location.type === LocationType.Archive && termId === null;
 
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				__privatePreviewState: {
-					isPreview: isGenericArchiveTemplate
-						? !! attributes?.query?.inherit
-						: false,
-					previewMessage: __(
-						'Actual products will vary depending on the page being viewed.',
-						'woocommerce'
-					),
-				},
+			setLocalPreviewState( {
+				isPreview: isGenericArchiveTemplate
+					? !! attributes?.query?.inherit
+					: false,
+				previewMessage: __(
+					'Actual products will vary depending on the page being viewed.',
+					'woocommerce'
+				),
 			} );
 		}
 	}, [
@@ -501,10 +492,11 @@ export const useSetPreviewState = ( {
 		usesReferencePreviewMessage,
 		termId,
 		location.type,
-		setAttributes,
 		setPreviewState,
 		isUsingReferencePreviewMode,
 	] );
+
+	return previewState;
 };
 export const getDefaultQueryForSettingsSection = (
 	currentQuery: ProductCollectionQuery

--- a/plugins/woocommerce/tests/e2e/tests/blocks/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, FrontendUtils } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	FrontendUtils,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 // Instead of testing the block individually, we test the Cart and Checkout
 // templates, which make use of the block.
@@ -68,6 +73,32 @@ for ( const template of templates ) {
 			// Verify edits are in the template when viewed from the frontend.
 			await template.visitPage( { frontendUtils } );
 			await expect( page.getByText( userText ).first() ).toBeVisible();
+		} );
+
+		// Regression test for #48936: opening a template that uses this block in
+		// the Site Editor must not flag it as dirty. Previously the block wrote
+		// postId/postType to its attributes on mount, enabling the Save button
+		// with no user edits — which could overwrite the template with empty
+		// content.
+		test( `opening the ${ template.title } template in the Site Editor does not enable the Save button`, async ( {
+			page,
+			admin,
+			editor,
+		} ) => {
+			await admin.visitSiteEditor( {
+				postId: `${ BLOCK_THEME_SLUG }//page-${ template.slug }`,
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+
+			// Wait for the template content to render before asserting state.
+			await expect(
+				editor.canvas.locator( template.blockClassName )
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'button', { name: 'Save', exact: true } )
+			).toBeDisabled();
 		} );
 	} );
 }

--- a/plugins/woocommerce/tests/e2e/tests/blocks/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/page-content-wrapper/page-content-wrapper.block_theme.spec.ts
@@ -75,11 +75,9 @@ for ( const template of templates ) {
 			await expect( page.getByText( userText ).first() ).toBeVisible();
 		} );
 
-		// Regression test for #48936: opening a template that uses this block in
-		// the Site Editor must not flag it as dirty. Previously the block wrote
-		// postId/postType to its attributes on mount, enabling the Save button
-		// with no user edits — which could overwrite the template with empty
-		// content.
+		// Regression test for #48936: opening a template that uses this block
+		// must not flag it as dirty (the block previously wrote postId/postType
+		// to attributes on mount, enabling the Save button with no edits).
 		test( `opening the ${ template.title } template in the Site Editor does not enable the Save button`, async ( {
 			page,
 			admin,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Opening a WooCommerce Cart or Checkout template in the Site Editor flagged it as having unsaved changes. Same for opening the templates view where cart/checkout templates were visible.

The cause was a class of bug where blocks wrote editor-only state into persisted block attributes; every such write marks the entity dirty, even when the saved markup doesn't actually change.

I've moved that state off mutated attributes:

- `page-content-wrapper` provides `postId`/`postType` to its inner blocks via `BlockContextProvider` instead of `setAttributes` on mount.
- `product-collection` keeps its persisted `queryId` instead of reassigning it on mount, and its editor-only preview state (`__privatePreviewState`) now flows through `BlockContextProvider` and local state rather than a serialised attribute.
- The checkout Shipping Method block reads its local pickup label from settings at render time instead of writing it on mount.
- The Cart/Checkout view switcher marks `currentView` toggles non-persistent.

The removed `__privatePreviewState` attribute and `__privateProductCollectionPreviewState` context are editor-internal (the `__private` prefix marks them as such), so this isn't an external backward-compatibility change.

Closes #48936

### How to test the changes in this Pull Request:

1. With a block theme active, go to **Appearance → Editor → Templates** and open **Page: Cart**. Confirm the **Save** button stays disabled — no unsaved changes on load.
2. Repeat for **Page: Checkout**.
3. From the templates list, navigate into **Page: Cart** and back out a couple of times. Confirm no unsaved changes appear.
4. Edit the **Cart** page (**Pages → Cart**), select the **Cart** block, and switch between the **Filled Cart** and **Empty Cart** views in the block toolbar. Confirm switching doesn't enable **Save**.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally on WordPress 7.0 with a block theme:

- Cart and Checkout templates and pages load clean (Save disabled) in both the post editor and the Site Editor, including after navigating between the templates list and a template.
- Switching Cart/Checkout editor views no longer enables Save.
- The Product Collection cross-sells block still renders its preview (heading + sample products), confirming the preview state still reaches inner blocks via block context.
- Confirmed via `__experimentalGetDirtyEntityRecords()` that the entity is clean on open, navigation, and view switching.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
