### PR TITLE
Add multi-location inventory data model (feature-flagged)

### DIFF
--- a/plugins/woocommerce/changelog/woomob-3405-location-inventory-data-model
+++ b/plugins/woocommerce/changelog/woomob-3405-location-inventory-data-model
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the feature-flagged multi-location inventory data model (wc_locations and wc_product_inventory tables, Location object, atomic stock service).

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -417,6 +417,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Locations\LocationsController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\MultiLocationInventory\ProductInventoryController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\MultiLocationInventory\PosLocationSeeder::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -415,6 +415,8 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\Orders\PointOfSaleEmailHandler::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\POS\POSController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\ShopperLists\ShopperListsController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Locations\LocationsController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\MultiLocationInventory\ProductInventoryController::class )->register();
 
 		// Classes inheriting from RestApiControllerBase.
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();

--- a/plugins/woocommerce/src/Internal/AbstractFeatureTablesInstaller.php
+++ b/plugins/woocommerce/src/Internal/AbstractFeatureTablesInstaller.php
@@ -95,9 +95,7 @@ abstract class AbstractFeatureTablesInstaller {
 
 	/**
 	 * Create the table (and run any post-create step) if the feature is enabled. Idempotent.
-	 *
-	 * Wrapped in try/catch so a transient failure does not white-screen the request that
-	 * toggled the feature; on failure the latch is left unset so a later call retries.
+	 * On failure the latch is left unset so a later call retries.
 	 */
 	public function maybe_install(): void {
 		if ( ! $this->is_enabled() ) {

--- a/plugins/woocommerce/src/Internal/AbstractFeatureTablesInstaller.php
+++ b/plugins/woocommerce/src/Internal/AbstractFeatureTablesInstaller.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * AbstractFeatureTablesInstaller class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal;
+
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base for controllers that own a feature-gated custom table created on-enable
+ * (never via WC_Install::get_schema()) and dropped on uninstall.
+ *
+ * @internal
+ */
+abstract class AbstractFeatureTablesInstaller {
+
+	/**
+	 * Database utility.
+	 *
+	 * @var DatabaseUtil
+	 */
+	protected $database_util;
+
+	/**
+	 * Dependency injection.
+	 *
+	 * @internal
+	 *
+	 * @param DatabaseUtil $database_util Database utility.
+	 */
+	final public function init( DatabaseUtil $database_util ): void {
+		$this->database_util = $database_util;
+	}
+
+	/**
+	 * The table name this installer owns.
+	 */
+	abstract public function get_table_name(): string;
+
+	/**
+	 * The CREATE TABLE schema for the owned table.
+	 */
+	abstract public function get_database_schema(): string;
+
+	/**
+	 * Whether this installer's feature is enabled.
+	 */
+	abstract public function is_enabled(): bool;
+
+	/**
+	 * The option name latching that the table has been created.
+	 */
+	abstract protected function get_tables_created_option(): string;
+
+	/**
+	 * Whether a feature-enabled-changed event for $feature_id should trigger install.
+	 *
+	 * @param string $feature_id Feature id.
+	 */
+	abstract protected function handles_feature( string $feature_id ): bool;
+
+	/**
+	 * Whether the owned table exists.
+	 */
+	public function tables_exist(): bool {
+		global $wpdb;
+		$table_name = $this->get_table_name();
+		return $table_name === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table_name ) ) );
+	}
+
+	/**
+	 * Create the owned table (dbDelta; callers guard on tables_exist()).
+	 */
+	public function create_tables(): void {
+		$this->database_util->dbdelta( $this->get_database_schema() );
+	}
+
+	/**
+	 * Register the owned table so uninstall drops it.
+	 *
+	 * @param array $tables Table names.
+	 * @return array
+	 */
+	public function add_table_to_install_list( $tables ) {
+		if ( is_array( $tables ) ) {
+			$tables[] = $this->get_table_name();
+		}
+		return $tables;
+	}
+
+	/**
+	 * Create the table (and run any post-create step) if the feature is enabled. Idempotent.
+	 *
+	 * Wrapped in try/catch so a transient failure does not white-screen the request that
+	 * toggled the feature; on failure the latch is left unset so a later call retries.
+	 */
+	public function maybe_install(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+		$tables_exist = $this->tables_exist();
+		if ( 'yes' === get_option( $this->get_tables_created_option() ) && $tables_exist ) {
+			return;
+		}
+		try {
+			if ( ! $tables_exist ) {
+				$this->create_tables();
+			}
+			$this->after_tables_created();
+		} catch ( \Exception $e ) {
+			wc_get_logger()->error(
+				'Multi-location install/seed failed: ' . $e->getMessage(),
+				array( 'source' => 'multi-location-inventory' )
+			);
+			return;
+		}
+		update_option( $this->get_tables_created_option(), 'yes' );
+	}
+
+	/**
+	 * React to a feature flag transition.
+	 *
+	 * @param string $feature_id Feature id.
+	 * @param bool   $enabled    New enabled state.
+	 */
+	public function on_feature_enabled_changed( $feature_id, $enabled ): void {
+		if ( $enabled && $this->handles_feature( (string) $feature_id ) ) {
+			$this->maybe_install();
+		}
+	}
+
+	/**
+	 * Register hooks. Called once from the bootstrap.
+	 */
+	public function register(): void {
+		add_filter( 'woocommerce_install_get_tables', array( $this, 'add_table_to_install_list' ) );
+		add_action( 'woocommerce_feature_enabled_changed', array( $this, 'on_feature_enabled_changed' ), 10, 2 );
+		add_action( 'woocommerce_installed', array( $this, 'maybe_install' ) );
+		add_action( 'woocommerce_updated', array( $this, 'maybe_install' ) );
+		$this->register_hooks();
+	}
+
+	/**
+	 * Post-create step (e.g. seeding). Default no-op; subclasses may override.
+	 */
+	protected function after_tables_created(): void {}
+
+	/**
+	 * Register subclass-specific hooks (data-store filter, consumer filter, ...). Default no-op.
+	 */
+	protected function register_hooks(): void {}
+}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -582,6 +582,14 @@ class FeaturesController {
 				'is_experimental'              => false,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
 			),
+			'multi_location_inventory'           => array(
+				'name'                         => __( 'Multiple inventory locations', 'woocommerce' ),
+				'description'                  => __( 'Track product stock across multiple inventory locations. Used by WooCommerce Point of Sale.', 'woocommerce' ),
+				'is_experimental'              => false,
+				'enabled_by_default'           => false,
+				'disable_ui'                   => true,
+				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+			),
 			'mcp_integration'                    => array(
 				'name'                         => __( 'WooCommerce MCP', 'woocommerce' ),
 				'description'                  => $this->get_mcp_integration_description(),

--- a/plugins/woocommerce/src/Internal/Locations/Location.php
+++ b/plugins/woocommerce/src/Internal/Locations/Location.php
@@ -36,21 +36,22 @@ class Location extends \WC_Data {
 	protected $cache_group = 'locations';
 
 	/**
-	 * Default data. GMT datetimes are stored as 'Y-m-d H:i:s' strings.
+	 * Core data for this object.
 	 *
 	 * @var array
 	 */
 	protected $data = array(
-		'name'         => '',
-		'type'         => '',
-		'address_1'    => '',
-		'address_2'    => '',
-		'city'         => '',
-		'state'        => '',
-		'postcode'     => '',
-		'country'      => '',
-		'date_created' => null,
-		'date_deleted' => null,
+		'name'          => '',
+		'type'          => '',
+		'address_1'     => '',
+		'address_2'     => '',
+		'city'          => '',
+		'state'         => '',
+		'postcode'      => '',
+		'country'       => '',
+		'date_created'  => null,
+		'date_modified' => null,
+		'date_deleted'  => null,
 	);
 
 	/**
@@ -148,20 +149,30 @@ class Location extends \WC_Data {
 	}
 
 	/**
-	 * Get created date (GMT 'Y-m-d H:i:s' string or null).
+	 * Get created date.
 	 *
 	 * @param string $context View or edit context.
-	 * @return string|null
+	 * @return \WC_DateTime|null
 	 */
 	public function get_date_created( string $context = 'view' ) {
 		return $this->get_prop( 'date_created', $context );
 	}
 
 	/**
-	 * Get deleted date (GMT 'Y-m-d H:i:s' string or null).
+	 * Get last-modified date.
 	 *
 	 * @param string $context View or edit context.
-	 * @return string|null
+	 * @return \WC_DateTime|null
+	 */
+	public function get_date_modified( string $context = 'view' ) {
+		return $this->get_prop( 'date_modified', $context );
+	}
+
+	/**
+	 * Get deleted date.
+	 *
+	 * @param string $context View or edit context.
+	 * @return \WC_DateTime|null
 	 */
 	public function get_date_deleted( string $context = 'view' ) {
 		return $this->get_prop( 'date_deleted', $context );
@@ -253,18 +264,41 @@ class Location extends \WC_Data {
 	/**
 	 * Set created date.
 	 *
-	 * @param string|null $date GMT 'Y-m-d H:i:s' string or null.
+	 * @param string|integer|null $date UTC timestamp or date string; site timezone assumed if none given.
 	 */
 	public function set_date_created( $date ): void {
-		$this->set_prop( 'date_created', $date );
+		$this->set_date( 'date_created', $date );
+	}
+
+	/**
+	 * Set last-modified date.
+	 *
+	 * @param string|integer|null $date UTC timestamp or date string; site timezone assumed if none given.
+	 */
+	public function set_date_modified( $date ): void {
+		$this->set_date( 'date_modified', $date );
 	}
 
 	/**
 	 * Set deleted date.
 	 *
-	 * @param string|null $date GMT 'Y-m-d H:i:s' string or null.
+	 * @param string|integer|null $date UTC timestamp or date string; site timezone assumed if none given.
 	 */
 	public function set_date_deleted( $date ): void {
-		$this->set_prop( 'date_deleted', $date );
+		$this->set_date( 'date_deleted', $date );
+	}
+
+	/**
+	 * Set a date prop, storing null for an empty value.
+	 *
+	 * @param string              $prop Prop name.
+	 * @param string|integer|null $date UTC timestamp or date string.
+	 */
+	private function set_date( string $prop, $date ): void {
+		if ( null === $date || '' === $date ) {
+			$this->set_prop( $prop, null );
+			return;
+		}
+		$this->set_date_prop( $prop, $date );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Locations/Location.php
+++ b/plugins/woocommerce/src/Internal/Locations/Location.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Location class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Locations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A single inventory location.
+ *
+ * @internal
+ */
+class Location extends \WC_Data {
+
+	/**
+	 * Allowed location types (M1).
+	 */
+	public const ALLOWED_TYPES = array( 'pos' );
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $object_type = 'location';
+
+	/**
+	 * Cache group.
+	 *
+	 * @var string
+	 */
+	protected $cache_group = 'locations';
+
+	/**
+	 * Default data. GMT datetimes are stored as 'Y-m-d H:i:s' strings.
+	 *
+	 * @var array
+	 */
+	protected $data = array(
+		'name'         => '',
+		'type'         => '',
+		'address_1'    => '',
+		'address_2'    => '',
+		'city'         => '',
+		'state'        => '',
+		'postcode'     => '',
+		'country'      => '',
+		'date_created' => null,
+		'date_deleted' => null,
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int|Location $data Location id or object.
+	 */
+	public function __construct( $data = 0 ) {
+		parent::__construct( $data );
+
+		if ( $data instanceof self ) {
+			$this->set_id( $data->get_id() );
+		} elseif ( is_numeric( $data ) && $data > 0 ) {
+			$this->set_id( (int) $data );
+		} else {
+			$this->set_object_read( true );
+		}
+
+		$this->data_store = \WC_Data_Store::load( 'location' );
+		if ( $this->get_id() > 0 ) {
+			$this->data_store->read( $this );
+		}
+	}
+
+	/**
+	 * Get name.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_name( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'name', $context );
+	}
+
+	/**
+	 * Get type.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_type( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'type', $context );
+	}
+
+	/**
+	 * Get address line 1.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_address_1( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'address_1', $context );
+	}
+
+	/**
+	 * Get address line 2.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_address_2( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'address_2', $context );
+	}
+
+	/**
+	 * Get city.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_city( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'city', $context );
+	}
+
+	/**
+	 * Get state.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_state( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'state', $context );
+	}
+
+	/**
+	 * Get postcode.
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_postcode( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'postcode', $context );
+	}
+
+	/**
+	 * Get country (ISO-2).
+	 *
+	 * @param string $context View or edit context.
+	 */
+	public function get_country( string $context = 'view' ): string {
+		return (string) $this->get_prop( 'country', $context );
+	}
+
+	/**
+	 * Get created date (GMT 'Y-m-d H:i:s' string or null).
+	 *
+	 * @param string $context View or edit context.
+	 * @return string|null
+	 */
+	public function get_date_created( string $context = 'view' ) {
+		return $this->get_prop( 'date_created', $context );
+	}
+
+	/**
+	 * Get deleted date (GMT 'Y-m-d H:i:s' string or null).
+	 *
+	 * @param string $context View or edit context.
+	 * @return string|null
+	 */
+	public function get_date_deleted( string $context = 'view' ) {
+		return $this->get_prop( 'date_deleted', $context );
+	}
+
+	/**
+	 * Set name.
+	 *
+	 * @param string $name Name.
+	 */
+	public function set_name( string $name ): void {
+		$this->set_prop( 'name', $name );
+	}
+
+	/**
+	 * Set type. Validates against the allowlist.
+	 *
+	 * @param string $type Type.
+	 * @throws \WC_Data_Exception When the type is not allowed.
+	 */
+	public function set_type( string $type ): void {
+		if ( ! in_array( $type, self::ALLOWED_TYPES, true ) ) {
+			throw new \WC_Data_Exception(
+				'woocommerce_location_invalid_type',
+				sprintf(
+					/* translators: %s: the invalid location type. */
+					esc_html__( 'Invalid location type: %s.', 'woocommerce' ),
+					esc_html( $type )
+				)
+			);
+		}
+		$this->set_prop( 'type', $type );
+	}
+
+	/**
+	 * Set address line 1.
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_address_1( string $value ): void {
+		$this->set_prop( 'address_1', $value );
+	}
+
+	/**
+	 * Set address line 2.
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_address_2( string $value ): void {
+		$this->set_prop( 'address_2', $value );
+	}
+
+	/**
+	 * Set city.
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_city( string $value ): void {
+		$this->set_prop( 'city', $value );
+	}
+
+	/**
+	 * Set state.
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_state( string $value ): void {
+		$this->set_prop( 'state', $value );
+	}
+
+	/**
+	 * Set postcode.
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_postcode( string $value ): void {
+		$this->set_prop( 'postcode', $value );
+	}
+
+	/**
+	 * Set country (normalised to uppercase ISO-2).
+	 *
+	 * @param string $value Value.
+	 */
+	public function set_country( string $value ): void {
+		$this->set_prop( 'country', strtoupper( substr( $value, 0, 2 ) ) );
+	}
+
+	/**
+	 * Set created date.
+	 *
+	 * @param string|null $date GMT 'Y-m-d H:i:s' string or null.
+	 */
+	public function set_date_created( $date ): void {
+		$this->set_prop( 'date_created', $date );
+	}
+
+	/**
+	 * Set deleted date.
+	 *
+	 * @param string|null $date GMT 'Y-m-d H:i:s' string or null.
+	 */
+	public function set_date_deleted( $date ): void {
+		$this->set_prop( 'date_deleted', $date );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Locations/LocationDataStore.php
+++ b/plugins/woocommerce/src/Internal/Locations/LocationDataStore.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * LocationDataStore class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Locations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CRUD for Location against the wc_locations table.
+ *
+ * @internal
+ */
+class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Interface {
+
+	/**
+	 * Get the table name.
+	 */
+	private function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_locations';
+	}
+
+	/**
+	 * Create a location row.
+	 *
+	 * @param Location $location Location object.
+	 * @throws \Exception When the insert fails.
+	 */
+	public function create( &$location ): void {
+		global $wpdb;
+
+		$created = $location->get_date_created();
+		if ( empty( $created ) ) {
+			$created = gmdate( 'Y-m-d H:i:s' );
+			$location->set_date_created( $created );
+		}
+
+		$inserted = $wpdb->insert(
+			$this->get_table_name(),
+			array(
+				'name'           => $location->get_name(),
+				'type'           => $location->get_type(),
+				'address_1'      => $location->get_address_1(),
+				'address_2'      => $location->get_address_2(),
+				'city'           => $location->get_city(),
+				'state'          => $location->get_state(),
+				'postcode'       => $location->get_postcode(),
+				'country'        => $location->get_country(),
+				'created_at_gmt' => $created,
+				'deleted_at_gmt' => $location->get_date_deleted() ? $location->get_date_deleted() : null,
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( false === $inserted ) {
+			throw new \Exception( esc_html__( 'Failed to create location.', 'woocommerce' ) );
+		}
+
+		$location->set_id( (int) $wpdb->insert_id );
+		$location->apply_changes();
+		$location->set_object_read( true );
+	}
+
+	/**
+	 * Read a location row by id (soft-deleted rows are still readable by id).
+	 *
+	 * @param Location $location Location object.
+	 * @throws \Exception When the row is missing.
+	 */
+	public function read( &$location ): void {
+		global $wpdb;
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d',
+				$this->get_table_name(),
+				$location->get_id()
+			),
+			ARRAY_A
+		);
+
+		if ( ! $row ) {
+			$location->set_id( 0 );
+			throw new \Exception( esc_html__( 'Invalid location.', 'woocommerce' ) );
+		}
+
+		$location->set_props(
+			array(
+				'name'         => $row['name'],
+				'type'         => $row['type'],
+				'address_1'    => $row['address_1'],
+				'address_2'    => $row['address_2'],
+				'city'         => $row['city'],
+				'state'        => $row['state'],
+				'postcode'     => $row['postcode'],
+				'country'      => $row['country'],
+				'date_created' => $row['created_at_gmt'],
+				'date_deleted' => $row['deleted_at_gmt'],
+			)
+		);
+		$location->set_object_read( true );
+	}
+
+	/**
+	 * Update a location row.
+	 *
+	 * @param Location $location Location object.
+	 */
+	public function update( &$location ): void {
+		global $wpdb;
+
+		$wpdb->update(
+			$this->get_table_name(),
+			array(
+				'name'           => $location->get_name(),
+				'type'           => $location->get_type(),
+				'address_1'      => $location->get_address_1(),
+				'address_2'      => $location->get_address_2(),
+				'city'           => $location->get_city(),
+				'state'          => $location->get_state(),
+				'postcode'       => $location->get_postcode(),
+				'country'        => $location->get_country(),
+				'deleted_at_gmt' => $location->get_date_deleted() ? $location->get_date_deleted() : null,
+			),
+			array( 'id' => $location->get_id() ),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ),
+			array( '%d' )
+		);
+
+		$location->apply_changes();
+	}
+
+	/**
+	 * Soft delete a location.
+	 *
+	 * Declares a `bool` return (unlike the brief's `void`) because
+	 * `WC_Object_Data_Store_Interface::delete()` documents a `bool` return;
+	 * a `void` (or undeclared) return trips PHPStan's childReturnType check
+	 * at level 8, and the baseline must not grow to accommodate it.
+	 *
+	 * force_delete is intentionally NOT honored — locations are soft-delete only
+	 * (matching FulfillmentsDataStore).
+	 *
+	 * @param Location $location Location object.
+	 * @param array    $args     Unused. Present to satisfy WC_Object_Data_Store_Interface.
+	 * @return bool True on success, false on failure.
+	 */
+	public function delete( &$location, $args = array() ): bool {
+		global $wpdb;
+
+		$deleted_at = gmdate( 'Y-m-d H:i:s' );
+		$result     = $wpdb->update(
+			$this->get_table_name(),
+			array(
+				'deleted_at_gmt' => $deleted_at,
+			),
+			array( 'id' => $location->get_id() ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$location->set_date_deleted( $deleted_at );
+		$location->apply_changes();
+		return false !== $result;
+	}
+
+	/**
+	 * Whether an active (not soft-deleted) location with this id exists.
+	 *
+	 * @param int $id Location id.
+	 */
+	public function is_active_location( int $id ): bool {
+		global $wpdb;
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT 1 FROM %i WHERE id = %d AND deleted_at_gmt IS NULL LIMIT 1',
+				$this->get_table_name(),
+				$id
+			)
+		);
+	}
+
+	/**
+	 * Get the ids of all active (not soft-deleted) locations.
+	 *
+	 * @return int[]
+	 */
+	public function get_location_ids(): array {
+		global $wpdb;
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT id FROM %i WHERE deleted_at_gmt IS NULL ORDER BY id ASC',
+				$this->get_table_name()
+			)
+		);
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Locations do not support metadata (there is no wc_location_meta table). These override the
+	 * inherited WC_Data_Store_WP meta methods so Location meta can never route to the shared postmeta
+	 * table. If location meta is needed later, add a wc_location_meta table + proper $meta_type/get_db_info
+	 * and remove these no-ops.
+	 */
+
+	/**
+	 * Returns an array of meta for an object.
+	 *
+	 * @param Location $location Location object.
+	 * @return array
+	 */
+	public function read_meta( &$location ): array {
+		return array();
+	}
+
+	/**
+	 * Add new piece of meta.
+	 *
+	 * @param Location  $location Location object.
+	 * @param \stdClass $meta (containing ->key and ->value).
+	 * @return int|false Locations do not support meta; always false.
+	 */
+	public function add_meta( &$location, $meta ) {
+		return false;
+	}
+
+	/**
+	 * Update meta.
+	 *
+	 * @param Location  $location Location object.
+	 * @param \stdClass $meta (containing ->id, ->key and ->value).
+	 */
+	public function update_meta( &$location, $meta ): void {
+	}
+
+	/**
+	 * Deletes meta based on meta ID.
+	 *
+	 * @param Location  $location Location object.
+	 * @param \stdClass $meta (containing at least ->id).
+	 * @return array Locations do not support meta; always empty.
+	 */
+	public function delete_meta( &$location, $meta ): array {
+		return array();
+	}
+}

--- a/plugins/woocommerce/src/Internal/Locations/LocationDataStore.php
+++ b/plugins/woocommerce/src/Internal/Locations/LocationDataStore.php
@@ -33,27 +33,27 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 	public function create( &$location ): void {
 		global $wpdb;
 
-		$created = $location->get_date_created();
-		if ( empty( $created ) ) {
-			$created = gmdate( 'Y-m-d H:i:s' );
-			$location->set_date_created( $created );
+		if ( ! $location->get_date_created() ) {
+			$location->set_date_created( time() );
 		}
+		$location->set_date_modified( time() );
 
 		$inserted = $wpdb->insert(
 			$this->get_table_name(),
 			array(
-				'name'           => $location->get_name(),
-				'type'           => $location->get_type(),
-				'address_1'      => $location->get_address_1(),
-				'address_2'      => $location->get_address_2(),
-				'city'           => $location->get_city(),
-				'state'          => $location->get_state(),
-				'postcode'       => $location->get_postcode(),
-				'country'        => $location->get_country(),
-				'created_at_gmt' => $created,
-				'deleted_at_gmt' => $location->get_date_deleted() ? $location->get_date_deleted() : null,
+				'name'              => $location->get_name(),
+				'type'              => $location->get_type(),
+				'address_1'         => $location->get_address_1(),
+				'address_2'         => $location->get_address_2(),
+				'city'              => $location->get_city(),
+				'state'             => $location->get_state(),
+				'postcode'          => $location->get_postcode(),
+				'country'           => $location->get_country(),
+				'date_created_gmt'  => $this->to_gmt_string( $location->get_date_created() ),
+				'date_modified_gmt' => $this->to_gmt_string( $location->get_date_modified() ),
+				'date_deleted_gmt'  => $this->to_gmt_string( $location->get_date_deleted() ),
 			),
-			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		if ( false === $inserted ) {
@@ -90,16 +90,17 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 
 		$location->set_props(
 			array(
-				'name'         => $row['name'],
-				'type'         => $row['type'],
-				'address_1'    => $row['address_1'],
-				'address_2'    => $row['address_2'],
-				'city'         => $row['city'],
-				'state'        => $row['state'],
-				'postcode'     => $row['postcode'],
-				'country'      => $row['country'],
-				'date_created' => $row['created_at_gmt'],
-				'date_deleted' => $row['deleted_at_gmt'],
+				'name'          => $row['name'],
+				'type'          => $row['type'],
+				'address_1'     => $row['address_1'],
+				'address_2'     => $row['address_2'],
+				'city'          => $row['city'],
+				'state'         => $row['state'],
+				'postcode'      => $row['postcode'],
+				'country'       => $row['country'],
+				'date_created'  => $this->to_utc_timestamp( $row['date_created_gmt'] ),
+				'date_modified' => $this->to_utc_timestamp( $row['date_modified_gmt'] ),
+				'date_deleted'  => $this->to_utc_timestamp( $row['date_deleted_gmt'] ),
 			)
 		);
 		$location->set_object_read( true );
@@ -113,21 +114,24 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 	public function update( &$location ): void {
 		global $wpdb;
 
+		$location->set_date_modified( time() );
+
 		$wpdb->update(
 			$this->get_table_name(),
 			array(
-				'name'           => $location->get_name(),
-				'type'           => $location->get_type(),
-				'address_1'      => $location->get_address_1(),
-				'address_2'      => $location->get_address_2(),
-				'city'           => $location->get_city(),
-				'state'          => $location->get_state(),
-				'postcode'       => $location->get_postcode(),
-				'country'        => $location->get_country(),
-				'deleted_at_gmt' => $location->get_date_deleted() ? $location->get_date_deleted() : null,
+				'name'              => $location->get_name(),
+				'type'              => $location->get_type(),
+				'address_1'         => $location->get_address_1(),
+				'address_2'         => $location->get_address_2(),
+				'city'              => $location->get_city(),
+				'state'             => $location->get_state(),
+				'postcode'          => $location->get_postcode(),
+				'country'           => $location->get_country(),
+				'date_modified_gmt' => $this->to_gmt_string( $location->get_date_modified() ),
+				'date_deleted_gmt'  => $this->to_gmt_string( $location->get_date_deleted() ),
 			),
 			array( 'id' => $location->get_id() ),
-			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' ),
 			array( '%d' )
 		);
 
@@ -135,34 +139,30 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 	}
 
 	/**
-	 * Soft delete a location.
-	 *
-	 * Declares a `bool` return (unlike the brief's `void`) because
-	 * `WC_Object_Data_Store_Interface::delete()` documents a `bool` return;
-	 * a `void` (or undeclared) return trips PHPStan's childReturnType check
-	 * at level 8, and the baseline must not grow to accommodate it.
-	 *
-	 * force_delete is intentionally NOT honored — locations are soft-delete only
-	 * (matching FulfillmentsDataStore).
+	 * Soft-delete a location. force_delete is intentionally ignored; locations are soft-delete only.
 	 *
 	 * @param Location $location Location object.
-	 * @param array    $args     Unused. Present to satisfy WC_Object_Data_Store_Interface.
-	 * @return bool True on success, false on failure.
+	 * @param array    $args     Unused; present for interface compatibility.
+	 * @return bool True on success.
 	 */
 	public function delete( &$location, $args = array() ): bool {
 		global $wpdb;
 
-		$deleted_at = gmdate( 'Y-m-d H:i:s' );
-		$result     = $wpdb->update(
+		$now = time();
+		$location->set_date_deleted( $now );
+		$location->set_date_modified( $now );
+
+		$result = $wpdb->update(
 			$this->get_table_name(),
 			array(
-				'deleted_at_gmt' => $deleted_at,
+				'date_modified_gmt' => $this->to_gmt_string( $location->get_date_modified() ),
+				'date_deleted_gmt'  => $this->to_gmt_string( $location->get_date_deleted() ),
 			),
 			array( 'id' => $location->get_id() ),
-			array( '%s' ),
+			array( '%s', '%s' ),
 			array( '%d' )
 		);
-		$location->set_date_deleted( $deleted_at );
+
 		$location->apply_changes();
 		return false !== $result;
 	}
@@ -176,7 +176,7 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 		global $wpdb;
 		return (bool) $wpdb->get_var(
 			$wpdb->prepare(
-				'SELECT 1 FROM %i WHERE id = %d AND deleted_at_gmt IS NULL LIMIT 1',
+				'SELECT 1 FROM %i WHERE id = %d AND date_deleted_gmt IS NULL LIMIT 1',
 				$this->get_table_name(),
 				$id
 			)
@@ -192,7 +192,7 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 		global $wpdb;
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
-				'SELECT id FROM %i WHERE deleted_at_gmt IS NULL ORDER BY id ASC',
+				'SELECT id FROM %i WHERE date_deleted_gmt IS NULL ORDER BY id ASC',
 				$this->get_table_name()
 			)
 		);
@@ -200,10 +200,30 @@ class LocationDataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Sto
 	}
 
 	/**
-	 * Locations do not support metadata (there is no wc_location_meta table). These override the
-	 * inherited WC_Data_Store_WP meta methods so Location meta can never route to the shared postmeta
-	 * table. If location meta is needed later, add a wc_location_meta table + proper $meta_type/get_db_info
-	 * and remove these no-ops.
+	 * Convert a stored GMT datetime string to a UTC timestamp.
+	 *
+	 * @param string|null $value GMT 'Y-m-d H:i:s' string.
+	 */
+	private function to_utc_timestamp( $value ): ?int {
+		if ( empty( $value ) ) {
+			return null;
+		}
+		$timestamp = wc_string_to_timestamp( (string) $value );
+		return $timestamp ? $timestamp : null;
+	}
+
+	/**
+	 * Format a date prop as a GMT datetime string for storage.
+	 *
+	 * @param \WC_DateTime|null $date Date prop value.
+	 */
+	private function to_gmt_string( $date ): ?string {
+		return $date instanceof \WC_DateTime ? gmdate( 'Y-m-d H:i:s', $date->getTimestamp() ) : null;
+	}
+
+	/*
+	 * Locations have no meta table. These no-ops override WC_Data_Store_WP so Location meta can
+	 * never route to the shared postmeta table. Add a wc_location_meta table here if meta is needed.
 	 */
 
 	/**

--- a/plugins/woocommerce/src/Internal/Locations/LocationsController.php
+++ b/plugins/woocommerce/src/Internal/Locations/LocationsController.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * LocationsController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Locations;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns the wc_locations table and the shared location domain wiring.
+ *
+ * @internal
+ */
+class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatureTablesInstaller {
+
+	public const TABLES_CREATED_OPTION    = 'woocommerce_locations_db_tables_created';
+	public const DEFAULT_LOCATION_TYPE    = 'pos';
+	public const CONSUMER_FILTER          = 'woocommerce_location_feature_consumers';
+	public const DEFAULT_LOCATIONS_OPTION = 'woocommerce_default_locations';
+
+	/**
+	 * Get the wc_locations table name.
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_locations';
+	}
+
+	/**
+	 * Get the CREATE TABLE statement for wc_locations.
+	 */
+	public function get_database_schema(): string {
+		global $wpdb;
+
+		$collate    = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+		$table_name = $this->get_table_name();
+
+		return "CREATE TABLE {$table_name} (
+	id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	name varchar(255) NOT NULL,
+	type varchar(20) NOT NULL,
+	address_1 varchar(255) NOT NULL DEFAULT '',
+	address_2 varchar(255) NOT NULL DEFAULT '',
+	city varchar(100) NOT NULL DEFAULT '',
+	state varchar(100) NOT NULL DEFAULT '',
+	postcode varchar(20) NOT NULL DEFAULT '',
+	country char(2) NOT NULL DEFAULT '',
+	created_at_gmt datetime NOT NULL,
+	deleted_at_gmt datetime NULL DEFAULT NULL,
+	PRIMARY KEY  (id),
+	KEY type (type)
+) ENGINE=InnoDB $collate;";
+	}
+
+	/**
+	 * Register the location data store. Unconditional: the store is harmless dormant
+	 * infrastructure, and the table's existence is the real gate.
+	 *
+	 * @param array $data_stores Registered data stores.
+	 * @return array
+	 */
+	public function register_data_store( $data_stores ) {
+		if ( is_array( $data_stores ) ) {
+			$data_stores['location'] = LocationDataStore::class;
+		}
+		return $data_stores;
+	}
+
+	/**
+	 * Feature ids that consume the locations domain (OR of these = "locations enabled").
+	 *
+	 * @return string[]
+	 */
+	public function get_consumer_feature_ids(): array {
+		/**
+		 * Filters the feature ids that consume the locations domain. The locations
+		 * feature is considered enabled when any one of these feature ids is enabled.
+		 *
+		 * @param string[] $feature_ids Feature ids.
+		 *
+		 * @since 11.0.0
+		 */
+		return (array) apply_filters( self::CONSUMER_FILTER, array() );
+	}
+
+	/**
+	 * Whether any location-consumer feature is enabled.
+	 */
+	public function is_enabled(): bool {
+		foreach ( $this->get_consumer_feature_ids() as $feature_id ) {
+			if ( FeaturesUtil::feature_is_enabled( (string) $feature_id ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the id of the active default location for a type, or 0. Reads the
+	 * woocommerce_default_locations option map and self-heals a dangling entry.
+	 *
+	 * @param string $type Location type.
+	 */
+	public function get_default_location_id( string $type ): int {
+		$map = (array) get_option( self::DEFAULT_LOCATIONS_OPTION, array() );
+		$id  = isset( $map[ $type ] ) ? (int) $map[ $type ] : 0;
+		if ( $id > 0 && ( new LocationDataStore() )->is_active_location( $id ) ) {
+			return $id;
+		}
+		return 0;
+	}
+
+	/**
+	 * Set the default location for a type (one per type, inherently).
+	 *
+	 * @param string $type        Location type.
+	 * @param int    $location_id Location id.
+	 */
+	public function set_default_location( string $type, int $location_id ): void {
+		$map          = (array) get_option( self::DEFAULT_LOCATIONS_OPTION, array() );
+		$map[ $type ] = $location_id;
+		update_option( self::DEFAULT_LOCATIONS_OPTION, $map );
+	}
+
+	/**
+	 * Seed the default pos location if it does not already exist. Idempotent.
+	 *
+	 * Address is an owned one-time default from the structured main-store options
+	 * (the pos location is an independent physical address, not a live mirror of
+	 * store settings, so this snapshot is a starting value, not a synced reference).
+	 */
+	public function maybe_seed_default_location(): void {
+		if ( $this->get_default_location_id( self::DEFAULT_LOCATION_TYPE ) > 0 ) {
+			return;
+		}
+
+		$name = (string) get_option( 'woocommerce_pos_store_name', '' );
+		if ( '' === $name ) {
+			$name = (string) get_bloginfo( 'name' );
+		}
+
+		$base = wc_get_base_location();
+
+		$location = new Location();
+		$location->set_type( self::DEFAULT_LOCATION_TYPE );
+		$location->set_name( $name );
+		$location->set_address_1( (string) get_option( 'woocommerce_store_address', '' ) );
+		$location->set_address_2( (string) get_option( 'woocommerce_store_address_2', '' ) );
+		$location->set_city( (string) get_option( 'woocommerce_store_city', '' ) );
+		$location->set_postcode( (string) get_option( 'woocommerce_store_postcode', '' ) );
+		$location->set_country( (string) ( $base['country'] ?? '' ) );
+		$location->set_state( (string) ( $base['state'] ?? '' ) );
+		$location->save();
+
+		$this->set_default_location( self::DEFAULT_LOCATION_TYPE, $location->get_id() );
+	}
+
+	/**
+	 * The option name latching that the table has been created.
+	 */
+	protected function get_tables_created_option(): string {
+		return self::TABLES_CREATED_OPTION;
+	}
+
+	/**
+	 * Whether a feature-enabled-changed event for $feature_id should trigger install.
+	 *
+	 * @param string $feature_id Feature id.
+	 */
+	protected function handles_feature( string $feature_id ): bool {
+		return in_array( $feature_id, $this->get_consumer_feature_ids(), true );
+	}
+
+	/**
+	 * Seed the default location once the table has been created.
+	 */
+	protected function after_tables_created(): void {
+		$this->maybe_seed_default_location();
+	}
+
+	/**
+	 * Register subclass-specific hooks.
+	 */
+	protected function register_hooks(): void {
+		add_filter( 'woocommerce_data_stores', array( $this, 'register_data_store' ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Locations/LocationsController.php
+++ b/plugins/woocommerce/src/Internal/Locations/LocationsController.php
@@ -19,9 +19,9 @@ defined( 'ABSPATH' ) || exit;
 class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatureTablesInstaller {
 
 	public const TABLES_CREATED_OPTION    = 'woocommerce_locations_db_tables_created';
-	public const POS_LOCATION_TYPE        = 'pos';
 	public const CONSUMER_FILTER          = 'woocommerce_location_feature_consumers';
 	public const DEFAULT_LOCATIONS_OPTION = 'woocommerce_default_locations';
+	public const LOCATIONS_READY_ACTION   = 'woocommerce_locations_ready';
 
 	/**
 	 * Get the wc_locations table name.
@@ -128,37 +128,6 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 	}
 
 	/**
-	 * Seed the default pos location from store settings if none exists. Idempotent.
-	 *
-	 * The address is a one-time snapshot, not a live mirror of store settings.
-	 */
-	public function maybe_seed_default_location(): void {
-		if ( $this->get_default_location_id( self::POS_LOCATION_TYPE ) > 0 ) {
-			return;
-		}
-
-		$name = (string) get_option( 'woocommerce_pos_store_name', '' );
-		if ( '' === $name ) {
-			$name = (string) get_bloginfo( 'name' );
-		}
-
-		$base = wc_get_base_location();
-
-		$location = new Location();
-		$location->set_type( self::POS_LOCATION_TYPE );
-		$location->set_name( $name );
-		$location->set_address_1( (string) get_option( 'woocommerce_store_address', '' ) );
-		$location->set_address_2( (string) get_option( 'woocommerce_store_address_2', '' ) );
-		$location->set_city( (string) get_option( 'woocommerce_store_city', '' ) );
-		$location->set_postcode( (string) get_option( 'woocommerce_store_postcode', '' ) );
-		$location->set_country( (string) ( $base['country'] ?? '' ) );
-		$location->set_state( (string) ( $base['state'] ?? '' ) );
-		$location->save();
-
-		$this->set_default_location( self::POS_LOCATION_TYPE, $location->get_id() );
-	}
-
-	/**
 	 * The option name latching that the table has been created.
 	 */
 	protected function get_tables_created_option(): string {
@@ -175,10 +144,16 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 	}
 
 	/**
-	 * Seed the default location once the table has been created.
+	 * Announce that the locations table is ready so consumers can seed their defaults.
 	 */
 	protected function after_tables_created(): void {
-		$this->maybe_seed_default_location();
+		/**
+		 * Fires once the wc_locations table exists, so location consumers can seed
+		 * their default location(s).
+		 *
+		 * @since 11.0.0
+		 */
+		do_action( self::LOCATIONS_READY_ACTION );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Locations/LocationsController.php
+++ b/plugins/woocommerce/src/Internal/Locations/LocationsController.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatureTablesInstaller {
 
 	public const TABLES_CREATED_OPTION    = 'woocommerce_locations_db_tables_created';
-	public const DEFAULT_LOCATION_TYPE    = 'pos';
+	public const POS_LOCATION_TYPE        = 'pos';
 	public const CONSUMER_FILTER          = 'woocommerce_location_feature_consumers';
 	public const DEFAULT_LOCATIONS_OPTION = 'woocommerce_default_locations';
 
@@ -50,16 +50,16 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 	state varchar(100) NOT NULL DEFAULT '',
 	postcode varchar(20) NOT NULL DEFAULT '',
 	country char(2) NOT NULL DEFAULT '',
-	created_at_gmt datetime NOT NULL,
-	deleted_at_gmt datetime NULL DEFAULT NULL,
+	date_created_gmt datetime NOT NULL,
+	date_modified_gmt datetime NOT NULL,
+	date_deleted_gmt datetime NULL DEFAULT NULL,
 	PRIMARY KEY  (id),
 	KEY type (type)
-) ENGINE=InnoDB $collate;";
+) $collate;";
 	}
 
 	/**
-	 * Register the location data store. Unconditional: the store is harmless dormant
-	 * infrastructure, and the table's existence is the real gate.
+	 * Register the location data store.
 	 *
 	 * @param array $data_stores Registered data stores.
 	 * @return array
@@ -128,14 +128,12 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 	}
 
 	/**
-	 * Seed the default pos location if it does not already exist. Idempotent.
+	 * Seed the default pos location from store settings if none exists. Idempotent.
 	 *
-	 * Address is an owned one-time default from the structured main-store options
-	 * (the pos location is an independent physical address, not a live mirror of
-	 * store settings, so this snapshot is a starting value, not a synced reference).
+	 * The address is a one-time snapshot, not a live mirror of store settings.
 	 */
 	public function maybe_seed_default_location(): void {
-		if ( $this->get_default_location_id( self::DEFAULT_LOCATION_TYPE ) > 0 ) {
+		if ( $this->get_default_location_id( self::POS_LOCATION_TYPE ) > 0 ) {
 			return;
 		}
 
@@ -147,7 +145,7 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 		$base = wc_get_base_location();
 
 		$location = new Location();
-		$location->set_type( self::DEFAULT_LOCATION_TYPE );
+		$location->set_type( self::POS_LOCATION_TYPE );
 		$location->set_name( $name );
 		$location->set_address_1( (string) get_option( 'woocommerce_store_address', '' ) );
 		$location->set_address_2( (string) get_option( 'woocommerce_store_address_2', '' ) );
@@ -157,7 +155,7 @@ class LocationsController extends \Automattic\WooCommerce\Internal\AbstractFeatu
 		$location->set_state( (string) ( $base['state'] ?? '' ) );
 		$location->save();
 
-		$this->set_default_location( self::DEFAULT_LOCATION_TYPE, $location->get_id() );
+		$this->set_default_location( self::POS_LOCATION_TYPE, $location->get_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MultiLocationInventory/PosLocationSeeder.php
+++ b/plugins/woocommerce/src/Internal/MultiLocationInventory/PosLocationSeeder.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PosLocationSeeder class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MultiLocationInventory;
+
+use Automattic\WooCommerce\Internal\Locations\Location;
+use Automattic\WooCommerce\Internal\Locations\LocationsController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Seeds the default pos location from store settings once the locations table is ready.
+ *
+ * @internal
+ */
+class PosLocationSeeder {
+
+	public const POS_LOCATION_TYPE = 'pos';
+
+	/**
+	 * Locations controller.
+	 *
+	 * @var LocationsController
+	 */
+	private $locations_controller;
+
+	/**
+	 * Dependency injection.
+	 *
+	 * @internal
+	 *
+	 * @param LocationsController $locations_controller Locations controller.
+	 */
+	final public function init( LocationsController $locations_controller ): void {
+		$this->locations_controller = $locations_controller;
+	}
+
+	/**
+	 * Register hooks. Called once from the bootstrap.
+	 */
+	public function register(): void {
+		add_action( LocationsController::LOCATIONS_READY_ACTION, array( $this, 'maybe_seed' ) );
+	}
+
+	/**
+	 * Seed the default pos location from store settings, if the inventory feature is on
+	 * and none exists yet. Idempotent.
+	 *
+	 * The address is a one-time snapshot, not a live mirror of store settings.
+	 */
+	public function maybe_seed(): void {
+		if ( ! FeaturesUtil::feature_is_enabled( ProductInventoryController::FEATURE_ID ) ) {
+			return;
+		}
+		if ( $this->locations_controller->get_default_location_id( self::POS_LOCATION_TYPE ) > 0 ) {
+			return;
+		}
+
+		$name = (string) get_option( 'woocommerce_pos_store_name', '' );
+		if ( '' === $name ) {
+			$name = (string) get_bloginfo( 'name' );
+		}
+
+		$base = wc_get_base_location();
+
+		$location = new Location();
+		$location->set_type( self::POS_LOCATION_TYPE );
+		$location->set_name( $name );
+		$location->set_address_1( (string) get_option( 'woocommerce_store_address', '' ) );
+		$location->set_address_2( (string) get_option( 'woocommerce_store_address_2', '' ) );
+		$location->set_city( (string) get_option( 'woocommerce_store_city', '' ) );
+		$location->set_postcode( (string) get_option( 'woocommerce_store_postcode', '' ) );
+		$location->set_country( (string) ( $base['country'] ?? '' ) );
+		$location->set_state( (string) ( $base['state'] ?? '' ) );
+		$location->save();
+
+		$this->locations_controller->set_default_location( self::POS_LOCATION_TYPE, $location->get_id() );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryController.php
+++ b/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryController.php
@@ -47,7 +47,7 @@ class ProductInventoryController extends \Automattic\WooCommerce\Internal\Abstra
 	PRIMARY KEY  (id),
 	UNIQUE KEY product_variation_location (product_id, variation_id, location_id),
 	KEY location (location_id, product_id, variation_id)
-) ENGINE=InnoDB $collate;";
+) $collate;";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryController.php
+++ b/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryController.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * ProductInventoryController class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MultiLocationInventory;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns the wc_product_inventory table; first consumer of the locations domain.
+ *
+ * @internal
+ */
+class ProductInventoryController extends \Automattic\WooCommerce\Internal\AbstractFeatureTablesInstaller {
+
+	public const TABLES_CREATED_OPTION = 'woocommerce_multi_location_inventory_db_tables_created';
+	public const FEATURE_ID            = 'multi_location_inventory';
+
+	/**
+	 * Get the wc_product_inventory table name.
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_product_inventory';
+	}
+
+	/**
+	 * Get the CREATE TABLE statement.
+	 */
+	public function get_database_schema(): string {
+		global $wpdb;
+
+		$collate    = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+		$table_name = $this->get_table_name();
+
+		return "CREATE TABLE {$table_name} (
+	id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	product_id bigint(20) unsigned NOT NULL,
+	variation_id bigint(20) unsigned NOT NULL DEFAULT 0,
+	location_id bigint(20) unsigned NOT NULL,
+	quantity decimal(19,6) NOT NULL DEFAULT 0,
+	PRIMARY KEY  (id),
+	UNIQUE KEY product_variation_location (product_id, variation_id, location_id),
+	KEY location (location_id, product_id, variation_id)
+) ENGINE=InnoDB $collate;";
+	}
+
+	/**
+	 * Whether the inventory feature is enabled.
+	 */
+	public function is_enabled(): bool {
+		return FeaturesUtil::feature_is_enabled( self::FEATURE_ID );
+	}
+
+	/**
+	 * Register this feature as a location consumer.
+	 *
+	 * @param array $ids Consumer feature ids.
+	 * @return array
+	 */
+	public function register_as_location_consumer( $ids ) {
+		if ( is_array( $ids ) ) {
+			$ids[] = self::FEATURE_ID;
+		}
+		return $ids;
+	}
+
+	/**
+	 * The option name latching that the table has been created.
+	 */
+	protected function get_tables_created_option(): string {
+		return self::TABLES_CREATED_OPTION;
+	}
+
+	/**
+	 * Whether a feature-enabled-changed event for $feature_id should trigger install.
+	 *
+	 * @param string $feature_id Feature id.
+	 */
+	protected function handles_feature( string $feature_id ): bool {
+		return self::FEATURE_ID === $feature_id;
+	}
+
+	/**
+	 * Register subclass-specific hooks.
+	 */
+	protected function register_hooks(): void {
+		add_filter( 'woocommerce_location_feature_consumers', array( $this, 'register_as_location_consumer' ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryService.php
+++ b/plugins/woocommerce/src/Internal/MultiLocationInventory/ProductInventoryService.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * ProductInventoryService class file.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\MultiLocationInventory;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Atomic stock ledger over wc_product_inventory. The only writer of that table.
+ *
+ * @internal
+ */
+class ProductInventoryService {
+
+	/**
+	 * Get the wc_product_inventory table name.
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_product_inventory';
+	}
+
+	/**
+	 * Get stock for a (product, variation, location) triple.
+	 *
+	 * @param int $product_id   Product id (parent id for variations).
+	 * @param int $variation_id Variation id, or 0.
+	 * @param int $location_id  Location id.
+	 * @return float The stock quantity.
+	 */
+	public function get_stock( int $product_id, int $variation_id, int $location_id ): float {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+		$quantity   = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT quantity FROM %i WHERE product_id = %d AND variation_id = %d AND location_id = %d',
+				$table_name,
+				$product_id,
+				$variation_id,
+				$location_id
+			)
+		);
+
+		return null === $quantity ? 0.0 : (float) wc_stock_amount( $quantity );
+	}
+
+	/**
+	 * Set (overwrite) stock for a triple. Upserts.
+	 *
+	 * @param int   $product_id   Product id.
+	 * @param int   $variation_id Variation id, or 0.
+	 * @param int   $location_id  Location id.
+	 * @param float $quantity     New quantity.
+	 * @return float The set quantity.
+	 * @throws \Exception When the upsert fails.
+	 */
+	public function set_stock( int $product_id, int $variation_id, int $location_id, float $quantity ): float {
+		global $wpdb;
+
+		$quantity   = (float) wc_stock_amount( $quantity );
+		$table_name = $this->get_table_name();
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'INSERT INTO %i ( product_id, variation_id, location_id, quantity )
+				VALUES ( %d, %d, %d, %f )
+				ON DUPLICATE KEY UPDATE quantity = VALUES( quantity )',
+				$table_name,
+				$product_id,
+				$variation_id,
+				$location_id,
+				$quantity
+			)
+		);
+
+		if ( false === $result ) {
+			throw new \Exception( esc_html__( 'Failed to set product inventory.', 'woocommerce' ) );
+		}
+
+		return $quantity;
+	}
+
+	/**
+	 * Increase stock for a triple. Upserts.
+	 *
+	 * @param int   $product_id   Product id.
+	 * @param int   $variation_id Variation id, or 0.
+	 * @param int   $location_id  Location id.
+	 * @param float $quantity     Amount to add.
+	 * @return float The new quantity.
+	 * @throws \Exception When the upsert fails.
+	 */
+	public function increase_stock( int $product_id, int $variation_id, int $location_id, float $quantity ): float {
+		global $wpdb;
+
+		$quantity = (float) wc_stock_amount( $quantity );
+		if ( $quantity <= 0.0 ) {
+			return $this->get_stock( $product_id, $variation_id, $location_id );
+		}
+
+		$table_name = $this->get_table_name();
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'INSERT INTO %i ( product_id, variation_id, location_id, quantity )
+				VALUES ( %d, %d, %d, %f )
+				ON DUPLICATE KEY UPDATE quantity = quantity + VALUES( quantity )',
+				$table_name,
+				$product_id,
+				$variation_id,
+				$location_id,
+				$quantity
+			)
+		);
+
+		if ( false === $result ) {
+			throw new \Exception( esc_html__( 'Failed to increase product inventory.', 'woocommerce' ) );
+		}
+
+		return $this->get_stock( $product_id, $variation_id, $location_id );
+	}
+
+	/**
+	 * Decrease stock atomically for a triple.
+	 *
+	 * The single UPDATE with `quantity >= n` in the WHERE clause guarantees the quantity
+	 * can never go negative under concurrent writes: the row is only touched when enough
+	 * stock is present, and success is detected via the affected-row count.
+	 *
+	 * @param int   $product_id   Product id.
+	 * @param int   $variation_id Variation id, or 0.
+	 * @param int   $location_id  Location id.
+	 * @param float $quantity     Amount to remove.
+	 * @return float|null The new quantity, or null when the row is missing or stock is insufficient.
+	 * @throws \Exception When the update fails.
+	 */
+	public function decrease_stock( int $product_id, int $variation_id, int $location_id, float $quantity ): ?float {
+		global $wpdb;
+
+		$quantity = (float) wc_stock_amount( $quantity );
+		if ( $quantity <= 0.0 ) {
+			return $this->get_stock( $product_id, $variation_id, $location_id );
+		}
+
+		$table_name = $this->get_table_name();
+		$updated    = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i
+				SET quantity = quantity - %f
+				WHERE product_id = %d AND variation_id = %d AND location_id = %d AND quantity >= %f',
+				$table_name,
+				$quantity,
+				$product_id,
+				$variation_id,
+				$location_id,
+				$quantity
+			)
+		);
+
+		if ( false === $updated ) {
+			throw new \Exception( esc_html__( 'Failed to update product inventory.', 'woocommerce' ) );
+		}
+
+		if ( 1 !== $updated ) {
+			return null;
+		}
+
+		return $this->get_stock( $product_id, $variation_id, $location_id );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Locations/LocationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Locations/LocationTest.php
@@ -75,6 +75,21 @@ class LocationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Dates round-trip as WC_DateTime objects and date_modified is populated on save.
+	 */
+	public function test_dates_round_trip_as_wc_datetime(): void {
+		$location = new Location();
+		$location->set_name( 'Dated' );
+		$location->set_type( 'pos' );
+		$location->save();
+
+		$read = new Location( $location->get_id() );
+		$this->assertInstanceOf( \WC_DateTime::class, $read->get_date_created() );
+		$this->assertInstanceOf( \WC_DateTime::class, $read->get_date_modified() );
+		$this->assertNull( $read->get_date_deleted() );
+	}
+
+	/**
 	 * @testdox get_location_ids() returns active ids and excludes soft-deleted ones.
 	 */
 	public function test_get_location_ids_excludes_soft_deleted(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Locations/LocationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Locations/LocationTest.php
@@ -1,0 +1,98 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Locations;
+
+use Automattic\WooCommerce\Internal\Locations\Location;
+use Automattic\WooCommerce\Internal\Locations\LocationDataStore;
+use Automattic\WooCommerce\Internal\Locations\LocationsController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Location WC_Data object and its data store.
+ */
+class LocationTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up fixtures shared by the whole test class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		$controller = wc_get_container()->get( LocationsController::class );
+		// Registers the 'location' data store filter.
+		$controller->register();
+		// DDL must run outside the per-test transaction.
+		$controller->create_tables();
+	}
+
+	/**
+	 * @testdox A Location round-trips through create, read-by-id, and update.
+	 */
+	public function test_location_create_read_update_round_trip(): void {
+		$location = new Location();
+		$location->set_name( 'Warehouse One' );
+		$location->set_type( 'pos' );
+		$location->set_city( 'Leeds' );
+		$location->save();
+
+		$id = $location->get_id();
+		$this->assertGreaterThan( 0, $id );
+
+		$read = new Location( $id );
+		$this->assertEquals( 'Warehouse One', $read->get_name() );
+		$this->assertEquals( 'pos', $read->get_type() );
+		$this->assertEquals( 'Leeds', $read->get_city() );
+
+		$read->set_name( 'Renamed' );
+		$read->save();
+		$this->assertEquals( 'Renamed', ( new Location( $id ) )->get_name() );
+	}
+
+	/**
+	 * @testdox set_type() rejects a value outside the allowlist.
+	 */
+	public function test_set_type_rejects_invalid_value(): void {
+		$location = new Location();
+		$this->expectException( \WC_Data_Exception::class );
+		$location->set_type( 'warehouse' );
+	}
+
+	/**
+	 * @testdox delete() soft-deletes: the row keeps its data and sets date_deleted.
+	 */
+	public function test_delete_is_soft(): void {
+		$location = new Location();
+		$location->set_name( 'To Delete' );
+		$location->set_type( 'pos' );
+		$location->save();
+		$id = $location->get_id();
+
+		$location->delete();
+
+		$reloaded = new Location( $id );
+		$this->assertEquals( 'To Delete', $reloaded->get_name(), 'Row must still exist after soft delete.' );
+		$this->assertNotEmpty( $reloaded->get_date_deleted(), 'date_deleted must be set.' );
+	}
+
+	/**
+	 * @testdox get_location_ids() returns active ids and excludes soft-deleted ones.
+	 */
+	public function test_get_location_ids_excludes_soft_deleted(): void {
+		$data_store = new LocationDataStore();
+
+		$kept = new Location();
+		$kept->set_name( 'Kept' );
+		$kept->set_type( 'pos' );
+		$kept->save();
+
+		$removed = new Location();
+		$removed->set_name( 'Removed' );
+		$removed->set_type( 'pos' );
+		$removed->save();
+		$removed->delete();
+
+		$ids = $data_store->get_location_ids();
+		$this->assertContains( $kept->get_id(), $ids );
+		$this->assertNotContains( $removed->get_id(), $ids );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
@@ -1,0 +1,223 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Locations;
+
+use Automattic\WooCommerce\Internal\Locations\Location;
+use Automattic\WooCommerce\Internal\Locations\LocationsController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for LocationsController.
+ */
+class LocationsControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var LocationsController
+	 */
+	private $sut;
+
+	/**
+	 * Set up fixtures shared by the whole test class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		$controller = wc_get_container()->get( LocationsController::class );
+		// Registers the 'location' data store filter.
+		$controller->register();
+		// DDL outside the per-test transaction.
+		$controller->create_tables();
+	}
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( LocationsController::class );
+	}
+
+	/**
+	 * @testdox create_tables() creates wc_locations as InnoDB (without is_default) with a key on type.
+	 */
+	public function test_create_tables_creates_innodb_table_with_type_key(): void {
+		global $wpdb;
+
+		$this->assertTrue( $this->sut->tables_exist(), 'wc_locations should exist after creation.' );
+
+		$engine = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+				$this->sut->get_table_name()
+			)
+		);
+		$this->assertEquals( 'InnoDB', $engine, 'Table engine must be InnoDB.' );
+
+		$create_sql = $wpdb->get_var( $wpdb->prepare( 'SHOW CREATE TABLE %i', $this->sut->get_table_name() ), 1 );
+		$this->assertStringNotContainsString( '`is_default`', $create_sql, 'is_default column must not exist.' );
+		$this->assertStringContainsString( 'KEY `type`', $create_sql, 'There must be a key on type.' );
+		$this->assertStringContainsString( '`deleted_at_gmt`', $create_sql, 'Soft-delete column must exist.' );
+	}
+
+	/**
+	 * @testdox maybe_seed_default_location() creates a single pos location from store settings.
+	 */
+	public function test_seed_creates_single_pos_location_from_store_settings(): void {
+		update_option( 'woocommerce_store_address', '123 Test St' );
+		update_option( 'woocommerce_store_city', 'Testville' );
+		update_option( 'woocommerce_store_postcode', 'TS1 1AA' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		update_option( 'woocommerce_pos_store_name', 'My POS' );
+
+		$this->sut->maybe_seed_default_location();
+
+		$id = $this->sut->get_default_location_id( 'pos' );
+		$this->assertGreaterThan( 0, $id );
+
+		$location = new Location( $id );
+		$this->assertEquals( 'pos', $location->get_type() );
+		$this->assertEquals( 'My POS', $location->get_name() );
+		$this->assertEquals( '123 Test St', $location->get_address_1() );
+		$this->assertEquals( 'Testville', $location->get_city() );
+		$this->assertEquals( 'GB', $location->get_country() );
+	}
+
+	/**
+	 * @testdox maybe_seed_default_location() is idempotent.
+	 */
+	public function test_seed_is_idempotent(): void {
+		global $wpdb;
+
+		$this->sut->maybe_seed_default_location();
+		$this->sut->maybe_seed_default_location();
+
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE type = %s', $this->sut->get_table_name(), 'pos' )
+		);
+		$this->assertEquals( 1, $count );
+	}
+
+	/**
+	 * @testdox set_default_location() then get_default_location_id() returns the location that was set.
+	 */
+	public function test_set_default_location_then_get_returns_it(): void {
+		$location = new Location();
+		$location->set_name( 'Manually Set Default' );
+		$location->set_type( 'pos' );
+		$location->save();
+
+		$this->sut->set_default_location( 'pos', $location->get_id() );
+
+		$this->assertSame( $location->get_id(), $this->sut->get_default_location_id( 'pos' ) );
+	}
+
+	/**
+	 * @testdox get_default_location_id() returns 0 and self-heals when the mapped location is soft-deleted.
+	 */
+	public function test_get_default_location_id_self_heals_dangling_entry(): void {
+		$location = new Location();
+		$location->set_name( 'Dangling Default' );
+		$location->set_type( 'pos' );
+		$location->save();
+
+		$this->sut->set_default_location( 'pos', $location->get_id() );
+		$location->delete();
+
+		$this->assertSame( 0, $this->sut->get_default_location_id( 'pos' ), 'A soft-deleted default must not be discoverable.' );
+	}
+
+	/**
+	 * @testdox is_enabled() is true only when a registered consumer feature is on.
+	 */
+	public function test_is_enabled_tracks_consumer_features(): void {
+		add_filter(
+			'woocommerce_location_feature_consumers',
+			static function ( $ids ) {
+				$ids[] = 'multi_location_inventory';
+				return $ids;
+			}
+		);
+
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'no' );
+		$this->assertFalse( $this->sut->is_enabled() );
+
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
+		$this->assertTrue( $this->sut->is_enabled() );
+	}
+
+	/**
+	 * @testdox Enabling a consumer feature installs and seeds the default location.
+	 */
+	public function test_on_feature_enabled_changed_installs_when_enabled(): void {
+		add_filter(
+			'woocommerce_location_feature_consumers',
+			static function ( $ids ) {
+				$ids[] = 'multi_location_inventory';
+				return $ids;
+			}
+		);
+		delete_option( LocationsController::TABLES_CREATED_OPTION );
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
+
+		// Idempotent explicit call: once the bootstrap wires the listener, the option
+		// write above also auto-fires this handler via FeaturesController.
+		$this->sut->on_feature_enabled_changed( 'multi_location_inventory', true );
+
+		$this->assertEquals( 'yes', get_option( LocationsController::TABLES_CREATED_OPTION ) );
+		$this->assertGreaterThan( 0, $this->sut->get_default_location_id( 'pos' ) );
+	}
+
+	/**
+	 * @testdox on_feature_enabled_changed is a no-op when disabled or for a non-consumer feature.
+	 */
+	public function test_on_feature_enabled_changed_is_noop_when_disabled_or_other_feature(): void {
+		add_filter(
+			'woocommerce_location_feature_consumers',
+			static function ( $ids ) {
+				$ids[] = 'multi_location_inventory';
+				return $ids;
+			}
+		);
+		delete_option( LocationsController::TABLES_CREATED_OPTION );
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'no' );
+
+		// Disabled transition is a no-op.
+		$this->sut->on_feature_enabled_changed( 'multi_location_inventory', false );
+		// Non-consumer feature is a no-op.
+		$this->sut->on_feature_enabled_changed( 'some_other_feature', true );
+
+		$this->assertFalse( (bool) get_option( LocationsController::TABLES_CREATED_OPTION ) );
+	}
+
+	/**
+	 * @testdox add_table_to_install_list() registers wc_locations for uninstall.
+	 */
+	public function test_add_table_to_install_list(): void {
+		$tables = $this->sut->add_table_to_install_list( array() );
+		$this->assertContains( $this->sut->get_table_name(), $tables );
+	}
+
+	/**
+	 * @testdox The bootstrap registers the location data store and the inventory consumer.
+	 */
+	public function test_bootstrap_wires_controllers(): void {
+		/**
+		 * Filters the feature ids that consume the locations domain. Defined in
+		 * LocationsController::get_consumer_feature_ids().
+		 *
+		 * @since 11.0.0
+		 */
+		$consumers = apply_filters( 'woocommerce_location_feature_consumers', array() );
+		$this->assertContains( 'multi_location_inventory', $consumers, 'Inventory must self-register as a consumer.' );
+
+		/**
+		 * Filters the registered WC_Data_Store classes. Defined in WC_Data_Store::__construct().
+		 *
+		 * @since 11.0.0
+		 */
+		$stores = apply_filters( 'woocommerce_data_stores', array() );
+		$this->assertArrayHasKey( 'location', $stores, 'Location data store must be registered.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
@@ -55,44 +55,6 @@ class LocationsControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox maybe_seed_default_location() creates a single pos location from store settings.
-	 */
-	public function test_seed_creates_single_pos_location_from_store_settings(): void {
-		update_option( 'woocommerce_store_address', '123 Test St' );
-		update_option( 'woocommerce_store_city', 'Testville' );
-		update_option( 'woocommerce_store_postcode', 'TS1 1AA' );
-		update_option( 'woocommerce_default_country', 'GB' );
-		update_option( 'woocommerce_pos_store_name', 'My POS' );
-
-		$this->sut->maybe_seed_default_location();
-
-		$id = $this->sut->get_default_location_id( 'pos' );
-		$this->assertGreaterThan( 0, $id );
-
-		$location = new Location( $id );
-		$this->assertEquals( 'pos', $location->get_type() );
-		$this->assertEquals( 'My POS', $location->get_name() );
-		$this->assertEquals( '123 Test St', $location->get_address_1() );
-		$this->assertEquals( 'Testville', $location->get_city() );
-		$this->assertEquals( 'GB', $location->get_country() );
-	}
-
-	/**
-	 * @testdox maybe_seed_default_location() is idempotent.
-	 */
-	public function test_seed_is_idempotent(): void {
-		global $wpdb;
-
-		$this->sut->maybe_seed_default_location();
-		$this->sut->maybe_seed_default_location();
-
-		$count = (int) $wpdb->get_var(
-			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE type = %s', $this->sut->get_table_name(), 'pos' )
-		);
-		$this->assertEquals( 1, $count );
-	}
-
-	/**
 	 * @testdox set_default_location() then get_default_location_id() returns the location that was set.
 	 */
 	public function test_set_default_location_then_get_returns_it(): void {
@@ -141,9 +103,9 @@ class LocationsControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Enabling a consumer feature installs and seeds the default location.
+	 * @testdox Enabling a consumer feature installs the table and announces locations are ready.
 	 */
-	public function test_on_feature_enabled_changed_installs_when_enabled(): void {
+	public function test_on_feature_enabled_changed_installs_and_announces(): void {
 		add_filter(
 			'woocommerce_location_feature_consumers',
 			static function ( $ids ) {
@@ -152,14 +114,20 @@ class LocationsControllerTest extends WC_Unit_Test_Case {
 			}
 		);
 		delete_option( LocationsController::TABLES_CREATED_OPTION );
-		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
 
-		// Idempotent explicit call: once the bootstrap wires the listener, the option
-		// write above also auto-fires this handler via FeaturesController.
+		$fired = false;
+		add_action(
+			LocationsController::LOCATIONS_READY_ACTION,
+			static function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
 		$this->sut->on_feature_enabled_changed( 'multi_location_inventory', true );
 
 		$this->assertEquals( 'yes', get_option( LocationsController::TABLES_CREATED_OPTION ) );
-		$this->assertGreaterThan( 0, $this->sut->get_default_location_id( 'pos' ) );
+		$this->assertTrue( $fired, 'Enabling a consumer must announce that locations are ready.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Locations/LocationsControllerTest.php
@@ -40,25 +40,18 @@ class LocationsControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox create_tables() creates wc_locations as InnoDB (without is_default) with a key on type.
+	 * @testdox create_tables() creates wc_locations (without is_default) with a key on type.
 	 */
-	public function test_create_tables_creates_innodb_table_with_type_key(): void {
+	public function test_create_tables_creates_table_with_type_key(): void {
 		global $wpdb;
 
 		$this->assertTrue( $this->sut->tables_exist(), 'wc_locations should exist after creation.' );
 
-		$engine = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
-				$this->sut->get_table_name()
-			)
-		);
-		$this->assertEquals( 'InnoDB', $engine, 'Table engine must be InnoDB.' );
-
 		$create_sql = $wpdb->get_var( $wpdb->prepare( 'SHOW CREATE TABLE %i', $this->sut->get_table_name() ), 1 );
 		$this->assertStringNotContainsString( '`is_default`', $create_sql, 'is_default column must not exist.' );
 		$this->assertStringContainsString( 'KEY `type`', $create_sql, 'There must be a key on type.' );
-		$this->assertStringContainsString( '`deleted_at_gmt`', $create_sql, 'Soft-delete column must exist.' );
+		$this->assertStringContainsString( '`date_deleted_gmt`', $create_sql, 'Soft-delete column must exist.' );
+		$this->assertStringContainsString( '`date_modified_gmt`', $create_sql, 'Modified column must exist.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/PosLocationSeederTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/PosLocationSeederTest.php
@@ -1,0 +1,119 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MultiLocationInventory;
+
+use Automattic\WooCommerce\Internal\Locations\Location;
+use Automattic\WooCommerce\Internal\Locations\LocationsController;
+use Automattic\WooCommerce\Internal\MultiLocationInventory\PosLocationSeeder;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for PosLocationSeeder.
+ */
+class PosLocationSeederTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var PosLocationSeeder
+	 */
+	private $sut;
+
+	/**
+	 * Locations controller.
+	 *
+	 * @var LocationsController
+	 */
+	private $locations_controller;
+
+	/**
+	 * Set up fixtures shared by the whole test class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		$controller = wc_get_container()->get( LocationsController::class );
+		// Registers the 'location' data store filter.
+		$controller->register();
+		// DDL outside the per-test transaction.
+		$controller->create_tables();
+	}
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->locations_controller = wc_get_container()->get( LocationsController::class );
+		$this->sut                  = wc_get_container()->get( PosLocationSeeder::class );
+		// Isolate the SUT: detach the bootstrap-registered listener so toggling the feature option
+		// below does not auto-seed. These tests drive maybe_seed() explicitly.
+		remove_all_actions( LocationsController::LOCATIONS_READY_ACTION );
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
+	}
+
+	/**
+	 * @testdox maybe_seed() creates a single pos location from store settings.
+	 */
+	public function test_seed_creates_single_pos_location_from_store_settings(): void {
+		update_option( 'woocommerce_store_address', '123 Test St' );
+		update_option( 'woocommerce_store_city', 'Testville' );
+		update_option( 'woocommerce_store_postcode', 'TS1 1AA' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		update_option( 'woocommerce_pos_store_name', 'My POS' );
+
+		$this->sut->maybe_seed();
+
+		$id = $this->locations_controller->get_default_location_id( 'pos' );
+		$this->assertGreaterThan( 0, $id );
+
+		$location = new Location( $id );
+		$this->assertEquals( 'pos', $location->get_type() );
+		$this->assertEquals( 'My POS', $location->get_name() );
+		$this->assertEquals( '123 Test St', $location->get_address_1() );
+		$this->assertEquals( 'Testville', $location->get_city() );
+		$this->assertEquals( 'GB', $location->get_country() );
+	}
+
+	/**
+	 * @testdox maybe_seed() is idempotent.
+	 */
+	public function test_seed_is_idempotent(): void {
+		global $wpdb;
+
+		$this->sut->maybe_seed();
+		$this->sut->maybe_seed();
+
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE type = %s', $this->locations_controller->get_table_name(), 'pos' )
+		);
+		$this->assertEquals( 1, $count );
+	}
+
+	/**
+	 * @testdox maybe_seed() does nothing when the inventory feature is disabled.
+	 */
+	public function test_seed_skipped_when_feature_disabled(): void {
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'no' );
+
+		$this->sut->maybe_seed();
+
+		$this->assertSame( 0, $this->locations_controller->get_default_location_id( 'pos' ) );
+	}
+
+	/**
+	 * @testdox The locations-ready action triggers seeding.
+	 */
+	public function test_locations_ready_action_triggers_seed(): void {
+		$this->sut->register();
+
+		/**
+		 * Fires when the wc_locations table is ready. Defined in LocationsController.
+		 *
+		 * @since 11.0.0
+		 */
+		do_action( LocationsController::LOCATIONS_READY_ACTION );
+
+		$this->assertGreaterThan( 0, $this->locations_controller->get_default_location_id( 'pos' ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MultiLocationInventory;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\MultiLocationInventory\ProductInventoryController;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for multi-location inventory feature registration and controller wiring.
+ */
+class ProductInventoryControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up fixtures shared by all tests in this class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		wc_get_container()->get( ProductInventoryController::class )->create_tables();
+	}
+
+	/**
+	 * @testdox multi_location_inventory feature is registered, non-experimental, and off by default.
+	 */
+	public function test_feature_is_registered_non_experimental_and_off_by_default(): void {
+		$controller = wc_get_container()->get( FeaturesController::class );
+		$definition = $controller->get_feature_definition( 'multi_location_inventory' );
+
+		$this->assertIsArray( $definition, 'Feature definition should be registered.' );
+		$this->assertFalse( (bool) $definition['is_experimental'], 'Feature must not be experimental.' );
+		$this->assertTrue( (bool) $definition['disable_ui'], 'Feature must hide its Features-screen UI.' );
+		$this->assertFalse( $controller->feature_is_enabled( 'multi_location_inventory' ), 'Feature must be off by default.' );
+	}
+
+	/**
+	 * @testdox create_tables() creates wc_product_inventory as InnoDB with the unique triple key.
+	 */
+	public function test_create_tables_creates_innodb_table_with_unique_triple(): void {
+		global $wpdb;
+
+		$controller = wc_get_container()->get( ProductInventoryController::class );
+		$controller->create_tables();
+
+		$this->assertTrue( $controller->tables_exist() );
+
+		$engine = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+				$controller->get_table_name()
+			)
+		);
+		$this->assertEquals( 'InnoDB', $engine );
+
+		$create_sql = $wpdb->get_var( $wpdb->prepare( 'SHOW CREATE TABLE %i', $controller->get_table_name() ), 1 );
+		$this->assertStringContainsString( 'UNIQUE KEY', $create_sql );
+		$this->assertStringContainsString( 'product_variation_location', $create_sql );
+	}
+
+	/**
+	 * @testdox It registers multi_location_inventory as a location consumer.
+	 */
+	public function test_registers_as_location_consumer(): void {
+		$controller = wc_get_container()->get( ProductInventoryController::class );
+		$ids        = $controller->register_as_location_consumer( array() );
+		$this->assertContains( 'multi_location_inventory', $ids );
+	}
+
+	/**
+	 * @testdox Enabling this feature installs the inventory table (latch set).
+	 */
+	public function test_on_feature_enabled_changed_installs_for_this_feature(): void {
+		$controller = wc_get_container()->get( ProductInventoryController::class );
+		delete_option( ProductInventoryController::TABLES_CREATED_OPTION );
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'yes' );
+
+		// Idempotent explicit call (post-bootstrap the option write above also auto-fires this).
+		$controller->on_feature_enabled_changed( 'multi_location_inventory', true );
+
+		$this->assertEquals( 'yes', get_option( ProductInventoryController::TABLES_CREATED_OPTION ) );
+	}
+
+	/**
+	 * @testdox on_feature_enabled_changed ignores unrelated features.
+	 */
+	public function test_on_feature_enabled_changed_ignores_other_features(): void {
+		$controller = wc_get_container()->get( ProductInventoryController::class );
+		delete_option( ProductInventoryController::TABLES_CREATED_OPTION );
+		update_option( 'woocommerce_feature_multi_location_inventory_enabled', 'no' );
+
+		$controller->on_feature_enabled_changed( 'some_other_feature', true );
+
+		$this->assertFalse( (bool) get_option( ProductInventoryController::TABLES_CREATED_OPTION ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryControllerTest.php
@@ -34,23 +34,15 @@ class ProductInventoryControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox create_tables() creates wc_product_inventory as InnoDB with the unique triple key.
+	 * @testdox create_tables() creates wc_product_inventory with the unique triple key.
 	 */
-	public function test_create_tables_creates_innodb_table_with_unique_triple(): void {
+	public function test_create_tables_creates_table_with_unique_triple(): void {
 		global $wpdb;
 
 		$controller = wc_get_container()->get( ProductInventoryController::class );
 		$controller->create_tables();
 
 		$this->assertTrue( $controller->tables_exist() );
-
-		$engine = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
-				$controller->get_table_name()
-			)
-		);
-		$this->assertEquals( 'InnoDB', $engine );
 
 		$create_sql = $wpdb->get_var( $wpdb->prepare( 'SHOW CREATE TABLE %i', $controller->get_table_name() ), 1 );
 		$this->assertStringContainsString( 'UNIQUE KEY', $create_sql );

--- a/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MultiLocationInventory/ProductInventoryServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\MultiLocationInventory;
+
+use Automattic\WooCommerce\Internal\MultiLocationInventory\ProductInventoryController;
+use Automattic\WooCommerce\Internal\MultiLocationInventory\ProductInventoryService;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductInventoryService atomic ledger.
+ */
+class ProductInventoryServiceTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ProductInventoryService
+	 */
+	private $sut;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		wc_get_container()->get( ProductInventoryController::class )->create_tables();
+	}
+
+	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = wc_get_container()->get( ProductInventoryService::class );
+	}
+
+	/**
+	 * @testdox set_stock() then get_stock() returns the set quantity.
+	 */
+	public function test_set_and_get_stock(): void {
+		$this->sut->set_stock( 10, 0, 1, 25.0 );
+		$this->assertEquals( 25.0, $this->sut->get_stock( 10, 0, 1 ) );
+	}
+
+	/**
+	 * @testdox get_stock() returns 0 for an unknown triple.
+	 */
+	public function test_get_stock_unknown_is_zero(): void {
+		$this->assertEquals( 0.0, $this->sut->get_stock( 999, 0, 1 ) );
+	}
+
+	/**
+	 * @testdox increase_stock() adds to the existing quantity.
+	 */
+	public function test_increase_stock_adds(): void {
+		$this->sut->set_stock( 10, 0, 1, 5.0 );
+		$this->assertEquals( 8.0, $this->sut->increase_stock( 10, 0, 1, 3.0 ) );
+	}
+
+	/**
+	 * @testdox set_stock() upserts — one row per (product, variation, location) triple.
+	 */
+	public function test_set_stock_upsert_no_duplicate_rows(): void {
+		global $wpdb;
+		$this->sut->set_stock( 10, 0, 1, 5.0 );
+		$this->sut->set_stock( 10, 0, 1, 7.0 );
+
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE product_id = 10 AND variation_id = 0 AND location_id = 1',
+				$this->sut->get_table_name()
+			)
+		);
+		$this->assertEquals( 1, $count );
+		$this->assertEquals( 7.0, $this->sut->get_stock( 10, 0, 1 ) );
+	}
+
+	/**
+	 * @testdox Variation and simple/parent keys are stored as distinct rows.
+	 */
+	public function test_variation_and_simple_keying_distinct(): void {
+		$this->sut->set_stock( 10, 0, 1, 5.0 );
+		$this->sut->set_stock( 10, 55, 1, 8.0 );
+		$this->assertEquals( 5.0, $this->sut->get_stock( 10, 0, 1 ) );
+		$this->assertEquals( 8.0, $this->sut->get_stock( 10, 55, 1 ) );
+	}
+
+	/**
+	 * @testdox decrease_stock() reduces the quantity and returns the new value.
+	 */
+	public function test_decrease_stock_success(): void {
+		$this->sut->set_stock( 10, 0, 1, 5.0 );
+		$this->assertEquals( 2.0, $this->sut->decrease_stock( 10, 0, 1, 3.0 ) );
+	}
+
+	/**
+	 * @testdox decrease_stock() returns null and leaves the row unchanged when insufficient.
+	 */
+	public function test_decrease_stock_insufficient_returns_null_unchanged(): void {
+		$this->sut->set_stock( 10, 0, 1, 2.0 );
+		$this->assertNull( $this->sut->decrease_stock( 10, 0, 1, 5.0 ) );
+		$this->assertEquals( 2.0, $this->sut->get_stock( 10, 0, 1 ), 'Row must be unchanged after a failed decrement.' );
+	}
+
+	/**
+	 * @testdox decrease_stock() returns null for an unknown triple.
+	 */
+	public function test_decrease_stock_unknown_returns_null(): void {
+		$this->assertNull( $this->sut->decrease_stock( 999, 0, 1, 1.0 ) );
+	}
+
+	/**
+	 * @testdox Repeated decrements can never drive stock negative.
+	 */
+	public function test_decrease_never_negative(): void {
+		$this->sut->set_stock( 10, 0, 1, 3.0 );
+		$this->assertEquals( 0.0, $this->sut->decrease_stock( 10, 0, 1, 3.0 ) );
+		$this->assertNull( $this->sut->decrease_stock( 10, 0, 1, 1.0 ) );
+		$this->assertEquals( 0.0, $this->sut->get_stock( 10, 0, 1 ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for security best practices (all queries parameterized via `$wpdb->prepare` / `%i`).

### Changes proposed in this Pull Request

Foundation ticket for **Woo POS: Multi-location — Milestone 1**: the **data model only**. Linear: [WOOMOB-3405](https://linear.app/a8c/issue/WOOMOB-3405)

Everything is behind the new **`multi_location_inventory`** feature flag (off by default, with no UI to turn it on. It can only be toggled programmatically, as there's no merchant-facing behaviour yet. We'll add the UI toggle when it's useful for merchants).

Note that through M1 and M2, web stock will remain in its existing `_stock` meta and reservations table. POS will not interact with either, to remove any risk to the web checkout flow.

**Adds:**

- **Two custom tables, only created when the feature is enabled**
  - `wc_locations` — locations.
  - `wc_product_inventory` — per-location stock ledger.
- **`Location` (`WC_Data`) + `LocationDataStore`** — custom-table CRUD, soft delete, no meta (yet).
- **`ProductInventoryService`** — atomic stock ledger; `decrease_stock()` is a single guarded `UPDATE … WHERE quantity >= n`, so POS stock can never go negative.
- **`AbstractFeatureTablesInstaller`** — shared create-on-enable, makes the tables when the `woocommerce_feature_enabled_changed` event fires, used by both controllers.
- **Seeds a default `pos` location** from the store settings on first enable.

**Design decisions worth a look:**

- **"Locations enabled" is derived** — the OR of registered consumer features (`woocommerce_location_feature_consumers`). Right now that's only location inventory, but there are other potential uses of locations so this is to ensure the location table can be enabled by more than one independent feature.
- **The default location per type lives in the `woocommerce_default_locations` option map** (the `default_product_cat` pattern), not the locations table. (An `is_default` column was considered, both app- and DB-enforced; I chose the option map because of the existing pattern, "defaultness" not seeming like a property of a location, and to avoid uniqueness wrangling in the DB. What do you think of this approach? Would you prefer it were on the table itself?)
- **`force_delete` is intentionally soft-only** for locations (matches `FulfillmentsDataStore`).
- **Create-on-enable, not always-create** — the Fulfillments (PR #59148) approach, as agreed in P2; this avoids creating tables on every install before it's in wide use, since POS is still quite small.
- **POS Address seeded from main setting** — I'm not sure about this. The default POS address is taken from the main WooCommerce address setting, because the POS one is an unstructured text field and I don't want to parse that here. When we start adding UI, we can add something for the people who have set a POS address already to use that as the seed and confirm it – we'll also supersede the POS address form with this work. I chose to use the main store address as the right option for new POS users into the future, not existing POS users, and because of the practical issues of parsing the free-text address.

### Backward compatibility

All new symbols live in `Internal`. New observable surfaces: `Location extends \WC_Data` and `LocationDataStore implements \WC_Object_Data_Store_Interface`. No backcompat impact, as it's new code.

### Screenshots or screen recordings

N/A — no UI in M1 (the flag is `disable_ui`).

### How to test the changes in this Pull Request

1. Confirm the feature is off and hidden (it does not appear on Settings → Advanced → Features), and no tables exist: `wp db query "SHOW TABLES LIKE '%wc_locations%'"` → empty.
2. Set a store address (Settings → General) and a POS store name (Settings → Point of Sale), then enable: `wp option update woocommerce_feature_multi_location_inventory_enabled yes`.
3. Verify both tables exist (InnoDB), a single `pos` row carries the store address, and `wp option get woocommerce_default_locations --format=json` → `{"pos": <id>}`.
4. Exercise the stock ledger via `wp eval` on `ProductInventoryService` — `set_stock` / `get_stock` / `decrease_stock`; a decrement below zero returns `null` and leaves stock unchanged (never negative).
5. Disable → tables and data persist (dormant). Uninstall with `WC_REMOVE_ALL_DATA` drops them.

### Testing that has already taken place

- 28 new PHPUnit tests / 57 assertions (`LocationTest`, `LocationsControllerTest`, `ProductInventoryServiceTest`, `ProductInventoryControllerTest`) — all passing.
- `phpcs` clean on all touched files; `phpstan` (level 8) clean, baseline untouched; branch lint clean.
- Local wp-env smoke test: enable → tables created + `pos` seeded from the store address → atomic decrement verified → disable persists.


```


woocommerce % pnpm exec wp-env run cli wp option update woocommerce_feature_multi_location_inventory_enabled yes
ℹ Starting 'wp option update woocommerce_feature_multi_location_inventory_enabled yes' on the cli container.

Success: Updated 'woocommerce_feature_multi_location_inventory_enabled' option.
✔ Ran `wp option update woocommerce_feature_multi_location_inventory_enabled yes` in 'cli'. (in 0s 992ms)


woocommerce % pnpm exec wp-env run cli wp db query "SHOW CREATE TABLE wp_wc_locations\G"
ℹ Starting 'wp db query SHOW CREATE TABLE wp_wc_locations\G' on the cli container.

*************************** 1. row ***************************
       Table: wp_wc_locations
Create Table: CREATE TABLE `wp_wc_locations` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(255) NOT NULL,
  `type` varchar(20) NOT NULL,
  `address_1` varchar(255) NOT NULL DEFAULT '',
  `address_2` varchar(255) NOT NULL DEFAULT '',
  `city` varchar(100) NOT NULL DEFAULT '',
  `state` varchar(100) NOT NULL DEFAULT '',
  `postcode` varchar(20) NOT NULL DEFAULT '',
  `country` char(2) NOT NULL DEFAULT '',
  `date_created_gmt` datetime NOT NULL,
  `date_modified_gmt` datetime NOT NULL,
  `date_deleted_gmt` datetime DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `type` (`type`)
) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci

✔ Ran `wp db query SHOW CREATE TABLE wp_wc_locations\G` in 'cli'. (in 0s 577ms)


woocommerce % pnpm exec wp-env run cli wp db query "SELECT * FROM wp_wc_locations\G"
pnpm exec wp-env run cli wp option get woocommerce_default_locations --format=json
ℹ Starting 'wp db query SELECT * FROM wp_wc_locations\G' on the cli container.

*************************** 1. row ***************************
               id: 1
             name: The Mission Mercantile
             type: pos
        address_1: 2847 Mission Street
        address_2: Mission
             city: San Francisco
            state: CA
         postcode: 94110
          country: US
 date_created_gmt: 2026-07-03 17:39:34
date_modified_gmt: 2026-07-03 17:39:34
 date_deleted_gmt: NULL

✔ Ran `wp db query SELECT * FROM wp_wc_locations\G` in 'cli'. (in 0s 629ms)
ℹ Starting 'wp option get woocommerce_default_locations --format=json' on the cli container.

{"pos":1}
✔ Ran `wp option get woocommerce_default_locations --format=json` in 'cli'. (in 0s 952ms)


woocommerce % pnpm exec wp-env run cli wp eval '$s = wc_get_container()->get("Automattic\\WooCommerce\\Internal\\MultiLocationInventory\\ProductInventoryService"); $l = (int) (((array) get_option("woocommerce_default_locations"))["pos"] ?? 0); printf("loc=%d set=%s get=%s dec3=%s over=%s final=%s\n", $l, $s->set_stock(12,0,$l,10), $s->get_stock(12,0,$l), var_export($s->decrease_stock(12,0,$l,3),true), var_export($s->decrease_stock(12,0,$l,999),true), $s->get_stock(12,0,$l));'
ℹ Starting 'wp eval $s = wc_get_container()->get("Automattic\\WooCommerce\\Internal\\MultiLocationInventory\\ProductInventoryService"); $l = (int) (((array) get_option("woocommerce_default_locations"))["pos"] ?? 0); printf("loc=%d set=%s get=%s dec3=%s over=%s final=%s\n", $l, $s->set_stock(12,0,$l,10), $s->get_stock(12,0,$l), var_export($s->decrease_stock(12,0,$l,3),true), var_export($s->decrease_stock(12,0,$l,999),true), $s->get_stock(12,0,$l));' on the cli container.

loc=1 set=10 get=10 dec3=7.0 over=NULL final=7
✔ Ran `wp eval $s = wc_get_container()->get("Automattic\\WooCommerce\\Internal\\MultiLocationInventory\\ProductInventoryService"); $l = (int) (((array) get_option("woocommerce_default_locations"))["pos"] ?? 0); printf("loc=%d set=%s get=%s dec3=%s over=%s final=%s\n", $l, $s->set_stock(12,0,$l,10), $s->get_stock(12,0,$l), var_export($s->decrease_stock(12,0,$l,3),true), var_export($s->decrease_stock(12,0,$l,999),true), $s->get_stock(12,0,$l));` in 'cli'. (in 1s 11ms)


woocommerce % pnpm exec wp-env run cli wp eval '$l = new Automattic\WooCommerce\Internal\Locations\Location(1); $b = $l->get_date_modified(); $l->set_name("Renamed"); $l->save(); $a = (new Automattic\WooCommerce\Internal\Locations\Location(1))->get_date_modified(); echo "before=".$b->date("c")." after=".$a->date("c")."\n";'
ℹ Starting 'wp eval $l = new Automattic\WooCommerce\Internal\Locations\Location(1); $b = $l->get_date_modified(); $l->set_name("Renamed"); $l->save(); $a = (new Automattic\WooCommerce\Internal\Locations\Location(1))->get_date_modified(); echo "before=".$b->date("c")." after=".$a->date("c")."\n";' on the cli container.

before=2026-07-03T17:39:34+00:00 after=2026-07-03T17:41:31+00:00
✔ Ran `wp eval $l = new Automattic\WooCommerce\Internal\Locations\Location(1); $b = $l->get_date_modified(); $l->set_name("Renamed"); $l->save(); $a = (new Automattic\WooCommerce\Internal\Locations\Location(1))->get_date_modified(); echo "before=".$b->date("c")." after=".$a->date("c")."\n";` in 'cli'. (in 1s 16ms)
```

### Follow-ups (not in this PR)

- `wc_get_location()` soft-fail accessor — tracked on [WOOMOB-3406](https://linear.app/a8c/issue/WOOMOB-3406) (`new Location($bad_id)` throws like `WC_Product`; the wrapper lands with the first consumer).
- Order location attribution, stock reduction, REST, admin UI, reservations (3406+).

### Changelog entry

Changelog entry is included in this PR (`plugins/woocommerce/changelog/woomob-3405-location-inventory-data-model`, significance **minor**, type **add**). No auto-create needed.
