### PR TITLE
Store API: add payment-deferral filters for trusted-actor checkout

### DIFF
--- a/plugins/woocommerce/changelog/66147-add-store-api-payment-deferral-filters
+++ b/plugins/woocommerce/changelog/66147-add-store-api-payment-deferral-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Select if this PR needs a generated summary for release notes:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice. - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions. - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  An AI will analyze your PR and post a draft comment for you to review and edit.
+

--- a/plugins/woocommerce/changelog/66147-add-store-api-payment-deferral-filters
+++ b/plugins/woocommerce/changelog/66147-add-store-api-payment-deferral-filters
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Select if this PR needs a generated summary for release notes:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice. - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions. - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  An AI will analyze your PR and post a draft comment for you to review and edit.
-

--- a/plugins/woocommerce/changelog/add-store-api-payment-deferral-filters
+++ b/plugins/woocommerce/changelog/add-store-api-payment-deferral-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Store API: add `woocommerce_store_api_checkout_require_payment_method` and `woocommerce_store_api_order_default_payment_method` filters so trusted-actor checkout clients can defer payment selection past order creation. Both default to current web behaviour.

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -184,7 +184,21 @@ trait CheckoutTrait {
 			$order->set_payment_method_title( $payment_method->title );
 		} else {
 			$order_needs_payment = $order->needs_payment();
-			if ( $order_needs_payment && 'POST' === $request->get_method() ) {
+
+			/**
+			 * Filters whether a payment method is required for a POST /checkout request that creates an order needing payment.
+			 *
+			 * Defaults to true. Trusted-actor callers that defer payment selection past order creation can return false; the
+			 * order then stays pending until a later flow supplies the payment method.
+			 *
+			 * @since 11.0.0
+			 *
+			 * @param bool             $require Whether a payment method is required. Default true.
+			 * @param \WP_REST_Request $request The current REST request.
+			 * @param \WC_Order        $order   The order being checked out.
+			 */
+			$require_payment_method = (bool) apply_filters( 'woocommerce_store_api_checkout_require_payment_method', true, $request, $order );
+			if ( $require_payment_method && $order_needs_payment && 'POST' === $request->get_method() ) {
 				throw new RouteException(
 					'woocommerce_rest_checkout_missing_payment_method',
 					esc_html__( 'No payment method provided.', 'woocommerce' ),

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -87,7 +87,19 @@ class OrderController {
 		$order->set_customer_id( get_current_user_id() );
 		$order->set_customer_ip_address( \WC_Geolocation::get_ip_address() );
 		$order->set_customer_user_agent( wc_get_user_agent() );
-		$order->set_payment_method( PaymentUtils::get_default_payment_method() );
+		/**
+		 * Filters the default payment method stamped onto a draft order built from the cart.
+		 *
+		 * The default ({@see PaymentUtils::get_default_payment_method()}) returns the first enabled gateway, which fits web
+		 * checkout. Trusted-actor callers that defer payment selection past order creation can return an empty string.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param string    $payment_method The default payment method id. Defaults to the first enabled gateway.
+		 * @param \WC_Order $order          Order object being updated.
+		 */
+		$payment_method = (string) apply_filters( 'woocommerce_store_api_order_default_payment_method', PaymentUtils::get_default_payment_method(), $order );
+		$order->set_payment_method( $payment_method );
 		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( wc()->cart->get_customer()->get_is_vat_exempt() ) );
 		$order->calculate_totals();
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -239,23 +239,25 @@ class Checkout extends MockeryTestCase {
 		add_filter( 'woocommerce_store_api_checkout_require_payment_method', '__return_false' );
 		add_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
 
-		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$request->set_body_params(
-			array(
-				'billing_address'  => (object) $this->get_test_address( true ),
-				'shipping_address' => (object) $this->get_test_address(),
-			)
-		);
+		try {
+			$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+			$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+			$request->set_body_params(
+				array(
+					'billing_address'  => (object) $this->get_test_address( true ),
+					'shipping_address' => (object) $this->get_test_address(),
+				)
+			);
 
-		$response = rest_get_server()->dispatch( $request );
+			$response = rest_get_server()->dispatch( $request );
 
-		remove_filter( 'woocommerce_store_api_checkout_require_payment_method', '__return_false' );
-		remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
-
-		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
-		$order = wc_get_order( $response->get_data()['order_id'] );
-		$this->assertSame( '', $order->get_payment_method(), 'Order should be created without a payment method.' );
+			$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+			$order = wc_get_order( $response->get_data()['order_id'] );
+			$this->assertSame( '', $order->get_payment_method(), 'Order should be created without a payment method.' );
+		} finally {
+			remove_filter( 'woocommerce_store_api_checkout_require_payment_method', '__return_false' );
+			remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -214,6 +214,78 @@ class Checkout extends MockeryTestCase {
 	}
 
 	/**
+	 * Ensure that a missing payment method is rejected by default on a POST that needs payment.
+	 */
+	public function test_post_data_requires_payment_method_by_default() {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) $this->get_test_address( true ),
+				'shipping_address' => (object) $this->get_test_address(),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status(), print_r( $response->get_data(), true ) );
+		$this->assertEquals( 'woocommerce_rest_checkout_missing_payment_method', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Ensure the payment method requirement can be waived so an order is created pending.
+	 */
+	public function test_post_data_allows_missing_payment_method_when_requirement_waived() {
+		add_filter( 'woocommerce_store_api_checkout_require_payment_method', '__return_false' );
+		add_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) $this->get_test_address( true ),
+				'shipping_address' => (object) $this->get_test_address(),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'woocommerce_store_api_checkout_require_payment_method', '__return_false' );
+		remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+		$order = wc_get_order( $response->get_data()['order_id'] );
+		$this->assertSame( '', $order->get_payment_method(), 'Order should be created without a payment method.' );
+	}
+
+	/**
+	 * A complete billing/shipping address that passes Store API validation.
+	 *
+	 * @param bool $with_email Whether to include the billing email (only valid on the billing address).
+	 * @return array
+	 */
+	private function get_test_address( bool $with_email = false ) {
+		$address = array(
+			'first_name' => 'test',
+			'last_name'  => 'test',
+			'company'    => '',
+			'address_1'  => 'test',
+			'address_2'  => '',
+			'city'       => 'test',
+			'state'      => '',
+			'postcode'   => 'cb241ab',
+			'country'    => 'GB',
+			'phone'      => '01234567890',
+		);
+
+		if ( $with_email ) {
+			$address['email'] = 'testaccount@test.com';
+		}
+
+		return $address;
+	}
+
+	/**
 	 * Ensure that orders can be placed with virtual products.
 	 */
 	public function test_virtual_product_post_data() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -8,6 +8,7 @@ use WC_Helper_Product;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\StoreApi\Utilities\PaymentUtils;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -324,6 +325,46 @@ class OrderControllerTests extends TestCase {
 		$this->sut->validate_address_fields( $order, 'shipping', $errors );
 		$this->assertEmpty( $errors->get_error_messages() );
 		remove_filter( 'woocommerce_get_country_locale', $hide_postcode );
+	}
+
+	/**
+	 * @testdox create_order_from_cart() stamps the default payment method on the draft order.
+	 */
+	public function test_create_order_from_cart_uses_default_payment_method(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		$order = $this->sut->create_order_from_cart();
+		WC()->cart->empty_cart();
+
+		$this->assertSame(
+			PaymentUtils::get_default_payment_method(),
+			$order->get_payment_method(),
+			'The draft order should default to the first enabled gateway.'
+		);
+	}
+
+	/**
+	 * @testdox The draft order default payment method can be filtered to an empty string.
+	 */
+	public function test_create_order_from_cart_default_payment_method_is_filterable(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		add_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+
+		$order = $this->sut->create_order_from_cart();
+
+		remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+		WC()->cart->empty_cart();
+
+		$this->assertSame(
+			'',
+			$order->get_payment_method(),
+			'A trusted-actor caller should be able to defer the payment method by filtering it to empty.'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -355,10 +355,12 @@ class OrderControllerTests extends TestCase {
 
 		add_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
 
-		$order = $this->sut->create_order_from_cart();
-
-		remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
-		WC()->cart->empty_cart();
+		try {
+			$order = $this->sut->create_order_from_cart();
+		} finally {
+			remove_filter( 'woocommerce_store_api_order_default_payment_method', '__return_empty_string' );
+			WC()->cart->empty_cart();
+		}
 
 		$this->assertSame(
 			'',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

First step of a small stacked series adding the Store API seams needed for Point-of-Sale checkout (chain at the bottom).

Store API checkout is built around the web flow: the shopper picks a payment method, then a single place-order POST creates and pays for the order. The route therefore rejects requests without a payment method, and new draft orders get a default gateway stamped on them.

A trusted client like POS works the other way around: it creates the order first and settles payment out-of-band (card reader, cash) against the order id. For that flow the order should start out pending, with no payment method at all.

This adds two opt-out filters, both defaulting to the current behaviour:

-   `woocommerce_store_api_checkout_require_payment_method` (`CheckoutTrait`) — waives the "no payment method provided" check so a POST can create a pending order without one. With no method set, `process_payment` matches no gateway and no-ops.
-   `woocommerce_store_api_order_default_payment_method` (`OrderController`) — allows clearing the default gateway stamped at order creation, so the order reflects "no method chosen yet" instead of a bogus default.

No signatures change; existing callers are unaffected unless they opt in.

### How to test the changes in this Pull Request:

Covered by the unit tests on CI.

### Testing that has already taken place:

Added tests in the checkout route suite and `OrderControllerTests` covering the defaults and the overridden behaviour; passing locally in wp-env.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry is committed to the branch (`plugins/woocommerce/changelog/add-store-api-payment-deferral-filters`), so auto-generation is not needed.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

---

Stacked series (review/merge in order; each PR is based on the previous branch):

1. → this PR — payment-deferral filters
2. #66189 — input-validation relaxation filters
3. #66190 — checkout place-order pipeline extraction

More POS steps to follow. Base branch: `trunk`.
