### PR TITLE
Add woocommerce_format_phone_number filter, decouple from is_phone

### DIFF
--- a/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add a woocommerce_format_phone_number filter for customizing the output of wc_format_phone_number(), plus a WC_Validation::is_phone_format() method for country-agnostic phone shape checks. wc_format_phone_number() now gates on is_phone_format() instead of is_phone(), so a woocommerce_validate_phone filter can no longer blank numbers during formatting.
+Add a woocommerce_format_phone_number filter and a WC_Validation::is_phone_format() method.

--- a/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a woocommerce_format_phone_number filter for customizing the output of wc_format_phone_number(), plus a WC_Validation::is_phone_format() method for country-agnostic phone shape checks. wc_format_phone_number() now gates on is_phone_format() instead of is_phone(), so a woocommerce_validate_phone filter can no longer blank numbers during formatting.

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -38,8 +38,8 @@ class WC_Validation {
 	 * @param  string $phone Phone number to check.
 	 * @return bool
 	 */
-	public static function is_phone_format( $phone ) {
-		return 0 === strlen( trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)\.]/', '', (string) $phone ) ) );
+	public static function is_phone_format( $phone ): bool {
+		return '' === trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)\.]/', '', (string) $phone ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -24,6 +24,25 @@ class WC_Validation {
 	}
 
 	/**
+	 * Checks whether a string has the basic shape of a phone number, i.e. it contains
+	 * only digits and characters commonly used in phone numbers (whitespace and the
+	 * "# _ - + / ( ) ." characters).
+	 *
+	 * Unlike `is_phone`, this method doesn't apply the `woocommerce_validate_phone` filter,
+	 * so its result always reflects the default validation rules regardless of any
+	 * merchant-defined validation policy. It's intended for contexts that need a
+	 * country-agnostic sanity check, such as phone number formatting.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param  string $phone Phone number to check.
+	 * @return bool
+	 */
+	public static function is_phone_format( $phone ) {
+		return 0 === strlen( trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)\.]/', '', (string) $phone ) ) );
+	}
+
+	/**
 	 * Validates a phone number using a regular expression.
 	 *
 	 * @param  string      $phone   Phone number to validate.
@@ -31,7 +50,7 @@ class WC_Validation {
 	 * @return bool
 	 */
 	public static function is_phone( $phone, $country = null ) {
-		$valid = 0 === strlen( trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)\.]/', '', $phone ) ) );
+		$valid = self::is_phone_format( $phone );
 
 		/**
 		 * Filters whether a phone number is considered valid.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1082,12 +1082,23 @@ function wc_normalize_postcode( $postcode ) {
  * @return string
  */
 function wc_format_phone_number( $phone ) {
-	$phone = $phone ?? '';
+	$original = $phone ?? '';
 
-	if ( ! WC_Validation::is_phone( $phone ) ) {
-		return '';
-	}
-	return preg_replace( '/[^0-9\+\-\(\)\s]/', '-', preg_replace( '/[\x00-\x1F\x7F-\xFF]/', '', $phone ) );
+	$is_valid  = WC_Validation::is_phone_format( $original );
+	$formatted = $is_valid
+		? (string) preg_replace( '/[^0-9\+\-\(\)\s]/', '-', preg_replace( '/[\x00-\x1F\x7F-\xFF]/', '', $original ) )
+		: '';
+
+	/**
+	 * Filters the formatted phone number.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string $formatted The formatted phone number, or an empty string if $original isn't a valid phone number.
+	 * @param string $original  The phone number passed to the function.
+	 * @param bool   $is_valid  Whether $original passed the default phone number validation.
+	 */
+	return apply_filters( 'woocommerce_format_phone_number', $formatted, $original, $is_valid );
 }
 
 /**

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -34432,12 +34432,6 @@ parameters:
 			path: includes/wc-formatting-functions.php
 
 		-
-			message: '#^Function wc_format_phone_number\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/wc-formatting-functions.php
-
-		-
 			message: '#^Function wc_get_filename_from_url\(\) should return string but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -856,6 +856,49 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that wc_format_phone_number() isn't affected by the woocommerce_validate_phone filter.
+	 *
+	 * The filter is country-aware and used for validation; formatting has no country context,
+	 * so it must not let the filter blank otherwise-formattable numbers.
+	 */
+	public function test_wc_format_phone_number_is_not_affected_by_validate_phone_filter() {
+		add_filter( 'woocommerce_validate_phone', '__return_false' );
+
+		try {
+			$this->assertEquals( '1-610-385-0000', wc_format_phone_number( '1.610.385.0000' ) );
+		} finally {
+			remove_filter( 'woocommerce_validate_phone', '__return_false' );
+		}
+	}
+
+	/**
+	 * Test that wc_format_phone_number() applies the woocommerce_format_phone_number filter.
+	 */
+	public function test_wc_format_phone_number_applies_format_filter() {
+		$received = array();
+
+		$callback = function ( $formatted, $original, $is_valid ) use ( &$received ) {
+			$received = array(
+				'formatted' => $formatted,
+				'original'  => $original,
+				'is_valid'  => $is_valid,
+			);
+			return 'filtered';
+		};
+
+		add_filter( 'woocommerce_format_phone_number', $callback, 10, 3 );
+
+		try {
+			$this->assertEquals( 'filtered', wc_format_phone_number( '1.610.385.0000' ) );
+			$this->assertEquals( '1-610-385-0000', $received['formatted'] );
+			$this->assertEquals( '1.610.385.0000', $received['original'] );
+			$this->assertTrue( $received['is_valid'] );
+		} finally {
+			remove_filter( 'woocommerce_format_phone_number', $callback, 10 );
+		}
+	}
+
+	/**
 	 * Test wc_sanitize_phone_number().
 	 *
 	 * @since 3.6.0

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
@@ -230,4 +230,27 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 		$this->assertEquals( '+00-000-00-00-000', WC_Validation::format_phone( '+00.000.00.00.000' ) );
 		$this->assertEquals( '+00 000 00 00 000', WC_Validation::format_phone( '+00 000 00 00 000' ) );
 	}
+
+	/**
+	 * Test is_phone_format().
+	 */
+	public function test_is_phone_format() {
+		$this->assertTrue( WC_Validation::is_phone_format( '+00 000 00 00 000' ) );
+		$this->assertTrue( WC_Validation::is_phone_format( '(000) 00 00 000' ) );
+		$this->assertFalse( WC_Validation::is_phone_format( '+00 aaa dd ee fff' ) );
+	}
+
+	/**
+	 * Test that is_phone_format() ignores the woocommerce_validate_phone filter while is_phone() honors it.
+	 */
+	public function test_is_phone_format_ignores_validate_phone_filter() {
+		add_filter( 'woocommerce_validate_phone', '__return_false' );
+
+		try {
+			$this->assertTrue( WC_Validation::is_phone_format( '+00 000 00 00 000' ) );
+			$this->assertFalse( WC_Validation::is_phone( '+00 000 00 00 000' ) );
+		} finally {
+			remove_filter( 'woocommerce_validate_phone', '__return_false' );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR #65817 added the `woocommerce_validate_phone` filter and a `$country` parameter to `WC_Validation::is_phone()` so that phone validation can be customized per country. `wc_format_phone_number()` also calls `is_phone()`, but as a formatting helper it has no country context, so it passes `null`.

The problem is that this couples merchant validation policy to formatting: a `woocommerce_validate_phone` filter that *accepts* a country-specific format the default rules reject (e.g. a format containing letters) would have that phone accepted at checkout, but then **silently blanked** when run through `wc_format_phone_number()`, because the filter receives `null` for the country there and falls back to rejecting the number.

This pull request decouples formatting from the customizable validation, and adds a dedicated filter for customizing the formatted output:

- **New `WC_Validation::is_phone_format()` method**: a country-agnostic, filter-free check for whether a string has the basic shape of a phone number. It always reflects the default validation rules, regardless of any merchant-defined validation policy.
- **`WC_Validation::is_phone()`** now delegates its default check to `is_phone_format()` before applying the `woocommerce_validate_phone` filter. Behavior is unchanged.
- **`wc_format_phone_number()`** now gates on `is_phone_format()` instead of `is_phone()`, so a `woocommerce_validate_phone` filter can no longer blank numbers during formatting. It also applies a new **`woocommerce_format_phone_number`** filter (`$formatted`, `$original`, `$is_valid`), consistent with the other `woocommerce_format_*` hooks in `wc-formatting-functions.php`. Consumers that need to customize formatted output (including honoring accepted country-specific formats) now have a purpose-built hook for it instead of having to account for a `null` country inside the validation filter.

Net effect: the default behavior of all four call sites is unchanged, the `woocommerce_validate_phone` filter is no longer able to discard numbers in the formatting path, and extenders get a proper formatting hook.

Related to PR #65817 (which introduced the `woocommerce_validate_phone` filter).

### How to test the changes in this Pull Request:

1. Add the following snippet (e.g. to a small plugin or to the end of `woocommerce.php`). It registers a `woocommerce_validate_phone` filter that only accepts a phone for a specific country and rejects it otherwise:

   ```php
   add_filter(
       'woocommerce_validate_phone',
       function ( $valid, $phone, $country ) {
           // Only consider phones valid for the US in this example.
           return 'US' === $country ? $valid : false;
       },
       10,
       3
   );
   ```

2. Confirm that **formatting is no longer affected by the validation filter**. With the snippet active, run:

   ```php
   echo wc_format_phone_number( '1.610.385.0000' );
   ```

   - Before this change: returns an empty string (the filter receives `null` for the country and rejects the number).
   - After this change: returns `1-610-385-0000`.

3. Confirm the **new formatting filter** is applied:

   ```php
   add_filter(
       'woocommerce_format_phone_number',
       function ( $formatted, $original, $is_valid ) {
           return $is_valid ? "+$formatted" : $formatted;
       },
       10,
       3
   );

   echo wc_format_phone_number( '1.610.385.0000' ); // +1-610-385-0000
   ```

4. Confirm **validation is unchanged** at checkout: validation call sites (checkout, "edit address", Store API) still honor the `woocommerce_validate_phone` filter and the `$country` it is given.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Release Communication

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
