### PR TITLE
Warn when additional checkout fields are registered too early

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -199,7 +199,11 @@ There are plans to expand this list, but for now these are the types available.
 
 To register additional checkout fields you must use the `woocommerce_register_additional_checkout_field` function.
 
-It is recommended to run this function after the `woocommerce_init` action.
+:::note
+
+Register fields on the `woocommerce_init` action (or later). Registering earlier can cause initialization and translation issues.
+
+:::
 
 The registration function takes an array of options describing your field. Some field types take additional options.
 

--- a/plugins/woocommerce/changelog/issue-64592-checkout-fields-textdomain-too-early
+++ b/plugins/woocommerce/changelog/issue-64592-checkout-fields-textdomain-too-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Warn when additional checkout fields are registered before the woocommerce_init action, which can load translations too early.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -189,6 +189,11 @@ class CheckoutFields {
 	 * @return WP_Error|void True if the field was registered, a WP_Error otherwise.
 	 */
 	public function register_checkout_field( $options ) {
+		// Warn when fields are registered before `after_setup_theme`. Registering that early can cause problems, such as loading translations before they're ready.
+		if ( ! did_action( 'after_setup_theme' ) && ! doing_action( 'after_setup_theme' ) ) {
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', 'Additional checkout fields should be registered on the woocommerce_init action or later.', '11.0.0' );
+		}
+
 		// Check the options and show warnings if they're not supplied. Return early if an error that would prevent registration is encountered.
 		if ( false === $this->validate_options( $options ) ) {
 			return;

--- a/plugins/woocommerce/tests/e2e/test-plugins/blocks/additional-checkout-fields.php
+++ b/plugins/woocommerce/tests/e2e/test-plugins/blocks/additional-checkout-fields.php
@@ -14,7 +14,7 @@ class Additional_Checkout_Fields_Test_Helper {
 	public function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'enable_custom_checkout_fields' ) );
 		add_action( 'plugins_loaded', array( $this, 'disable_custom_checkout_fields' ) );
-		add_action( 'woocommerce_loaded', array( $this, 'register_custom_checkout_fields' ) );
+		add_action( 'woocommerce_init', array( $this, 'register_custom_checkout_fields' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -188,4 +188,30 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
 		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields );
 	}
+
+	/**
+	 * Registering a field before after_setup_theme warns the developer.
+	 */
+	public function test_registering_before_after_setup_theme_triggers_notice() {
+		$this->setExpectedIncorrectUsage( 'woocommerce_register_additional_checkout_field' );
+
+		$saved_action = $GLOBALS['wp_actions']['after_setup_theme'] ?? null;
+		unset( $GLOBALS['wp_actions']['after_setup_theme'] );
+
+		try {
+			woocommerce_register_additional_checkout_field(
+				array(
+					'id'       => 'test-namespace/early-field',
+					'label'    => 'Early field',
+					'location' => 'contact',
+				)
+			);
+		} finally {
+			if ( null !== $saved_action ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the count cleared above to simulate registering before after_setup_theme.
+				$GLOBALS['wp_actions']['after_setup_theme'] = $saved_action;
+			}
+			__internal_woocommerce_blocks_deregister_checkout_field( 'test-namespace/early-field' );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Registering additional checkout fields before `after_setup_theme` (for example on `woocommerce_blocks_loaded`) can result in their translated labels to be evaluated too early, making WordPress trigger a "translation loading was triggered too early" notice, and possibly resolving translations under the wrong locale.

Given WooCommerce itself adds an optional label to the fields, the warning in the logs seems to imply WooCommerce as the source. This PR adds a `_doing_it_wrong` warning that points developers to register on `woocommerce_init` or later, making it more clear that WC itself didn't produce the notice.

The PR also updates the docs and WooCommerce's own e2e example plugin to follow the guidance of registering on `woocommerce_init`, which was already the suggested approach.

Closes #64592.

### How to test the changes in this Pull Request:

#### Confirm the notice
1. Enable `WP_DEBUG` (and `WP_DEBUG_LOG`) on a site using blocks checkout.
2. Add the following as an mu-plugin (`wp-content/mu-plugins/wrong-hook-field.php`).
    ```php
    <?php
    add_action( 'woocommerce_blocks_loaded', function () {
        woocommerce_register_additional_checkout_field(
            array(
                'id'       => 'my-plugin/how-did-you-hear',
                'label'    => 'How did you hear about us?',
                'location' => 'contact',
            )
        );
    } );
    ```
3. Load any page and confirm a doing it wrong notice appears:
   "Additional checkout fields should be registered on the woocommerce_init action or later."

   You will also see a "Function _load_textdomain_just_in_time was called incorrectly" notice from WP, but the other notice will help pinpoint the problem instead of shifting the blame to WooCommerce silently.
5. Change the hook from `woocommerce_blocks_loaded` to `woocommerce_init`. Confirm all notices are gone and the field still renders in the checkout form.

#### Doc updates
1. Run `npm install && npm run build && npm run serve` from within `docs/_docu-tools/`.
2. Visit `http://localhost:3000/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields/#using-the-api` to see the guidance on using `woocommerce_init`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.