### PR TITLE
Store API: add checkout input-validation relaxation filters (POS series, step 2)

### DIFF
--- a/plugins/woocommerce/changelog/add-store-api-input-validation-relaxation-filters
+++ b/plugins/woocommerce/changelog/add-store-api-input-validation-relaxation-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Store API: add `woocommerce_store_api_require_billing_email` and `woocommerce_store_api_validate_addresses` filters so trusted-actor checkout clients can relax billing-email and address validation. Both default to current web behaviour.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -334,7 +334,25 @@ class OrderController {
 	protected function validate_email( \WC_Order $order ) {
 		$email = $order->get_billing_email();
 
+		/**
+		 * Filters whether a billing email is required on a Store API order.
+		 *
+		 * Defaults to true for web checkout. Trusted-actor callers that defer or omit customer identity (e.g. an
+		 * in-person point-of-sale flow) can return false to allow an order without a billing email. Relaxing the
+		 * requirement only skips the missing-email check; a billing email that IS provided is still validated for format.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool      $require Whether a billing email is required. Default true.
+		 * @param \WC_Order $order   Order object being validated.
+		 */
+		$require_email = (bool) apply_filters( 'woocommerce_store_api_require_billing_email', true, $order );
+
 		if ( empty( $email ) ) {
+			if ( ! $require_email ) {
+				return;
+			}
+
 			throw new RouteException(
 				'woocommerce_rest_missing_email_address',
 				__( 'A valid email address is required', 'woocommerce' ),
@@ -363,6 +381,27 @@ class OrderController {
 	 * @param bool      $needs_shipping Whether the order needs shipping.
 	 */
 	protected function validate_addresses( \WC_Order $order, bool $needs_shipping ) {
+		/**
+		 * Filters whether the Store API validates order addresses.
+		 *
+		 * Defaults to true for web checkout. Trusted-actor callers that accept incomplete or unverified addresses (e.g.
+		 * an in-person point-of-sale flow) can return false to skip address validation entirely — both the country
+		 * allow-list checks and the locale required-field checks. Address validation is store policy plus required-field
+		 * presence, so this is a single all-or-nothing gate; callers that only want to skip validation for empty
+		 * addresses can inspect $order in their callback and return true when address data is present.
+		 *
+		 * @since 11.0.0
+		 *
+		 * @param bool      $validate       Whether to validate order addresses. Default true.
+		 * @param \WC_Order $order          Order object being validated.
+		 * @param bool      $needs_shipping Whether the order needs shipping.
+		 */
+		$validate_addresses = (bool) apply_filters( 'woocommerce_store_api_validate_addresses', true, $order, $needs_shipping );
+
+		if ( ! $validate_addresses ) {
+			return;
+		}
+
 		$errors           = new \WP_Error();
 		$billing_country  = $order->get_billing_country();
 		$shipping_country = $order->get_shipping_country();

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -326,7 +326,8 @@ class OrderController {
 	}
 
 	/**
-	 * Validates the customer email. This is a required field.
+	 * Validates the customer email. Required by default, but the requirement can be relaxed via the
+	 * `woocommerce_store_api_require_billing_email` filter; a provided email is always validated for format.
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
 	 * @param \WC_Order $order Order object.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -41,6 +41,25 @@ class OrderControllerTests extends TestCase {
 			public function validate_address_fields( \WC_Order $order, $address_type, \WP_Error $errors ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 				parent::validate_address_fields( $order, $address_type, $errors );
 			}
+
+			/**
+			 * Validate the customer email. Parent is protected.
+			 *
+			 * @param \WC_Order $order Order object.
+			 */
+			public function validate_email( \WC_Order $order ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+				parent::validate_email( $order );
+			}
+
+			/**
+			 * Validate the order addresses. Parent is protected.
+			 *
+			 * @param \WC_Order $order Order object.
+			 * @param bool      $needs_shipping Whether the order needs shipping.
+			 */
+			public function validate_addresses( \WC_Order $order, bool $needs_shipping ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+				parent::validate_addresses( $order, $needs_shipping );
+			}
 		};
 	}
 
@@ -325,6 +344,140 @@ class OrderControllerTests extends TestCase {
 		$this->sut->validate_address_fields( $order, 'shipping', $errors );
 		$this->assertEmpty( $errors->get_error_messages() );
 		remove_filter( 'woocommerce_get_country_locale', $hide_postcode );
+	}
+
+	/**
+	 * @testdox validate_email() requires a billing email by default.
+	 */
+	public function test_validate_email_requires_email_by_default(): void {
+		$this->expectException( RouteException::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'A valid email address is required' );
+
+		$order = new \WC_Order();
+		$order->set_billing_email( '' );
+
+		$this->sut->validate_email( $order );
+	}
+
+	/**
+	 * Build an unsaved order whose billing email bypasses WC_Order::set_billing_email() format
+	 * validation, so validate_email() can be exercised against a malformed value (as can happen for
+	 * orders whose stored data predates validation or was set outside the setter).
+	 *
+	 * @param string $email Billing email to return from get_billing_email().
+	 * @return \WC_Order
+	 */
+	private function order_with_billing_email( string $email ): \WC_Order {
+		return new class( $email ) extends \WC_Order {
+			/**
+			 * Forced billing email.
+			 *
+			 * @var string
+			 */
+			private $forced_email;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $email Billing email.
+			 */
+			public function __construct( string $email ) {
+				$this->forced_email = $email;
+				parent::__construct();
+			}
+
+			/**
+			 * Return the forced billing email, bypassing stored data.
+			 *
+			 * @param string $context Context.
+			 * @return string
+			 */
+			public function get_billing_email( $context = 'view' ) {
+				return $this->forced_email;
+			}
+		};
+	}
+
+	/**
+	 * @testdox validate_email() rejects a malformed billing email by default.
+	 */
+	public function test_validate_email_rejects_malformed_email_by_default(): void {
+		$this->expectException( RouteException::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'is not valid' );
+
+		$this->sut->validate_email( $this->order_with_billing_email( 'not-an-email' ) );
+	}
+
+	/**
+	 * @testdox validate_email() allows a missing billing email when the requirement is filtered off.
+	 */
+	public function test_validate_email_missing_email_allowed_when_relaxed(): void {
+		$order = new \WC_Order();
+		$order->set_billing_email( '' );
+
+		add_filter( 'woocommerce_store_api_require_billing_email', '__return_false' );
+		try {
+			$this->assertNull(
+				$this->sut->validate_email( $order ),
+				'A relaxed caller should be allowed to omit the billing email.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_store_api_require_billing_email', '__return_false' );
+		}
+	}
+
+	/**
+	 * @testdox validate_email() still rejects a malformed billing email even when the requirement is filtered off.
+	 */
+	public function test_validate_email_still_validates_format_when_relaxed(): void {
+		$order = $this->order_with_billing_email( 'not-an-email' );
+
+		add_filter( 'woocommerce_store_api_require_billing_email', '__return_false' );
+		try {
+			$this->expectException( RouteException::class );
+			$this->expectExceptionCode( 400 );
+			$this->expectExceptionMessage( 'is not valid' );
+
+			$this->sut->validate_email( $order );
+		} finally {
+			remove_filter( 'woocommerce_store_api_require_billing_email', '__return_false' );
+		}
+	}
+
+	/**
+	 * @testdox validate_addresses() validates the country allow-list by default.
+	 */
+	public function test_validate_addresses_validates_by_default(): void {
+		$this->expectException( RouteException::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'Sorry, we do not allow orders from the provided country (Invalid)' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_country( 'Invalid' );
+		$order->save();
+
+		$this->sut->validate_addresses( $order, false );
+	}
+
+	/**
+	 * @testdox validate_addresses() skips validation entirely when filtered off.
+	 */
+	public function test_validate_addresses_skipped_when_relaxed(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_country( 'Invalid' );
+		$order->save();
+
+		add_filter( 'woocommerce_store_api_validate_addresses', '__return_false' );
+		try {
+			$this->assertNull(
+				$this->sut->validate_addresses( $order, false ),
+				'A relaxed caller should be able to skip validation for an otherwise-invalid address.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_store_api_validate_addresses', '__return_false' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Step 2 of the stacked series toward Point-of-Sale support in the Store API — stacked on #66147, chain at the bottom.

Store API checkout hard-requires a billing email and validated billing/shipping addresses. A trusted server-side caller — for example an in-person POS that identifies the customer differently and charges at the counter — needs to create orders without collecting these.

This adds two filters so such a caller can relax those requirements:

-   `woocommerce_store_api_require_billing_email` — allow an order without a billing email. An email that is provided is still format-validated.
-   `woocommerce_store_api_validate_addresses` — skip country and required-field address validation.

Both default to `true`, so web checkout behaviour is unchanged. The seam stands on its own and doesn't depend on any POS code.

### How to test the changes in this Pull Request:

Send a checkout POST to `/wc/store/v1/checkout` without `billing_address.email` — it should still return `400` (`woocommerce_rest_missing_email_address`), i.e. the default is unchanged.

### Testing that has already taken place:

New unit tests in `OrderControllerTests` cover the defaults (still enforced, malformed emails still rejected when relaxed) and both relaxations; passing in wp-env (PHP 8.1). Lint and PHPStan clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry is committed to the branch (`plugins/woocommerce/changelog/add-store-api-input-validation-relaxation-filters`), so auto-generation is not needed.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

---

Stacked series (review/merge in order; each PR is based on the previous branch):

1. #66147 — payment-deferral filters
2. → this PR — input-validation relaxation filters
3. #66190 — checkout place-order pipeline extraction

Base branch: `add/store-api-payment-deferral-filters` (#66147).
