### PR TITLE
Fix db update callback version test failing on release branches

### DIFF
--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -319,10 +319,16 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 			'WC_Install::$db_update_callbacks must be sorted by version.',
 		);
 
-		// Greatest version can't be ahead of current stable (except, possibly, for its suffix).
+		// Unreleased builds (-dev/-rc) can't go past the version being developed. Clean versions also
+		// allow the next patch, since a release branch collects it before shipping.
+		$stable  = WC()->stable_version();
+		$ceiling = WC()->version === $stable
+			? preg_replace_callback( '/\d+$/', fn( $m ) => $m[0] + 1, $stable )
+			: $stable;
+
 		$this->assertTrue(
-			empty( $versions ) || version_compare( preg_replace( '/-.*$/', '', end( $versions ) ), WC()->stable_version(), '<=' ),
-			'WC_Install::$db_update_callbacks must not contain versions that are ahead of current stable (except, possibly, for suffix).',
+			empty( $versions ) || version_compare( preg_replace( '/-.*$/', '', end( $versions ) ), $ceiling, '<=' ),
+			'WC_Install::$db_update_callbacks must not contain versions ahead of this branch.',
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Install_Test::test_db_update_callbacks_versions` capped the greatest db update callback key at the current stable version, so on a resting release branch (e.g. `10.0.0` collecting a `10.0.1` backport) it failed even though the key was correct. The test can't tell from the version string alone whether a clean version has shipped, so it now allows the next patch on clean versions while staying strict on unreleased `-dev`/`-rc` builds; the exact next-patch validation already happens at release build time.

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm test:php:env -- --filter test_db_update_callbacks_versions`; confirm it passes on trunk (a `-dev` build).
2. Simulate an unreleased build: keep `$version` as `X.Y.Z-dev`, add a callback key of `X.Y.(Z+1)` to `WC_Install::$db_updates`, and confirm the test now fails (nothing may exceed the version being developed).
3. Simulate a resting release branch: set `$version` in `plugins/woocommerce/includes/class-woocommerce.php` to a clean `X.Y.Z` (no suffix). Add a callback key of `X.Y.(Z+1)` and confirm the test passes (next patch allowed); change it to `X.Y.(Z+2)` and confirm it fails (jumps beyond the next patch are rejected).
4. Revert the temporary version and callback edits.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Test-only change, not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)