### PR TITLE
Fix Product Collection fatal in new post editor

### DIFF
--- a/plugins/woocommerce/changelog/66124-load-post-new-editor-includes
+++ b/plugins/woocommerce/changelog/66124-load-post-new-editor-includes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Load frontend includes during new post editor requests to avoid Product Collection block hydration fatals.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -326,6 +326,7 @@ final class WooCommerce {
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'load-post.php', array( $this, 'includes' ) );
+		add_action( 'load-post-new.php', array( $this, 'includes' ) );
 		add_action( 'init', array( $this, 'init' ), 0 );
 		add_action( 'init', array( $this, 'maybe_init_order_reviews' ), 1 );
 		add_action( 'init', array( $this, 'maybe_init_abandoned_cart_recovery' ), 1 );

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -108,5 +108,9 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 			$query_after_action,
 			'New post editor load action should invoke WooCommerce includes.'
 		);
+		$this->assertTrue(
+			function_exists( 'wc_set_notices' ),
+			'New post editor load action should load frontend includes such as wc-notice-functions.php.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -70,4 +70,43 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
 		$this->assertEquals( WC()->is_rest_api_request(), true );
 	}
+
+	/**
+	 * @testdox Should load WooCommerce includes in post editor load actions.
+	 */
+	public function test_loads_woocommerce_includes_for_post_editor_load_actions(): void {
+		$this->assertSame(
+			10,
+			has_action( 'load-post.php', array( WC(), 'includes' ) ),
+			'Existing post editor requests should invoke WooCommerce includes before block rendering.'
+		);
+		$this->assertSame(
+			10,
+			has_action( 'load-post-new.php', array( WC(), 'includes' ) ),
+			'New post editor requests should invoke WooCommerce includes before block rendering.'
+		);
+
+		$original_query     = WC()->query;
+		$original_screen    = $GLOBALS['current_screen'] ?? null;
+		WC()->query         = null;
+		$query_after_action = null;
+		set_current_screen( 'post' );
+
+		try {
+			$this->assertTrue( is_admin(), 'New post editor load action should run in an admin context.' );
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment, WordPress.NamingConventions.ValidHookName.UseUnderscores
+			do_action( 'load-post-new.php' );
+			// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingHookComment, WordPress.NamingConventions.ValidHookName.UseUnderscores
+			$query_after_action = WC()->query;
+		} finally {
+			WC()->query                = $original_query;
+			$GLOBALS['current_screen'] = $original_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		$this->assertInstanceOf(
+			WC_Query::class,
+			$query_after_action,
+			'New post editor load action should invoke WooCommerce includes.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

New post editor requests can server-render WooCommerce blocks before the frontend include set is loaded, which can fatal when Product Collection hydration restores notices. This wires `load-post-new.php` to the same WooCommerce include pass as `load-post.php`, so editor preloads for new/duplicated posts load the frontend helpers they already expect.

Closes #66124.

(For Bug Fixes) Bug introduced in PR #40648.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Have WooCommerce active with at least one published product.
2. Create and publish a page containing a Product Collection block.
3. Duplicate that page into a new draft, for example with Jetpack's Copy (see instructions below) to a new draft flow that opens `/wp-admin/post-new.php?post_type=page&jetpack-copy=<source_page_id>`.
4. Confirm the editor loads without a critical error and the Product Collection block server-renders

How to enable Jetpack's Copy
1. Go to Jetpack > Settings > Writing
2. Enable "Duplicate any post or page in one click to speed up content creation."
3. Then Duplicate functionality appears under Pages in admin

<img width="368" height="76" alt="image" src="https://github.com/user-attachments/assets/709be068-47b7-40d1-b2d3-b6a634498242" />

To be fair, I couldn't reproduce the issue on `trunk`. But I used this snippet to recreate conditions that affected user had and then reproduced the problem. With this filter you see fatal on `trunk`, but it works fine on this branch:

```
add_filter(
	'woocommerce_hydration_request_after_callbacks',
	function ( $response ) {
		if ( is_admin() && function_exists( 'WC' ) && WC() && null === WC()->session ) {
			WC()->initialize_session();
		}
		return $response;
	}
);
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran `corepack pnpm --filter='@woocommerce/plugin-woocommerce' lint:php:changes`.
- Ran `composer exec -- phpstan analyse includes/class-woocommerce.php --memory-limit=2G`.
- Ran `corepack pnpm --filter='@woocommerce/plugin-woocommerce' lint:changes:branch:php`.
- Attempted `corepack pnpm run test:php:env -- --filter WooCommerce_Test`, but `wp-env` is not initialized locally because Docker is not reachable.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
