### PR TITLE
Fix lazy-loaded REST namespaces not loading for batch subrequests

### DIFF
--- a/plugins/woocommerce/changelog/66250-fix-lazy-rest-namespace-batch-requests
+++ b/plugins/woocommerce/changelog/66250-fix-lazy-rest-namespace-batch-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix lazy-loaded REST API namespaces returning 404 for subrequests inside /batch/v1 requests.

--- a/plugins/woocommerce/src/Utilities/RestApiUtil.php
+++ b/plugins/woocommerce/src/Utilities/RestApiUtil.php
@@ -84,8 +84,10 @@ class RestApiUtil {
 		if ( '' !== $rest_route ) {
 			$rest_route      = trailingslashit( ltrim( $rest_route, '/' ) );
 			$route_namespace = trailingslashit( $route_namespace );
-			if ( '/' === $rest_route || str_starts_with( $rest_route, $route_namespace ) ) {
-				// Load all namespaces for root requests (/wp-json/) to maintain API discovery functionality.
+			// Load all namespaces for root requests (/wp-json/, discovery) and batch requests
+			// (/batch/v1): batch subrequests are matched against the route table without going
+			// through dispatch(), so they cannot be lazy loaded at rest_pre_dispatch time.
+			if ( '/' === $rest_route || 'batch/v1/' === $rest_route || str_starts_with( $rest_route, $route_namespace ) ) {
 				if ( '' !== $callback_filter_id ) {
 					// Remove the current filter prior to the callback, to prevent recursive callback issues.
 					// This is crucial for APIs like wc-analytics that may callback to their own namespace when loading.

--- a/plugins/woocommerce/tests/php/src/Utilities/RestApiUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/RestApiUtilTest.php
@@ -156,6 +156,23 @@ class RestApiUtilTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `lazy_load_namespace` should execute callback immediately for batch requests, because batch subrequests bypass `rest_pre_dispatch`.
+	 */
+	public function test_lazy_load_namespace_executes_callback_for_batch_requests() {
+		$callback_executed = false;
+		$callback          = function () use ( &$callback_executed ) {
+			$callback_executed = true;
+		};
+
+		// Set up a batch REST route.
+		$GLOBALS['wp']->query_vars['rest_route'] = '/batch/v1';
+
+		$this->rest_api_util->lazy_load_namespace( 'wc/v3', $callback );
+
+		$this->assertTrue( $callback_executed );
+	}
+
+	/**
 	 * @testdox `lazy_load_namespace` should handle missing rest_route gracefully.
 	 */
 	public function test_lazy_load_namespace_handles_missing_rest_route() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress core's `/batch/v1` endpoint matches each subrequest against the route table directly (via `match_request_to_handler()`), without going through `WP_REST_Server::dispatch()`. This means the `rest_pre_dispatch` filter that `RestApiUtil::lazy_load_namespace()` relies on never fires for batch subrequests, so lazy-loaded namespaces (currently `wc-analytics`) return `404 rest_no_route` inside batch requests.

This PR treats `/batch/v1` like the API root: namespaces load eagerly when the primary request is a batch request, restoring the pre-lazy-loading behavior. A unit test covering the batch route case is included.

This also unblocks converting further namespaces to lazy loading without regressing batch behavior.

Bug introduced in the lazy namespace loading work (PR 60684, WooCommerce 10.3).

### How to test the changes in this Pull Request:

1. On `trunk`, send an authenticated batch request containing a `wc-analytics` subrequest: `curl -X POST 'https://yoursite.test/wp-json/batch/v1' -u admin:APP_PASSWORD -H 'Content-Type: application/json' -d '{"requests":[{"method":"POST","path":"/wc-analytics/reports/products?per_page=1"}]}'` and observe the inner response is `404 rest_no_route`.
2. Apply this PR and repeat the request: the inner response should now resolve the route (a non-404 response).
3. Run `pnpm test:php:env -- --filter RestApiUtilTest` and confirm all tests pass.

### Testing that has already taken place:

Reproduced the 404 on a local wp-env (WP 7.0, PHP 8.1) via a `wc/v3` namespace converted to lazy loading; verified the fix resolves route matching and that behavior is byte-identical to trunk afterwards. `RestApiUtilTest` passes (8 tests) including the new batch coverage. PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix lazy-loaded REST API namespaces returning 404 for subrequests inside /batch/v1 requests.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)