### PR TITLE
Add `WC_Product::is_*viewable()` methods to consolidate product visibility checks

### DIFF
--- a/plugins/woocommerce/changelog/65498-centralize-product-is-viewable
+++ b/plugins/woocommerce/changelog/65498-centralize-product-is-viewable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add WC_Product::is_viewable() and is_publicly_viewable() to centralize product visibility checks.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1714,6 +1714,33 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
+	 * Whether the current user can view this product: it is published, or they can edit it.
+	 * A variation additionally requires its parent to be viewable.
+	 *
+	 * @since 11.0.0
+	 * @return bool
+	 */
+	public function is_viewable() {
+		$parent_id = $this->get_parent_id();
+
+		return ( ProductStatus::PUBLISH === $this->get_status() || current_user_can( 'edit_post', $this->get_id() ) )
+			&& ( ! $parent_id || ProductStatus::PUBLISH === get_post_status( $parent_id ) || current_user_can( 'edit_post', $parent_id ) );
+	}
+
+	/**
+	 * Whether this product is publicly viewable: the product and its parent (if it has one) are published.
+	 *
+	 * @since 11.0.0
+	 * @return bool
+	 */
+	public function is_publicly_viewable() {
+		$parent_id = $this->get_parent_id();
+
+		return ProductStatus::PUBLISH === $this->get_status()
+			&& ( ! $parent_id || ProductStatus::PUBLISH === get_post_status( $parent_id ) );
+	}
+
+	/**
 	 * Returns whether or not the product is visible in the catalog.
 	 *
 	 * @return bool
@@ -1731,18 +1758,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	protected function is_visible_core() {
 		$visible = CatalogVisibility::VISIBLE === $this->get_catalog_visibility() || ( is_search() && CatalogVisibility::SEARCH === $this->get_catalog_visibility() ) || ( ! is_search() && CatalogVisibility::CATALOG === $this->get_catalog_visibility() );
 
-		if ( ProductStatus::TRASH === $this->get_status() ) {
+		if ( ProductStatus::TRASH === $this->get_status() || ! $this->is_viewable() ) {
 			$visible = false;
-		} elseif ( ProductStatus::PUBLISH !== $this->get_status() && ! current_user_can( 'edit_post', $this->get_id() ) ) {
-			$visible = false;
-		}
-
-		if ( $this->get_parent_id() ) {
-			$parent_product = wc_get_product( $this->get_parent_id() );
-
-			if ( $parent_product && ProductStatus::PUBLISH !== $parent_product->get_status() && ! current_user_can( 'edit_post', $parent_product->get_id() ) ) {
-				$visible = false;
-			}
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->is_in_stock() ) {
@@ -1765,7 +1782,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		 * @param bool          $purchasable Whether the product is purchasable.
 		 * @param WC_Product    $product     Product object.
 		 */
-		return apply_filters( 'woocommerce_is_purchasable', $this->exists() && ( ProductStatus::PUBLISH === $this->get_status() || current_user_can( 'edit_post', $this->get_id() ) ) && '' !== $this->get_price(), $this );
+		return apply_filters( 'woocommerce_is_purchasable', $this->exists() && $this->is_viewable() && '' !== $this->get_price(), $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1717,7 +1717,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Whether the current user can view this product: it is published, or they can edit it.
 	 * A variation additionally requires its parent to be viewable.
 	 *
-	 * @since 11.0.0
+	 * @since 11.1.0
 	 * @return bool
 	 */
 	public function is_viewable() {
@@ -1730,7 +1730,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Whether this product is publicly viewable: the product and its parent (if it has one) are published.
 	 *
-	 * @since 11.0.0
+	 * @since 11.1.0
 	 * @return bool
 	 */
 	public function is_publicly_viewable() {

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -618,7 +618,7 @@ class WC_AJAX {
 			wp_die();
 		}
 
-		if ( ProductStatus::PUBLISH !== $variable_product->get_status() && ! current_user_can( 'edit_post', $variable_product->get_id() ) ) {
+		if ( ! $variable_product->is_viewable() ) {
 			wp_die();
 		}
 

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -559,7 +559,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		 * @param bool $purchasable If the variation is purchasable.
 		 * @param object $variation The variation object.
 		 */
-		return apply_filters( 'woocommerce_variation_is_purchasable', $this->variation_is_visible() && parent::is_purchasable() && ( ProductStatus::PUBLISH === $this->parent_data['status'] || current_user_can( 'edit_post', $this->get_parent_id() ) ), $this );
+		return apply_filters( 'woocommerce_variation_is_purchasable', $this->variation_is_visible() && parent::is_purchasable(), $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-shortcodes.php
+++ b/plugins/woocommerce/includes/class-wc-shortcodes.php
@@ -575,13 +575,12 @@ class WC_Shortcodes {
 
 		$single_product = new WP_Query( $args );
 
-		if (
-			! isset( $force_rendering ) &&
-			$single_product->have_posts() &&
-			ProductStatus::PUBLISH !== $single_product->post->post_status &&
-			! current_user_can( 'read_product', $single_product->post->ID )
-		) {
-			return '';
+		if ( ! isset( $force_rendering ) && $single_product->have_posts() ) {
+			$queried_product = wc_get_product( $single_product->post->ID );
+
+			if ( $queried_product && ! $queried_product->is_viewable() ) {
+				return '';
+			}
 		}
 
 		$preselected_id = '0';

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -9,7 +9,6 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
@@ -1740,7 +1739,7 @@ function wc_products_array_filter_visible( $product ) {
  * @return bool
  */
 function wc_products_array_filter_visible_grouped( $product ) {
-	return $product && is_a( $product, 'WC_Product' ) && ( ProductStatus::PUBLISH === $product->get_status() || current_user_can( 'edit_product', $product->get_id() ) );
+	return $product && is_a( $product, 'WC_Product' ) && $product->is_viewable();
 }
 
 /**

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -15187,12 +15187,6 @@ parameters:
 			path: includes/class-wc-shortcodes.php
 
 		-
-			message: '#^Cannot access property \$post_status on WP_Post\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: includes/class-wc-shortcodes.php
-
-		-
 			message: '#^Cannot access property \$post_type on WP_Post\|null\.$#'
 			identifier: property.nonObject
 			count: 1

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProduct.php
@@ -2,7 +2,6 @@
 declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 
 /**
@@ -26,7 +25,7 @@ class FeaturedProduct extends FeaturedItem {
 		$id = absint( $attributes['productId'] ?? 0 );
 
 		$product = wc_get_product( $id );
-		if ( ! $product || ( ProductStatus::PUBLISH !== $product->get_status() && ! current_user_can( 'read_product', $id ) ) ) {
+		if ( ! $product || ! $product->is_viewable() ) {
 			return null;
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -1,7 +1,6 @@
 <?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
-use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\ProductLinksTrait;
 
@@ -83,17 +82,8 @@ class ProductsById extends AbstractRoute {
 	protected function get_route_response( \WP_REST_Request $request ) {
 		$object = wc_get_product( (int) $request['id'] );
 
-		if ( ! $object || 0 === $object->get_id() || ProductStatus::PUBLISH !== $object->get_status() ) {
+		if ( ! $object || 0 === $object->get_id() || ! $object->is_publicly_viewable() ) {
 			throw new RouteException( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), 404 );
-		}
-
-		// A variation's visibility follows its parent product.
-		if ( $object->get_parent_id() ) {
-			$parent = wc_get_product( $object->get_parent_id() );
-
-			if ( ! $parent || ProductStatus::PUBLISH !== $parent->get_status() ) {
-				throw new RouteException( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), 404 ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- REST API JSON response, not HTML.
-			}
 		}
 
 		return $this->prepare_item_for_response( $object, $request );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -1,7 +1,6 @@
 <?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
-use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\ProductLinksTrait;
 
@@ -88,17 +87,8 @@ class ProductsBySlug extends AbstractRoute {
 			$object = $this->get_product_variation_by_slug( $slug );
 		}
 
-		if ( ! $object || 0 === $object->get_id() || ProductStatus::PUBLISH !== $object->get_status() ) {
+		if ( ! $object || 0 === $object->get_id() || ! $object->is_publicly_viewable() ) {
 			throw new RouteException( 'woocommerce_rest_product_invalid_slug', __( 'Invalid product slug.', 'woocommerce' ), 404 );
-		}
-
-		// A variation's visibility follows its parent product.
-		if ( $object->get_parent_id() ) {
-			$parent = wc_get_product( $object->get_parent_id() );
-
-			if ( ! $parent || ProductStatus::PUBLISH !== $parent->get_status() ) {
-				throw new RouteException( 'woocommerce_rest_product_invalid_slug', __( 'Invalid product slug.', 'woocommerce' ), 404 ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- REST API JSON response, not HTML.
-			}
 		}
 
 		return $this->prepare_item_for_response( $object, $request );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -454,4 +454,45 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'outofstock', $product->get_stock_status() );
 	}
+
+	/**
+	 * @testdox A published product is viewable by anyone, with or without capability checks.
+	 */
+	public function test_is_viewable_published_product() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		wp_set_current_user( 0 );
+		$this->assertTrue( $product->is_viewable(), 'Published products are viewable when logged out.' );
+		$this->assertTrue( $product->is_publicly_viewable(), 'Published products are publicly viewable.' );
+
+		wp_set_current_user( $this->admin_user );
+		$this->assertTrue( $product->is_viewable(), 'Published products are viewable by admins.' );
+	}
+
+	/**
+	 * @testdox A non-published product is hidden from the public but viewable by users who can edit it, unless capability checks are disabled.
+	 * @testWith ["draft"]
+	 *           ["pending"]
+	 *           ["private"]
+	 * @param string $status A non-published product status.
+	 */
+	public function test_is_viewable_non_published_product( $status ) {
+		$customer = self::factory()->user->create( array( 'role' => 'customer' ) );
+		$product  = WC_Helper_Product::create_simple_product();
+		$product->set_status( $status );
+		$product->save();
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( $product->is_viewable(), "A $status product is not viewable when logged out." );
+
+		wp_set_current_user( $customer );
+		$this->assertFalse( $product->is_viewable(), "A $status product is not viewable by customers." );
+
+		wp_set_current_user( $this->shop_manager_user );
+		$this->assertTrue( $product->is_viewable(), "A $status product is viewable by shop managers." );
+
+		wp_set_current_user( $this->admin_user );
+		$this->assertTrue( $product->is_viewable(), "A $status product is viewable by admins." );
+		$this->assertFalse( $product->is_publicly_viewable(), "A $status product is never publicly viewable, even for admins." );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -121,4 +121,24 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );
 	}
+
+	/**
+	 * @testdox A variation's viewability follows its parent's status.
+	 */
+	public function test_is_viewable_variation_follows_parent_status() {
+		wp_set_current_user( 0 );
+		$this->assertTrue( $this->variation->is_viewable(), 'A variation of a published parent is viewable when logged out.' );
+		$this->assertTrue( $this->variation->is_publicly_viewable(), 'A variation of a published parent is publicly viewable.' );
+
+		$this->parent_product->set_status( 'draft' );
+		$this->parent_product->save();
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->variation->is_viewable(), 'A variation whose parent is a draft is not viewable when logged out.' );
+
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+		$this->assertTrue( $this->variation->is_viewable(), 'A variation whose parent is a draft is viewable by admins.' );
+		$this->assertFalse( $this->variation->is_publicly_viewable(), 'A variation whose parent is a draft is never publicly viewable.' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following #65209, the same "is this product published, or can the current user edit it" check was duplicated across roughly nine places in the codebase, some with inconsistent capabilities (`edit_post` / `edit_product` / `read_product`).

This PR adds `WC_Product::is_viewable()` and `WC_Product::is_publicly_viewable()` methods for consolidation. The capability check inside `is_viewable()` is standardized on `edit_post` (which is essentially the same as the other capabilities for non-published products).

Closes #65498.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For easier testing, log in as admin in a window and open an incognito one. Similarly, have a HTTP tool ready (Insomnia, etc.) for Store Api testing, authenticated as an admin and anonymous.

1. **Simple product visibility:**
   1. Publish a simple product and confirm it appears in the shop and can be added to cart.
   1. (Store Api) `GET /wp-json/wc/store/v1/products/<id>` returns the product both as admin or anonymous.
   1. Set it to **Draft** and confirm:
      1. As an admin, you can still open and preview its URL, but logged out, that URL returns 404.
      1. (Store Api) `GET /wp-json/wc/store/v1/products/<id>` returns 404 either as admin or anonymous.
   1. Re-publish and confirm it's back to normal.
   1. Toggle **catalog visibility** for the product to **hidden** and confirm the product is accessible via its URL (for admin and logged out) but is not listed in the shop catalog.
   1. Set **catalog visibility** back to **shop and search results**.
   1. In **Product data > Inventory** set the product as **out of stock**.
   1. Confirm the product is still visible in the catalog.
   1. Go to **WooCommerce > Settings > Products > Inventory** and check **Hide out of stock items from the catalog**.
   1. Confirm the product is no longer visible in the catalog.
   1. Change the product back to **in stock** and confirm it reappears in the catalog.
3. **Variable product / variations:**
   1. Create a variable product with a few variations and publish.
   1. Confirm that:
      1. On the frontend, all variations show in the dropdowns and add to cart works.
      1. (Store Api) `GET /wp-json/wc/store/v1/products/<id>` works for the variable product as well as its variations both as admin or anonymous.
   4. Set the variable product to **Draft** and confirm:
      1. As admin, the product is still visible (including variations) on the frontend but logged out it's not.
      1. (Store Api) `GET /wp-json/wc/store/v1/products/<id>` returns 404 either as admin or anonymous for both the variable product or any variation.
      1. Logged out, run in the browser console (using the product ID and one of its variation attributes):
         ```js
         fetch('/?wc-ajax=get_variation', { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: 'product_id=<ID>&attribute_pa_color=<value>' }).then( r => r.text() ).then( console.log );
         ```
         Confirm the response is empty. As an admin, confirm it returns the variation JSON.
      1. Re-publish and confirm it returns JSON logged out again.
   9. On the published variable product, **disable** one variation (uncheck **Enabled**). Confirm that variation can't be selected/added to cart, while the others still work.
4. **Purchasability in the cart:**
   1. On a **published** variable product, add a variation to the cart.
   3. Set the parent product to **Draft** and reload the cart. Confirm the item is flagged as no longer available / removed (a variation of an unpublished parent is not purchasable).
   4. Re-publish the parent and confirm the variation is purchasable again.
5. **Grouped product:**
   1. Create a grouped product with a few items and publish.
   3. Confirm the frontend page lists its child products and lets you add them to cart.
   4. Set one child product to **Draft**. Logged out, confirm it's excluded from the grouped listing but as an admin, it's still shown.
6. **Featured product block:**
   1. Add a Featured Product block to a page, pointing to a published product.
   3. Confirm it renders for both admin and logged-out user.
   4. Turn the product into a draft.
   5. Confirm the block renders nothing when logged out, but renders for an admin.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
