### PR TITLE
Fix: Preserve pending review status on product CSV export/import

### DIFF
--- a/plugins/woocommerce/changelog/28798-fix-import-pending-review-products
+++ b/plugins/woocommerce/changelog/28798-fix-import-pending-review-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve the "Pending review" product status when exporting and re-importing products via CSV, instead of importing them as drafts.

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -332,6 +332,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 			ProductStatus::DRAFT   => -1,
 			ProductStatus::PRIVATE => 0,
 			ProductStatus::PUBLISH => 1,
+			ProductStatus::PENDING => 2,
 		);
 
 		// Fix display for variations when parent product is a draft.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -725,7 +725,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
-	 * Parse the published field. 1 is published, 0 is private, -1 is draft.
+	 * Parse the published field. 1 is published, 0 is private, -1 is draft, 2 is pending review.
 	 * Alternatively, 'true' can be used for published and 'false' for draft.
 	 *
 	 * @param string $value Field value.
@@ -913,6 +913,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				-1 => ProductStatus::DRAFT,
 				0  => ProductStatus::PRIVATE,
 				1  => ProductStatus::PUBLISH,
+				2  => ProductStatus::PENDING,
 			);
 			$data['status'] = $statuses[ $published ] ?? ProductStatus::DRAFT;
 

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -730,7 +730,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 *
 	 * @param string $value Field value.
 	 *
-	 * @return float|string
+	 * @return int|float|string
 	 */
 	public function parse_published_field( $value ) {
 		if ( '' === $value ) {

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -68,4 +68,34 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 		}
 		remove_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
 	}
+
+	/**
+	 * @testdox pending review products should export with a distinct published value.
+	 */
+	public function test_get_column_value_published_for_pending_product() {
+		$product = new WC_Product_Simple();
+		$product->set_status( ProductStatus::PENDING );
+		$product->save();
+
+		$reflected_exporter = new ReflectionClass( WC_Product_CSV_Exporter::class );
+		$get_data_to_export = $reflected_exporter->getMethod( 'get_data_to_export' );
+		$get_data_to_export->setAccessible( true );
+
+		$this->product_ids = array( $product->get_id() );
+
+		add_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
+
+		// Required for brands to be registered because wc-admin-brands.php adds a filter that depends on it.
+		WC_Brands::init_taxonomy();
+
+		$exporter = new WC_Product_CSV_Exporter();
+		$exporter->prepare_data_to_export();
+		$data = $get_data_to_export->invoke( $exporter );
+
+		$this->assertNotEmpty( $data, 'Pending review product should be included in the export.' );
+		foreach ( $data as $row ) {
+			$this->assertEquals( 2, $row['published'], 'Pending review products should not export as draft (-1).' );
+		}
+		remove_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -85,17 +85,17 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 
 		add_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
 
-		// Required for brands to be registered because wc-admin-brands.php adds a filter that depends on it.
-		WC_Brands::init_taxonomy();
+		try {
+			$exporter = new WC_Product_CSV_Exporter();
+			$exporter->prepare_data_to_export();
+			$data = $get_data_to_export->invoke( $exporter );
 
-		$exporter = new WC_Product_CSV_Exporter();
-		$exporter->prepare_data_to_export();
-		$data = $get_data_to_export->invoke( $exporter );
-
-		$this->assertNotEmpty( $data, 'Pending review product should be included in the export.' );
-		foreach ( $data as $row ) {
-			$this->assertEquals( 2, $row['published'], 'Pending review products should not export as draft (-1).' );
+			$this->assertNotEmpty( $data, 'Pending review product should be included in the export.' );
+			foreach ( $data as $row ) {
+				$this->assertEquals( 2, $row['published'], 'Pending review products should not export as draft (-1).' );
+			}
+		} finally {
+			remove_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
 		}
-		remove_filter( 'woocommerce_product_export_product_query_args', array( $this, 'set_export_product_query_args' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -65,6 +65,28 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox published value of 2 maps to the pending review status on import.
+	 */
+	public function test_expand_data_maps_published_to_pending() {
+		$csv_file = __DIR__ . '/sample.csv';
+
+		$reflected_importer = new ReflectionClass( WC_Product_CSV_Importer::class );
+		$expand_data        = $reflected_importer->getMethod( 'expand_data' );
+		$expand_data->setAccessible( true );
+
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+		$parsed   = $expand_data->invoke(
+			$importer,
+			array(
+				'type'      => array( ProductType::SIMPLE ),
+				'published' => 2,
+			)
+		);
+
+		$this->assertEquals( ProductStatus::PENDING, $parsed['status'] );
+	}
+
+	/**
 	 * @testdox Test that the importer calculates the percent complete as 99 when it's >= 99.5% through the file.
 	 */
 	public function test_import_completion_issue_36618_lines_remaining() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The product CSV export/import round-trip encodes status in a numeric `published` column, but it only ever handled three states — `publish`, `private`, and `draft`. A **Pending review** product had no code of its own, so it fell through to the `-1` default on export (identical to a draft) and came back as a draft on import. Same story for the reverse: the importer's status map had no entry for anything beyond those three.

This PR gives **Pending review** its own code — `2` — on both sides:

-   `WC_Product_CSV_Exporter::get_column_value_published()` now maps `ProductStatus::PENDING => 2`.
-   `WC_Product_CSV_Importer` maps `2 => ProductStatus::PENDING` and the `parse_published_field()` docblock documents the new value.

I kept it backward compatible on purpose — existing CSVs (`-1`/`0`/`1`) are untouched, and an older WooCommerce reading a `2` simply falls back to draft, which is the current behaviour anyway.

Worth noting: I left `future` (scheduled) products out of scope. Round-tripping those would also need the publish date, which the CSV doesn't carry today — that's a separate problem from this bug.

Closes #28798.

### How to test the changes in this Pull Request:

1.  Create a new product and set its status to **Pending review**.
2.  Export it via **Products → Export**.
3.  In the CSV, change the `ID` and `Name` so a brand new product gets created on import.
4.  Import the CSV via **Products → Import**.
5.  Open the imported product — its status should be **Pending review** (before this PR it came in as **Draft**).

### Testing that has already taken place:

-   Added unit tests on both sides of the round-trip:
    -   `WC_Product_CSV_Exporter_Test::test_get_column_value_published_for_pending_product` — a pending product exports as `2`, not `-1`.
    -   `WC_Product_CSV_Importer_Test::test_expand_data_maps_published_to_pending` — a `published` value of `2` maps to `pending`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request includes a changelog entry (added manually at `plugins/woocommerce/changelog/28798-fix-import-pending-review-products`).
