### PR TITLE
Lazy-load All Products editor UI

### DIFF
--- a/plugins/woocommerce/changelog/fix-lazy-load-all-products-editor
+++ b/plugins/woocommerce/changelog/fix-lazy-load-all-products-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Lazy-load the All Products block editor UI after merchants choose to edit the legacy block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/products/all-products/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/products/all-products/index.js
@@ -2,20 +2,90 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { Button, Placeholder } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@wordpress/icons';
-import '@woocommerce/atomic-blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
 import deprecated from './deprecated';
-import edit from './edit';
 import save from './save';
-import defaults from './defaults';
 
 const { name } = metadata;
 export { metadata, name };
+
+let loadedEdit = null;
+let loadEditPromise = null;
+
+const loadAllProductsEdit = () => {
+	if ( loadedEdit ) {
+		return Promise.resolve( loadedEdit );
+	}
+
+	if ( ! loadEditPromise ) {
+		loadEditPromise = import(
+			/* webpackChunkName: "all-products-edit" */ './edit'
+		).then( ( module ) => {
+			loadedEdit = module.default;
+			return loadedEdit;
+		} );
+	}
+
+	return loadEditPromise;
+};
+
+const AllProductsEditShell = ( props ) => {
+	const [ EditComponent, setEditComponent ] = useState( () => loadedEdit );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const blockProps = useBlockProps();
+
+	if ( EditComponent ) {
+		return <EditComponent { ...props } />;
+	}
+
+	const loadEditor = () => {
+		setIsLoading( true );
+		loadAllProductsEdit()
+			.then( ( LoadedEdit ) => {
+				setEditComponent( () => LoadedEdit );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<Placeholder
+				icon={ <Icon icon={ grid } /> }
+				label={ __(
+					'All Products Block is a soft-deprecated block',
+					'woocommerce'
+				) }
+			>
+				<p>
+					{ __(
+						'For better performance and more flexible layouts, use the Product Collection block. You can continue editing this block if needed.',
+						'woocommerce'
+					) }
+				</p>
+				<Button
+					variant="primary"
+					onClick={ loadEditor }
+					isBusy={ isLoading }
+					disabled={ isLoading }
+				>
+					{ __( 'Edit All Products', 'woocommerce' ) }
+				</Button>
+			</Placeholder>
+		</div>
+	);
+};
 
 const settings = {
 	icon: {
@@ -26,11 +96,27 @@ const settings = {
 			/>
 		),
 	},
-	edit,
+	edit: AllProductsEditShell,
 	// Save the props to post content.
 	save,
 	deprecated,
-	defaults,
+	defaults: {
+		columns: getSetting( 'defaultColumns', 3 ),
+		rows: getSetting( 'defaultRows', 3 ),
+		alignButtons: false,
+		contentVisibility: {
+			orderBy: true,
+		},
+		orderby: 'date',
+		layoutConfig: [
+			[ 'woocommerce/product-image', { imageSizing: 'thumbnail' } ],
+			[ 'woocommerce/product-title' ],
+			[ 'woocommerce/product-price' ],
+			[ 'woocommerce/product-rating' ],
+			[ 'woocommerce/product-button' ],
+		],
+		isPreview: false,
+	},
 };
 
 registerBlockType( name, settings );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/products/all-products/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/products/all-products/index.js
@@ -7,7 +7,6 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@wordpress/icons';
 import { useBlockProps } from '@wordpress/block-editor';
-import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -101,8 +100,8 @@ const settings = {
 	save,
 	deprecated,
 	defaults: {
-		columns: getSetting( 'defaultColumns', 3 ),
-		rows: getSetting( 'defaultRows', 3 ),
+		columns: 3,
+		rows: 3,
 		alignButtons: false,
 		contentVisibility: {
 			orderBy: true,

--- a/plugins/woocommerce/client/blocks/assets/js/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import '@woocommerce/atomic-blocks';
+
+/**
  * Internal dependencies
  */
 import '../css/editor.scss';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AllProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AllProducts.php
@@ -41,6 +41,6 @@ class AllProducts extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$this->register_chunk_translations( [ $this->block_name ] );
+		$this->register_chunk_translations( [ $this->block_name, 'all-products-edit' ] );
 	}
 }

--- a/plugins/woocommerce/tests/e2e/tests/blocks/all-products/all-products.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/all-products/all-products.block_theme.spec.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { Page } from '@playwright/test';
 import { BLOCK_THEME_SLUG, expect, test } from '@woocommerce/e2e-utils';
 
 /**
@@ -8,8 +9,82 @@ import { BLOCK_THEME_SLUG, expect, test } from '@woocommerce/e2e-utils';
  */
 
 const BLOCK_NAME = 'woocommerce/all-products';
+const BLOCK_MARKUP = '<!-- wp:woocommerce/all-products /-->';
+const PLACEHOLDER_TITLE = 'All Products Block is a soft-deprecated block';
+const PLACEHOLDER_DESCRIPTION =
+	'For better performance and more flexible layouts, use the Product Collection block. You can continue editing this block if needed.';
+const SCRIPT_SELECTOR =
+	'script#wc-all-products-block-js, script[src*="/all-products.js"]';
+const EDIT_SCRIPT_SELECTOR = 'script[src*="all-products-edit"]';
+
+async function expectAllProductsEditorScriptLoaded(
+	page: Page,
+	isLoaded: boolean
+) {
+	await expect( page.locator( SCRIPT_SELECTOR ) ).toHaveCount(
+		isLoaded ? 1 : 0
+	);
+}
+
+async function expectAllProductsEditorChunkLoaded(
+	page: Page,
+	isLoaded: boolean
+) {
+	await expect( page.locator( EDIT_SCRIPT_SELECTOR ) ).toHaveCount(
+		isLoaded ? 1 : 0
+	);
+}
 
 test.describe( `${ BLOCK_NAME } Block`, () => {
+	test( 'editor assets load in the Site Editor', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: `${ BLOCK_THEME_SLUG }//header`,
+			postType: 'wp_template_part',
+			canvas: 'edit',
+		} );
+
+		await expect( page.locator( SCRIPT_SELECTOR ) ).toHaveCount( 1 );
+		await expect( page.locator( EDIT_SCRIPT_SELECTOR ) ).toHaveCount( 0 );
+	} );
+
+	test( 'full editor assets load after choosing to edit a raw All Products block', async ( {
+		admin,
+		editor,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'All Products raw block asset loading',
+			content:
+				'<!-- wp:paragraph --><p>Initial content</p><!-- /wp:paragraph -->',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+
+		await admin.editPost( post.id );
+		await expectAllProductsEditorScriptLoaded( page, true );
+		await expectAllProductsEditorChunkLoaded( page, false );
+
+		await editor.setContent( BLOCK_MARKUP );
+
+		const allProductsBlock = await editor.getBlockByName( BLOCK_NAME );
+		await expect( allProductsBlock ).toContainText( PLACEHOLDER_TITLE );
+		await expect( allProductsBlock ).toContainText(
+			PLACEHOLDER_DESCRIPTION
+		);
+		await expectAllProductsEditorChunkLoaded( page, false );
+
+		await allProductsBlock
+			.getByRole( 'button', { name: 'Edit All Products' } )
+			.click();
+
+		await expectAllProductsEditorChunkLoaded( page, true );
+		await expect( allProductsBlock ).toBeVisible();
+	} );
+
 	test( 'block can be inserted and it is rendered on the frontend', async ( {
 		editor,
 		admin,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The legacy All Products block currently loads its full editor UI whenever the block script is loaded. This PR changes the registered block script to a lightweight shell that recommends Product Collection and only lazy-loads the full All Products editor after the merchant chooses to edit the block.

Atomic product blocks are now registered from the shared blocks entry instead of piggybacking on All Products. The All Products lazy edit chunk also has translation registration, and e2e coverage verifies the shell loads before the full editor chunk.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not included. The visible change is the lightweight editor placeholder for the legacy All Products block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open the post editor and insert or paste an All Products block.
2. Confirm the block shows the soft-deprecation placeholder recommending Product Collection.
3. Confirm the full All Products editor UI loads only after clicking **Edit All Products**.
4. Open the Site Editor and confirm the editor loads without the full All Products editor chunk being loaded on entry.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `php -l plugins/woocommerce/src/Blocks/BlockTypes/AllProducts.php`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `WP_EXPERIMENTAL_MODULES=true pnpm --filter=@woocommerce/block-library exec wp-scripts lint-js --ext=js,ts,tsx assets/js/index.js assets/js/blocks/products/all-products/index.js`
- `pnpm exec eslint plugins/woocommerce/tests/e2e/tests/blocks/all-products/all-products.block_theme.spec.ts`
  - Reports the existing direct-run alias-resolution warning for `@woocommerce/e2e-utils`; no errors.
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
