### PR TITLE
Improve Cart and Checkout editor asset loading

### DIFF
--- a/plugins/woocommerce/changelog/performance-cart-checkout-editor-assets
+++ b/plugins/woocommerce/changelog/performance-cart-checkout-editor-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Bundle Cart and Checkout editor dependencies directly to avoid loading frontend Cart and Checkout chunks in the editor.

--- a/plugins/woocommerce/client/blocks/bin/webpack-configs.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-configs.js
@@ -26,6 +26,8 @@ const {
 	NODE_ENV,
 	CHECK_CIRCULAR_DEPS,
 	requestToExternal,
+	requestToEditorExternal,
+	requestToEditorHandle,
 	requestToHandle,
 	getProgressBarPluginConfig,
 	getCacheGroups,
@@ -44,6 +46,10 @@ const BABEL_CACHE_DIR = path.join(
 	'node_modules/.cache/babel-loader'
 );
 const isProduction = NODE_ENV === 'production';
+const editorBundledPackages = [
+	'@woocommerce/blocks-checkout',
+	'@woocommerce/blocks-components',
+];
 
 /**
  * Shared config for all script builds.
@@ -51,7 +57,10 @@ const isProduction = NODE_ENV === 'production';
 let initialBundleAnalyzerPort = 8888;
 const getSharedPlugins = ( {
 	bundleAnalyzerReportTitle,
+	bundledPackages = [],
 	checkCircularDeps = true,
+	scriptRequestToExternal = requestToExternal,
+	scriptRequestToHandle = requestToHandle,
 } ) =>
 	[
 		CHECK_CIRCULAR_DEPS === 'true' && checkCircularDeps !== false
@@ -69,11 +78,12 @@ const getSharedPlugins = ( {
 				reportTitle: bundleAnalyzerReportTitle,
 			} ),
 		new DependencyExtractionWebpackPlugin( {
+			bundledPackages,
 			injectPolyfill: true,
 			combineAssets: ASSET_CHECK,
 			outputFormat: ASSET_CHECK ? 'json' : 'php',
-			requestToExternal,
-			requestToHandle,
+			requestToExternal: scriptRequestToExternal,
+			requestToHandle: scriptRequestToHandle,
 		} ),
 		// Substitute the `__i18n_text_domain__` identifier used by the
 		// @woocommerce/email-editor package with the WooCommerce text
@@ -225,7 +235,10 @@ const getMainConfig = ( options = {} ) => {
 		},
 		plugins: [
 			...getSharedPlugins( {
+				bundledPackages: editorBundledPackages,
 				bundleAnalyzerReportTitle: 'Main',
+				scriptRequestToExternal: requestToEditorExternal,
+				scriptRequestToHandle: requestToEditorHandle,
 			} ),
 			new ProgressBarPlugin( getProgressBarPluginConfig( 'Main' ) ),
 			/**

--- a/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
@@ -44,6 +44,11 @@ const wcHandleMap = {
 	'@woocommerce/sanitize': 'wc-sanitize',
 };
 
+const bundledEditorPackages = new Set( [
+	'@woocommerce/blocks-checkout',
+	'@woocommerce/blocks-components',
+] );
+
 const getAlias = ( options = {} ) => {
 	let { pathPart } = options;
 	pathPart = pathPart ? `${ pathPart }/` : '';
@@ -91,6 +96,14 @@ const getAlias = ( options = {} ) => {
 		'@woocommerce/block-settings': path.resolve(
 			__dirname,
 			'../assets/js/settings/blocks'
+		),
+		'@woocommerce/blocks-checkout': path.resolve(
+			__dirname,
+			'../packages/checkout'
+		),
+		'@woocommerce/blocks-components': path.resolve(
+			__dirname,
+			'../packages/components'
 		),
 		'@woocommerce/icons': path.resolve( __dirname, `../assets/js/icons` ),
 		'@woocommerce/resource-previews': path.resolve(
@@ -143,6 +156,20 @@ const requestToHandle = ( request ) => {
 	if ( request === 'react-dom/client' ) {
 		return 'react-dom';
 	}
+};
+
+const requestToEditorExternal = ( request ) => {
+	if ( bundledEditorPackages.has( request ) ) {
+		return;
+	}
+	return requestToExternal( request );
+};
+
+const requestToEditorHandle = ( request ) => {
+	if ( bundledEditorPackages.has( request ) ) {
+		return;
+	}
+	return requestToHandle( request );
 };
 
 const getProgressBarPluginConfig = ( name ) => {
@@ -226,6 +253,8 @@ module.exports = {
 	getResolve,
 	requestToHandle,
 	requestToExternal,
+	requestToEditorHandle,
+	requestToEditorExternal,
 	getProgressBarPluginConfig,
 	getCacheGroups,
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Cart and Checkout editor bundles were depending on the public checkout/component package handles, which made the editor load the frontend Cart and Checkout split chunks. This updates the editor webpack config to bundle `@woocommerce/blocks-checkout` and `@woocommerce/blocks-components` directly into the editor assets while preserving the existing frontend split chunk behavior.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; this is an asset loading change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce/client/blocks`, run `WP_EXPERIMENTAL_MODULES=true BABEL_ENV=default NODE_ENV=production pnpm exec webpack`.
2. Inspect `plugins/woocommerce/assets/client/blocks/cart.asset.php` and `plugins/woocommerce/assets/client/blocks/checkout.asset.php`.
3. Confirm those editor asset manifests do not list `wc-cart-checkout-base`, `wc-cart-checkout-vendors`, `wc-blocks-checkout`, or `wc-blocks-components` as dependencies.
4. Inspect `plugins/woocommerce/assets/client/blocks/blocks-checkout.asset.php` and `plugins/woocommerce/assets/client/blocks/blocks-components.asset.php`.
5. Confirm the frontend package manifests still depend on the Cart and Checkout frontend split chunks.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran `pnpm exec prettier --check bin/webpack-configs.js bin/webpack-helpers.js`.
- Ran `pnpm exec eslint bin/webpack-configs.js bin/webpack-helpers.js`; it completed with no errors and reported the existing webpack config resolution warning from `webpack-config-interactive-blocks.js`.
- Ran `WP_EXPERIMENTAL_MODULES=true BABEL_ENV=default NODE_ENV=production pnpm exec webpack`.
- Verified the generated `cart.asset.php` and `checkout.asset.php` no longer reference the frontend Cart and Checkout chunks or the public checkout/components package handles.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
