### PR TITLE
Keep Settings UI field values in the schema's value vocabulary

### DIFF
--- a/packages/js/settings-ui/changelog/fix-checkbox-value-vocabulary
+++ b/packages/js/settings-ui/changelog/fix-checkbox-value-vocabulary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep checkbox field values in the schema's value vocabulary ('yes'/'no', '1'/'0', or boolean) instead of emitting raw booleans, fixing dirty tracking, fieldVisibility predicates, and the values passed to save handlers.

--- a/packages/js/settings-ui/changelog/fix-checkbox-value-vocabulary
+++ b/packages/js/settings-ui/changelog/fix-checkbox-value-vocabulary
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep checkbox field values in the schema's value vocabulary ('yes'/'no', '1'/'0', or boolean) instead of emitting raw booleans, fixing dirty tracking, fieldVisibility predicates, and the values passed to save handlers.
+Keep checkbox values in the format the schema supplied ('yes'/'no', '1'/'0' or boolean), fixing dirty tracking, fieldVisibility predicates and the values passed to save handlers.

--- a/packages/js/settings-ui/changelog/fix-preserve-initial-value-representation
+++ b/packages/js/settings-ui/changelog/fix-preserve-initial-value-representation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve the schema's value representation for all fields when an edit reverts to the initial value, so string-emitting controls and custom components no longer leave the form dirty on a type difference alone.

--- a/packages/js/settings-ui/changelog/fix-preserve-initial-value-representation
+++ b/packages/js/settings-ui/changelog/fix-preserve-initial-value-representation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Preserve the schema's value representation for all fields when an edit reverts to the initial value, so string-emitting controls and custom components no longer leave the form dirty on a type difference alone.
+Restore the schema's value format when an edit reverts to the initial value, so fields no longer leave the form dirty on a type difference alone.

--- a/packages/js/settings-ui/src/hidden-inputs.tsx
+++ b/packages/js/settings-ui/src/hidden-inputs.tsx
@@ -19,6 +19,10 @@ const getFieldName = ( field: SettingsUIField ) => field.save?.name || field.id;
 const getArrayFieldName = ( name: string ) =>
 	name.endsWith( '[]' ) ? name : `${ name }[]`;
 
+/**
+ * Build the hidden inputs that mirror a field's value into the legacy
+ * settings form, so form_post saves go through the existing PHP save path.
+ */
 export const getHiddenInputs = (
 	field: SettingsUIField,
 	value: SettingsValue
@@ -66,6 +70,9 @@ export const getHiddenInputs = (
 	];
 };
 
+/**
+ * Render the hidden inputs for a field. See getHiddenInputs.
+ */
 export const HiddenInputs = ( {
 	field,
 	value,

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -45,10 +45,10 @@ const toStringValue = ( value: SettingsValue ) =>
 const isCheckboxChecked = ( value: SettingsValue ) =>
 	value === true || value === 'yes' || value === '1';
 
-// CheckboxControl emits raw booleans, but schemas usually supply 'yes'/'no'
-// (or '1'/'0') strings and dirty tracking, visibility predicates and save
-// handlers all compare against that format. Keep the initial value's format,
-// and return the initial value itself when the state reverts.
+// Convert a checked state to the initial value's format ('yes'/'no', '1'/'0'
+// or boolean), returning the initial value itself when the state reverts.
+// This keeps checkbox values in the format the schema declared, since
+// CheckboxControl only emits raw booleans.
 const toCheckboxValue = (
 	checked: boolean,
 	initialValue: SettingsValue

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -116,6 +116,10 @@ const getHelp = ( description?: string ) =>
 		/>
 	) : undefined;
 
+/**
+ * Render a schema field with the core control matching its type. Unsupported
+ * types warn and fall back to a text control.
+ */
 export const NativeSettingsField = ( {
 	field,
 	value,

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -42,6 +42,34 @@ const textInputTypes: TextInputType[] = [
 const toStringValue = ( value: SettingsValue ) =>
 	value === null || typeof value === 'undefined' ? '' : String( value );
 
+const isCheckboxChecked = ( value: SettingsValue ) =>
+	value === true || value === 'yes' || value === '1';
+
+// Preserve the schema's value vocabulary: legacy settings store checkboxes as
+// 'yes'/'no' (or '1'/'0') strings, and dirty tracking, visibility predicates,
+// and save handlers all compare against that vocabulary. Emitting
+// CheckboxControl's raw boolean would permanently change the value's type on
+// first interaction, so map the checked state back onto the initial value's
+// representation — returning the initial value itself when the state reverts.
+const toCheckboxValue = (
+	checked: boolean,
+	initialValue: SettingsValue
+): SettingsValue => {
+	if ( checked === isCheckboxChecked( initialValue ) ) {
+		return initialValue;
+	}
+
+	if ( typeof initialValue === 'boolean' ) {
+		return checked;
+	}
+
+	if ( initialValue === '1' || initialValue === '0' ) {
+		return checked ? '1' : '0';
+	}
+
+	return checked ? 'yes' : 'no';
+};
+
 const isTextInputType = ( type: string ): type is TextInputType =>
 	textInputTypes.includes( type as TextInputType );
 
@@ -93,6 +121,7 @@ const getHelp = ( description?: string ) =>
 export const NativeSettingsField = ( {
 	field,
 	value,
+	initialValues,
 	onChange,
 }: SettingsFieldComponentProps ) => {
 	if ( field.type === 'info' ) {
@@ -114,9 +143,13 @@ export const NativeSettingsField = ( {
 				className="wc-settings-ui__control"
 				label={ field.label }
 				help={ getHelp( field.description ) }
-				checked={ value === true || value === 'yes' || value === '1' }
+				checked={ isCheckboxChecked( value ) }
 				disabled={ field.disabled }
-				onChange={ onChange }
+				onChange={ ( checked: boolean ) =>
+					onChange(
+						toCheckboxValue( checked, initialValues?.[ field.id ] )
+					)
+				}
 				__nextHasNoMarginBottom
 			/>
 		);

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -45,12 +45,10 @@ const toStringValue = ( value: SettingsValue ) =>
 const isCheckboxChecked = ( value: SettingsValue ) =>
 	value === true || value === 'yes' || value === '1';
 
-// Preserve the schema's value vocabulary: legacy settings store checkboxes as
-// 'yes'/'no' (or '1'/'0') strings, and dirty tracking, visibility predicates,
-// and save handlers all compare against that vocabulary. Emitting
-// CheckboxControl's raw boolean would permanently change the value's type on
-// first interaction, so map the checked state back onto the initial value's
-// representation — returning the initial value itself when the state reverts.
+// CheckboxControl emits raw booleans, but schemas usually supply 'yes'/'no'
+// (or '1'/'0') strings and dirty tracking, visibility predicates and save
+// handlers all compare against that format. Keep the initial value's format,
+// and return the initial value itself when the state reverts.
 const toCheckboxValue = (
 	checked: boolean,
 	initialValue: SettingsValue

--- a/packages/js/settings-ui/src/registry.ts
+++ b/packages/js/settings-ui/src/registry.ts
@@ -140,6 +140,12 @@ const hasDuplicateScopeAndKeys = (
 	return false;
 };
 
+/**
+ * Register scoped extension points for a settings page or section: custom
+ * field components, field overrides, type renderers, visibility predicates,
+ * save handlers and region components. Registering the same keys for the
+ * same scope again replaces the previous registration.
+ */
 export const registerSettingsExtension = (
 	registration: SettingsExtensionRegistration
 ) => {
@@ -174,10 +180,18 @@ export const registerSettingsExtension = (
 	registrations.push( registration );
 };
 
+/**
+ * Clear all registrations. Only intended for tests.
+ */
 export const __resetRegistry = () => {
 	registrations.splice( 0 );
 };
 
+/**
+ * Resolve the component that renders a field: a named `field.component`
+ * registration first, then a field override by id, then a type renderer.
+ * The most recent matching registration wins.
+ */
 export const resolveFieldComponent = (
 	field: SettingsUIField,
 	context: SettingsFieldContext
@@ -215,6 +229,10 @@ export const resolveFieldComponent = (
 	return undefined;
 };
 
+/**
+ * Resolve the visibility predicate registered for a field id in the given
+ * context, if any.
+ */
 export const resolveFieldVisibilityPredicate = (
 	fieldId: string,
 	context: SettingsFieldContext
@@ -224,6 +242,10 @@ export const resolveFieldVisibilityPredicate = (
 		( registration ) => registration.fieldVisibility?.[ fieldId ]
 	);
 
+/**
+ * Resolve the visibility predicate registered for a group id in the given
+ * context, if any.
+ */
 export const resolveGroupVisibilityPredicate = (
 	groupId: string,
 	context: SettingsFieldContext
@@ -233,6 +255,10 @@ export const resolveGroupVisibilityPredicate = (
 		( registration ) => registration.groupVisibility?.[ groupId ]
 	);
 
+/**
+ * Resolve a named save handler for the given context. Warns and returns
+ * undefined when the handler is not registered.
+ */
 export const resolveSaveHandler = (
 	handler: string,
 	context: SettingsFieldContext
@@ -250,6 +276,10 @@ export const resolveSaveHandler = (
 	return undefined;
 };
 
+/**
+ * Resolve a named region component for the given context. Warns and returns
+ * undefined when the component is not registered.
+ */
 export const resolveRegionComponent = (
 	component: string,
 	context: SettingsFieldContext

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -80,11 +80,11 @@ const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	return a === b;
 };
 
-// Field controls emit fixed types (strings, arrays, booleans), so an edit
-// that reverts can leave the form dirty on a type difference alone ('5' !== 5)
-// and save handlers can receive values in a format the schema never declared.
-// Restore the initial value when the emitted value is just a re-encoding of
-// it ('5' for 5, '' for null, [] for '').
+// Preserve the initial representation of a value, returning the initial
+// value when the emitted value is just a re-encoding of it ('5' for 5,
+// '' for null, [] for ''). This prevents reverted changes leaving the form
+// dirty on a type difference alone (e.g. '5' !== 5), and keeps values in
+// the format the schema declared.
 const preserveInitialRepresentation = (
 	value: SettingsValue,
 	initialValue: SettingsValue

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -80,6 +80,40 @@ const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	return a === b;
 };
 
+// Restore the schema's value representation when a control's emitted value is
+// just a re-encoding of the initial value (e.g. '5' for 5, '' for null, [] for
+// ''). Field controls emit fixed types — strings, arrays, booleans — so
+// without this, an edit that reverts to the initial value leaves the form
+// dirty on a type difference alone, and save handlers receive values in a
+// vocabulary the schema never declared.
+const preserveInitialRepresentation = (
+	value: SettingsValue,
+	initialValue: SettingsValue
+): SettingsValue => {
+	if ( typeof initialValue === 'undefined' || value === initialValue ) {
+		return value;
+	}
+
+	if (
+		typeof value === 'string' &&
+		typeof initialValue !== 'string' &&
+		! Array.isArray( initialValue ) &&
+		( initialValue === null ? '' : String( initialValue ) ) === value
+	) {
+		return initialValue;
+	}
+
+	if (
+		Array.isArray( value ) &&
+		value.length === 0 &&
+		( initialValue === '' || initialValue === null )
+	) {
+		return initialValue;
+	}
+
+	return value;
+};
+
 const getChangedValues = (
 	values: SettingsValues,
 	initialValues: SettingsValues
@@ -568,10 +602,13 @@ export const SettingsUIPage = ( {
 		( fieldId: string, nextValue: SettingsValue ) => {
 			setValuesState( ( currentValues ) => ( {
 				...currentValues,
-				[ fieldId ]: nextValue,
+				[ fieldId ]: preserveInitialRepresentation(
+					nextValue,
+					initialValues[ fieldId ]
+				),
 			} ) );
 		},
-		[]
+		[ initialValues ]
 	);
 
 	const allowNavigation = useCallback( () => {
@@ -613,7 +650,11 @@ export const SettingsUIPage = ( {
 				Object.entries( nextValues ).forEach(
 					( [ fieldId, value ] ) => {
 						if ( typeof value !== 'undefined' ) {
-							mergedValues[ fieldId ] = value;
+							mergedValues[ fieldId ] =
+								preserveInitialRepresentation(
+									value,
+									initialValues[ fieldId ]
+								);
 						}
 					}
 				);
@@ -621,7 +662,7 @@ export const SettingsUIPage = ( {
 				return mergedValues;
 			} );
 		},
-		[]
+		[ initialValues ]
 	);
 
 	const handleCustomSave = useCallback( async () => {

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -80,12 +80,11 @@ const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	return a === b;
 };
 
-// Restore the schema's value representation when a control's emitted value is
-// just a re-encoding of the initial value (e.g. '5' for 5, '' for null, [] for
-// ''). Field controls emit fixed types — strings, arrays, booleans — so
-// without this, an edit that reverts to the initial value leaves the form
-// dirty on a type difference alone, and save handlers receive values in a
-// vocabulary the schema never declared.
+// Field controls emit fixed types (strings, arrays, booleans), so an edit
+// that reverts can leave the form dirty on a type difference alone ('5' !== 5)
+// and save handlers can receive values in a format the schema never declared.
+// Restore the initial value when the emitted value is just a re-encoding of
+// it ('5' for 5, '' for null, [] for '').
 const preserveInitialRepresentation = (
 	value: SettingsValue,
 	initialValue: SettingsValue

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -360,6 +360,10 @@ type ErrorBoundaryState = {
 	hasError: boolean;
 };
 
+/**
+ * Render an error notice instead of a broken page when a settings UI render
+ * throws.
+ */
 export class SettingsUIErrorBoundary extends Component<
 	ErrorBoundaryProps,
 	ErrorBoundaryState
@@ -549,6 +553,11 @@ const ShellHeader = ( {
 	);
 };
 
+/**
+ * Render a settings UI schema as a full settings page: shell header with
+ * save button, section navigation, grouped field cards, dirty tracking,
+ * unsaved-changes guards and save handling.
+ */
 export const SettingsUIPage = ( {
 	schema,
 	page,

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -237,6 +237,86 @@ describe( 'settings HTML rendering', () => {
 		container.remove();
 	} );
 
+	it( 'keeps checkbox values in the schema vocabulary for visibility predicates and dirty tracking', () => {
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'env',
+							label: 'Enable environment',
+							type: 'checkbox',
+							value: 'no',
+						},
+						{
+							id: 'dependent_field',
+							label: 'Dependent field',
+							type: 'text',
+							value: 'abc',
+						},
+					],
+				},
+			},
+		};
+
+		registerSettingsExtension( {
+			scope: { page: 'test-page' },
+			fieldVisibility: {
+				dependent_field: ( { values } ) => values.env === 'yes',
+			},
+		} );
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } page="test-page" />
+		);
+
+		const getSaveButton = () => {
+			const saveButton = container.querySelector< HTMLButtonElement >(
+				'.woocommerce-save-button'
+			);
+
+			if ( ! saveButton ) {
+				throw new Error( 'Expected a save button.' );
+			}
+
+			return saveButton;
+		};
+
+		const clickCheckbox = () => {
+			const checkbox = container.querySelector< HTMLInputElement >(
+				'input[type="checkbox"]'
+			);
+
+			act( () => {
+				checkbox?.click();
+			} );
+		};
+
+		// Initially: predicate unmet, nothing dirty.
+		expect( container.textContent ).not.toContain( 'Dependent field' );
+		expect( getSaveButton().disabled ).toBe( true );
+
+		// Toggle on: the predicate sees 'yes' (not a raw boolean) and the
+		// change is a real edit, so Save enables.
+		clickCheckbox();
+		expect( container.textContent ).toContain( 'Dependent field' );
+		expect( getSaveButton().disabled ).toBe( false );
+
+		// Toggle back off: the value returns to the initial 'no', so the
+		// form is clean again and Save disables.
+		clickCheckbox();
+		expect( container.textContent ).not.toContain( 'Dependent field' );
+		expect( getSaveButton().disabled ).toBe( true );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
 	it( 'hides fields with unmet native visibility rules', () => {
 		const schema: SettingsUISchema = {
 			id: 'test-page',

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -317,6 +317,157 @@ describe( 'settings HTML rendering', () => {
 		container.remove();
 	} );
 
+	it( 'restores non-string schema values when an edit reverts to the initial value', () => {
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'threshold',
+							label: 'Threshold',
+							type: 'number',
+							value: 5,
+							customAttributes: { step: 1 },
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } page="test-page" />
+		);
+
+		const getSaveButton = () => {
+			const saveButton = container.querySelector< HTMLButtonElement >(
+				'.woocommerce-save-button'
+			);
+
+			if ( ! saveButton ) {
+				throw new Error( 'Expected a save button.' );
+			}
+
+			return saveButton;
+		};
+
+		const clickSpinButton = ( ariaLabel: string ) => {
+			const button = container.querySelector< HTMLButtonElement >(
+				`button[aria-label="${ ariaLabel }"]`
+			);
+
+			act( () => {
+				button?.dispatchEvent(
+					new MouseEvent( 'click', { bubbles: true } )
+				);
+			} );
+		};
+
+		expect( getSaveButton().disabled ).toBe( true );
+
+		// The spin control emits strings; the schema supplied the number 5.
+		clickSpinButton( 'Increment Threshold' );
+		expect( getSaveButton().disabled ).toBe( false );
+
+		// Stepping back to "5" restores the schema's numeric 5, so the form
+		// is clean again instead of dirty on '5' !== 5.
+		clickSpinButton( 'Decrement Threshold' );
+		expect( getSaveButton().disabled ).toBe( true );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	it( 'preserves the initial representation for custom component setValue writes', () => {
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'tags_field',
+							label: 'Tags',
+							type: 'array',
+							value: '',
+						},
+					],
+				},
+			},
+		};
+
+		registerSettingsExtension( {
+			scope: { page: 'test-page' },
+			fieldOverrides: {
+				tags_field: ( { setValue } ) => (
+					<div>
+						<button
+							type="button"
+							onClick={ () => setValue( 'tags_field', [] ) }
+						>
+							Clear tags
+						</button>
+						<button
+							type="button"
+							onClick={ () =>
+								setValue( 'tags_field', [ 'featured' ] )
+							}
+						>
+							Add tag
+						</button>
+					</div>
+				),
+			},
+		} );
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } page="test-page" />
+		);
+
+		const getSaveButton = () => {
+			const saveButton = container.querySelector< HTMLButtonElement >(
+				'.woocommerce-save-button'
+			);
+
+			if ( ! saveButton ) {
+				throw new Error( 'Expected a save button.' );
+			}
+
+			return saveButton;
+		};
+
+		const clickButton = ( text: string ) => {
+			const button = [
+				...container.querySelectorAll< HTMLButtonElement >( 'button' ),
+			].find( ( el ) => el.textContent === text );
+
+			act( () => {
+				button?.dispatchEvent(
+					new MouseEvent( 'click', { bubbles: true } )
+				);
+			} );
+		};
+
+		// An empty array is a re-encoding of the initial '' value, so a
+		// custom component writing [] through setValue keeps the form clean.
+		clickButton( 'Clear tags' );
+		expect( getSaveButton().disabled ).toBe( true );
+
+		// A real change still dirties the form.
+		clickButton( 'Add tag' );
+		expect( getSaveButton().disabled ).toBe( false );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
 	it( 'hides fields with unmet native visibility rules', () => {
 		const schema: SettingsUISchema = {
 			id: 'test-page',

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -419,6 +419,95 @@ describe( 'NativeSettingsField', () => {
 		} );
 	} );
 
+	describe( 'checkbox fields', () => {
+		const checkboxField: SettingsUIField = {
+			id: 'wc_test_checkbox',
+			label: 'Enable feature',
+			type: 'checkbox',
+		};
+
+		const getCheckbox = ( container: HTMLElement ) => {
+			const checkbox = container.querySelector(
+				'input[type="checkbox"]'
+			);
+
+			if ( ! ( checkbox instanceof HTMLInputElement ) ) {
+				throw new Error( 'Expected a checkbox input.' );
+			}
+
+			return checkbox;
+		};
+
+		const renderCheckbox = (
+			value: SettingsValue,
+			initialValue: SettingsValue,
+			onChange: ( next: SettingsValue ) => void
+		) =>
+			render(
+				<NativeSettingsField
+					{ ...makeProps( checkboxField, value, onChange ) }
+					initialValues={ { [ checkboxField.id ]: initialValue } }
+				/>
+			);
+
+		const clickCheckbox = ( container: HTMLElement ) => {
+			act( () => {
+				getCheckbox( container ).click();
+			} );
+		};
+
+		it( "keeps the 'yes'/'no' value vocabulary when toggling", () => {
+			const onChange = jest.fn();
+			const container = renderCheckbox( 'no', 'no', onChange );
+
+			expect( getCheckbox( container ).checked ).toBe( false );
+
+			clickCheckbox( container );
+
+			expect( onChange ).toHaveBeenCalledWith( 'yes' );
+		} );
+
+		it( 'restores the exact initial value when toggled back', () => {
+			const onChange = jest.fn();
+			const container = renderCheckbox( 'yes', 'no', onChange );
+
+			expect( getCheckbox( container ).checked ).toBe( true );
+
+			clickCheckbox( container );
+
+			expect( onChange ).toHaveBeenCalledWith( 'no' );
+		} );
+
+		it( "keeps the '1'/'0' value vocabulary when toggling", () => {
+			const onChange = jest.fn();
+			const container = renderCheckbox( '1', '1', onChange );
+
+			expect( getCheckbox( container ).checked ).toBe( true );
+
+			clickCheckbox( container );
+
+			expect( onChange ).toHaveBeenCalledWith( '0' );
+		} );
+
+		it( 'keeps boolean values boolean when toggling', () => {
+			const onChange = jest.fn();
+			const container = renderCheckbox( false, false, onChange );
+
+			clickCheckbox( container );
+
+			expect( onChange ).toHaveBeenCalledWith( true );
+		} );
+
+		it( 'restores an empty-string initial value when toggled back', () => {
+			const onChange = jest.fn();
+			const container = renderCheckbox( 'yes', '', onChange );
+
+			clickCheckbox( container );
+
+			expect( onChange ).toHaveBeenCalledWith( '' );
+		} );
+	} );
+
 	describe( 'text fields', () => {
 		it( 'renders text fields without spin buttons', () => {
 			const container = render(


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the new Settings UI, interacting with a field can change the value's type. The controls always emit a fixed type (checkboxes emit booleans, text and number inputs emit strings), even when the schema declared something else ('yes'/'no', a number, null). That mismatch breaks anything comparing against the original value:

* Reverting a change leaves Save enabled, because `false !== 'no'` and `'5' !== 5`.
* `fieldVisibility` predicates stop matching, because `values.env === 'yes'` fails once the checkbox emits `true`.
* Custom save handlers receive values the schema never declared. Square reported this as a Save button stuck in a loading state.

The fix keeps every value in the format the schema declared:

* Checkboxes (`native-fields.tsx`): map the checked state back to the initial value's format ('yes'/'no', '1'/'0' or boolean), and return the exact initial value on revert.
* All other fields (`settings-ui-page.tsx`): `setValue` / `setValues` restore the initial representation when the new value is just a re-encoding of it ('5' for 5, '' for null). Every field writes through these setters, including extension-registered components, so custom renderers are covered too.
* Also adds description-only docblocks to the package's exported API.

Closes woocommerce/woocommerce#66204.

Bug introduced in PR [#64387](<https://github.com/woocommerce/woocommerce/issues/64387>).

Fixes [WOOPRD-3560](https://linear.app/a8c/issue/WOOPRD-3560/settings-ui-checkbox-fields-flip-values-to-booleans-breaking-dirty).

### Backwards compatibility

No public API changes. Both fixes only affect the feature-flagged Settings UI rendering path (`settings-ui`, off by default). Save handlers and visibility predicates now receive values in the schema's declared format, which is the documented contract.

### How to test the changes in this Pull Request:

**Core settings (Products tab)**

1. Enable the `settings-ui` feature flag (e.g. via the `woocommerce_admin_features` filter).
2. Go to WooCommerce → Settings → Products. The Save button should start disabled.
3. Toggle "Enable product reviews" off, then back on. Save should enable after the first toggle and disable again after the revert (before this fix it stayed enabled).
4. Edit a text field (e.g. Placeholder image) and revert it. Change a select (e.g. Weight unit) and change it back. Save should return to disabled in both cases.

**Extension-registered section**

1. Register a settings section whose schema declares a checkbox with `value: 'no'`, plus a `fieldVisibility` predicate like `( { values } ) => values.env === 'yes'` on another field.
2. Check the box: the dependent field should appear. Uncheck it: the field should hide.
3. After checking and unchecking, Save should be disabled again.

### Testing that has already taken place:

* `packages/js/settings-ui` jest suite: 45/45 passing, with new tests covering checkbox format preservation, the reported `fieldVisibility` + dirty-tracking scenario, a number field revert, and a custom component writing through `setValue`.
* `eslint` and `tsc --build` clean on the package.
* Smoke tested with the flag enabled: checkbox, text and select fields each enable Save on a real change and disable it again on revert, and dependent fields show/hide correctly across the toggle cycle.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>