### PR TITLE
Improve Store API product collection count performance

### DIFF
--- a/plugins/woocommerce/changelog/wccom-2729-store-api-filter-data-counts
+++ b/plugins/woocommerce/changelog/wccom-2729-store-api-filter-data-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve Store API product collection filter count performance.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -1,7 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
-use Automattic\WooCommerce\StoreApi\Utilities\ProductQueryFilters;
+use Automattic\WooCommerce\Internal\ProductFilters\FilterData;
+use Automattic\WooCommerce\Internal\ProductFilters\FilterDataProvider;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 
 /**
  * ProductCollectionData route.
@@ -76,7 +78,7 @@ class ProductCollectionData extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$data    = [
+		$data = [
 			'min_price'           => null,
 			'max_price'           => null,
 			'attribute_counts'    => null,
@@ -84,21 +86,33 @@ class ProductCollectionData extends AbstractRoute {
 			'rating_counts'       => null,
 			'taxonomy_counts'     => null,
 		];
-		$filters = new ProductQueryFilters();
+
+		$product_query = new ProductQuery();
+		/**
+		 * Product filter data service.
+		 *
+		 * @var FilterData $filter_data
+		 */
+		$filter_data = wc_get_container()->get( FilterDataProvider::class )->with( $product_query );
 
 		if ( ! empty( $request['calculate_price_range'] ) ) {
 			$filter_request = clone $request;
 			$filter_request->set_param( 'min_price', null );
 			$filter_request->set_param( 'max_price', null );
 
-			$price_results     = $filters->get_filtered_price( $filter_request );
-			$data['min_price'] = $price_results->min_price;
-			$data['max_price'] = $price_results->max_price;
+			$price_results     = (array) $filter_data->get_filtered_price( $this->get_filter_data_query_vars( $filter_request, $product_query ) );
+			$data['min_price'] = $price_results['min_price'] ?? null;
+			$data['max_price'] = $price_results['max_price'] ?? null;
 		}
 
 		if ( ! empty( $request['calculate_stock_status_counts'] ) ) {
 			$filter_request = clone $request;
-			$counts         = $filters->get_stock_status_counts( $filter_request );
+			$filter_request->set_param( 'stock_status', null );
+			$stock_statuses = array_keys( wc_get_product_stock_status_options() );
+			$counts         = array_replace(
+				array_fill_keys( $stock_statuses, 0 ),
+				$filter_data->get_stock_status_counts( $this->get_filter_data_query_vars( $filter_request, $product_query ), $stock_statuses )
+			);
 
 			$data['stock_status_counts'] = [];
 
@@ -167,7 +181,7 @@ class ProductCollectionData extends AbstractRoute {
 					}
 
 					$filter_request->set_param( 'attributes', $filter_attributes );
-					$counts = $filters->get_attribute_counts( $filter_request, [ $taxonomy ] );
+					$counts = $filter_data->get_attribute_counts( $this->get_filter_data_query_vars( $filter_request, $product_query ), $taxonomy );
 
 					foreach ( $counts as $key => $value ) {
 						$data['attribute_counts'][] = (object) [
@@ -179,21 +193,28 @@ class ProductCollectionData extends AbstractRoute {
 			}
 
 			if ( $taxonomy__and_queries ) {
-				$counts = $filters->get_attribute_counts( $request, $taxonomy__and_queries );
+				$query_vars = $this->get_filter_data_query_vars( $request, $product_query );
 
-				foreach ( $counts as $key => $value ) {
-					$data['attribute_counts'][] = (object) [
-						'term'  => $key,
-						'count' => $value,
-					];
+				foreach ( $taxonomy__and_queries as $taxonomy ) {
+					$counts = $filter_data->get_attribute_counts( $query_vars, $taxonomy );
+
+					foreach ( $counts as $key => $value ) {
+						$data['attribute_counts'][] = (object) [
+							'term'  => $key,
+							'count' => $value,
+						];
+					}
 				}
 			}
 		}
 
 		if ( ! empty( $request['calculate_rating_counts'] ) ) {
-			$filter_request        = clone $request;
-			$counts                = $filters->get_rating_counts( $filter_request );
+			$filter_request = clone $request;
+			$filter_request->set_param( 'rating', null );
+			$counts                = $filter_data->get_rating_counts( $this->get_filter_data_query_vars( $filter_request, $product_query ) );
 			$data['rating_counts'] = [];
+
+			ksort( $counts, SORT_NUMERIC );
 
 			foreach ( $counts as $key => $value ) {
 				$data['rating_counts'][] = (object) [
@@ -211,18 +232,41 @@ class ProductCollectionData extends AbstractRoute {
 			$data['taxonomy_counts'] = [];
 
 			if ( $taxonomies ) {
-				$counts = $filters->get_taxonomy_counts( $request, $taxonomies );
+				$query_vars = $this->get_filter_data_query_vars( $request, $product_query );
 
-				foreach ( $counts as $key => $value ) {
-					$data['taxonomy_counts'][] = (object) [
-						'term'  => $key,
-						'count' => $value,
-					];
+				foreach ( $taxonomies as $taxonomy ) {
+					$counts = $filter_data->get_taxonomy_counts( $query_vars, $taxonomy );
+
+					foreach ( $counts as $key => $value ) {
+						$data['taxonomy_counts'][] = (object) [
+							'term'  => $key,
+							'count' => $value,
+						];
+					}
 				}
 			}
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $data ) );
+	}
+
+	/**
+	 * Get query vars for FilterData from a Store API request.
+	 *
+	 * @param \WP_REST_Request $request       Request object.
+	 * @param ProductQuery     $product_query Product query utility.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return array
+	 */
+	private function get_filter_data_query_vars( \WP_REST_Request $request, ProductQuery $product_query ) {
+		$filter_request = clone $request;
+
+		$filter_request->set_param( 'page', null );
+		$filter_request->set_param( 'per_page', null );
+		$filter_request->set_param( 'order', null );
+		$filter_request->set_param( 'orderby', null );
+
+		return $product_query->prepare_objects_query( $filter_request );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
 
+use Automattic\WooCommerce\Internal\ProductFilters\CacheController;
 use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\ValidateSchema;
@@ -732,6 +733,36 @@ class ProductCollectionData extends ControllerTestCase {
 			0,
 			$cached_entries,
 			'Attribute counts should be written to the shared filter-data cache (proves the cached path is used).'
+		);
+	}
+
+	/**
+	 * @testdox Price, stock, and rating counts are computed through the cached filter-data path.
+	 */
+	public function test_calculate_price_stock_and_rating_counts_use_filter_data_cache() {
+		global $wpdb;
+
+		delete_transient( CacheController::CACHE_ENTRY_COUNT_TRANSIENT );
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_wc_filter_data_%' AND option_name <> '_transient_wc_filter_data_entry_count'" );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
+		$request->set_param( 'calculate_price_range', true );
+		$request->set_param( 'calculate_stock_status_counts', true );
+		$request->set_param( 'calculate_rating_counts', true );
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotNull( $data['price_range'], 'Price range should be returned.' );
+		$this->assertNotEmpty( $data['stock_status_counts'], 'Stock status counts should be returned.' );
+		$this->assertNotEmpty( $data['rating_counts'], 'Rating counts should be returned.' );
+
+		$cached_entries = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_wc_filter_data_%' AND option_name <> '_transient_wc_filter_data_entry_count'" );
+		$this->assertGreaterThanOrEqual(
+			3,
+			$cached_entries,
+			'Price, stock, and rating counts should be written to the shared filter-data cache.'
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product collection filter counts currently mix the newer cached `FilterData` path with older Store API count helpers that rebuild product queries and count data separately. This updates `/wc/store/v1/products/collection-data` to use `FilterDataProvider::with( ProductQuery )` for price, stock, rating, attribute, and taxonomy counts while preserving the response shape and attribute OR behavior.

This is part of the WCCOM-2729 / WCCOM-2635 performance work.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

No UI changes. This is a Store API performance refactor.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the focused Store API route tests:

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter ProductCollectionData
    ```

2. Optional manual API check: in a local store with products, reviews, and product attributes, request collection data:

    ```bash
    curl 'http://localhost:8888/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_stock_status_counts=true&calculate_rating_counts=true'
    ```

3. Confirm the response still contains the existing `price_range`, `stock_status_counts`, and `rating_counts` shapes.
4. For attribute filters, confirm an OR count request still returns counts for the active attribute taxonomy instead of being constrained by the active selection.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

-   Ran `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter ProductCollectionData` against the local `wp-env` test container.
-   Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`.
-   Ran `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`.
-   Ran `composer exec -- phpstan analyse src/StoreApi/Routes/V1/ProductCollectionData.php --memory-limit=2G`.
-   Reviewed the diff to confirm only the Store API collection-data route, its route tests, and the WooCommerce Core changelog entry are included.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
