### PR TITLE
Hold applied coupons before payment in the Agentic Checkout complete handler

### DIFF
--- a/plugins/woocommerce/changelog/fix-pcb-254-agentic-checkout-coupon-usage-limit
+++ b/plugins/woocommerce/changelog/fix-pcb-254-agentic-checkout-coupon-usage-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enforce coupon usage limits when completing Agentic Checkout sessions.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Agentic/CheckoutSessionsComplete.php
@@ -300,6 +300,15 @@ class CheckoutSessionsComplete extends AbstractCartRoute {
 			return Error::invalid_request( ErrorCode::INVALID, $message )->to_rest_response();
 		}
 
+		// Hold applied coupons before payment, mirroring the classic checkout path.
+		try {
+			$this->order->hold_applied_coupons( $this->order->get_billing_email() );
+		} catch ( \Exception $e ) {
+			wc_release_stock_for_order( $this->order );
+			$message = wp_specialchars_decode( $e->getMessage(), ENT_QUOTES );
+			return Error::invalid_request( ErrorCode::INVALID, $message )->to_rest_response();
+		}
+
 		// Set the order status to 'pending' as an initial step.
 		$this->order->update_status( 'pending' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/CheckoutSessionsComplete.php
@@ -669,6 +669,84 @@ class CheckoutSessionsComplete extends ControllerTestCase {
 	}
 
 	/**
+	 * @testdox Should not complete when a concurrent session claims a limited-use coupon after validation, and should release reserved stock.
+	 */
+	public function test_complete_checkout_session_holds_limited_use_coupon() {
+		// The agentic fulfillment address carries no phone; keep it optional.
+		update_option( 'woocommerce_checkout_phone_field', 'optional' );
+
+		$coupon = \WC_Helper_Coupon::create_coupon(
+			'race_once',
+			array( 'usage_limit' => 1 )
+		);
+
+		$this->products[0]->set_manage_stock( true );
+		$this->products[0]->set_stock_quantity( 5 );
+		$this->products[0]->save();
+
+		$create_response = $this->create_session(
+			$this->create_checkout_request(
+				array(
+					'fulfillment_address' => $this->get_test_address(),
+					'buyer'               => $this->get_test_buyer(),
+				)
+			)
+		);
+
+		$create_data        = $create_response->get_data();
+		$session_id         = $create_data['id'];
+		$shipping_method_id = $create_data['fulfillment_options'][0]['id'];
+		$this->update_session(
+			$session_id,
+			array(
+				'fulfillment_option_id' => $shipping_method_id,
+			)
+		);
+
+		// Stock reservation runs after coupon validation but before the coupon
+		// hold: use that window to simulate a concurrent session claiming the coupon.
+		$injected = false;
+		$inject   = function ( $enabled ) use ( $coupon, &$injected ) {
+			if ( ! $injected ) {
+				$injected = true;
+				WC()->cart->apply_coupon( $coupon->get_code() );
+				$coupon->get_data_store()->check_and_hold_coupon( $coupon );
+			}
+			return $enabled;
+		};
+		add_filter( 'woocommerce_hold_stock_for_checkout', $inject );
+
+		$complete_response = $this->complete_session(
+			$session_id,
+			array(
+				'payment_data' => $this->get_payment_data(),
+			)
+		);
+		$complete_data     = $complete_response->get_data();
+
+		remove_filter( 'woocommerce_hold_stock_for_checkout', $inject );
+
+		$this->assertTrue( $injected, 'The concurrent-session hold should have been injected during stock reservation.' );
+
+		$this->assertEquals( 400, $complete_response->get_status(), 'Completion must fail when the coupon usage limit is claimed by a concurrent session.' );
+		$this->assertArrayHasKey( 'code', $complete_data );
+		$this->assertEquals( 'invalid', $complete_data['code'] );
+		$this->assertArrayHasKey( 'message', $complete_data );
+		$this->assertStringContainsString( 'usage limit', strtolower( $complete_data['message'] ), 'Error should indicate the coupon usage limit was reached.' );
+
+		$this->assertNull(
+			WC()->session->get( SessionKey::AGENTIC_CHECKOUT_COMPLETED_ORDER_ID ),
+			'No order should be completed when the coupon hold fails.'
+		);
+
+		$this->assertEquals(
+			0,
+			wc_get_held_stock_quantity( $this->products[0] ),
+			'Reserved stock should be released when the coupon hold fails.'
+		);
+	}
+
+	/**
 	 * Test error response format matches ACP spec.
 	 */
 	public function test_complete_error_response_format() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Agentic Checkout `complete` handler (`CheckoutSessionsComplete`) did not hold applied coupons before processing payment, unlike the classic Store API checkout path (`Checkout.php`), which holds them via `WC_Abstract_Order::hold_applied_coupons()` before payment. This brings the two paths into alignment so coupon usage limits are enforced consistently when an order is completed through Agentic Checkout.

- Hold applied coupons before payment in the Agentic Checkout `complete` handler.
- Release the stock reserved earlier in the request if the coupon hold cannot be acquired, so a failed completion does not leave stock reserved.

Agentic Checkout is an experimental, opt-in feature (`is_experimental=true`, `enabled_by_default=false`).

**Backward compatibility:** No public class/method/function signatures change. The change is limited to internal behavior within the route handler.

### How to test the changes in this Pull Request:

1. Enable the Agentic Checkout feature.
2. Create a coupon with a usage limit (e.g. **Usage limit per coupon = 1**).
3. Complete an Agentic Checkout session that applies the coupon and confirm the order completes and the coupon usage is recorded.
4. Confirm that once the coupon's usage limit is reached, a subsequent completion applying the same coupon is rejected (rather than completing) and that no stock remains reserved for the rejected attempt.
5. Confirm normal completions (no coupon, or coupon under its limit) are unaffected.

Automated coverage: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_complete_checkout_session_holds_limited_use_coupon`

### Testing that has already taken place:

- Added a regression test in `CheckoutSessionsComplete` that fails without this change and passes with it.
- Confirmed `php -l`, `phpcs-changed`, and the new test pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type
-   [x] Fix
-   [ ] Add
-   [ ] Update
-   [ ] Dev
-   [ ] Tweak
-   [ ] Performance
-   [ ] Enhancement

#### Message
Enforce coupon usage limits when completing Agentic Checkout sessions.

</details>

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Changelog entry already added in the branch.

</details>

cc @rtio 