### PR TITLE
Restore reduced stock when an order transitions to failed

### DIFF
--- a/plugins/woocommerce/changelog/36702-fix-restore-stock-on-failed
+++ b/plugins/woocommerce/changelog/36702-fix-restore-stock-on-failed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore reduced stock when an order transitions to failed, so inventory held by an order that reduced stock while on-hold (e.g. an accepted-but-pending SEPA/ACH payment) is released instead of staying reduced indefinitely.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -127,7 +127,8 @@ add_action( 'woocommerce_order_status_processing', 'wc_maybe_reduce_stock_levels
 add_action( 'woocommerce_order_status_on-hold', 'wc_maybe_reduce_stock_levels' );
 
 /**
- * When a payment is cancelled, restore stock.
+ * Restore stock for an order that reduced it, when it moves to a status that releases stock
+ * (cancelled, pending, or failed).
  *
  * @since 3.0.0
  * @param int $order_id Order ID.
@@ -154,6 +155,11 @@ function wc_maybe_increase_stock_levels( $order_id ) {
 }
 add_action( 'woocommerce_order_status_cancelled', 'wc_maybe_increase_stock_levels' );
 add_action( 'woocommerce_order_status_pending', 'wc_maybe_increase_stock_levels' );
+// Restore stock when a stock-reduced order fails. wc_maybe_increase_stock_levels() only acts when
+// the order carries the `_order_stock_reduced` flag, so it restores an order that reduced stock
+// (in practice one left on-hold by an async payment such as SEPA/ACH) and does nothing for a
+// pending -> failed decline that never reduced. Added in 11.0.0.
+add_action( 'woocommerce_order_status_failed', 'wc_maybe_increase_stock_levels' );
 
 /**
  * Reduce stock levels for items within an order, if stock has not already been reduced for the items.

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -28,13 +28,13 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	public $order_stock_restore_statuses = array(
 		OrderInternalStatus::CANCELLED,
 		OrderInternalStatus::PENDING,
+		OrderInternalStatus::FAILED,
 	);
 
 	/**
 	 * @var array List of statuses which have no impact on inventory.
 	 */
 	public $order_stock_no_effect_statuses = array(
-		OrderInternalStatus::FAILED,
 		OrderInternalStatus::REFUNDED,
 	);
 
@@ -266,6 +266,68 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 				$this->transition_order_status_and_assert_stock_quantity( $order_status_from, $order_status_to, 10, 10 );
 			}
 		}
+	}
+
+	/**
+	 * An order that reduced stock while on-hold (e.g. an accepted-but-pending payment) and then fails
+	 * should have its stock restored and its stock-reduced flag cleared, mirroring cancel/pending.
+	 */
+	public function test_on_hold_to_failed_restores_stock_and_clears_reduced_flag() {
+		$order      = $this->create_order_from_cart_with_status( OrderInternalStatus::ON_HOLD );
+		$product_id = array_values( $order->get_items( 'line_item' ) )[0]->get_product_id();
+
+		$this->assertEquals( 9, wc_get_product( $product_id )->get_stock_quantity(), 'On-hold should reduce stock by the ordered quantity.' );
+		$this->assertTrue( (bool) $order->get_data_store()->get_stock_reduced( $order->get_id() ), 'The stock-reduced flag should be set while on-hold.' );
+
+		$order->set_status( OrderInternalStatus::FAILED );
+		$order->save();
+
+		$this->assertEquals( 10, wc_get_product( $product_id )->get_stock_quantity(), 'Failing an order that reduced stock should restore it.' );
+		$this->assertFalse( (bool) $order->get_data_store()->get_stock_reduced( $order->get_id() ), 'The stock-reduced flag should be cleared after the stock is restored.' );
+
+		$restore_notes = array_filter(
+			wc_get_order_notes( array( 'order_id' => $order->get_id() ) ),
+			function ( $note ) {
+				return false !== strpos( $note->content, 'Stock levels increased' );
+			}
+		);
+		$this->assertNotEmpty( $restore_notes, 'A "Stock levels increased" order note should be recorded when the stock is restored.' );
+	}
+
+	/**
+	 * A plain pending -> failed order (a payment declined before any stock was reduced) should be a
+	 * no-op: there is nothing to restore, so stock stays put.
+	 */
+	public function test_pending_to_failed_does_not_change_stock() {
+		$order      = $this->create_order_from_cart_with_status( OrderInternalStatus::PENDING );
+		$product_id = array_values( $order->get_items( 'line_item' ) )[0]->get_product_id();
+
+		$this->assertEquals( 10, wc_get_product( $product_id )->get_stock_quantity(), 'Pending should not reduce stock.' );
+
+		$order->set_status( OrderInternalStatus::FAILED );
+		$order->save();
+
+		$this->assertEquals( 10, wc_get_product( $product_id )->get_stock_quantity(), 'Failing an order that never reduced stock should not change stock.' );
+	}
+
+	/**
+	 * Admin-path safety check. A failed order is a dead end in the gateway flow, but an admin can
+	 * manually move it back to a paid status. Because the failure already restored the stock, doing
+	 * so must reduce stock exactly once, not twice.
+	 */
+	public function test_reactivating_a_failed_order_reduces_stock_only_once() {
+		$order      = $this->create_order_from_cart_with_status( OrderInternalStatus::ON_HOLD );
+		$product_id = array_values( $order->get_items( 'line_item' ) )[0]->get_product_id();
+
+		$order->set_status( OrderInternalStatus::FAILED );
+		$order->save();
+		$this->assertEquals( 10, wc_get_product( $product_id )->get_stock_quantity(), 'Failure should restore the reduced stock.' );
+
+		// Admin manually re-activates the order.
+		$order->set_status( OrderInternalStatus::PROCESSING );
+		$order->save();
+		$this->assertEquals( 9, wc_get_product( $product_id )->get_stock_quantity(), 'Re-activating the order should reduce stock exactly once.' );
+		$this->assertTrue( (bool) $order->get_data_store()->get_stock_reduced( $order->get_id() ), 'The stock-reduced flag should be set again after re-activation.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines
- [x] I have followed the WooCommerce Contributing Guidelines.
- [x] My code follows the WooCommerce coding standards.
- [x] I have added tests where applicable.

### Changes proposed in this Pull Request
Stock is restored on `cancelled` and `pending`, but not on `failed`. So an order that reduced stock while `on-hold` and then fails keeps its stock reduced, and nothing puts it back: the unpaid-order cron only cancels `pending` orders, never `failed` ones.

This hooks `wc_maybe_increase_stock_levels()` on `woocommerce_order_status_failed`, next to the existing `cancelled` and `pending` hooks. It's guarded by the `_order_stock_reduced` flag, so it only restores an order that actually reduced stock and does nothing otherwise.

The real case is an async payment like Stripe SEPA/ACH: it's accepted as pending, the order goes `on-hold` and reduces stock, then the debit is rejected and the order goes `failed`. That's a dead end, so the stock has to come back there.
Closes WOOPLUG-6971
Closes #66244
Closes #66085
Closes WOOPLUG-6931


The reservation side (WOOPLUG-3158, WOOPLUG-1936) isn't touched here.

#### Backward compatibility
This restores stock on `failed` for every store and gateway. Anyone who wants the old behaviour can opt out with `remove_action( 'woocommerce_order_status_failed', 'wc_maybe_increase_stock_levels' );`

### 📝 Dev note

**Stock is now restored when an order moves to `failed`.**

Previously WooCommerce restored reduced stock when an order became `cancelled` or `pending`, but not `failed` — a `failed` order kept its stock reduced indefinitely. As of this release, `failed` restores stock too, via `wc_maybe_increase_stock_levels()` on `woocommerce_order_status_failed`. Restoration is guarded by the `_order_stock_reduced` flag, so only orders that actually reduced stock are affected.

**Why:** `failed` is a payment status. It marks an order as unpaid (`is_paid()` is false, `needs_payment()` is true for `pending`/`failed`), so an order that ends there never completed and its stock should return to the pool. The common trigger is an async payment (e.g. Stripe SEPA/ACH) that is accepted as pending, reduces stock at `on-hold`, then gets rejected and lands on `failed`.

**Who's affected:** Stores or extensions that repurpose the `failed` status for non-payment flows — for example marking an order `failed` when *delivery* fails while the goods are still committed. These stores will now see stock restored where it previously stayed reduced. We looked at scoping the change with `get_date_paid()` to target only never-paid orders, but that's unreliable: an order can reach `failed` after `processing`/`completed` and still carry a paid date.

**How to keep the old behavior:** remove the hook.

```php
remove_action( 'woocommerce_order_status_failed', 'wc_maybe_increase_stock_levels' );
```

### How to test the changes in this Pull Request

I'm treating the missing `failed` restore as a bug; flagging it for reviewers in case it was intentional.

1. Turn on stock management and give a simple product a stock of 5.
2. In Stripe test mode, pay with SEPA using IBAN `AT611904300234573201`. The order goes On hold and stock drops to 4.
3. Set the order to Failed. Stock goes back to 5.
4. Or run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Stock_Functions_Tests`.

### Testing that has already taken place
`WC_Stock_Functions_Tests` passes (20 tests, 126 assertions). Confirmed manually with Stripe SEPA in test mode.

### Milestone
- [x] Assign to the first available milestone.

### Changelog entry
`fix`, patch. Entry added.
