### PR TITLE
Skip blocks bootstrap on block-free core REST routes

### DIFF
--- a/plugins/woocommerce/changelog/66258-perf-skip-blocks-bootstrap-block-free-rest-routes
+++ b/plugins/woocommerce/changelog/66258-perf-skip-blocks-bootstrap-block-free-rest-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Skip block, pattern and template registration on REST requests to core endpoints that never render block content, with a woocommerce_blocks_block_free_rest_routes filter to customize the route list.

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -196,6 +196,10 @@ class Bootstrap {
 		 * Filters the REST route prefixes for which the blocks infrastructure (block types,
 		 * patterns, templates) is not loaded because those routes never render block content.
 		 *
+		 * Note that wp/v2/settings is deliberately NOT in this list: block classes register
+		 * settings with show_in_rest (for example woocommerce_default_catalog_orderby in
+		 * ProductCollection), so that endpoint needs the blocks infrastructure loaded.
+		 *
 		 * Return an empty array to always load the blocks infrastructure on REST requests.
 		 *
 		 * @param string[] $block_free_route_prefixes REST route prefixes, each starting with '/'.
@@ -207,7 +211,6 @@ class Bootstrap {
 				'/wp/v2/types',
 				'/wp/v2/taxonomies',
 				'/wp/v2/users',
-				'/wp/v2/settings',
 				'/wp/v2/statuses',
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -109,7 +109,7 @@ class Bootstrap {
 			function () {
 				$is_store_api_request = wc()->is_store_api_request();
 
-				if ( ! $is_store_api_request && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+				if ( ! $is_store_api_request && ! $this->is_block_free_rest_request() && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
 					$this->container->get( BlockTemplatesRegistry::class )->init();
 					$this->container->get( BlockTemplatesController::class )->init();
 				}
@@ -144,7 +144,7 @@ class Bootstrap {
 		}
 
 		// Load assets unless this is a request specifically for the store API.
-		if ( ! $is_store_api_request ) {
+		if ( ! $is_store_api_request && ! $this->is_block_free_rest_request() ) {
 			// Template related functionality. These won't be loaded for store API requests, but may be loaded for
 			// regular rest requests to maintain compatibility with the store editor.
 			$this->container->get( BlockPatterns::class );
@@ -160,6 +160,65 @@ class Bootstrap {
 				$this->container->get( TemplateOptions::class )->init();
 			}
 		}
+	}
+
+	/**
+	 * Whether the current request is a REST request to a core route that can never
+	 * render block content, so block types, patterns and templates are not needed.
+	 *
+	 * Kept deliberately conservative: only structural wp/v2 endpoints that return
+	 * schema-like data (no rendered post content) are listed. Anything else —
+	 * including posts, pages, templates, patterns and unknown/third-party routes —
+	 * keeps loading the full blocks infrastructure.
+	 *
+	 * @return bool
+	 */
+	private function is_block_free_rest_request() {
+		if ( ! wc()->is_rest_api_request() ) {
+			return false;
+		}
+
+		$route = '';
+		if ( ! empty( $_GET['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$route = sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} elseif ( ! empty( $_SERVER['REQUEST_URI'] ) && function_exists( 'rest_get_url_prefix' ) ) {
+			$path   = (string) wp_parse_url( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+			$prefix = '/' . rest_get_url_prefix();
+			$pos    = strpos( $path, $prefix );
+			if ( false !== $pos ) {
+				$route = substr( $path, $pos + strlen( $prefix ) );
+			}
+		}
+
+		$route = '/' . ltrim( $route, '/' );
+
+		/**
+		 * Filters the REST route prefixes for which the blocks infrastructure (block types,
+		 * patterns, templates) is not loaded because those routes never render block content.
+		 *
+		 * Return an empty array to always load the blocks infrastructure on REST requests.
+		 *
+		 * @param string[] $block_free_route_prefixes REST route prefixes, each starting with '/'.
+		 * @since 11.0.0
+		 */
+		$block_free_route_prefixes = apply_filters(
+			'woocommerce_blocks_block_free_rest_routes',
+			array(
+				'/wp/v2/types',
+				'/wp/v2/taxonomies',
+				'/wp/v2/users',
+				'/wp/v2/settings',
+				'/wp/v2/statuses',
+			)
+		);
+
+		foreach ( $block_free_route_prefixes as $block_free_route_prefix ) {
+			if ( $route === $block_free_route_prefix || str_starts_with( $route, $block_free_route_prefix . '/' ) || str_starts_with( $route, $block_free_route_prefix . '?' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WooCommerce registers 120+ block type classes, block patterns and block templates on every non-Store-API request — including REST requests to structural `wp/v2` endpoints that return schema-like data and can never render block content. Profiling attributes ~15ms per request to this work (block type instantiation ~7ms, template registry ~6ms, patterns ~2ms), and these are exactly the chatty requests the block editor issues on every editor load (`types`, `taxonomies`, `users`, `settings`).

This PR skips the blocks bootstrap (BlockTypesController, BlockPatterns, block templates registry/controller, ClassicTemplatesCompatibility, Notices) for a deliberately conservative allowlist of core routes: `wp/v2/types`, `wp/v2/taxonomies`, `wp/v2/users`, `wp/v2/statuses`. Note `wp/v2/settings` was initially in the list but is deliberately excluded: block classes register REST-visible settings (ProductCollection registers `woocommerce_default_catalog_orderby`), which the product-collection e2e tests caught. Everything else — posts, pages, templates, patterns, block-renderer, search, unknown and third-party routes — keeps loading the full blocks infrastructure. The allowlist is filterable via a new `woocommerce_blocks_block_free_rest_routes` filter; returning an empty array disables the optimization entirely.

**Backward compatibility impact:** on the five allowlisted routes, WooCommerce blocks/patterns/templates are not registered, so hooks such as `woocommerce_get_block_types` will not fire during those requests. An extension that renders block content inside those specific responses (not a pattern we are aware of) would need the filter. Response bodies on a default install are byte-identical with and without this change.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

### How to test the changes in this Pull Request:

1. As a logged-in admin, open the block editor with the DevTools Network tab filtered to `wp-json`, and compare server response time of `wp/v2/types?context=edit` and `wp/v2/taxonomies?context=edit` on trunk vs this branch (~15ms faster locally); response bodies should be identical.
2. Verify the block editor: WooCommerce blocks appear in the inserter, a page containing WooCommerce blocks saves and previews correctly.
3. Verify the Site Editor: WooCommerce templates (Single Product, Product Catalog, Cart, Checkout) are listed and open with their content intact (`wp/v2/templates` is not gated).
4. Verify `wp/v2/pages?context=edit` still returns rendered content for a page containing WooCommerce blocks (content rendering routes are not gated).
5. Verify `wp/v2/settings` still includes `woocommerce_default_catalog_orderby` (and changing "Default sort by" on a Product Collection block in the editor persists).
6. Frontend smoke test: shop, product page, cart, checkout render normally (frontend requests are not affected).

### Testing that has already taken place:

Local wp-env (WP 7.0, PHP 8.1, opcache on, Twenty Twenty-Three). 25-sample medians: `wp/v2/types` drops ~15ms with this change; response bodies for the four gated endpoints verified byte-identical against trunk (fetched with a delay after switching code to avoid opcache serving stale results). Browser-tested block editor with WooCommerce blocks, Site Editor template editing, block cart/checkout with completed orders, mini-cart. Blocks PHP test suites show no new failures vs trunk. PHPStan and phpcs clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Skip block, pattern and template registration on REST requests to core endpoints that never render block content, with a woocommerce_blocks_block_free_rest_routes filter to customize the route list.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
