### PR TITLE
Add Woo Home click tracking to Things to do next tasks

### DIFF
--- a/plugins/woocommerce/changelog/add-whats-next-task-click-tracking
+++ b/plugins/woocommerce/changelog/add-whats-next-task-click-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add click tracking for the Things to do next task list.

--- a/plugins/woocommerce/client/admin/client/task-lists/components/task-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/task-list-item.tsx
@@ -27,6 +27,7 @@ export type TaskListItemProps = {
 	task: TaskType & {
 		onClick?: () => void;
 	};
+	trackClick?: () => void;
 };
 
 export const TaskListItem = ( {
@@ -34,6 +35,7 @@ export const TaskListItem = ( {
 	isExpanded = false,
 	setExpandedTask,
 	task,
+	trackClick: trackTaskListClick,
 }: TaskListItemProps ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { layoutString } = useLayoutContext();
@@ -166,6 +168,7 @@ export const TaskListItem = ( {
 			const onClickActions = (
 				event?: React.MouseEvent | React.KeyboardEvent
 			) => {
+				trackTaskListClick?.();
 				trackClick().then( () => {
 					if ( ! isComplete ) {
 						// Invalidate the task list selector cache to force a re-fetch.
@@ -200,7 +203,10 @@ export const TaskListItem = ( {
 					onClick={
 						! isExpandable || isComplete
 							? onClickActions
-							: () => setExpandedTask( id )
+							: () => {
+									trackTaskListClick?.();
+									setExpandedTask( id );
+							  }
 					}
 				/>
 			);
@@ -214,6 +220,7 @@ export const TaskListItem = ( {
 			actionLabel,
 			isExpandable,
 			isComplete,
+			trackTaskListClick,
 		]
 	);
 

--- a/plugins/woocommerce/client/admin/client/task-lists/components/task-list.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/task-list.tsx
@@ -69,6 +69,15 @@ export const TaskList = ( {
 		} );
 	};
 
+	const trackClick = ( task: TaskListProps[ 'tasks' ][ number ] ) => {
+		recordEvent( eventPrefix + 'task_clicked', {
+			task_name: task.id,
+			task_complete: task.isComplete,
+			task_dismissed: task.isDismissed,
+			context: layoutString,
+		} );
+	};
+
 	useEffect( () => {
 		recordTaskListView();
 	}, [] );
@@ -106,6 +115,7 @@ export const TaskList = ( {
 			isExpandable={ isExpandable }
 			task={ task }
 			setExpandedTask={ setExpandedTask }
+			trackClick={ () => trackClick( task ) }
 		/>
 	) );
 

--- a/plugins/woocommerce/client/admin/client/task-lists/components/task-list.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/task-list.tsx
@@ -70,7 +70,7 @@ export const TaskList = ( {
 	};
 
 	const trackClick = ( task: TaskListProps[ 'tasks' ][ number ] ) => {
-		recordEvent( eventPrefix + 'task_clicked', {
+		recordEvent( eventPrefix + 'task_click', {
 			task_name: task.id,
 			task_complete: task.isComplete,
 			task_dismissed: task.isDismissed,

--- a/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list-item.test.tsx
@@ -208,6 +208,49 @@ describe( 'TaskListItem', () => {
 		} );
 	} );
 
+	it( 'should call trackClick when clicking tasklist item', () => {
+		const trackClick = jest.fn();
+		render(
+			<TaskListItem
+				task={ { ...task } }
+				isExpandable={ false }
+				isExpanded={ false }
+				setExpandedTask={ () => {} }
+				trackClick={ trackClick }
+			/>
+		);
+
+		act( () => {
+			userEvent.click( screen.getByText( task.title ) );
+		} );
+
+		expect( trackClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should call trackClick before expanding expandable tasklist item', () => {
+		const trackClick = jest.fn();
+		const setExpandedTask = jest.fn();
+		render(
+			<TaskListItem
+				task={ { ...task } }
+				isExpandable={ true }
+				isExpanded={ false }
+				setExpandedTask={ setExpandedTask }
+				trackClick={ trackClick }
+			/>
+		);
+
+		act( () => {
+			userEvent.click( screen.getByText( task.title ) );
+		} );
+
+		expect( trackClick ).toHaveBeenCalledTimes( 1 );
+		expect( setExpandedTask ).toHaveBeenCalledWith( task.id );
+		expect( trackClick.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			setExpandedTask.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
 	it( 'should not call dismissTask when isDismissable is set to false', () => {
 		const { queryByRole } = render(
 			<TaskListItem

--- a/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskType } from '@woocommerce/data';
 
@@ -16,7 +16,7 @@ jest.mock( '@woocommerce/tracks', () => ( {
 } ) );
 jest.mock( '../task-list-item', () => ( {
 	TaskListItem: ( props: TaskListItemProps ) => (
-		<div>{ props.task.title }</div>
+		<button onClick={ props.trackClick }>{ props.task.title }</button>
 	),
 } ) );
 jest.mock( '../task-list-menu', () => ( {
@@ -255,5 +255,65 @@ describe( 'TaskList', () => {
 		expect(
 			queryByText( dismissedTask[ 0 ].title )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'should fire extended tasklist task clicked event when a task is clicked', () => {
+		const { getByText } = render(
+			<TaskList
+				id="extended"
+				eventPrefix="extended_tasklist_"
+				tasks={ [ ...tasks.extension ] }
+				title="List title"
+				query={ {} }
+				isVisible={ true }
+				isHidden={ false }
+				isComplete={ false }
+				displayProgressHeader={ false }
+				keepCompletedTaskList="no"
+			/>
+		);
+
+		( recordEvent as jest.Mock ).mockClear();
+
+		fireEvent.click( getByText( tasks.extension[ 0 ].title ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'extended_tasklist_task_clicked',
+			{
+				task_name: 'extension',
+				task_complete: false,
+				task_dismissed: false,
+				context: 'home',
+			}
+		);
+	} );
+
+	it( 'should include task_complete when a completed task is clicked', () => {
+		const { getByText } = render(
+			<TaskList
+				id="extended"
+				eventPrefix="extended_tasklist_"
+				tasks={ [ tasks.setup[ 2 ] ] }
+				title="List title"
+				query={ {} }
+				isVisible={ true }
+				isHidden={ false }
+				isComplete={ false }
+				displayProgressHeader={ false }
+				keepCompletedTaskList="no"
+			/>
+		);
+
+		( recordEvent as jest.Mock ).mockClear();
+
+		fireEvent.click( getByText( tasks.setup[ 2 ].title ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'extended_tasklist_task_clicked',
+			expect.objectContaining( {
+				task_name: 'completed',
+				task_complete: true,
+			} )
+		);
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
@@ -280,7 +280,7 @@ describe( 'TaskList', () => {
 		);
 
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'extended_tasklist_task_clicked',
+			'extended_tasklist_task_click',
 			{
 				task_name: 'extension',
 				task_complete: false,
@@ -313,7 +313,7 @@ describe( 'TaskList', () => {
 		);
 
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'extended_tasklist_task_clicked',
+			'extended_tasklist_task_click',
 			expect.objectContaining( {
 				task_name: 'completed',
 				task_complete: true,

--- a/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list.test.tsx
@@ -258,7 +258,7 @@ describe( 'TaskList', () => {
 	} );
 
 	it( 'should fire extended tasklist task clicked event when a task is clicked', () => {
-		const { getByText } = render(
+		const { getByRole } = render(
 			<TaskList
 				id="extended"
 				eventPrefix="extended_tasklist_"
@@ -275,7 +275,9 @@ describe( 'TaskList', () => {
 
 		( recordEvent as jest.Mock ).mockClear();
 
-		fireEvent.click( getByText( tasks.extension[ 0 ].title ) );
+		fireEvent.click(
+			getByRole( 'button', { name: tasks.extension[ 0 ].title } )
+		);
 
 		expect( recordEvent ).toHaveBeenCalledWith(
 			'extended_tasklist_task_clicked',
@@ -289,7 +291,7 @@ describe( 'TaskList', () => {
 	} );
 
 	it( 'should include task_complete when a completed task is clicked', () => {
-		const { getByText } = render(
+		const { getByRole } = render(
 			<TaskList
 				id="extended"
 				eventPrefix="extended_tasklist_"
@@ -306,7 +308,9 @@ describe( 'TaskList', () => {
 
 		( recordEvent as jest.Mock ).mockClear();
 
-		fireEvent.click( getByText( tasks.setup[ 2 ].title ) );
+		fireEvent.click(
+			getByRole( 'button', { name: tasks.setup[ 2 ].title } )
+		);
 
 		expect( recordEvent ).toHaveBeenCalledWith(
 			'extended_tasklist_task_clicked',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Things to do next task list shown on Woo Home records completion and list-level events, but it did not record individual task clicks. This adds a click event for each task so we can understand whether merchants engage with the Woo Home list before completing or hiding it.

The new event is wired from the extended task list into each task item and includes the task ID, completion state, dismissal state, and layout context. Existing setup task list click tracking is unchanged.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm run test:js -- client/task-lists/components/test/task-list.test.tsx client/task-lists/components/test/task-list-item.test.tsx` from `plugins/woocommerce/client/admin`.
2. Confirm the task list tests pass.
3. Review `TaskList` and confirm the event recorded for the Woo Home extended list is `extended_tasklist_task_clicked`, which is sent as the `wcadmin_extended_tasklist_task_clicked` Tracks event.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm run test:js -- client/task-lists/components/test/task-list.test.tsx client/task-lists/components/test/task-list-item.test.tsx`
- `npx eslint client/task-lists/components/task-list.tsx client/task-lists/components/task-list-item.tsx client/task-lists/components/test/task-list.test.tsx client/task-lists/components/test/task-list-item.test.tsx` completed with no errors. It reports existing `react-hooks/exhaustive-deps` warnings in the touched components.
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>