### PR TITLE
Fix Quantity Selector block styles when outside the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-quantity-selector-styles-outside-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-quantity-selector-styles-outside-add-to-cart-with-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Quantity Selector block styles when outside the Add to Cart + Options block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -18,7 +18,8 @@
 	height: 100%;
 }
 
-:where(.wc-block-add-to-cart-with-options) {
+:where(.wc-block-add-to-cart-with-options),
+:where(.wc-block-add-to-cart-with-options__quantity-selector) {
 	// This resets some WC component styles, so we need it to have specificity
 	// until those stylesheets are updated.
 	.wc-block-components-quantity-selector.wc-block-components-quantity-selector {
@@ -27,6 +28,7 @@
 		margin-bottom: 0;
 		margin-right: 0;
 	}
+
 	:where(.wc-block-components-quantity-selector) {
 		&::after {
 			border: 1px solid currentColor;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -19,7 +19,8 @@
 }
 
 :where(.wc-block-add-to-cart-with-options),
-:where(.wc-block-add-to-cart-with-options__quantity-selector) {
+:where(.wc-block-add-to-cart-with-options__quantity-selector),
+:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
 	// This resets some WC component styles, so we need it to have specificity
 	// until those stylesheets are updated.
 	.wc-block-components-quantity-selector.wc-block-components-quantity-selector {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPLUG-6946.
Closes #66140.

The _Quantity Selector_ block styles depended on it being inside the _Add to Cart + Options_ block, but when editing the template parts directly, that's not the case, so the styles were missing. This PR fixes that.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Patterns_ > _Add to Cart + Options_ and edit any of them (except external).
2. Verify the _Quantity Selector_ block is rendered correctly.

Before | After
--- | ---
<img width="498" height="201" alt="imatge" src="https://github.com/user-attachments/assets/d58b053b-d434-4bbf-925b-02cc36378edd" /> | <img width="498" height="201" alt="imatge" src="https://github.com/user-attachments/assets/3334f747-a76a-4075-add9-37a46efd4595" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->