### PR TITLE
Store API: add is_cookie_authenticated() nonce seam

### DIFF
--- a/plugins/woocommerce/changelog/add-store-api-cookie-auth-nonce-seam
+++ b/plugins/woocommerce/changelog/add-store-api-cookie-auth-nonce-seam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Store API: add an `is_cookie_authenticated()` seam to AbstractCartRoute so routes authenticated by other means can opt out of the nonce requirement without re-implementing the nonce logic.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -215,6 +215,24 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	}
 
 	/**
+	 * Whether the request is authenticated via the WordPress auth cookie.
+	 *
+	 * The Store API nonce only guards cookie-authenticated requests against CSRF.
+	 * Routes authenticated by other means (e.g. a Jetpack blog token) are not a
+	 * CSRF target and can override this to opt out of the nonce requirement.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return bool
+	 */
+	protected function is_cookie_authenticated( \WP_REST_Request $request ) {
+		unset( $request );
+		return true;
+	}
+
+	/**
 	 * Checks if a nonce is required for the route.
 	 *
 	 * @param \WP_REST_Request $request Request.
@@ -222,6 +240,9 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return bool
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
+		if ( ! $this->is_cookie_authenticated( $request ) ) {
+			return false;
+		}
 		return $this->is_update_request( $request ) && ! $this->has_cart_token( $request );
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessions.php
@@ -116,13 +116,15 @@ class CheckoutSessions extends AbstractCartRoute {
 	}
 
 	/**
-	 * Check if a nonce is required for the route.
+	 * Authenticated via Jetpack blog token (see is_authorized()), not the auth
+	 * cookie, so the route is not a CSRF target and opts out of the nonce.
 	 *
 	 * @param \WP_REST_Request $request Request object.
-	 * @return bool False, Jetpack blog token auth used instead.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return bool
 	 */
-	protected function requires_nonce( \WP_REST_Request $request ) {
-		// Uses Jetpack blog token authentication via is_authorized().
+	protected function is_cookie_authenticated( \WP_REST_Request $request ) {
+		unset( $request );
 		return false;
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessionsComplete.php
@@ -195,13 +195,15 @@ class CheckoutSessionsComplete extends AbstractCartRoute {
 	}
 
 	/**
-	 * Check if a nonce is required for the route.
+	 * Authenticated via Jetpack blog token (see is_authorized()), not the auth
+	 * cookie, so the route is not a CSRF target and opts out of the nonce.
 	 *
 	 * @param \WP_REST_Request $request Request object.
-	 * @return bool False, Jetpack blog token auth used instead.
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 * @return bool
 	 */
-	protected function requires_nonce( \WP_REST_Request $request ) {
-		// Uses Jetpack blog token authentication via is_authorized().
+	protected function is_cookie_authenticated( \WP_REST_Request $request ) {
+		unset( $request );
 		return false;
 	}
 

--- a/plugins/woocommerce/tests/php/src/StoreApi/Routes/V1/AbstractCartRouteTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Routes/V1/AbstractCartRouteTest.php
@@ -1,0 +1,170 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
+use WC_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * Tests for the AbstractCartRoute nonce / cookie-authentication seam.
+ */
+class AbstractCartRouteTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Build a dependency-free cart route that exposes the protected nonce seam.
+	 *
+	 * @param bool $cookie_authenticated Value the route reports for cookie auth.
+	 * @return AbstractCartRoute
+	 */
+	private function make_route( bool $cookie_authenticated = true ): AbstractCartRoute {
+		return new class( $cookie_authenticated ) extends AbstractCartRoute {
+			/**
+			 * Whether the stubbed route is cookie authenticated.
+			 *
+			 * @var bool
+			 */
+			private $cookie_authenticated;
+
+			/**
+			 * Constructor without the schema dependencies the seam does not need.
+			 *
+			 * @param bool $cookie_authenticated Value to report for cookie auth.
+			 */
+			public function __construct( bool $cookie_authenticated ) {
+				$this->cookie_authenticated = $cookie_authenticated;
+			}
+
+			/**
+			 * Get the path of this REST route.
+			 *
+			 * @return string
+			 */
+			public function get_path() {
+				return '/test';
+			}
+
+			/**
+			 * Get method arguments for this REST route.
+			 *
+			 * @return array
+			 */
+			public function get_args() {
+				return array();
+			}
+
+			/**
+			 * Expose is_cookie_authenticated for assertions.
+			 *
+			 * @param WP_REST_Request $request Request object.
+			 * @return bool
+			 */
+			public function expose_is_cookie_authenticated( WP_REST_Request $request ): bool {
+				return $this->is_cookie_authenticated( $request );
+			}
+
+			/**
+			 * Expose requires_nonce for assertions.
+			 *
+			 * @param WP_REST_Request $request Request object.
+			 * @return bool
+			 */
+			public function expose_requires_nonce( WP_REST_Request $request ): bool {
+				return $this->requires_nonce( $request );
+			}
+
+			/**
+			 * Honour the constructor-supplied cookie-auth value.
+			 *
+			 * @param WP_REST_Request $request Request object.
+			 * @return bool
+			 */
+			protected function is_cookie_authenticated( WP_REST_Request $request ) {
+				unset( $request );
+				return $this->cookie_authenticated;
+			}
+		};
+	}
+
+	/**
+	 * @testdox Should treat requests as cookie authenticated by default.
+	 */
+	public function test_is_cookie_authenticated_defaults_to_true(): void {
+		$route = new class() extends AbstractCartRoute {
+			/**
+			 * Constructor without the schema dependencies the seam does not need.
+			 */
+			public function __construct() {}
+
+			/**
+			 * Get the path of this REST route.
+			 *
+			 * @return string
+			 */
+			public function get_path() {
+				return '/test';
+			}
+
+			/**
+			 * Get method arguments for this REST route.
+			 *
+			 * @return array
+			 */
+			public function get_args() {
+				return array();
+			}
+
+			/**
+			 * Expose is_cookie_authenticated for assertions.
+			 *
+			 * @param WP_REST_Request $request Request object.
+			 * @return bool
+			 */
+			public function expose_is_cookie_authenticated( WP_REST_Request $request ): bool {
+				return $this->is_cookie_authenticated( $request );
+			}
+		};
+
+		$this->assertTrue(
+			$route->expose_is_cookie_authenticated( new WP_REST_Request( 'POST', '/test' ) ),
+			'Routes should default to cookie-authenticated so the nonce is required.'
+		);
+	}
+
+	/**
+	 * @testdox Should not require a nonce for read requests.
+	 */
+	public function test_read_request_does_not_require_nonce(): void {
+		$route = $this->make_route();
+
+		$this->assertFalse(
+			$route->expose_requires_nonce( new WP_REST_Request( 'GET', '/test' ) ),
+			'GET requests should never require a nonce.'
+		);
+	}
+
+	/**
+	 * @testdox Should require a nonce for cookie-authenticated update requests.
+	 */
+	public function test_update_request_requires_nonce_when_cookie_authenticated(): void {
+		$route = $this->make_route( true );
+
+		$this->assertTrue(
+			$route->expose_requires_nonce( new WP_REST_Request( 'POST', '/test' ) ),
+			'Cookie-authenticated update requests must require a nonce.'
+		);
+	}
+
+	/**
+	 * @testdox Should skip the nonce for update requests that are not cookie authenticated.
+	 */
+	public function test_update_request_skips_nonce_when_not_cookie_authenticated(): void {
+		$route = $this->make_route( false );
+
+		$this->assertFalse(
+			$route->expose_requires_nonce( new WP_REST_Request( 'POST', '/test' ) ),
+			'Non-cookie-authenticated routes are not a CSRF target and opt out of the nonce.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Store API cart routes force a CSRF nonce whenever a request is cookie-authenticated. Routes that authenticate by other means (e.g. an application password or a POS/agentic token) currently have to re-implement the cart-token and update-request handling in `requires_nonce()` just to opt out of the nonce.

This adds a protected `is_cookie_authenticated()` seam to `AbstractCartRoute` and has `requires_nonce()` honour it, so such routes can opt out of the nonce without duplicating that logic. The default is `true`, so existing routes are unchanged, and the two agentic routes that already opted out are migrated to the seam.

This is one of the first, self-contained steps toward supporting the Store API for Point of Sale; it is intentionally scoped to the extensibility seam and carries no POS-specific behaviour on its own.

**Backward compatibility:** `AbstractCartRoute` is an externally-extended base class. This change only *adds* a protected method with a safe default (`true`) and does not alter any existing method signature, so existing subclasses are unaffected.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

_No UI changes._

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run the new unit tests: `pnpm test:php:env -- --filter AbstractCartRouteTest`.
2. Confirm existing Store API behaviour is unchanged: a cookie-authenticated `POST` to a cart route (e.g. `wc/store/v1/cart/add-item`) without a valid nonce should still be rejected.
3. Confirm a route overriding `is_cookie_authenticated()` to return `false` no longer requires the nonce while still honouring cart-token / update-request handling.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Added `AbstractCartRouteTest` covering `requires_nonce()` with the seam defaulting to `true` (nonce still required) and returning `false` (nonce skipped). Tests pass locally under the wp-env PHPUnit environment.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
