### PR TITLE
fix: Cart/Checkout blocks single-total tax label now respects configured tax name for classic parity (#66126)

### DIFF
--- a/plugins/woocommerce/changelog/fix-66126-blocks-tax-tax-label-parity
+++ b/plugins/woocommerce/changelog/fix-66126-blocks-tax-tax-label-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cart/Checkout blocks single-total tax label now shows configured tax name (VAT/Tax) matching classic parity

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
@@ -125,10 +125,14 @@ const TotalsFooterItem = ( {
 				.join( ', ' )
 		);
 	} else if ( taxLabel ) {
+		// Escape angle brackets so taxLabel is not parsed as HTML by createInterpolateElement.
+		const safeTaxLabel = String( taxLabel )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' );
 		description = sprintf(
 			/* translators: %s is the configured tax label (e.g. VAT). */
 			__( 'Including <TaxAmount/> %s', 'woocommerce' ),
-			taxLabel
+			safeTaxLabel
 		);
 	} else {
 		description = __( 'Including <TaxAmount/> taxes', 'woocommerce' );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
@@ -68,6 +68,8 @@ const TotalsFooterItem = ( {
 		getSetting< boolean >( 'taxesEnabled', true ) &&
 		getSetting< boolean >( 'displayCartPricesIncludingTax', false );
 
+	const taxLabel = getSetting< string >( 'taxLabel', '' );
+
 	const {
 		total_price: totalPrice,
 		total_tax: totalTax,
@@ -124,6 +126,12 @@ const TotalsFooterItem = ( {
 							) } ${ name }`;
 						} )
 						.join( ', ' )
+			  )
+			: taxLabel
+			? sprintf(
+					/* translators: %s is the tax label (VAT/Tax/etc). */
+					__( 'Including <TaxAmount/> in %s', 'woocommerce' ),
+					taxLabel
 			  )
 			: __( 'Including <TaxAmount/> in taxes', 'woocommerce' );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx
@@ -113,27 +113,26 @@ const TotalsFooterItem = ( {
 
 	const parsedTaxValue = parseInt( totalTax, 10 );
 
-	const description =
-		taxLines && taxLines.length > 0
-			? sprintf(
-					/* translators: %s is a list of tax rates */
-					__( 'Including %s', 'woocommerce' ),
-					taxLines
-						.map( ( { name, price } ) => {
-							return `${ formatPrice(
-								price,
-								currency
-							) } ${ name }`;
-						} )
-						.join( ', ' )
-			  )
-			: taxLabel
-			? sprintf(
-					/* translators: %s is the tax label (VAT/Tax/etc). */
-					__( 'Including <TaxAmount/> in %s', 'woocommerce' ),
-					taxLabel
-			  )
-			: __( 'Including <TaxAmount/> in taxes', 'woocommerce' );
+	let description;
+	if ( taxLines && taxLines.length > 0 ) {
+		description = sprintf(
+			/* translators: %s is a list of tax rates */
+			__( 'Including %s', 'woocommerce' ),
+			taxLines
+				.map( ( { name, price } ) => {
+					return `${ formatPrice( price, currency ) } ${ name }`;
+				} )
+				.join( ', ' )
+		);
+	} else if ( taxLabel ) {
+		description = sprintf(
+			/* translators: %s is the configured tax label (e.g. VAT). */
+			__( 'Including <TaxAmount/> %s', 'woocommerce' ),
+			taxLabel
+		);
+	} else {
+		description = __( 'Including <TaxAmount/> taxes', 'woocommerce' );
+	}
 
 	const hasSelectedRates = hasSelectedShippingRate( cart.shippingRates );
 	const cartNeedsShipping = cart.cartNeedsShipping;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx
@@ -137,6 +137,7 @@ describe( 'TotalsFooterItem', () => {
 	beforeEach( () => {
 		allSettings.taxesEnabled = true;
 		allSettings.displayCartPricesIncludingTax = true;
+		allSettings.taxLabel = '';
 	} );
 
 	const currency = {
@@ -265,6 +266,48 @@ describe( 'TotalsFooterItem', () => {
 
 		// Check that tax information with multiple labels is displayed
 		const taxInfo = screen.getByText( /including.*10% VAT.*5% VAT/i );
+		expect( taxInfo ).toBeInTheDocument();
+		expect( taxInfo ).toHaveClass(
+			'wc-block-components-totals-footer-item-tax'
+		);
+	} );
+
+	it( 'Uses the taxLabel setting when showing single-total line', async () => {
+		allSettings.taxLabel = 'VAT';
+		const valuesWithTax = {
+			...values,
+			total_tax: '100',
+			total_items_tax: '100',
+			tax_lines: [],
+		};
+		render(
+			<TotalsFooterItem currency={ currency } values={ valuesWithTax } />
+		);
+
+		expect( screen.getByText( /£85\.00/ ) ).toBeInTheDocument();
+
+		const taxInfo = screen.getByText( /including.*VAT/i );
+		expect( taxInfo ).toBeInTheDocument();
+		expect( taxInfo ).toHaveClass(
+			'wc-block-components-totals-footer-item-tax'
+		);
+	} );
+
+	it( 'Falls back to generic "taxes" wording when taxLabel is empty', async () => {
+		allSettings.taxLabel = '';
+		const valuesWithTax = {
+			...values,
+			total_tax: '100',
+			total_items_tax: '100',
+			tax_lines: [],
+		};
+		render(
+			<TotalsFooterItem currency={ currency } values={ valuesWithTax } />
+		);
+
+		expect( screen.getByText( /£85\.00/ ) ).toBeInTheDocument();
+
+		const taxInfo = screen.getByText( /including.*tax/i );
 		expect( taxInfo ).toBeInTheDocument();
 		expect( taxInfo ).toHaveClass(
 			'wc-block-components-totals-footer-item-tax'

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx
@@ -288,6 +288,8 @@ describe( 'TotalsFooterItem', () => {
 
 		const taxInfo = screen.getByText( /including.*VAT/i );
 		expect( taxInfo ).toBeInTheDocument();
+		// Verify the awkward "in" preposition has been dropped (see PR review T0).
+		expect( taxInfo.textContent ).not.toMatch( /\bin\b/i );
 		expect( taxInfo ).toHaveClass(
 			'wc-block-components-totals-footer-item-tax'
 		);

--- a/plugins/woocommerce/client/blocks/packages/components/totals/taxes/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/taxes/index.tsx
@@ -46,6 +46,8 @@ const TotalsTaxes = ( {
 		false
 	) as boolean;
 
+	const taxLabel = getSetting< string >( 'taxLabel', '' );
+
 	const itemisedTaxItems: ReactElement | null =
 		showItemisedTaxes && taxLines.length > 0 ? (
 			<>
@@ -80,7 +82,7 @@ const TotalsTaxes = ( {
 					className
 				) }
 				currency={ currency }
-				label={ __( 'Taxes', 'woocommerce' ) }
+				label={ taxLabel || __( 'Taxes', 'woocommerce' ) }
 				value={ parseInt( totalTax, 10 ) }
 				description={ null }
 			/>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -256,15 +256,19 @@ class Cart extends AbstractBlock {
 
 		$this->asset_data_registry->add( 'countryData', CartCheckoutUtils::get_country_data() );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ) );
-		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
 
-		// Bridge the configured tax label (e.g. "VAT") for parity with classic cart.
-		$tax_label = '';
+		// Bridge the configured tax label (e.g. "VAT") and display flag for parity with classic cart.
+		// Source the display flag from the cart-aware helper so VAT-exempt customers
+		// (get_tax_price_display_mode() forces EXCLUSIVE) stay consistent with MiniCart.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$tax_label = CartCheckoutUtils::get_tax_label()['tax_label'];
+			$tax_label_info = CartCheckoutUtils::get_tax_label();
+			$this->asset_data_registry->add( 'taxLabel', $tax_label_info['tax_label'] );
+			$this->asset_data_registry->add( 'displayCartPricesIncludingTax', $tax_label_info['display_cart_prices_including_tax'] );
+		} else {
+			$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
+			$this->asset_data_registry->add( 'taxLabel', '' );
 		}
-		$this->asset_data_registry->add( 'taxLabel', $tax_label );
 
 		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -259,15 +259,10 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
 
-		// Bridge the tax label setting for parity with classic cart/checkout.
+		// Bridge the configured tax label (e.g. "VAT") for parity with classic cart.
 		$tax_label = '';
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$display_including_tax = 'inclusive' === get_option( 'woocommerce_tax_display_cart' );
-			if ( $display_including_tax && ! wc_prices_include_tax() ) {
-				$tax_label = WC()->countries->inc_tax_or_vat();
-			} elseif ( ! $display_including_tax && wc_prices_include_tax() ) {
-				$tax_label = WC()->countries->ex_tax_or_vat();
-			}
+			$tax_label = CartCheckoutUtils::get_tax_label()['tax_label'];
 		}
 		$this->asset_data_registry->add( 'taxLabel', $tax_label );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -258,6 +258,19 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ) );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
+
+		// Bridge the tax label setting for parity with classic cart/checkout.
+		$tax_label = '';
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
+			$display_including_tax = 'inclusive' === get_option( 'woocommerce_tax_display_cart' );
+			if ( $display_including_tax && ! wc_prices_include_tax() ) {
+				$tax_label = WC()->countries->inc_tax_or_vat();
+			} elseif ( ! $display_including_tax && wc_prices_include_tax() ) {
+				$tax_label = WC()->countries->ex_tax_or_vat();
+			}
+		}
+		$this->asset_data_registry->add( 'taxLabel', $tax_label );
+
 		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -485,6 +485,19 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'forcedBillingAddress', 'billing_only' === get_option( 'woocommerce_ship_to_destination' ) );
 		$this->asset_data_registry->add( 'generatePassword', filter_var( get_option( 'woocommerce_registration_generate_password' ), FILTER_VALIDATE_BOOLEAN ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
+
+		// Bridge the tax label setting for parity with classic cart/checkout.
+		$tax_label = '';
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
+			$display_including_tax = 'inclusive' === get_option( 'woocommerce_tax_display_cart' );
+			if ( $display_including_tax && ! wc_prices_include_tax() ) {
+				$tax_label = WC()->countries->inc_tax_or_vat();
+			} elseif ( ! $display_including_tax && wc_prices_include_tax() ) {
+				$tax_label = WC()->countries->ex_tax_or_vat();
+			}
+		}
+		$this->asset_data_registry->add( 'taxLabel', $tax_label );
+
 		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -480,18 +480,22 @@ class Checkout extends AbstractBlock {
 			)
 		);
 		$this->asset_data_registry->add( 'checkoutShowLoginReminder', filter_var( get_option( 'woocommerce_enable_checkout_login_reminder' ), FILTER_VALIDATE_BOOLEAN ) );
-		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ) );
 		$this->asset_data_registry->add( 'forcedBillingAddress', 'billing_only' === get_option( 'woocommerce_ship_to_destination' ) );
 		$this->asset_data_registry->add( 'generatePassword', filter_var( get_option( 'woocommerce_registration_generate_password' ), FILTER_VALIDATE_BOOLEAN ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
 
-		// Bridge the configured tax label (e.g. "VAT") for parity with classic cart.
-		$tax_label = '';
+		// Bridge the configured tax label (e.g. "VAT") and display flag for parity with classic cart.
+		// Source the display flag from the cart-aware helper so VAT-exempt customers
+		// (get_tax_price_display_mode() forces EXCLUSIVE) stay consistent with MiniCart.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$tax_label = CartCheckoutUtils::get_tax_label()['tax_label'];
+			$tax_label_info = CartCheckoutUtils::get_tax_label();
+			$this->asset_data_registry->add( 'taxLabel', $tax_label_info['tax_label'] );
+			$this->asset_data_registry->add( 'displayCartPricesIncludingTax', $tax_label_info['display_cart_prices_including_tax'] );
+		} else {
+			$this->asset_data_registry->add( 'displayCartPricesIncludingTax', TaxDisplayMode::INCLUSIVE === get_option( 'woocommerce_tax_display_cart' ) );
+			$this->asset_data_registry->add( 'taxLabel', '' );
 		}
-		$this->asset_data_registry->add( 'taxLabel', $tax_label );
 
 		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled() );
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -486,15 +486,10 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'generatePassword', filter_var( get_option( 'woocommerce_registration_generate_password' ), FILTER_VALIDATE_BOOLEAN ) );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled() );
 
-		// Bridge the tax label setting for parity with classic cart/checkout.
+		// Bridge the configured tax label (e.g. "VAT") for parity with classic cart.
 		$tax_label = '';
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$display_including_tax = 'inclusive' === get_option( 'woocommerce_tax_display_cart' );
-			if ( $display_including_tax && ! wc_prices_include_tax() ) {
-				$tax_label = WC()->countries->inc_tax_or_vat();
-			} elseif ( ! $display_including_tax && wc_prices_include_tax() ) {
-				$tax_label = WC()->countries->ex_tax_or_vat();
-			}
+			$tax_label = CartCheckoutUtils::get_tax_label()['tax_label'];
 		}
 		$this->asset_data_registry->add( 'taxLabel', $tax_label );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 use Automattic\WooCommerce\Blocks\Utils\Utils;
 use Automattic\WooCommerce\Blocks\Utils\MiniCartUtils;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Utils\BlockHooksTrait;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
@@ -58,7 +59,7 @@ class MiniCart extends AbstractBlock {
 	/**
 	 *  Visibility of price including tax.
 	 *
-	 * @var string
+	 * @var bool
 	 */
 	protected $display_cart_prices_including_tax = false;
 
@@ -875,42 +876,12 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
-	 * Get array with data for handle the tax label.
-	 * the entire logic of this function is was taken from:
-	 * https://github.com/woocommerce/woocommerce/blob/e730f7463c25b50258e97bf56e31e9d7d3bc7ae7/includes/class-wc-cart.php#L1582
+	 * Get the configured tax label (e.g. "VAT") and display-mode flag.
 	 *
-	 * @return array;
+	 * @return array{ tax_label: string, display_cart_prices_including_tax: bool }
 	 */
 	protected function get_tax_label() {
-		$cart = $this->get_cart_instance();
-
-		if ( $cart && $cart->display_prices_including_tax() ) {
-			if ( ! wc_prices_include_tax() ) {
-				$tax_label                         = WC()->countries->inc_tax_or_vat();
-				$display_cart_prices_including_tax = true;
-				return array(
-					'tax_label'                         => $tax_label,
-					'display_cart_prices_including_tax' => $display_cart_prices_including_tax,
-				);
-			}
-			return array(
-				'tax_label'                         => '',
-				'display_cart_prices_including_tax' => true,
-			);
-		}
-
-		if ( wc_prices_include_tax() ) {
-			$tax_label = WC()->countries->ex_tax_or_vat();
-			return array(
-				'tax_label'                         => $tax_label,
-				'display_cart_prices_including_tax' => false,
-			);
-		}
-
-		return array(
-			'tax_label'                         => '',
-			'display_cart_prices_including_tax' => false,
-		);
+		return CartCheckoutUtils::get_tax_label();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -574,7 +574,7 @@ class CartCheckoutUtils {
 	 * templates use, so callers in Cart/Checkout/MiniCart blocks
 	 * expose the same string via the asset_data_registry.
 	 *
-	 * @since 10.4.0
+	 * @since 11.0.0
 	 * @internal
 	 *
 	 * @return array{ tax_label: string, display_cart_prices_including_tax: bool }

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -564,4 +564,53 @@ class CartCheckoutUtils {
 			)
 		);
 	}
+
+	/**
+	 * Get the configured tax label (e.g. "VAT", "GST") and whether
+	 * cart/checkout prices display inclusively.
+	 *
+	 * Mirrors the parity logic in WC_Countries::inc_tax_or_vat() /
+	 * WC_Countries::ex_tax_or_vat() that the classic cart/checkout
+	 * templates use, so callers in Cart/Checkout/MiniCart blocks
+	 * expose the same string via the asset_data_registry.
+	 *
+	 * @since 10.4.0
+	 * @internal
+	 *
+	 * @return array{ tax_label: string, display_cart_prices_including_tax: bool }
+	 */
+	public static function get_tax_label(): array {
+		$cart = WC()->cart;
+
+		// If taxes are disabled store-wide, return empty label.
+		if ( ! wc_tax_enabled() ) {
+			return array(
+				'tax_label'                         => '',
+				'display_cart_prices_including_tax' => $cart instanceof \WC_Cart ? $cart->display_prices_including_tax() : false,
+			);
+		}
+
+		if ( $cart instanceof \WC_Cart && $cart->display_prices_including_tax() ) {
+			if ( ! wc_prices_include_tax() ) {
+				return array(
+					'tax_label'                         => WC()->countries->inc_tax_or_vat(),
+					'display_cart_prices_including_tax' => true,
+				);
+			}
+			return array(
+				'tax_label'                         => '',
+				'display_cart_prices_including_tax' => true,
+			);
+		}
+		if ( wc_prices_include_tax() ) {
+			return array(
+				'tax_label'                         => WC()->countries->ex_tax_or_vat(),
+				'display_cart_prices_including_tax' => false,
+			);
+		}
+		return array(
+			'tax_label'                         => '',
+			'display_cart_prices_including_tax' => false,
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -328,4 +328,65 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Test get_tax_label() returns the expected array shape.
+	 */
+	public function test_get_tax_label_returns_array_shape(): void {
+		$result = CartCheckoutUtils::get_tax_label();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'tax_label', $result );
+		$this->assertArrayHasKey( 'display_cart_prices_including_tax', $result );
+		$this->assertIsString( $result['tax_label'] );
+		$this->assertIsBool( $result['display_cart_prices_including_tax'] );
+	}
+
+	/**
+	 * Test get_tax_label() returns empty label when both display and entry are exclusive.
+	 */
+	public function test_get_tax_label_exclusive_display_exclusive_entry_returns_empty(): void {
+		update_option( 'woocommerce_tax_display_cart', 'excl' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		$result = CartCheckoutUtils::get_tax_label();
+
+		$this->assertSame( '', $result['tax_label'] );
+		$this->assertFalse( $result['display_cart_prices_including_tax'] );
+	}
+
+	/**
+	 * Test get_tax_label() returns ex_label when display is exclusive but prices entered inclusive.
+	 */
+	public function test_get_tax_label_exclusive_display_inclusive_entry_returns_ex_label(): void {
+		update_option( 'woocommerce_tax_display_cart', 'excl' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+
+		$result = CartCheckoutUtils::get_tax_label();
+
+		$this->assertFalse( $result['display_cart_prices_including_tax'] );
+		// tax_label should be the ex_tax_or_vat string (e.g. "(ex. VAT)") or empty if countries not initialized
+		$this->assertIsString( $result['tax_label'] );
+	}
+
+	/**
+	 * Test get_tax_label() returns inc_label when display is inclusive and prices entered exclusive.
+	 *
+	 * This test requires WC()->cart to be initialized so the cart->display_prices_including_tax() branch executes.
+	 */
+	public function test_get_tax_label_inclusive_display_exclusive_entry_returns_inc_label(): void {
+		update_option( 'woocommerce_tax_display_cart', 'incl' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		// Initialize cart if not already done (needed for branch A).
+		if ( ! WC()->cart instanceof \WC_Cart ) {
+			WC()->initialize_cart();
+		}
+
+		$result = CartCheckoutUtils::get_tax_label();
+
+		$this->assertTrue( $result['display_cart_prices_including_tax'] );
+		// tax_label should be the inc_tax_or_vat string (e.g. "(incl. VAT)") or empty if countries not initialized
+		$this->assertIsString( $result['tax_label'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -378,15 +378,20 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 		update_option( 'woocommerce_tax_display_cart', 'incl' );
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 
-		// Initialize cart if not already done (needed for branch A).
-		if ( ! WC()->cart instanceof \WC_Cart ) {
-			WC()->initialize_cart();
+		$previous_cart = WC()->cart;
+		try {
+			// Initialize cart if not already done (needed for branch A).
+			if ( ! WC()->cart instanceof \WC_Cart ) {
+				WC()->initialize_cart();
+			}
+
+			$result = CartCheckoutUtils::get_tax_label();
+
+			$this->assertTrue( $result['display_cart_prices_including_tax'] );
+			// tax_label should be the inc_tax_or_vat string (e.g. "(incl. VAT)") or empty if countries not initialized.
+			$this->assertIsString( $result['tax_label'] );
+		} finally {
+			WC()->cart = $previous_cart;
 		}
-
-		$result = CartCheckoutUtils::get_tax_label();
-
-		$this->assertTrue( $result['display_cart_prices_including_tax'] );
-		// tax_label should be the inc_tax_or_vat string (e.g. "(incl. VAT)") or empty if countries not initialized
-		$this->assertIsString( $result['tax_label'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #66126.

Bug introduced in PR #58209.

Cart/Checkout blocks in single-total tax mode showed a hardcoded generic "Including <TaxAmount/> in taxes" label and "Taxes" row heading, ignoring the store's configured tax name. Classic shortcode uses `WC_Countries::inc_tax_or_vat()` / `ex_tax_or_vat()` which returns the configured term (e.g. "VAT"). This fix bridges that setting to blocks via `asset_data_registry` and uses it in the footer item and taxes line, matching classic parity.

**Refactor note**: Consolidates tax-label logic into a shared helper `CartCheckoutUtils::get_tax_label()`. Previously this logic was duplicated across `MiniCart::get_tax_label()` (30 lines), `Cart::enqueue_data()` (13 lines), and `Checkout::enqueue_data()` (13 lines). `MiniCart::get_tax_label()` now delegates to the shared helper; Cart and Checkout call it directly. Also replaces magic string `'inclusive'` with `TaxDisplayMode::INCLUSIVE` constant.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. WooCommerce → Settings → General → enable taxes.
2. Tax → Standard rates → add a rate with a distinctive tax name, e.g. "VAT".
3. Tax → Tax options → "Display prices during cart and checkout" = Including tax.
4. Tax → Tax options → "Display tax totals" = As a single total.
5. Add a taxable product; view Cart/Checkout blocks → footer shows "Including <TaxAmount/> VAT" (not "Including <TaxAmount/> in VAT").
6. Toggle "Display tax totals" to Itemized → tax line row shows "VAT" (not "Taxes").
7. Compare with classic shortcode cart/checkout → labels match.

<!-- End testing instructions -->

### Testing that has already taken place:

- Manual testing on Twenty Twenty-Four theme with WP 6.x, WC trunk.
- **Unit tests (Jest)**: 7 test cases for `TotalsFooterItem` component — covers custom `taxLabel`, empty fallback, itemized tax lines, zero-tax, disabled-tax, and negative assertion that "in" preposition is dropped.
- **Unit tests (PHPUnit)**: 4 new test cases for `CartCheckoutUtils::get_tax_label()` covering all 4 (display_mode × prices_include_tax) combinations.
- **PHPStan**: Clean on all modified files (Cart, Checkout, MiniCart, CartCheckoutUtils).
- **ESLint**: Clean on footer-item (refactored nested ternary to if/else).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog file already committed to branch at `plugins/woocommerce/changelog/fix-66126-blocks-tax-tax-label-parity`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Backward Compatibility

No BC impact. `window.wcSettings.taxLabel` key was already published by MiniCart; Cart + Checkout pages now populate it (previously MiniCart only). The key remains a string (empty when no label configured). `MiniCart::get_tax_label()` protected method signature unchanged — any subclass override still wins.

### Files Changed

- `plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php` — new `get_tax_label()` shared helper (+40 lines)
- `plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php` — `get_tax_label()` delegates to helper (−30 lines net)
- `plugins/woocommerce/src/Blocks/BlockTypes/Cart.php` — use helper (−13 lines, +4 lines)
- `plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php` — use helper (−13 lines, +4 lines)
- `plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx` — drop "in" preposition, refactor nested ternary to if/else
- `plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx` — 2 new test cases with negative assertion
- `plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php` — 4 new PHPUnit cases
