### PR TITLE
[Performance] Audit wc_product_dropdown_categories usages in admin

### DIFF
--- a/plugins/woocommerce/changelog/performance-audit-wc_product_dropdown_categories-usages-in-admin
+++ b/plugins/woocommerce/changelog/performance-audit-wc_product_dropdown_categories-usages-in-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Audit wc_product_dropdown_categories usages in admin

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -598,8 +598,6 @@ class WC_Brands_Admin {
 		if ( $brands_count <= apply_filters( 'woocommerce_product_brand_filter_threshold', 100 ) ) {
 			wc_product_dropdown_categories(
 				array(
-					'pad_counts'        => true,
-					'show_count'        => true,
 					'orderby'           => 'name',
 					'selected'          => $current_brand_slug,
 					'show_option_none'  => __( 'Filter by brand', 'woocommerce' ),
@@ -608,6 +606,10 @@ class WC_Brands_Admin {
 					'taxonomy'          => 'product_brand',
 					'name'              => 'product_brand',
 					'class'             => 'dropdown_product_brand',
+					// Performance note: pad_counts=0 skips the hierarchical count SQL — O(all published products), degrades linearly
+					// with catalog size. show_count=0 suppresses the raw wp_term_taxonomy.count that would otherwise render in its place.
+					'pad_counts'        => 0,
+					'show_count'        => 0,
 				)
 			);
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Based on #66176, audit `wc_product_dropdown_categories` usages to identify similar unreported cases.
Removes product counters from the brands filter on the products page in admin. 

Benchmarking: please refer to #66176.

### How to test the changes in this Pull Request:

- Navigate to the admin area: `Products -> All products`
- Alternating between this branch and trunk, verify the counters in the brands filter are not present on this branch
