### PR TITLE
Fix Date and Status columns ignoring Screen Options on small screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-list-hidden-columns
+++ b/plugins/woocommerce/changelog/fix-orders-list-hidden-columns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect hidden Date and Status columns on the admin orders list below 782px, so the Columns menu (Screen Options) is honored at every screen width.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3617,6 +3617,19 @@ body.woocommerce_page_wc-orders {
 			}
 		}
 
+		// Respect the Columns menu (Screen Options) on small screens: hide the
+		// duplicated date/status copies in the order-number cell whenever the
+		// real column is hidden. WordPress toggles `.hidden` on the column
+		// header live, so this updates in both directions without JS.
+		// See https://github.com/woocommerce/woocommerce/issues/26495.
+		&:has( thead th.column-order_date.hidden ) .order_date.small-screen-only {
+			display: none;
+		}
+
+		&:has( thead th.column-order_status.hidden ) .order_status.small-screen-only {
+			display: none;
+		}
+
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3617,11 +3617,7 @@ body.woocommerce_page_wc-orders {
 			}
 		}
 
-		// Respect the Columns menu (Screen Options) on small screens: hide the
-		// duplicated date/status copies in the order-number cell whenever the
-		// real column is hidden. WordPress toggles `.hidden` on the column
-		// header live, so this updates in both directions without JS.
-		// See https://github.com/woocommerce/woocommerce/issues/26495.
+		// Hide the small-screen date/status copies when the corresponding column is hidden via Screen Options.
 		&:has( thead th.column-order_date.hidden ) .order_date.small-screen-only {
 			display: none;
 		}

--- a/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { tags, expect, test } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+// A narrow viewport below the 782px breakpoint that shows the duplicated
+// date/status copies inside the order-number cell.
+const SMALL_SCREEN = { width: 480, height: 900 };
+
+test.describe(
+	'WooCommerce Orders > Hidden columns on small screens',
+	{ tag: [ tags.HPOS ] },
+	() => {
+		test.use( { storageState: ADMIN_STATE_PATH } );
+
+		let orderId: number;
+
+		test.beforeAll( async ( { restApi } ) => {
+			// One order is enough to render a row with the copies.
+			await restApi
+				.post( `${ WC_API_PATH }/orders`, { status: 'processing' } )
+				.then( ( response: { data: { id: number } } ) => {
+					orderId = response.data.id;
+				} );
+		} );
+
+		test.afterAll( async ( { restApi } ) => {
+			if ( orderId ) {
+				await restApi.delete( `${ WC_API_PATH }/orders/${ orderId }`, {
+					force: true,
+				} );
+			}
+		} );
+
+		test( 'date/status copies follow the Columns menu below 782px', async ( {
+			page,
+		} ) => {
+			await page.setViewportSize( SMALL_SCREEN );
+			await page.goto( 'wp-admin/admin.php?page=wc-orders' );
+
+			const dateCopy = page
+				.locator(
+					'td.column-order_number .order_date.small-screen-only'
+				)
+				.first();
+			const statusCopy = page
+				.locator(
+					'td.column-order_number .order_status.small-screen-only'
+				)
+				.first();
+
+			// Both copies visible by default (both columns shown).
+			await expect( dateCopy ).toBeVisible();
+			await expect( statusCopy ).toBeVisible();
+
+			// Open Screen Options.
+			await page
+				.getByRole( 'button', { name: 'Screen Options' } )
+				.click();
+
+			// Hide the Date column -> its copy disappears live.
+			await page.locator( '#order_date-hide' ).uncheck();
+			await expect( dateCopy ).toBeHidden();
+			// Status copy is untouched.
+			await expect( statusCopy ).toBeVisible();
+
+			// Re-show the Date column -> its copy returns live (both directions).
+			await page.locator( '#order_date-hide' ).check();
+			await expect( dateCopy ).toBeVisible();
+
+			// Hide the Status column -> its copy disappears live.
+			await page.locator( '#order_status-hide' ).uncheck();
+			await expect( statusCopy ).toBeHidden();
+			await expect( dateCopy ).toBeVisible();
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
@@ -41,6 +41,7 @@ test.describe(
 		test( 'date/status copies follow the Columns menu below 782px', async ( {
 			page,
 		} ) => {
+			await page.setViewportSize( SMALL_SCREEN );
 			await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
 			const dateCopy = page
@@ -54,31 +55,43 @@ test.describe(
 				)
 				.first();
 
-			// Open Screen Options at desktop width: WordPress hides the toggle
-			// below 782px, so it can only be opened before shrinking. The panel
-			// stays open across the resize, and the fix reacts to the column's
-			// `hidden` class regardless of the width at which it was toggled.
-			await page.locator( '#show-settings-link' ).click();
-
-			// Shrink below the 782px breakpoint that renders the copies.
-			await page.setViewportSize( SMALL_SCREEN );
+			// This test verifies the CSS contract of the fix: a small-screen
+			// copy is hidden whenever its real column header carries the
+			// `hidden` class. We toggle that class directly the way WordPress's
+			// Screen Options JS (wp-admin/js/common.js `columns`) does, because
+			// the Screen Options panel toggle is not reliably actionable in
+			// headless CI below 782px, and hiding a column is core behavior we
+			// only react to, not own.
+			const setColumnHidden = ( column: string, hidden: boolean ) =>
+				page.evaluate(
+					( { col, hide } ) => {
+						document
+							.querySelectorAll(
+								`.wp-list-table th.column-${ col }, .wp-list-table td.column-${ col }`
+							)
+							.forEach( ( cell ) =>
+								cell.classList.toggle( 'hidden', hide )
+							);
+					},
+					{ col: column, hide: hidden }
+				);
 
 			// Both copies visible by default (both columns shown).
 			await expect( dateCopy ).toBeVisible();
 			await expect( statusCopy ).toBeVisible();
 
-			// Hide the Date column -> its copy disappears live.
-			await page.locator( '#order_date-hide' ).uncheck();
+			// Hide the Date column -> its copy disappears.
+			await setColumnHidden( 'order_date', true );
 			await expect( dateCopy ).toBeHidden();
 			// Status copy is untouched.
 			await expect( statusCopy ).toBeVisible();
 
-			// Re-show the Date column -> its copy returns live (both directions).
-			await page.locator( '#order_date-hide' ).check();
+			// Re-show the Date column -> its copy returns (both directions).
+			await setColumnHidden( 'order_date', false );
 			await expect( dateCopy ).toBeVisible();
 
-			// Hide the Status column -> its copy disappears live.
-			await page.locator( '#order_status-hide' ).uncheck();
+			// Hide the Status column -> its copy disappears.
+			await setColumnHidden( 'order_status', true );
 			await expect( statusCopy ).toBeHidden();
 			await expect( dateCopy ).toBeVisible();
 		} );

--- a/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
@@ -41,7 +41,6 @@ test.describe(
 		test( 'date/status copies follow the Columns menu below 782px', async ( {
 			page,
 		} ) => {
-			await page.setViewportSize( SMALL_SCREEN );
 			await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
 			const dateCopy = page
@@ -55,13 +54,18 @@ test.describe(
 				)
 				.first();
 
+			// Open Screen Options at desktop width: WordPress hides the toggle
+			// below 782px, so it can only be opened before shrinking. The panel
+			// stays open across the resize, and the fix reacts to the column's
+			// `hidden` class regardless of the width at which it was toggled.
+			await page.locator( '#show-settings-link' ).click();
+
+			// Shrink below the 782px breakpoint that renders the copies.
+			await page.setViewportSize( SMALL_SCREEN );
+
 			// Both copies visible by default (both columns shown).
 			await expect( dateCopy ).toBeVisible();
 			await expect( statusCopy ).toBeVisible();
-
-			// Open Screen Options. Target the toggle by its stable ID: the
-			// accessible name "Screen Options" matches more than one element.
-			await page.locator( '#show-settings-link' ).click();
 
 			// Hide the Date column -> its copy disappears live.
 			await page.locator( '#order_date-hide' ).uncheck();

--- a/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
@@ -59,10 +59,9 @@ test.describe(
 			await expect( dateCopy ).toBeVisible();
 			await expect( statusCopy ).toBeVisible();
 
-			// Open Screen Options.
-			await page
-				.getByRole( 'button', { name: 'Screen Options' } )
-				.click();
+			// Open Screen Options. Target the toggle by its stable ID: the
+			// accessible name "Screen Options" matches more than one element.
+			await page.locator( '#show-settings-link' ).click();
 
 			// Hide the Date column -> its copy disappears live.
 			await page.locator( '#order_date-hide' ).uncheck();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On the admin Orders list below 782px, WooCommerce renders duplicate Date and Status values inside the Order-number cell. Those copies were forced visible with `!important`, so they ignored the Columns menu (Screen Options) entirely: a merchant could hide the Date or Status column and it would still reappear on small screens.

This makes the Columns menu the single source of truth at every width. Instead of the `!important` override, two `:has()` rules hide each copy whenever its real column header carries WordPress's `hidden` class. Because WordPress toggles that class live when a checkbox changes, the copies now update instantly in both directions, with no JavaScript. No PHP or markup changes; both the HPOS and legacy (CPT) order tables are covered by the shared selector.

`:has()` is baseline across WooCommerce's supported browsers (last two major versions); older browsers simply fall back to today's behavior, so nothing regresses.

Closes #26495.

(For Bug Fixes) Bug introduced in PR #19111.

### Screenshots or screen recordings:

Below 782px, with the **Date** column unchecked in Screen Options.

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/6723003/81831286-76fc2080-953d-11ea-8bcf-8aa1fb7f392a.png) | <img width="978" height="2162" alt="Orders-‹-columns-small-view-—-WordPress-07-03-2026_02_56_PM (2)" src="https://github.com/user-attachments/assets/ad561dca-c695-43f6-80b0-75ff238703e8" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to **WooCommerce → Orders** with at least one order present.
2. Narrow the browser window below **782px** (or use responsive/device mode). Confirm each row shows the date and a status pill inside the order-number cell.
3. Open **Screen Options** (top right) and **uncheck Date**. The date copy should disappear from every row immediately. Re-check Date and confirm it returns immediately.
4. **Uncheck Status** and confirm the status pill copy disappears immediately; re-check to confirm it returns.
5. Reload the page with a column still unchecked and confirm the copy stays hidden.
6. Narrow further below **400px** and confirm the layout variant still hides the correct copies.
7. Repeat on the legacy orders screen (`edit.php?post_type=shop_order`, with HPOS disabled) — same behavior, since both tables share the markup.
8. With both columns checked (the default), confirm nothing looks different from before.

<!-- End testing instructions -->

### Testing that has already taken place:

Manually verified on a local WordPress Studio site (WooCommerce 11.0.0-dev, SQLite, HPOS) with three orders of different statuses. Confirmed the Date and Status copies follow the Columns menu live in both directions at 480px and desktop widths, and that with both columns hidden the order-number cell is clean. An e2e test (`order-list-hidden-columns-small-screen.spec.ts`) exercises the toggle at a mobile viewport for both columns and both directions.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)