### PR TITLE
Fix deferred product transient shutdown order

### DIFF
--- a/plugins/woocommerce/src/Internal/Caches/ProductTransientsDeferrer.php
+++ b/plugins/woocommerce/src/Internal/Caches/ProductTransientsDeferrer.php
@@ -14,6 +14,13 @@ use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
 class ProductTransientsDeferrer {
 
 	/**
+	 * Shutdown priority used to flush deferred product transients before product sync callbacks.
+	 *
+	 * @var int
+	 */
+	public const SHUTDOWN_PRIORITY = 9;
+
+	/**
 	 * The product utility instance.
 	 *
 	 * @var ProductUtil
@@ -54,7 +61,7 @@ class ProductTransientsDeferrer {
 	public function start_deferring(): void {
 		++$this->deferral_level;
 		if ( 1 === $this->deferral_level ) {
-			add_action( 'shutdown', array( $this, 'handle_shutdown' ) );
+			add_action( 'shutdown', array( $this, 'handle_shutdown' ), self::SHUTDOWN_PRIORITY );
 		}
 	}
 
@@ -72,7 +79,7 @@ class ProductTransientsDeferrer {
 
 		--$this->deferral_level;
 		if ( 0 === $this->deferral_level ) {
-			remove_action( 'shutdown', array( $this, 'handle_shutdown' ) );
+			remove_action( 'shutdown', array( $this, 'handle_shutdown' ), self::SHUTDOWN_PRIORITY );
 			$this->flush();
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/ProductTransientsDeferrerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/ProductTransientsDeferrerTest.php
@@ -43,4 +43,96 @@ class ProductTransientsDeferrerTest extends \WC_Unit_Test_Case {
 
 		$this->assertSame( array( 123, 456 ), $deleted_ids );
 	}
+
+	/**
+	 * @testdox Product transient deferral shutdown flush runs before deferred parent product sync.
+	 * @see https://github.com/woocommerce/woocommerce/issues/65686
+	 */
+	public function test_shutdown_flush_runs_before_deferred_parent_product_sync(): void {
+		global $wc_deferred_product_sync;
+
+		$wc_deferred_product_sync = array();
+
+		$parent = new \WC_Product_Variable();
+		$parent->set_name( 'Issue 65686 variable product' );
+		$parent->set_status( 'publish' );
+		$parent->save();
+
+		$existing_variation = $this->create_variation( $parent->get_id(), '11' );
+		\WC_Product_Variable::sync( $parent->get_id() );
+
+		$parent = wc_get_product( $parent->get_id() );
+		$this->assertSame(
+			array( $existing_variation->get_id() ),
+			$parent->get_visible_children(),
+			'Precondition: the parent children transient should contain only the existing variation.'
+		);
+
+		$deferrer = wc_get_container()->get( ProductTransientsDeferrer::class );
+		$deferrer->start_deferring();
+		$this->create_variation( $parent->get_id(), '66' );
+
+		$product_sync_shutdown_priority = has_action( 'shutdown', array( \WC_Post_Data::class, 'do_deferred_product_sync' ) );
+		$deferrer_shutdown_priority     = has_action( 'shutdown', array( $deferrer, 'handle_shutdown' ) );
+
+		$this->assertNotFalse( $product_sync_shutdown_priority, 'Deferred product sync should be registered on shutdown.' );
+		$this->assertNotFalse( $deferrer_shutdown_priority, 'Product transient deferral should be registered on shutdown.' );
+
+		try {
+			$shutdown_callbacks = array(
+				array(
+					'priority' => $product_sync_shutdown_priority,
+					'order'    => 0,
+					'callback' => array( \WC_Post_Data::class, 'do_deferred_product_sync' ),
+				),
+				array(
+					'priority' => $deferrer_shutdown_priority,
+					'order'    => 1,
+					'callback' => array( $deferrer, 'handle_shutdown' ),
+				),
+			);
+
+			usort(
+				$shutdown_callbacks,
+				static function ( array $a, array $b ): int {
+					return $a['priority'] === $b['priority'] ? $a['order'] <=> $b['order'] : $a['priority'] <=> $b['priority'];
+				}
+			);
+
+			foreach ( $shutdown_callbacks as $shutdown_callback ) {
+				call_user_func( $shutdown_callback['callback'] );
+			}
+		} finally {
+			$deferrer->stop_deferring();
+			$wc_deferred_product_sync = array();
+		}
+
+		$parent_price_rows = get_post_meta( $parent->get_id(), '_price', false );
+		$parent_price_rows = array_map( 'strval', $parent_price_rows );
+		sort( $parent_price_rows, SORT_NUMERIC );
+
+		$this->assertSame(
+			array( '11', '66' ),
+			$parent_price_rows,
+			'Deferred parent sync should include variations created while product transient deletion was deferred.'
+		);
+	}
+
+	/**
+	 * Create a published variation with a fixed price.
+	 *
+	 * @param int    $parent_id Parent product ID.
+	 * @param string $price Variation price.
+	 * @return \WC_Product_Variation
+	 */
+	private function create_variation( int $parent_id, string $price ): \WC_Product_Variation {
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $parent_id );
+		$variation->set_status( 'publish' );
+		$variation->set_regular_price( $price );
+		$variation->set_price( $price );
+		$variation->save();
+
+		return $variation;
+	}
 }


### PR DESCRIPTION
## What changed
- Flush `ProductTransientsDeferrer` during shutdown before WooCommerce's deferred product sync callback.
- Add a regression test for #65686 covering a newly created variation price after stale parent children transient warm-up and shutdown-ordered sync.

Fixes #65686.

## Testing
- `php -l src/Internal/Caches/ProductTransientsDeferrer.php`
- `php -l tests/php/src/Internal/Caches/ProductTransientsDeferrerTest.php`
- `corepack pnpm --filter='@woocommerce/plugin-woocommerce' test:php --filter ProductTransientsDeferrerTest` could not run locally because the WordPress PHPUnit test library is not installed at the configured temp path.
- `corepack pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env --filter ProductTransientsDeferrerTest` could not run locally because wp-env is not initialized.
- Homeboy Lab run `woo-rest-product-batch-import-20260702-fix-65686-37ffd8e`: the `wordpress.run-workload` step exited `0`, so the original guardrail did not reproduce. The campaign still reported failed because `wordpress.collect-workload-result` could not find a `raw_result` typed payload after the successful workload step.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, code change, regression test drafting, and verification orchestration.
