### PR TITLE
Clean misplaced ISBN-10 X in GTIN instead of rejecting the value

### DIFF
--- a/plugins/woocommerce/changelog/fix-gtin-misplaced-x-api-bc
+++ b/plugins/woocommerce/changelog/fix-gtin-misplaced-x-api-bc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore lenient GTIN handling: strip a misplaced ISBN-10 X check digit instead of rejecting the value, fixing REST API product creates/updates that succeeded before 10.9.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -890,13 +890,13 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 */
 	public function set_global_unique_id( $global_unique_id ) {
 		// Strip characters that are never valid (digits, hyphens, and X/x for the ISBN-10 check digit).
-		$global_unique_id = preg_replace( '/[^0-9Xx\-]/', '', (string) $global_unique_id );
+		$global_unique_id = (string) preg_replace( '/[^0-9Xx\-]/', '', (string) $global_unique_id );
 
 		// X is only valid as the final ISBN-10 check digit character (ISO 2108). Strip it from any
 		// other position instead of rejecting the value: releases before 10.9 silently cleaned
 		// invalid characters, and REST API clients rely on that behavior.
 		if ( ! preg_match( '/^[0-9\-]*[0-9Xx]?$/', $global_unique_id ) ) {
-			$global_unique_id = preg_replace( '/[Xx](?!$)/', '', $global_unique_id );
+			$global_unique_id = (string) preg_replace( '/[Xx](?!$)/', '', $global_unique_id );
 		}
 
 		if ( $this->get_object_read() && ! empty( $global_unique_id ) && ! wc_product_has_global_unique_id( $this->get_id(), $global_unique_id ) ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -892,13 +892,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		// Strip characters that are never valid (digits, hyphens, and X/x for the ISBN-10 check digit).
 		$global_unique_id = preg_replace( '/[^0-9Xx\-]/', '', (string) $global_unique_id );
 
-		// X is only valid as the final ISBN-10 check digit character (ISO 2108) — reject anywhere else.
-		if ( $this->get_object_read() && ! empty( $global_unique_id ) && ! preg_match( '/^[0-9\-]*[0-9Xx]?$/', $global_unique_id ) ) {
-			$this->error(
-				'product_invalid_global_unique_id_format',
-				__( 'Invalid GTIN, UPC, EAN, or ISBN. The letter X is only valid as the final ISBN-10 check digit.', 'woocommerce' ),
-				400
-			);
+		// X is only valid as the final ISBN-10 check digit character (ISO 2108). Strip it from any
+		// other position instead of rejecting the value: releases before 10.9 silently cleaned
+		// invalid characters, and REST API clients rely on that behavior.
+		if ( ! preg_match( '/^[0-9\-]*[0-9Xx]?$/', $global_unique_id ) ) {
+			$global_unique_id = preg_replace( '/[Xx](?!$)/', '', $global_unique_id );
 		}
 
 		if ( $this->get_object_read() && ! empty( $global_unique_id ) && ! wc_product_has_global_unique_id( $this->get_id(), $global_unique_id ) ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -892,11 +892,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		// Strip characters that are never valid (digits, hyphens, and X/x for the ISBN-10 check digit).
 		$global_unique_id = (string) preg_replace( '/[^0-9Xx\-]/', '', (string) $global_unique_id );
 
-		// X is only valid as the final ISBN-10 check digit character (ISO 2108). Strip it from any
-		// other position instead of rejecting the value: releases before 10.9 silently cleaned
-		// invalid characters, and REST API clients rely on that behavior.
+		// X is only valid as the final ISBN-10 check digit character (ISO 2108). If the value is not
+		// shaped like that, clean it exactly as releases before 10.9 did (strip all X) instead of
+		// rejecting it: REST API clients rely on that behavior. Valid ISBN-10s keep their X.
 		if ( ! preg_match( '/^[0-9\-]*[0-9Xx]?$/', $global_unique_id ) ) {
-			$global_unique_id = (string) preg_replace( '/[Xx](?!$)/', '', $global_unique_id );
+			$global_unique_id = str_replace( array( 'X', 'x' ), '', $global_unique_id );
 		}
 
 		if ( $this->get_object_read() && ! empty( $global_unique_id ) && ! wc_product_has_global_unique_id( $this->get_id(), $global_unique_id ) ) {

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -482,7 +482,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 			'hyphenated ISBN-10 X preserved'  => array( '0-9752298-0-X', '0-9752298-0-X' ),
 			'lowercase final x preserved'     => array( '097522980x', '097522980x' ),
 			'mid-string X stripped'           => array( '12X4567890123', '124567890123' ),
-			'only final X kept when multiple' => array( '12X45X', '1245X' ),
+			'all X stripped when shape is invalid' => array( '12X45X', '1245' ),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -476,13 +476,14 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	 */
 	public function global_unique_id_provider(): array {
 		return array(
-			'plain digits untouched'          => array( '4006381333931', '4006381333931' ),
-			'letters stripped'                => array( 'ABC-4006381333931', '-4006381333931' ),
-			'final ISBN-10 X preserved'       => array( '097522980X', '097522980X' ),
-			'hyphenated ISBN-10 X preserved'  => array( '0-9752298-0-X', '0-9752298-0-X' ),
-			'lowercase final x preserved'     => array( '097522980x', '097522980x' ),
-			'mid-string X stripped'           => array( '12X4567890123', '124567890123' ),
-			'all X stripped when shape is invalid' => array( '12X45X', '1245' ),
+			'plain digits untouched'                => array( '4006381333931', '4006381333931' ),
+			'letters stripped'                      => array( 'ABC-4006381333931', '-4006381333931' ),
+			'final ISBN-10 X preserved'             => array( '097522980X', '097522980X' ),
+			'hyphenated ISBN-10 X preserved'        => array( '0-9752298-0-X', '0-9752298-0-X' ),
+			'lowercase final x preserved'           => array( '097522980x', '097522980x' ),
+			'mid-string X stripped'                 => array( '12X4567890123', '124567890123' ),
+			'all X stripped when shape is invalid'  => array( '12X45X', '1245' ),
+			'all invalid stripped to empty'         => array( 'ABC', '' ),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -454,4 +454,35 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'outofstock', $product->get_stock_status() );
 	}
+	/**
+	 * @testdox Setting a GTIN cleans invalid characters instead of rejecting the value, preserving a final ISBN-10 X check digit.
+	 * @dataProvider global_unique_id_provider
+	 *
+	 * @param string $input    Raw value passed to the setter.
+	 * @param string $expected Expected stored value.
+	 */
+	public function test_set_global_unique_id_cleans_invalid_characters( string $input, string $expected ): void {
+		$product = new WC_Product_Simple();
+
+		$product->set_global_unique_id( $input );
+
+		$this->assertSame( $expected, $product->get_global_unique_id(), "Input '{$input}' should be stored as '{$expected}'" );
+	}
+
+	/**
+	 * Data provider for GTIN cleaning tests.
+	 *
+	 * @return array[]
+	 */
+	public function global_unique_id_provider(): array {
+		return array(
+			'plain digits untouched'          => array( '4006381333931', '4006381333931' ),
+			'letters stripped'                => array( 'ABC-4006381333931', '-4006381333931' ),
+			'final ISBN-10 X preserved'       => array( '097522980X', '097522980X' ),
+			'hyphenated ISBN-10 X preserved'  => array( '0-9752298-0-X', '0-9752298-0-X' ),
+			'lowercase final x preserved'     => array( '097522980x', '097522980x' ),
+			'mid-string X stripped'           => array( '12X4567890123', '124567890123' ),
+			'only final X kept when multiple' => array( '12X45X', '1245X' ),
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce 10.9 (#64889) started preserving the ISBN-10 `X` check digit in the GTIN field (`global_unique_id`) — but as a side effect it also began **rejecting** values containing `X` anywhere else with a `400 product_invalid_global_unique_id_format` error. Before 10.9, such values were **silently cleaned** and accepted.

This is an API BC break: REST clients (product feeds in particular) that send legacy/messy GTIN data now fail to create products entirely (single-request flow) or get stuck as half-created placeholders (create-then-enrich flow). Verified against real `wc/v3` requests: the same payload returns `201` on 10.8.1 and `400` on 10.9.1.

This PR strips a misplaced `X` instead of erroring — keeping #64889's actual goal (a final ISBN-10 `X` check digit is preserved, no longer corrupted) while restoring the pre-10.9 lenient contract:

| Input | 10.8.1 | 10.9.x current | With this PR |
|---|---|---|---|
| `12X4567890123` | cleaned → saved | ❌ 400, nothing saved | cleaned → saved |
| `097522980X` (valid ISBN-10) | X stripped (corrupted) | saved ✅ | saved ✅ |

Bug introduced in PR #64889.

### How to test the changes in this Pull Request:

1. On this branch, create a product via the REST API with a malformed GTIN:
   `POST /wp-json/wc/v3/products` with `{"name":"Test","type":"simple","regular_price":"9","global_unique_id":"12X4567890123"}`
2. Confirm the request returns `201` and the product's `global_unique_id` is `124567890123` (X cleaned, product created).
3. Create a product with a valid ISBN-10: `global_unique_id: "097522980X"` — confirm the trailing `X` is preserved.
4. Run the new unit tests: `pnpm test:php:env -- --filter WC_Abstract_Product_Test`

### Testing that has already taken place:

- The cleaning logic was validated against 8 input cases (plain digits, letters, final X upper/lower, hyphenated ISBN, mid-string X, multiple X).
- The BC break itself was reproduced end-to-end with real `wc/v3` requests on 10.8.1 vs 10.9.1.
- New PHPUnit data-provider tests added to `WC_Abstract_Product_Test` (will run in CI).

### Changelog entry

> Added changelog manually (`Significance: patch`, `Type: fix`).
