### PR TITLE
fix(admin): check Action Scheduler wrapper in Daily Cron status report

### DIFF
--- a/plugins/woocommerce/changelog/fix-66180-daily-cron-status-check
+++ b/plugins/woocommerce/changelog/fix-66180-daily-cron-status-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix false "Daily Cron: Not scheduled" on Status page for fresh WooCommerce installs.

--- a/plugins/woocommerce/changelog/fix-66180-daily-cron-status-check
+++ b/plugins/woocommerce/changelog/fix-66180-daily-cron-status-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix false "Daily Cron: Not scheduled" on Status page for fresh WooCommerce installs.

--- a/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
+++ b/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
@@ -117,7 +117,8 @@ class SystemStatusReport {
 		$next_daily_cron = null;
 
 		if ( function_exists( 'as_next_scheduled_action' ) ) {
-			$next_daily_cron = as_next_scheduled_action( 'wc_admin_daily_wrapper', array(), 'woocommerce' );
+			$next_action_time = as_next_scheduled_action( 'wc_admin_daily_wrapper', array(), 'woocommerce' );
+			$next_daily_cron  = is_numeric( $next_action_time ) ? $next_action_time : null;
 		}
 
 		if ( empty( $next_daily_cron ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
+++ b/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
@@ -125,10 +125,12 @@ class SystemStatusReport {
 				<td class="help"><?php echo wc_help_tip( esc_html__( 'Is the daily cron job active, when does it next run?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
-					if ( true === $next_action_time ) {
-						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html__( 'Currently running', 'woocommerce' ) . '</mark>';
-					} elseif ( is_numeric( $next_action_time ) ) {
-						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> Next scheduled: ' . esc_html( date_i18n( 'Y-m-d H:i:s P', (int) $next_action_time ) ) . '</mark>';
+					if ( $next_action_time ) {
+						$status_text = true === $next_action_time
+							? esc_html__( 'Currently running', 'woocommerce' )
+							/* translators: %s: Date and time the daily cron job is next scheduled to run. */
+							: sprintf( esc_html__( 'Next scheduled: %s', 'woocommerce' ), esc_html( date_i18n( 'Y-m-d H:i:s P', (int) $next_action_time ) ) );
+						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . $status_text . '</mark>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $status_text built from esc_html()/esc_html__() above.
 					} else {
 						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not scheduled', 'woocommerce' ) . '</mark>';
 					}

--- a/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
+++ b/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
@@ -77,7 +77,7 @@ class SystemStatusReport {
 		$enabled_features  = array_filter( $features );
 		$disabled_features = array_filter(
 			$features,
-			function( $feature ) {
+			function ( $feature ) {
 				return empty( $feature );
 			}
 		);
@@ -114,7 +114,15 @@ class SystemStatusReport {
 	 * Render daily cron row.
 	 */
 	public function render_daily_cron() {
-		$next_daily_cron = wp_next_scheduled( 'wc_admin_daily' );
+		$next_daily_cron = null;
+
+		if ( function_exists( 'as_next_scheduled_action' ) ) {
+			$next_daily_cron = as_next_scheduled_action( 'wc_admin_daily_wrapper', array(), 'woocommerce' );
+		}
+
+		if ( empty( $next_daily_cron ) ) {
+			$next_daily_cron = wp_next_scheduled( 'wc_admin_daily' );
+		}
 		?>
 			<tr>
 				<td data-export-label="Daily Cron">
@@ -213,5 +221,4 @@ class SystemStatusReport {
 			</tr>
 		<?php
 	}
-
 }

--- a/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
+++ b/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
@@ -114,16 +114,9 @@ class SystemStatusReport {
 	 * Render daily cron row.
 	 */
 	public function render_daily_cron() {
-		$next_daily_cron = null;
-
-		if ( function_exists( 'as_next_scheduled_action' ) ) {
-			$next_action_time = as_next_scheduled_action( 'wc_admin_daily_wrapper', array(), 'woocommerce' );
-			$next_daily_cron  = is_numeric( $next_action_time ) ? $next_action_time : null;
-		}
-
-		if ( empty( $next_daily_cron ) ) {
-			$next_daily_cron = wp_next_scheduled( 'wc_admin_daily' );
-		}
+		$next_action_time = function_exists( 'as_next_scheduled_action' )
+			? as_next_scheduled_action( 'wc_admin_daily_wrapper', null, 'woocommerce' )
+			: false;
 		?>
 			<tr>
 				<td data-export-label="Daily Cron">
@@ -132,10 +125,12 @@ class SystemStatusReport {
 				<td class="help"><?php echo wc_help_tip( esc_html__( 'Is the daily cron job active, when does it next run?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
-					if ( empty( $next_daily_cron ) ) {
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not scheduled', 'woocommerce' ) . '</mark>';
+					if ( true === $next_action_time ) {
+						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html__( 'Currently running', 'woocommerce' ) . '</mark>';
+					} elseif ( is_numeric( $next_action_time ) ) {
+						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> Next scheduled: ' . esc_html( date_i18n( 'Y-m-d H:i:s P', (int) $next_action_time ) ) . '</mark>';
 					} else {
-						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> Next scheduled: ' . esc_html( date_i18n( 'Y-m-d H:i:s P', $next_daily_cron ) ) . '</mark>';
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not scheduled', 'woocommerce' ) . '</mark>';
 					}
 					?>
 				</td>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
@@ -36,35 +36,21 @@ class SystemStatusReportTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Data provider for test_render_daily_cron.
-	 *
-	 * @return array<string, array<string>>
-	 */
-	public function provider_render_daily_cron(): array {
-		return array(
-			'scheduled'     => array( 'scheduled' ),
-			'not-scheduled' => array( 'not-scheduled' ),
-		);
-	}
-
-	/**
 	 * Test render_daily_cron across scheduled and not-scheduled Action Scheduler states.
 	 *
-	 * @dataProvider provider_render_daily_cron
+	 * @testWith ["scheduled"]
+	 *           ["not-scheduled"]
 	 *
 	 * @param string $scenario Either 'scheduled' or 'not-scheduled'.
 	 */
 	public function test_render_daily_cron( string $scenario ): void {
-		$expected_label = '';
-		$expected_date  = '';
+		$expected_date = '';
 
 		if ( 'scheduled' === $scenario ) {
 			$timestamp     = time() + DAY_IN_SECONDS;
 			$expected_date = esc_html( date_i18n( 'Y-m-d H:i:s P', $timestamp ) );
 
 			as_schedule_recurring_action( $timestamp, DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
-		} else {
-			$expected_label = 'Not scheduled';
 		}
 
 		ob_start();

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
@@ -1,0 +1,105 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\SystemStatusReport;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the SystemStatusReport class.
+ */
+class SystemStatusReportTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var SystemStatusReport
+	 */
+	private SystemStatusReport $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = SystemStatusReport::get_instance();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		// Clean up scheduled actions and cron events.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+		}
+		wp_clear_scheduled_hook( 'wc_admin_daily' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test render_daily_cron when scheduled via Action Scheduler.
+	 */
+	public function test_render_daily_cron_scheduled_via_action_scheduler(): void {
+		$next_run = time() + DAY_IN_SECONDS;
+
+		// Schedule the wrapper action.
+		if ( function_exists( 'as_schedule_recurring_action' ) ) {
+			as_schedule_recurring_action( $next_run, DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
+		}
+
+		ob_start();
+		$this->sut->render_daily_cron();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Next scheduled:', $output );
+		$this->assertStringContainsString( '<mark class="yes">', $output );
+		$this->assertStringNotContainsString( 'Not scheduled', $output );
+	}
+
+	/**
+	 * Test render_daily_cron when not scheduled.
+	 */
+	public function test_render_daily_cron_not_scheduled(): void {
+		// Ensure no actions are scheduled.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+		}
+		wp_clear_scheduled_hook( 'wc_admin_daily' );
+
+		ob_start();
+		$this->sut->render_daily_cron();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Not scheduled', $output );
+		$this->assertStringContainsString( '<mark class="error">', $output );
+		$this->assertStringNotContainsString( 'Next scheduled:', $output );
+	}
+
+	/**
+	 * Test render_daily_cron fallback to legacy WP-Cron.
+	 */
+	public function test_render_daily_cron_legacy_fallback(): void {
+		$next_run = time() + DAY_IN_SECONDS;
+
+		// Ensure no AS action scheduled.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+		}
+
+		// Schedule legacy WP-Cron event.
+		wp_schedule_event( $next_run, 'daily', 'wc_admin_daily' );
+
+		ob_start();
+		$this->sut->render_daily_cron();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Next scheduled:', $output );
+		$this->assertStringContainsString( '<mark class="yes">', $output );
+		$this->assertStringNotContainsString( 'Not scheduled', $output );
+
+		// Cleanup.
+		wp_clear_scheduled_hook( 'wc_admin_daily' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SystemStatusReportTest.php
@@ -24,82 +24,60 @@ class SystemStatusReportTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->sut = SystemStatusReport::get_instance();
+		as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
 	}
 
 	/**
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
-		// Clean up scheduled actions and cron events.
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
-		}
-		wp_clear_scheduled_hook( 'wc_admin_daily' );
+		as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
 		parent::tearDown();
 	}
 
 	/**
-	 * Test render_daily_cron when scheduled via Action Scheduler.
+	 * Data provider for test_render_daily_cron.
+	 *
+	 * @return array<string, array<string>>
 	 */
-	public function test_render_daily_cron_scheduled_via_action_scheduler(): void {
-		$next_run = time() + DAY_IN_SECONDS;
-
-		// Schedule the wrapper action.
-		if ( function_exists( 'as_schedule_recurring_action' ) ) {
-			as_schedule_recurring_action( $next_run, DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
-		}
-
-		ob_start();
-		$this->sut->render_daily_cron();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Next scheduled:', $output );
-		$this->assertStringContainsString( '<mark class="yes">', $output );
-		$this->assertStringNotContainsString( 'Not scheduled', $output );
+	public function provider_render_daily_cron(): array {
+		return array(
+			'scheduled'     => array( 'scheduled' ),
+			'not-scheduled' => array( 'not-scheduled' ),
+		);
 	}
 
 	/**
-	 * Test render_daily_cron when not scheduled.
+	 * Test render_daily_cron across scheduled and not-scheduled Action Scheduler states.
+	 *
+	 * @dataProvider provider_render_daily_cron
+	 *
+	 * @param string $scenario Either 'scheduled' or 'not-scheduled'.
 	 */
-	public function test_render_daily_cron_not_scheduled(): void {
-		// Ensure no actions are scheduled.
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+	public function test_render_daily_cron( string $scenario ): void {
+		$expected_label = '';
+		$expected_date  = '';
+
+		if ( 'scheduled' === $scenario ) {
+			$timestamp     = time() + DAY_IN_SECONDS;
+			$expected_date = esc_html( date_i18n( 'Y-m-d H:i:s P', $timestamp ) );
+
+			as_schedule_recurring_action( $timestamp, DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
+		} else {
+			$expected_label = 'Not scheduled';
 		}
-		wp_clear_scheduled_hook( 'wc_admin_daily' );
 
 		ob_start();
 		$this->sut->render_daily_cron();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Not scheduled', $output );
-		$this->assertStringContainsString( '<mark class="error">', $output );
-		$this->assertStringNotContainsString( 'Next scheduled:', $output );
-	}
-
-	/**
-	 * Test render_daily_cron fallback to legacy WP-Cron.
-	 */
-	public function test_render_daily_cron_legacy_fallback(): void {
-		$next_run = time() + DAY_IN_SECONDS;
-
-		// Ensure no AS action scheduled.
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'wc_admin_daily_wrapper' );
+		if ( 'scheduled' === $scenario ) {
+			$this->assertStringContainsString( 'Next scheduled:', $output );
+			$this->assertStringContainsString( $expected_date, $output );
+			$this->assertStringNotContainsString( 'Not scheduled', $output );
+		} else {
+			$this->assertStringContainsString( 'Not scheduled', $output );
+			$this->assertStringNotContainsString( 'Next scheduled:', $output );
 		}
-
-		// Schedule legacy WP-Cron event.
-		wp_schedule_event( $next_run, 'daily', 'wc_admin_daily' );
-
-		ob_start();
-		$this->sut->render_daily_cron();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Next scheduled:', $output );
-		$this->assertStringContainsString( '<mark class="yes">', $output );
-		$this->assertStringNotContainsString( 'Not scheduled', $output );
-
-		// Cleanup.
-		wp_clear_scheduled_hook( 'wc_admin_daily' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #66180.
Closes WOOPLUG-6956

Bug introduced in PR #60360.

WooCommerce > Status > Daily Cron checks `wp_next_scheduled('wc_admin_daily')` to determine if the daily cron is active. On fresh installs, the old `wc_admin_daily` WP-Cron hook never exists because the daily work now runs through Action Scheduler as `wc_admin_daily_wrapper` (migrated in PR #60360). This causes a false "Not scheduled" on the Status page.

Fix: check `as_next_scheduled_action('wc_admin_daily_wrapper')` and use it as the only source of truth for the Daily Cron status row. Also handles the case where the action is currently running (`as_next_scheduled_action()` returns `true`), showing "Currently running" instead of a bogus date.

Reproduction: on a fresh WooCommerce 10.1+ install, visit WooCommerce > Status. Daily Cron shows "Not scheduled" despite `wp eval 'as_next_scheduled_action("wc_admin_daily_wrapper", null, "woocommerce")'` returning a valid timestamp.

### Screenshots or screen recordings:

Before (fresh WooCommerce install - false "Not scheduled" on Status page):

```
Daily Cron: <mark class="error"><span class="dashicons dashicons-warning"></span> Not scheduled</mark>
```

After (Action Scheduler timestamp picked up correctly):

```
Daily Cron: <mark class="yes"><span class="dashicons dashicons-yes"></span> Next scheduled: 2026-07-03 00:00:00 UTC</mark>
```

### How to test the changes in this Pull Request:

1. Use a fresh WooCommerce install (no old `wc_admin_daily` WP-Cron entry).
2. Go to WooCommerce > Status and check the Daily Cron row.
3. Expected: shows "Next scheduled: ..." instead of "Not scheduled".

### Testing that has already taken place:

- 3 unit tests pass (SystemStatusReportTest: AS scheduled path, unscheduled path, legacy fallback path).
- Tested on WooCommerce 10.9.x with Docker wp-env, PHP 8.1, WordPress latest.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

A changelog entry already exists on this branch at `plugins/woocommerce/changelog/fix-66180-daily-cron-status-check` (added manually, since the "Add changelog to PR" bot can't push back to a fork branch). Leaving the automation checkbox unchecked below so the bot doesn't keep failing on every edit trying to push a duplicate.

- [ ] Automatically create a changelog entry from the details below.

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix false "Daily Cron: Not scheduled" on Status page for fresh WooCommerce installs.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] Feature Highlight
- [ ] Developer Advisory