### PR TITLE
Use HTTPS for all geolocation IP lookup and geo-IP requests

### DIFF
--- a/plugins/woocommerce/changelog/46099-fix-geolocation-https
+++ b/plugins/woocommerce/changelog/46099-fix-geolocation-https
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use HTTPS for all geolocation IP-lookup and geo-IP requests. Switch the IP-lookup services (ipify, ipecho, ident, tnedi) to HTTPS and replace the HTTP-only ip-api.com geo-IP provider with the HTTPS-based country.is, so visitor IP addresses are never sent over unencrypted connections.

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -47,10 +47,10 @@ class WC_Geolocation {
 	 * @var array
 	 */
 	private static $ip_lookup_apis = array(
-		'ipify'  => 'http://api.ipify.org/',
-		'ipecho' => 'http://ipecho.net/plain',
-		'ident'  => 'http://ident.me',
-		'tnedi'  => 'http://tnedi.me',
+		'ipify'  => 'https://api.ipify.org/',
+		'ipecho' => 'https://ipecho.net/plain',
+		'ident'  => 'https://ident.me',
+		'tnedi'  => 'https://tnedi.me',
 	);
 
 	/**
@@ -60,7 +60,7 @@ class WC_Geolocation {
 	 */
 	private static $geoip_apis = array(
 		'ipinfo.io'  => 'https://ipinfo.io/%s/json',
-		'ip-api.com' => 'http://ip-api.com/json/%s',
+		'country.is' => 'https://api.country.is/%s',
 	);
 
 	/**
@@ -313,9 +313,9 @@ class WC_Geolocation {
 							$data         = json_decode( $response['body'] );
 							$country_code = isset( $data->country ) ? $data->country : '';
 							break;
-						case 'ip-api.com':
+						case 'country.is':
 							$data         = json_decode( $response['body'] );
-							$country_code = isset( $data->countryCode ) ? $data->countryCode : ''; // @codingStandardsIgnoreLine
+							$country_code = isset( $data->country ) ? $data->country : '';
 							break;
 						default:
 							$country_code = apply_filters( 'woocommerce_geolocation_geoip_response_' . $service_name, '', $response['body'] );

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -310,12 +310,14 @@ class WC_Geolocation {
 				if ( ! is_wp_error( $response ) && $response['body'] ) {
 					switch ( $service_name ) {
 						case 'ipinfo.io':
-							$data         = json_decode( $response['body'] );
-							$country_code = isset( $data->country ) ? $data->country : '';
-							break;
 						case 'country.is':
 							$data         = json_decode( $response['body'] );
 							$country_code = isset( $data->country ) ? $data->country : '';
+							break;
+						case 'ip-api.com':
+							// Not a default provider (HTTP-only), but retained so extensions that re-add it via the woocommerce_geolocation_geoip_apis filter keep working.
+							$data         = json_decode( $response['body'] );
+							$country_code = isset( $data->countryCode ) ? $data->countryCode : ''; // @codingStandardsIgnoreLine
 							break;
 						default:
 							$country_code = apply_filters( 'woocommerce_geolocation_geoip_response_' . $service_name, '', $response['body'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -97,33 +97,26 @@ class WC_Tests_Geolocation extends WC_Unit_Test_Case {
 		delete_transient( 'geoip_' . $ip_address );
 
 		// Force the database lookup to return nothing so the API fallback runs.
-		add_filter(
-			'woocommerce_get_geolocation',
-			function ( $data ) {
-				$data['country'] = '';
-				return $data;
-			},
-			999
-		);
+		$force_empty_geolocation = function ( $data ) {
+			$data['country'] = '';
+			return $data;
+		};
+		add_filter( 'woocommerce_get_geolocation', $force_empty_geolocation, 999 );
 
 		// Intercept the outgoing request; the body is valid for both configured providers.
-		add_filter(
-			'pre_http_request',
-			function ( $pre, $args, $url ) use ( &$requested_url ) {
-				$requested_url = $url;
-				return array(
-					'body'     => wp_json_encode( array( 'country' => 'US' ) ),
-					'response' => array( 'code' => 200 ),
-				);
-			},
-			10,
-			3
-		);
+		$intercept_request = function ( $pre, $args, $url ) use ( &$requested_url ) {
+			$requested_url = $url;
+			return array(
+				'body'     => wp_json_encode( array( 'country' => 'US' ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		add_filter( 'pre_http_request', $intercept_request, 10, 3 );
 
 		$geolocation = WC_Geolocation::geolocate_ip( $ip_address, false, true );
 
-		remove_all_filters( 'pre_http_request' );
-		remove_all_filters( 'woocommerce_get_geolocation' );
+		remove_filter( 'pre_http_request', $intercept_request, 10 );
+		remove_filter( 'woocommerce_get_geolocation', $force_empty_geolocation, 999 );
 		delete_transient( 'geoip_' . $ip_address );
 
 		$this->assertEquals( 'US', $geolocation['country'], 'The country code from the API response should be returned' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -49,4 +49,84 @@ class WC_Tests_Geolocation extends WC_Unit_Test_Case {
 		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
 		unset( $_SERVER['REMOTE_ADDR'] );
 	}
+
+	/**
+	 * Read the value of a private static property on WC_Geolocation.
+	 *
+	 * @param string $property Property name.
+	 * @return mixed
+	 */
+	private function get_private_static( $property ) {
+		$ref = new ReflectionProperty( 'WC_Geolocation', $property );
+		$ref->setAccessible( true );
+
+		return $ref->getValue();
+	}
+
+	/**
+	 * @testdox Every geo-IP lookup endpoint should use HTTPS so visitor IP addresses are never sent unencrypted.
+	 */
+	public function test_geoip_apis_all_use_https() {
+		$apis = $this->get_private_static( 'geoip_apis' );
+
+		foreach ( $apis as $service_name => $endpoint ) {
+			$this->assertStringStartsWith( 'https://', $endpoint, "Geo-IP service {$service_name} must use HTTPS" );
+		}
+
+		$this->assertArrayNotHasKey( 'ip-api.com', $apis, 'The HTTP-only ip-api.com provider should no longer be used' );
+	}
+
+	/**
+	 * @testdox Every IP-lookup endpoint should use HTTPS so visitor IP addresses are never sent unencrypted.
+	 */
+	public function test_ip_lookup_apis_all_use_https() {
+		$apis = $this->get_private_static( 'ip_lookup_apis' );
+
+		foreach ( $apis as $service_name => $endpoint ) {
+			$this->assertStringStartsWith( 'https://', $endpoint, "IP-lookup service {$service_name} must use HTTPS" );
+		}
+	}
+
+	/**
+	 * @testdox Geolocating via the API should parse the country code and only request HTTPS endpoints.
+	 */
+	public function test_geolocate_via_api_uses_https_and_parses_country() {
+		$ip_address    = '8.8.8.8';
+		$requested_url = '';
+
+		delete_transient( 'geoip_' . $ip_address );
+
+		// Force the database lookup to return nothing so the API fallback runs.
+		add_filter(
+			'woocommerce_get_geolocation',
+			function ( $data ) {
+				$data['country'] = '';
+				return $data;
+			},
+			999
+		);
+
+		// Intercept the outgoing request; the body is valid for both configured providers.
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( &$requested_url ) {
+				$requested_url = $url;
+				return array(
+					'body'     => wp_json_encode( array( 'country' => 'US' ) ),
+					'response' => array( 'code' => 200 ),
+				);
+			},
+			10,
+			3
+		);
+
+		$geolocation = WC_Geolocation::geolocate_ip( $ip_address, false, true );
+
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'woocommerce_get_geolocation' );
+		delete_transient( 'geoip_' . $ip_address );
+
+		$this->assertEquals( 'US', $geolocation['country'], 'The country code from the API response should be returned' );
+		$this->assertStringStartsWith( 'https://', $requested_url, 'The geolocation request must be made over HTTPS' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Visitor IP addresses are PII, but `WC_Geolocation` sent some geolocation requests over unencrypted HTTP, which breaks stores behind firewalls that block plaintext traffic for data-protection compliance and exposes IPs in transit. This makes every geolocation request use HTTPS:

- The IP-lookup services (`ipify`, `ipecho`, `ident`, `tnedi`) now use `https://` — all four already support it.
- The HTTP-only `ip-api.com` geo-IP provider is replaced with the HTTPS-based [`country.is`](https://country.is/). `country.is` uses HTTPS by default, requires no API key, explicitly permits commercial use, and returns only an `{ip, country}` pair (less data than `ip-api.com`, which returned city/region/ISP). `ipinfo.io` (already HTTPS) is unchanged.

Note: `ip-api.com`'s free tier is also HTTP-only _and_ prohibits commercial use, so it was never a good fit for WooCommerce stores.

Closes #46099.

### Screenshots or screen recordings:

<!-- This section can be removed if not applicable. -->

Not applicable — no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

These changes only affect the geolocation API fallback path (used when no MaxMind database is configured), so the fastest way to verify is with WP-CLI.

**1. Automated unit tests**

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Geolocation
```

Expected: all tests pass. The new tests assert both provider arrays are HTTPS-only, that `ip-api.com` is gone, and that the API fallback parses the country while only requesting HTTPS.

**2. Real-network check (proves `country.is` works and no HTTP is used)**

Save this as `wp-content/geo-test.php`:

```php
<?php
$urls = array();
add_action( 'http_api_debug', function ( $r, $c, $cl, $a, $url ) use ( &$urls ) {
	if ( preg_match( '#ipinfo\.io|api\.country\.is|ip-api\.com#', $url ) ) {
		$urls[] = $url;
	}
}, 10, 5 );

// Force the local-DB lookup to miss so the API fallback path runs.
add_filter( 'woocommerce_get_geolocation', function ( $d ) { $d['country'] = ''; return $d; }, 999 );

for ( $i = 0; $i < 6; $i++ ) {
	delete_transient( 'geoip_8.8.8.8' );
	$geo = WC_Geolocation::geolocate_ip( '8.8.8.8', false, true );
	echo "run {$i}: country={$geo['country']}\n";
}
echo "Requested URLs:\n  " . implode( "\n  ", array_unique( $urls ) ) . "\n";
```

Run it:

```sh
wp eval-file wp-content/geo-test.php
```

**Expected (this branch):** `8.8.8.8` resolves to `US` on every run, and every requested URL is `https://` — only `https://ipinfo.io/...` and `https://api.country.is/...` appear. No `http://` request is made.

**Before (on `trunk`):** running the same script shows an insecure `http://ip-api.com/json/8.8.8.8` request — that is the bug this PR fixes.

<!-- End testing instructions -->

### Testing that has already taken place:

- `WC_Tests_Geolocation` PHPUnit suite passes in wp-env (PHP 8.1): 4 tests, 25 assertions.
- End-to-end on a Jurassic Ninja site running released **WooCommerce 10.9.2** with real outbound network, using the script above:
  - **Before (unpatched 10.9.2):** requested `http://ip-api.com/json/8.8.8.8` (plaintext, IP in URL).
  - **After (this fix):** 6 runs all resolved `US`; distinct requests were only `https://ipinfo.io/8.8.8.8/json` and `https://api.country.is/8.8.8.8`; HTTPS-only assertion passed; a `country.is`-only run also resolved `US`, confirming the new provider + parsing work over real HTTPS.
- `phpcs` clean on the changed lines; `php -l` clean.
- Verified provider terms for `country.is`: HTTPS default, no API key, commercial use free, operating since 2015, data from MaxMind GeoLite2 + Cloudflare.

**Backward compatibility:** `WC_Geolocation::$geoip_apis` / `$ip_lookup_apis` and the response handling in `geolocate_via_api()` are extensible via the `woocommerce_geolocation_geoip_apis` and `woocommerce_geolocation_ip_lookup_apis` filters. Removing `ip-api.com` from the default list changes which response formats core parses out of the box. Extensions that added their own providers via these filters are unaffected; any relying on `ip-api.com` being present by default should re-add it via the filter.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
