### PR TITLE
Lazy load Store API route registration

### DIFF
--- a/plugins/woocommerce/changelog/66257-perf-lazy-load-store-api-routes
+++ b/plugins/woocommerce/changelog/66257-perf-lazy-load-store-api-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Lazy load Store API route registration so wc/store routes are only registered for requests that target them.

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -35,8 +35,22 @@ final class StoreApi {
 				if ( ! wc_rest_should_load_namespace( 'wc/store' ) && ! wc_rest_should_load_namespace( 'wc/private' ) ) {
 					return;
 				}
-				self::container()->get( Legacy::class )->init();
-				self::container()->get( RoutesController::class )->register_all_routes();
+				// Both namespaces share one callback; guard against double registration per
+				// server instance (not a static flag, which would break when tests reset the server).
+				$registered_server = null;
+				$register_routes   = function () use ( &$registered_server ) {
+					$server = rest_get_server();
+					if ( $registered_server === $server ) {
+						return;
+					}
+					$registered_server = $server;
+					self::container()->get( Legacy::class )->init();
+					self::container()->get( RoutesController::class )->register_all_routes();
+				};
+
+				$rest_api_util = wc_get_container()->get( \Automattic\WooCommerce\Utilities\RestApiUtil::class );
+				$rest_api_util->lazy_load_namespace( 'wc/store', $register_routes );
+				$rest_api_util->lazy_load_namespace( 'wc/private', $register_routes );
 			}
 		);
 		// Runs on priority 11 after rest_api_default_filters() which is hooked at 10.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
@@ -16,6 +16,8 @@ class ControllerTests extends \WP_Test_REST_TestCase {
 		/** @var \WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
+		// Register namespaces eagerly so route tests can assert against the route table directly.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
 		do_action( 'rest_api_init', $wp_rest_server );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -42,6 +42,9 @@ class Checkout extends MockeryTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
+		// Register namespaces eagerly so the mock checkout route below reliably overrides the
+		// container-registered one; lazy loading would re-register it at dispatch time.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
 		do_action( 'rest_api_init', $wp_rest_server );
 
 		wp_set_current_user( 0 );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ControllerTestCase.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ControllerTestCase.php
@@ -31,6 +31,9 @@ abstract class ControllerTestCase extends \WP_Test_REST_TestCase {
 		/** @var \WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
+		// Register namespaces eagerly so route tests can assert against the route table directly.
+		// The lazy-loading machinery itself is covered by RestApiUtilTest.
+		add_filter( 'woocommerce_rest_should_lazy_load_namespace', '__return_false' );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'rest_api_init', $wp_rest_server );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Store API routes (`wc/store`, `wc/private`) are registered on every REST request to any unrecognized namespace, because `wc_rest_should_load_namespace()` defaults to loading on foreign routes. This PR registers them through `RestApiUtil::lazy_load_namespace()` so registration only happens for requests that target them (with API root and batch requests loading eagerly for discovery, and internal `rest_do_request()` calls hydrating at `rest_pre_dispatch`).

Two deliberate design points: **authentication stays eager** — Store API auth hooks (`rest_authentication_errors`, session handler) run before dispatch, so they cannot be lazy; and the shared registration callback for the two namespaces is guarded **per REST server instance** rather than with a static flag, which would break when tests (or anything else) reset the global REST server. Route-table tests disable lazy loading in their `setUp` via the existing `woocommerce_rest_should_lazy_load_namespace` filter.

**Backward compatibility impact:** code inspecting the route table during foreign-namespace requests will not see Store API routes (discovery and dispatch unaffected); Store API route registration moves from `rest_api_init` to first dispatch on such requests. The `woocommerce_rest_should_lazy_load_namespace` filter restores eager loading.

**Note:** this builds on the batch-subrequest fix in the "Fix lazy-loaded REST namespaces not loading for batch subrequests" PR and should land after it.

### How to test the changes in this Pull Request:

1. On the frontend, add a product to the cart; open the mini-cart drawer and confirm it shows the item and total.
2. On the block cart page: change quantity, apply a coupon, and confirm totals update.
3. Complete a purchase through the block checkout (e.g. Cash on delivery) and confirm the order is placed.
4. Request `wp-json/wc/store/v1/products` and `wp-json/wc/store/v1/cart` directly and confirm normal responses.
5. Request `wp-json/` and confirm `wc/store` and `wc/private` are still listed in `namespaces`.
6. Run `pnpm test:php:env -- --filter "Automattic\\WooCommerce\\Tests\\StoreApi"` and the Blocks StoreApi suites; confirm no failures.

### Testing that has already taken place:

Local wp-env (WP 7.0, PHP 8.1). Completed real orders through the block checkout and shortcode checkout, exercised mini-cart, quantity updates and coupons through the Store API. StoreApi test suite passes (40 tests); Blocks suite failure list is identical to trunk (full-suite diff). PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Lazy load Store API route registration so wc/store routes are only registered for requests that target them.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)