### PR TITLE
Warn when an order status key is too long to store

### DIFF
--- a/plugins/woocommerce/changelog/54584-fix-order-status-key-length
+++ b/plugins/woocommerce/changelog/54584-fix-order-status-key-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Warn when an order status key is too long and can't be stored.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -378,6 +378,18 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			$post_status = 'wc-' . $post_status;
 		}
 
+		// The status column holds at most 20 characters, so a longer key can't be stored.
+		if ( strlen( $post_status ) > 20 ) {
+			wc_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					'Order status "%s" is longer than the storage limit of 20 characters and cannot be stored.',
+					esc_html( $order_status )
+				),
+				'11.0.0'
+			);
+		}
+
 		return $post_status;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -18,9 +18,22 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	use CogsAwareUnitTestSuiteTrait;
 
 	/**
+	 * Post statuses registered during a test, to clean up on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $registered_order_statuses = array();
+
+	/**
 	 * Runs after each test.
 	 */
 	public function tearDown(): void {
+		// register_post_status() mutates the global registry, which WP_UnitTestCase does not restore.
+		foreach ( $this->registered_order_statuses as $status ) {
+			unset( $GLOBALS['wp_post_statuses'][ $status ] );
+		}
+		$this->registered_order_statuses = array();
+
 		parent::tearDown();
 		$this->disable_cogs_feature();
 	}
@@ -994,5 +1007,57 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		} finally {
 			remove_filter( 'woocommerce_order_type_to_group', $adjust );
 		}
+	}
+
+	/**
+	 * Register a custom order status so it survives set_status() and is prefixed on save.
+	 *
+	 * Registers it in the valid order statuses (so set_status keeps it) and as a post status
+	 * (so get_post_status adds the wc- prefix, which is what pushes it over the column limit).
+	 *
+	 * @param string $status Unprefixed order status key.
+	 */
+	private function register_custom_order_status( string $status ): void {
+		$prefixed = 'wc-' . $status;
+
+		add_filter(
+			'wc_order_statuses',
+			function ( $statuses ) use ( $prefixed ) {
+				$statuses[ $prefixed ] = 'Custom status for testing';
+				return $statuses;
+			}
+		);
+		register_post_status( $prefixed );
+		$this->registered_order_statuses[] = $prefixed;
+	}
+
+	/**
+	 * @testdox Should warn when an order is saved with a status that exceeds the storage limit.
+	 */
+	public function test_saving_an_order_with_a_too_long_status_warns() {
+		$this->setExpectedIncorrectUsage( 'Abstract_WC_Order_Data_Store_CPT::get_post_status' );
+
+		// 'wc-' + 18 characters = 21, one over the 20-character storage limit.
+		$status = str_repeat( 'a', 18 );
+		$this->register_custom_order_status( $status );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( $status );
+		$order->save();
+	}
+
+	/**
+	 * @testdox Should not warn when an order is saved with a status at the storage limit.
+	 */
+	public function test_saving_an_order_with_a_status_at_the_limit_does_not_warn() {
+		// 'wc-' + 17 characters = 20, exactly the storage limit.
+		$status = str_repeat( 'a', 17 );
+		$this->register_custom_order_status( $status );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( $status );
+		$order->save();
+
+		$this->assertSame( $status, wc_get_order( $order->get_id() )->get_status() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Order status (`post_status` in CPT, `wc_orders.status` in HPOS) is stored in a `varchar(20)` column, so a custom status key longer than 20 characters including the `wc-` prefix can't be properly stored.

Under HPOS, this makes the order disappear from admin lists, **My Account**, etc.

This PR adds a `wc_doing_it_wrong()` notice when an order is saved with a too-long status so developers catch it instead of losing orders silently.

> [!NOTE]
> Depending on the order datastore, behavior is different: under HPOS, orders are saved but MySQL silently truncates the long status; while under CPT, orders are not saved at all because `$wpdb` rejects the insert.
> I believe parity would be ideal, but the behavior is a side effect of using `$wpdb` and not a conscious decision or limit on WooCommerce's side, which is why I opted for adding a warning first before we need to make more heavy changes.
> In any case, a scan in the marketplace revealed no extension registering a status longer than 20 characters, so adding new behavior seems unnecessary to address an scenario that might only exist in custom code, and even then, the warning should flag it clearly.

Closes #54584.

<details>
<summary>Notes on implementation and alternatives considered</summary>

- Truncating a status ourselves at registration time doesn't fix anything and would produce the same value the database already stores. In order to make truncation work we would need to canonicalize the status among all known ones everywhere (registration, `wc_order_statuses` filter, queries, database, etc.) which isn't feasible and will break anyways as any code registering the long status name will be expecting to use it in checks, etc.
- Rejecting a long status is a behavior change with its own problems: doesn't help orders already assigned to it and will silently coerce all orders with that status to "pending" on the API side, while the order remains with a truncated status in the database.
- Extending the status column char limit doesn't help unless WP does it as well for `wp_posts`, so outside of scope.
</details>


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable HPOS in **WooCommerce > Settings > Advanced > Features**.
1. With `WP_DEBUG` on, register a custom order status whose key exceeds 20 characters including the `wc-` prefix, e.g. add this snippet to a plugin or your theme's `functions.php`:
   ```php
   add_action(
	   'init',
	   function () {
		   register_post_status(
			   'wc-my-very-long-status-key',
			   array(
				   'label'                     => 'Too long',
				   'public'                    => false,
				   'show_in_admin_all_list'    => true,
				   'show_in_admin_status_list' => true,
			   )
		   );
	   }
   );
   
   add_filter(
	   'wc_order_statuses',
	   function ( $statuses ) {
		   $statuses['wc-my-very-long-status-key'] = 'Too long';
		   return $statuses;
	   }
   );
   ```
1. Create an order, assign it the custom status, and save. Confirm a `_doing_it_wrong` notice fires when the order is saved (from `Abstract_WC_Order_Data_Store_CPT::get_post_status`).
1. Open a new tab with **WooCommerce > Orders** and confirm the order is not listed anymore (given its status doesn't match any known one). This is expected: the notices are meant to surface the cause, not change existing behavior.
1. Assign the order to a known regular status and confirm it is listed again in admin lists.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.