### PR TITLE
Fix duplicate "Password Changed" admin email on customer password reset

### DIFF
--- a/plugins/woocommerce/changelog/66145-fix-66103-duplicate-password-changed-email
+++ b/plugins/woocommerce/changelog/66145-fix-66103-duplicate-password-changed-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Select if this PR needs a generated summary for release notes:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice. - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions. - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  An AI will analyze your PR and post a draft comment for you to review and edit.
+

--- a/plugins/woocommerce/changelog/66145-fix-66103-duplicate-password-changed-email
+++ b/plugins/woocommerce/changelog/66145-fix-66103-duplicate-password-changed-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Select if this PR needs a generated summary for release notes:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice. - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions. - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  An AI will analyze your PR and post a draft comment for you to review and edit.
-

--- a/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
+++ b/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
@@ -1,3 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Fix duplicate "Password Changed" admin notification email sent when a customer resets their password.
+
+Fix duplicate "Password Changed" admin notification email sent when a customer resets their password.

--- a/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
+++ b/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix duplicate "Password Changed" admin notification email sent when a customer resets their password.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -387,19 +387,21 @@ class WC_Shortcode_My_Account {
 			remove_action( 'after_password_reset', 'wp_password_change_notification', $core_notification_priority );
 		}
 
-		/**
-		 * Fires after the user's password has been reset via WooCommerce.
-		 *
-		 * This provides parity with WordPress core's reset_password() function.
-		 *
-		 * @since 10.9.0
-		 * @param WP_User $user     The user.
-		 * @param string  $new_pass New user password in plaintext.
-		 */
-		do_action( 'after_password_reset', $user, $new_pass );
-
-		if ( false !== $core_notification_priority ) {
-			add_action( 'after_password_reset', 'wp_password_change_notification', $core_notification_priority );
+		try {
+			/**
+			 * Fires after the user's password has been reset via WooCommerce.
+			 *
+			 * This provides parity with WordPress core's reset_password() function.
+			 *
+			 * @since 10.9.0
+			 * @param WP_User $user     The user.
+			 * @param string  $new_pass New user password in plaintext.
+			 */
+			do_action( 'after_password_reset', $user, $new_pass );
+		} finally {
+			if ( false !== $core_notification_priority ) {
+				add_action( 'after_password_reset', 'wp_password_change_notification', $core_notification_priority );
+			}
 		}
 
 		self::set_reset_password_cookie();

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -379,6 +379,14 @@ class WC_Shortcode_My_Account {
 		wp_set_password( $new_pass, $user->ID );
 		update_user_meta( $user->ID, 'default_password_nag', false );
 
+		// WordPress core hooks wp_password_change_notification() onto after_password_reset. Detach it around
+		// the action so it doesn't duplicate the notification WooCommerce sends directly below (guarded by the
+		// woocommerce_disable_password_change_notification filter), then restore it to its original priority.
+		$core_notification_priority = has_action( 'after_password_reset', 'wp_password_change_notification' );
+		if ( false !== $core_notification_priority ) {
+			remove_action( 'after_password_reset', 'wp_password_change_notification', $core_notification_priority );
+		}
+
 		/**
 		 * Fires after the user's password has been reset via WooCommerce.
 		 *
@@ -389,6 +397,11 @@ class WC_Shortcode_My_Account {
 		 * @param string  $new_pass New user password in plaintext.
 		 */
 		do_action( 'after_password_reset', $user, $new_pass );
+
+		if ( false !== $core_notification_priority ) {
+			add_action( 'after_password_reset', 'wp_password_change_notification', $core_notification_priority );
+		}
+
 		self::set_reset_password_cookie();
 		wc_set_customer_auth_cookie( $user->ID );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes #66103, closes WOOPLUG-6937

Since 10.9.0, `WC_Shortcode_My_Account::reset_password()` fires a new `after_password_reset` action (added in #64380). WordPress core hooks `wp_password_change_notification()` onto that action in `wp-includes/default-filters.php`, so it now runs *in addition* to the pre-existing direct `wp_password_change_notification()` call further down the method — sending the site admin two identical "Password Changed" emails per reset.

This detaches core's handler around the `do_action( 'after_password_reset' )` call and restores it to its original priority afterward, so third-party listeners on `after_password_reset` still fire while WooCommerce's own filter-guarded (`woocommerce_disable_password_change_notification`) direct call remains the single notification source.

Bug introduced in PR #64380.

### How to test the changes in this Pull Request

1. Install WordPress with only WooCommerce active.
2. Set WooCommerce Site Visibility to Live.
3. Create a customer account, then log out.
4. Go to `/my-account/lost-password` and request a password reset.
5. Click the reset link and set a new password.
6. Check the admin inbox: **exactly one** "Password Changed" notification should arrive (previously two).
7. Confirm `add_filter( 'woocommerce_disable_password_change_notification', '__return_true' )` still suppresses the notification entirely.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix duplicate "Password Changed" admin notification email sent when a customer resets their password.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
