### PR TITLE
Add update-window guard and class-removal CI check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,10 @@ Closes # .
 
 (For Bug Fixes) Bug introduced in PR # .
 
+<!-- If this PR intentionally removes PHP classes, interfaces, traits or enums that exist on the base branch, check the box below and explain in the description why the removal is safe during in-place updates. Shipped classes should normally be deprecated and kept as stubs for at least one release before removal — see the Class Removal Check workflow. -->
+
+-   [ ] This Pull Request intentionally removes PHP classes. (Comment required in the description)
+
 ### Screenshots or screen recordings:
 
 <!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

--- a/.github/workflows/class-removal-check.yml
+++ b/.github/workflows/class-removal-check.yml
@@ -57,7 +57,7 @@ jobs:
           echo "Removing a shipped class causes fatal errors during in-place updates. Deprecate it and"
           echo "keep it as a stub for at least one release instead. If the removal is intentional and"
           echo "update-safe (e.g. the class was never shipped, or its deprecation window has passed),"
-          echo "acknowledge it by adding this line to the PR description, with an explanation:"
+          echo "acknowledge it by checking the box in the PR description, with an explanation:"
           echo ""
-          echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required below)"
+          echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required in the description)"
           exit 1

--- a/.github/workflows/class-removal-check.yml
+++ b/.github/workflows/class-removal-check.yml
@@ -1,0 +1,63 @@
+name: Class Removal Check
+
+# Fails when a PHP class/interface/trait/enum declared on the base branch is missing from
+# the PR result, unless the author explicitly acknowledges the removal in the PR description.
+# Removing shipped classes without a deprecation-stub window causes fatal errors during
+# in-place updates, because code from the previous version can still reference them while
+# the plugin files are being swapped on disk.
+on:
+  pull_request:
+    paths:
+      - 'plugins/woocommerce/src/**'
+      - 'plugins/woocommerce/includes/**'
+      - 'plugins/woocommerce/bin/check-removed-classes.php'
+      - '.github/workflows/class-removal-check.yml'
+
+concurrency:
+  group: class-removal-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-removed-classes:
+    name: Detect removed PHP classes vs base branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract base branch tree
+        run: |
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          mkdir -p /tmp/wc-base
+          git archive FETCH_HEAD plugins/woocommerce/src plugins/woocommerce/includes | tar -x -C /tmp/wc-base
+
+      - name: Scan base and PR class declarations
+        run: |
+          php plugins/woocommerce/bin/check-removed-classes.php scan /tmp/wc-base/plugins/woocommerce /tmp/base-classes.json
+          php plugins/woocommerce/bin/check-removed-classes.php scan plugins/woocommerce /tmp/pr-classes.json
+
+      - name: Compare class declarations
+        id: compare
+        continue-on-error: true
+        run: php plugins/woocommerce/bin/check-removed-classes.php compare /tmp/base-classes.json /tmp/pr-classes.json
+
+      - name: Check for author acknowledgment
+        if: steps.compare.outcome == 'failure'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qiE '\[x\][[:space:]]+This Pull Request intentionally removes PHP classes'; then
+            echo "Class removals acknowledged by the author in the PR description."
+            exit 0
+          fi
+          echo "::error::This PR removes PHP classes that exist on the base branch (see the compare step above)."
+          echo ""
+          echo "Removing a shipped class causes fatal errors during in-place updates. Deprecate it and"
+          echo "keep it as a stub for at least one release instead. If the removal is intentional and"
+          echo "update-safe (e.g. the class was never shipped, or its deprecation window has passed),"
+          echo "acknowledge it by adding this line to the PR description, with an explanation:"
+          echo ""
+          echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required below)"
+          exit 1

--- a/.github/workflows/class-removal-check.yml
+++ b/.github/workflows/class-removal-check.yml
@@ -1,10 +1,8 @@
 name: Class Removal Check
 
-# Fails when a PHP class/interface/trait/enum declared on the base branch is missing from
-# the PR result, unless the author explicitly acknowledges the removal in the PR description.
-# Removing shipped classes without a deprecation-stub window causes fatal errors during
-# in-place updates, because code from the previous version can still reference them while
-# the plugin files are being swapped on disk.
+# Fails when a type declared on the base branch is missing from the PR result, unless the
+# author acknowledges the removal in the PR description. Removing shipped classes causes
+# fatal errors during in-place updates (stale code/classmaps can still reference them).
 on:
   pull_request:
     paths:

--- a/plugins/woocommerce/bin/check-removed-classes.php
+++ b/plugins/woocommerce/bin/check-removed-classes.php
@@ -2,32 +2,23 @@
 /**
  * WooCommerce Removed Classes Checker
  *
- * Detects PHP classes, interfaces, traits and enums that exist in a previous
- * WooCommerce release but are missing from the current source tree.
- *
- * Removing a shipped class without a deprecation stub causes update-time fatal
- * errors: during an in-place update, code from the previous version that is
- * still loaded in memory (or a stale autoloader classmap) can reference the
- * class, and the autoloader then tries to require a file that no longer exists,
- * which is an uncatchable fatal. Shipped classes must be deprecated and kept as
- * stubs for at least one release before being removed.
+ * Detects PHP classes, interfaces, traits and enums that exist in a baseline tree
+ * but are missing from the current one. Removing a shipped class causes update-time
+ * fatal errors (stale code/classmaps from the previous version can still reference
+ * it during an in-place update), so shipped classes should be deprecated and kept
+ * as stubs for at least one release before removal.
  *
  * Usage:
  *   php check-removed-classes.php scan <plugin_root> <output.json>
  *   php check-removed-classes.php compare <old.json> <new.json> [<allowlist_file>]
  *
- * The 'scan' command writes a JSON map of fully qualified type name => file to
- * <output.json>. The 'compare' command exits with code 1 if any type present in
- * <old.json> is missing from <new.json> and not listed in the optional
- * <allowlist_file> (one fully qualified name per line, '#' comments allowed).
+ * 'scan' writes a JSON map of fully qualified type name => file. 'compare' exits 1
+ * if any type in <old.json> is missing from <new.json> and not in the optional
+ * <allowlist_file> (one name per line, '#' comments allowed).
  *
- * In CI (class-removal-check.yml) this compares a PR against its base branch, and
- * the author acknowledges intentional removals in the PR description. The script
- * also works against arbitrary baselines, e.g. to audit a release against the
- * previous one before shipping:
- *   php check-removed-classes.php scan /path/to/previous-release-checkout old.json
- *   php check-removed-classes.php scan plugins/woocommerce new.json
- *   php check-removed-classes.php compare old.json new.json
+ * CI (class-removal-check.yml) compares a PR against its base branch. The script
+ * also works against arbitrary baselines, e.g. auditing a release against the
+ * previous shipped version: scan both checkouts, then compare.
  *
  * @package WooCommerce
  */

--- a/plugins/woocommerce/bin/check-removed-classes.php
+++ b/plugins/woocommerce/bin/check-removed-classes.php
@@ -293,8 +293,9 @@ if ( 'cli' === PHP_SAPI && isset( $argv[0] ) && realpath( $argv[0] ) === __FILE_
 		echo "\nRemoving a shipped class causes fatal errors during in-place updates: code from the\n";
 		echo "previous version can still reference it while the files are being swapped on disk.\n";
 		echo "Deprecate the class and keep it as a stub for at least one release instead. If the\n";
-		echo "removal is intentional and update-safe, acknowledge it in the PR description with:\n";
-		echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required below)\n";
+		echo "removal is intentional and update-safe, acknowledge it by checking this box in the\n";
+		echo "PR description (part of the PR template) and explaining why:\n";
+		echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required in the description)\n";
 		exit( 1 );
 	}
 

--- a/plugins/woocommerce/bin/check-removed-classes.php
+++ b/plugins/woocommerce/bin/check-removed-classes.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * WooCommerce Removed Classes Checker
+ *
+ * Detects PHP classes, interfaces, traits and enums that exist in a previous
+ * WooCommerce release but are missing from the current source tree.
+ *
+ * Removing a shipped class without a deprecation stub causes update-time fatal
+ * errors: during an in-place update, code from the previous version that is
+ * still loaded in memory (or a stale autoloader classmap) can reference the
+ * class, and the autoloader then tries to require a file that no longer exists,
+ * which is an uncatchable fatal. Shipped classes must be deprecated and kept as
+ * stubs for at least one release before being removed.
+ *
+ * Usage:
+ *   php check-removed-classes.php scan <plugin_root> <output.json>
+ *   php check-removed-classes.php compare <old.json> <new.json> [<allowlist_file>]
+ *
+ * The 'scan' command writes a JSON map of fully qualified type name => file to
+ * <output.json>. The 'compare' command exits with code 1 if any type present in
+ * <old.json> is missing from <new.json> and not listed in the optional
+ * <allowlist_file> (one fully qualified name per line, '#' comments allowed).
+ *
+ * In CI (class-removal-check.yml) this compares a PR against its base branch, and
+ * the author acknowledges intentional removals in the PR description. The script
+ * also works against arbitrary baselines, e.g. to audit a release against the
+ * previous one before shipping:
+ *   php check-removed-classes.php scan /path/to/previous-release-checkout old.json
+ *   php check-removed-classes.php scan plugins/woocommerce new.json
+ *   php check-removed-classes.php compare old.json new.json
+ *
+ * @package WooCommerce
+ */
+
+// This is a CLI-only script: it writes plain text to stdout and reads local files.
+// WordPress's web-oriented escaping, filesystem and file-naming sniffs therefore don't apply here.
+// phpcs:disable WordPress.Security.EscapeOutput, WordPress.WP.AlternativeFunctions, WordPress.Files.FileName
+
+/**
+ * Scans PHP source trees for type declarations and diffs them between versions.
+ */
+class WC_Removed_Classes_Checker {
+
+	/**
+	 * Directories scanned inside the plugin root, relative to it.
+	 *
+	 * @var string[]
+	 */
+	const SCAN_DIRS = array( 'src', 'includes' );
+
+	/**
+	 * Path fragments that exclude a file from scanning (bundled/generated/dev code).
+	 *
+	 * @var string[]
+	 */
+	const EXCLUDED_PATH_FRAGMENTS = array(
+		'/vendor/',
+		'/lib/',
+		'/tests/',
+		'/node_modules/',
+		'/DesignTime/',
+	);
+
+	/**
+	 * Scan a plugin root for PHP type declarations.
+	 *
+	 * @param string $plugin_root Path to the root of the WooCommerce plugin.
+	 * @return array Map of fully qualified type name => file path relative to the plugin root, sorted by name.
+	 * @throws \InvalidArgumentException If the plugin root doesn't look like a WooCommerce checkout.
+	 */
+	public function scan( string $plugin_root ): array {
+		$plugin_root = rtrim( $plugin_root, '/' );
+		if ( ! is_dir( $plugin_root . '/' . self::SCAN_DIRS[0] ) ) {
+			throw new \InvalidArgumentException( "'$plugin_root' does not contain a '" . self::SCAN_DIRS[0] . "' directory; is it a WooCommerce plugin root?" );
+		}
+
+		$types = array();
+		foreach ( self::SCAN_DIRS as $dir ) {
+			$base = $plugin_root . '/' . $dir;
+			if ( ! is_dir( $base ) ) {
+				continue;
+			}
+
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator( $base, \FilesystemIterator::SKIP_DOTS )
+			);
+			foreach ( $iterator as $file ) {
+				if ( 'php' !== strtolower( $file->getExtension() ) ) {
+					continue;
+				}
+				$path = str_replace( '\\', '/', $file->getPathname() );
+				if ( $this->is_excluded( $path ) ) {
+					continue;
+				}
+				$relative_path = ltrim( substr( $path, strlen( $plugin_root ) ), '/' );
+				foreach ( $this->extract_declarations( (string) file_get_contents( $file->getPathname() ) ) as $type_name ) {
+					$types[ $type_name ] = $relative_path;
+				}
+			}
+		}
+
+		ksort( $types, SORT_STRING );
+		return $types;
+	}
+
+	/**
+	 * Extract the fully qualified names of all named classes, interfaces, traits and enums
+	 * declared in a piece of PHP code. Anonymous classes and '::class' references are ignored.
+	 *
+	 * @param string $code PHP source code.
+	 * @return string[] Fully qualified type names.
+	 */
+	public function extract_declarations( string $code ): array {
+		$tokens       = token_get_all( $code );
+		$count        = count( $tokens );
+		$namespace    = '';
+		$declarations = array();
+		$type_tokens  = array( T_CLASS, T_INTERFACE, T_TRAIT );
+		if ( defined( 'T_ENUM' ) ) {
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.t_enumFound -- guarded by defined().
+			$type_tokens[] = T_ENUM;
+		}
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$token = $tokens[ $i ];
+			if ( ! is_array( $token ) ) {
+				continue;
+			}
+
+			if ( T_NAMESPACE === $token[0] ) {
+				$namespace = $this->read_namespace( $tokens, $i, $count );
+				continue;
+			}
+
+			if ( ! in_array( $token[0], $type_tokens, true ) ) {
+				continue;
+			}
+
+			// 'Foo::class' constant references and 'new class' anonymous classes are not declarations.
+			$previous = $this->significant_token( $tokens, $i, -1 );
+			if ( is_array( $previous ) && in_array( $previous[0], array( T_DOUBLE_COLON, T_NEW ), true ) ) {
+				continue;
+			}
+
+			$next = $this->significant_token( $tokens, $i, 1 );
+			if ( ! is_array( $next ) || T_STRING !== $next[0] ) {
+				continue;
+			}
+
+			$declarations[] = ( '' === $namespace ? '' : $namespace . '\\' ) . $next[1];
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Determine which types were removed between two scans and are not allowlisted.
+	 *
+	 * @param array    $old_types Map of type name => file from the previous version.
+	 * @param array    $new_types Map of type name => file from the current version.
+	 * @param string[] $allowlist Type names that are allowed to be removed.
+	 * @return array Map of type name => old file path for each unallowed removal.
+	 */
+	public function find_unallowed_removals( array $old_types, array $new_types, array $allowlist ): array {
+		$removed = array_diff_key( $old_types, $new_types );
+		return array_diff_key( $removed, array_flip( $allowlist ) );
+	}
+
+	/**
+	 * Parse an allowlist file: one fully qualified type name per line,
+	 * blank lines and lines starting with '#' are ignored.
+	 *
+	 * @param string $contents Contents of the allowlist file.
+	 * @return string[] Allowlisted type names.
+	 */
+	public function parse_allowlist( string $contents ): array {
+		$entries = array();
+		foreach ( preg_split( '/\R/', $contents ) as $line ) {
+			$line = trim( $line );
+			if ( '' === $line || str_starts_with( $line, '#' ) ) {
+				continue;
+			}
+			$entries[] = ltrim( $line, '\\' );
+		}
+		return $entries;
+	}
+
+	/**
+	 * Read a namespace declaration starting at the T_NAMESPACE token.
+	 *
+	 * @param array $tokens Token list from token_get_all.
+	 * @param int   $index Index of the T_NAMESPACE token.
+	 * @param int   $count Total token count.
+	 * @return string The namespace name, '' for the global namespace.
+	 */
+	private function read_namespace( array $tokens, int $index, int $count ): string {
+		$namespace = '';
+		for ( $i = $index + 1; $i < $count; $i++ ) {
+			$token = $tokens[ $i ];
+			if ( is_array( $token ) ) {
+				if ( in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+					continue;
+				}
+				$is_name_token = in_array( $token[0], array( T_STRING, T_NS_SEPARATOR ), true )
+					// phpcs:ignore PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound -- guarded by defined().
+					|| ( defined( 'T_NAME_QUALIFIED' ) && T_NAME_QUALIFIED === $token[0] );
+				if ( $is_name_token ) {
+					$namespace .= $token[1];
+					continue;
+				}
+			}
+			break;
+		}
+		return $namespace;
+	}
+
+	/**
+	 * Get the nearest non-whitespace, non-comment token in the given direction.
+	 *
+	 * @param array $tokens Token list from token_get_all.
+	 * @param int   $index Index to start from (exclusive).
+	 * @param int   $direction 1 for forwards, -1 for backwards.
+	 * @return array|string|null The token, or null if none found.
+	 */
+	private function significant_token( array $tokens, int $index, int $direction ) {
+		$count = count( $tokens );
+		for ( $i = $index + $direction; $i >= 0 && $i < $count; $i += $direction ) {
+			$token = $tokens[ $i ];
+			if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+				continue;
+			}
+			return $token;
+		}
+		return null;
+	}
+
+	/**
+	 * Whether a file path is excluded from scanning.
+	 *
+	 * @param string $path Normalized (forward-slash) absolute file path.
+	 * @return bool True if the file must not be scanned.
+	 */
+	private function is_excluded( string $path ): bool {
+		foreach ( self::EXCLUDED_PATH_FRAGMENTS as $fragment ) {
+			if ( false !== strpos( $path, $fragment ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+// Run the CLI only when executed directly, so that tests can require this file as a library.
+if ( 'cli' === PHP_SAPI && isset( $argv[0] ) && realpath( $argv[0] ) === __FILE__ ) {
+	$checker = new WC_Removed_Classes_Checker();
+	$command = $argv[1] ?? '';
+
+	if ( 'scan' === $command && isset( $argv[2], $argv[3] ) ) {
+		try {
+			$types = $checker->scan( $argv[2] );
+		} catch ( \InvalidArgumentException $e ) {
+			echo 'Error: ' . $e->getMessage() . "\n";
+			exit( 1 );
+		}
+		file_put_contents( $argv[3], json_encode( $types, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+		echo 'Scanned ' . count( $types ) . " types from {$argv[2]} into {$argv[3]}\n";
+		exit( 0 );
+	}
+
+	if ( 'compare' === $command && isset( $argv[2], $argv[3] ) ) {
+		$old_types = json_decode( (string) file_get_contents( $argv[2] ), true );
+		$new_types = json_decode( (string) file_get_contents( $argv[3] ), true );
+		if ( ! is_array( $old_types ) || ! is_array( $new_types ) ) {
+			echo "Error: could not read the scan result files.\n";
+			exit( 1 );
+		}
+
+		$allowlist = array();
+		if ( isset( $argv[4] ) && file_exists( $argv[4] ) ) {
+			$allowlist = $checker->parse_allowlist( (string) file_get_contents( $argv[4] ) );
+		}
+
+		$removals = $checker->find_unallowed_removals( $old_types, $new_types, $allowlist );
+		if ( empty( $removals ) ) {
+			echo "No unallowed class removals detected.\n";
+			exit( 0 );
+		}
+
+		echo count( $removals ) . " type(s) present in the baseline are missing from the compared tree:\n\n";
+		foreach ( $removals as $removed_type => $removed_file ) {
+			echo "  - $removed_type (was in $removed_file)\n";
+		}
+		echo "\nRemoving a shipped class causes fatal errors during in-place updates: code from the\n";
+		echo "previous version can still reference it while the files are being swapped on disk.\n";
+		echo "Deprecate the class and keep it as a stub for at least one release instead. If the\n";
+		echo "removal is intentional and update-safe, acknowledge it in the PR description with:\n";
+		echo "- [x] This Pull Request intentionally removes PHP classes. (Comment required below)\n";
+		exit( 1 );
+	}
+
+	echo "Usage:\n";
+	echo "  php check-removed-classes.php scan <plugin_root> <output.json>\n";
+	echo "  php check-removed-classes.php compare <old.json> <new.json> [<allowlist_file>]\n";
+	exit( 1 );
+}

--- a/plugins/woocommerce/changelog/add-class-removal-ci-check
+++ b/plugins/woocommerce/changelog/add-class-removal-ci-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a class-removal CI check that fails when a PR removes a PHP class declared on its base branch, unless the author explicitly acknowledges the removal in the PR description, enforcing a deprecation-stub window for shipped classes.

--- a/plugins/woocommerce/changelog/add-update-window-guard
+++ b/plugins/woocommerce/changelog/add-update-window-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add an UpdateDetection guard that suppresses deferrable late-request work (settings lazy data, wc-admin REST controller registration, shutdown cleanup) while WooCommerce plugin files are being updated in place, preventing update-time class-not-found fatal errors.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -397,6 +397,7 @@ final class WooCommerce {
 		 * These classes have a register method for attaching hooks.
 		 */
 		$container->get( Automattic\WooCommerce\Internal\Utilities\PluginInstaller::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Utilities\UpdateDetection::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\TransientFiles\TransientFilesEngine::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderAttributionController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderAttributionBlocksController::class )->register();

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -37638,7 +37638,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method object\:\:register_routes\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 1
 			path: src/Admin/API/Init.php
 
 		-

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -62,9 +62,7 @@ class Init {
 	public function rest_api_init() {
 		$update_detection = $this->get_update_detection();
 		if ( $update_detection && $update_detection->is_update_in_progress() ) {
-			// Registering controllers mid-update can load classes from a half-swapped file state,
-			// including requires of files that no longer exist, which fatal uncatchably.
-			// Skip registration for this request; the next request will register normally.
+			// Registration can fatal uncatchably on autoload mid-update; the next request registers normally.
 			$update_detection->log_suppressed_work( 'wc_admin_rest_controllers' );
 			return;
 		}
@@ -222,10 +220,7 @@ class Init {
 
 	/**
 	 * Instantiate the given controller class names and register their routes.
-	 *
-	 * Controllers whose classes cannot be loaded (e.g. added via the
-	 * 'woocommerce_admin_rest_controllers' filter by an extension that is mid-update)
-	 * are skipped and logged instead of fataling the whole REST registration.
+	 * Controllers whose classes cannot be loaded are skipped and logged instead of fataling.
 	 *
 	 * @param array $controllers List of fully qualified controller class names.
 	 */
@@ -248,8 +243,7 @@ class Init {
 	}
 
 	/**
-	 * Get the UpdateDetection instance, or null if it cannot be resolved.
-	 * Failures resolving the guard must never break REST registration.
+	 * Get the UpdateDetection instance, or null if it cannot be resolved (the guard must never break REST registration).
 	 *
 	 * @return UpdateDetection|null The UpdateDetection instance or null.
 	 */

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
 use Automattic\WooCommerce\Utilities\RestApiUtil;
 
 /**
@@ -59,6 +60,15 @@ class Init {
 	 * @return void
 	 */
 	public function rest_api_init() {
+		$update_detection = $this->get_update_detection();
+		if ( $update_detection && $update_detection->is_update_in_progress() ) {
+			// Registering controllers mid-update can load classes from a half-swapped file state,
+			// including requires of files that no longer exist, which fatal uncatchably.
+			// Skip registration for this request; the next request will register normally.
+			$update_detection->log_suppressed_work( 'wc_admin_rest_controllers' );
+			return;
+		}
+
 		if ( wc_rest_should_load_namespace( 'wc-admin' ) ) {
 			$this->rest_api_init_wc_admin();
 		}
@@ -123,13 +133,7 @@ class Init {
 			}
 		}
 
-		$controllers = array_values( array_unique( $controllers ) );
-		foreach ( $controllers as $controller ) {
-			if ( is_string( $controller ) ) {
-				$this->$controller = new $controller();
-				$this->$controller->register_routes();
-			}
-		}
+		$this->register_controllers( $controllers );
 	}
 
 	/**
@@ -213,12 +217,47 @@ class Init {
 			}
 		}
 
+		$this->register_controllers( $controllers );
+	}
+
+	/**
+	 * Instantiate the given controller class names and register their routes.
+	 *
+	 * Controllers whose classes cannot be loaded (e.g. added via the
+	 * 'woocommerce_admin_rest_controllers' filter by an extension that is mid-update)
+	 * are skipped and logged instead of fataling the whole REST registration.
+	 *
+	 * @param array $controllers List of fully qualified controller class names.
+	 */
+	private function register_controllers( array $controllers ): void {
 		$controllers = array_values( array_unique( $controllers ) );
 		foreach ( $controllers as $controller ) {
-			if ( is_string( $controller ) ) {
-				$this->$controller = new $controller();
-				$this->$controller->register_routes();
+			if ( ! is_string( $controller ) ) {
+				continue;
 			}
+			if ( ! class_exists( $controller ) ) {
+				$update_detection = $this->get_update_detection();
+				if ( $update_detection ) {
+					$update_detection->log_suppressed_work( 'rest_controller:' . $controller );
+				}
+				continue;
+			}
+			$this->$controller = new $controller();
+			$this->$controller->register_routes();
+		}
+	}
+
+	/**
+	 * Get the UpdateDetection instance, or null if it cannot be resolved.
+	 * Failures resolving the guard must never break REST registration.
+	 *
+	 * @return UpdateDetection|null The UpdateDetection instance or null.
+	 */
+	private function get_update_detection() {
+		try {
+			return wc_get_container()->get( UpdateDetection::class );
+		} catch ( \Throwable $throwable ) {
+			return null;
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -182,8 +182,7 @@ class Api {
 		if ( ! $this->script_data_modified ) {
 			return;
 		}
-		// Script data computed while an update is swapping the plugin files may mix old and new
-		// asset state; don't persist it, the next request will rebuild it consistently.
+		// Don't persist script data computed mid-update; it may mix old and new asset state.
 		if ( $this->is_woocommerce_update_in_progress() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
 use Exception;
 use Automattic\Jetpack\Constants;
 /**
@@ -181,6 +182,11 @@ class Api {
 		if ( ! $this->script_data_modified ) {
 			return;
 		}
+		// Script data computed while an update is swapping the plugin files may mix old and new
+		// asset state; don't persist it, the next request will rebuild it consistently.
+		if ( $this->is_woocommerce_update_in_progress() ) {
+			return;
+		}
 		set_transient(
 			$this->script_data_transient_key,
 			wp_json_encode(
@@ -192,6 +198,20 @@ class Api {
 			),
 			DAY_IN_SECONDS * 30
 		);
+	}
+
+	/**
+	 * Whether a WooCommerce update window is active for this request.
+	 * Failures resolving the guard must never break asset registration.
+	 *
+	 * @return bool True if an update is in progress.
+	 */
+	private function is_woocommerce_update_in_progress() {
+		try {
+			return wc_get_container()->get( UpdateDetection::class )->is_update_in_progress();
+		} catch ( \Throwable $throwable ) {
+			return false;
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Internal\Logging\RemoteLogger;
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
 use Exception;
 use InvalidArgumentException;
 
@@ -271,7 +272,31 @@ class AssetDataRegistry {
 	 */
 	protected function execute_lazy_data() {
 		foreach ( $this->lazy_data as $key => $callback ) {
-			$this->data[ $key ] = $callback();
+			try {
+				$this->data[ $key ] = $callback();
+			} catch ( \Throwable $throwable ) {
+				// A failing callback degrades to a missing data key instead of fataling the whole page.
+				// This cannot catch a stale-classmap require of a deleted file; that case is prevented
+				// by the update-window skip in enqueue_asset_data().
+				$update_detection = $this->get_update_detection();
+				if ( $update_detection ) {
+					$update_detection->log_suppressed_work( 'asset_data_registry:' . $key, $throwable );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the UpdateDetection instance, or null if it cannot be resolved.
+	 * Failures resolving the guard must never break asset data output.
+	 *
+	 * @return UpdateDetection|null The UpdateDetection instance or null.
+	 */
+	private function get_update_detection() {
+		try {
+			return wc_get_container()->get( UpdateDetection::class );
+		} catch ( \Throwable $throwable ) {
+			return null;
 		}
 	}
 
@@ -396,7 +421,15 @@ class AssetDataRegistry {
 	public function enqueue_asset_data() {
 		if ( wp_script_is( $this->handle, 'enqueued' ) ) {
 			$this->initialize_core_data();
-			$this->execute_lazy_data();
+
+			$update_detection = $this->get_update_detection();
+			if ( $update_detection && $update_detection->is_update_in_progress() ) {
+				// Executing the lazy callbacks mid-update can autoload classes from a half-swapped
+				// file state and fatal; skip them for this request, the next one will hydrate fully.
+				$update_detection->log_suppressed_work( 'asset_data_registry_lazy_data' );
+			} else {
+				$this->execute_lazy_data();
+			}
 
 			$data                          = rawurlencode( wp_json_encode( $this->data ) );
 			$wc_settings_script            = "var wcSettings = JSON.parse( decodeURIComponent( '" . esc_js( $data ) . "' ) );";

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -275,9 +275,8 @@ class AssetDataRegistry {
 			try {
 				$this->data[ $key ] = $callback();
 			} catch ( \Throwable $throwable ) {
-				// A failing callback degrades to a missing data key instead of fataling the whole page.
-				// This cannot catch a stale-classmap require of a deleted file; that case is prevented
-				// by the update-window skip in enqueue_asset_data().
+				// A stale-classmap require of a deleted file is not catchable; that case is
+				// handled by the update-window skip in enqueue_asset_data().
 				$update_detection = $this->get_update_detection();
 				if ( $update_detection ) {
 					$update_detection->log_suppressed_work( 'asset_data_registry:' . $key, $throwable );
@@ -287,8 +286,7 @@ class AssetDataRegistry {
 	}
 
 	/**
-	 * Get the UpdateDetection instance, or null if it cannot be resolved.
-	 * Failures resolving the guard must never break asset data output.
+	 * Get the UpdateDetection instance, or null if it cannot be resolved (the guard must never break asset output).
 	 *
 	 * @return UpdateDetection|null The UpdateDetection instance or null.
 	 */
@@ -424,8 +422,7 @@ class AssetDataRegistry {
 
 			$update_detection = $this->get_update_detection();
 			if ( $update_detection && $update_detection->is_update_in_progress() ) {
-				// Executing the lazy callbacks mid-update can autoload classes from a half-swapped
-				// file state and fatal; skip them for this request, the next one will hydrate fully.
+				// Lazy callbacks can fatal on autoload mid-update; the next request hydrates fully.
 				$update_detection->log_suppressed_work( 'asset_data_registry_lazy_data' );
 			} else {
 				$this->execute_lazy_data();

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -579,8 +579,7 @@ class BatchProcessingController {
 			return;
 		}
 
-		// Processor class names stored in the database can't be reliably autoloaded while an update
-		// is swapping the plugin files; skip the cleanup, it will run again on the next request.
+		// Stored processor class names can't be reliably autoloaded mid-update; the cleanup reruns next request.
 		if ( ! is_null( $this->update_detection ) && $this->update_detection->is_update_in_progress() ) {
 			$this->update_detection->log_suppressed_work( 'batch_processing_shutdown_cleanup' );
 			return;

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -21,6 +21,8 @@
 
 namespace Automattic\WooCommerce\Internal\BatchProcessing;
 
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
+
 /**
  * Class BatchProcessingController
  *
@@ -57,6 +59,24 @@ class BatchProcessingController {
 	 * @var \WC_Logger_Interface
 	 */
 	private $logger;
+
+	/**
+	 * The UpdateDetection instance to use.
+	 *
+	 * @var UpdateDetection|null
+	 */
+	private ?UpdateDetection $update_detection = null;
+
+	/**
+	 * Initialize the class instance.
+	 *
+	 * @internal
+	 *
+	 * @param UpdateDetection $update_detection The UpdateDetection instance to use.
+	 */
+	final public function init( UpdateDetection $update_detection ): void {
+		$this->update_detection = $update_detection;
+	}
 
 	/**
 	 * BatchProcessingController constructor.
@@ -556,6 +576,13 @@ class BatchProcessingController {
 	 */
 	private function remove_or_retry_failed_processors(): void {
 		if ( ! did_action( 'wp_loaded' ) ) {
+			return;
+		}
+
+		// Processor class names stored in the database can't be reliably autoloaded while an update
+		// is swapping the plugin files; skip the cleanup, it will run again on the next request.
+		if ( ! is_null( $this->update_detection ) && $this->update_detection->is_update_in_progress() ) {
+			$this->update_detection->log_suppressed_work( 'batch_processing_shutdown_cleanup' );
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/UpdateDetection.php
+++ b/plugins/woocommerce/src/Internal/Utilities/UpdateDetection.php
@@ -1,0 +1,208 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\RegisterHooksInterface;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+
+/**
+ * Detects requests that are running with a mixed old-code/new-files state.
+ *
+ * When WooCommerce is updated in place, WordPress swaps the plugin files on disk
+ * mid-request while the code already loaded in memory (and any per-request autoloader
+ * classmap snapshot) still belongs to the previous version. Code that runs late in
+ * such a request — footer hooks, 'shutdown', REST controller registration — can then
+ * reference classes that the stale classmap cannot resolve (new classes) or whose
+ * files no longer exist (removed classes), producing fatal errors.
+ *
+ * This class provides a signal ('is_update_in_progress') that deferrable late work
+ * can consult in order to skip execution for the remainder of the request. Two
+ * detection mechanisms are used:
+ *
+ * - The 'upgrader_pre_install' and 'upgrader_process_complete' hooks, which cover the
+ *   request that performs the update itself.
+ * - A comparison of the plugin version on disk against the loaded code version, which
+ *   covers requests served by still-warm PHP workers (e.g. with a stale opcache) after
+ *   the update happened in another process. This check is admin-only, since all known
+ *   failure paths are admin-side and it involves a file read.
+ *
+ * @since 11.0.0
+ */
+class UpdateDetection implements RegisterHooksInterface {
+
+	/**
+	 * Transient name prefix used to throttle log entries.
+	 *
+	 * @var string
+	 */
+	private const LOG_THROTTLE_TRANSIENT_PREFIX = 'wc_update_detection_log_';
+
+	/**
+	 * Flag indicating that a WooCommerce update has started or completed within this request.
+	 *
+	 * @var bool
+	 */
+	private bool $update_started = false;
+
+	/**
+	 * Memoized result of the on-disk version comparison, null if not computed yet.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $version_on_disk_differs = null;
+
+	/**
+	 * The LegacyProxy instance to use.
+	 *
+	 * @var LegacyProxy
+	 */
+	private LegacyProxy $proxy;
+
+	/**
+	 * Initialize the class instance.
+	 *
+	 * @internal
+	 *
+	 * @param LegacyProxy $proxy The LegacyProxy instance to use.
+	 */
+	final public function init( LegacyProxy $proxy ): void {
+		$this->proxy = $proxy;
+	}
+
+	/**
+	 * Attach hooks used by the class.
+	 */
+	public function register(): void {
+		add_filter( 'upgrader_pre_install', array( $this, 'handle_upgrader_pre_install' ), 10, 2 );
+		add_action( 'upgrader_process_complete', array( $this, 'handle_upgrader_process_complete' ), 10, 2 );
+	}
+
+	/**
+	 * Handler for the 'upgrader_pre_install' filter. Flags the start of a WooCommerce update
+	 * so that late-request work can be suppressed before the files are swapped on disk.
+	 *
+	 * @param bool|\WP_Error $response The installation response before the installation has started.
+	 * @param array          $hook_extra Extra arguments passed to hooked filters.
+	 * @return bool|\WP_Error The unmodified $response.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 */
+	public function handle_upgrader_pre_install( $response, $hook_extra ) {
+		if ( $this->hook_extra_references_woocommerce( (array) $hook_extra ) ) {
+			$this->update_started = true;
+		}
+		return $response;
+	}
+
+	/**
+	 * Handler for the 'upgrader_process_complete' action. Flags the completion of a WooCommerce
+	 * update: from this point until the end of the request the files on disk belong to the new
+	 * version while the loaded code is still the old one.
+	 *
+	 * @param \WP_Upgrader $upgrader The upgrader instance that performed the update.
+	 * @param array        $hook_extra Extra information about the update process.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 */
+	public function handle_upgrader_process_complete( $upgrader, $hook_extra ): void {
+		if ( $this->hook_extra_references_woocommerce( (array) $hook_extra ) ) {
+			$this->update_started = true;
+		}
+	}
+
+	/**
+	 * Whether the current request may be running with plugin files that don't match the loaded code.
+	 *
+	 * True when a WooCommerce update has started or completed within this request, or (in admin
+	 * requests) when the plugin version on disk differs from the version of the loaded code.
+	 * Deferrable work hooked late in the request should skip execution when this returns true:
+	 * class autoloading is unreliable in this state and can produce fatal errors.
+	 *
+	 * @return bool True if an update window is active for this request.
+	 */
+	public function is_update_in_progress(): bool {
+		return $this->update_started || $this->version_on_disk_differs();
+	}
+
+	/**
+	 * Log that deferrable work was skipped or failed during an update window, throttled to one
+	 * entry per context per hour to avoid flooding logs while a stale cache window persists.
+	 *
+	 * @param string          $context Identifier of the work that was skipped, e.g. 'asset_data_registry:someDataKey'.
+	 * @param \Throwable|null $throwable The error that was caught, if the work failed rather than being skipped.
+	 */
+	public function log_suppressed_work( string $context, ?\Throwable $throwable = null ): void {
+		$transient_name = self::LOG_THROTTLE_TRANSIENT_PREFIX . md5( $context );
+		if ( get_transient( $transient_name ) ) {
+			return;
+		}
+		set_transient( $transient_name, 1, HOUR_IN_SECONDS );
+
+		if ( is_null( $throwable ) ) {
+			$message = sprintf( 'Deferred work "%s" was skipped because a WooCommerce update appears to be in progress. It will resume on the next request.', $context );
+		} else {
+			$message = sprintf( 'Deferred work "%s" failed: %s. This is expected while a WooCommerce update is in progress; if it persists, clearing the opcode cache or restarting PHP should resolve it.', $context, $throwable->getMessage() );
+		}
+
+		$this->proxy->call_function( 'wc_get_logger' )->warning(
+			$message,
+			array(
+				'source' => 'update-detection',
+				'error'  => is_null( $throwable ) ? null : array(
+					'class' => get_class( $throwable ),
+					'file'  => $throwable->getFile(),
+					'line'  => $throwable->getLine(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Whether the WooCommerce version on disk differs from the loaded code version.
+	 *
+	 * Only computed for admin requests, and only once per request: the result is memoized,
+	 * so consulting the guard from multiple late hooks costs a single file read at most.
+	 *
+	 * @return bool True if the on-disk version differs (or could not be read).
+	 */
+	private function version_on_disk_differs(): bool {
+		if ( ! is_null( $this->version_on_disk_differs ) ) {
+			return $this->version_on_disk_differs;
+		}
+
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		$loaded_version = WC()->version;
+		$file_data      = $this->proxy->call_function( 'get_file_data', WC_PLUGIN_FILE, array( 'Version' => 'Version' ), 'plugin' );
+		$disk_version   = $file_data['Version'] ?? '';
+
+		// An unreadable version is treated as a mismatch: it can only mean the file is mid-swap or gone.
+		$this->version_on_disk_differs = '' === $disk_version || $disk_version !== $loaded_version;
+
+		return $this->version_on_disk_differs;
+	}
+
+	/**
+	 * Whether the $hook_extra information passed to an upgrader hook refers to WooCommerce.
+	 *
+	 * @param array $hook_extra Extra arguments passed to hooked upgrader filters/actions.
+	 * @return bool True if WooCommerce is the plugin (or among the plugins) being updated.
+	 */
+	private function hook_extra_references_woocommerce( array $hook_extra ): bool {
+		// 'type' is absent on 'upgrader_pre_install' but present on 'upgrader_process_complete'.
+		if ( 'plugin' !== ( $hook_extra['type'] ?? 'plugin' ) ) {
+			return false;
+		}
+
+		$woocommerce_basename = plugin_basename( WC_PLUGIN_FILE );
+
+		if ( ( $hook_extra['plugin'] ?? '' ) === $woocommerce_basename ) {
+			return true;
+		}
+
+		return in_array( $woocommerce_basename, (array) ( $hook_extra['plugins'] ?? array() ), true );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Utilities/UpdateDetection.php
+++ b/plugins/woocommerce/src/Internal/Utilities/UpdateDetection.php
@@ -7,25 +7,15 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
- * Detects requests that are running with a mixed old-code/new-files state.
+ * Detects requests running with a mixed old-code/new-files state: an in-place update
+ * has swapped the plugin files on disk while the loaded code and autoloader classmap
+ * still belong to the previous version. Autoloading is unreliable in that state, so
+ * deferrable late work (footer hooks, 'shutdown', REST registration) should consult
+ * 'is_update_in_progress' and skip for the remainder of the request.
  *
- * When WooCommerce is updated in place, WordPress swaps the plugin files on disk
- * mid-request while the code already loaded in memory (and any per-request autoloader
- * classmap snapshot) still belongs to the previous version. Code that runs late in
- * such a request — footer hooks, 'shutdown', REST controller registration — can then
- * reference classes that the stale classmap cannot resolve (new classes) or whose
- * files no longer exist (removed classes), producing fatal errors.
- *
- * This class provides a signal ('is_update_in_progress') that deferrable late work
- * can consult in order to skip execution for the remainder of the request. Two
- * detection mechanisms are used:
- *
- * - The 'upgrader_pre_install' and 'upgrader_process_complete' hooks, which cover the
- *   request that performs the update itself.
- * - A comparison of the plugin version on disk against the loaded code version, which
- *   covers requests served by still-warm PHP workers (e.g. with a stale opcache) after
- *   the update happened in another process. This check is admin-only, since all known
- *   failure paths are admin-side and it involves a file read.
+ * Detection uses the upgrader hooks (covers the request performing the update) and an
+ * admin-only disk-vs-loaded version comparison (covers still-warm workers after an
+ * update in another process).
  *
  * @since 11.0.0
  */
@@ -79,8 +69,7 @@ class UpdateDetection implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Handler for the 'upgrader_pre_install' filter. Flags the start of a WooCommerce update
-	 * so that late-request work can be suppressed before the files are swapped on disk.
+	 * Handler for the 'upgrader_pre_install' filter: flags the start of a WooCommerce update.
 	 *
 	 * @param bool|\WP_Error $response The installation response before the installation has started.
 	 * @param array          $hook_extra Extra arguments passed to hooked filters.
@@ -96,9 +85,8 @@ class UpdateDetection implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Handler for the 'upgrader_process_complete' action. Flags the completion of a WooCommerce
-	 * update: from this point until the end of the request the files on disk belong to the new
-	 * version while the loaded code is still the old one.
+	 * Handler for the 'upgrader_process_complete' action: flags that a WooCommerce update
+	 * just swapped the files in this request.
 	 *
 	 * @param \WP_Upgrader $upgrader The upgrader instance that performed the update.
 	 * @param array        $hook_extra Extra information about the update process.
@@ -112,12 +100,8 @@ class UpdateDetection implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Whether the current request may be running with plugin files that don't match the loaded code.
-	 *
-	 * True when a WooCommerce update has started or completed within this request, or (in admin
-	 * requests) when the plugin version on disk differs from the version of the loaded code.
-	 * Deferrable work hooked late in the request should skip execution when this returns true:
-	 * class autoloading is unreliable in this state and can produce fatal errors.
+	 * Whether the current request may be running with plugin files that don't match the
+	 * loaded code. Deferrable late work should skip execution when this returns true.
 	 *
 	 * @return bool True if an update window is active for this request.
 	 */
@@ -126,8 +110,8 @@ class UpdateDetection implements RegisterHooksInterface {
 	}
 
 	/**
-	 * Log that deferrable work was skipped or failed during an update window, throttled to one
-	 * entry per context per hour to avoid flooding logs while a stale cache window persists.
+	 * Log that deferrable work was skipped or failed during an update window,
+	 * throttled to one entry per context per hour.
 	 *
 	 * @param string          $context Identifier of the work that was skipped, e.g. 'asset_data_registry:someDataKey'.
 	 * @param \Throwable|null $throwable The error that was caught, if the work failed rather than being skipped.
@@ -160,9 +144,7 @@ class UpdateDetection implements RegisterHooksInterface {
 
 	/**
 	 * Whether the WooCommerce version on disk differs from the loaded code version.
-	 *
-	 * Only computed for admin requests, and only once per request: the result is memoized,
-	 * so consulting the guard from multiple late hooks costs a single file read at most.
+	 * Admin-only and memoized, so it costs at most one file read per request.
 	 *
 	 * @return bool True if the on-disk version differs (or could not be read).
 	 */

--- a/plugins/woocommerce/tests/php/src/Admin/API/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/InitTest.php
@@ -1,0 +1,65 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\API;
+
+use Automattic\WooCommerce\Admin\API\Init;
+use Automattic\WooCommerce\Admin\API\Notice;
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
+use Automattic\WooCommerce\Tests\Internal\Utilities\UpdateDetectionStub;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the REST API Init class.
+ */
+class InitTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wc_get_container()->reset_replacement( UpdateDetection::class );
+		remove_all_filters( 'woocommerce_admin_rest_controllers' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox REST controller registration is skipped and logged while a WooCommerce update window is active.
+	 */
+	public function test_rest_api_init_skips_registration_during_update_window(): void {
+		$stub = new UpdateDetectionStub( true );
+		wc_get_container()->replace( UpdateDetection::class, $stub );
+
+		$sut = new Init();
+		$sut->rest_api_init();
+
+		$this->assertCount( 1, $stub->logged, 'The skipped registration should be logged' );
+		$this->assertSame( 'wc_admin_rest_controllers', $stub->logged[0]['context'] );
+	}
+
+	/**
+	 * @testdox A controller class that cannot be loaded is skipped and logged instead of fataling, without affecting other controllers.
+	 */
+	public function test_unloadable_rest_controller_is_skipped_and_logged(): void {
+		$this->setExpectedIncorrectUsage( 'register_rest_route' );
+
+		$stub = new UpdateDetectionStub( false );
+		wc_get_container()->replace( UpdateDetection::class, $stub );
+
+		$missing_controller = 'Automattic\WooCommerce\Admin\API\ClassThatDoesNotExist';
+		add_filter(
+			'woocommerce_admin_rest_controllers',
+			function ( $controllers ) use ( $missing_controller ) {
+				$controllers[] = $missing_controller;
+				return $controllers;
+			}
+		);
+
+		$sut = new Init();
+		$sut->rest_api_init_wc_admin();
+
+		$skip_contexts = array_column( $stub->logged, 'context' );
+		$this->assertContains( 'rest_controller:' . $missing_controller, $skip_contexts, 'The unloadable controller should be logged as skipped' );
+		$this->assertInstanceOf( Notice::class, $sut->{Notice::class}, 'Loadable controllers should still be registered' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Bin/CheckRemovedClassesTest.php
+++ b/plugins/woocommerce/tests/php/src/Bin/CheckRemovedClassesTest.php
@@ -1,0 +1,184 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Bin;
+
+use WC_Unit_Test_Case;
+
+require_once __DIR__ . '/../../../../bin/check-removed-classes.php';
+
+/**
+ * Tests for the WC_Removed_Classes_Checker class (bin/check-removed-classes.php).
+ */
+class CheckRemovedClassesTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var \WC_Removed_Classes_Checker
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new \WC_Removed_Classes_Checker();
+	}
+
+	/**
+	 * @testdox Should extract namespaced class, interface, trait and enum declarations.
+	 */
+	public function test_extracts_namespaced_type_declarations(): void {
+		$code = '<?php
+namespace Automattic\WooCommerce\Internal\Foo;
+
+class SomeClass {}
+interface SomeInterface {}
+trait SomeTrait {}
+enum SomeEnum: string {
+	case A = "a";
+}
+';
+
+		$declarations = $this->sut->extract_declarations( $code );
+
+		$this->assertSame(
+			array(
+				'Automattic\WooCommerce\Internal\Foo\SomeClass',
+				'Automattic\WooCommerce\Internal\Foo\SomeInterface',
+				'Automattic\WooCommerce\Internal\Foo\SomeTrait',
+				'Automattic\WooCommerce\Internal\Foo\SomeEnum',
+			),
+			$declarations
+		);
+	}
+
+	/**
+	 * @testdox Should extract global-namespace legacy class declarations.
+	 */
+	public function test_extracts_global_namespace_declarations(): void {
+		$code = '<?php
+class WC_Legacy_Thing extends WC_Other_Thing {
+	public function noop() {}
+}
+';
+
+		$this->assertSame( array( 'WC_Legacy_Thing' ), $this->sut->extract_declarations( $code ) );
+	}
+
+	/**
+	 * @testdox Should ignore anonymous classes and ::class constant references.
+	 */
+	public function test_ignores_anonymous_classes_and_class_constants(): void {
+		$code = '<?php
+namespace Foo;
+
+class RealClass {
+	public function make() {
+		$anonymous = new class() {
+			public function noop() {}
+		};
+		return array( $anonymous, RealClass::class, \Bar\Other::class );
+	}
+}
+';
+
+		$this->assertSame( array( 'Foo\RealClass' ), $this->sut->extract_declarations( $code ) );
+	}
+
+	/**
+	 * @testdox Should report a type present in the old scan but missing from the new scan.
+	 */
+	public function test_reports_removed_type(): void {
+		$old = array(
+			'Foo\KeptClass'    => 'src/KeptClass.php',
+			'Foo\RemovedClass' => 'src/RemovedClass.php',
+		);
+		$new = array(
+			'Foo\KeptClass' => 'src/KeptClass.php',
+			'Foo\NewClass'  => 'src/NewClass.php',
+		);
+
+		$removals = $this->sut->find_unallowed_removals( $old, $new, array() );
+
+		$this->assertSame( array( 'Foo\RemovedClass' => 'src/RemovedClass.php' ), $removals );
+	}
+
+	/**
+	 * @testdox Should not report a type whose file moved but whose name is unchanged.
+	 */
+	public function test_does_not_report_moved_type(): void {
+		$old = array( 'Foo\MovedClass' => 'src/Old/MovedClass.php' );
+		$new = array( 'Foo\MovedClass' => 'src/New/MovedClass.php' );
+
+		$this->assertSame( array(), $this->sut->find_unallowed_removals( $old, $new, array() ) );
+	}
+
+	/**
+	 * @testdox Should not report removals that are allowlisted.
+	 */
+	public function test_does_not_report_allowlisted_removal(): void {
+		$old = array( 'Foo\RemovedClass' => 'src/RemovedClass.php' );
+		$new = array();
+
+		$removals = $this->sut->find_unallowed_removals( $old, $new, array( 'Foo\RemovedClass' ) );
+
+		$this->assertSame( array(), $removals );
+	}
+
+	/**
+	 * @testdox Should parse allowlist files ignoring comments and blank lines.
+	 */
+	public function test_parses_allowlist_ignoring_comments_and_blank_lines(): void {
+		$contents = "# A comment\n\nFoo\\AllowedOne\n  \\Foo\\AllowedTwo  \n# Another comment\n";
+
+		$this->assertSame( array( 'Foo\AllowedOne', 'Foo\AllowedTwo' ), $this->sut->parse_allowlist( $contents ) );
+	}
+
+	/**
+	 * @testdox Should scan a plugin-shaped directory tree and skip excluded paths.
+	 */
+	public function test_scans_plugin_tree_and_skips_excluded_paths(): void {
+		// phpcs:disable WordPress.WP.AlternativeFunctions -- direct filesystem calls to build and clean up a temp fixture tree.
+		$root = sys_get_temp_dir() . '/wc-class-check-' . uniqid();
+		mkdir( $root . '/src/Deep', 0777, true );
+		mkdir( $root . '/src/vendor', 0777, true );
+		mkdir( $root . '/includes', 0777, true );
+		file_put_contents( $root . '/src/Deep/A.php', "<?php\nnamespace Foo\\Deep;\nclass A {}\n" );
+		file_put_contents( $root . '/src/vendor/B.php', "<?php\nnamespace Bundled;\nclass B {}\n" );
+		file_put_contents( $root . '/includes/class-wc-legacy.php', "<?php\nclass WC_Legacy {}\n" );
+
+		try {
+			$types = $this->sut->scan( $root );
+		} finally {
+			unlink( $root . '/src/Deep/A.php' );
+			unlink( $root . '/src/vendor/B.php' );
+			unlink( $root . '/includes/class-wc-legacy.php' );
+			rmdir( $root . '/src/Deep' );
+			rmdir( $root . '/src/vendor' );
+			rmdir( $root . '/src' );
+			rmdir( $root . '/includes' );
+			rmdir( $root );
+		}
+		// phpcs:enable WordPress.WP.AlternativeFunctions
+
+		$this->assertSame(
+			array(
+				'Foo\Deep\A' => 'src/Deep/A.php',
+				'WC_Legacy'  => 'includes/class-wc-legacy.php',
+			),
+			$types
+		);
+	}
+
+	/**
+	 * @testdox Should reject a scan root that is not a plugin checkout.
+	 */
+	public function test_scan_rejects_non_plugin_root(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->sut->scan( sys_get_temp_dir() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
@@ -4,7 +4,9 @@ namespace Automattic\WooCommerce\Tests\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
+use Automattic\WooCommerce\Tests\Internal\Utilities\UpdateDetectionStub;
 use Automattic\WooCommerce\Blocks\Package;
 use InvalidArgumentException;
 
@@ -22,6 +24,105 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 		$this->registry = new AssetDataRegistryMock(
 			Package::container()->get( API::class )
 		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		wc_get_container()->reset_replacement( UpdateDetection::class );
+		wp_dequeue_script( 'wc-settings' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create an UpdateDetection stub with a controllable update-window state that records log calls.
+	 *
+	 * @param bool $in_progress The value 'is_update_in_progress' should report.
+	 * @return UpdateDetectionStub The stub, already registered as a container replacement.
+	 */
+	private function replace_update_detection_with_stub( bool $in_progress ): UpdateDetectionStub {
+		$stub = new UpdateDetectionStub( $in_progress );
+		wc_get_container()->replace( UpdateDetection::class, $stub );
+
+		return $stub;
+	}
+
+	/**
+	 * @testdox A lazy data callback that throws is dropped and logged without breaking sibling keys.
+	 */
+	public function test_lazy_data_callback_failure_does_not_break_sibling_keys() {
+		$stub = $this->replace_update_detection_with_stub( false );
+
+		$this->registry->add( 'healthy', fn () => 'healthy-value' );
+		$this->registry->add(
+			'broken',
+			function () {
+				throw new \Error( 'Class "Automattic\WooCommerce\Some\NewClass" not found' );
+			}
+		);
+		$this->registry->add( 'alsoHealthy', fn () => 'also-healthy-value' );
+
+		$this->registry->execute_lazy_data();
+		$data = $this->registry->get();
+
+		$this->assertSame( 'healthy-value', $data['healthy'], 'Keys before the failing one should be populated' );
+		$this->assertSame( 'also-healthy-value', $data['alsoHealthy'], 'Keys after the failing one should be populated' );
+		$this->assertArrayNotHasKey( 'broken', $data, 'The failing key should be dropped' );
+		$this->assertCount( 1, $stub->logged, 'The failure should be logged' );
+		$this->assertSame( 'asset_data_registry:broken', $stub->logged[0]['context'] );
+	}
+
+	/**
+	 * @testdox Lazy data callbacks are skipped and logged when an update window is active.
+	 */
+	public function test_enqueue_asset_data_skips_lazy_data_during_update_window() {
+		$stub = $this->replace_update_detection_with_stub( true );
+
+		$executed = false;
+		$this->registry->add(
+			'lazyKey',
+			function () use ( &$executed ) {
+				$executed = true;
+				return 'lazy-value';
+			}
+		);
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter,WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script( 'wc-settings', '' );
+		wp_enqueue_script( 'wc-settings' );
+
+		$this->registry->enqueue_asset_data();
+
+		$this->assertFalse( $executed, 'Lazy callbacks should not execute during an update window' );
+		$this->assertArrayNotHasKey( 'lazyKey', $this->registry->get(), 'Lazy data should not be present during an update window' );
+		$this->assertCount( 1, $stub->logged, 'The skip should be logged' );
+		$this->assertSame( 'asset_data_registry_lazy_data', $stub->logged[0]['context'] );
+	}
+
+	/**
+	 * @testdox Lazy data callbacks execute normally when no update window is active.
+	 */
+	public function test_enqueue_asset_data_executes_lazy_data_without_update_window() {
+		$this->replace_update_detection_with_stub( false );
+
+		$executed = false;
+		$this->registry->add(
+			'lazyKey',
+			function () use ( &$executed ) {
+				$executed = true;
+				return 'lazy-value';
+			}
+		);
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter,WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script( 'wc-settings', '' );
+		wp_enqueue_script( 'wc-settings' );
+
+		$this->registry->enqueue_asset_data();
+
+		$this->assertTrue( $executed, 'Lazy callbacks should execute when no update window is active' );
+		$this->assertSame( 'lazy-value', $this->registry->get()['lazyKey'] );
 	}
 
 	public function test_initial_data() {

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Internal\BatchProcessing;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Tests\Internal\Utilities\UpdateDetectionStub;
 
 /**
  * Class BatchProcessingControllerTests.
@@ -331,5 +332,34 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->assertFalse( $this->sut->is_enqueued( get_class( $second_processor ) ) );
 		$this->assertFalse( $this->sut->is_scheduled( get_class( $second_processor ) ) );
 		$this->assertFalse( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+	}
+
+	/**
+	 * @testdox The shutdown cleanup routine is skipped and logged while a WooCommerce update window is active.
+	 */
+	public function test_shutdown_cleanup_is_skipped_during_update_window() {
+		$stub = new UpdateDetectionStub( true );
+		$this->sut->init( $stub );
+
+		$method = new \ReflectionMethod( $this->sut, 'remove_or_retry_failed_processors' );
+		$method->setAccessible( true );
+		$method->invoke( $this->sut );
+
+		$this->assertCount( 1, $stub->logged, 'The skipped cleanup should be logged' );
+		$this->assertSame( 'batch_processing_shutdown_cleanup', $stub->logged[0]['context'] );
+	}
+
+	/**
+	 * @testdox The shutdown cleanup routine runs normally when no update window is active.
+	 */
+	public function test_shutdown_cleanup_runs_without_update_window() {
+		$stub = new UpdateDetectionStub( false );
+		$this->sut->init( $stub );
+
+		$method = new \ReflectionMethod( $this->sut, 'remove_or_retry_failed_processors' );
+		$method->setAccessible( true );
+		$method->invoke( $this->sut );
+
+		$this->assertCount( 0, $stub->logged, 'No skip should be logged when no update window is active' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/UpdateDetectionStub.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/UpdateDetectionStub.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
+
+/**
+ * UpdateDetection stub with a controllable update-window state that records suppressed-work log calls.
+ */
+class UpdateDetectionStub extends UpdateDetection {
+
+	/**
+	 * The update-window state to report.
+	 *
+	 * @var bool
+	 */
+	public $in_progress = false;
+
+	/**
+	 * Recorded log_suppressed_work calls, each an array with 'context' and 'throwable' keys.
+	 *
+	 * @var array
+	 */
+	public $logged = array();
+
+	/**
+	 * Initialize the stub.
+	 *
+	 * @param bool $in_progress The update-window state to report.
+	 */
+	public function __construct( bool $in_progress = false ) {
+		$this->in_progress = $in_progress;
+	}
+
+	/**
+	 * Report the configured update-window state.
+	 *
+	 * @return bool
+	 */
+	public function is_update_in_progress(): bool {
+		return $this->in_progress;
+	}
+
+	/**
+	 * Record a suppressed-work log call instead of logging.
+	 *
+	 * @param string          $context The context identifier.
+	 * @param \Throwable|null $throwable The caught error, if any.
+	 */
+	public function log_suppressed_work( string $context, ?\Throwable $throwable = null ): void {
+		$this->logged[] = array(
+			'context'   => $context,
+			'throwable' => $throwable,
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/UpdateDetectionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/UpdateDetectionTest.php
@@ -1,0 +1,289 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\UpdateDetection;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the UpdateDetection class.
+ */
+class UpdateDetectionTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var UpdateDetection
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new UpdateDetection();
+		$this->sut->init( wc_get_container()->get( LegacyProxy::class ) );
+
+		if ( ! class_exists( \WP_Upgrader::class ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		set_current_screen( 'front' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should report no update in progress by default.
+	 */
+	public function test_no_update_in_progress_by_default(): void {
+		$this->assertFalse( $this->sut->is_update_in_progress(), 'No update signal should be active on a plain request' );
+	}
+
+	/**
+	 * @testdox Should report an update in progress after upgrader_pre_install fires for WooCommerce.
+	 */
+	public function test_update_in_progress_after_pre_install_for_woocommerce(): void {
+		$this->sut->register();
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		$response = apply_filters( 'upgrader_pre_install', true, array( 'plugin' => plugin_basename( WC_PLUGIN_FILE ) ) );
+
+		$this->assertTrue( $response, 'The filter should return the response unmodified' );
+		$this->assertTrue( $this->sut->is_update_in_progress(), 'A WooCommerce pre-install should activate the update window' );
+	}
+
+	/**
+	 * @testdox Should not report an update in progress when another plugin is updated.
+	 */
+	public function test_no_update_in_progress_for_other_plugin(): void {
+		$this->sut->register();
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		apply_filters( 'upgrader_pre_install', true, array( 'plugin' => 'some-plugin/some-plugin.php' ) );
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action(
+			'upgrader_process_complete',
+			new \WP_Upgrader(),
+			array(
+				'type'    => 'plugin',
+				'action'  => 'update',
+				'plugins' => array( 'some-plugin/some-plugin.php' ),
+			)
+		);
+
+		$this->assertFalse( $this->sut->is_update_in_progress(), 'Updates of other plugins should not activate the update window' );
+	}
+
+	/**
+	 * @testdox Should report an update in progress after a bulk upgrader_process_complete that includes WooCommerce.
+	 */
+	public function test_update_in_progress_after_bulk_process_complete(): void {
+		$this->sut->register();
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action(
+			'upgrader_process_complete',
+			new \WP_Upgrader(),
+			array(
+				'type'    => 'plugin',
+				'action'  => 'update',
+				'bulk'    => true,
+				'plugins' => array( 'some-plugin/some-plugin.php', plugin_basename( WC_PLUGIN_FILE ) ),
+			)
+		);
+
+		$this->assertTrue( $this->sut->is_update_in_progress(), 'A bulk update including WooCommerce should activate the update window' );
+	}
+
+	/**
+	 * @testdox Should not report an update in progress for theme updates.
+	 */
+	public function test_no_update_in_progress_for_theme_update(): void {
+		$this->sut->register();
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action(
+			'upgrader_process_complete',
+			new \WP_Upgrader(),
+			array(
+				'type'   => 'theme',
+				'action' => 'update',
+				'themes' => array( 'storefront' ),
+			)
+		);
+
+		$this->assertFalse( $this->sut->is_update_in_progress(), 'Theme updates should not activate the update window' );
+	}
+
+	/**
+	 * @testdox Should report an update in progress in admin when the version on disk differs from the loaded code.
+	 */
+	public function test_update_in_progress_when_disk_version_differs_in_admin(): void {
+		set_current_screen( 'dashboard' );
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_file_data' => function ( $file, $headers, $context ) {
+					// Avoid parameter not used PHPCS errors.
+					unset( $file, $headers, $context );
+					return array( 'Version' => '0.0.1' );
+				},
+			)
+		);
+
+		$this->assertTrue( $this->sut->is_update_in_progress(), 'A disk/loaded version mismatch in admin should activate the update window' );
+	}
+
+	/**
+	 * @testdox Should not report an update in progress in admin when the version on disk matches the loaded code.
+	 */
+	public function test_no_update_in_progress_when_disk_version_matches_in_admin(): void {
+		set_current_screen( 'dashboard' );
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_file_data' => function ( $file, $headers, $context ) {
+					// Avoid parameter not used PHPCS errors.
+					unset( $file, $headers, $context );
+					return array( 'Version' => WC()->version );
+				},
+			)
+		);
+
+		$this->assertFalse( $this->sut->is_update_in_progress(), 'A matching disk version should not activate the update window' );
+	}
+
+	/**
+	 * @testdox Should treat an unreadable version on disk as an update in progress.
+	 */
+	public function test_update_in_progress_when_disk_version_unreadable(): void {
+		set_current_screen( 'dashboard' );
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_file_data' => function ( $file, $headers, $context ) {
+					// Avoid parameter not used PHPCS errors.
+					unset( $file, $headers, $context );
+					return array( 'Version' => '' );
+				},
+			)
+		);
+
+		$this->assertTrue( $this->sut->is_update_in_progress(), 'An unreadable disk version should be treated as an update window' );
+	}
+
+	/**
+	 * @testdox Should skip the disk version check outside of admin requests.
+	 */
+	public function test_disk_version_check_skipped_outside_admin(): void {
+		$get_file_data_calls = 0;
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_file_data' => function () use ( &$get_file_data_calls ) {
+					++$get_file_data_calls;
+					return array( 'Version' => '0.0.1' );
+				},
+			)
+		);
+
+		$this->assertFalse( $this->sut->is_update_in_progress(), 'The disk version check should not run on frontend requests' );
+		$this->assertSame( 0, $get_file_data_calls, 'get_file_data should not be called outside admin' );
+	}
+
+	/**
+	 * @testdox Should read the version on disk only once per request.
+	 */
+	public function test_disk_version_check_is_memoized(): void {
+		set_current_screen( 'dashboard' );
+		$get_file_data_calls = 0;
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_file_data' => function () use ( &$get_file_data_calls ) {
+					++$get_file_data_calls;
+					return array( 'Version' => '0.0.1' );
+				},
+			)
+		);
+
+		$this->sut->is_update_in_progress();
+		$this->sut->is_update_in_progress();
+		$this->sut->is_update_in_progress();
+
+		$this->assertSame( 1, $get_file_data_calls, 'The disk version should be read at most once per request' );
+	}
+
+	/**
+	 * @testdox Should log suppressed work once per context per throttle window.
+	 */
+	public function test_log_suppressed_work_is_throttled_per_context(): void {
+		$fake_logger = $this->create_fake_logger();
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_get_logger' => function () use ( $fake_logger ) {
+					return $fake_logger;
+				},
+			)
+		);
+
+		$this->sut->log_suppressed_work( 'test_context_one' );
+		$this->sut->log_suppressed_work( 'test_context_one' );
+		$this->sut->log_suppressed_work( 'test_context_two' );
+
+		$this->assertCount( 2, $fake_logger->warnings, 'Repeated logging for the same context should be throttled' );
+	}
+
+	/**
+	 * @testdox Should include the caught error details when logging failed work.
+	 */
+	public function test_log_suppressed_work_includes_throwable_details(): void {
+		$fake_logger = $this->create_fake_logger();
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_get_logger' => function () use ( $fake_logger ) {
+					return $fake_logger;
+				},
+			)
+		);
+
+		$this->sut->log_suppressed_work( 'test_context_error', new \Error( 'Class "Foo" not found' ) );
+
+		$this->assertCount( 1, $fake_logger->warnings );
+		$this->assertStringContainsString( 'Class "Foo" not found', $fake_logger->warnings[0]['message'] );
+		$this->assertSame( \Error::class, $fake_logger->warnings[0]['context']['error']['class'] );
+	}
+
+	/**
+	 * Create a minimal fake logger that records warning calls.
+	 *
+	 * @return object The fake logger.
+	 */
+	private function create_fake_logger() {
+		// phpcs:ignore Squiz.Commenting
+		return new class() {
+			/**
+			 * Recorded warning calls.
+			 *
+			 * @var array
+			 */
+			public $warnings = array();
+
+			/**
+			 * Record a warning call.
+			 *
+			 * @param string $message The log message.
+			 * @param array  $context The log context.
+			 */
+			public function warning( $message, $context = array() ) {
+				$this->warnings[] = array(
+					'message' => $message,
+					'context' => $context,
+				);
+			}
+		};
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In-place updates swap the plugin files on disk mid-request while the loaded code and the autoloader's classmap snapshot still belong to the old version. Late-request code that autoloads classes in that window fatals — this caused the 10.7→10.8 (#65337) and 10.8→10.9 (#66031) update fatals. This PR is the general-case mitigation:

- **`UpdateDetection` service** (`src/Internal/Utilities/`) — detects an active update window via the upgrader hooks (the request performing the update) and an admin-only disk-vs-loaded version comparison (stale workers after an update in another process), with throttled logging (source `update-detection`).
- **Guarded choke points** — `AssetDataRegistry` lazy `wc-settings` data (the 10.9.1 stack trace), `Admin\API\Init` REST controller registration, `BatchProcessingController` shutdown cleanup, and the Blocks script-data cache write all skip during the window; skipped work self-heals on the next request. `AssetDataRegistry` also degrades per-key on `Throwable` instead of fataling the whole page.
- **Class-removal CI check** — fails a PR that removes a class/interface/trait/enum declared on its base branch (scans declarations, so renames and namespace moves are caught too), unless the author acknowledges it with a checked `This Pull Request intentionally removes PHP classes` line in the PR description (mirrors the no-changelog checkbox). Intended policy: deprecate-and-stub for at least one release before removing.

Known limitations, accepted as a starting point:

- Only protects updates *from* versions that carry the guard — the old, in-memory code is what fatals.
- The disk-version signal is admin-only; frontend requests rely on the same-request upgrader hooks.
- The per-PR check can't see removals via reverts, direct pushes, or cherry-picks; the script supports manual release-vs-release audits for release leads (usage in the script header).
- Trunk already removed 23 types relative to 10.9.x (#65500, #65456, #65503). Two (`WC_REST_Layout_Templates_Controller`, `WC_REST_Products_Catalog_Controller`) are in 10.9's composer classmap and need an update-safety review before the next major ships.

Backward compatibility: additive only — no public signatures changed or symbols removed. Related: #66031, #65337; complements the PSR-4 fallback autoloader from #65338 (which covers the new-class direction).

### How to test the changes in this Pull Request:

1. Run the unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter "UpdateDetectionTest|InitTest|BatchProcessingControllerTests|CheckRemovedClassesTest|AssetDataRegistry"` — all should pass.
2. Confirm normal behavior is unchanged: visit WooCommerce → Home and a few admin screens; pages load and `window.wcSettings` is populated.
3. Simulate an update window with WP-CLI and confirm suppression:

   ```sh
   wp eval '
   require_once ABSPATH . "wp-admin/includes/class-wp-upgrader.php";
   do_action( "upgrader_process_complete", new WP_Upgrader(), array( "type" => "plugin", "action" => "update", "plugin" => plugin_basename( WC_PLUGIN_FILE ) ) );
   wp_register_script( "wc-settings", "http://example.com/x.js", array(), "1", true );
   wp_enqueue_script( "wc-settings" );
   $adr = Automattic\WooCommerce\Blocks\Package::container()->get( Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class );
   $ran = false;
   $adr->add( "simKey", function () use ( &$ran ) { $ran = true; return "x"; } );
   $adr->enqueue_asset_data();
   $GLOBALS["wp_rest_server"] = null;
   $routes = rest_get_server()->get_routes();
   echo "lazy ran: " . var_export( $ran, true ) . "\n";
   echo "wc-admin options route: " . var_export( isset( $routes["/wc-admin/options"] ), true ) . "\n";
   '
   ```

   Expect both `false` (both `true` without the `do_action` line), and a warning per context under WooCommerce → Status → Logs, source `update-detection`.
4. Exercise the class-removal check: delete any class file under `plugins/woocommerce/src/`, then:

   ```sh
   mkdir -p /tmp/wc-base && git archive trunk plugins/woocommerce/src plugins/woocommerce/includes | tar -x -C /tmp/wc-base
   php plugins/woocommerce/bin/check-removed-classes.php scan /tmp/wc-base/plugins/woocommerce /tmp/base.json
   php plugins/woocommerce/bin/check-removed-classes.php scan plugins/woocommerce /tmp/pr.json
   php plugins/woocommerce/bin/check-removed-classes.php compare /tmp/base.json /tmp/pr.json
   ```

   Expect the deleted class reported with exit code 1; restore it and expect a pass.
5. (Full regression, recommended before merge) Build a zip from this branch (`pnpm --filter=@woocommerce/plugin-woocommerce build:zip`), install WooCommerce 10.9.1 on a disposable site, update in place to the built zip, and confirm no fatal notice or recovery-mode email.

### Testing that has already taken place:

- 34 new PHPUnit tests; the five affected suites pass (71 tests, 141 assertions) in wp-env (PHP 8.1).
- WP-CLI behavioral simulation in wp-env: control run normal; simulated update → lazy data and wc-admin controller registration skipped, both logged once (throttle verified in unit tests).
- Removal script verified against real trees: branch vs trunk passes; reversed comparison flags the new class; run against the published 10.9.1 zip it identified the 23 known trunk removals. Acknowledgment grep tested against checked/unchecked/absent variants.
- PHPCS, PHPStan (baseline shrank by one entry), and branch-level lint all clean.
- Step 5 (full 10.9.1 → built-zip upgrade) has **not** been run yet and is the main remaining manual verification.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>