### PR TITLE
Add TreeSelect prototype source references

### DIFF
--- a/plugins/woocommerce/changelog/add-treeselect-prototype-source-reference
+++ b/plugins/woocommerce/changelog/add-treeselect-prototype-source-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add TreeSelect prototype source references for future component implementation work.

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/README.md
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/README.md
@@ -1,0 +1,65 @@
+# TreeSelect prototype source reference
+
+This folder keeps a source snapshot from the RSM TreeSelect prototype so the interaction work is easier to inspect from GitHub.
+
+The code here is **not production-ready component code**. It was copied from the standalone React prototype and kept as reference material for future TreeSelect / Combobox implementation work in Woo.
+
+## Why this exists
+
+During the Shipping Native in Woo exploration, TreeSelect became a larger reusable pattern question. Shipping was the source case, but the same interaction shape also surfaced product-category needs.
+
+The earlier PRs captured the design and feedback notes:
+
+- [Shipping-first TreeSelect handoff notes](https://github.com/woocommerce/woocommerce/pull/64732)
+- [Product-category TreeSelect follow-up notes](https://github.com/woocommerce/woocommerce/pull/65237)
+
+This source snapshot adds the working prototype code behind those notes, so future implementation work can inspect the behavior rather than reconstructing it from screenshots.
+
+## Included cases
+
+- Shipping source case: regions, countries, selected chips, suggested destinations, and custom-rate exceptions.
+- Product-category stress case: deeper trees, repeated labels, selected chips, parent-path context, mobile handling, and the product-specific primary category / storefront path exploration.
+
+## Files
+
+```text
+source/
+├── treecombo-only.jsx.txt
+├── styles.treecombo-excerpt.css
+├── components/
+│   ├── ProductCategoryTreeCombo.jsx.txt
+│   ├── TreeCombo.jsx.txt
+│   └── TreeComboLab.jsx.txt
+└── data/
+    ├── countryTree.js.txt
+    └── productCategoryTree.js.txt
+```
+
+The JavaScript and JSX snapshots keep their original source filenames before the `.txt` suffix so GitHub can carry the reference without CI treating them as production source files.
+
+## How to read this
+
+- `TreeCombo.jsx.txt` is the shipping-oriented source case.
+- `ProductCategoryTreeCombo.jsx.txt` is the category-oriented stress case.
+- `TreeComboLab.jsx.txt` wires both cases together and includes the product editor fit exploration.
+- `countryTree.js.txt` and `productCategoryTree.js.txt` are prototype fixtures.
+- `styles.treecombo-excerpt.css` is a trimmed stylesheet excerpt for the TreeSelect lab and product editor fit views.
+
+## Before production
+
+A production Woo component would still need:
+
+- a final component API and ownership decision;
+- accessibility review for combobox / tree keyboard behavior and screen-reader announcements;
+- tests for selection, search, nested paths, and bulk actions;
+- alignment with the current WordPress / Woo component stack;
+- a decision on what stays generic TreeSelect behavior versus product-specific logic.
+
+For example, TreeSelect can own finding and selecting items in a hierarchy. Shipping can layer custom-rate rules on top. Product categories can layer primary category / storefront breadcrumb decisions on top.
+
+## Related P2 notes
+
+- [Shipping Native in Woo update 1](https://radicalupdates.wordpress.com/2026/05/05/shipping-native-in-woo-update-1/)
+- [Shipping Native in Woo update 2](https://radicalupdates.wordpress.com/2026/05/11/shipping-native-in-woo-update-2/)
+- [Combobox / TreeSelect breakout update 1](https://radicalupdates.wordpress.com/2026/05/14/combobox-treeselect-breakout-update-1/)
+- [Combobox / TreeSelect breakout: product category follow-up, update 2](https://radicalupdates.wordpress.com/2026/05/22/combobox-treeselect-breakout-product-category-follow-up-update-2/)

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/ProductCategoryTreeCombo.jsx.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/ProductCategoryTreeCombo.jsx.txt
@@ -1,0 +1,373 @@
+import { useEffect, useRef, useState } from 'react';
+import { Icon, chevronRight } from '@wordpress/icons';
+import {
+  PRODUCT_CATEGORY_TREE,
+  computeProductCategoryTags,
+  findProductCategoryById,
+  findProductCategoryMatches,
+  findProductCategoryPath,
+  formatProductCategoryPath,
+  getProductCategoryLeaves,
+  getProductCategoryNodeAtPath,
+  getProductCategorySelectionState,
+} from '../data/productCategoryTree.js';
+
+export default function ProductCategoryTreeCombo({
+  value,
+  onChange,
+  label = 'Assign categories',
+  defaultOpen = false,
+  defaultSearchQuery = '',
+  showCounts = true,
+  showPathChips = false,
+  pathFirstSearchResults = false,
+  drillParentOnRowClick = true,
+  defaultActivePathTagId = null,
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [currentPath, setCurrentPath] = useState([]);
+  const [searchQuery, setSearchQuery] = useState(defaultSearchQuery);
+  const [activePathTagId, setActivePathTagId] = useState(defaultActivePathTagId);
+  const containerRef = useRef(null);
+  const inputRef = useRef(null);
+  const selected = value instanceof Set ? value : new Set(value || []);
+  const tags = computeProductCategoryTags(selected);
+  const activePathTag = tags.find((tag) => tag.id === activePathTagId && tag.path);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(event) {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  useEffect(() => {
+    function handleEscape(event) {
+      if (event.key === 'Escape') {
+        setSearchQuery('');
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, []);
+
+  function openPopover() {
+    setIsOpen(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function toggleNode(node) {
+    const leaves = getProductCategoryLeaves(node);
+    const state = getProductCategorySelectionState(node, selected);
+    const next = new Set(selected);
+
+    leaves.forEach((leaf) => {
+      if (state === 'checked') {
+        next.delete(leaf.id);
+      } else {
+        next.add(leaf.id);
+      }
+    });
+
+    onChange(next);
+  }
+
+  function removeTag(tag) {
+    const node = findProductCategoryById(PRODUCT_CATEGORY_TREE, tag.id);
+    if (!node) return;
+
+    const next = new Set(selected);
+    getProductCategoryLeaves(node).forEach((leaf) => next.delete(leaf.id));
+    if (activePathTagId === tag.id) {
+      setActivePathTagId(null);
+    }
+    onChange(next);
+  }
+
+  function togglePathHint(tag) {
+    if (!tag.path) return;
+    setActivePathTagId(activePathTagId === tag.id ? null : tag.id);
+  }
+
+  function selectVisible(shouldSelect) {
+    const visibleNodes = searchQuery
+      ? findProductCategoryMatches(PRODUCT_CATEGORY_TREE, searchQuery).map((match) => match.node)
+      : getProductCategoryNodeAtPath(currentPath)?.children || [];
+    const next = new Set(selected);
+
+    visibleNodes
+      .flatMap((node) => getProductCategoryLeaves(node))
+      .forEach((leaf) => {
+        if (shouldSelect) {
+          next.add(leaf.id);
+        } else {
+          next.delete(leaf.id);
+        }
+      });
+
+    onChange(next);
+  }
+
+  function renderBreadcrumb() {
+    if (searchQuery) {
+      return (
+        <div className="tree-breadcrumb product-tree-breadcrumb">
+          <span className="crumb current">
+            {pathFirstSearchResults
+              ? `Categories matching "${searchQuery}"`
+              : 'Search results'}
+          </span>
+        </div>
+      );
+    }
+
+    const parts = [{ label: 'All categories', depth: 0 }];
+    let node = PRODUCT_CATEGORY_TREE;
+    currentPath.forEach((id, index) => {
+      node = (node.children || []).find((child) => child.id === id);
+      if (node) {
+        parts.push({ label: node.label, depth: index + 1 });
+      }
+    });
+
+    return (
+      <div className="tree-breadcrumb product-tree-breadcrumb">
+        {parts.map((part, index) => (
+          <span className="product-tree-crumb-wrap" key={`${part.label}-${part.depth}`}>
+            {index > 0 && <span className="sep">&gt;</span>}
+            {index < parts.length - 1 ? (
+              <button
+                type="button"
+                className="crumb product-tree-crumb-button"
+                onClick={() => {
+                  setCurrentPath(currentPath.slice(0, part.depth));
+                  setSearchQuery('');
+                }}
+              >
+                {part.label}
+              </button>
+            ) : (
+              <span className="crumb current">{part.label}</span>
+            )}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  function renderToolbar(visibleNodes) {
+    const visibleLeaves = visibleNodes.flatMap((node) => getProductCategoryLeaves(node));
+    const selectedCount = visibleLeaves.filter((leaf) => selected.has(leaf.id)).length;
+    const selectLabel = searchQuery ? 'Select matches' : 'Select all';
+    const clearLabel = searchQuery ? 'Clear matches' : 'Deselect all';
+    const labelText = searchQuery
+      ? `${visibleNodes.length} matching categories`
+      : `${selectedCount} of ${visibleLeaves.length} selected`;
+
+    return (
+      <div className="tree-level-toolbar product-tree-toolbar">
+        <button
+          type="button"
+          onClick={() => selectVisible(true)}
+          disabled={visibleLeaves.length > 0 && selectedCount === visibleLeaves.length}
+        >
+          {selectLabel}
+        </button>
+        <button
+          type="button"
+          onClick={() => selectVisible(false)}
+          disabled={selectedCount === 0}
+        >
+          {clearLabel}
+        </button>
+        <span className="level-count">{labelText}</span>
+      </div>
+    );
+  }
+
+  function renderRow(node, pathLabels = []) {
+    const hasChildren = node.children && node.children.length > 0;
+    const state = getProductCategorySelectionState(node, selected);
+    const leaves = getProductCategoryLeaves(node);
+    const checkedCount = leaves.filter((leaf) => selected.has(leaf.id)).length;
+    const fullPathLabel = [...pathLabels, node.label].join(' > ');
+    const rowName = node.label;
+    const ariaLabelName = searchQuery ? fullPathLabel : rowName;
+    const rawPathLabel = searchQuery
+      ? fullPathLabel
+      : showCounts ? `${checkedCount}/${leaves.length} selected` : formatProductCategoryPath(node.id);
+    const pathLabel = rawPathLabel === rowName ? '' : rawPathLabel;
+    const shouldDrillOnRowClick = drillParentOnRowClick && hasChildren;
+
+    function drillIntoNode() {
+      setCurrentPath(findProductCategoryPath(PRODUCT_CATEGORY_TREE, node.id, []) || [...currentPath, node.id]);
+      setSearchQuery('');
+    }
+
+    return (
+      <div
+        key={node.id}
+        className={`tree-item product-tree-item${shouldDrillOnRowClick ? ' opens-children' : ''}${state === 'checked' ? ' checked' : state === 'indeterminate' ? ' indeterminate' : ''}`}
+      >
+        <button
+          type="button"
+          className="row-toggle product-tree-toggle product-tree-checkbox-toggle"
+          aria-pressed={state === 'checked'}
+          aria-label={`${state === 'checked' ? 'Clear' : 'Select'} ${ariaLabelName}`}
+          onClick={() => toggleNode(node)}
+        >
+          <span className="ck" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className="product-tree-row-content"
+          aria-label={shouldDrillOnRowClick ? `Open ${node.label}` : `${state === 'checked' ? 'Clear' : 'Select'} ${ariaLabelName}`}
+          onClick={() => {
+            if (shouldDrillOnRowClick) {
+              drillIntoNode();
+              return;
+            }
+            toggleNode(node);
+          }}
+        >
+          <span className="label product-tree-label">
+            <span className="label-name">{rowName}</span>
+            {pathLabel && <span className="path-prefix product-tree-path">{pathLabel}</span>}
+          </span>
+        </button>
+        {hasChildren && (
+          <button
+            type="button"
+            className="drill product-tree-drill"
+            aria-label={`Open ${node.label}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              drillIntoNode();
+            }}
+          >
+            <Icon icon={chevronRight} size={24} />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const currentNode = getProductCategoryNodeAtPath(currentPath);
+  const visibleMatches = searchQuery
+    ? findProductCategoryMatches(PRODUCT_CATEGORY_TREE, searchQuery).slice(0, 40)
+    : [];
+  const visibleNodes = searchQuery
+    ? visibleMatches.map((match) => match.node)
+    : currentNode?.children || [];
+
+  return (
+    <div className="tree-combo product-tree-combo" ref={containerRef}>
+      <label className="tree-combo-label" onClick={openPopover}>
+        {label}
+      </label>
+
+      <div className="product-tree-combo-control">
+        {tags.length > 0 && (
+          <div className="tree-combo-chips">
+            <div className="tree-combo-chip-row">
+              {tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className={`dest-tag product-category-tag${showPathChips && tag.path ? ' has-path' : ''}`}
+                  data-tooltip={!showPathChips && tag.path ? tag.path : undefined}
+                  title={tag.path || tag.label}
+                >
+                  {tag.path ? (
+                    <button
+                      type="button"
+                      className="product-category-tag-main product-category-tag-label"
+                      aria-label={`Show path for ${tag.label}: ${tag.path}`}
+                      aria-pressed={activePathTagId === tag.id}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        togglePathHint(tag);
+                      }}
+                    >
+                      {tag.type === 'group' && tag.count && showCounts ? `${tag.label} (${tag.count})` : tag.label}
+                    </button>
+                  ) : (
+                    <span className="product-category-tag-main">
+                      {tag.type === 'group' && tag.count && showCounts ? `${tag.label} (${tag.count})` : tag.label}
+                    </span>
+                  )}
+                  {showPathChips && tag.path && (
+                    <span className="product-category-tag-path">
+                      {tag.path.split(' > ').slice(0, -1).join(' > ')}
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    className="tag-remove"
+                    aria-label={`Remove ${tag.path || tag.label}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      removeTag(tag);
+                    }}
+                  >
+                    x
+                  </button>
+                </span>
+              ))}
+            </div>
+            {activePathTag && (
+              <div className="product-category-chip-hint">
+                {activePathTag.path}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="tree-combo-search-row" onClick={() => { if (!isOpen) openPopover(); }}>
+          <span className="tree-combo-search-icon" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </span>
+          <input
+            ref={inputRef}
+            className="tree-combo-search"
+            placeholder={tags.length === 0 ? 'Search categories or browse' : 'Add more categories'}
+            value={searchQuery}
+            aria-expanded={isOpen}
+            aria-label="Search product categories"
+            onChange={(event) => {
+              setSearchQuery(event.target.value);
+              if (!isOpen) setIsOpen(true);
+            }}
+            onFocus={() => { if (!isOpen) openPopover(); }}
+          />
+        </div>
+      </div>
+
+      {isOpen && (
+        <div className="tree-popover product-tree-popover">
+          {renderBreadcrumb()}
+          {renderToolbar(visibleNodes)}
+          <div className="tree-list product-tree-list" role="listbox" aria-multiselectable="true" aria-label="Product category options">
+            {visibleNodes.length > 0 ? (
+              searchQuery
+                ? visibleMatches.map((match) => renderRow(match.node, match.pathLabels))
+                : visibleNodes.map((node) => renderRow(node))
+            ) : (
+              <div className="tree-empty">No categories found.</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/TreeCombo.jsx.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/TreeCombo.jsx.txt
@@ -1,0 +1,613 @@
+import { useState, useEffect, useRef } from 'react';
+import { Icon, chevronRight, close } from '@wordpress/icons';
+import {
+  COUNTRY_TREE,
+  findNodeById, getAllLeaves, getNodeSelectionState,
+  findAllMatches, getNodeAtPath, computeTags, findPathToNode,
+} from '../data/countryTree.js';
+
+function formatExcludedLabels(excluded) {
+  if (!excluded?.length) return '';
+  if (excluded.length === 1) return excluded[0].label;
+  if (excluded.length === 2) return `${excluded[0].label} and ${excluded[1].label}`;
+  return `${excluded.length} countries`;
+}
+
+function findParentAtPath(pathLabels) {
+  let node = COUNTRY_TREE;
+  for (const label of pathLabels) {
+    node = (node.children || []).find((child) => child.label === label);
+    if (!node) return null;
+  }
+  return node;
+}
+
+function formatLeafNames(leaves) {
+  if (leaves.length === 0) return '';
+  if (leaves.length === 1) return leaves[0].label;
+  if (leaves.length === 2) return `${leaves[0].label} and ${leaves[1].label}`;
+  return `${leaves.length} places`;
+}
+
+export default function TreeCombo({
+  value,
+  onChange,
+  label,
+  defaultOpen = false,
+  maxVisibleTags = 5,
+  minFilterQueryLength = 3,
+  suggestions = [],
+  suggestionsLabel = 'Suggested destinations',
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [currentPath, setCurrentPath] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showAllTags, setShowAllTags] = useState(false);
+  const containerRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const selected = value.selected;
+  const anywhereElseSelected = value.anywhereElseSelected;
+  const splitOut = value.splitOut instanceof Set
+    ? value.splitOut
+    : new Set(value.splitOut || []);
+
+  // Close on click-outside
+  useEffect(() => {
+    if (!isOpen) return;
+    function handle(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handle(e) {
+      if (e.key === 'Escape') setIsOpen(false);
+    }
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, []);
+
+  function openPopover() {
+    setIsOpen(true);
+    setCurrentPath([]);
+    setSearchQuery('');
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  // Open popover near a selected chip so merchants can refine a group or set a
+  // custom rate for a selected country.
+  function openTreeAtNode(nodeId) {
+    const path = findPathToNode(COUNTRY_TREE, nodeId, []);
+    if (path === null) return;
+    const node = findNodeById(COUNTRY_TREE, nodeId);
+    if (node && !node.children?.length) {
+      setCurrentPath([]);
+      setSearchQuery(node.label);
+      setIsOpen(true);
+      return;
+    }
+    const targetPath = node?.children?.length ? path : path.slice(0, -1);
+    setCurrentPath(targetPath);
+    setSearchQuery('');
+    setIsOpen(true);
+  }
+
+  function handleGroupChipKeyDown(event, nodeId) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    openTreeAtNode(nodeId);
+  }
+
+  function commitValue(nextValue) {
+    onChange(nextValue);
+    setSearchQuery('');
+  }
+
+  function toggleNode(id) {
+    const node = findNodeById(COUNTRY_TREE, id);
+    if (!node) return;
+    const state = getNodeSelectionState(node, selected);
+    const leaves = getAllLeaves(node);
+    const next = new Set(selected);
+    const nextSplitOut = new Set(splitOut);
+    if (state === 'checked') {
+      leaves.forEach((l) => {
+        next.delete(l.id);
+        nextSplitOut.delete(l.id);
+      });
+    } else {
+      leaves.forEach(l => next.add(l.id));
+    }
+    commitValue({ selected: next, anywhereElseSelected, splitOut: nextSplitOut });
+  }
+
+  function removeTag(id) {
+    if (id === 'anywhere-else') {
+      commitValue({ selected, anywhereElseSelected: false, splitOut });
+      return;
+    }
+    const node = findNodeById(COUNTRY_TREE, id);
+    if (!node) return;
+    const next = new Set(selected);
+    const nextSplitOut = new Set(splitOut);
+    getAllLeaves(node).forEach((l) => {
+      next.delete(l.id);
+      nextSplitOut.delete(l.id);
+    });
+    commitValue({ selected: next, anywhereElseSelected, splitOut: nextSplitOut });
+  }
+
+  function addGroupQuick(groupId) {
+    if (groupId === 'anywhere-else') {
+      commitValue({ selected, anywhereElseSelected: !anywhereElseSelected, splitOut });
+      return;
+    }
+    const node = findNodeById(COUNTRY_TREE, groupId);
+    if (!node) return;
+    const next = new Set(selected);
+    getAllLeaves(node).forEach(l => next.add(l.id));
+    commitValue({ selected: next, anywhereElseSelected, splitOut });
+  }
+
+  function addLeaf(id) {
+    const next = new Set(selected);
+    next.add(id);
+    commitValue({ selected: next, anywhereElseSelected, splitOut });
+  }
+
+  function getVisibleSuggestions() {
+    return suggestions.map((suggestion) => {
+      if (suggestion.id === 'anywhere-else') {
+        return anywhereElseSelected ? null : suggestion;
+      }
+
+      const node = findNodeById(COUNTRY_TREE, suggestion.id);
+      if (!node) return null;
+
+      const leaves = getAllLeaves(node);
+      const selectedCount = leaves.filter((leaf) => selected.has(leaf.id)).length;
+      if (selectedCount === leaves.length) return null;
+
+      return {
+        ...suggestion,
+        count: selectedCount > 0 ? null : suggestion.count,
+        label: suggestion.label,
+      };
+    }).filter(Boolean);
+  }
+
+  function applySuggestion(suggestion) {
+    if (suggestion.id === 'anywhere-else') {
+      addGroupQuick(suggestion.id);
+      return;
+    }
+
+    const node = findNodeById(COUNTRY_TREE, suggestion.id);
+    if (!node) return;
+
+    if (!node.children?.length) {
+      addLeaf(suggestion.id);
+      return;
+    }
+
+    addGroupQuick(suggestion.id);
+  }
+
+  function selectAllInCurrent() {
+    const node = getNodeAtPath(currentPath);
+    if (!node) return;
+    const next = new Set(selected);
+    getAllLeaves(node).forEach(l => next.add(l.id));
+    commitValue({ selected: next, anywhereElseSelected, splitOut });
+  }
+
+  function deselectAllInCurrent() {
+    const node = getNodeAtPath(currentPath);
+    if (!node) return;
+    const next = new Set(selected);
+    const nextSplitOut = new Set(splitOut);
+    getAllLeaves(node).forEach((l) => {
+      next.delete(l.id);
+      nextSplitOut.delete(l.id);
+    });
+    commitValue({ selected: next, anywhereElseSelected, splitOut: nextSplitOut });
+  }
+
+  function toggleSplitOut(id) {
+    const next = new Set(selected);
+    next.add(id);
+    const nextSplitOut = new Set(splitOut);
+    if (nextSplitOut.has(id)) {
+      nextSplitOut.delete(id);
+    } else {
+      nextSplitOut.add(id);
+    }
+    commitValue({ selected: next, anywhereElseSelected, splitOut: nextSplitOut });
+  }
+
+  function canSplitOut(node) {
+    if (node.children?.length) return false;
+    if (!selected.has(node.id)) return false;
+    return true;
+  }
+
+  function canSplitOutFromSearch(node, pathLabels) {
+    if (node.children?.length) return false;
+    return true;
+  }
+
+  function getSplitOutActionLabel(node, parent) {
+    if (!splitOut.has(node.id)) return 'Set custom rate';
+    if (parent && getNodeSelectionState(parent, selected) === 'checked') return 'Use group rate';
+    return 'Use standard rate';
+  }
+
+  function getDisplayState(node) {
+    const isLeaf = !node.children || node.children.length === 0;
+    if (isLeaf && splitOut.has(node.id)) return 'unchecked';
+    return getNodeSelectionState(node, selected);
+  }
+
+  function toggleRowNode(node) {
+    const isLeaf = !node.children || node.children.length === 0;
+    if (isLeaf && splitOut.has(node.id)) {
+      toggleSplitOut(node.id);
+      return;
+    }
+    toggleNode(node.id);
+  }
+
+  const tags = computeTags(selected, anywhereElseSelected, splitOut);
+  const standardTags = tags.filter((tag) => !tag.splitOut);
+  const splitTags = tags.filter((tag) => tag.splitOut);
+  const allDisplayTags = [...standardTags, ...splitTags];
+  const maxTags = Math.max(0, maxVisibleTags);
+  const shouldShowAllTags = showAllTags || maxTags === 0;
+  const visibleTags = shouldShowAllTags ? allDisplayTags : allDisplayTags.slice(0, maxTags);
+  const hiddenTagCount = Math.max(allDisplayTags.length - visibleTags.length, 0);
+  const trimmedSearchQuery = searchQuery.trim();
+  const activeSearchQuery = trimmedSearchQuery.length >= minFilterQueryLength ? trimmedSearchQuery : '';
+
+  // --- Breadcrumb ---
+  function renderBreadcrumb() {
+    if (activeSearchQuery) {
+      return <div className="tree-breadcrumb"><span className="crumb current">Search: &ldquo;{activeSearchQuery}&rdquo;</span></div>;
+    }
+    const parts = [{ label: 'All regions', depth: 0 }];
+    let n = COUNTRY_TREE;
+    currentPath.forEach((id, i) => {
+      n = (n.children || []).find(c => c.id === id);
+      if (n) parts.push({ label: n.label, depth: i + 1 });
+    });
+    return (
+      <div className="tree-breadcrumb">
+        {parts.map((p, i) => (
+          <span key={i}>
+            {i > 0 && <span className="sep">›</span>}
+            {i < parts.length - 1
+              ? (
+                <button
+                  type="button"
+                  className="crumb tree-crumb-button"
+                  onClick={() => { setCurrentPath(currentPath.slice(0, p.depth)); setSearchQuery(''); }}
+                >
+                  {p.label}
+                </button>
+              )
+              : <span className="crumb current">{p.label}</span>
+            }
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  // --- Toolbar (browse mode only) ---
+  function renderToolbar() {
+    if (searchQuery) return null;
+    const node = getNodeAtPath(currentPath);
+    if (!node || !node.children || node.children.length === 0) return null;
+    const leaves = getAllLeaves(node);
+    const checkedCount = leaves.filter(l => selected.has(l.id)).length;
+    const customLeaves = leaves.filter(l => selected.has(l.id) && splitOut.has(l.id));
+    const customCount = customLeaves.length;
+    const isRootLevel = currentPath.length === 0;
+    let countLabel = isRootLevel ? '' : `${checkedCount} of ${leaves.length} selected`;
+    if (!isRootLevel && customCount > 0 && checkedCount === leaves.length) {
+      countLabel = `Group rate excludes ${formatLeafNames(customLeaves)}`;
+    } else if (!isRootLevel && customCount > 0) {
+      countLabel = `${formatLeafNames(customLeaves)} use custom rates`;
+    }
+    return (
+      <div className="tree-level-toolbar">
+        <button onClick={selectAllInCurrent} disabled={checkedCount === leaves.length}>Select all</button>
+        <button onClick={deselectAllInCurrent} disabled={checkedCount === 0}>Deselect all</button>
+        {countLabel && <span className="level-count">{countLabel}</span>}
+      </div>
+    );
+  }
+
+  function renderSuggestions() {
+    if (trimmedSearchQuery || currentPath.length > 0) return null;
+
+    const visibleSuggestions = getVisibleSuggestions();
+    if (visibleSuggestions.length === 0) return null;
+
+    return (
+      <div className="tree-suggestion-block" aria-label={suggestionsLabel}>
+        <div className="tree-suggestion-heading">{suggestionsLabel}</div>
+        <div className="tree-suggestion-row">
+          {visibleSuggestions.map((suggestion) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              className="tree-suggestion-pill"
+              onClick={() => applySuggestion(suggestion)}
+            >
+              {suggestion.count ? `${suggestion.label} (${suggestion.count})` : suggestion.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // --- Tree list ---
+  function renderList() {
+    if (activeSearchQuery) {
+      const matches = findAllMatches(COUNTRY_TREE, activeSearchQuery).slice(0, 30);
+      if (matches.length === 0) {
+        return <div className="tree-list"><div className="tree-empty">No matches for &ldquo;{activeSearchQuery}&rdquo;</div></div>;
+      }
+      return (
+        <div className="tree-list">
+          {matches.map(({ node: n, pathLabels }) => {
+            const state = getDisplayState(n);
+            const hasChildren = n.children && n.children.length > 0;
+            const canSeparate = canSplitOutFromSearch(n, pathLabels);
+            const isSplitOut = splitOut.has(n.id);
+            const parent = findParentAtPath(pathLabels);
+            const drillIntoMatch = () => {
+              const path = findPathToNode(COUNTRY_TREE, n.id, []);
+              if (path) {
+                setCurrentPath(path);
+                setSearchQuery('');
+              }
+            };
+            return (
+              <div
+                key={n.id}
+                className={`tree-item search-result${state === 'checked' ? ' checked' : state === 'indeterminate' ? ' indeterminate' : ''}`}
+                role="treeitem"
+                aria-checked={state === 'indeterminate' ? 'mixed' : state === 'checked'}
+              >
+                <div className="row">
+                  {hasChildren ? (
+                    <>
+                      <button
+                        type="button"
+                        className="row-toggle tree-checkbox-toggle"
+                        aria-pressed={state === 'checked'}
+                        aria-label={`${state === 'checked' ? 'Clear' : 'Select'} ${n.label}`}
+                        onClick={() => toggleRowNode(n)}
+                      >
+                        <span className="ck" />
+                      </button>
+                      <button
+                        type="button"
+                        className="tree-row-content"
+                        aria-label={`Open ${n.label}`}
+                        onClick={drillIntoMatch}
+                      >
+                        <span className="label">
+                          <span className="label-name">{n.label}</span>
+                          {isSplitOut && <span className="tree-rate-status">Custom rate</span>}
+                          <span className="label-count"> ({n.children.length})</span>
+                        </span>
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      className="row-toggle"
+                      aria-pressed={state === 'checked'}
+                      onClick={() => toggleRowNode(n)}
+                    >
+                      <span className="ck" />
+                      <span className="label">
+                        <span className="label-name">{n.label}</span>
+                        {isSplitOut && <span className="tree-rate-status">Custom rate</span>}
+                      </span>
+                    </button>
+                  )}
+                  {canSeparate && (
+                    <button
+                      type="button"
+                      className={`tree-separate-rate${isSplitOut ? ' is-active' : ''}`}
+                      onClick={(e) => { e.stopPropagation(); toggleSplitOut(n.id); }}
+                    >
+                      {getSplitOutActionLabel(n, parent)}
+                    </button>
+                  )}
+                </div>
+                {pathLabels.length > 0 && <span className="path-prefix">{pathLabels.join(' › ')}</span>}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    const currentNode = getNodeAtPath(currentPath);
+    if (!currentNode || !currentNode.children) {
+      return <div className="tree-list"><div className="tree-empty">Nothing here.</div></div>;
+    }
+    return (
+      <div className="tree-list">
+        {currentNode.children.map(child => {
+          const hasChildren = child.children && child.children.length > 0;
+          const state = getDisplayState(child);
+          const leaves = getAllLeaves(child);
+          const checkedCount = leaves.filter(l => selected.has(l.id)).length;
+          const canSeparate = canSplitOut(child);
+          const isSplitOut = splitOut.has(child.id);
+          const parent = currentNode;
+          const drillIntoChild = () => {
+            setCurrentPath([...currentPath, child.id]);
+            setSearchQuery('');
+          };
+          return (
+            <div
+              key={child.id}
+              className={`tree-item${hasChildren ? ' opens-children' : ''}${state === 'checked' ? ' checked' : state === 'indeterminate' ? ' indeterminate' : ''}`}
+              role="treeitem"
+              aria-checked={state === 'indeterminate' ? 'mixed' : state === 'checked'}
+              aria-expanded={hasChildren ? currentPath.includes(child.id) : undefined}
+            >
+              <button
+                type="button"
+                className="row-toggle tree-checkbox-toggle"
+                aria-pressed={state === 'checked'}
+                aria-label={`${state === 'checked' ? 'Clear' : 'Select'} ${child.label}`}
+                onClick={() => toggleRowNode(child)}
+              >
+                <span className="ck" />
+              </button>
+              <button
+                type="button"
+                className="tree-row-content"
+                aria-label={hasChildren ? `Open ${child.label}` : `${state === 'checked' ? 'Clear' : 'Select'} ${child.label}`}
+                onClick={() => {
+                  if (hasChildren) {
+                    drillIntoChild();
+                    return;
+                  }
+                  toggleRowNode(child);
+                }}
+              >
+                <span className="label">
+                  <span className="label-name">{child.label}</span>
+                  {isSplitOut && <span className="tree-rate-status">Custom rate</span>}
+                  {hasChildren && <span className="label-count"> {checkedCount}/{leaves.length}</span>}
+                </span>
+              </button>
+              {canSeparate && (
+                <button
+                  type="button"
+                  className={`tree-separate-rate${isSplitOut ? ' is-active' : ''}`}
+                  onClick={(e) => { e.stopPropagation(); toggleSplitOut(child.id); }}
+                >
+                  {getSplitOutActionLabel(child, parent)}
+                </button>
+              )}
+              {hasChildren && (
+                <button
+                  type="button"
+                  className="drill"
+                  onClick={(e) => { e.stopPropagation(); drillIntoChild(); }}
+                  title={`Open ${child.label}`}
+                  aria-label={`Open ${child.label}`}
+                >
+                  <Icon icon={chevronRight} size={24} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  function renderTag(t) {
+    let chipLabel;
+    if (t.partial) chipLabel = `${t.label} (${t.partial.selected}/${t.partial.total})`;
+    else if (t.type === 'group' && t.count) chipLabel = `${t.label} (${t.count})`;
+    else chipLabel = t.label;
+    if (t.excluded?.length) chipLabel = `${t.label} (${t.count}/${t.count + t.excluded.length})`;
+
+    const isClickable = t.type === 'group' || t.type === 'leaf';
+    const tooltip = t.excluded?.length
+      ? `${t.label} except ${formatExcludedLabels(t.excluded)}`
+      : (isClickable ? 'Click to refine selection' : undefined);
+    const isSplitOut = t.splitOut;
+
+    return (
+      <span
+        key={`${t.id}-${isSplitOut ? 'split' : 'standard'}`}
+        className={`dest-tag${isSplitOut ? ' dest-tag-split' : ''}${isClickable ? ' dest-tag-clickable' : ''}`}
+        title={isSplitOut ? `${t.label} will use custom rates` : tooltip}
+        role={isClickable ? 'button' : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        onClick={isClickable ? (e) => { e.stopPropagation(); openTreeAtNode(t.id); } : undefined}
+        onKeyDown={isClickable ? (e) => handleGroupChipKeyDown(e, t.id) : undefined}
+      >
+        {isSplitOut ? `${t.label} (custom rate)` : chipLabel}
+        <button
+          className="tag-remove"
+          onClick={(e) => { e.stopPropagation(); removeTag(t.id); }}
+          aria-label={`Remove ${isSplitOut ? `${t.label} custom rate` : chipLabel}`}
+        >
+          <Icon icon={close} size={14} />
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <div className="tree-combo" ref={containerRef}>
+      {label && <div className="tree-combo-label">{label}</div>}
+
+      {/* Search input row */}
+      <div className="tree-combo-search-row" onClick={() => { if (!isOpen) openPopover(); }}>
+        {visibleTags.map(renderTag)}
+        {hiddenTagCount > 0 && (
+          <button
+            type="button"
+            className="tree-show-more-tags"
+            onClick={(e) => { e.stopPropagation(); setShowAllTags(true); }}
+          >
+            + {hiddenTagCount} more
+          </button>
+        )}
+        {showAllTags && allDisplayTags.length > maxTags && (
+          <button
+            type="button"
+            className="tree-show-more-tags"
+            onClick={(e) => { e.stopPropagation(); setShowAllTags(false); }}
+          >
+            Show less
+          </button>
+        )}
+        <input
+          ref={inputRef}
+          className="tree-combo-search"
+          placeholder={tags.length === 0 ? 'Search countries and regions' : 'Add more'}
+          value={searchQuery}
+          onChange={e => { setSearchQuery(e.target.value); if (!isOpen) setIsOpen(true); }}
+          onFocus={() => { if (!isOpen) openPopover(); }}
+        />
+      </div>
+
+      {/* Popover */}
+      {isOpen && (
+        <div
+          className="tree-popover open"
+          onClick={e => e.stopPropagation()}
+          role="tree"
+          aria-multiselectable="true"
+        >
+          {renderBreadcrumb()}
+          {renderSuggestions()}
+          {renderToolbar()}
+          {renderList()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/TreeComboLab.jsx.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/components/TreeComboLab.jsx.txt
@@ -1,0 +1,900 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@wordpress/components';
+import TreeCombo from './TreeCombo.jsx';
+import ProductCategoryTreeCombo from './ProductCategoryTreeCombo.jsx';
+import {
+  computeProductCategoryTags,
+  formatProductCategoryPath,
+} from '../data/productCategoryTree.js';
+import {
+  COUNTRY_TREE,
+  computeTags,
+  findNodeById,
+  getAllLeaves,
+  tagsToZones,
+} from '../data/countryTree.js';
+
+function makeInitialShippingValue() {
+  const usLeaves = getAllLeaves(findNodeById(COUNTRY_TREE, 'us')).map((leaf) => leaf.id);
+  const canadaLeaves = getAllLeaves(findNodeById(COUNTRY_TREE, 'ca')).map((leaf) => leaf.id);
+
+  return {
+    selected: new Set([...usLeaves, ...canadaLeaves]),
+    anywhereElseSelected: true,
+    splitOut: new Set(['us-ak', 'us-hi']),
+  };
+}
+
+const initialCategories = new Set([
+  'petite-linen-long-sleeve',
+  'speckled-glaze-ceramic-mugs',
+  'thunderbolt-4-1m-braided',
+  'canon-refills',
+]);
+
+const initialRepeatedCategories = new Set();
+const initialPathCategories = new Set([
+  'women-tees',
+  'men-tees',
+]);
+const longPathProductEditorCategories = new Set([
+  'thunderbolt-4-1m-braided',
+  'petite-linen-long-sleeve',
+  'summer-sale-t-shirts',
+]);
+
+const labTabs = [
+  { id: 'shipping', label: 'Shipping source case' },
+  { id: 'categories', label: 'Category stress test' },
+  { id: 'product-details', label: 'Product details' },
+  { id: 'product-editor', label: 'Current editor fit' },
+  { id: 'mobile', label: 'Mobile + accessibility' },
+];
+
+const categoryVariants = [
+  { id: 'deep', label: 'Deep hierarchy' },
+  { id: 'repeated', label: 'Repeated labels' },
+];
+
+const categoryStressPaths = [
+  'Clothing > Women > Tops > Shirts > Linen shirts > Long sleeve > Petite',
+  'Electronics > Computers > Accessories > Cables & adapters > USB-C cables > Thunderbolt 4 > 1m braided',
+  'Home & Kitchen > Kitchen > Drinkware > Mugs > Ceramic mugs > Handmade > Speckled glaze',
+];
+
+const accessibilityChecks = [
+  'Keyboardable row, breadcrumb, drill, and remove actions',
+  'Search results include full path context',
+  'Partial selection is visible and still needs announcement text',
+  'Mobile rows keep large hit targets at 375px',
+];
+
+const shippingDestinationSuggestions = [
+  {
+    id: 'north-america',
+    label: 'North America',
+    count: 3,
+  },
+  {
+    id: 'european-union',
+    label: 'European Union',
+    count: 27,
+  },
+  {
+    id: 'asia-pacific',
+    label: 'Asia Pacific',
+    count: 7,
+  },
+  {
+    id: 'latin-america',
+    label: 'Latin America',
+    count: 4,
+  },
+  {
+    id: 'de',
+    label: 'Germany',
+  },
+];
+
+const productClassifierSuggestions = [
+  {
+    id: 'women-tees',
+    label: 'T-shirts',
+    path: 'Clothing > Women > Tops > T-shirts',
+    reason: 'Suggested from the product title and description',
+  },
+  {
+    id: 'men-tees',
+    label: 'T-shirts',
+    path: 'Clothing > Men > Tops > T-shirts',
+    reason: 'Suggested from product copy mentioning women’s and men’s tops',
+  },
+  {
+    id: 'summer-sale-t-shirts',
+    label: 'T-shirts',
+    path: 'Sale > Summer > T-shirts',
+    reason: 'Add if this shirt belongs in the summer campaign',
+  },
+  {
+    id: 'petite-linen-long-sleeve',
+    label: 'Petite',
+    path: 'Clothing > Women > Tops > Shirts > Linen shirts > Long sleeve > Petite',
+    reason: 'Long-path example for category hierarchy testing',
+  },
+];
+
+const productSignals = [
+  ['Title', 'Nice black shirt'],
+  ['Description', 'Soft black shirt for everyday wear.'],
+  ['Tags', 'unisex, summer'],
+];
+
+function makeCategoryPathOption(id) {
+  const path = formatProductCategoryPath(id);
+  const parts = path.split(' > ');
+
+  return {
+    id,
+    label: parts[parts.length - 1],
+    parentPath: parts.slice(0, -1).join(' > '),
+    path,
+  };
+}
+
+function PrimaryCategoryPicker({
+  id,
+  options,
+  value,
+  onChange,
+  disabled = false,
+  helpText,
+  className = '',
+  defaultOpen = false,
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const selectedOption = options.find((option) => option.id === value);
+  const labelId = `${id}-label`;
+  const listboxId = `${id}-listbox`;
+
+  return (
+    <div className={`primary-category-field${className ? ` ${className}` : ''}`}>
+      <span id={labelId}>Primary category</span>
+      <div className={`primary-category-picker${isOpen ? ' is-open' : ''}`}>
+        <button
+          id={id}
+          type="button"
+          className="primary-category-trigger"
+          aria-labelledby={`${labelId} ${id}`}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          disabled={disabled}
+          title={selectedOption?.path || undefined}
+          onClick={() => setIsOpen((open) => !open)}
+        >
+          <span>{selectedOption?.path || 'Choose a category'}</span>
+          <span className="primary-category-caret" aria-hidden="true" />
+        </button>
+
+        {isOpen && !disabled && (
+          <div className="primary-category-menu" id={listboxId} role="listbox" aria-labelledby={labelId}>
+            {options.length > 0 ? (
+              options.map((option) => (
+                <button
+                  type="button"
+                  className={`primary-category-option${option.id === selectedOption?.id ? ' is-selected' : ''}`}
+                  key={option.id}
+                  role="option"
+                  aria-selected={option.id === selectedOption?.id}
+                  title={option.path}
+                  onClick={() => {
+                    onChange(option.id);
+                    setIsOpen(false);
+                  }}
+                >
+                  <strong>{option.label}</strong>
+                  <small>{option.path}</small>
+                </button>
+              ))
+            ) : (
+              <div className="primary-category-empty">Assign a category first.</div>
+            )}
+          </div>
+        )}
+      </div>
+      {helpText && <small>{helpText}</small>}
+    </div>
+  );
+}
+
+export default function TreeComboLab({ onBack }) {
+  const query = new URLSearchParams(window.location.search);
+  const initialView = query.get('view');
+  const initialCase = query.get('case');
+  const hideBack = query.get('hideBack') === '1';
+  const openProductTree = query.get('openTree') === '1';
+  const openPrimaryPicker = query.get('openPrimary') === '1';
+  const productName =
+    initialCase === 'long-paths' ? 'Braided USB-C cable' : 'Nice black shirt';
+  const productDescription =
+    initialCase === 'long-paths'
+      ? 'Braided cable for laptops, monitors, and charging docks. This stress case uses a deliberately deep product-category path.'
+      : 'Soft black shirt for everyday wear. Works across multiple storefront categories, including women’s tops and men’s tops.';
+  const initialLabTab =
+    initialView === 'categories' || initialView === 'mobile' || initialView === 'product-details' || initialView === 'product-editor'
+      ? initialView
+      : initialView === 'path' || initialView === 'product-path'
+        ? 'product-details'
+        : 'shipping';
+  const [shippingValue, setShippingValue] = useState(makeInitialShippingValue);
+  const [categories, setCategories] = useState(initialCategories);
+  const [repeatedCategories, setRepeatedCategories] = useState(initialRepeatedCategories);
+  const [productDetailCategories, setProductDetailCategories] = useState(
+    () =>
+      initialLabTab === 'product-editor' || initialLabTab === 'product-details'
+        ? new Set(initialCase === 'long-paths' ? longPathProductEditorCategories : [])
+        : initialPathCategories
+  );
+  const [mobileCategories, setMobileCategories] = useState(initialCategories);
+  const [primaryPathId, setPrimaryPathId] = useState(
+    initialCase === 'long-paths' ? 'thunderbolt-4-1m-braided' : 'women-tees'
+  );
+  const [activeTab, setActiveTab] = useState(initialLabTab);
+  const [categoryVariant, setCategoryVariant] = useState(
+    initialCase === 'repeated' ? 'repeated' : 'deep'
+  );
+
+  const generatedZones = useMemo(() => {
+    const tags = computeTags(
+      shippingValue.selected,
+      shippingValue.anywhereElseSelected,
+      shippingValue.splitOut
+    );
+    return tagsToZones(tags);
+  }, [shippingValue]);
+
+  const repeatedTags = useMemo(
+    () => computeProductCategoryTags(repeatedCategories),
+    [repeatedCategories]
+  );
+  const primaryBreadcrumbPath = repeatedTags[0]?.path || repeatedTags[0]?.label;
+  const storefrontPathOptions = useMemo(
+    () => [...productDetailCategories].map(makeCategoryPathOption),
+    [productDetailCategories]
+  );
+  const availableProductSuggestions = useMemo(
+    () => productClassifierSuggestions.filter((suggestion) => !productDetailCategories.has(suggestion.id)),
+    [productDetailCategories]
+  );
+  const selectedStorefrontPath =
+    storefrontPathOptions.find((option) => option.id === primaryPathId) || storefrontPathOptions[0];
+
+  function updateProductDetailCategories(nextValue) {
+    const next = nextValue instanceof Set ? nextValue : new Set(nextValue || []);
+    setProductDetailCategories(next);
+
+    if (next.size === 0) {
+      setPrimaryPathId('');
+      return;
+    }
+
+    if (!next.has(primaryPathId)) {
+      setPrimaryPathId(next.values().next().value);
+    }
+  }
+
+  function toggleProductSuggestion(id) {
+    const next = new Set(productDetailCategories);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    updateProductDetailCategories(next);
+  }
+
+  function removeProductCategory(id) {
+    const next = new Set(productDetailCategories);
+    next.delete(id);
+    updateProductDetailCategories(next);
+  }
+
+  function setMainProductPath(id) {
+    if (!productDetailCategories.has(id)) {
+      const next = new Set(productDetailCategories);
+      next.add(id);
+      updateProductDetailCategories(next);
+    }
+
+    setPrimaryPathId(id);
+  }
+
+  return (
+    <div className="tree-lab-shell">
+      <header className="tree-lab-header">
+        <div>
+          <div className="tree-lab-kicker">Prototype lab</div>
+          <h1>TreeCombo breakout</h1>
+          <p>
+            One TreeCombo pattern tested through the shipping source case, a deeper
+            product-category taxonomy, a storefront path decision, and a narrow
+            mobile/a11y check.
+          </p>
+        </div>
+        {!hideBack && (
+          <Button variant="secondary" onClick={onBack} __next40pxDefaultSize>
+            Back to shipping prototype
+          </Button>
+        )}
+      </header>
+
+      <nav className="tree-lab-tabs" aria-label="TreeCombo lab examples">
+        {labTabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`tree-lab-tab${activeTab === tab.id ? ' is-active' : ''}`}
+            aria-current={activeTab === tab.id ? 'page' : undefined}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <main className="tree-lab-main">
+        {activeTab === 'categories' && (
+          <section className="tree-lab-showcase" aria-labelledby="tree-lab-categories-title">
+            <div className="tree-lab-panel tree-lab-demo-panel tree-lab-product-demo">
+              <div className="tree-lab-panel-header">
+                <div>
+                  <h2 id="tree-lab-categories-title">Product categories</h2>
+                  <p>
+                    {categoryVariant === 'deep'
+                      ? 'Realistic product taxonomy with a few deliberate 7-layer branches.'
+                      : 'One product can be assigned to more than one category path.'}
+                  </p>
+                </div>
+                <span className="tree-lab-pill">Stress case</span>
+              </div>
+
+              <div className="tree-lab-subtabs" aria-label="Product category stress variants">
+                {categoryVariants.map((variant) => (
+                  <button
+                    key={variant.id}
+                    type="button"
+                    className={`tree-lab-subtab${categoryVariant === variant.id ? ' is-active' : ''}`}
+                    aria-pressed={categoryVariant === variant.id}
+                    onClick={() => setCategoryVariant(variant.id)}
+                  >
+                    {variant.label}
+                  </button>
+                ))}
+              </div>
+
+              {categoryVariant === 'deep' ? (
+                <ProductCategoryTreeCombo
+                  label="Assign categories"
+                  value={categories}
+                  onChange={setCategories}
+                  defaultOpen
+                />
+              ) : (
+                <>
+                  <div className="tree-lab-product-context">
+                    <span>Product being edited</span>
+                    <strong>Everyday tee</strong>
+                  </div>
+                  <ProductCategoryTreeCombo
+                    label="Categories"
+                    value={repeatedCategories}
+                    onChange={setRepeatedCategories}
+                    defaultOpen
+                    defaultSearchQuery="T-shirts"
+                    showCounts={false}
+                    pathFirstSearchResults
+                  />
+                </>
+              )}
+            </div>
+
+            <aside className="tree-lab-side-panel" aria-label="Product category stress notes">
+              {categoryVariant === 'deep' ? (
+                <>
+                  <h3>What this tests</h3>
+                  <ul>
+                    <li>Deep category paths without losing the user in the tree.</li>
+                    <li>Search results that show where each match lives.</li>
+                    <li>Mixed leaf and group selections at realistic store scale.</li>
+                  </ul>
+                  <h3>7-layer examples</h3>
+                  <div className="tree-lab-path-list">
+                    {categoryStressPaths.map((path) => (
+                      <div className="tree-lab-path" key={path}>{path}</div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <h3>What this tests</h3>
+                  <ul>
+                    <li>The product is already selected; this only assigns categories.</li>
+                    <li>Repeated category names like T-shirts need full path context.</li>
+                    <li>Product-category counts can be hidden when they add noise.</li>
+                    <li>Breadcrumb choice is related, but separate from generic selection.</li>
+                  </ul>
+                  <h3>Selected paths</h3>
+                  {repeatedTags.length > 0 ? (
+                    <div className="tree-lab-path-list">
+                      {repeatedTags.map((tag) => (
+                        <div className="tree-lab-path" key={tag.id}>
+                          {tag.path || tag.label}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="tree-lab-path">No categories selected yet.</div>
+                  )}
+                  <h3>Storefront breadcrumb preview</h3>
+                  {primaryBreadcrumbPath ? (
+                    <div className="tree-lab-breadcrumb-preview">
+                      Home &gt; {primaryBreadcrumbPath} &gt; Everyday tee
+                    </div>
+                  ) : (
+                    <div className="tree-lab-breadcrumb-preview">
+                      Select a category path to preview.
+                    </div>
+                  )}
+                  <p className="tree-lab-note">
+                    The primary breadcrumb path is a product/catalogue decision, not
+                    generic TreeCombo behavior.
+                  </p>
+                </>
+              )}
+            </aside>
+          </section>
+        )}
+
+        {activeTab === 'shipping' && (
+          <section className="tree-lab-showcase" aria-labelledby="tree-lab-shipping-title">
+            <div className="tree-lab-panel tree-lab-demo-panel tree-lab-panel-shipping">
+              <div className="tree-lab-panel-header">
+                <div>
+                  <h2 id="tree-lab-shipping-title">Shipping destinations</h2>
+                </div>
+                <span className="tree-lab-pill">Source case</span>
+              </div>
+
+              <TreeCombo
+                label="Countries and regions"
+                value={shippingValue}
+                onChange={setShippingValue}
+                defaultOpen={initialView === 'shipping-open'}
+                suggestions={shippingDestinationSuggestions}
+              />
+            </div>
+
+            <aside className="tree-lab-side-panel" aria-label="Generated shipping zones">
+              <h3>Generated zones</h3>
+              <div className="tree-lab-zone-preview">
+                {generatedZones.map((zone) => (
+                  <div className="tree-lab-zone-row" key={zone.id}>
+                    <span>{zone.name}</span>
+                    <span>{zone.regions}</span>
+                  </div>
+                ))}
+              </div>
+            </aside>
+          </section>
+        )}
+
+        {activeTab === 'product-details' && (
+          <section className="tree-lab-product-details" aria-labelledby="tree-lab-product-details-title">
+            <div className="tree-lab-panel tree-lab-product-details-panel">
+              <div className="tree-lab-panel-header product-detail-heading">
+                <div>
+                  <h2 id="tree-lab-product-details-title">Product details</h2>
+                  <p>
+                    Category suggestions, TreeCombo review, and storefront path choice in one merchant workflow.
+                  </p>
+                </div>
+                <span className="tree-lab-pill">Follow-up</span>
+              </div>
+
+              <div className="product-detail-layout">
+                <div className="product-detail-main">
+                  <section className="product-detail-section product-detail-summary" aria-label="Product summary">
+                    <div>
+                      <span className="product-detail-section-label">Product being edited</span>
+                      <h3>{productName}</h3>
+                    </div>
+                    <div className="product-detail-signal-list">
+                      {productSignals.map(([label, value]) => (
+                        <div className="product-detail-signal" key={label}>
+                          <span>{label}</span>
+                          <strong>{value}</strong>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+
+                  <section className="product-detail-section product-detail-category-section" aria-labelledby="product-detail-categories-title">
+                    <div className="product-detail-section-heading">
+                      <div>
+                        <h3 id="product-detail-categories-title">Product categories</h3>
+                        <p>Start from suggestions or TreeSelect search, then choose one assigned path for the storefront.</p>
+                      </div>
+                      <span>{productDetailCategories.size} assigned</span>
+                    </div>
+
+                    <div className="product-category-flow">
+                      <div className="product-category-flow-step product-detail-add-card">
+                        <div className="product-category-flow-heading">
+                          <span>1</span>
+                          <div>
+                            <h4>Add categories</h4>
+                            <p>Use product suggestions, or search and browse the category tree.</p>
+                          </div>
+                        </div>
+
+                        <ProductCategoryTreeCombo
+                          label="Search or browse categories"
+                          value={productDetailCategories}
+                          onChange={updateProductDetailCategories}
+                          defaultOpen={openProductTree}
+                          showCounts={false}
+                          pathFirstSearchResults
+                          defaultActivePathTagId="women-tees"
+                        />
+
+                        <div className="classifier-suggestions" aria-label="Suggested categories">
+                          <div className="classifier-suggestions-heading">
+                            <span>Suggestions</span>
+                            <span>Optional</span>
+                          </div>
+                          <div className="classifier-suggestion-list">
+                            {availableProductSuggestions.length > 0 ? availableProductSuggestions.map((suggestion) => (
+                              <button
+                                type="button"
+                                className="classifier-suggestion"
+                                key={suggestion.id}
+                                onClick={() => toggleProductSuggestion(suggestion.id)}
+                              >
+                                <div className="classifier-suggestion-body">
+                                  <span className="classifier-suggestion-title">{suggestion.label}</span>
+                                  <span className="classifier-suggestion-path">{suggestion.path}</span>
+                                  <span className="classifier-suggestion-reason">{suggestion.reason}</span>
+                                </div>
+                                <span className="classifier-suggestion-action">Add</span>
+                              </button>
+                            )) : (
+                              <div className="classifier-suggestion-empty">
+                                All suggested categories are already assigned.
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="product-category-flow-step">
+                        <div className="product-category-flow-heading">
+                          <span>2</span>
+                          <div>
+                            <h4>Review assigned categories</h4>
+                            <p>Assigned categories are saved to the product. Choose one primary category for the storefront path.</p>
+                          </div>
+                        </div>
+
+                        <div className="assigned-category-card">
+                          <div className="assigned-category-card-heading">
+                            <span>Assigned categories</span>
+                            <span>{productDetailCategories.size} assigned</span>
+                          </div>
+                          <div className="assigned-category-list">
+                            {storefrontPathOptions.length > 0 ? (
+                              storefrontPathOptions.map((option) => (
+                                <div
+                                  className={`assigned-category-row${selectedStorefrontPath?.id === option.id ? ' is-main-path' : ''}`}
+                                  key={option.id}
+                                >
+                                  <div className="assigned-category-body">
+                                    <span className="assigned-category-title">{option.label}</span>
+                                    <span className="assigned-category-path">{option.path}</span>
+                                  </div>
+                                  <div className="assigned-category-actions">
+                                    <button
+                                      type="button"
+                                      className="assigned-category-remove"
+                                      aria-label={`Remove ${option.path}`}
+                                      onClick={() => removeProductCategory(option.id)}
+                                    >
+                                      Remove
+                                    </button>
+                                  </div>
+                                </div>
+                              ))
+                            ) : (
+                              <div className="storefront-path-empty">
+                                No categories assigned yet.
+                              </div>
+                            )}
+                          </div>
+                        </div>
+
+                        <PrimaryCategoryPicker
+                          id="product-detail-primary-category"
+                          options={storefrontPathOptions}
+                          value={selectedStorefrontPath?.id || ''}
+                          disabled={storefrontPathOptions.length === 0}
+                          onChange={setMainProductPath}
+                          helpText="Used for the storefront path preview."
+                          defaultOpen={openPrimaryPicker}
+                        />
+
+                        <div className="storefront-path-card product-detail-storefront-path">
+                          <div className="storefront-path-card-heading">Storefront path</div>
+                          <div className="storefront-path-summary">
+                            <span>Shoppers will see</span>
+                            <strong>
+                              {selectedStorefrontPath
+                                ? `Home > ${selectedStorefrontPath.path} > ${productName}`
+                                : 'Choose a category to preview the storefront path'}
+                            </strong>
+                            <p>
+                              Change this by choosing a different primary category above.
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+
+                <aside className="product-detail-side" aria-label="Product details preview">
+                  <section className="product-detail-preview">
+                    <h3>Storefront preview</h3>
+                    <div className="tree-lab-breadcrumb-preview storefront-path-preview">
+                      {selectedStorefrontPath
+                        ? <>Home &gt; {selectedStorefrontPath.path} &gt; {productName}</>
+                        : 'Select a storefront path to preview.'}
+                    </div>
+                    <div className="product-detail-preview-box">
+                      <span>{productName}</span>
+                      <strong>$28.00</strong>
+                      <small>{selectedStorefrontPath?.label || 'No primary path selected'}</small>
+                    </div>
+                  </section>
+
+                  <section className="product-detail-preview product-detail-notes">
+                    <h3>What this tests</h3>
+                    <ul>
+                      <li>Suggestions feed the same TreeSelect selected state.</li>
+                      <li>Assigned categories are the source of truth.</li>
+                      <li>Storefront path is chosen from assigned category paths.</li>
+                    </ul>
+                  </section>
+                </aside>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {activeTab === 'product-editor' && (
+          <section className="current-editor-fit" aria-labelledby="current-editor-fit-title">
+            <div className="current-editor-frame">
+              <div className="current-editor-topbar">
+                <div>
+                  <span className="current-editor-kicker">WooCommerce product</span>
+                  <h2 id="current-editor-fit-title">Edit product</h2>
+                </div>
+              </div>
+
+              <div className="current-editor-grid">
+                <div className="current-editor-content">
+                  <label className="current-editor-title-field">
+                    <span>Product name</span>
+                    <input type="text" value={productName} readOnly />
+                  </label>
+                  <div className="current-editor-block">
+                    <span>Description</span>
+                    <p>
+                      {productDescription}
+                    </p>
+                  </div>
+                  <div className="current-editor-product-data">
+                    <div className="current-editor-product-data-tabs">
+                      <span className="is-active">General</span>
+                      <span>Inventory</span>
+                      <span>Shipping</span>
+                      <span>Attributes</span>
+                    </div>
+                    <div className="current-editor-product-data-panel">
+                      <label>
+                        <span>Regular price</span>
+                        <input type="text" value="$28.00" readOnly />
+                      </label>
+                    </div>
+                  </div>
+                </div>
+
+                <aside className="current-editor-sidebar" aria-label="Product settings sidebar">
+                  <section className="current-editor-postbox current-editor-publish">
+                    <div className="current-editor-postbox-heading">Publish</div>
+                    <div className="current-editor-publish-body">
+                      <div className="current-editor-publish-actions">
+                        <button type="button">Save Draft</button>
+                        <button type="button">Preview</button>
+                      </div>
+                      <div className="current-editor-publish-row">
+                        <span>Status: <strong>Draft</strong></span>
+                        <button type="button">Edit</button>
+                      </div>
+                      <div className="current-editor-publish-row">
+                        <span>Visibility: <strong>Public</strong></span>
+                        <button type="button">Edit</button>
+                      </div>
+                      <div className="current-editor-publish-row">
+                        <span>Catalog visibility: <strong>Shop and search results</strong></span>
+                        <button type="button">Edit</button>
+                      </div>
+                    </div>
+                    <div className="current-editor-publish-footer">
+                      <button type="button" className="is-link">Move to Trash</button>
+                      <button type="button" className="is-primary">Publish</button>
+                    </div>
+                  </section>
+
+                  <section className="current-editor-postbox">
+                    <div className="current-editor-postbox-heading">Product image</div>
+                    <div className="current-editor-image-placeholder">{productName}</div>
+                    <div className="current-editor-image-caption">Click the image to edit or update</div>
+                  </section>
+
+                  <section className="current-editor-postbox">
+                    <div className="current-editor-postbox-heading">Product gallery</div>
+                    <div className="current-editor-simple-link">Add product gallery images</div>
+                  </section>
+
+                  <section className="current-editor-postbox">
+                    <div className="current-editor-postbox-heading">Product categories</div>
+                    <div className="current-product-categories-box">
+                      <div className="current-editor-tabs" aria-label="Product category tabs">
+                        <button type="button" className="is-active">All categories</button>
+                        <button type="button">Most used</button>
+                      </div>
+
+                      <div className="current-category-current">
+                        <div className="current-category-heading">
+                          <span>Assigned categories</span>
+                          <span>{productDetailCategories.size} assigned</span>
+                        </div>
+                        <div className="current-category-assigned-list">
+                          {storefrontPathOptions.length > 0 ? (
+                            storefrontPathOptions.map((option) => (
+                              <div
+                                className={`current-category-assigned-row${selectedStorefrontPath?.id === option.id ? ' is-main-path' : ''}`}
+                                key={option.id}
+                              >
+                                <span className="current-category-assigned-body">
+                                  <strong>{option.label}</strong>
+                                  <small>{option.path}</small>
+                                </span>
+                                <div className="current-category-assigned-actions">
+                                  <button
+                                    type="button"
+                                    aria-label={`Remove ${option.path}`}
+                                    onClick={() => removeProductCategory(option.id)}
+                                  >
+                                    Remove
+                                  </button>
+                                </div>
+                              </div>
+                            ))
+                          ) : (
+                            <div className="current-category-empty">No categories assigned yet.</div>
+                          )}
+                        </div>
+                      </div>
+
+                        <PrimaryCategoryPicker
+                          id="current-editor-primary-category"
+                          options={storefrontPathOptions}
+                          value={selectedStorefrontPath?.id || ''}
+                        disabled={storefrontPathOptions.length === 0}
+                        onChange={setMainProductPath}
+                        className="current-primary-category-field"
+                        defaultOpen={openPrimaryPicker}
+                      />
+
+                      <div className="current-category-storefront-preview">
+                        <span>Storefront path</span>
+                        <strong>
+                          {selectedStorefrontPath
+                            ? `Home > ${selectedStorefrontPath.path} > ${productName}`
+                            : 'Choose a main category path'}
+                        </strong>
+                      </div>
+
+                      <ProductCategoryTreeCombo
+                        label="Add categories"
+                        value={productDetailCategories}
+                        onChange={updateProductDetailCategories}
+                        defaultOpen={openProductTree}
+                        showCounts={false}
+                        pathFirstSearchResults
+                        defaultActivePathTagId="women-tees"
+                      />
+
+                      {availableProductSuggestions.length > 0 && (
+                        <div className="current-category-inline-suggestions" aria-label="Suggested categories">
+                          <div className="current-category-inline-heading">Suggestions</div>
+                          <div className="current-category-inline-list">
+                            {availableProductSuggestions.map((suggestion) => (
+                              <button
+                                type="button"
+                                className="current-category-inline-suggestion"
+                                key={suggestion.id}
+                                onClick={() => toggleProductSuggestion(suggestion.id)}
+                              >
+                                <span>
+                                  <strong>{suggestion.label}</strong>
+                                  <small>{suggestion.path}</small>
+                                </span>
+                                <span>Add</span>
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </section>
+
+                  <section className="current-editor-postbox">
+                    <div className="current-editor-postbox-heading">Product tags</div>
+                    <div className="current-editor-tag-box">
+                      <input type="text" aria-label="Product tags" readOnly />
+                      <button type="button">Add</button>
+                    </div>
+                    <div className="current-editor-simple-link">Choose from the most used tags</div>
+                  </section>
+                </aside>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {activeTab === 'mobile' && (
+          <section className="tree-lab-showcase tree-lab-mobile-showcase" aria-labelledby="tree-lab-mobile-title">
+            <div className="tree-lab-mobile-wrap">
+              <div className="tree-lab-mobile-device">
+                <div className="tree-lab-mobile-header">
+                  <h2 id="tree-lab-mobile-title">Mobile web</h2>
+                  <span>375px</span>
+                </div>
+                <ProductCategoryTreeCombo
+                  label="Assign categories"
+                  value={mobileCategories}
+                  onChange={setMobileCategories}
+                  defaultOpen
+                  defaultActivePathTagId="petite-linen-long-sleeve"
+                />
+              </div>
+            </div>
+
+            <aside className="tree-lab-side-panel" aria-labelledby="tree-lab-a11y-title">
+              <h3 id="tree-lab-a11y-title">Accessibility checklist</h3>
+              <ul className="tree-lab-a11y-list">
+                {accessibilityChecks.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <p className="tree-lab-note">
+                This is still a prototype. The next real component pass needs the full
+                combobox/tree keyboard model and screen reader announcement contract.
+              </p>
+            </aside>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/data/countryTree.js.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/data/countryTree.js.txt
@@ -1,0 +1,407 @@
+export const COUNTRY_TREE = {
+  id: 'all', label: 'All regions',
+  children: [
+    {
+      id: 'north-america', label: 'North America',
+      children: [
+        {
+          id: 'us', label: 'United States',
+          children: [
+            { id: 'us-al', label: 'Alabama' }, { id: 'us-ak', label: 'Alaska' },
+            { id: 'us-az', label: 'Arizona' }, { id: 'us-ar', label: 'Arkansas' },
+            { id: 'us-ca', label: 'California' }, { id: 'us-co', label: 'Colorado' },
+            { id: 'us-ct', label: 'Connecticut' }, { id: 'us-de', label: 'Delaware' },
+            { id: 'us-fl', label: 'Florida' }, { id: 'us-ga', label: 'Georgia' },
+            { id: 'us-hi', label: 'Hawaii' }, { id: 'us-id', label: 'Idaho' },
+            { id: 'us-il', label: 'Illinois' }, { id: 'us-in', label: 'Indiana' },
+            { id: 'us-ia', label: 'Iowa' }, { id: 'us-ks', label: 'Kansas' },
+            { id: 'us-ky', label: 'Kentucky' }, { id: 'us-la', label: 'Louisiana' },
+            { id: 'us-me', label: 'Maine' }, { id: 'us-md', label: 'Maryland' },
+            { id: 'us-ma', label: 'Massachusetts' }, { id: 'us-mi', label: 'Michigan' },
+            { id: 'us-mn', label: 'Minnesota' }, { id: 'us-ms', label: 'Mississippi' },
+            { id: 'us-mo', label: 'Missouri' }, { id: 'us-mt', label: 'Montana' },
+            { id: 'us-ne', label: 'Nebraska' }, { id: 'us-nv', label: 'Nevada' },
+            { id: 'us-nh', label: 'New Hampshire' }, { id: 'us-nj', label: 'New Jersey' },
+            { id: 'us-nm', label: 'New Mexico' }, { id: 'us-ny', label: 'New York' },
+            { id: 'us-nc', label: 'North Carolina' }, { id: 'us-nd', label: 'North Dakota' },
+            { id: 'us-oh', label: 'Ohio' }, { id: 'us-ok', label: 'Oklahoma' },
+            { id: 'us-or', label: 'Oregon' }, { id: 'us-pa', label: 'Pennsylvania' },
+            { id: 'us-ri', label: 'Rhode Island' }, { id: 'us-sc', label: 'South Carolina' },
+            { id: 'us-sd', label: 'South Dakota' }, { id: 'us-tn', label: 'Tennessee' },
+            { id: 'us-tx', label: 'Texas' }, { id: 'us-ut', label: 'Utah' },
+            { id: 'us-vt', label: 'Vermont' }, { id: 'us-va', label: 'Virginia' },
+            { id: 'us-wa', label: 'Washington' }, { id: 'us-wv', label: 'West Virginia' },
+            { id: 'us-wi', label: 'Wisconsin' }, { id: 'us-wy', label: 'Wyoming' },
+            { id: 'us-dc', label: 'District of Columbia' },
+          ]
+        },
+        {
+          id: 'ca', label: 'Canada',
+          children: [
+            { id: 'ca-ab', label: 'Alberta' }, { id: 'ca-bc', label: 'British Columbia' },
+            { id: 'ca-mb', label: 'Manitoba' }, { id: 'ca-nb', label: 'New Brunswick' },
+            { id: 'ca-nl', label: 'Newfoundland and Labrador' }, { id: 'ca-ns', label: 'Nova Scotia' },
+            { id: 'ca-nt', label: 'Northwest Territories' }, { id: 'ca-nu', label: 'Nunavut' },
+            { id: 'ca-on', label: 'Ontario' }, { id: 'ca-pe', label: 'Prince Edward Island' },
+            { id: 'ca-qc', label: 'Quebec' }, { id: 'ca-sk', label: 'Saskatchewan' },
+            { id: 'ca-yt', label: 'Yukon' },
+          ]
+        },
+        { id: 'mx', label: 'Mexico' },
+      ]
+    },
+    {
+      id: 'europe', label: 'Europe',
+      children: [
+        {
+          id: 'european-union', label: 'European Union',
+          children: [
+            { id: 'at', label: 'Austria' }, { id: 'be', label: 'Belgium' },
+            { id: 'bg', label: 'Bulgaria' }, { id: 'hr', label: 'Croatia' },
+            { id: 'cy', label: 'Cyprus' }, { id: 'cz', label: 'Czech Republic' },
+            { id: 'dk', label: 'Denmark' }, { id: 'ee', label: 'Estonia' },
+            { id: 'fi', label: 'Finland' }, { id: 'fr', label: 'France' },
+            { id: 'de', label: 'Germany' }, { id: 'gr', label: 'Greece' },
+            { id: 'hu', label: 'Hungary' }, { id: 'ie', label: 'Ireland' },
+            { id: 'it', label: 'Italy' }, { id: 'lv', label: 'Latvia' },
+            { id: 'lt', label: 'Lithuania' }, { id: 'lu', label: 'Luxembourg' },
+            { id: 'mt', label: 'Malta' }, { id: 'nl', label: 'Netherlands' },
+            { id: 'pl', label: 'Poland' }, { id: 'pt', label: 'Portugal' },
+            { id: 'ro', label: 'Romania' }, { id: 'sk', label: 'Slovakia' },
+            { id: 'si', label: 'Slovenia' }, { id: 'es', label: 'Spain' },
+            { id: 'se', label: 'Sweden' },
+          ]
+        },
+        { id: 'gb', label: 'United Kingdom' },
+        { id: 'no', label: 'Norway' },
+        { id: 'ch', label: 'Switzerland' },
+        { id: 'is', label: 'Iceland' },
+      ]
+    },
+    {
+      id: 'asia-pacific', label: 'Asia Pacific',
+      children: [
+        { id: 'au', label: 'Australia' }, { id: 'nz', label: 'New Zealand' },
+        { id: 'jp', label: 'Japan' }, { id: 'sg', label: 'Singapore' },
+        { id: 'hk', label: 'Hong Kong' }, { id: 'kr', label: 'South Korea' },
+        { id: 'tw', label: 'Taiwan' },
+      ]
+    },
+    {
+      id: 'latin-america', label: 'Latin America',
+      children: [
+        { id: 'br', label: 'Brazil' }, { id: 'ar', label: 'Argentina' },
+        { id: 'cl', label: 'Chile' }, { id: 'co', label: 'Colombia' },
+      ]
+    },
+    {
+      id: 'middle-east-africa', label: 'Middle East & Africa',
+      children: [
+        { id: 'ae', label: 'United Arab Emirates' }, { id: 'sa', label: 'Saudi Arabia' },
+        { id: 'za', label: 'South Africa' }, { id: 'eg', label: 'Egypt' },
+      ]
+    },
+  ]
+};
+
+export const QUICK_GROUPS = [
+  { id: 'north-america', label: 'North America', count: 3 },
+  { id: 'european-union', label: 'European Union', count: 27 },
+  { id: 'asia-pacific', label: 'Asia Pacific', count: 7 },
+  { id: 'latin-america', label: 'Latin America', count: 4 },
+];
+
+// --- Pure helpers (no DOM, no React) ---
+
+export function findNodeById(node, id) {
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const c of node.children) {
+      const f = findNodeById(c, id);
+      if (f) return f;
+    }
+  }
+  return null;
+}
+
+export function getAllLeaves(node) {
+  if (!node.children || node.children.length === 0) return [node];
+  return node.children.flatMap(getAllLeaves);
+}
+
+export function getNodeSelectionState(node, selected) {
+  const leaves = getAllLeaves(node);
+  if (leaves.length === 0) return 'unchecked';
+  const count = leaves.filter(l => selected.has(l.id)).length;
+  if (count === 0) return 'unchecked';
+  if (count === leaves.length) return 'checked';
+  return 'indeterminate';
+}
+
+function normalizeSearchTerm(value) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+export function findAllMatches(node, query, pathLabels = []) {
+  const results = [];
+  const normalizedQuery = normalizeSearchTerm(query);
+  if (node.id !== 'all' && normalizeSearchTerm(node.label).includes(normalizedQuery)) {
+    results.push({ node, pathLabels: [...pathLabels] });
+  }
+  if (node.children) {
+    const nextPath = node.id === 'all' ? pathLabels : [...pathLabels, node.label];
+    node.children.forEach(c => results.push(...findAllMatches(c, query, nextPath)));
+  }
+  return results;
+}
+
+export function findPathToNode(root, nodeId, currentPath = []) {
+  if (!root.children) return null;
+  for (const child of root.children) {
+    if (child.id === nodeId) return [...currentPath, child.id];
+    const p = findPathToNode(child, nodeId, [...currentPath, child.id]);
+    if (p) return p;
+  }
+  return null;
+}
+
+export function getNodeAtPath(path) {
+  let n = COUNTRY_TREE;
+  for (const id of path) {
+    n = (n.children || []).find(c => c.id === id);
+    if (!n) return null;
+  }
+  return n;
+}
+
+// Compute tag list from selected Set + anywhereElseSelected — same logic as the
+// static prototype's syncTreeSelectionToTags() but returns data instead of DOM.
+export function computeTags(selected, anywhereElseSelected, splitOut = new Set()) {
+  const tags = [];
+  function visit(node) {
+    if (node.id === 'all') { (node.children || []).forEach(visit); return; }
+    const state = getNodeSelectionState(node, selected);
+    if (state === 'unchecked') return;
+    const isLeaf = !node.children || node.children.length === 0;
+    if (isLeaf) {
+      tags.push({ id: node.id, label: node.label, type: 'leaf', splitOut: splitOut.has(node.id) });
+      return;
+    }
+    if (state === 'checked') {
+      const leaves = getAllLeaves(node);
+      const excluded = leaves.filter((leaf) => splitOut.has(leaf.id));
+      excluded.forEach((leaf) => {
+        tags.push({ id: leaf.id, label: leaf.label, type: 'leaf', splitOut: true });
+      });
+      if (excluded.length < leaves.length) {
+        tags.push({
+          id: node.id,
+          label: node.label,
+          type: 'group',
+          count: leaves.length - excluded.length,
+          excluded: excluded.map((leaf) => ({ id: leaf.id, label: leaf.label })),
+        });
+      }
+      return;
+    }
+    const childrenAreAllLeaves = node.children.every(c => !c.children || c.children.length === 0);
+    if (childrenAreAllLeaves) {
+      const leaves = getAllLeaves(node);
+      const checkedLeaves = leaves.filter(l => selected.has(l.id));
+      const splitLeaves = checkedLeaves.filter(l => splitOut.has(l.id));
+      const standardLeaves = checkedLeaves.filter(l => !splitOut.has(l.id));
+      splitLeaves.forEach((leaf) => {
+        tags.push({ id: leaf.id, label: leaf.label, type: 'leaf', splitOut: true });
+      });
+      if (standardLeaves.length === 1) {
+        tags.push({ id: standardLeaves[0].id, label: standardLeaves[0].label, type: 'leaf' });
+      } else if (standardLeaves.length > 1) {
+        tags.push({ id: node.id, label: node.label, type: 'group', partial: { selected: standardLeaves.length, total: leaves.length } });
+      }
+    } else {
+      node.children.forEach(visit);
+    }
+  }
+  visit(COUNTRY_TREE);
+  if (anywhereElseSelected) {
+    tags.push({ id: 'anywhere-else', label: 'Anywhere else', type: 'special' });
+  }
+  return tags;
+}
+
+// Convert a tag list to zone objects (used when wizard completes)
+export function tagsToZones(tags) {
+  const COUNTRY_ZONE_NAMES = {
+    'us': { name: 'United States', regions: 'United States' },
+    'us-ak': { name: 'Alaska', regions: 'Alaska' },
+    'us-hi': { name: 'Hawaii', regions: 'Hawaii' },
+    'ca': { name: 'Canada', regions: 'Canada' },
+    'gb': { name: 'United Kingdom', regions: 'United Kingdom' },
+  };
+  const standardTags = tags.filter((tag) => tag.id !== 'anywhere-else' && !tag.splitOut);
+  const customRateTags = tags.filter((tag) => tag.id !== 'anywhere-else' && tag.splitOut);
+  const orderedTags = [...standardTags, ...customRateTags];
+  const zones = [];
+  for (const tag of orderedTags) {
+    if (tag.id === 'anywhere-else') continue;
+    const preset = COUNTRY_ZONE_NAMES[tag.id];
+    const isContiguousUsPreset = tag.id === 'us' &&
+      tag.excluded?.some((item) => item.id === 'us-ak') &&
+      tag.excluded?.some((item) => item.id === 'us-hi');
+    const name = isContiguousUsPreset
+      ? 'Contiguous US'
+      : (preset ? preset.name : tag.label);
+    const node = findNodeById(COUNTRY_TREE, tag.id);
+    const regions = tag.excluded?.length
+      ? `${preset ? preset.regions : tag.label} except ${formatExcludedLabels(tag.excluded)}`
+      : (preset ? preset.regions : (node ? tag.label : tag.label));
+    zones.push({
+      id: `zone-${tag.id}`,
+      name,
+      regions,
+      methods: defaultMethods(tag.id),
+      taxOnShipping: 'default',
+    });
+  }
+  if (tags.some(t => t.id === 'anywhere-else')) {
+    zones.push({
+      id: 'zone-anywhere-else',
+      name: 'Anywhere else',
+      regions: 'Any country not in another zone',
+      methods: defaultMethods('anywhere-else'),
+      taxOnShipping: 'default',
+    });
+  }
+  return zones;
+}
+
+function formatExcludedLabels(excluded) {
+  if (excluded.length === 1) return excluded[0].label;
+  if (excluded.length === 2) return `${excluded[0].label} and ${excluded[1].label}`;
+  return `${excluded.length} countries`;
+}
+
+function defaultMethods(zoneId = 'default') {
+  const presets = {
+    us: {
+      flatRate: '7.00',
+      freeOn: true,
+      freeThreshold: '50',
+      carriers: { usps: true, ups: true, fedex: false, dhl: false },
+      serviceLevel: 'all',
+      fallback: '12',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'separate',
+    },
+    'us-ak': {
+      flatRate: '18.00',
+      freeOn: true,
+      freeThreshold: '150',
+      carriers: { usps: true, ups: false, fedex: false, dhl: false },
+      serviceLevel: 'ground-express',
+      fallback: '24',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'separate',
+    },
+    'us-hi': {
+      flatRate: '20.00',
+      freeOn: true,
+      freeThreshold: '150',
+      carriers: { usps: true, ups: false, fedex: false, dhl: false },
+      serviceLevel: 'ground-express',
+      fallback: '26',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'separate',
+    },
+    ca: {
+      flatRate: '15.00',
+      freeOn: true,
+      freeThreshold: '100',
+      carriers: { canadaPost: true, fedex: false, ups: false, dhl: false },
+      serviceLevel: 'ground-express',
+      fallback: '24',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'separate',
+    },
+    'european-union': {
+      flatRate: '22.00',
+      freeOn: true,
+      freeThreshold: '150',
+      carriers: { dhl: true, fedex: true, ups: false, usps: false },
+      serviceLevel: 'ground-express',
+      fallback: '30',
+      overlapBehavior: 'backup',
+      packaging: 'product-dimensions',
+      rateDisplay: 'cheapest',
+    },
+    'asia-pacific': {
+      flatRate: '28.00',
+      freeOn: true,
+      freeThreshold: '180',
+      carriers: { dhl: true, fedex: false, ups: false, usps: false },
+      serviceLevel: 'express',
+      fallback: '38',
+      overlapBehavior: 'backup',
+      packaging: 'product-dimensions',
+      rateDisplay: 'cheapest',
+    },
+    'latin-america': {
+      flatRate: '24.00',
+      freeOn: true,
+      freeThreshold: '160',
+      carriers: { dhl: true, fedex: true, ups: false, usps: false },
+      serviceLevel: 'ground-express',
+      fallback: '34',
+      overlapBehavior: 'backup',
+      packaging: 'product-dimensions',
+      rateDisplay: 'cheapest',
+    },
+    'anywhere-else': {
+      flatRate: '35.00',
+      freeOn: false,
+      freeThreshold: '',
+      liveOn: true,
+      carriers: { dhl: true, fedex: false, ups: false, usps: false },
+      serviceLevel: 'all',
+      fallback: '45',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'cheapest',
+    },
+    default: {
+      flatRate: '18.00',
+      freeOn: true,
+      freeThreshold: '120',
+      carriers: { dhl: true, fedex: false, ups: false, usps: false },
+      serviceLevel: 'all',
+      fallback: '28',
+      overlapBehavior: 'backup',
+      packaging: 'store-default',
+      rateDisplay: 'separate',
+    },
+  };
+  const preset = presets[zoneId] || presets.default;
+
+  return {
+    flat:   { on: true,  rate: preset.flatRate, name: 'Standard shipping' },
+    free:   { on: preset.freeOn,  threshold: preset.freeThreshold, name: 'Free shipping', trigger: 'threshold', coupon: '' },
+    pickup: { on: false, name: 'Local pickup', address: '456 Hub Avenue, Brooklyn, NY 11201', hours: '', instructions: '' },
+    live:   {
+      on: !!preset.liveOn,
+      name: 'Live carrier rates',
+      carriers: preset.carriers,
+      serviceLevel: preset.serviceLevel,
+      fallback: preset.fallback,
+      overlapBehavior: preset.overlapBehavior,
+      packaging: preset.packaging,
+      rateDisplay: preset.rateDisplay,
+    },
+  };
+}

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/data/productCategoryTree.js.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/data/productCategoryTree.js.txt
@@ -1,0 +1,370 @@
+export const PRODUCT_CATEGORY_TREE = {
+  id: 'all-categories',
+  label: 'All categories',
+  children: [
+    {
+      id: 'clothing',
+      label: 'Clothing',
+      children: [
+        {
+          id: 'women',
+          label: 'Women',
+          children: [
+            {
+              id: 'women-tops',
+              label: 'Tops',
+              children: [
+                {
+                  id: 'women-shirts',
+                  label: 'Shirts',
+                  children: [
+                    {
+                      id: 'linen-shirts',
+                      label: 'Linen shirts',
+                      children: [
+                        {
+                          id: 'linen-shirts-long-sleeve',
+                          label: 'Long sleeve',
+                          children: [
+                            { id: 'petite-linen-long-sleeve', label: 'Petite' },
+                            { id: 'tall-linen-long-sleeve', label: 'Tall' },
+                          ],
+                        },
+                        { id: 'linen-shirts-short-sleeve', label: 'Short sleeve' },
+                      ],
+                    },
+                    { id: 'cotton-shirts', label: 'Cotton shirts' },
+                    { id: 'oversized-shirts', label: 'Oversized shirts' },
+                    { id: 'work-shirts', label: 'Work shirts' },
+                  ],
+                },
+                {
+                  id: 'women-knitwear',
+                  label: 'Knitwear',
+                  children: [
+                    { id: 'cardigans', label: 'Cardigans' },
+                    { id: 'fine-knit-sweaters', label: 'Fine-knit sweaters' },
+                    { id: 'cashmere-blends', label: 'Cashmere blends' },
+                  ],
+                },
+                { id: 'women-tees', label: 'T-shirts' },
+                { id: 'women-unisex-tops', label: 'Unisex' },
+                { id: 'women-tanks', label: 'Tanks' },
+              ],
+            },
+            {
+              id: 'women-bottoms',
+              label: 'Bottoms',
+              children: [
+                { id: 'wide-leg-pants', label: 'Wide-leg pants' },
+                { id: 'straight-jeans', label: 'Straight jeans' },
+                { id: 'midi-skirts', label: 'Midi skirts' },
+              ],
+            },
+            { id: 'women-dresses', label: 'Dresses' },
+            { id: 'women-outerwear', label: 'Outerwear' },
+          ],
+        },
+        {
+          id: 'men',
+          label: 'Men',
+          children: [
+            {
+              id: 'men-tops',
+              label: 'Tops',
+              children: [
+                { id: 'men-oxford-shirts', label: 'Oxford shirts' },
+                { id: 'men-tees', label: 'T-shirts' },
+                { id: 'men-polo-shirts', label: 'Polo shirts' },
+                { id: 'men-unisex-tops', label: 'Unisex' },
+                { id: 'men-hoodies', label: 'Hoodies' },
+              ],
+            },
+            { id: 'men-denim', label: 'Denim' },
+            { id: 'men-jackets', label: 'Jackets' },
+          ],
+        },
+        { id: 'kids', label: 'Kids' },
+        { id: 'sale-clothing', label: 'Sale clothing' },
+      ],
+    },
+    {
+      id: 'home-kitchen',
+      label: 'Home & Kitchen',
+      children: [
+        {
+          id: 'kitchen',
+          label: 'Kitchen',
+          children: [
+            {
+              id: 'drinkware',
+              label: 'Drinkware',
+              children: [
+                {
+                  id: 'mugs',
+                  label: 'Mugs',
+                  children: [
+                    {
+                      id: 'ceramic-mugs',
+                      label: 'Ceramic mugs',
+                      children: [
+                        {
+                          id: 'handmade-ceramic-mugs',
+                          label: 'Handmade',
+                          children: [
+                            { id: 'speckled-glaze-ceramic-mugs', label: 'Speckled glaze' },
+                            { id: 'matte-white-ceramic-mugs', label: 'Matte white' },
+                          ],
+                        },
+                        { id: 'stackable-ceramic-mugs', label: 'Stackable' },
+                      ],
+                    },
+                    { id: 'travel-mugs', label: 'Travel mugs' },
+                    { id: 'espresso-cups', label: 'Espresso cups' },
+                  ],
+                },
+                { id: 'tumblers', label: 'Tumblers' },
+                { id: 'water-bottles', label: 'Water bottles' },
+              ],
+            },
+            { id: 'cookware', label: 'Cookware' },
+            { id: 'storage-jars', label: 'Storage jars' },
+          ],
+        },
+        { id: 'bedding', label: 'Bedding' },
+        { id: 'bath', label: 'Bath' },
+      ],
+    },
+    {
+      id: 'electronics',
+      label: 'Electronics',
+      children: [
+        {
+          id: 'computers',
+          label: 'Computers',
+          children: [
+            {
+              id: 'computer-accessories',
+              label: 'Accessories',
+              children: [
+                {
+                  id: 'cables-adapters',
+                  label: 'Cables & adapters',
+                  children: [
+                    {
+                      id: 'usb-c-cables',
+                      label: 'USB-C cables',
+                      children: [
+                        {
+                          id: 'thunderbolt-4-cables',
+                          label: 'Thunderbolt 4',
+                          children: [
+                            { id: 'thunderbolt-4-1m-braided', label: '1m braided' },
+                            { id: 'thunderbolt-4-2m-braided', label: '2m braided' },
+                          ],
+                        },
+                        { id: 'usb-c-fast-charge', label: 'Fast charge' },
+                      ],
+                    },
+                    { id: 'hdmi-adapters', label: 'HDMI adapters' },
+                    { id: 'charging-docks', label: 'Charging docks' },
+                  ],
+                },
+                { id: 'keyboards', label: 'Keyboards' },
+                { id: 'laptop-stands', label: 'Laptop stands' },
+              ],
+            },
+            { id: 'laptops', label: 'Laptops' },
+            { id: 'monitors', label: 'Monitors' },
+          ],
+        },
+        { id: 'audio', label: 'Audio' },
+        { id: 'cameras', label: 'Cameras' },
+      ],
+    },
+    {
+      id: 'beauty',
+      label: 'Beauty',
+      children: [
+        {
+          id: 'skin-care',
+          label: 'Skin care',
+          children: [
+            {
+              id: 'face-care',
+              label: 'Face',
+              children: [
+                {
+                  id: 'moisturizers',
+                  label: 'Moisturizers',
+                  children: [
+                    { id: 'day-creams', label: 'Day creams' },
+                    { id: 'night-creams', label: 'Night creams' },
+                    { id: 'gel-moisturizers', label: 'Gel moisturizers' },
+                  ],
+                },
+                { id: 'cleansers', label: 'Cleansers' },
+                { id: 'serums', label: 'Serums' },
+              ],
+            },
+            { id: 'body-care', label: 'Body' },
+          ],
+        },
+        { id: 'hair-care', label: 'Hair care' },
+        { id: 'makeup', label: 'Makeup' },
+      ],
+    },
+    {
+      id: 'office',
+      label: 'Office',
+      children: [
+        {
+          id: 'printers',
+          label: 'Printers',
+          children: [
+            {
+              id: 'ink-toner',
+              label: 'Ink & toner',
+              children: [
+                {
+                  id: 'printer-refills',
+                  label: 'Printer refills',
+                  children: [
+                    { id: 'canon-refills', label: 'Canon refills' },
+                    { id: 'hp-refills', label: 'HP refills' },
+                    { id: 'epson-refills', label: 'Epson refills' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { id: 'paper', label: 'Paper' },
+        { id: 'desk-accessories', label: 'Desk accessories' },
+      ],
+    },
+    {
+      id: 'sale',
+      label: 'Sale',
+      children: [
+        {
+          id: 'summer-sale',
+          label: 'Summer',
+          children: [
+            { id: 'summer-sale-t-shirts', label: 'T-shirts' },
+            { id: 'summer-sale-unisex', label: 'Unisex' },
+          ],
+        },
+        { id: 'last-chance', label: 'Last chance' },
+      ],
+    },
+  ],
+};
+
+export function findProductCategoryById(node, id) {
+  if (node.id === id) return node;
+  if (!node.children) return null;
+  for (const child of node.children) {
+    const found = findProductCategoryById(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function getProductCategoryLeaves(node) {
+  if (!node.children || node.children.length === 0) return [node];
+  return node.children.flatMap(getProductCategoryLeaves);
+}
+
+export function getProductCategorySelectionState(node, selected) {
+  const leaves = getProductCategoryLeaves(node);
+  const selectedCount = leaves.filter((leaf) => selected.has(leaf.id)).length;
+  if (selectedCount === 0) return 'unchecked';
+  if (selectedCount === leaves.length) return 'checked';
+  return 'indeterminate';
+}
+
+export function getProductCategoryNodeAtPath(path) {
+  let node = PRODUCT_CATEGORY_TREE;
+  for (const id of path) {
+    node = (node.children || []).find((child) => child.id === id);
+    if (!node) return null;
+  }
+  return node;
+}
+
+export function findProductCategoryPath(root, nodeId, currentPath = []) {
+  if (!root.children) return null;
+  for (const child of root.children) {
+    if (child.id === nodeId) return [...currentPath, child.id];
+    const path = findProductCategoryPath(child, nodeId, [...currentPath, child.id]);
+    if (path) return path;
+  }
+  return null;
+}
+
+export function findProductCategoryMatches(node, query, pathLabels = []) {
+  const results = [];
+  const cleanQuery = query.trim().toLowerCase();
+  const pathText = [...pathLabels, node.label].join(' > ').toLowerCase();
+
+  if (
+    node.id !== PRODUCT_CATEGORY_TREE.id &&
+    (node.label.toLowerCase().includes(cleanQuery) || pathText.includes(cleanQuery))
+  ) {
+    results.push({ node, pathLabels });
+  }
+
+  if (node.children) {
+    const nextPath = node.id === PRODUCT_CATEGORY_TREE.id ? pathLabels : [...pathLabels, node.label];
+    node.children.forEach((child) => {
+      results.push(...findProductCategoryMatches(child, cleanQuery, nextPath));
+    });
+  }
+
+  return results;
+}
+
+export function formatProductCategoryPath(nodeId) {
+  const path = findProductCategoryPath(PRODUCT_CATEGORY_TREE, nodeId, []);
+  if (!path) return '';
+  return path
+    .map((id) => findProductCategoryById(PRODUCT_CATEGORY_TREE, id)?.label)
+    .filter(Boolean)
+    .join(' > ');
+}
+
+export function computeProductCategoryTags(selected) {
+  const tags = [];
+  const covered = new Set();
+
+  PRODUCT_CATEGORY_TREE.children.forEach((node) => {
+    const state = getProductCategorySelectionState(node, selected);
+    if (state === 'checked') {
+      const leaves = getProductCategoryLeaves(node);
+      leaves.forEach((leaf) => covered.add(leaf.id));
+      tags.push({
+        id: node.id,
+        label: node.label,
+        type: 'group',
+        count: leaves.length,
+      });
+    }
+  });
+
+  [...selected]
+    .filter((id) => !covered.has(id))
+    .map((id) => findProductCategoryById(PRODUCT_CATEGORY_TREE, id))
+    .filter(Boolean)
+    .sort((a, b) => formatProductCategoryPath(a.id).localeCompare(formatProductCategoryPath(b.id)))
+    .forEach((node) => {
+      tags.push({
+        id: node.id,
+        label: node.label,
+        type: 'leaf',
+        path: formatProductCategoryPath(node.id),
+      });
+    });
+
+  return tags;
+}

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/styles.treecombo-excerpt.css
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/styles.treecombo-excerpt.css
@@ -1,0 +1,2118 @@
+.tree-combo {
+  position: relative;
+  cursor: text;
+  margin-bottom: 14px;
+  overflow: visible;
+}
+.tree-combo:focus-within .tree-combo-search-row {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 1px var(--brand);
+}
+.tree-combo-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--neutral-fg);
+  margin-bottom: 6px;
+}
+.tree-combo-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 8px 4px;
+}
+
+.tree-combo-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.tree-combo-chip-row-split {
+  padding-top: 0;
+}
+.tree-combo-search-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 40px;
+  padding: 6px 8px;
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+  background: var(--surface);
+}
+.tree-combo-search {
+  flex: 1;
+  min-width: 120px;
+  border: none;
+  outline: none;
+  font-size: 13px;
+  min-height: 26px;
+  background: transparent;
+  color: var(--neutral-fg);
+}
+.tree-combo-search-icon {
+  color: var(--neutral-fg-weak);
+  display: flex;
+  flex-shrink: 0;
+}
+/* Tags / chips */
+.dest-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #f6f7f7;
+  color: var(--neutral-fg);
+  border-radius: 4px;
+  min-height: 24px;
+  padding: 2px 4px 2px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  user-select: none;
+}
+.dest-tag-split {
+  background: color-mix(in srgb, var(--brand) 9%, #f6f7f7);
+  color: var(--neutral-fg);
+}
+.tag-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.6;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+.tag-remove:hover { opacity: 1; }
+.tree-show-more-tags {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: var(--brand);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  min-height: 24px;
+  padding: 2px 6px;
+}
+.tree-show-more-tags:hover,
+.tree-show-more-tags:focus-visible {
+  background: var(--neutral-bg);
+  outline: none;
+}
+/* Popover */
+.tree-popover {
+  position: absolute;
+  left: 0; right: 0;
+  top: calc(100% + 8px);
+  z-index: 100010;
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  display: flex;
+  flex-direction: column;
+  max-height: min(350px, calc(100vh - 260px));
+  overflow: hidden;
+}
+.tree-breadcrumb {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--neutral-fg-weak);
+  border-bottom: 1px solid var(--stroke-weak);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+.tree-breadcrumb .crumb { color: var(--neutral-fg-weak); }
+.tree-breadcrumb .crumb:not(.current) {
+  color: var(--brand);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.tree-breadcrumb .tree-crumb-button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  padding: 0;
+}
+.tree-breadcrumb .sep { margin: 0 4px; }
+.tree-level-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--stroke-weak);
+  font-size: 13px;
+}
+.tree-level-toolbar button {
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+  padding: 4px 8px;
+  min-height: 28px;
+  font-size: 13px;
+  line-height: 1.2;
+  cursor: pointer;
+  color: var(--brand);
+}
+.tree-level-toolbar button:hover:not(:disabled) {
+  border-color: var(--brand);
+}
+.tree-level-toolbar button:disabled {
+  color: var(--neutral-fg-weak);
+  cursor: default;
+  background: var(--surface);
+}
+.level-count {
+  color: var(--neutral-fg-weak);
+  margin-left: auto;
+  text-align: right;
+}
+.tree-suggestion-block {
+  border-bottom: 1px solid var(--stroke-weak);
+  padding: 10px 12px;
+}
+.tree-suggestion-heading {
+  color: var(--neutral-fg-weak);
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.tree-suggestion-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.tree-suggestion-pill {
+  appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  color: var(--neutral-fg);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  min-height: 30px;
+  padding: 3px 10px;
+}
+.tree-suggestion-pill:hover,
+.tree-suggestion-pill:focus-visible {
+  border-color: var(--brand);
+  color: var(--brand);
+  outline: none;
+}
+.tree-list {
+  max-height: 192px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.tree-empty {
+  padding: 12px 16px;
+  font-size: 13px;
+  color: var(--neutral-fg-weak);
+}
+.tree-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.tree-item:hover { background: var(--neutral-bg); }
+.tree-item .row { flex: 1; display: flex; align-items: center; }
+.tree-item .row-toggle {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  display: flex;
+  font: inherit;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  cursor: pointer;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+  user-select: none;
+}
+.tree-item .tree-checkbox-toggle {
+  flex: 0 0 auto;
+  min-height: 24px;
+  min-width: 24px;
+}
+.tree-item .tree-row-content {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex: 1;
+  font: inherit;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+.tree-item .tree-row-content:hover {
+  background: transparent;
+}
+.tree-item .ck {
+  width: 16px; height: 16px;
+  border: 2px solid var(--stroke);
+  border-radius: 2px;
+  flex-shrink: 0;
+  position: relative;
+  background: var(--surface);
+  transition: border-color 0.1s, background 0.1s;
+}
+.tree-item.checked .ck {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+.tree-item.checked .ck::after {
+  content: '';
+  position: absolute;
+  left: 3px; top: 0px;
+  width: 5px; height: 9px;
+  border: 2px solid #fff;
+  border-top: none; border-left: none;
+  transform: rotate(45deg);
+}
+.tree-item.indeterminate .ck {
+  border-color: var(--brand);
+}
+.tree-item.indeterminate .ck::after {
+  content: '';
+  position: absolute;
+  left: 2px; top: 5px;
+  width: 8px; height: 2px;
+  background: var(--brand);
+}
+.tree-item .label { display: flex; align-items: baseline; gap: 4px; }
+.tree-item .label-name { color: var(--neutral-fg); }
+.tree-item .label-count { color: var(--neutral-fg-weak); font-size: 11px; }
+.tree-rate-status {
+  color: var(--neutral-fg-weak);
+  font-size: 11px;
+  font-weight: 500;
+}
+.tree-separate-rate {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--stroke);
+  border-radius: 3px;
+  color: var(--brand);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 500;
+  margin-left: 8px;
+  min-height: 26px;
+  padding: 3px 8px;
+}
+.tree-separate-rate:hover {
+  border-color: var(--brand);
+}
+.tree-separate-rate:focus-visible {
+  box-shadow: 0 0 0 2px var(--brand);
+  outline: none;
+}
+.tree-separate-rate.is-active {
+  background: #f6f7f7;
+  border-color: var(--neutral-fg-subtle);
+  color: var(--neutral-fg);
+}
+.tree-item .drill {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--neutral-fg-weak);
+  border-radius: 3px;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+.tree-item .drill:hover { background: var(--neutral-bg); color: var(--neutral-fg); }
+.tree-item .drill svg {
+  display: block;
+  height: 24px;
+  width: 24px;
+}
+.tree-item .row-toggle:focus-visible,
+.tree-item .tree-row-content:focus-visible,
+.tree-item .drill:focus-visible,
+.tree-breadcrumb .tree-crumb-button:focus-visible,
+.dest-tag-clickable:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+.path-prefix {
+  font-size: 11px;
+  color: var(--neutral-fg-weak);
+  padding-left: 24px;
+}
+.search-result { flex-direction: column; align-items: flex-start; gap: 2px; }
+.search-result .row { width: 100%; }
+
+/* Clickable group chip — lets users drill into a group to refine or deselect */
+.dest-tag-clickable { cursor: pointer; }
+.dest-tag-clickable:hover {
+  background: color-mix(in srgb, var(--brand) 18%, transparent);
+}
+
+/* TreeCombo breakout lab */
+.tree-lab-shell {
+  min-height: 100vh;
+  background: var(--neutral-bg);
+  color: var(--neutral-fg);
+  padding: 28px;
+}
+
+.tree-lab-header,
+.tree-lab-tabs,
+.tree-lab-main {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1120px;
+}
+
+.tree-lab-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.tree-lab-kicker {
+  color: var(--neutral-fg-weak);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.tree-lab-header h1 {
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0 0 8px;
+}
+
+.tree-lab-header p,
+.tree-lab-panel-header p,
+.tree-lab-side-panel li,
+.tree-lab-note {
+  color: var(--neutral-fg-weak);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.tree-lab-tabs {
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 4px;
+  width: max-content;
+}
+
+.tree-lab-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: var(--neutral-fg-weak);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  min-height: 32px;
+  padding: 5px 12px;
+}
+
+.tree-lab-tab:hover {
+  background: var(--neutral-bg);
+  color: var(--neutral-fg);
+}
+
+.tree-lab-tab:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.tree-lab-tab.is-active {
+  background: var(--neutral-bg);
+  color: var(--neutral-fg);
+  box-shadow: inset 0 0 0 1px var(--stroke);
+}
+
+.tree-lab-subtabs {
+  align-items: center;
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 6px;
+  display: inline-flex;
+  gap: 3px;
+  margin-bottom: 14px;
+  padding: 3px;
+}
+
+.tree-lab-subtab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: var(--neutral-fg-weak);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  min-height: 28px;
+  padding: 4px 10px;
+}
+
+.tree-lab-subtab:hover,
+.tree-lab-subtab:focus-visible {
+  background: var(--surface);
+  color: var(--neutral-fg);
+  outline: none;
+}
+
+.tree-lab-subtab.is-active {
+  background: var(--surface);
+  box-shadow: inset 0 0 0 1px var(--stroke);
+  color: var(--neutral-fg);
+}
+
+.tree-lab-main {
+  display: block;
+}
+
+.tree-lab-showcase {
+  align-items: start;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 720px) minmax(280px, 1fr);
+}
+
+.tree-lab-panel,
+.tree-lab-side-panel,
+.tree-lab-mobile-device {
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+}
+
+.tree-lab-panel {
+  min-width: 0;
+  padding: 18px;
+}
+
+.tree-lab-demo-panel {
+  overflow: visible;
+}
+
+.tree-lab-panel-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.tree-lab-panel-header h2,
+.tree-lab-mobile-header h2 {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0 0 4px;
+}
+
+.tree-lab-pill {
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  color: var(--neutral-fg-weak);
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 8px;
+}
+
+.tree-lab-side-panel {
+  padding: 18px;
+}
+
+.tree-lab-side-panel h3 {
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 0 10px;
+}
+
+.tree-lab-side-panel h3 + ul,
+.tree-lab-a11y-list {
+  margin: 0 0 18px;
+  padding-left: 18px;
+}
+
+.tree-lab-path-list {
+  display: grid;
+  gap: 8px;
+}
+
+.tree-lab-path {
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 4px;
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 8px 10px;
+}
+
+.tree-lab-product-context {
+  align-items: baseline;
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 4px;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 8px 10px;
+}
+
+.tree-lab-product-context span {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+}
+
+.tree-lab-product-context strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.tree-lab-breadcrumb-preview {
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 4px;
+  color: var(--neutral-fg);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.tree-lab-path-panel {
+  overflow: visible;
+}
+
+.tree-lab-product-details {
+  display: block;
+}
+
+.tree-lab-product-details-panel {
+  max-width: none;
+}
+
+.product-detail-heading {
+  border-bottom: 1px solid var(--stroke-weak);
+  margin: -2px 0 18px;
+  padding-bottom: 16px;
+}
+
+.product-detail-layout {
+  align-items: start;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+}
+
+.product-detail-main {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.product-detail-section,
+.product-detail-preview {
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.product-detail-section {
+  padding: 14px;
+}
+
+.product-detail-summary {
+  align-items: start;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(180px, 0.75fr) minmax(0, 1fr);
+}
+
+.product-detail-section-label {
+  color: var(--neutral-fg-weak);
+  display: block;
+  font-size: 12px;
+  line-height: 1.35;
+  margin-bottom: 4px;
+}
+
+.product-detail-section h3,
+.product-detail-preview h3 {
+  color: var(--neutral-fg);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.product-detail-signal-list {
+  display: grid;
+  gap: 0;
+}
+
+.product-detail-signal {
+  align-items: baseline;
+  border-bottom: 1px solid var(--stroke-weak);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 96px minmax(0, 1fr);
+  padding: 7px 0;
+}
+
+.product-detail-signal:first-child {
+  padding-top: 0;
+}
+
+.product-detail-signal:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.product-detail-signal span,
+.product-detail-signal strong {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.product-detail-signal span {
+  color: var(--neutral-fg-weak);
+}
+
+.product-detail-signal strong {
+  color: var(--neutral-fg);
+  font-weight: 500;
+}
+
+.product-detail-section-heading {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.product-detail-section-heading p {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 4px 0 0;
+}
+
+.product-detail-section-heading > span {
+  color: var(--neutral-fg-weak);
+  flex: 0 0 auto;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.product-category-flow {
+  display: grid;
+  gap: 14px;
+}
+
+.product-category-flow-step {
+  border: 1px solid var(--stroke-weak);
+  border-radius: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.product-category-flow-heading {
+  align-items: start;
+  background: var(--neutral-bg);
+  border-bottom: 1px solid var(--stroke-weak);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 12px;
+}
+
+.product-category-flow-heading > span {
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  color: var(--neutral-fg);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  height: 24px;
+  justify-content: center;
+  line-height: 1;
+  width: 24px;
+}
+
+.product-category-flow-heading h4 {
+  color: var(--neutral-fg);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+  margin: 1px 0 2px;
+}
+
+.product-category-flow-heading p {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.assigned-category-card {
+  border: 0;
+  border-radius: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+}
+
+.assigned-category-card-heading {
+  align-items: center;
+  background: var(--neutral-bg);
+  border-bottom: 1px solid var(--stroke-weak);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) 150px;
+  padding: 10px 12px;
+}
+
+.assigned-category-card-heading span {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.assigned-category-card-heading span:last-child {
+  color: var(--neutral-fg-weak);
+  font-size: 11px;
+  font-weight: 400;
+  text-align: right;
+}
+
+.assigned-category-list {
+  display: grid;
+}
+
+.assigned-category-row {
+  align-items: start;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr);
+  padding: 12px;
+}
+
+.assigned-category-row + .assigned-category-row {
+  border-top: 1px solid var(--stroke-weak);
+}
+
+.assigned-category-row.is-main-path {
+  background: color-mix(in srgb, var(--brand) 6%, transparent);
+}
+
+.assigned-category-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.assigned-category-remove {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: #b32d2e;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.assigned-category-remove:hover {
+  color: #8a2424;
+}
+
+.assigned-category-remove:focus-visible,
+.classifier-suggestion-check:focus-visible,
+.primary-category-trigger:focus-visible,
+.primary-category-option:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.assigned-category-body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.assigned-category-title {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.assigned-category-path {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assigned-category-main {
+  align-items: center;
+  color: var(--neutral-fg);
+  cursor: pointer;
+  display: flex;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.primary-category-field {
+  border-top: 1px solid var(--stroke-weak);
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.primary-category-field > span {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.primary-category-picker {
+  min-width: 0;
+  position: relative;
+}
+
+.primary-category-trigger {
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+  color: var(--neutral-fg);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 13px;
+  gap: 8px;
+  justify-content: space-between;
+  max-width: 100%;
+  min-height: 34px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 6px 30px 6px 8px;
+  text-align: left;
+  width: 100%;
+}
+
+.primary-category-trigger span:first-child {
+  display: block;
+  flex: 1 1 auto;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.primary-category-trigger:disabled {
+  background: var(--neutral-bg);
+  color: var(--neutral-fg-weak);
+  cursor: default;
+}
+
+.primary-category-caret {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  flex: 0 0 auto;
+  height: 0;
+  opacity: 0.7;
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+}
+
+.primary-category-menu {
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+  display: grid;
+  left: 0;
+  max-height: 240px;
+  overflow: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+}
+
+.primary-category-option {
+  appearance: none;
+  background: var(--surface);
+  border: 0;
+  border-bottom: 1px solid var(--stroke-weak);
+  color: var(--neutral-fg);
+  cursor: pointer;
+  display: grid;
+  gap: 2px;
+  font: inherit;
+  padding: 9px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.primary-category-option:last-child {
+  border-bottom: 0;
+}
+
+.primary-category-option:hover,
+.primary-category-option.is-selected {
+  background: #f0f6fc;
+}
+
+.primary-category-option strong {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.primary-category-option small {
+  color: var(--neutral-fg-weak);
+  display: -webkit-box;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.primary-category-empty {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  padding: 10px;
+}
+
+.primary-category-field small {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.classifier-suggestions {
+  border: 1px solid var(--stroke-weak);
+  border-radius: 6px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+
+.classifier-suggestions-heading {
+  align-items: center;
+  background: var(--neutral-bg);
+  border-bottom: 1px solid var(--stroke-weak);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+.classifier-suggestions-heading span:first-child {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.classifier-suggestions-heading span:last-child {
+  color: var(--neutral-fg-weak);
+  font-size: 11px;
+}
+
+.classifier-suggestion-list {
+  display: grid;
+}
+
+.classifier-suggestion-empty {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 10px 12px;
+}
+
+.classifier-suggestion {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 10px 12px;
+  text-align: left;
+  width: 100%;
+}
+
+.classifier-suggestion + .classifier-suggestion {
+  border-top: 1px solid var(--stroke-weak);
+}
+
+.classifier-suggestion:hover {
+  background: var(--neutral-bg);
+}
+
+.classifier-suggestion-body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.classifier-suggestion-check {
+  margin: 2px 0 0;
+}
+
+.classifier-suggestion-title {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.classifier-suggestion-path,
+.classifier-suggestion-reason {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.classifier-suggestion-action {
+  color: var(--brand);
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.product-detail-category-section .product-tree-combo {
+  border: 0;
+  border-bottom: 1px solid var(--stroke-weak);
+  border-radius: 0;
+  margin-bottom: 0;
+}
+
+.product-detail-add-card .tree-combo-chips {
+  display: none;
+}
+
+.product-detail-storefront-path {
+  margin-top: 0;
+}
+
+.product-detail-side {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.product-detail-preview {
+  padding: 14px;
+}
+
+.product-detail-preview h3 {
+  margin-bottom: 10px;
+}
+
+.product-detail-preview-box {
+  background: var(--surface);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 6px;
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+}
+
+.product-detail-preview-box span {
+  color: var(--neutral-fg);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.product-detail-preview-box strong,
+.product-detail-preview-box small {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.product-detail-preview-box strong {
+  color: var(--neutral-fg);
+}
+
+.product-detail-preview-box small {
+  color: var(--neutral-fg-weak);
+}
+
+.product-detail-notes ul {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.product-detail-notes li + li {
+  margin-top: 6px;
+}
+
+.current-editor-fit {
+  display: block;
+}
+
+.current-editor-frame {
+  background: #f0f0f1;
+  border: 1px solid #c3c4c7;
+  color: #1d2327;
+  font-size: 13px;
+  min-height: 720px;
+}
+
+.current-editor-topbar {
+  align-items: center;
+  background: #fff;
+  border-bottom: 1px solid #c3c4c7;
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 16px;
+}
+
+.current-editor-kicker {
+  color: #646970;
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.4;
+  margin-bottom: 2px;
+  text-transform: uppercase;
+}
+
+.current-editor-topbar h2 {
+  color: #1d2327;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.current-editor-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.current-editor-actions button {
+  appearance: none;
+  background: #fff;
+  border: 1px solid #2271b1;
+  border-radius: 3px;
+  color: #2271b1;
+  cursor: pointer;
+  font: inherit;
+  min-height: 30px;
+  padding: 4px 10px;
+}
+
+.current-editor-actions button.is-primary {
+  background: #2271b1;
+  color: #fff;
+}
+
+.current-editor-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  padding: 16px;
+}
+
+.current-editor-content,
+.current-editor-sidebar {
+  min-width: 0;
+}
+
+.current-editor-title-field,
+.current-editor-block,
+.current-editor-product-data,
+.current-editor-postbox {
+  background: #fff;
+  border: 1px solid #c3c4c7;
+  display: block;
+  min-width: 0;
+}
+
+.current-editor-title-field {
+  padding: 12px;
+}
+
+.current-editor-title-field span,
+.current-editor-block span {
+  color: #646970;
+  display: block;
+  font-size: 12px;
+  line-height: 1.4;
+  margin-bottom: 6px;
+}
+
+.current-editor-title-field input,
+.current-editor-product-data-panel input {
+  border: 1px solid #8c8f94;
+  border-radius: 2px;
+  color: #1d2327;
+  font: inherit;
+  min-height: 36px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.current-editor-title-field input {
+  font-size: 20px;
+}
+
+.current-editor-block,
+.current-editor-product-data {
+  margin-top: 16px;
+}
+
+.current-editor-block {
+  min-height: 220px;
+  padding: 12px;
+}
+
+.current-editor-block p {
+  color: #50575e;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 620px;
+}
+
+.current-editor-product-data {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  min-height: 220px;
+}
+
+.current-editor-product-data-tabs {
+  background: #f6f7f7;
+  border-right: 1px solid #c3c4c7;
+  display: grid;
+  align-content: start;
+}
+
+.current-editor-product-data-tabs span {
+  border-bottom: 1px solid #dcdcde;
+  color: #50575e;
+  padding: 10px 12px;
+}
+
+.current-editor-product-data-tabs span.is-active {
+  background: #fff;
+  color: #1d2327;
+  font-weight: 600;
+}
+
+.current-editor-product-data-panel {
+  padding: 16px;
+}
+
+.current-editor-product-data-panel label span {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.current-editor-sidebar {
+  display: grid;
+  gap: 12px;
+}
+
+.current-editor-publish-body {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.current-editor-publish-actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.current-editor-publish button,
+.current-editor-tag-box button {
+  appearance: none;
+  background: #fff;
+  border: 1px solid #2271b1;
+  border-radius: 3px;
+  color: #2271b1;
+  cursor: pointer;
+  font: inherit;
+  min-height: 30px;
+  padding: 4px 10px;
+}
+
+.current-editor-publish-row {
+  align-items: start;
+  color: #50575e;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  line-height: 1.4;
+}
+
+.current-editor-publish-row strong {
+  color: #1d2327;
+}
+
+.current-editor-publish-row button {
+  border: 0;
+  min-height: 0;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.current-editor-publish-footer {
+  align-items: center;
+  background: #f6f7f7;
+  border-top: 1px solid #c3c4c7;
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+.current-editor-publish-footer button.is-link {
+  border: 0;
+  color: #b32d2e;
+  min-height: 0;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.current-editor-publish-footer button.is-primary {
+  background: #2271b1;
+  color: #fff;
+}
+
+.current-editor-postbox-heading {
+  align-items: center;
+  border-bottom: 1px solid #c3c4c7;
+  display: flex;
+  font-weight: 600;
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.current-product-categories-box {
+  min-width: 0;
+  padding: 0;
+}
+
+.current-editor-tabs {
+  border-bottom: 1px solid #c3c4c7;
+  display: flex;
+  gap: 0;
+  padding: 8px 10px 0;
+}
+
+.current-editor-tabs button {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  color: #2271b1;
+  cursor: pointer;
+  font: inherit;
+  margin-bottom: -1px;
+  padding: 6px 9px;
+}
+
+.current-editor-tabs button.is-active {
+  background: #fff;
+  border-color: #c3c4c7;
+  color: #1d2327;
+}
+
+.current-category-current {
+  border-bottom: 1px solid #dcdcde;
+}
+
+.current-category-heading {
+  align-items: center;
+  background: #f6f7f7;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 8px 10px;
+}
+
+.current-category-heading span:first-child {
+  font-weight: 600;
+}
+
+.current-category-heading span:last-child {
+  color: #646970;
+  font-size: 11px;
+}
+
+.current-category-assigned-list {
+  display: grid;
+}
+
+.current-category-assigned-row {
+  align-items: start;
+  display: grid;
+  gap: 7px;
+  grid-template-columns: minmax(0, 1fr);
+  padding: 9px 10px;
+}
+
+.current-category-assigned-row + .current-category-assigned-row {
+  border-top: 1px solid #f0f0f1;
+}
+
+.current-category-assigned-row.is-main-path {
+  background: #f0f6fc;
+}
+
+.current-category-assigned-body,
+.current-category-assigned-actions {
+  min-width: 0;
+}
+
+.current-category-assigned-body {
+  overflow: hidden;
+}
+
+.current-category-assigned-row strong,
+.current-category-suggestion strong {
+  display: block;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.current-category-assigned-row small,
+.current-category-suggestion small {
+  color: #646970;
+  display: block;
+  font-size: 11px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.current-category-assigned-row label {
+  align-items: center;
+  color: #1d2327;
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  gap: 6px;
+  line-height: 1.35;
+}
+
+.current-category-assigned-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.current-category-assigned-actions button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: #b32d2e;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.current-category-assigned-actions button:hover {
+  color: #8a2424;
+}
+
+.current-category-empty {
+  color: #646970;
+  padding: 10px;
+}
+
+.current-primary-category-field {
+  border-top: 0;
+  border-bottom: 1px solid #dcdcde;
+  padding: 10px;
+}
+
+.current-primary-category-field > span {
+  color: #1d2327;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.current-primary-category-field .primary-category-trigger {
+  border-color: #8c8f94;
+  border-radius: 2px;
+  min-height: 32px;
+}
+
+.current-primary-category-field .primary-category-menu {
+  border-color: #8c8f94;
+  border-radius: 2px;
+}
+
+.current-product-categories-box .product-tree-combo {
+  border: 0;
+  border-bottom: 1px solid #dcdcde;
+  border-radius: 0;
+  margin: 0;
+  padding: 10px;
+}
+
+.current-product-categories-box .product-tree-combo:focus-within {
+  border-color: #dcdcde;
+  box-shadow: none;
+}
+
+.current-product-categories-box .tree-combo-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.current-product-categories-box .tree-combo-chips {
+  display: none;
+}
+
+.current-product-categories-box .product-tree-combo-control {
+  border: 1px solid #8c8f94;
+  border-radius: 2px;
+}
+
+.current-product-categories-box .tree-combo-search-row {
+  min-height: 34px;
+}
+
+.current-product-categories-box .tree-popover {
+  border: 1px solid #c3c4c7;
+  border-radius: 2px;
+  left: 10px;
+  max-height: 420px;
+  right: 10px;
+  width: auto;
+}
+
+.current-category-suggestions-heading,
+.current-category-inline-heading {
+  color: #1d2327;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-bottom: 8px;
+}
+
+.current-category-suggestion {
+  align-items: start;
+  cursor: pointer;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 7px 0;
+}
+
+.current-category-suggestion + .current-category-suggestion {
+  border-top: 1px solid #f0f0f1;
+}
+
+.current-category-suggestion input {
+  margin-top: 2px;
+}
+
+.current-category-inline-suggestions {
+  background: #fff;
+  padding: 0 10px 10px;
+}
+
+.current-category-inline-list {
+  display: grid;
+  gap: 6px;
+}
+
+.current-category-inline-suggestion {
+  align-items: center;
+  appearance: none;
+  background: #f6f7f7;
+  border: 1px solid #dcdcde;
+  border-radius: 2px;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 7px 8px;
+  text-align: left;
+}
+
+.current-category-inline-suggestion:hover {
+  background: #f0f0f1;
+  border-color: #c3c4c7;
+}
+
+.current-category-inline-suggestion > span:first-child {
+  min-width: 0;
+}
+
+.current-category-inline-suggestion > span:last-child {
+  color: #2271b1;
+  font-size: 12px;
+}
+
+.current-category-inline-suggestion strong {
+  display: block;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.current-category-inline-suggestion small {
+  color: #646970;
+  display: block;
+  font-size: 11px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.current-category-storefront-preview {
+  background: #f6f7f7;
+  border-bottom: 1px solid #dcdcde;
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+}
+
+.current-category-storefront-preview span {
+  color: #646970;
+  font-size: 11px;
+}
+
+.current-category-storefront-preview strong {
+  color: #1d2327;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.current-editor-image-placeholder {
+  align-items: center;
+  background: #f6f7f7;
+  color: #646970;
+  display: flex;
+  font-size: 12px;
+  height: 180px;
+  justify-content: center;
+  margin: 12px;
+}
+
+.current-editor-image-caption,
+.current-editor-simple-link {
+  color: #646970;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 0 12px 12px;
+}
+
+.current-editor-simple-link {
+  color: #2271b1;
+  text-decoration: underline;
+}
+
+.current-editor-tag-box {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 12px;
+}
+
+.current-editor-tag-box input {
+  border: 1px solid #8c8f94;
+  border-radius: 2px;
+  font: inherit;
+  min-height: 30px;
+  padding: 4px 6px;
+}
+
+.storefront-path-card {
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+
+.storefront-path-card-heading {
+  border-bottom: 1px solid var(--stroke-weak);
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 12px;
+}
+
+.storefront-path-fieldset {
+  border: 0;
+  margin: 0;
+  padding: 14px 12px 12px;
+}
+
+.storefront-path-fieldset legend {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 0;
+}
+
+.storefront-path-fieldset p {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 4px 0 12px;
+}
+
+.storefront-path-options {
+  display: grid;
+  gap: 8px;
+}
+
+.storefront-path-option {
+  align-items: flex-start;
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+}
+
+.storefront-path-option:hover {
+  border-color: var(--neutral-fg-subtle);
+}
+
+.storefront-path-option.is-selected {
+  background: color-mix(in srgb, var(--brand) 7%, transparent);
+  border-color: color-mix(in srgb, var(--brand) 45%, transparent);
+}
+
+.storefront-path-option input {
+  flex: 0 0 auto;
+  margin: 3px 0 0;
+}
+
+.storefront-path-option-body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.storefront-path-option-title {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.storefront-path-option-path {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.storefront-path-empty {
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 4px;
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 10px;
+}
+
+.storefront-path-summary {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+}
+
+.storefront-path-summary span {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.storefront-path-summary strong {
+  color: var(--neutral-fg);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.storefront-path-summary p {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 4px 0 0;
+}
+
+.storefront-path-preview {
+  color: var(--neutral-fg);
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.tree-lab-zone-preview {
+  display: grid;
+  gap: 0;
+}
+
+.tree-lab-zone-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(105px, 0.7fr) minmax(0, 1fr);
+  padding: 8px 0;
+  font-size: 12px;
+}
+
+.tree-lab-zone-row + .tree-lab-zone-row {
+  border-top: 1px solid var(--stroke-weak);
+}
+
+.tree-lab-zone-row span:last-child {
+  color: var(--neutral-fg-weak);
+}
+
+.tree-lab-mobile-showcase {
+  grid-template-columns: minmax(0, 420px) minmax(280px, 1fr);
+}
+
+.tree-lab-mobile-wrap {
+  display: flex;
+  justify-content: center;
+}
+
+.tree-lab-mobile-device {
+  border-color: var(--neutral-fg-subtle);
+  border-radius: 18px;
+  max-width: 100%;
+  padding: 16px;
+  width: 375px;
+}
+
+.tree-lab-mobile-header {
+  border-bottom: 1px solid var(--stroke-weak);
+  margin: -16px -16px 16px;
+  padding: 16px;
+}
+
+.tree-lab-mobile-header span {
+  color: var(--neutral-fg-weak);
+  font-size: 12px;
+}
+
+.product-tree-combo .tree-combo-label {
+  display: block;
+}
+
+.product-tree-combo-control {
+  background: var(--surface);
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+}
+
+.product-tree-combo:focus-within .product-tree-combo-control {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 1px var(--brand);
+}
+
+.product-tree-combo .tree-combo-search-row {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.product-tree-combo:focus-within .tree-combo-search-row {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.product-category-tag[data-tooltip] {
+  position: relative;
+}
+
+.product-category-tag[data-tooltip]::after {
+  background: var(--neutral-fg);
+  border-radius: 4px;
+  bottom: calc(100% + 8px);
+  color: var(--surface);
+  content: attr(data-tooltip);
+  font-size: 11px;
+  font-weight: 400;
+  left: 50%;
+  line-height: 1.35;
+  max-width: min(420px, 80vw);
+  opacity: 0;
+  padding: 6px 8px;
+  pointer-events: none;
+  position: absolute;
+  transform: translate(-50%, 2px);
+  transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
+  visibility: hidden;
+  white-space: normal;
+  width: max-content;
+  z-index: 100020;
+}
+
+.product-category-tag[data-tooltip]::before {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid var(--neutral-fg);
+  bottom: calc(100% + 3px);
+  content: '';
+  left: 50%;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  transform: translateX(-50%);
+  transition: opacity 120ms ease, visibility 120ms ease;
+  visibility: hidden;
+  z-index: 100020;
+}
+
+.product-category-tag-label {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  padding: 0;
+}
+
+.product-category-tag-label:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.product-category-chip-hint {
+  background: var(--neutral-bg);
+  border: 1px solid var(--stroke-weak);
+  border-radius: 4px;
+  color: var(--neutral-fg-weak);
+  display: none;
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 6px 8px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .product-category-tag[data-tooltip]:hover::after,
+  .product-category-tag[data-tooltip]:focus-within::after,
+  .product-category-tag[data-tooltip]:hover::before,
+  .product-category-tag[data-tooltip]:focus-within::before {
+    opacity: 1;
+    transform: translate(-50%, 0);
+    visibility: visible;
+  }
+
+  .product-category-tag[data-tooltip]:hover::before,
+  .product-category-tag[data-tooltip]:focus-within::before {
+    transform: translateX(-50%);
+  }
+}
+
+@media (hover: none), (pointer: coarse), (max-width: 600px) {
+  .product-category-tag[data-tooltip]::after,
+  .product-category-tag[data-tooltip]::before {
+    content: none;
+    display: none;
+  }
+
+  .product-category-chip-hint {
+    display: block;
+  }
+}
+
+.tree-lab-mobile-device .product-category-tag[data-tooltip]::after,
+.tree-lab-mobile-device .product-category-tag[data-tooltip]::before {
+  content: none;
+  display: none;
+}
+
+.tree-lab-mobile-device .product-category-chip-hint {
+  display: block;
+}
+
+.product-category-tag.has-path {
+  align-items: flex-start;
+  flex-direction: column;

--- a/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/treecombo-only.jsx.txt
+++ b/plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/treecombo-only.jsx.txt
@@ -1,0 +1,29 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import TreeComboLab from './components/TreeComboLab.jsx';
+
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/dataviews/build-style/style.css';
+import './styles.treecombo-excerpt.css';
+
+const params = new URLSearchParams(window.location.search);
+
+if (!params.has('view')) {
+  params.set('view', 'product-editor');
+}
+
+params.set('hideBack', '1');
+
+if (window.location.hash !== '#tree-combo-lab' || window.location.search !== `?${params.toString()}`) {
+  window.history.replaceState(
+    null,
+    document.title,
+    `${window.location.pathname}?${params.toString()}#tree-combo-lab`
+  );
+}
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <TreeComboLab onBack={() => {}} />
+  </StrictMode>
+);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a TreeSelect prototype source reference under `plugins/woocommerce/docs/superpowers/prototypes/tree-select/` so the RSM interaction work is inspectable from GitHub instead of living only in the standalone React prototype.

The snapshot includes the shipping source case, the product-category stress case, the lab wrapper, fixture data, and a trimmed TreeCombo-related stylesheet excerpt. The JS/JSX snapshots are intentionally stored as `.txt` files so they are readable reference source without being treated as production code by JS linting.

Related context:

- Shipping-first TreeSelect handoff notes: #64732
- Product-category TreeSelect follow-up notes: #65237
- TreeSelect breakout P2: https://radicalupdates.wordpress.com/2026/05/14/combobox-treeselect-breakout-update-1/
- Product-category follow-up P2: https://radicalupdates.wordpress.com/2026/05/22/combobox-treeselect-breakout-product-category-follow-up-update-2/

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/docs/superpowers/prototypes/tree-select/README.md`.
2. Confirm the README clearly states this is prototype reference source, not production-ready component code.
3. Confirm the source snapshot files are available under `plugins/woocommerce/docs/superpowers/prototypes/tree-select/source/`.
4. Confirm the JS/JSX reference files use the `.txt` suffix so they are not picked up as production JS changes.

### Testing that has already taken place:

- Ran `git diff --cached --check` successfully before committing.
- Confirmed the branch has no changed `*.js`, `*.jsx`, `*.ts`, or `*.tsx` files under `plugins/woocommerce`.
- Attempted `pnpm exec markdownlint plugins/woocommerce/docs/superpowers/prototypes/tree-select/README.md`, but the command was blocked before markdownlint ran because the local pnpm supply-chain policy rejected existing lockfile entries for `allure-js-commons@3.7.1` and `allure-playwright@3.7.1`.

### Changelog entry

Manual changelog entry created: `plugins/woocommerce/changelog/add-treeselect-prototype-source-reference`.

### Release Communication

This PR does not need release communication because it only adds internal prototype reference material.
