### PR TITLE
Fix: Respect store decimal separator in product CSV weight & dimensions import

### DIFF
--- a/plugins/woocommerce/changelog/38116-fix-csv-import-weight-decimal-separator
+++ b/plugins/woocommerce/changelog/38116-fix-csv-import-weight-decimal-separator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product CSV importer: respect the store's decimal separator setting when parsing weight and dimensions, so comma-separated values (e.g. "1,5") are no longer discarded.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -373,7 +373,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		// Remove the ' prepended to fields that start with - if needed.
 		$value = $this->unescape_data( $value );
 
-		return floatval( $value );
+		// Use wc_format_decimal() rather than floatval() so the store's decimal separator
+		// setting is respected (e.g. a comma-separated weight like "1,5"). This mirrors how
+		// price fields are parsed above and how the product setters normalize these values.
+		return (float) wc_format_decimal( $value );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -25,6 +25,15 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'wc_get_price_decimal_separator' );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * @testdox variations need to set the status back to published if parent product is a draft
 	 */
 	public function test_expand_data_with_draft_variable() {
@@ -223,5 +232,51 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 		wc_delete_attribute( $color_attr_id );
 		wc_delete_attribute( $size_attr_id );
+	}
+
+	/**
+	 * @testdox parse_float_field should respect the store's decimal separator setting (issue #38116).
+	 * @dataProvider provider_parse_float_field_decimal_separator
+	 *
+	 * @param string $decimal_sep The store's decimal separator setting.
+	 * @param string $value       The raw CSV value to parse.
+	 * @param float  $expected    The expected parsed float.
+	 */
+	public function test_parse_float_field_respects_decimal_separator( string $decimal_sep, string $value, float $expected ) {
+		add_filter( 'wc_get_price_decimal_separator', fn() => $decimal_sep );
+
+		$importer = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv' );
+		$result   = $importer->parse_float_field( $value );
+
+		$this->assertSame( $expected, $result, "Expected '{$value}' to parse to {$expected} with '{$decimal_sep}' as the decimal separator." );
+	}
+
+	/**
+	 * Data provider for test_parse_float_field_respects_decimal_separator.
+	 *
+	 * @return array
+	 */
+	public function provider_parse_float_field_decimal_separator(): array {
+		return array(
+			'comma separator, comma value'   => array( ',', '1,5', 1.5 ),
+			'comma separator, sub-one value' => array( ',', '0,5', 0.5 ),
+			'period separator, period value' => array( '.', '1.5', 1.5 ),
+			'comma separator, integer value' => array( ',', '10', 10.0 ),
+
+			// With a period separator the comma is treated as a grouping separator and
+			// stripped, mirroring how price fields (which also use wc_format_decimal) behave.
+			// A comma-decimal CSV therefore requires the store's separator to be set to comma.
+			'period separator, comma value'  => array( '.', '0,5', 5.0 ),
+			'period separator, comma+int'    => array( '.', '1,5', 15.0 ),
+		);
+	}
+
+	/**
+	 * @testdox parse_float_field should return an empty string unchanged.
+	 */
+	public function test_parse_float_field_returns_empty_string_unchanged() {
+		$importer = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv' );
+
+		$this->assertSame( '', $importer->parse_float_field( '' ), 'Empty values should be returned unchanged.' );
 	}
 }


### PR DESCRIPTION
Fixes #38116.

### Description

The product CSV importer parsed weight and dimensions with raw `floatval()`, which only understands `.` as a decimal point. So on a store configured with `,` as the decimal separator, importing a weight like `0,5` gave `0` — the value was silently dropped.

The fix is a one-liner: parse those fields through `wc_format_decimal()` instead, so the store's decimal separator setting is respected. This mirrors how **price** fields in the same importer are already parsed, and how the product setters (`set_weight`, `set_length`, …) normalize these values — so weight/dimensions now behave consistently with everything else.

```php
- return floatval( $value );
+ return (float) wc_format_decimal( $value );
```

### Worth noting

- This only affects stores whose decimal separator is set to `,` — exactly the scenario in the issue. On a period-separator store a stray comma is still treated as a grouping separator (same as prices), so a comma-decimal CSV needs the store separator set to comma to import correctly.
- `parse_float_field()` is a public method, so technically externally exposed. The change is behavior-preserving for period stores and keeps the same return type (`float`), so it's non-breaking.

### How to test

1. **WooCommerce → Settings → General** → set **Decimal separator** to `,`.
2. Products → Import a CSV with a weight like `0,5`.
3. Confirm the imported product's weight is `0.5` (before this PR it was empty/`0`).
4. Repeat with the separator set to `.` and a weight like `0.5` — still imports fine.

### Changelog

Added — `changelog/38116-fix-csv-import-weight-decimal-separator` (patch / fix).
