### PR TITLE
Email Editor: Make full-width blocks render properly as full width in the editor

### DIFF
--- a/packages/js/email-editor/changelog/fix-email-editor-full-width-blocks
+++ b/packages/js/email-editor/changelog/fix-email-editor-full-width-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show full-width blocks as full width in the email editor canvas to match the rendered email.

--- a/packages/js/email-editor/src/blocks/core/full-width.tsx
+++ b/packages/js/email-editor/src/blocks/core/full-width.tsx
@@ -1,0 +1,176 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { addFilterForEmail } from '../../config-tools/filters';
+import { unwrapCompressedPresetStyleVariable } from '../../style-variables';
+
+type SpacingPadding =
+	| string
+	| { top?: string; right?: string; bottom?: string; left?: string };
+
+// Columns handle their own width, so don't let full-width blocks inside a
+// column break out (the renderer doesn't either).
+const COLUMN_BLOCKS = [ 'core/column', 'core/columns' ];
+
+// User blocks live inside these wrappers, which add no inset of their own. We
+// skip them so a full-width block breaks out of the padded template group above.
+const PASSTHROUGH_BLOCKS = [ 'core/post-content', 'woocommerce/email-content' ];
+
+/**
+ * Checks whether the value is zero (0, 0px, 0em, 0%, ...)
+ */
+function isZeroValue( value?: string ): boolean {
+	if ( value === undefined || value === null ) {
+		return false;
+	}
+	return parseFloat( String( value ) ) === 0;
+}
+
+/**
+ * Reads a block's left/right padding as CSS values (preset vars resolved).
+ * Returns null for a side when it's missing or zero.
+ */
+function getHorizontalPadding( padding?: SpacingPadding ): {
+	left: string | null;
+	right: string | null;
+} {
+	const toCss = ( value?: string ): string | null => {
+		if ( value === undefined || value === null || isZeroValue( value ) ) {
+			return null;
+		}
+		return unwrapCompressedPresetStyleVariable( String( value ) );
+	};
+
+	if ( ! padding ) {
+		return { left: null, right: null };
+	}
+	if ( typeof padding === 'string' ) {
+		const value = toCss( padding );
+		return { left: value, right: value };
+	}
+	return { left: toCss( padding.left ), right: toCss( padding.right ) };
+}
+
+type BreakoutInfo = {
+	left: string | null;
+	right: string | null;
+};
+
+/**
+ * Finds the padding a full-width block should break out of.
+ *
+ * Inside the post content (user blocks), a block breaks out of its direct
+ * parent group's padding only, matching the core editor - if the direct parent
+ * has no padding there's nothing to break out of.
+ *
+ * Returns false when the block sits in a column, since columns keep their width.
+ */
+function useBreakoutPadding( clientId: string ): BreakoutInfo | false {
+	return useSelect(
+		( select ) => {
+			const { getBlockParents, getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
+			// getBlockParents lists ancestors root-first, so the last entry is
+			// the direct parent. Walk from there up to the root.
+			const parents = getBlockParents( clientId ) as string[];
+			let inTemplate = false;
+
+			for ( let i = parents.length - 1; i >= 0; i-- ) {
+				const parentId = parents[ i ];
+				const name = getBlockName( parentId ) as string;
+
+				if ( COLUMN_BLOCKS.includes( name ) ) {
+					return false;
+				}
+				// Post content wrappers separate user blocks from the template.
+				// Once we pass one, we're climbing the template layout.
+				if ( PASSTHROUGH_BLOCKS.includes( name ) ) {
+					inTemplate = true;
+					continue;
+				}
+
+				const padding = getHorizontalPadding(
+					getBlockAttributes( parentId )?.style?.spacing
+						?.padding as SpacingPadding
+				);
+				if ( padding.left || padding.right ) {
+					return padding;
+				}
+				// Parent has no padding. In user content, stop here - there's
+				// nothing to break out of. In the template, keep going up to
+				// find the padded group.
+				if ( ! inTemplate ) {
+					return { left: null, right: null };
+				}
+			}
+
+			return { left: null, right: null };
+		},
+		[ clientId ]
+	);
+}
+
+function BlockWithFullWidth( { block: BlockListBlock, props } ) {
+	const breakout = useBreakoutPadding( props.clientId );
+
+	// Inside a column: leave it alone.
+	if ( breakout === false ) {
+		return <BlockListBlock { ...props } />;
+	}
+
+	const style: Record< string, string > = {
+		...( props.wrapperProps?.style || {} ),
+	};
+	if ( breakout.left ) {
+		style.marginLeft = `calc(-1 * ${ breakout.left })`;
+	}
+	if ( breakout.right ) {
+		style.marginRight = `calc(-1 * ${ breakout.right })`;
+	}
+
+	return (
+		<BlockListBlock
+			{ ...props }
+			className={ clsx( props.className, 'is-email-full-width' ) }
+			wrapperProps={ { ...props.wrapperProps, style } }
+		/>
+	);
+}
+
+/**
+ * Marks full-width aligned blocks so they go edge-to-edge in the editor canvas,
+ * the same way they show up in the sent email.
+ */
+const withFullWidthClassName = createHigherOrderComponent(
+	( BlockListBlock ) =>
+		function maybeAddFullWidthClassName( props ) {
+			if ( props.attributes?.align !== 'full' ) {
+				return <BlockListBlock { ...props } />;
+			}
+
+			return (
+				<BlockWithFullWidth block={ BlockListBlock } props={ props } />
+			);
+		},
+	'withFullWidthClassName'
+);
+
+/**
+ * Makes full-width blocks span the full width in the editor, the same way they
+ * show up in the sent email.
+ */
+export function enableFullWidthBlocks(): void {
+	addFilterForEmail(
+		'editor.BlockListBlock',
+		'woocommerce-email-editor/full-width-blocks',
+		withFullWidthClassName
+	);
+}

--- a/packages/js/email-editor/src/blocks/core/full-width.tsx
+++ b/packages/js/email-editor/src/blocks/core/full-width.tsx
@@ -72,10 +72,19 @@ type BreakoutInfo = {
  * has no padding there's nothing to break out of.
  *
  * Returns false when the block sits in a column, since columns keep their width.
+ *
+ * Skips the ancestor lookup when `enabled` is false (block isn't full width) so
+ * we don't traverse the tree for every block in the editor.
  */
-function useBreakoutPadding( clientId: string ): BreakoutInfo | false {
+function useBreakoutPadding(
+	clientId: string,
+	enabled: boolean
+): BreakoutInfo | false {
 	return useSelect(
 		( select ) => {
+			if ( ! enabled ) {
+				return { left: null, right: null };
+			}
 			const { getBlockParents, getBlockName, getBlockAttributes } =
 				select( blockEditorStore );
 			// getBlockParents lists ancestors root-first, so the last entry is
@@ -114,15 +123,16 @@ function useBreakoutPadding( clientId: string ): BreakoutInfo | false {
 
 			return { left: null, right: null };
 		},
-		[ clientId ]
+		[ clientId, enabled ]
 	);
 }
 
 function BlockWithFullWidth( { block: BlockListBlock, props } ) {
-	const breakout = useBreakoutPadding( props.clientId );
+	const isFullWidth = props.attributes?.align === 'full';
+	const breakout = useBreakoutPadding( props.clientId, isFullWidth );
 
-	// Inside a column: leave it alone.
-	if ( breakout === false ) {
+	// Not full width, or inside a column: render the block untouched.
+	if ( ! isFullWidth || breakout === false ) {
 		return <BlockListBlock { ...props } />;
 	}
 
@@ -147,15 +157,12 @@ function BlockWithFullWidth( { block: BlockListBlock, props } ) {
 
 /**
  * Marks full-width aligned blocks so they go edge-to-edge in the editor canvas,
- * the same way they show up in the sent email.
+ * the same way they show up in the sent email. Always renders the same component
+ * so toggling alignment doesn't remount the block.
  */
 const withFullWidthClassName = createHigherOrderComponent(
 	( BlockListBlock ) =>
 		function maybeAddFullWidthClassName( props ) {
-			if ( props.attributes?.align !== 'full' ) {
-				return <BlockListBlock { ...props } />;
-			}
-
 			return (
 				<BlockWithFullWidth block={ BlockListBlock } props={ props } />
 			);

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -28,6 +28,7 @@ import { enhanceQuoteBlock } from './core/quote';
 import { filterSetUrlAttribute } from './core/block-edit';
 import { enhanceSocialLinksBlock } from './core/social-links';
 import { enhanceSiteLogoBlock } from './core/site-logo';
+import { enableFullWidthBlocks } from './core/full-width';
 import { enableProductImageAlignment } from './woocommerce/product-image';
 
 export { getAllowedBlockNames } from './utils';
@@ -53,6 +54,7 @@ export function initBlocks() {
 	alterSupportConfiguration();
 	enhanceSocialLinksBlock();
 	enhanceSiteLogoBlock();
+	enableFullWidthBlocks();
 	enableProductImageAlignment();
 	removeBlockStylesFromAllBlocks();
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Full-width blocks render edge-to-edge in the email, but the editor kept them inset. So the canvas didn't match the sent email.

We can't use core's full-width handling here, because core adds it via block layout support, which we currently don't have support for in the email editor.

This PR adds a filter that gives these blocks a negative margin equal to their direct parent's padding, so they fill the parent's width (same behavior as core). Blocks inside columns are left alone.

Closes [WOOPRD-3213: Mirror the php full width rendering in the editor](https://linear.app/a8c/issue/WOOPRD-3213/mirror-the-php-full-width-rendering-in-the-editor).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="2620" height="1761" alt="75UyFaMMbBwtDf3B@2x" src="https://github.com/user-attachments/assets/885856bd-53cd-46f1-b0c0-1c476034c44f" /> | <img width="2620" height="1762" alt="em9uHuoXNYGgkaEz@2x" src="https://github.com/user-attachments/assets/b2f62ee7-d483-4cca-926e-3fa47ba5c25a" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
2. Open any transaction email in the email editor.
3. Add a Group or Image and set it to Full width. It should span its parent's full width.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
