### PR TITLE
Guard %i SQL identifier placeholders behind wpdb::has_cap()

### DIFF
--- a/plugins/woocommerce/changelog/fix-guard-identifier-placeholders
+++ b/plugins/woocommerce/changelog/fix-guard-identifier-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard the `%i` SQL identifier placeholder behind `wpdb::has_cap( 'identifier_placeholders' )` so WooCommerce produces valid queries on database layers that run on a supported WordPress version but don't implement `%i`.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -563,16 +564,18 @@ class WC_Session_Handler extends WC_Session {
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
 
+			$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->_table );
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 			$wpdb->query(
 				$wpdb->prepare(
-					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
- 					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
-					$this->_table,
+					"INSERT INTO {$table_sql} (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
+ 					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
 					$this->get_customer_id(),
 					maybe_serialize( $this->_data ),
 					$this->_session_expiration
 				)
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			wp_cache_set( $this->get_cache_prefix() . $this->get_customer_id(), $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
 
@@ -638,11 +641,12 @@ class WC_Session_Handler extends WC_Session {
 		// Batch size of 100 and sleep time of 10ms = max 100 SQL queries and 10K entries deletion per second.
 		$batch_size            = 100;
 		$deleted_entries_total = 0;
+		$table_sql             = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->_table );
 		do {
-			$deleted_entries_count  = (int) $wpdb->query(
+			$deleted_entries_count = (int) $wpdb->query(
 				$wpdb->prepare(
-					'DELETE FROM %i WHERE session_expiry < %d ORDER BY session_expiry LIMIT %d',
-					$this->_table,
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+					"DELETE FROM {$table_sql} WHERE session_expiry < %d ORDER BY session_expiry LIMIT %d",
 					time(),
 					$batch_size
 				)
@@ -674,7 +678,9 @@ class WC_Session_Handler extends WC_Session {
 		$value = wp_cache_get( $this->get_cache_prefix() . $customer_id, WC_SESSION_CACHE_GROUP );
 
 		if ( false === $value ) {
-			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT session_value FROM %i WHERE session_key = %s', $this->_table, $customer_id ) );
+			$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->_table );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT session_value FROM {$table_sql} WHERE session_key = %s", $customer_id ) );
 
 			if ( is_null( $value ) ) {
 				$value = $default_value;
@@ -763,6 +769,8 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	private function session_exists( $customer_id ) {
-		return $customer_id && null !== $GLOBALS['wpdb']->get_var( $GLOBALS['wpdb']->prepare( 'SELECT session_key FROM %i WHERE session_key = %s', $this->_table, $customer_id ) );
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->_table );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		return $customer_id && null !== $GLOBALS['wpdb']->get_var( $GLOBALS['wpdb']->prepare( "SELECT session_key FROM {$table_sql} WHERE session_key = %s", $customer_id ) );
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -976,7 +977,9 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	protected function get_refund_orders_join_clause( int $order_id ): string {
 		global $wpdb;
-		return $wpdb->prepare( '%i AS refunds ON ( refunds.post_type = %s AND refunds.post_parent = %d )', $wpdb->posts, 'shop_order_refund', $order_id );
+		$posts_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->posts );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		return $wpdb->prepare( "{$posts_sql} AS refunds ON ( refunds.post_type = %s AND refunds.post_parent = %d )", 'shop_order_refund', $order_id );
 	}
 
 	/**
@@ -991,9 +994,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	protected function get_refund_orders_batch_join_clause( array $order_ids ): string {
 		global $wpdb;
-		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
-		return $wpdb->prepare( "%i AS refunds ON ( refunds.post_type = %s AND refunds.post_parent IN ( $id_list ) )", $wpdb->posts, 'shop_order_refund' );
+		$id_list   = implode( ', ', array_map( 'absint', $order_ids ) );
+		$posts_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->posts );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above; table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		return $wpdb->prepare( "{$posts_sql} AS refunds ON ( refunds.post_type = %s AND refunds.post_parent IN ( $id_list ) )", 'shop_order_refund' );
 	}
 
 	/**
@@ -1022,18 +1026,17 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
+		$postmeta_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->postmeta );
+		$posts_sql    = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->posts );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above; table names are quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$refund_totals = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT posts.post_parent AS order_id, SUM( postmeta.meta_value ) AS total
-				FROM %i AS postmeta
-				INNER JOIN %i AS posts ON ( posts.post_type = 'shop_order_refund' AND posts.post_parent IN ( $id_list ) )
+			"SELECT posts.post_parent AS order_id, SUM( postmeta.meta_value ) AS total
+				FROM {$postmeta_sql} AS postmeta
+				INNER JOIN {$posts_sql} AS posts ON ( posts.post_type = 'shop_order_refund' AND posts.post_parent IN ( $id_list ) )
 				WHERE postmeta.meta_key = '_refund_amount'
 				AND postmeta.post_id = posts.ID
-				GROUP BY posts.post_parent",
-				$wpdb->postmeta,
-				$wpdb->posts
-			)
+				GROUP BY posts.post_parent"
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
@@ -1060,18 +1063,19 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$refund_join      = $this->get_refund_orders_join_clause( $order->get_id() );
 		$meta_placeholder = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
 
+		$order_itemmeta_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_itemmeta' );
+		$order_items_sql    = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_items' );
+
 		$total = $wpdb->get_var(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $refund_join is already prepared.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $refund_join is already prepared; table names are quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $meta_keys is splatted.
 			$wpdb->prepare(
 				"SELECT SUM( order_itemmeta.meta_value )
-				FROM %i AS order_itemmeta
+				FROM {$order_itemmeta_sql} AS order_itemmeta
 				INNER JOIN $refund_join
-				INNER JOIN %i AS order_items ON ( order_items.order_id = refunds.id AND order_items.order_item_type = %s )
+				INNER JOIN {$order_items_sql} AS order_items ON ( order_items.order_id = refunds.id AND order_items.order_item_type = %s )
 				WHERE order_itemmeta.order_item_id = order_items.order_item_id
 				AND order_itemmeta.meta_key IN ( $meta_placeholder )",
-				$wpdb->prefix . 'woocommerce_order_itemmeta',
-				$wpdb->prefix . 'woocommerce_order_items',
 				$item_type,
 				...$meta_keys,
 			)
@@ -1162,19 +1166,18 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$refund_join = $this->get_refund_orders_batch_join_clause( $non_cached_ids );
 		$parent_col  = $this->get_refund_parent_column();
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $refund_join is already prepared, $parent_col is hardcoded.
+		$order_itemmeta_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_itemmeta' );
+		$order_items_sql    = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_items' );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $refund_join is already prepared, $parent_col is hardcoded, table names are quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$tax_totals = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT $parent_col AS order_id, SUM( order_itemmeta.meta_value ) AS total
-				FROM %i AS order_itemmeta
+			"SELECT $parent_col AS order_id, SUM( order_itemmeta.meta_value ) AS total
+				FROM {$order_itemmeta_sql} AS order_itemmeta
 				INNER JOIN $refund_join
-				INNER JOIN %i AS order_items ON ( order_items.order_id = refunds.id AND order_items.order_item_type = 'tax' )
+				INNER JOIN {$order_items_sql} AS order_items ON ( order_items.order_id = refunds.id AND order_items.order_item_type = 'tax' )
 				WHERE order_itemmeta.order_item_id = order_items.order_item_id
 				AND order_itemmeta.meta_key IN ('tax_amount', 'shipping_tax_amount')
-				GROUP BY $parent_col",
-				$wpdb->prefix . 'woocommerce_order_itemmeta',
-				$wpdb->prefix . 'woocommerce_order_items'
-			)
+				GROUP BY $parent_col"
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\Utilities\Users;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -398,12 +399,12 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 
 			//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( $this->is_cot_in_use() ) {
-				$sql           = $wpdb->prepare(
-					"SELECT id FROM %i WHERE customer_id = %d AND status IN $order_statuses_sql ORDER BY id DESC LIMIT 1",
-					OrdersTableDataStore::get_orders_table_name(),
+				$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
+				$sql              = $wpdb->prepare(
+					"SELECT id FROM {$orders_table_sql} WHERE customer_id = %d AND status IN $order_statuses_sql ORDER BY id DESC LIMIT 1",
 					$customer_id
 				);
-				$last_order_id = $wpdb->get_var( $sql );
+				$last_order_id    = $wpdb->get_var( $sql );
 			} else {
 				$last_order_id = $wpdb->get_var(
 					"SELECT posts.ID
@@ -459,12 +460,12 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 
 			//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( $this->is_cot_in_use() ) {
-				$sql   = $wpdb->prepare(
-					"SELECT COUNT(id) FROM %i WHERE customer_id = %d AND status IN $order_statuses_sql",
-					OrdersTableDataStore::get_orders_table_name(),
+				$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
+				$sql              = $wpdb->prepare(
+					"SELECT COUNT(id) FROM {$orders_table_sql} WHERE customer_id = %d AND status IN $order_statuses_sql",
 					$customer_id
 				);
-				$count = $wpdb->get_var( $sql );
+				$count            = $wpdb->get_var( $sql );
 			} else {
 				$count = $wpdb->get_var(
 					"SELECT COUNT(*)
@@ -516,9 +517,9 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 
 			//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( $this->is_cot_in_use() ) {
-				$sql = $wpdb->prepare(
-					"SELECT SUM(total_amount) FROM %i WHERE customer_id = %d AND status IN $statuses_sql",
-					OrdersTableDataStore::get_orders_table_name(),
+				$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
+				$sql              = $wpdb->prepare(
+					"SELECT SUM(total_amount) FROM {$orders_table_sql} WHERE customer_id = %d AND status IN $statuses_sql",
 					$customer_id
 				);
 			} else {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\Traits\OrderAttributionMeta;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 
 /**
@@ -627,8 +628,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$statuses = wp_cache_get( self::ORDERS_STATUSES_ALL_CACHE_KEY, 'woocommerce_analytics' );
 		if ( false === $statuses ) {
-			$table_name = self::get_db_table_name();
-			$statuses   = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT status FROM %i', $table_name ) );
+			$table_name_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_db_table_name() );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+			$statuses = $wpdb->get_col( "SELECT DISTINCT status FROM {$table_name_sql}" );
 			wp_cache_set( self::ORDERS_STATUSES_ALL_CACHE_KEY, $statuses, 'woocommerce_analytics', YEAR_IN_SECONDS );
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -24,6 +24,7 @@ use WC_Order;
 use WC_Order_Refund;
 use Automattic\WooCommerce\Admin\Overrides\Order;
 use Automattic\WooCommerce\Admin\Overrides\OrderRefund;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * API\Reports\Orders\Stats\DataStore.
@@ -836,12 +837,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected static function set_customer_first_order( $customer_id, $order_id ) {
 		global $wpdb;
-		$orders_stats_table = self::get_db_table_name();
+		$orders_stats_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_db_table_name() );
 
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE %i SET returning_customer = CASE WHEN order_id = %d THEN false ELSE true END WHERE customer_id = %d',
-				$orders_stats_table,
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"UPDATE {$orders_stats_table_sql} SET returning_customer = CASE WHEN order_id = %d THEN false ELSE true END WHERE customer_id = %d",
 				$order_id,
 				$customer_id
 			)

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * API\Reports\Products\DataStore.
@@ -498,6 +499,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$order_items     = $parent_order->get_items();
 
 			// Get the partially refunded product and variation IDs along with their sum of product_net_revenue from the parent order.
+			$table_name_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $table_name );
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 			$partial_refund_products = $wpdb->get_results(
 				$wpdb->prepare(
 					"
@@ -505,7 +508,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 							product_lookup.product_id,
 							product_lookup.variation_id,
 							SUM( product_lookup.product_net_revenue ) AS product_net_revenue
-						FROM %i AS product_lookup
+						FROM {$table_name_sql} AS product_lookup
 						INNER JOIN {$wpdb->prefix}wc_order_stats AS order_stats
 							ON order_stats.order_id = product_lookup.order_id
 						WHERE 1 = 1
@@ -513,10 +516,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 							AND product_lookup.product_net_revenue < 0
 						GROUP BY product_lookup.product_id, product_lookup.variation_id
 					",
-					$table_name,
 					$parent_order_id
 				)
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			/**
 			 * Create a lookup table for partially refunded products.

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsTax.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsTax.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
 use Automattic\WooCommerce\Blueprint\UseWPFunctions;
 use Automattic\WooCommerce\Blueprint\Steps\RunSql;
 use Automattic\WooCommerce\Admin\Features\Blueprint\SettingOptions;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * Class ExportWCSettingsTax
@@ -89,10 +90,11 @@ class ExportWCSettingsTax extends ExportWCSettings {
 	 */
 	private function generateTaxRateSteps( string $table ): array {
 		global $wpdb;
-		$prefixed_table = $wpdb->prefix . $table;
+		$prefixed_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . $table );
 		return array_map(
 			fn( $record ) => RunSql::from_table_row( $record, $table ),
-			$wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i', $prefixed_table ), ARRAY_A ),
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+			$wpdb->get_results( "SELECT * FROM {$prefixed_table_sql}", ARRAY_A ),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Database\Migrations;
 
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
 /**
  * Base class for implementing migrations from the standard WordPress meta table
  * to custom meta (key-value pairs) tables.
@@ -174,12 +176,13 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 
 			$meta_id_placeholders = implode( ',', array_fill( 0, count( $meta_ids ), '%d' ) );
 
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$entity_id_column_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $entity_id_column );
+			$meta_id_column_sql   = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $meta_id_column );
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 			$clauses[] = $wpdb->prepare(
-				"( %i = {$entity_id_placeholder} AND %i IN ({$meta_id_placeholders}) )",
-				$entity_id_column,
+				"( {$entity_id_column_sql} = {$entity_id_placeholder} AND {$meta_id_column_sql} IN ({$meta_id_placeholders}) )",
 				$entity_id,
-				$meta_id_column,
 				...$meta_ids
 			);
 			// phpcs:enable

--- a/plugins/woocommerce/src/Internal/Admin/OrderMilestoneEasterEgg.php
+++ b/plugins/woocommerce/src/Internal/Admin/OrderMilestoneEasterEgg.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * Displays a full-screen animated piñata overlay when a merchant opens a
@@ -321,19 +322,20 @@ class OrderMilestoneEasterEgg {
 			return array();
 		}
 
+		$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$qualifying_order_ids = array_map(
 			'absint',
 			$wpdb->get_col(
 				$wpdb->prepare(
-					'SELECT id
-					FROM %i
+					"SELECT id
+					FROM {$orders_table_sql}
 					WHERE type = %s
 					AND status IN ( %s, %s )
 					AND transaction_id IS NOT NULL
 					AND transaction_id <> %s
 					ORDER BY date_created_gmt ASC, id ASC
-					LIMIT %d',
-					OrdersTableDataStore::get_orders_table_name(),
+					LIMIT %d",
 					'shop_order',
 					'wc-processing',
 					'wc-completed',
@@ -342,6 +344,7 @@ class OrderMilestoneEasterEgg {
 				)
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$milestone_order_ids = array();
 		foreach ( self::MILESTONE_POSITIONS as $pos => $key ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 use WP_List_Table;
 use WP_Screen;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * Admin list table for orders as managed by the OrdersTableDataStore.
@@ -876,21 +877,21 @@ class ListTable extends WP_List_Table {
 	protected function get_months_filter_options(): array {
 		global $wpdb;
 
-		$table_name     = OrdersTableDataStore::get_orders_table_name();
+		$table_name_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT MIN(date_created_gmt) as min_date_gmt, MAX(date_created_gmt) as max_date_gmt
 				 FROM (
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt DESC LIMIT 1 )
+					( SELECT date_created_gmt FROM {$table_name_sql} WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt DESC LIMIT 1 )
 					UNION ALL
-					( SELECT date_created_gmt FROM %i WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt ASC LIMIT 1 )
+					( SELECT date_created_gmt FROM {$table_name_sql} WHERE type = %s AND status != 'trash' ORDER BY date_created_gmt ASC LIMIT 1 )
 				 ) d",
-				$table_name,
 				$this->order_type,
-				$table_name,
 				$this->order_type
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		/**
 		 * Normalize "this month" to be the first day of the month in the current timezone of the site.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Admin\Overrides\Order as AdminOrder;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * Class CustomerHistory
@@ -121,6 +122,7 @@ class CustomerHistory {
 
 		$excluded_statuses_sql = $this->get_excluded_statuses_sql();
 		$orders_table          = OrdersTableDataStore::get_orders_table_name();
+		$orders_table_sql      = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $orders_table );
 
 		$sql = null;
 
@@ -134,52 +136,45 @@ class CustomerHistory {
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
 					SELECT id, total_amount
-					FROM %i
+					FROM {$orders_table_sql}
 					WHERE customer_id = %d AND type = 'shop_order' $status_filter
 				) AS filtered
 				LEFT JOIN (
 					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
-					FROM %i AS rp
-					INNER JOIN %i AS co ON rp.parent_order_id = co.id
+					FROM {$orders_table_sql} AS rp
+					INNER JOIN {$orders_table_sql} AS co ON rp.parent_order_id = co.id
 					WHERE rp.type = 'shop_order_refund'
 						AND co.customer_id = %d AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
-				$orders_table,
 				$customer_id,
-				$orders_table,
-				$orders_table,
 				$customer_id
 			);
 		} elseif ( '' !== $billing_email ) {
-			$addresses_table  = OrdersTableDataStore::get_addresses_table_name();
-			$o_status_filter  = $excluded_statuses_sql ? "AND o.status NOT IN $excluded_statuses_sql" : '';
-			$co_status_filter = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
+			$addresses_table     = OrdersTableDataStore::get_addresses_table_name();
+			$addresses_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $addresses_table );
+			$o_status_filter     = $excluded_statuses_sql ? "AND o.status NOT IN $excluded_statuses_sql" : '';
+			$co_status_filter    = $excluded_statuses_sql ? "AND co.status NOT IN $excluded_statuses_sql" : '';
 
 			$sql = $wpdb->prepare(
 				"SELECT COUNT(*) AS orders_count,
 					COALESCE( SUM( filtered.total_amount ), 0 ) + COALESCE( SUM( r.refund_total ), 0 ) AS total_spend
 				FROM (
 					SELECT o.id, o.total_amount
-					FROM %i AS o
-					INNER JOIN %i AS a ON o.id = a.order_id AND a.address_type = 'billing'
+					FROM {$orders_table_sql} AS o
+					INNER JOIN {$addresses_table_sql} AS a ON o.id = a.order_id AND a.address_type = 'billing'
 					WHERE o.customer_id = 0 AND a.email = %s AND o.type = 'shop_order' $o_status_filter
 				) AS filtered
 				LEFT JOIN (
 					SELECT rp.parent_order_id, SUM( rp.total_amount ) AS refund_total
-					FROM %i AS rp
-					INNER JOIN %i AS co ON rp.parent_order_id = co.id
-					INNER JOIN %i AS ca ON co.id = ca.order_id AND ca.address_type = 'billing'
+					FROM {$orders_table_sql} AS rp
+					INNER JOIN {$orders_table_sql} AS co ON rp.parent_order_id = co.id
+					INNER JOIN {$addresses_table_sql} AS ca ON co.id = ca.order_id AND ca.address_type = 'billing'
 					WHERE rp.type = 'shop_order_refund'
 						AND co.customer_id = 0 AND ca.email = %s AND co.type = 'shop_order' $co_status_filter
 					GROUP BY rp.parent_order_id
 				) AS r ON filtered.id = r.parent_order_id",
-				$orders_table,
-				$addresses_table,
 				$billing_email,
-				$orders_table,
-				$orders_table,
-				$addresses_table,
 				$billing_email
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Customers/SearchService.php
+++ b/plugins/woocommerce/src/Internal/Customers/SearchService.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\Customers;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * Internal API for searching users/customers: no backward compatibility obligation.
@@ -25,12 +26,12 @@ final class SearchService {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			global $wpdb;
 
-			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 			$placeholders     = implode( ', ', array_fill( 0, count( $emails ), '%s' ) );
+			$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( OrdersTableDataStore::get_orders_table_name() );
 			$include_user_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT DISTINCT customer_id FROM %i WHERE billing_email IN ($placeholders)",
-					OrdersTableDataStore::get_orders_table_name(),
+					"SELECT DISTINCT customer_id FROM {$orders_table_sql} WHERE billing_email IN ($placeholders)",
 					...$emails
 				)
 			);

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores;
 
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
 /**
  * Implements functions similar to WP's add_metadata(), get_metadata(), and friends using a custom table.
  *
@@ -249,10 +251,11 @@ abstract class CustomMetaDataStore {
 	public function get_meta_keys( int $limit = 100 ): array {
 		global $wpdb;
 
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_db_info()['table'] );
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT DISTINCT meta_key FROM %i WHERE meta_key != '' AND meta_key NOT BETWEEN '_' AND '_z' AND meta_key NOT LIKE %s ORDER BY meta_key ASC LIMIT %d",
-				$this->get_db_info()['table'],
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"SELECT DISTINCT meta_key FROM {$table_sql} WHERE meta_key != '' AND meta_key NOT BETWEEN '_' AND '_z' AND meta_key NOT LIKE %s ORDER BY meta_key ASC LIMIT %d",
 				$wpdb->esc_like( '_' ) . '%',
 				$limit
 			)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1121,7 +1121,9 @@ WHERE
 	 */
 	protected function get_refund_orders_join_clause( int $order_id ): string {
 		global $wpdb;
-		return $wpdb->prepare( '%i AS refunds ON ( refunds.type = %s AND refunds.parent_order_id = %d )', self::get_orders_table_name(), 'shop_order_refund', $order_id );
+		$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_orders_table_name() );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		return $wpdb->prepare( "{$orders_table_sql} AS refunds ON ( refunds.type = %s AND refunds.parent_order_id = %d )", 'shop_order_refund', $order_id );
 	}
 
 	/**
@@ -3259,9 +3261,10 @@ FROM $order_meta_table
 	 */
 	protected function get_refund_orders_batch_join_clause( array $order_ids ): string {
 		global $wpdb;
-		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
-		return $wpdb->prepare( "%i AS refunds ON ( refunds.type = %s AND refunds.parent_order_id IN ( $id_list ) )", self::get_orders_table_name(), 'shop_order_refund' );
+		$id_list          = implode( ', ', array_map( 'absint', $order_ids ) );
+		$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_orders_table_name() );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above; table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		return $wpdb->prepare( "{$orders_table_sql} AS refunds ON ( refunds.type = %s AND refunds.parent_order_id IN ( $id_list ) )", 'shop_order_refund' );
 	}
 
 	/**
@@ -3287,17 +3290,15 @@ FROM $order_meta_table
 	protected function get_batch_refund_totals( array $order_ids ): array {
 		global $wpdb;
 
-		$id_list = implode( ', ', array_map( 'absint', $order_ids ) );
+		$id_list          = implode( ', ', array_map( 'absint', $order_ids ) );
+		$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_orders_table_name() );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $id_list is sanitized via absint above; table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$refund_totals = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT parent_order_id AS order_id, SUM( total_amount ) AS total
-				FROM %i
+			"SELECT parent_order_id AS order_id, SUM( total_amount ) AS total
+				FROM {$orders_table_sql}
 				WHERE type = 'shop_order_refund' AND parent_order_id IN ( $id_list )
-				GROUP BY parent_order_id",
-				self::get_orders_table_name()
-			)
+				GROUP BY parent_order_id"
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 

--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -222,10 +222,11 @@ CREATE TABLE $meta_table_name (
 			throw new \Exception( 'Invalid notification ID.' );
 		}
 
-		$data = $wpdb->get_row(
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$data      = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE id = %d',
-				$this->get_table_name(),
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"SELECT * FROM {$table_sql} WHERE id = %d",
 				$notification->get_id()
 			)
 		);
@@ -545,12 +546,12 @@ CREATE TABLE $meta_table_name (
 			return false;
 		}
 
-		$table    = $this->get_table_name();
-		$format   = array_fill( 0, count( $product_ids ), '%d' );
-		$query_in = '(' . implode( ',', $format ) . ')';
-		$sql      = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-			"SELECT 1 FROM %i WHERE product_id IN $query_in AND status = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			array( $table, ...$product_ids, NotificationStatus::ACTIVE )
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$format    = array_fill( 0, count( $product_ids ), '%d' );
+		$query_in  = '(' . implode( ',', $format ) . ')';
+		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			"SELECT 1 FROM {$table_sql} WHERE product_id IN $query_in AND status = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			array( ...$product_ids, NotificationStatus::ACTIVE )
 		);
 		return (int) $wpdb->get_var( $sql ) > 0; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
@@ -570,10 +571,10 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
-		$table = $this->get_table_name();
-		$sql   = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-			'SELECT 1 FROM %i WHERE product_id = %d AND user_email = %s AND status IN (%s, %s) LIMIT 1', // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			array( $table, $product_id, $email, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			"SELECT 1 FROM {$table_sql} WHERE product_id = %d AND user_email = %s AND status IN (%s, %s) LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			array( $product_id, $email, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
 		);
 		return (int) $wpdb->get_var( $sql ) > 0; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
@@ -593,10 +594,10 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
-		$table = $this->get_table_name();
-		$sql   = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-			'SELECT 1 FROM %i WHERE product_id = %d AND user_id = %d AND status IN (%s, %s) LIMIT 1', // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			array( $table, $product_id, $user_id, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			"SELECT 1 FROM {$table_sql} WHERE product_id = %d AND user_id = %d AND status IN (%s, %s) LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			array( $product_id, $user_id, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
 		);
 		return (int) $wpdb->get_var( $sql ) > 0; // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
@@ -610,16 +611,16 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT DISTINCT
+			"SELECT DISTINCT
 					YEAR(date_created_gmt) AS year,
 					MONTH(date_created_gmt) AS month
-				FROM %i
-				ORDER BY year DESC, month DESC',
-				$this->get_table_name()
-			)
+				FROM {$table_sql}
+				ORDER BY year DESC, month DESC"
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		return $results;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/StockNotifications/StockNotificationsDataStore.php
@@ -222,10 +222,10 @@ CREATE TABLE $meta_table_name (
 			throw new \Exception( 'Invalid notification ID.' );
 		}
 
-		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$table_sql = $this->database_util->get_sql_identifier( $this->get_table_name() );
 		$data      = $wpdb->get_row(
 			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by $this->database_util->get_sql_identifier().
 				"SELECT * FROM {$table_sql} WHERE id = %d",
 				$notification->get_id()
 			)
@@ -546,7 +546,7 @@ CREATE TABLE $meta_table_name (
 			return false;
 		}
 
-		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$table_sql = $this->database_util->get_sql_identifier( $this->get_table_name() );
 		$format    = array_fill( 0, count( $product_ids ), '%d' );
 		$query_in  = '(' . implode( ',', $format ) . ')';
 		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
@@ -571,7 +571,7 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
-		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$table_sql = $this->database_util->get_sql_identifier( $this->get_table_name() );
 		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			"SELECT 1 FROM {$table_sql} WHERE product_id = %d AND user_email = %s AND status IN (%s, %s) LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			array( $product_id, $email, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
@@ -594,7 +594,7 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
-		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
+		$table_sql = $this->database_util->get_sql_identifier( $this->get_table_name() );
 		$sql       = $wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 			"SELECT 1 FROM {$table_sql} WHERE product_id = %d AND user_id = %d AND status IN (%s, %s) LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			array( $product_id, $user_id, NotificationStatus::ACTIVE, NotificationStatus::PENDING )
@@ -611,8 +611,8 @@ CREATE TABLE $meta_table_name (
 
 		global $wpdb;
 
-		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->get_table_name() );
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+		$table_sql = $this->database_util->get_sql_identifier( $this->get_table_name() );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by $this->database_util->get_sql_identifier().
 		$results = $wpdb->get_results(
 			"SELECT DISTINCT
 					YEAR(date_created_gmt) AS year,

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -265,10 +266,11 @@ class LookupDataStore {
 
 		$in_stock = $product->is_in_stock();
 
+		$lookup_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->lookup_table_name );
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE %i SET in_stock = %d WHERE product_id = %d',
-				$this->lookup_table_name,
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"UPDATE {$lookup_table_sql} SET in_stock = %d WHERE product_id = %d",
 				$in_stock ? 1 : 0,
 				$product->get_id()
 			)
@@ -359,20 +361,21 @@ class LookupDataStore {
 		global $wpdb;
 
 		// Single query handled with `index_merge` strategy, while separate with `range` (better performing) on available indexes.
+		$lookup_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->lookup_table_name );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM %i WHERE product_or_parent_id = %d',
-				$this->lookup_table_name,
+				"DELETE FROM {$lookup_table_sql} WHERE product_or_parent_id = %d",
 				$product_id
 			)
 		);
 		$wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM %i WHERE product_id = %d',
-				$this->lookup_table_name,
+				"DELETE FROM {$lookup_table_sql} WHERE product_id = %d",
 				$product_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -616,9 +619,11 @@ class LookupDataStore {
 	private function insert_lookup_table_data( int $product_id, int $product_or_parent_id, string $taxonomy, int $term_id, bool $is_variation_attribute, bool $has_stock ) {
 		global $wpdb;
 
+		$lookup_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->lookup_table_name );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
 		$wpdb->query(
 			$wpdb->prepare(
-				'INSERT INTO %i (
+				"INSERT INTO {$lookup_table_sql} (
 					  product_id,
 					  product_or_parent_id,
 					  taxonomy,
@@ -626,8 +631,7 @@ class LookupDataStore {
 					  is_variation_attribute,
 					  in_stock)
 					VALUES
-					  ( %d, %d, %s, %d, %d, %d )',
-				$this->lookup_table_name,
+					  ( %d, %d, %s, %d, %d, %d )",
 				$product_id,
 				$product_or_parent_id,
 				$taxonomy,
@@ -636,6 +640,7 @@ class LookupDataStore {
 				$has_stock ? 1 : 0
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -847,10 +852,11 @@ class LookupDataStore {
 	private function create_data_for_product_cpt_core( int $product_id ) {
 		global $wpdb;
 
+		$lookup_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->lookup_table_name );
 		$wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM %i WHERE product_or_parent_id = %d',
-				$this->lookup_table_name,
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"DELETE FROM {$lookup_table_sql} WHERE product_or_parent_id = %d",
 				$product_id
 			)
 		);

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/CollectionQuery.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/CollectionQuery.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order_Query;
 use Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * CollectionQuery class.
@@ -243,11 +244,12 @@ class CollectionQuery extends AbstractCollectionQuery {
 		if ( ! empty( $request['product'] ) ) {
 			global $wpdb;
 
-			$order_ids = $wpdb->get_col(
+			$order_items_sql    = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_items' );
+			$order_itemmeta_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $wpdb->prefix . 'woocommerce_order_itemmeta' );
+			$order_ids          = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT order_id FROM %i WHERE order_item_id IN ( SELECT order_item_id FROM %i WHERE meta_key = '_product_id' AND meta_value = %d ) AND order_item_type = %s",
-					$wpdb->prefix . 'woocommerce_order_items',
-					$wpdb->prefix . 'woocommerce_order_itemmeta',
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+					"SELECT order_id FROM {$order_items_sql} WHERE order_item_id IN ( SELECT order_item_id FROM {$order_itemmeta_sql} WHERE meta_key = '_product_id' AND meta_value = %d ) AND order_item_type = %s",
 					$request['product'],
 					OrderItemType::LINE_ITEM
 				)

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -437,4 +437,32 @@ $on_duplicate_clause
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_item_table is hardcoded.
 		return ! empty( $wpdb->get_results( "SHOW INDEX FROM $order_item_table WHERE Key_name = 'order_item_fts'" ) );
 	}
+
+	/**
+	 * Return a query-safe, backtick-quoted SQL identifier (a table or column name) that is safe to
+	 * interpolate directly into a query string.
+	 *
+	 * When the active `$wpdb` supports identifier placeholders (WordPress 6.2+ with a compatible
+	 * database layer) the `%i` placeholder is used; otherwise the identifier is quoted manually.
+	 * This guards against `$wpdb` drop-ins that run on a supported WordPress version but do not
+	 * implement `%i`, per the `wpdb::prepare()` documentation's recommendation to check
+	 * `wpdb::has_cap( 'identifier_placeholders' )` before relying on the placeholder.
+	 *
+	 * The identifier MUST be a trusted, developer-provided value (a table or column name), never
+	 * raw user input. This method quotes a trusted identifier; it is not an input sanitizer.
+	 *
+	 * @since 11.0.0
+	 *
+	 * @param string $identifier Unquoted SQL identifier, e.g. a table or column name.
+	 * @return string The identifier, backtick-quoted and safe to interpolate into a query.
+	 */
+	public function get_sql_identifier( string $identifier ): string {
+		global $wpdb;
+
+		if ( $wpdb->has_cap( 'identifier_placeholders' ) ) {
+			return $wpdb->prepare( '%i', $identifier );
+		}
+
+		return '`' . str_replace( '`', '``', $identifier ) . '`';
+	}
 }

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\StoreApi;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\StoreApi\Utilities\CartTokenUtils;
 use WC_Session;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -125,10 +126,11 @@ final class SessionHandler extends WC_Session {
 			return $default_value;
 		}
 
-		$value = $wpdb->get_var(
+		$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->table );
+		$value     = $wpdb->get_var(
 			$wpdb->prepare(
-				'SELECT session_value FROM %i WHERE session_key = %s',
-				$this->table,
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+				"SELECT session_value FROM {$table_sql} WHERE session_key = %s",
 				$customer_id
 			)
 		);
@@ -184,10 +186,11 @@ final class SessionHandler extends WC_Session {
 		if ( $this->_dirty ) {
 			global $wpdb;
 
+			$table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( $this->table );
 			$wpdb->query(
 				$wpdb->prepare(
-					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
-					$this->table,
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+					"INSERT INTO {$table_sql} (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
 					$this->get_customer_id(),
 					maybe_serialize( $this->_data ),
 					$this->session_expiration

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 use Automattic\WooCommerce\Internal\Utilities\COTMigrationUtil;
 use WC_Order;
 use WP_Post;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 /**
  * A class of utilities for dealing with orders.
@@ -231,10 +232,11 @@ final class OrderUtil {
 
 		if ( null === $count_per_status ) {
 			if ( self::custom_orders_table_usage_is_enabled() ) {
+				$orders_table_sql = wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier( self::get_table_for_orders() );
 				$results          = $wpdb->get_results(
 					$wpdb->prepare(
-						'SELECT status, COUNT(*) AS count FROM %i WHERE type = %s GROUP BY status',
-						self::get_table_for_orders(),
+						// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is quoted by wc_get_container()->get( DatabaseUtil::class )->get_sql_identifier().
+						"SELECT status, COUNT(*) AS count FROM {$orders_table_sql} WHERE type = %s GROUP BY status",
 						$order_type
 					),
 					ARRAY_A

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
@@ -155,4 +155,53 @@ class DatabaseUtilTest extends \WC_Unit_Test_Case {
 			$this->assertEquals( $expected, $this->sut->sanitise_boolean_fts_search_term( $term ) );
 		}
 	}
+
+	/**
+	 * @testdox get_sql_identifier() returns a backtick-quoted identifier via %i when the database layer supports it.
+	 */
+	public function test_get_sql_identifier_uses_placeholder_when_cap_supported(): void {
+		global $wpdb;
+
+		// Stock WordPress (>= 6.2) reports support for the %i identifier placeholder.
+		$this->assertTrue(
+			$wpdb->has_cap( 'identifier_placeholders' ),
+			'The test environment is expected to support the %i identifier placeholder.'
+		);
+
+		$this->assertSame( '`wp_posts`', $this->sut->get_sql_identifier( 'wp_posts' ) );
+	}
+
+	/**
+	 * @testdox get_sql_identifier() falls back to manual backtick quoting when the database layer lacks %i support.
+	 */
+	public function test_get_sql_identifier_falls_back_when_cap_unsupported(): void {
+		$real_wpdb = $GLOBALS['wpdb'];
+
+		// Simulate a $wpdb drop-in that runs on a supported WordPress version but does not implement %i.
+		// Its has_cap() honestly returns false, so get_sql_identifier() must take the manual-quoting path
+		// and never call prepare() (the stub deliberately omits it).
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- intentionally swapping $wpdb for a stub; restored below.
+		$GLOBALS['wpdb'] = new class() {
+			/**
+			 * Report no support for any capability, including identifier placeholders.
+			 *
+			 * @param string $capability Capability name.
+			 * @return bool
+			 */
+			public function has_cap( $capability ) {
+				unset( $capability );
+				return false;
+			}
+		};
+
+		try {
+			$this->assertSame( '`wp_posts`', $this->sut->get_sql_identifier( 'wp_posts' ) );
+
+			// Backticks within the identifier are escaped by doubling.
+			$this->assertSame( '`odd``name`', $this->sut->get_sql_identifier( 'odd`name' ) );
+		} finally {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring the real $wpdb swapped above.
+			$GLOBALS['wpdb'] = $real_wpdb;
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/IdentifierPlaceholderGuardTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/IdentifierPlaceholderGuardTest.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Guards against unguarded use of the `%i` SQL identifier placeholder.
+ *
+ * WordPress 6.2 added `%i` to `wpdb::prepare()` for table/column names, but a
+ * `$wpdb` drop-in can run on a supported WordPress version without implementing
+ * it (its `has_cap( 'identifier_placeholders' )` returns false). On such a layer
+ * `prepare()` escapes `%i` to a literal and shifts the remaining arguments,
+ * silently producing malformed queries.
+ *
+ * Call sites must therefore route trusted identifiers through
+ * {@see \Automattic\WooCommerce\Internal\Utilities\DatabaseUtil::get_sql_identifier()}
+ * (or the `wc_get_sql_identifier()` wrapper) instead of passing a raw `%i`
+ * placeholder to `prepare()`. This test fails if a new raw `%i` placeholder is
+ * introduced in a `prepare()` call anywhere under `src/` or `includes/`.
+ */
+class IdentifierPlaceholderGuardTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The single legitimate `prepare( '%i', ... )` lives inside the helper itself.
+	 *
+	 * @var string
+	 */
+	private const ALLOWED_RELATIVE_PATH = 'src/Internal/Utilities/DatabaseUtil.php';
+
+	/**
+	 * @testdox No unguarded %i identifier placeholder is passed to wpdb::prepare() under src/ or includes/.
+	 */
+	public function test_no_unguarded_identifier_placeholder_in_prepare_calls(): void {
+		$roots = array(
+			WC_ABSPATH . 'src',
+			WC_ABSPATH . 'includes',
+		);
+
+		$allowed   = wp_normalize_path( WC_ABSPATH . self::ALLOWED_RELATIVE_PATH );
+		$offenders = array();
+
+		foreach ( $roots as $root ) {
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator( $root, \FilesystemIterator::SKIP_DOTS )
+			);
+
+			foreach ( $iterator as $file ) {
+				if ( 'php' !== strtolower( $file->getExtension() ) ) {
+					continue;
+				}
+
+				$path = wp_normalize_path( $file->getPathname() );
+				if ( $path === $allowed ) {
+					continue;
+				}
+
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a local source file for static analysis.
+				$contents = file_get_contents( $file->getPathname() );
+
+				// Flag a `%i` identifier placeholder appearing within a prepare() call.
+				// - `[^;]*?` keeps the match inside a single statement (no cross-statement spanning).
+				// - `(?<![:%])` excludes STR_TO_DATE minute specifiers (`%H:%i:%s`) and escaped `%%i`.
+				// - `(?![a-zA-Z0-9_])` excludes longer tokens such as `%input`.
+				if ( preg_match( '/->prepare\(\s*[^;]*?(?<![:%])%i(?![a-zA-Z0-9_])/s', $contents ) ) {
+					$offenders[] = $path;
+				}
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$offenders,
+			"Use wc_get_sql_identifier() (or DatabaseUtil::get_sql_identifier()) instead of a raw %i placeholder in wpdb::prepare() in:\n"
+				. implode( "\n", $offenders )
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress 6.2 added the `%i` placeholder to `wpdb::prepare()` for identifiers (table/column names), and the [`wpdb::prepare()` documentation](https://developer.wordpress.org/reference/classes/wpdb/prepare/#changelog) recommends checking `wpdb::has_cap( 'identifier_placeholders' )` before relying on it. WooCommerce uses `%i` in ~40 `prepare()` calls without ever checking the capability. On a `$wpdb` drop-in that runs on a supported WordPress version but does not implement `%i` (some HyperDB builds and managed-hosting database layers), `prepare()` escapes `%i` to a literal `%%i` and shifts the remaining placeholder arguments, silently producing malformed queries such as `SELECT * FROM %i WHERE id = 0`.

This PR:

-   adds `DatabaseUtil::get_sql_identifier()`, which uses `%i` when `wpdb::has_cap( 'identifier_placeholders' )` reports support and falls back to backtick quoting (with backtick escaping) otherwise;
-   routes the existing `%i` call sites in `src/` and `includes/` through it;
-   adds a regression test that fails if a new unguarded `%i` placeholder is introduced in a `prepare()` call.

Identifiers passed to the helper are trusted, developer-provided table/column names (`$wpdb->prefix` concatenations, `OrdersTableDataStore::get_orders_table_name()`, schema config, class properties) — never user input. The helper quotes a trusted identifier; it is not an input sanitizer. Non-SQL `%i` (`STR_TO_DATE( ..., '%H:%i:%s' )` minute specifiers, vendored regex flags) is left untouched.

**Backward-compatibility impact:** additive and non-breaking. `DatabaseUtil::get_sql_identifier()` is a new public method on an existing DI service; no existing signatures change. On stock WordPress ≥ 6.2 the capability is always present, so query output and behavior are unchanged there — the guardrail only alters behavior on database layers that report no `%i` support, where it now produces valid SQL instead of a malformed query.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a stock WordPress install (where `%i` is supported), confirm normal operation is unchanged: browse the store, place and refund orders, open the HPOS orders list and an order's Customer History meta box, and view Analytics → Orders/Products reports. All queries should return correct results.
2. Run the new unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter DatabaseUtilTest` — `get_sql_identifier()` returns a backtick-quoted identifier via `%i` when the capability is present and via manual quoting (with backtick escaping) when it is not.
3. Run the regression guard: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter IdentifierPlaceholderGuardTest` — it passes now and fails if a raw `%i` placeholder is reintroduced into a `prepare()` call.
4. (Optional) Simulate an unsupported layer by temporarily making `has_cap( 'identifier_placeholders' )` return `false` (e.g. via a `$wpdb` drop-in or a filter in a local test) and confirm the same flows in step 1 still produce valid queries.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

-   `php -l` on every changed file — no syntax errors.
-   `composer run-script lint` (phpcs-changed) and `composer run-script lint-branch` (phpcs-changed vs `trunk` + the "no new standalone functions" guard) — clean.
-   PHPStan on the changed source files — no new errors.
-   The regression scan was validated against the current tree (0 offenders) and against synthetic input (correctly flags a raw `%i` in `prepare()`, ignores `%H:%i:%s` and `%%i`).
-   Note: the full PHPUnit suite was not run in this environment (Docker/wp-env unavailable); CI will exercise it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (`plugins/woocommerce/changelog/fix-guard-identifier-placeholders`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
