### PR TITLE
Fix uncaught TypeError in WC_Email::send_notification() when mail callback returns non-bool

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-send-notification-bool-typeerror
+++ b/plugins/woocommerce/changelog/fix-email-send-notification-bool-typeerror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error in WC_Email::send_notification() when a filtered mail callback returns a non-bool value.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1233,7 +1233,7 @@ class WC_Email extends WC_Settings_API {
 		$message              = apply_filters( 'woocommerce_mail_content', $this->style_inline( $message ) );
 		$mail_callback        = apply_filters( 'woocommerce_mail_callback', 'wp_mail', $this );
 		$mail_callback_params = apply_filters( 'woocommerce_mail_callback_params', array( $to, wp_specialchars_decode( $subject ), $message, $headers, $attachments ), $this );
-		$return               = $mail_callback( ...$mail_callback_params );
+		$return               = (bool) $mail_callback( ...$mail_callback_params );
 
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
@@ -1252,7 +1252,7 @@ class WC_Email extends WC_Settings_API {
 		 */
 		do_action( 'woocommerce_email_sent', $return, (string) $this->id, $this );
 
-		return (bool) $return;
+		return $return;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1252,7 +1252,7 @@ class WC_Email extends WC_Settings_API {
 		 */
 		do_action( 'woocommerce_email_sent', $return, (string) $this->id, $this );
 
-		return $return;
+		return (bool) $return;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -29,6 +29,8 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/emails/class-wc-email.php';
 		$this->sut = new EmailLogger();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -39,6 +39,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_email_log_enabled' );
 		remove_all_filters( 'woocommerce_email_log_context' );
 		remove_all_filters( 'woocommerce_email_log_add_order_note' );
+		remove_all_filters( 'woocommerce_mail_callback' );
 		remove_all_actions( 'woocommerce_email_disabled' );
 		remove_all_actions( 'woocommerce_email_skipped' );
 		remove_action( 'woocommerce_email_sent', array( $this->sut, 'handle_woocommerce_email_sent' ) );
@@ -769,15 +770,16 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	 *
 	 * Exposes both protected helpers as public `run_*` wrappers and records whether send() was called.
 	 *
-	 * @param string $email_id    Email type ID.
-	 * @param string $recipient   Recipient email address (empty string = no recipient).
-	 * @param bool   $is_enabled  Return value for is_enabled().
-	 * @param bool   $send_return Return value for the stubbed send().
+	 * @param string $email_id       Email type ID.
+	 * @param string $recipient      Recipient email address (empty string = no recipient).
+	 * @param bool   $is_enabled     Return value for is_enabled().
+	 * @param bool   $send_return    Return value for the stubbed send() (ignored if $use_real_send is true).
+	 * @param bool   $use_real_send  If true, keep the real WC_Email::send() instead of stubbing it.
 	 * @return object Anonymous class instance with `run_send_notification()`, `run_send_if_recipient()`,
 	 *                `send_called`, and `send_args` properties.
 	 */
-	private function create_testable_email( string $email_id, string $recipient, bool $is_enabled, bool $send_return = false ): object {
-		return new class( $email_id, $recipient, $is_enabled, $send_return ) extends \WC_Email {
+	private function create_testable_email( string $email_id, string $recipient, bool $is_enabled, bool $send_return = false, bool $use_real_send = false ): object {
+		return new class( $email_id, $recipient, $is_enabled, $send_return, $use_real_send ) extends \WC_Email {
 			/** @var bool Whether send() has been invoked. */
 			public bool $send_called = false;
 			/** @var array Arguments captured from the most recent send() call. */
@@ -789,6 +791,8 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			private bool $test_is_enabled;
 			/** @var bool Value returned by send(). */
 			private bool $test_send_return;
+			/** @var bool Whether to delegate to the real WC_Email::send() instead of returning $test_send_return. */
+			private bool $use_real_send;
 
 			/**
 			 * Construct the test double.
@@ -797,13 +801,15 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			 * @param string $recipient   Recipient string for get_recipient().
 			 * @param bool   $is_enabled  Value to return from is_enabled().
 			 * @param bool   $send_return Value to return from send().
+			 * @param bool   $use_real_send Whether to delegate to the real send() instead of the stub.
 			 */
-			public function __construct( string $email_id, string $recipient, bool $is_enabled, bool $send_return ) {
+			public function __construct( string $email_id, string $recipient, bool $is_enabled, bool $send_return, bool $use_real_send ) {
 				// Deliberately skip parent::__construct() to avoid side-effects in tests.
 				$this->id               = $email_id;
 				$this->test_recipient   = $recipient;
 				$this->test_is_enabled  = $is_enabled;
 				$this->test_send_return = $send_return;
+				$this->use_real_send    = $use_real_send;
 			}
 
 			/**
@@ -861,6 +867,11 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			public function send( $to, $subject, $message, $headers, $attachments ): bool {
 				$this->send_called = true;
 				$this->send_args   = array( $to, $subject, $message, $headers, $attachments );
+
+				if ( $this->use_real_send ) {
+					return parent::send( $to, $subject, $message, $headers, $attachments );
+				}
+
 				return $this->test_send_return;
 			}
 
@@ -894,5 +905,46 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		$email->expects( $this->any() )->method( 'get_title' )->willReturn( $email_id );
 
 		return $email;
+	}
+
+	/**
+	 * @testdox send() coerces a non-bool return from the mail callback into a bool.
+	 */
+	public function test_send_coerces_non_bool_mail_callback_return_to_bool(): void {
+		add_filter(
+			'woocommerce_mail_callback',
+			function () {
+					return static function () {
+							return null;
+					};
+			}
+		);
+
+		$email  = new \WC_Email();
+		$result = $email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+
+		$this->assertIsBool( $result, 'send() should always return a bool, even if the mail callback does not' );
+		$this->assertFalse( $result, 'A non-bool (null) callback return should coerce to false' );
+	}
+
+	/**
+	 * @testdox send_notification() does not throw a TypeError when the mail callback returns a non-bool.
+	 */
+	public function test_send_notification_does_not_fatal_when_mail_callback_returns_non_bool(): void {
+		add_filter(
+			'woocommerce_mail_callback',
+			function () {
+					return static function () {
+							return null;
+					};
+			}
+		);
+
+		$email = $this->create_testable_email( 'my_email', 'admin@example.com', true, false, true );
+
+		$result = $email->run_send_notification();
+
+		$this->assertIsBool( $result, 'send_notification() should return a bool instead of fataling' );
+		$this->assertFalse( $result, 'Should resolve to false when the underlying mail callback returns null' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -949,4 +949,36 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		$this->assertIsBool( $result, 'send_notification() should return a bool instead of fataling' );
 		$this->assertFalse( $result, 'Should resolve to false when the underlying mail callback returns null' );
 	}
+
+	/**
+	 * @testdox send() casts the mail callback return to bool before firing woocommerce_email_sent.
+	 */
+	public function test_send_fires_email_sent_action_with_bool_when_callback_returns_non_bool(): void {
+		add_filter(
+			'woocommerce_mail_callback',
+			function () {
+					return static function () {
+							return null;
+					};
+			}
+		);
+
+		$received_return = null;
+		add_action(
+			'woocommerce_email_sent',
+			function ( $result ) use ( &$received_return ) {
+				$received_return = $result;
+			},
+			10,
+			1
+		);
+
+		$email = new \WC_Email();
+		$email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+
+		$this->assertIsBool( $received_return, 'woocommerce_email_sent should receive a bool even when the mail callback returns null' );
+		$this->assertFalse( $received_return );
+
+		remove_all_actions( 'woocommerce_email_sent' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

## Description

- Fixes a fatal `TypeError` introduced in WooCommerce 10.9.0, when `WC_Email::send_notification()` was declared `: bool` but its underlying `send()` method returns the raw result of the filterable `woocommerce_mail_callback` without any type coercion.
- If a filtered mail callback (commonly an SMTP plugin) returns a non-bool value such as `null`, this propagates through `send_notification()` and throws an uncaught `TypeError`:


**Do Note: While adding regression tests, I found `EmailLoggerTest.php` was missing a `require_once` for `class-wc-email.php` that every [sibling email test file has](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/php/includes/emails/class-wc-email-customer-fulfillment-created-test.php#L26). This caused the whole file (43/44 tests) to fail when run standalone, though it passes in full suite runs due to incidental load order.** 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66100, closes WOOPLUG-6935, closes #66143, closes WOOPLUG-6948

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/2d67f1a7-c568-4fdc-a939-1301769210be | https://github.com/user-attachments/assets/02a4d37e-37ee-4eec-9b59-4ff07fb5d5ac |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

- Add mu plugin:
```
add_filter( 'woocommerce_mail_callback', function () {
       return static function () {
           return null; // simulates a broken/SMTP-filtered mail callback
       };
   } );
```

- Go to WooCommerce → Orders, open any existing order.
- Change the order status dropdown to Completed.
- Click Update.
- Expected (broken) result: WordPress shows the "critical error" screen.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
