### PR TITLE
Lazy load wc/v1-v3, wc-telemetry and wc-admin REST namespaces

### DIFF
--- a/plugins/woocommerce/changelog/66252-perf-lazy-load-legacy-rest-namespaces
+++ b/plugins/woocommerce/changelog/66252-perf-lazy-load-legacy-rest-namespaces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Lazy load the wc/v1, wc/v2, wc/v3, wc-telemetry and wc-admin REST API namespaces so their controllers are only instantiated for requests that target them.

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -55,15 +55,24 @@ class Server {
 	 * Register REST API routes.
 	 */
 	public function register_rest_routes() {
-		$container    = wc_get_container();
-		$legacy_proxy = $container->get( LegacyProxy::class );
+		$rest_api_util = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
 		foreach ( $this->get_rest_namespaces() as $namespace => $controllers ) {
-			foreach ( $controllers as $controller_name => $controller_class ) {
-				$this->controllers[ $namespace ][ $controller_name ] = $container->has( $controller_class ) ?
-					$container->get( $controller_class ) :
-					$legacy_proxy->get_instance_of( $controller_class );
-				$this->controllers[ $namespace ][ $controller_name ]->register_routes();
+			if ( empty( $controllers ) ) {
+				continue;
 			}
+			$rest_api_util->lazy_load_namespace(
+				$namespace,
+				function () use ( $namespace, $controllers ) {
+					$container    = wc_get_container();
+					$legacy_proxy = $container->get( LegacyProxy::class );
+					foreach ( $controllers as $controller_name => $controller_class ) {
+						$this->controllers[ $namespace ][ $controller_name ] = $container->has( $controller_class ) ?
+							$container->get( $controller_class ) :
+							$legacy_proxy->get_instance_of( $controller_class );
+						$this->controllers[ $namespace ][ $controller_name ]->register_routes();
+					}
+				}
+			);
 		}
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -96,19 +96,19 @@ class Server {
 	/**
 	 * Instantiate the given controllers and register their routes.
 	 *
-	 * @param string $namespace   The namespace the controllers are grouped under.
-	 * @param array  $controllers Map of controller name => controller class.
+	 * @param string $rest_namespace The namespace the controllers are grouped under.
+	 * @param array  $controllers    Map of controller name => controller class.
 	 *
 	 * @return void
 	 */
-	private function register_namespace_controllers( $namespace, $controllers ): void {
+	private function register_namespace_controllers( $rest_namespace, $controllers ): void {
 		$container    = wc_get_container();
 		$legacy_proxy = $container->get( LegacyProxy::class );
 		foreach ( $controllers as $controller_name => $controller_class ) {
-			$this->controllers[ $namespace ][ $controller_name ] = $container->has( $controller_class ) ?
+			$this->controllers[ $rest_namespace ][ $controller_name ] = $container->has( $controller_class ) ?
 				$container->get( $controller_class ) :
 				$legacy_proxy->get_instance_of( $controller_class );
-			$this->controllers[ $namespace ][ $controller_name ]->register_routes();
+			$this->controllers[ $rest_namespace ][ $controller_name ]->register_routes();
 		}
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -55,24 +55,60 @@ class Server {
 	 * Register REST API routes.
 	 */
 	public function register_rest_routes() {
-		$rest_api_util = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
+		$rest_api_util       = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
+		$default_controllers = array(
+			'wc/v1'        => $this->get_v1_controllers(),
+			'wc/v2'        => $this->get_v2_controllers(),
+			'wc/v3'        => $this->get_v3_controllers(),
+			'wc-telemetry' => $this->get_telemetry_controllers(),
+			'wc/v4'        => $this->get_v4_controllers(),
+		);
+
 		foreach ( $this->get_rest_namespaces() as $namespace => $controllers ) {
 			if ( empty( $controllers ) ) {
 				continue;
 			}
-			$rest_api_util->lazy_load_namespace(
-				$namespace,
-				function () use ( $namespace, $controllers ) {
-					$container    = wc_get_container();
-					$legacy_proxy = $container->get( LegacyProxy::class );
-					foreach ( $controllers as $controller_name => $controller_class ) {
-						$this->controllers[ $namespace ][ $controller_name ] = $container->has( $controller_class ) ?
-							$container->get( $controller_class ) :
-							$legacy_proxy->get_instance_of( $controller_class );
-						$this->controllers[ $namespace ][ $controller_name ]->register_routes();
+
+			// Controllers added through the woocommerce_rest_api_get_rest_namespaces filter may
+			// register routes under a route namespace that differs from the key they are grouped
+			// under (RestApiControllerBase groups everything under wc/v3, for example), so only
+			// WooCommerce's own default controllers are lazy loaded; anything added by the filter
+			// keeps registering eagerly, as before.
+			$defaults          = $default_controllers[ $namespace ] ?? array();
+			$lazy_controllers  = array_intersect_key( $controllers, $defaults );
+			$eager_controllers = array_diff_key( $controllers, $defaults );
+
+			if ( $eager_controllers ) {
+				$this->register_namespace_controllers( $namespace, $eager_controllers );
+			}
+
+			if ( $lazy_controllers ) {
+				$rest_api_util->lazy_load_namespace(
+					$namespace,
+					function () use ( $namespace, $lazy_controllers ) {
+						$this->register_namespace_controllers( $namespace, $lazy_controllers );
 					}
-				}
-			);
+				);
+			}
+		}
+	}
+
+	/**
+	 * Instantiate the given controllers and register their routes.
+	 *
+	 * @param string $namespace   The namespace the controllers are grouped under.
+	 * @param array  $controllers Map of controller name => controller class.
+	 *
+	 * @return void
+	 */
+	private function register_namespace_controllers( $namespace, $controllers ): void {
+		$container    = wc_get_container();
+		$legacy_proxy = $container->get( LegacyProxy::class );
+		foreach ( $controllers as $controller_name => $controller_class ) {
+			$this->controllers[ $namespace ][ $controller_name ] = $container->has( $controller_class ) ?
+				$container->get( $controller_class ) :
+				$legacy_proxy->get_instance_of( $controller_class );
+			$this->controllers[ $namespace ][ $controller_name ]->register_routes();
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -59,11 +59,8 @@ class Init {
 	 * @return void
 	 */
 	public function rest_api_init() {
-		if ( wc_rest_should_load_namespace( 'wc-admin' ) ) {
-			$this->rest_api_init_wc_admin();
-		}
-
 		$rest_api_util = wc_get_container()->get( RestApiUtil::class );
+		$rest_api_util->lazy_load_namespace( 'wc-admin', array( $this, 'rest_api_init_wc_admin' ) );
 		$rest_api_util->lazy_load_namespace( 'wc-analytics', array( $this, 'rest_api_init_wc_analytics' ) );
 
 		if ( Features::is_enabled( 'launch-your-store' ) ) {

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
@@ -26,6 +26,9 @@ class WC_REST_Unit_Test_Case extends WC_Unit_Test_Case {
 		global $wp_rest_server;
 		$wp_rest_server = new WP_Test_Spy_REST_Server();
 		$this->server   = $wp_rest_server;
+		// Register namespaces eagerly so controller tests can assert against the route table directly.
+		// The lazy-loading machinery itself is covered by RestApiUtilTest.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
 		do_action( 'rest_api_init' );
 
 		// Reset payment gateways.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On any REST request to a namespace WooCommerce does not recognize (including every `wp/v2` request the block editor makes), `wc_rest_should_load_namespace()` falls back to loading everything, so all ~108 wc/v1-v3 controllers plus the wc-admin controllers are instantiated and their routes registered on requests that never use them. This also inflates the route table the server must match against (565 routes vs ~130 on a `wp/v2` request locally).

This PR registers those namespaces through the existing `RestApiUtil::lazy_load_namespace()` mechanism (introduced for wc-analytics in WooCommerce 10.3, see PR 60684; extending it to the remaining namespaces was previously explored in PR 60751). Requests targeting a WooCommerce namespace load it immediately; the API root loads everything to keep discovery intact; internal `rest_do_request()` calls hydrate on demand via `rest_pre_dispatch`. The `woocommerce_rest_api_get_rest_namespaces` filter still runs before registration, so extensions that add or remove controllers keep working.

Controller unit tests assert against the route table without dispatching, so the shared REST test case now disables lazy loading via the existing `woocommerce_rest_should_lazy_load_namespace` filter (the lazy machinery has its own dedicated tests).

**Backward compatibility impact:** code that inspects `rest_get_server()->get_routes()` during a foreign-namespace request will no longer see WooCommerce routes there (discovery via the API index and all actual dispatches are unaffected). Controller instantiation moves from `rest_api_init` to first dispatch. The `woocommerce_rest_should_lazy_load_namespace` filter can restore eager loading site-wide or per namespace.

**Note:** this builds on the batch-subrequest fix in the "Fix lazy-loaded REST namespaces not loading for batch subrequests" PR and should land after it.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. With an application password, request `wp-json/wc/v3/products`, `wp-json/wc/v3/orders`, `wp-json/wc-admin/options?options=woocommerce_demo_store` — all should respond normally.
2. Request `wp-json/` and confirm the `namespaces` array still lists `wc/v1`, `wc/v2`, `wc/v3`, `wc-telemetry` and `wc-admin`.
3. Run `wp wc product list` via WP-CLI and confirm commands are registered and return data.
4. Create a webhook (e.g. topic `product.updated`), trigger it, and confirm the payload delivers with full product data.
5. In the block editor with DevTools open, compare server response time of `wp/v2/types` before/after; expect a modest improvement (~5-8ms locally) and identical response bodies.
6. Run `pnpm test:php:env -- --testsuite=wc-phpunit-legacy --filter "REST"` and confirm controller tests pass.

### Testing that has already taken place:

Local wp-env (WP 7.0, PHP 8.1, opcache on). Benchmarked: `wp/v2/types` improves ~5-8ms on top of other gating; route count on foreign REST requests drops from 565 to ~200. Verified: wc/v3 CRUD, wc-admin options, REST index discovery, `wp wc` CLI (registers via API-root dispatch), webhook payload delivery from async context, block editor flows. Legacy REST controller suites and Admin API suites pass with no new failures vs trunk (full-suite failure-list diff). PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Lazy load the wc/v1, wc/v2, wc/v3, wc-telemetry and wc-admin REST API namespaces so their controllers are only instantiated for requests that target them.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)