### PR TITLE
Fix wc_cleanup_logs() only deleting 20 expired log files per run

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6928-cleanup-logs-more-than-20
+++ b/plugins/woocommerce/changelog/wooplug-6928-cleanup-logs-more-than-20
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_cleanup_logs() deleting at most 20 expired log files per run, so all expired files past the retention period are now removed.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -193,7 +193,7 @@ class FileController {
 	 *     @type int    $offset      Omit this number of files from the beginning of the list. Works with $per_page to do pagination.
 	 *     @type string $order       The sort direction. 'asc' or 'desc'. Defaults to 'desc'.
 	 *     @type string $orderby     The property to sort the list by. 'created', 'modified', 'source', 'size'. Defaults to 'modified'.
-	 *     @type int    $per_page    The number of files to include in the list. Works with $offset to do pagination.
+	 *     @type int    $per_page    The number of files to include in the list. Works with $offset to do pagination. Use -1 to include all files.
 	 *     @type string $source      Only include files from this source.
 	 * }
 	 * @param bool  $count_only Optional. True to return a total count of the files.
@@ -308,7 +308,11 @@ class FileController {
 
 		usort( $files, $sort_callback );
 
-		return array_slice( $files, $args['offset'], $args['per_page'] );
+		// A negative per_page value (e.g. -1) means "return all files" rather than being passed
+		// through to array_slice, where a negative length would drop files from the end of the list.
+		$length = $args['per_page'] < 0 ? null : $args['per_page'];
+
+		return array_slice( $files, $args['offset'], $length );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -240,6 +240,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				'date_filter' => 'created',
 				'date_start'  => 1,
 				'date_end'    => $timestamp,
+				'per_page'    => -1,
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -243,6 +243,35 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The get_files method should return every file when per_page is -1, ignoring the default page size.
+	 */
+	public function test_get_files_per_page_unlimited(): void {
+		// Create more files than a single default page.
+		$default_per_page = FileController::DEFAULTS_GET_FILES['per_page'];
+		$file_count       = $default_per_page + 5;
+
+		for ( $i = 1; $i <= $file_count; $i++ ) {
+			$this->handler->handle( time(), 'debug', 'entry', array( 'source' => 'source' . $i ) );
+		}
+
+		$default_page = $this->sut->get_files();
+		$this->assertCount( $default_per_page, $default_page, 'The default per_page value should cap the result.' );
+
+		$all_files = $this->sut->get_files( array( 'per_page' => -1 ) );
+		$this->assertCount( $file_count, $all_files, 'A per_page of -1 should return every file.' );
+
+		// Offset must still apply when per_page is unlimited.
+		$offset     = 5;
+		$offset_all = $this->sut->get_files(
+			array(
+				'per_page' => -1,
+				'offset'   => $offset,
+			)
+		);
+		$this->assertCount( $file_count - $offset, $offset_all, 'A per_page of -1 should still honor the offset.' );
+	}
+
+	/**
 	 * @testdox The get_files_by_id method should return an array of File instances given an array of valid file IDs.
 	 */
 	public function test_get_files_by_id() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\{ LogHandlerFileV2, Settings };
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ File, FileController };
 use WC_Unit_Test_Case;
 
 /**
@@ -376,6 +376,37 @@ MESSAGE;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$actual_content  = file_get_contents( reset( $paths ) );
 		$expected_string = '4 expired log files were deleted.';
+		$this->assertStringContainsString( $expected_string, $actual_content );
+	}
+
+	/**
+	 * @testdox Check that delete_logs_before_timestamp deletes more than one page of expired files.
+	 */
+	public function test_delete_logs_before_timestamp_deletes_more_than_one_page(): void {
+		// Create more files than a single default page.
+		$past_time  = strtotime( '-5 days' );
+		$file_count = FileController::DEFAULTS_GET_FILES['per_page'] + 5;
+
+		for ( $i = 1; $i <= $file_count; $i++ ) {
+			$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source' . $i ) );
+		}
+
+		$paths = glob( Settings::get_log_directory() . '*.log' );
+		$this->assertCount( $file_count, $paths );
+
+		$result = $this->sut->delete_logs_before_timestamp( strtotime( '-3 days' ) );
+		$this->assertEquals( $file_count, $result );
+
+		// Only the summary log created by the deletion should remain.
+		$paths = glob( Settings::get_log_directory() . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		$paths = glob( Settings::get_log_directory() . 'wc_logger*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content  = file_get_contents( reset( $paths ) );
+		$expected_string = sprintf( '%d expired log files were deleted.', $file_count );
 		$this->assertStringContainsString( $expected_string, $actual_content );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`wc_cleanup_logs()` (the daily `woocommerce_cleanup_logs` scheduled action) is meant to delete every log file older than the retention period, but it silently stopped after 20 files. The cause is `FileController::get_files()`: it defaults `per_page` to `20` and ends with `array_slice( $files, $offset, $per_page )`, so `LogHandlerFileV2::delete_logs_before_timestamp()` — which calls `get_files()` without a `per_page` — only ever received (and deleted) the first 20 expired files. On stores that generate more than 20 expired files between runs, the backlog grows indefinitely.

This teaches `get_files()` the standard WordPress `per_page => -1` "return everything" convention (a negative `per_page` maps to a `null` `array_slice` length, rather than being passed through as a negative length that would drop files from the *end* of the list) and passes `per_page => -1` from `delete_logs_before_timestamp()`. The source-scoped `clear()` path is intentionally left unchanged: it selects files with a prefix glob (`{source}*.log`) and no exact-source filter, so lifting its cap would amplify a separate, pre-existing over-deletion issue; that is out of scope here.

Note on scale: `get_files()` already globs, builds a `File` object per path, and sorts the entire log directory regardless of `per_page` (the slice only ever bounded the final delete loop), so this change adds no scanning cost — only cheap `unlink()` calls, each of which commits immediately. A store with a very large accumulated backlog will still converge across the daily cron runs. A dedicated batched/streaming cleanup for pathological-scale log directories would be a reasonable follow-up but is beyond this fix.

Closes #66071.
Fixes WOOPLUG-6928.

(For Bug Fixes) Bug introduced in PR #41802.

### How to test the changes in this Pull Request:

1. Ensure the file logging handler is active (`Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2`).
2. Create more than 20 distinct log files, e.g. `wp eval-file` a script that runs `wc_get_logger()->info( 'hello', array( 'source' => 'hello-logger-' . $letter ) )` for 26 letters `a`..`z`. Confirm ~26 files exist in `wp-content/uploads/wc-logs`.
3. Age them past the retention period, e.g. from the log directory: `for f in hello-logger-*.log; do mv "$f" "${f/-2026-/-2025-}"; done`.
4. Run `wp eval 'wc_cleanup_logs();'`.
5. **Expected:** all 26 expired files are removed and the `wc_logger-….log` summary reports "26 expired log files were deleted." (Before this fix it deleted only 20 and left the rest.)

### Testing that has already taken place:

- Added two PHPUnit regression tests (`FileControllerTest::test_get_files_per_page_unlimited` and `LogHandlerFileV2Test::test_delete_logs_before_timestamp_deletes_more_than_one_page`) that create more files than the default page size and assert all are returned/deleted. Verified they **fail** against the unfixed code and **pass** with the fix.
- Full class runs green in wp-env: `OK (35 tests, 126 assertions)`.
- `phpcs` clean on the changed lines; `phpstan` reports no errors on the modified source files.
- Reviewed via a multi-persona code review plus an independent Codex adversarial pass; findings were addressed (scoped out the `clear()` change, hardened the tests).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually (`plugins/woocommerce/changelog/wooplug-6928-cleanup-logs-more-than-20`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)