### PR TITLE
Defer settings and email loading to wc/v2 and wc/v3 REST requests

### DIFF
--- a/plugins/woocommerce/changelog/66253-perf-lazy-register-wp-admin-settings
+++ b/plugins/woocommerce/changelog/66253-perf-lazy-register-wp-admin-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Defer loading of settings pages and email classes on REST requests until a request targets the wc/v2 or wc/v3 settings endpoints.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1498,15 +1498,30 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function register_wp_admin_settings() {
-		$pages = WC_Admin_Settings::get_settings_pages();
-		foreach ( $pages as $page ) {
-			new WC_Register_WP_Admin_Settings( $page, 'page' );
-		}
+		// The registered settings groups are only consumed by the wc/v2 and wc/v3 settings
+		// endpoints, so defer the (expensive) settings pages and emails loading until a
+		// request actually targets one of those namespaces.
+		$register = function () {
+			static $registered = false;
+			if ( $registered ) {
+				return;
+			}
+			$registered = true;
 
-		$emails = WC_Emails::instance();
-		foreach ( $emails->get_emails() as $email ) {
-			new WC_Register_WP_Admin_Settings( $email, 'email' );
-		}
+			$pages = WC_Admin_Settings::get_settings_pages();
+			foreach ( $pages as $page ) {
+				new WC_Register_WP_Admin_Settings( $page, 'page' );
+			}
+
+			$emails = WC_Emails::instance();
+			foreach ( $emails->get_emails() as $email ) {
+				new WC_Register_WP_Admin_Settings( $email, 'email' );
+			}
+		};
+
+		$rest_api_util = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
+		$rest_api_util->lazy_load_namespace( 'wc/v2', $register );
+		$rest_api_util->lazy_load_namespace( 'wc/v3', $register );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1498,9 +1498,9 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function register_wp_admin_settings() {
-		// The registered settings groups are only consumed by the wc/v2 and wc/v3 settings
-		// endpoints, so defer the (expensive) settings pages and emails loading until a
-		// request actually targets one of those namespaces.
+		// The registered settings groups are consumed by the settings endpoints in the wc/v2,
+		// wc/v3, wc-admin and wc-analytics namespaces, so defer the (expensive) settings pages
+		// and emails loading until a request actually targets one of those namespaces.
 		$register = function () {
 			static $registered = false;
 			if ( $registered ) {
@@ -1522,6 +1522,8 @@ final class WooCommerce {
 		$rest_api_util = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
 		$rest_api_util->lazy_load_namespace( 'wc/v2', $register );
 		$rest_api_util->lazy_load_namespace( 'wc/v3', $register );
+		$rest_api_util->lazy_load_namespace( 'wc-admin', $register );
+		$rest_api_util->lazy_load_namespace( 'wc-analytics', $register );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
@@ -26,6 +26,9 @@ class WC_REST_Unit_Test_Case extends WC_Unit_Test_Case {
 		global $wp_rest_server;
 		$wp_rest_server = new WP_Test_Spy_REST_Server();
 		$this->server   = $wp_rest_server;
+		// Register namespaces eagerly so controller tests can assert against the route table directly.
+		// The lazy-loading machinery itself is covered by RestApiUtilTest.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
 		do_action( 'rest_api_init' );
 
 		// Reset payment gateways.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WooCommerce::register_wp_admin_settings()` runs on `rest_api_init`, instantiating every settings page class (`WC_Admin_Settings::get_settings_pages()`) and the full `WC_Emails` stack on **every** REST request — including block editor `wp/v2` calls. Its consumers are the `woocommerce_settings_groups` / `woocommerce_settings-{group}` filters read by the settings endpoints in the `wc/v2`, `wc/v3`, `wc-admin` and `wc-analytics` namespaces (the latter caught by the onboarding e2e tests, which surfaced that the core profiler reads settings through `wc-analytics`).

This PR registers that work through the existing `RestApiUtil::lazy_load_namespace()` mechanism under the `wc/v2`, `wc/v3`, `wc-admin` and `wc-analytics` namespaces, with an idempotence guard since they share one callback. The registration still happens for API-root and batch requests, and hydrates on demand for internal `rest_do_request()` calls.

**Backward compatibility impact:** third-party code that applies the `woocommerce_settings_groups` filters during REST requests *outside* the wc/v2, wc/v3, wc-admin and wc-analytics namespaces will now see them unpopulated. `WC_Emails` is no longer instantiated as a side effect of unrelated REST requests.

### How to test the changes in this Pull Request:

1. With an application password, request `wp-json/wc/v3/settings` and `wp-json/wc/v3/settings/general` — groups and settings should be returned as on trunk.
2. Request `wp-json/wc/v3/settings/email_new_order` — email settings should be returned.
3. In wp-admin, open WooCommerce → Settings → Emails → "New order", save, and confirm "Your settings have been saved."
4. In the block editor with DevTools open, compare `wp/v2/types` server response time before/after; expect a small improvement and identical response bodies.

### Testing that has already taken place:

Local wp-env (WP 7.0, PHP 8.1). Verified `wc/v3/settings/general` returns all 20 settings, email settings screens render and save, and callback profiling confirms the settings/emails loading no longer appears on foreign-namespace REST requests. PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Defer loading of settings pages and email classes on REST requests until a request targets the wc/v2 or wc/v3 settings endpoints.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
