### PR TITLE
Hide Downloadable product permissions metabox by default on the order edit screen

### DIFF
--- a/plugins/woocommerce/changelog/dsgwoo-1343-hide-downloads-metabox
+++ b/plugins/woocommerce/changelog/dsgwoo-1343-hide-downloads-metabox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Hide the Downloadable product permissions meta box by default on the order edit screen. Merchants can re-enable it via Screen Options.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -726,13 +726,18 @@ class WC_Admin_Post_Types {
 	/**
 	 * Hidden default Meta-Boxes.
 	 *
-	 * @param  array  $hidden Hidden boxes.
-	 * @param  object $screen Current screen.
+	 * @param  array     $hidden Hidden boxes.
+	 * @param  WP_Screen $screen Current screen.
 	 * @return array
 	 */
 	public function hidden_meta_boxes( $hidden, $screen ) {
 		if ( 'product' === $screen->post_type && 'post' === $screen->base ) {
 			$hidden = array_merge( $hidden, array( 'postcustom' ) );
+		}
+
+		// Download permissions are granted automatically, so hide the box by default on order screens (HPOS and legacy CPT). Merchants can re-enable it via Screen Options.
+		if ( wc_get_page_screen_id( 'shop-order' ) === $screen->id ) {
+			$hidden = array_merge( $hidden, array( 'woocommerce-order-downloads' ) );
 		}
 
 		return $hidden;

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -2407,12 +2407,6 @@ parameters:
 			path: includes/admin/class-wc-admin-pointers.php
 
 		-
-			message: '#^Access to an undefined property object\:\:\$base\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/admin/class-wc-admin-post-types.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$post_type\.$#'
 			identifier: property.notFound
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -2415,7 +2415,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$post_type\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: includes/admin/class-wc-admin-post-types.php
 
 		-

--- a/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
@@ -434,7 +434,7 @@ test.describe(
 			) );
 		} );
 
-		test.beforeEach( async ( { restApi } ) => {
+		test.beforeEach( async ( { page, restApi } ) => {
 			await restApi
 				.post( `${ WC_API_PATH }/products`, {
 					name: productName,
@@ -492,6 +492,20 @@ test.describe(
 				.then( ( response: { data: { id: number } } ) => {
 					noProductOrderId = response.data.id;
 				} );
+
+			// The "Downloadable product permissions" meta box is hidden by default on the order
+			// edit screen. Reveal it via Screen Options (the preference persists for the admin
+			// user, so it carries to every order) so the tests below can interact with it.
+			// check() is a no-op when the box is already revealed from a previous test.
+			await page.goto(
+				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+			);
+			await page.locator( '#show-settings-link' ).click();
+			await page.locator( '#woocommerce-order-downloads-hide' ).check();
+			await page.locator( '#show-settings-link' ).click();
+			await expect(
+				page.locator( '#woocommerce-order-downloads' )
+			).toBeVisible();
 		} );
 
 		test.afterEach( async ( { restApi } ) => {

--- a/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
@@ -10,6 +10,7 @@ import { tags, expect, test } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { random } from '../../utils/helpers';
 import { getMediaBySlug } from '../../utils/media';
+import { wpCLI } from '../../utils/cli';
 
 test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -391,6 +392,15 @@ test.describe(
 			email: 'john.doe@example.com',
 		};
 
+		// The downloads box is hidden by default on the order edit screen. These tests run
+		// in both the HPOS (woocommerce_page_wc-orders) and HPOS-disabled (shop_order) jobs,
+		// so the admin user's hidden-meta-boxes preference is cleared for both screen ids to
+		// keep the box visible. Keys are blog-prefixed user meta (single-site wp-env prefix).
+		const orderScreenHiddenMetaKeys = [
+			'wp_metaboxhidden_woocommerce_page_wc-orders',
+			'wp_metaboxhidden_shop_order',
+		];
+
 		let orderId: number,
 			productId: number,
 			product2Id: number,
@@ -432,9 +442,31 @@ test.describe(
 			( { source_url: downloadFile } = await getMediaBySlug(
 				'image-01'
 			) );
+
+			// Persist a Screen Options preference (an empty hidden-meta-boxes list) for the
+			// admin user (ID 1) so the box stays visible while the tests navigate between
+			// orders. An empty list short-circuits the default_hidden_meta_boxes filter that
+			// would otherwise hide it. --skip-plugins/--skip-themes bootstraps core only:
+			// the meta write needs no plugins, and loading them all exhausts WP-CLI's memory
+			// limit in the @services environment (google-listings-and-ads fatals on boot).
+			for ( const key of orderScreenHiddenMetaKeys ) {
+				await wpCLI(
+					`wp user meta update 1 ${ key } '[]' --format=json --skip-plugins --skip-themes`
+				);
+			}
 		} );
 
-		test.beforeEach( async ( { page, restApi } ) => {
+		test.afterAll( async () => {
+			// Restore the default-hidden behaviour so the visible state doesn't leak to
+			// other order-screen tests.
+			for ( const key of orderScreenHiddenMetaKeys ) {
+				await wpCLI(
+					`wp user meta delete 1 ${ key } --skip-plugins --skip-themes`
+				);
+			}
+		} );
+
+		test.beforeEach( async ( { restApi } ) => {
 			await restApi
 				.post( `${ WC_API_PATH }/products`, {
 					name: productName,
@@ -492,20 +524,6 @@ test.describe(
 				.then( ( response: { data: { id: number } } ) => {
 					noProductOrderId = response.data.id;
 				} );
-
-			// The "Downloadable product permissions" meta box is hidden by default on the order
-			// edit screen. Reveal it via Screen Options (the preference persists for the admin
-			// user, so it carries to every order) so the tests below can interact with it.
-			// check() is a no-op when the box is already revealed from a previous test.
-			await page.goto(
-				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
-			);
-			await page.locator( '#show-settings-link' ).click();
-			await page.locator( '#woocommerce-order-downloads-hide' ).check();
-			await page.locator( '#show-settings-link' ).click();
-			await expect(
-				page.locator( '#woocommerce-order-downloads' )
-			).toBeVisible();
 		} );
 
 		test.afterEach( async ( { restApi } ) => {

--- a/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
+++ b/plugins/woocommerce/tests/unit-tests/admin/class-wc-tests-admin-post-types.php
@@ -151,4 +151,38 @@ class WC_Tests_Admin_Post_Types extends WC_Unit_Test_Case {
 		$actual  = $product->{"get_{$type_of_price}_price"}();
 		$this->assertEquals( $expected_new_price, $actual );
 	}
+
+	/**
+	 * @test
+	 * @testdox The downloadable product permissions meta box is hidden by default on the order edit screen.
+	 */
+	public function hidden_meta_boxes_hides_order_downloads_on_order_screen() {
+		$sut    = new WC_Admin_Post_Types();
+		$screen = (object) array(
+			'id'        => wc_get_page_screen_id( 'shop-order' ),
+			'post_type' => 'shop_order',
+			'base'      => 'post',
+		);
+
+		$hidden = $sut->hidden_meta_boxes( array(), $screen );
+
+		$this->assertContains( 'woocommerce-order-downloads', $hidden );
+	}
+
+	/**
+	 * @test
+	 * @testdox The order downloads hide-by-default rule does not leak to unrelated screens.
+	 */
+	public function hidden_meta_boxes_leaves_other_screens_untouched() {
+		$sut    = new WC_Admin_Post_Types();
+		$screen = (object) array(
+			'id'        => 'dashboard',
+			'post_type' => '',
+			'base'      => 'dashboard',
+		);
+
+		$hidden = $sut->hidden_meta_boxes( array(), $screen );
+
+		$this->assertNotContains( 'woocommerce-order-downloads', $hidden );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change. (This supersedes #65205.)
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Linear: DSGWOO-1343

The "Downloadable product permissions" meta box shows on every order edit screen by default, even though download permissions are granted automatically when an order moves to processing/completed. Manual control is niche, so this hides the box by default to keep the order screen trimmed down.

This supersedes #65205 by @JanaMW27 — same thing but using `default_hidden_meta_boxes` which already exists in core. 

**Backward compatibility:** no public signatures or hooks change. Extensions that need a different default can hook `default_hidden_meta_boxes` directly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Note this applies to defaults, so existing users won't be affected. Delete `metaboxhidden_woocommerce_page_wc-orders` user meta to allow this to apply.

1. Open any order (WooCommerce → Orders → open one). The "Downloadable product permissions" box should be hidden.
2. Open Screen Options (top-right). The box is listed and unchecked. Tick it — the box appears.
3. Refresh, or open a different order. The box stays shown (the preference persists).
4. Open WooCommerce → Orders → Add order. The box should be hidden by default there too.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

_Changelog entry created manually at `plugins/woocommerce/changelog/dsgwoo-1343-hide-downloads-metabox`._
