### PR TITLE
Load wc-admin features on REST only for WooCommerce namespaces

### DIFF
--- a/plugins/woocommerce/changelog/66251-perf-gate-admin-features-by-rest-namespace
+++ b/plugins/woocommerce/changelog/66251-perf-gate-admin-features-by-rest-namespace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Skip loading wc-admin feature classes on REST API requests to non-WooCommerce namespaces, reducing response time for editor and core REST requests.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -336,11 +336,20 @@ class Features {
 			is_admin() ||
 			wp_doing_ajax() ||
 			wp_doing_cron() ||
-			( defined( 'WP_CLI' ) && WP_CLI ) ||
-			( WC()->is_rest_api_request() && ! WC()->is_store_api_request() ) ||
-			// Allow features to be loaded in frontend for admin users. This is needed for the use case such as the coming soon footer banner.
-			current_user_can( 'manage_woocommerce' )
+			( defined( 'WP_CLI' ) && WP_CLI )
 		);
+
+		if ( ! $should_load ) {
+			if ( WC()->is_rest_api_request() && ! WC()->is_store_api_request() ) {
+				// Only load features when the REST request targets a WooCommerce-owned
+				// namespace (or the API index, for route discovery). Foreign namespaces
+				// such as wp/v2 do not need wc-admin features.
+				$should_load = self::rest_request_targets_woocommerce();
+			} else {
+				// Allow features to be loaded in frontend for admin users. This is needed for the use case such as the coming soon footer banner.
+				$should_load = current_user_can( 'manage_woocommerce' );
+			}
+		}
 
 		/**
 		 * Filter to determine if admin features should be loaded.
@@ -349,5 +358,38 @@ class Features {
 		 * @param boolean $should_load Whether admin features should be loaded. It defaults to true when the current request is in an admin context.
 		 */
 		return apply_filters( 'woocommerce_admin_should_load_features', $should_load );
+	}
+
+	/**
+	 * Whether the current REST request targets a WooCommerce-owned namespace.
+	 *
+	 * Runs before the main query is parsed, so the route is derived from the
+	 * request URI (or the rest_route query argument on plain-permalink sites).
+	 *
+	 * @return boolean
+	 */
+	private static function rest_request_targets_woocommerce() {
+		$route = '';
+		if ( ! empty( $_GET['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$route = sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} elseif ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
+			$path   = (string) wp_parse_url( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+			$prefix = '/' . rest_get_url_prefix();
+			$pos    = strpos( $path, $prefix );
+			if ( false !== $pos ) {
+				$route = substr( $path, $pos + strlen( $prefix ) );
+			}
+		}
+
+		$route = '/' . ltrim( $route, '/' );
+
+		// API index (route discovery) and batch requests keep existing behavior: batch
+		// subrequests may target WooCommerce namespaces and cannot be inspected here.
+		if ( '/' === untrailingslashit( $route ) || '/' === $route || str_starts_with( $route, '/batch/v1' ) ) {
+			return true;
+		}
+
+		// Matches wc/v1..v4, wc/store, wc-admin, wc-analytics, wc-telemetry, etc.
+		return (bool) preg_match( '#^/wc(?:[-/]|$)#', $route );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -389,6 +389,13 @@ class Features {
 			return true;
 		}
 
+		// Feature classes contribute the woocommerce_meta fields that wc-admin persists user
+		// preferences through (via woocommerce_admin_get_user_data_fields), so users endpoints
+		// need features loaded for their responses to be complete.
+		if ( str_starts_with( $route, '/wp/v2/users' ) ) {
+			return true;
+		}
+
 		// Matches wc/v1..v4, wc/store, wc-admin, wc-analytics, wc-telemetry, etc.
 		return (bool) preg_match( '#^/wc(?:[-/]|$)#', $route );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`Features::should_load_features()` currently returns true for every REST request that is not a Store API request, so all ~30 enabled wc-admin feature classes are instantiated on REST requests that never use them — including the `wp/v2` calls the block editor makes on every editor load. Profiling on a clean install attributes ~25-32ms per request to this (over half of WooCommerce's total added overhead on foreign REST requests).

This PR gates feature loading on REST requests by the requested namespace: WooCommerce-owned namespaces (`wc/*`, `wc-admin`, `wc-analytics`, etc.), the API index, `/batch/v1` requests and `wp/v2/users` endpoints keep loading features exactly as before; requests to other foreign namespaces such as `wp/v2/types` skip them. The users endpoints are deliberately kept loading because feature classes contribute the `woocommerce_meta` fields wc-admin persists user preferences through (dashboard sections, report columns, chart settings) via `woocommerce_admin_get_user_data_fields`. Behavior in wp-admin, AJAX, cron, WP-CLI and the frontend-for-admin-users case (coming soon banner) is unchanged.

**Backward compatibility impact:** third-party REST endpoints in their own namespaces no longer get wc-admin feature *instance* hooks registered during their requests (static calls like `Features::is_enabled()` are unaffected). Additionally, logged-in users with `manage_woocommerce` no longer trigger feature loading on foreign-namespace REST requests via the `current_user_can` fallback (that fallback exists for the frontend coming soon banner, which is unaffected). The existing `woocommerce_admin_should_load_features` filter remains the escape hatch to force loading.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. As a logged-in admin, open the block editor (new page) with the browser DevTools Network tab open, filtered to `wp-json`.
2. On `trunk`, note the server response time (Timing tab, "Waiting for server response") of the `wp/v2/types`, `wp/v2/taxonomies` and `wp/v2/settings` requests.
3. Apply this PR and repeat: those requests should be meaningfully faster (~25-30ms less on a local install), with identical response bodies. Note: `wp/v2/users` responses intentionally keep loading features (see above), so `woocommerce_meta` remains fully populated.
4. Verify wc-admin still works: WooCommerce → Home, Analytics → Revenue, Marketing all render; the onboarding task list loads.
5. Verify the coming soon banner: enable Settings → Site visibility → Coming soon, view the frontend as a logged-in admin, and confirm the banner still shows.
6. Verify a WooCommerce REST request still loads features: `wp-json/wc-admin/options?options=woocommerce_demo_store` returns normally.

### Testing that has already taken place:

Local wp-env (WP 7.0, PHP 8.1, opcache on, Twenty Twenty-Three). Benchmarked with 25-sample medians: `wp/v2/types` 89.0ms → 57.0ms with this change alone. Response bodies for `wp/v2/types`, `taxonomies` and `settings` verified identical with and without the gate; `wp/v2/users` is exempted from the gate after the analytics-overview e2e tests caught missing `woocommerce_meta` fields (feature classes are the only code registering REST-visible data on non-WooCommerce namespaces, confirmed by audit). Browser-tested: block editor with WooCommerce blocks, site editor, wc-admin Home/Analytics/Marketing, settings tabs, coming soon banner, block and shortcode checkout with completed orders, `wp wc` CLI, webhooks delivery. Full Admin API test suite passes (133 tests); PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Skip loading wc-admin feature classes on REST API requests to non-WooCommerce namespaces, reducing response time for editor and core REST requests.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
