### PR TITLE
fix(product-data): trigger change on variation sale schedule clear

### DIFF
--- a/plugins/woocommerce/changelog/62270-variation-sale-schedule-clear
+++ b/plugins/woocommerce/changelog/62270-variation-sale-schedule-clear
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Trigger change event on cleared sale price schedule date inputs so variation rows are marked dirty and saved. Fixes issue where clicking "Cancel schedule" did not persist after saving.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -366,7 +366,7 @@ jQuery( function ( $ ) {
 			$( this ).hide();
 			$wrap.find( '.sale_schedule' ).show();
 			$wrap.find( '.sale_price_dates_fields' ).hide();
-			$wrap.find( '.sale_price_dates_fields' ).find( 'input' ).val( '' );
+			$wrap.find( '.sale_price_dates_fields' ).find( 'input' ).val( '' ).trigger( 'change' );
 
 			return false;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #62270.

The `cancel_sale_schedule` click handler in `meta-boxes-product.js` empties the sale price date inputs via `.val('')` but never fires the `change` event. The variation save pipeline (`meta-boxes-product-variation.js`) listens for `change` events to flag rows as `variation-needs-update`. Without it, the row is excluded from the AJAX save request, so PHP never processes the empty dates and the stored `_sale_price_dates_from` / `_sale_price_dates_to` post meta persist.

Fix: chain `.trigger('change')` after `.val('')` on the cleared inputs. This matches the existing datepicker `onSelect` behavior which already fires `change` and works correctly. No PHP changes needed.

### How to test the changes in this Pull Request:

1. Create a variable product with one variation. Set a sale price and schedule it with future start/end dates. Save.
2. Re-open the variation. Click "Cancel schedule" above the sale price.
3. Click "Save changes" in the Variations tab.
4. Reload the page. Re-open the variation.
5. Verify the schedule dates are empty and the "Schedule" link is visible (not "Cancel schedule").

Regression: repeat steps 1-3 but change the schedule dates to new future dates instead of cancelling. Verify new dates persist after save and reload.

### Testing that has already taken place:

Manual testing in wp-env with Docker. PHP 8.1, WordPress 6.x, WooCommerce built from branch. JS lint clean. No PHP changes.

### Milestone

- [ ] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Trigger change event on cleared sale price schedule date inputs so variation rows are marked dirty and saved. Fixes issue where clicking "Cancel schedule" did not persist after saving.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)