### PR TITLE
Scope order attribution install banner button styles to the banner

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-attribution-banner-unscoped-button-styles
+++ b/plugins/woocommerce/changelog/fix-order-attribution-banner-unscoped-button-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Scope the order attribution install banner button styles to the banner, so they no longer center the content of every icon+text components button rendered on WooCommerce admin pages.

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/style.scss
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/style.scss
@@ -95,7 +95,7 @@
 	}
 }
 
-.components-button {
+.woocommerce-order-attribution-install-banner .components-button {
 	&.small {
 		width: 100%;
 		display: flex;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The trailing `.components-button` block in `order-attribution-install-banner/style.scss` is unscoped, so its rules apply to **every** `@wordpress/components` `Button` on any admin page where the wc-admin (or embed) stylesheet is loaded — not just the banner's CTA:

```scss
.components-button {
	&.small { width: 100%; display: flex; justify-content: center; }
	&.has-icon.has-text { justify-content: center; }
}
```

The `has-icon.has-text` rule is the harmful one: `@wordpress/components` ships `justify-content: start` on the **exact same selector**, so with equal specificity the later-loaded wc-admin stylesheet wins and silently centers the content of every icon+text button on classic Woo screens (products list, orders, etc.). It goes unnoticed inside wc-admin because shrink-to-fit buttons have no free space to distribute, but any UI that renders full-width icon+text buttons — dropdown/menu items in particular — gets visibly broken. We hit this in the Woo AI plugin, where the docked Agents Manager three-dots menu renders centered on `edit.php?post_type=product` but correctly on `index.php` (woocommerce/woocommerce-ai#286).

The `small` rule is equally global (`.components-button.small` → full width + centered) and would reshape any third-party button that happens to use a `small` class.

Both rules were only ever intended for the banner's own CTA button — it originally rendered with an `external` icon + text and a bare `small` class (#52661). This PR scopes the block under `.woocommerce-order-attribution-install-banner`, keeping the declarations identical. The banner markup nests its CTA inside that Card class, so its appearance is unchanged (the scoped selector actually wins more robustly, by specificity instead of load order).

Closes # .

(For Bug Fixes) Bug introduced in PR #52661 (extended in #55715).

### Screenshots or screen recordings:

Effect of the leak on a third-party `DropdownMenu` rendered on `wp-admin/edit.php?post_type=product` (menu items are `components-button has-icon has-text`):

| Before | After |
| ------ | ----- |
| ![before](https://gist.githubusercontent.com/aaronfc/ec7ca87e3c7722e82a3d81a92b4e1d9e/raw/4fb0ba0501dedbab34b65688222b961b8bc9719f/docked-menu-desktop-before-zoom.png) | ![after](https://gist.githubusercontent.com/aaronfc/ec7ca87e3c7722e82a3d81a92b4e1d9e/raw/4fb0ba0501dedbab34b65688222b961b8bc9719f/docked-menu-desktop-after-zoom.png) |

Banner regression check — the install banner (small variant, as rendered in the order-editor sidebar) and the header-banner button are **visually unchanged** with the scoped rules. Verified by swapping the unscoped rules for the scoped ones via CSSOM on a live store and comparing:

| Before (unscoped rules) | After (scoped rules) |
| ------ | ----- |
| ![banner before](https://gist.githubusercontent.com/aaronfc/ec7ca87e3c7722e82a3d81a92b4e1d9e/raw/f46832fc30eedcb2117be1737876f21a93b26778/banner-desktop-before.png) | ![banner after](https://gist.githubusercontent.com/aaronfc/ec7ca87e3c7722e82a3d81a92b4e1d9e/raw/f46832fc30eedcb2117be1737876f21a93b26778/banner-desktop-after.png) |

Measured on the small-banner CTA: `justify-content`, `display: flex`, and full width (287px in a 287px container) are identical before/after. The header-banner button's computed `justify-content` changes `center` → `start`, but at its shrink-to-fit width there is no free space to distribute, so there is no visual difference (pixel-diff of the two captures shows only GIF-quantization noise on glyph edges).

### How to test the changes in this Pull Request:

1. Build wc-admin from this branch and load any classic WooCommerce admin screen (e.g. **Products → All Products**).
2. In DevTools, inspect any `.components-button.has-icon.has-text` element (or create one: any icon+text `Button` from `@wordpress/components`) and confirm its computed `justify-content` is `start` (the `@wordpress/components` default), not `center` from the wc-admin stylesheet.
3. Confirm the order attribution install banners are unchanged (requires the WooCommerce Analytics extension to not be installed):
   - **Analytics → Overview**: the big banner and, after dismissing it, the header banner render as before.
   - Classic **order editor**: the small banner in the sidebar still shows its CTA button full-width with centered content.

### Testing that has already taken place:

Reproduced the leak on a live store (products list with a docked Agents Manager sidebar): the three-dots menu items were centered; re-asserting `justify-content: start` restores the intended left alignment (screenshots above). The scoped selector keeps identical declarations for the banner subtree; verified visually on a live store by swapping the rules via CSSOM (screenshots above) — banner rendering is unchanged. wc-admin was not rebuilt locally for this change.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry is included in the PR (`plugins/woocommerce/changelog/fix-order-attribution-banner-unscoped-button-styles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz2QbkfnHaJ7VtUqAxAdTi
