### PR TITLE
Fix sales report refund timezone test flake

### DIFF
--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller-tests.php
@@ -62,12 +62,26 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 	/**
 	 * Helper: invoke the v3 controller and return the response body as an array.
 	 *
-	 * @param string $period Period to request.
+	 * @param string|null $period   Period to request. Null to use a custom date range.
+	 * @param string|null $date_min Start date for custom date ranges.
+	 * @param string|null $date_max End date for custom date ranges.
 	 * @return array
 	 */
-	private function get_report( string $period = 'month' ): array {
+	private function get_report(
+		?string $period = 'month',
+		?string $date_min = null,
+		?string $date_max = null
+	): array {
 		$request = new WP_REST_Request( 'GET', '/wc/v3/reports/sales' );
-		$request->set_param( 'period', $period );
+		if ( null !== $period ) {
+			$request->set_param( 'period', $period );
+		}
+		if ( null !== $date_min ) {
+			$request->set_param( 'date_min', $date_min );
+		}
+		if ( null !== $date_max ) {
+			$request->set_param( 'date_max', $date_max );
+		}
 
 		$controller = new WC_REST_Report_Sales_Controller();
 		$response   = $controller->prepare_item_for_response( null, $request );
@@ -166,10 +180,12 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 	public function test_refunds_bucketed_by_local_time_in_non_utc_site(): void {
 		$previous_php_tz = date_default_timezone_get();
 		$previous_wp_tz  = get_option( 'timezone_string' );
+		$previous_offset = get_option( 'gmt_offset' );
 
 		// Pacific/Auckland is UTC+12 (or +13 in DST) — large enough that a local-time-of-02:00
 		// is the previous calendar day in UTC, surfacing any date()/gmdate() mismatch.
 		update_option( 'timezone_string', 'Pacific/Auckland' );
+		update_option( 'gmt_offset', 12 );
 		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Need to change the PHP timezone to exercise local-vs-UTC date bucketing.
 		date_default_timezone_set( 'Pacific/Auckland' );
 
@@ -195,7 +211,7 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 				)
 			);
 
-			$data = $this->get_report( 'month' );
+			$data = $this->get_report( null, $local_today, $local_today );
 
 			$this->assertArrayHasKey(
 				$local_today,
@@ -211,6 +227,7 @@ class WC_REST_Report_Sales_Controller_Tests extends WC_REST_Unit_Test_Case {
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Restore the original PHP timezone.
 			date_default_timezone_set( $previous_php_tz );
 			update_option( 'timezone_string', $previous_wp_tz );
+			update_option( 'gmt_offset', $previous_offset );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The local-time refund bucketing regression test could build its report range from the implicit current month, which made it sensitive to leaked `gmt_offset` state from other tests. This keeps the test focused on the local refund date by requesting an explicit custom date range and restoring `gmt_offset` after the timezone setup.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #65467.

### Screenshots or screen recordings:

Not applicable; test-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `wp-env run --config /private/tmp/woo-wc-unit-wp-env.json --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit -c phpunit.xml --verbose --filter WC_REST_Report_Sales_Controller_Tests`.
2. Confirm all tests in `WC_REST_Report_Sales_Controller_Tests` pass.
3. Optionally repeat `WC_REST_Report_Sales_Controller_Tests::test_refunds_bucketed_by_local_time_in_non_utc_site` multiple times to confirm it remains stable.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Reproduced the reported failure shape by simulating leaked `gmt_offset` state before the fix: `Failed asserting that an array has the key '2026-06-30'.`
- `php -l plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller-tests.php`
- `wp-env run --config /private/tmp/woo-wc-unit-wp-env.json --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit -c phpunit.xml --verbose --filter WC_REST_Report_Sales_Controller_Tests` passed: 5 tests, 78 assertions.
- `test_refunds_bucketed_by_local_time_in_non_utc_site` passed for 10 consecutive runs.
- `composer run-script lint` could not complete because `phpcs-changed` is unavailable in this local dependency set.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` could not complete because the current lockfile fails the active pnpm supply-chain policy for `allure-js-commons@3.7.1` and `allure-playwright@3.7.1`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Test-only change; not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
