### PR TITLE
fix: use post-filter query args for no_found_rows gate in ListTable

### DIFF
--- a/plugins/woocommerce/changelog/fix-66160-list-table-prepare-items-cache-gate
+++ b/plugins/woocommerce/changelog/fix-66160-list-table-prepare-items-cache-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed incorrect order counts when custom query_args are added via the order list table prepare_items query args filter.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -436,7 +436,7 @@ class ListTable extends WP_List_Table {
 		$order_query_args['paginate'] = true;
 
 		// Attempt to use cache if no additional query arguments are used.
-		if ( empty( array_diff( array_keys( $this->order_query_args ), array( 'limit', 'page', 'paginate', 'type', 'status', 'orderby', 'order' ) ) ) ) {
+		if ( empty( array_diff( array_keys( $order_query_args ), array( 'limit', 'page', 'paginate', 'type', 'status', 'orderby', 'order' ) ) ) ) {
 			$this->order_query_args['no_found_rows'] = true;
 			$order_query_args['no_found_rows']       = true;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
@@ -283,4 +283,44 @@ class ListTableTest extends \WC_Unit_Test_Case {
 		$this->assertSame( 'order_id', $query_args['search_filter'] ?? null, 'The selected search filter should be applied' );
 		$this->assertArrayNotHasKey( 'no_found_rows', $query_args, 'Searches should count their actual results' );
 	}
+
+	/**
+	 * @testdox When a filter modifies the query args via woocommerce_order_list_table_prepare_items_query_args, the cache fast path is not used.
+	 */
+	public function test_filter_modifying_query_args_disables_no_found_rows(): void {
+		\WC_Helper_Order::create_order();
+
+		$called = false;
+
+		$callback = function ( $args ) use ( &$called ) {
+			$called               = true;
+			$args['meta_query'][] = array(
+				'key'     => 'my_custom_meta_key',
+				'value'   => 'any_value',
+				'compare' => '=',
+			);
+			return $args;
+		};
+		add_filter( 'woocommerce_order_list_table_prepare_items_query_args', $callback );
+
+		$this->sut->prepare_items();
+		$query_args = $this->get_order_query_args();
+
+		remove_filter( 'woocommerce_order_list_table_prepare_items_query_args', $callback );
+
+		$this->assertTrue( $called, 'The filter should have been invoked' );
+		$this->assertArrayNotHasKey( 'no_found_rows', $query_args, 'When a filter modifies the query args, the cache fast path should not be used' );
+	}
+
+	/**
+	 * @testdox Without any filter modifying the query args, the cache fast path is still used.
+	 */
+	public function test_basic_query_still_uses_no_found_rows(): void {
+		\WC_Helper_Order::create_order();
+
+		$this->sut->prepare_items();
+		$query_args = $this->get_order_query_args();
+
+		$this->assertTrue( $query_args['no_found_rows'] ?? false, 'A basic query should use the cache fast path' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #66160.

The cache fast-path gate in `ListTable::prepare_items()` compared `array_keys( $this->order_query_args )` (pre-filter) against a whitelist. When a callback hooked into `woocommerce_order_list_table_prepare_items_query_args` adds extra keys (e.g. `meta_query`), the check was blind to those keys and still set `no_found_rows = true`, returning incorrect cached totals.

**Repro before fix:**
```php
add_filter(
    'woocommerce_order_list_table_prepare_items_query_args',
    function( $args ) {
        $args['meta_query'][] = [
            'key'     => 'my_custom_meta_key',
            'value'   => 'any_value',
            'compare' => '=',
        ];
        return $args;
    }
);
```
After applying this filter, the admin orders list shows a stale total that ignores the meta_query filtering.

**Fix:** Changed the gate to inspect `$order_query_args` (post-filter) so any key added by a filter correctly disables the cache fast path.

### How to test the changes in this Pull Request:

1. Apply the filter snippet above (as a must-use plugin or in theme functions.php).
2. Go to WooCommerce > Orders — observe the total count reflects the filtered results, not a cached value from before the filter.
3. Remove the filter — confirm the full order count reappears and pagination works correctly.

### Testing that has already taken place:

- PHPUnit: 147 tests, 276 assertions — All OK (including 2 new tests).
- PHPCS: Clean (0 errors, 0 warnings).
- PHPStan: No errors.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

**Changelog Entry Details**

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fixed incorrect order counts when custom query_args are added via the order list table prepare_items query args filter.