### PR TITLE
Reject Store API checkout when the cart changed during the request

### DIFF
--- a/plugins/woocommerce/changelog/52663-fix-checkout-cart-hash-validation
+++ b/plugins/woocommerce/changelog/52663-fix-checkout-cart-hash-validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Store API: reject the checkout POST with a 409 when the cart changed server-side (price, quantity, coupon, shipping or totals) since the customer last saw it, so orders aren't placed with unexpected totals.

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-cart-hash.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-cart-hash.js
@@ -53,10 +53,16 @@ const appendCartHashHeader = ( request ) => {
 	if ( ! currentCartHash ) {
 		return request;
 	}
-	request.headers = {
-		...( request.headers || {} ),
-		'Cart-Hash': currentCartHash,
-	};
+	// Preserve the original headers type so existing headers (e.g. the nonce) are
+	// not dropped when it is a Headers instance rather than a plain object.
+	if ( request.headers instanceof Headers ) {
+		request.headers.set( 'Cart-Hash', currentCartHash );
+	} else {
+		request.headers = {
+			...( request.headers || {} ),
+			'Cart-Hash': currentCartHash,
+		};
+	}
 	return request;
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-cart-hash.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-cart-hash.js
@@ -3,6 +3,11 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
+import { isStoreApiRequest } from './store-api-nonce';
+
 // Stores the current hash for the middleware.
 let currentCartHash = window.localStorage.getItem( 'storeApiCartHash' );
 
@@ -36,4 +41,38 @@ const setCartHash = ( headers ) => {
 	}
 };
 
+/**
+ * Appends the last-seen cart hash to a request so the server can detect if the
+ * cart changed server-side (e.g. price, quantity, coupon or shipping) since the
+ * customer last saw it. The checkout POST rejects the order on a mismatch.
+ *
+ * @param {Object} request Fetch options.
+ * @return {Object} The request with the Cart-Hash header appended.
+ */
+const appendCartHashHeader = ( request ) => {
+	if ( ! currentCartHash ) {
+		return request;
+	}
+	request.headers = {
+		...( request.headers || {} ),
+		'Cart-Hash': currentCartHash,
+	};
+	return request;
+};
+
+/**
+ * Middleware which appends the current cart hash to store API requests.
+ *
+ * @param {Object}   options Fetch options.
+ * @param {Function} next    The next middleware or fetchHandler to call.
+ * @return {*} The evaluated result of the remaining middleware chain.
+ */
+const storeCartHashMiddleware = ( options, next ) => {
+	if ( isStoreApiRequest( options ) ) {
+		options = appendCartHashHeader( options );
+	}
+	return next( options, next );
+};
+
+apiFetch.use( storeCartHashMiddleware );
 apiFetch.setCartHash = setCartHash;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -562,6 +562,15 @@ class Checkout extends AbstractCartRoute {
 		$this->cart_controller->validate_cart();
 
 		/**
+		 * Reject the order if the cart changed server-side since the customer last saw it
+		 * (e.g. a product price, quantity, coupon or shipping cost changed during checkout),
+		 * so they aren't charged unexpected totals.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/issues/52663
+		 */
+		$this->validate_cart_hash_matches_request( $request );
+
+		/**
 		 * Persist customer session data from the request first so that OrderController::update_addresses_from_cart
 		 * uses the up-to-date customer address.
 		 */
@@ -1043,6 +1052,37 @@ class Checkout extends AbstractCartRoute {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Reject the request if the cart hash the client last saw no longer matches the server's
+	 * current cart hash. This catches server-side changes (product price/quantity, coupons,
+	 * shipping costs, taxes — all folded into the cart total the hash is built from) that
+	 * happened while the customer was checking out, so the order isn't placed with totals the
+	 * customer never agreed to.
+	 *
+	 * The check is skipped when the client sends no hash (e.g. third-party Store API clients),
+	 * preserving backward compatibility.
+	 *
+	 * @phpstan-param \WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @throws RouteException When the client's cart hash differs from the server's.
+	 */
+	private function validate_cart_hash_matches_request( \WP_REST_Request $request ): void {
+		$client_cart_hash = $request->get_header( 'Cart-Hash' );
+
+		if ( empty( $client_cart_hash ) ) {
+			return;
+		}
+
+		if ( ! hash_equals( WC()->cart->get_cart_hash(), $client_cart_hash ) ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_cart_changed',
+				esc_html__( 'The items or totals in your cart changed while placing your order. Please review your cart and try again.', 'woocommerce' ),
+				409
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -507,8 +507,11 @@ class Checkout extends \WP_Test_REST_TestCase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 409, $response->get_status(), print_r( $response->get_data(), true ) );
-		$this->assertEquals( 'woocommerce_rest_checkout_cart_changed', $response->get_data()['code'] );
+		$data     = $response->get_data();
+		$this->assertEquals( 409, $response->get_status(), print_r( $data, true ) );
+		$this->assertEquals( 'woocommerce_rest_checkout_cart_changed', $data['code'] );
+		// The 409 returns the fresh cart so the client can refresh the displayed totals.
+		$this->assertArrayHasKey( 'cart', $data['data'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -426,6 +426,92 @@ class Checkout extends \WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Ensure the order is placed when the client's cart hash still matches the server's.
+	 */
+	public function test_matching_cart_hash_post_data() {
+		WC()->cart->calculate_totals();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Cart-Hash', WC()->cart->get_cart_hash() );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+					'email'      => 'testaccount@test.com',
+				),
+				'shipping_address' => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+				),
+				'payment_method'   => WC_Gateway_BACS::ID,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+	}
+
+	/**
+	 * Ensure the order is rejected when the cart hash the client last saw no longer matches the
+	 * server's, e.g. a price, quantity or total changed server-side during checkout. See #52663.
+	 */
+	public function test_stale_cart_hash_post_data() {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Cart-Hash', 'stale-hash-that-no-longer-matches' );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+					'email'      => 'testaccount@test.com',
+				),
+				'shipping_address' => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+				),
+				'payment_method'   => WC_Gateway_BACS::ID,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 409, $response->get_status(), print_r( $response->get_data(), true ) );
+		$this->assertEquals( 'woocommerce_rest_checkout_cart_changed', $response->get_data()['code'] );
+	}
+
+	/**
 	 * Ensure that orders can be placed with virtual products.
 	 */
 	public function test_virtual_product_post_data() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Currently, if a product price, quantity, coupon, shipping cost or tax changes on the server while a customer is checking out, the order can go through with totals the customer never saw or agreed to (e.g. they saw $100, get charged $105).

This PR makes the Store API checkout **reject the order when the cart changed server-side during the request**:

- The block checkout client now sends the cart hash it last saw back to the server as a `Cart-Hash` request header (mirroring how the nonce is sent). The hash is `md5(cart_contents . cart_total)`, so it captures line items, quantities, coupons, shipping and taxes (all folded into the total).
- On the checkout `POST`, after totals are recalculated, the route compares the client's `Cart-Hash` against the server's current cart hash. On a mismatch it throws a `409` (`woocommerce_rest_checkout_cart_changed`), which already returns the fresh cart so the block checkout refreshes the displayed totals and surfaces the error, letting the customer review and try again.
- The check is **skipped when no hash is sent**, so third-party Store API clients that don't send the header keep working unchanged (backward compatible). Validation runs on `POST /checkout` only, not on other requests.

Closes #52663.

### Backward compatibility

No public method signatures change. A new optional request header (`Cart-Hash`) is read on `POST /checkout`; clients that omit it are unaffected. The new `409` response reuses the existing conflict-response shape (cart included in the error data), which the block checkout already handles.

### How to test the changes in this Pull Request:

1. Add a product to the cart and go to the block checkout. Note the order total.
2. In a separate admin tab (or via WP-CLI), change that product's price (or reduce its stock below the cart quantity, or add/expire a coupon) so the cart total would change.
3. Fill in the checkout form and click **Place order**.
4. **Expected:** the order is *not* placed. The checkout shows an error ("The items or totals in your cart changed while placing your order. Please review your cart and try again.") and the totals refresh to the new server values. Placing the order again succeeds at the new total.
5. Without changing anything server-side, place an order normally — **Expected:** it goes through as before.
6. Via a direct Store API `POST /wc/store/v1/checkout` request with **no** `Cart-Hash` header — **Expected:** the order is placed (backward compatible).

### Testing that has already taken place:

- New PHPUnit coverage in `tests/php/src/Blocks/StoreApi/Routes/Checkout.php`:
  - `test_matching_cart_hash_post_data` — order is placed (`200`) when the client hash matches the server.
  - `test_stale_cart_hash_post_data` — order is rejected (`409`, `woocommerce_rest_checkout_cart_changed`) when the client hash is stale.
  - Both pass locally against wp-env.
- `phpcs` (changed + branch) and PHPStan clean on the changed files; ESLint clean on the changed JS.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request includes a changelog entry (added manually at `plugins/woocommerce/changelog/52663-fix-checkout-cart-hash-validation`).
