### PR TITLE
Add build date and commit ID to nightly release notes

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
     steps:
       - name: 'Update nightly tag commit ref'
+        id: tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +39,8 @@ jobs:
               ref: `tags/${ targetRef }`,
               sha: branchData.data.commit.sha,
             });
+
+            core.setOutput('sha', branchData.data.commit.sha);
 
       - name: 'Checkout ref'
         uses: 'actions/checkout@v4'
@@ -63,3 +66,26 @@ jobs:
           asset_name: woocommerce-${{ env.SOURCE_REF }}-nightly.zip
           asset_content_type: application/zip
           max_releases: 1
+
+      - name: 'Update nightly release notes'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sha = '${{ steps.tag.outputs.sha }}';
+            const shortSha = sha.slice(0, 7);
+            const sourceRef = process.env.SOURCE_REF;
+            const builtAt = new Date().toISOString().replace('T', ' ').replace(/\..+/, ' UTC');
+            const body = [
+              `Nightly build, regenerated every night from the latest \`${ sourceRef }\`.`,
+              '',
+              `- Published: ${ builtAt }`,
+              `- Commit: ${ context.repo.owner }/${ context.repo.repo }@${ sha } (\`${ shortSha }\`)`,
+            ].join('\n');
+
+            await github.rest.repos.updateRelease({
+              ...context.repo,
+              release_id: Number(process.env.RELEASE_ID),
+              body,
+              target_commitish: sourceRef,
+            });


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The GitHub `nightly` pre-release shows a frozen 2020 date and a generic `Nightly build auto generated.` description with no commit reference. The automation only moves the tag and re-uploads the zip without touching release metadata.
I believe this is correct as re-publishing or creating a new release will trigger notifications for anyone watching the repo every single day, but I do think we can at least add some information (timestamp, commit hash) to the description so it's clear the nightly corresponds to a particular date, which is what this PR does.

Closes #58027.

### How to test the changes in this Pull Request:

1. Merge to `trunk`, then go to **Actions → Nightly builds → Run workflow** and run it against `trunk`.
2. Wait for the run to finish.
3. Run `gh release view nightly --repo woocommerce/woocommerce --json name,body,targetCommitish` (or open the [releases page](https://github.com/woocommerce/woocommerce/releases/tag/nightly)) and confirm: the name is still `Nightly`; the description shows a `Published: <today> UTC` line and a `Commit: woocommerce/woocommerce@<sha>` line matching the current head of `trunk`; the target ref is `trunk`.

### Testing that has already taken place:

Validated the release-notes string and the UTC date formatting locally with Node, and confirmed the workflow YAML parses. Verified against the GitHub REST docs that neither *Create* nor *Update a release* accepts a `published_at` parameter, so the displayed date is intentionally not changed (doing so would require re-publishing and notifying watchers).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal release tooling (GitHub Actions nightly-builds workflow), not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)