### PR TITLE
Add build date to nightly release notes

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
     steps:
       - name: 'Update nightly tag commit ref'
+        id: tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +39,8 @@ jobs:
               ref: `tags/${ targetRef }`,
               sha: branchData.data.commit.sha,
             });
+
+            core.setOutput('sha', branchData.data.commit.sha);
 
       - name: 'Checkout ref'
         uses: 'actions/checkout@v4'
@@ -63,3 +66,26 @@ jobs:
           asset_name: woocommerce-${{ env.SOURCE_REF }}-nightly.zip
           asset_content_type: application/zip
           max_releases: 1
+
+      - name: 'Update nightly release notes'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sha = '${{ steps.tag.outputs.sha }}';
+            const shortSha = sha.slice(0, 7);
+            const sourceRef = process.env.SOURCE_REF;
+            const builtAt = new Date().toISOString().replace('T', ' ').replace(/\..+/, ' UTC');
+            const body = [
+              `Nightly build, regenerated every night from the latest \`${ sourceRef }\`.`,
+              '',
+              `- Published: ${ builtAt }`,
+              `- Commit: ${ context.repo.owner }/${ context.repo.repo }@${ sha } (\`${ shortSha }\`)`,
+            ].join('\n');
+
+            await github.rest.repos.updateRelease({
+              ...context.repo,
+              release_id: Number(process.env.RELEASE_ID),
+              body,
+              target_commitish: sourceRef,
+            });

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -77,10 +77,9 @@ jobs:
             const sourceRef = process.env.SOURCE_REF;
             const builtAt = new Date().toISOString().replace('T', ' ').replace(/\..+/, ' UTC');
             const body = [
-              `Nightly build, regenerated every night from the latest \`${ sourceRef }\`.`,
+              `Nightly build, regenerated every night from \`${ sourceRef }\`.`,
               '',
-              `- Published: ${ builtAt }`,
-              `- Commit: ${ context.repo.owner }/${ context.repo.repo }@${ sha } (\`${ shortSha }\`)`,
+              `Last update: **${ builtAt }**`,
             ].join('\n');
 
             await github.rest.repos.updateRelease({

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -22,7 +22,6 @@ jobs:
       contents: write
     steps:
       - name: 'Update nightly tag commit ref'
-        id: tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,8 +38,6 @@ jobs:
               ref: `tags/${ targetRef }`,
               sha: branchData.data.commit.sha,
             });
-
-            core.setOutput('sha', branchData.data.commit.sha);
 
       - name: 'Checkout ref'
         uses: 'actions/checkout@v4'
@@ -72,8 +69,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const sha = '${{ steps.tag.outputs.sha }}';
-            const shortSha = sha.slice(0, 7);
             const sourceRef = process.env.SOURCE_REF;
             const builtAt = new Date().toISOString().replace('T', ' ').replace(/\..+/, ' UTC');
             const body = [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The GitHub `nightly` pre-release shows a frozen 2020 date and a generic description with no commit or date reference. The automation only moves the tag and re-uploads the zip without touching release metadata.
I believe this is correct as re-publishing or creating a new release will trigger notifications for anyone watching the repo every single day, but I do think we can at least add some information (timestamp, branch information) to the description so it's clear the nightly corresponds to a particular date, which is what this PR does.

|Before|After|
|-----|-----|
|<img width="1288" height="249" alt="Screenshot 2026-07-01 at 12 11 47" src="https://github.com/user-attachments/assets/cdd18aca-d669-4d91-a34f-5dc162e19134" />|<img width="1291" height="291" alt="Screenshot 2026-07-01 at 12 11 28" src="https://github.com/user-attachments/assets/a4bcfc07-65a9-45e3-a29b-7938781e6699" />|

Closes #58027.

### How to test the changes in this Pull Request:

Testing is possible in a fork or directly in this repo by going to **Actions > Nightly builds**, clicking **Run workflow** and choosing the appropriate branch in the **Use workflow from** selector before submitting the form.

The drawback is that it'll immediately update the nightly release with the new build, which might be ok.

A [test run](https://github.com/jorgeatorres/woocommerce/actions/runs/28512906543) in my fork could serve as verification. It produced [this nightly release](https://github.com/jorgeatorres/woocommerce/releases/tag/nightly) update.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal release tooling (GitHub Actions nightly-builds workflow).
</details>