### PR TITLE
fix(blocks): decouple featured block inner text from product/category data

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -873,6 +873,8 @@ Displays the current product title.
 - **Supports:** color (background, text), spacing (margin, padding), typography, ~~align~~, ~~html~~
 - **Attributes:** content, isLink, level, linkTarget, rel, textAlign
 
+Replaces `core/post-title` as the default title block for the Featured Product block. Text edits are stored locally in the `content` attribute rather than written back to the product, so customizing a single Featured Product layout does not rename the underlying product. Existing Featured Product blocks that still contain a `core/post-title` inner block are migrated automatically.
+
 ## Filter Block - woocommerce/filter-wrapper
 
 

--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -863,7 +863,7 @@ Highlight a product or variation.
 - **Supports:** align (full, wide), ariaLabel, color (background, text), filter (duotone), interactivity (clientNavigation), multiple, spacing (padding), ~~html~~
 - **Attributes:** alt, contentAlign, decoupledEdit, dimRatio, focalPoint, hasParallax, imageFit, isRepeated, linkText, mediaId, mediaSrc, minHeight, overlayColor, overlayGradient, previewProduct, productId
 
-## Product Title - woocommerce/featured-product-title
+## Featured Product Title - woocommerce/featured-product-title
 
 Displays the current product title.
 

--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -541,7 +541,7 @@ Displays the current category description.
 - **Name:** woocommerce/category-description
 - **Category:** woocommerce
 - **Supports:** color (background, text), spacing (margin, padding), typography, ~~align~~, ~~html~~
-- **Attributes:** textAlign
+- **Attributes:** content, textAlign
 
 ## Product Category Title - woocommerce/category-title
 
@@ -550,7 +550,7 @@ Displays the current category title and lets permitted users edit it.
 - **Name:** woocommerce/category-title
 - **Category:** woocommerce
 - **Supports:** color (background, text), spacing (margin, padding), typography, ~~align~~, ~~html~~
-- **Attributes:** isLink, level, linkTarget, rel, textAlign
+- **Attributes:** content, isLink, level, linkTarget, rel, textAlign
 
 ## Checkout - woocommerce/checkout
 
@@ -852,7 +852,7 @@ Visually highlight a product category and encourage prompt action.
 - **Name:** woocommerce/featured-category
 - **Category:** woocommerce
 - **Supports:** align (full, wide), ariaLabel, color (background, text), filter (duotone), interactivity (clientNavigation), spacing (padding), ~~html~~
-- **Attributes:** alt, categoryId, contentAlign, dimRatio, focalPoint, hasParallax, imageFit, isRepeated, linkText, mediaId, mediaSrc, minHeight, overlayColor, overlayGradient, previewCategory
+- **Attributes:** alt, categoryId, contentAlign, decoupledEdit, dimRatio, focalPoint, hasParallax, imageFit, isRepeated, linkText, mediaId, mediaSrc, minHeight, overlayColor, overlayGradient, previewCategory
 
 ## Featured Product - woocommerce/featured-product
 
@@ -861,7 +861,17 @@ Highlight a product or variation.
 - **Name:** woocommerce/featured-product
 - **Category:** woocommerce
 - **Supports:** align (full, wide), ariaLabel, color (background, text), filter (duotone), interactivity (clientNavigation), multiple, spacing (padding), ~~html~~
-- **Attributes:** alt, contentAlign, dimRatio, focalPoint, hasParallax, imageFit, isRepeated, linkText, mediaId, mediaSrc, minHeight, overlayColor, overlayGradient, previewProduct, productId
+- **Attributes:** alt, contentAlign, decoupledEdit, dimRatio, focalPoint, hasParallax, imageFit, isRepeated, linkText, mediaId, mediaSrc, minHeight, overlayColor, overlayGradient, previewProduct, productId
+
+## Product Title - woocommerce/featured-product-title
+
+Displays the current product title.
+
+- **Name:** woocommerce/featured-product-title
+- **Category:** woocommerce
+- **Ancestor:** woocommerce/featured-product
+- **Supports:** color (background, text), spacing (margin, padding), typography, ~~align~~, ~~html~~
+- **Attributes:** content, isLink, level, linkTarget, rel, textAlign
 
 ## Filter Block - woocommerce/filter-wrapper
 
@@ -1235,7 +1245,7 @@ Display a product's description, attributes, and reviews
 
 ## Product Filters - woocommerce/product-filters
 
-Let shoppers filter products displayed on the page.
+Add a set of filters shoppers can use.
 
 - **Name:** woocommerce/product-filters
 - **Category:** woocommerce
@@ -1244,7 +1254,7 @@ Let shoppers filter products displayed on the page.
 
 ## Active Filters - woocommerce/product-filter-active
 
-Display the currently active filters.
+Display all active filters.
 
 - **Name:** woocommerce/product-filter-active
 - **Category:** woocommerce
@@ -1253,7 +1263,7 @@ Display the currently active filters.
 
 ## Attribute Filter - woocommerce/product-filter-attribute
 
-Enable customers to filter the product grid by selecting one or more attributes, such as color.
+Let shoppers filter products by attribute.
 
 - **Name:** woocommerce/product-filter-attribute
 - **Category:** woocommerce
@@ -1263,7 +1273,7 @@ Enable customers to filter the product grid by selecting one or more attributes,
 
 ## List - woocommerce/product-filter-checkbox-list
 
-Display a list of filter options.
+Display filter options as a list.
 
 - **Name:** woocommerce/product-filter-checkbox-list
 - **Category:** woocommerce
@@ -1283,7 +1293,7 @@ Display filter options as chips.
 
 ## Clear filters - woocommerce/product-filter-clear-button
 
-Allows shoppers to clear active filters.
+Let shoppers clear any active filters.
 
 - **Name:** woocommerce/product-filter-clear-button
 - **Category:** woocommerce
@@ -1292,7 +1302,7 @@ Allows shoppers to clear active filters.
 
 ## Price Filter - woocommerce/product-filter-price
 
-Let shoppers filter products by choosing a price range.
+Let shoppers filter products by price.
 
 - **Name:** woocommerce/product-filter-price
 - **Category:** woocommerce
@@ -1301,7 +1311,7 @@ Let shoppers filter products by choosing a price range.
 
 ## Price Slider - woocommerce/product-filter-price-slider
 
-A slider helps shopper choose a price range.
+Let shoppers choose a price range with a slider.
 
 - **Name:** woocommerce/product-filter-price-slider
 - **Category:** woocommerce
@@ -1311,7 +1321,7 @@ A slider helps shopper choose a price range.
 
 ## Rating Filter - woocommerce/product-filter-rating
 
-Enable customers to filter the product collection by rating.
+Let shoppers filter products by rating.
 
 - **Name:** woocommerce/product-filter-rating
 - **Category:** woocommerce
@@ -1321,7 +1331,7 @@ Enable customers to filter the product collection by rating.
 
 ## Chips - woocommerce/product-filter-removable-chips
 
-Display removable active filters as chips.
+Display active filters as removable chips.
 
 - **Name:** woocommerce/product-filter-removable-chips
 - **Category:** woocommerce
@@ -1329,7 +1339,7 @@ Display removable active filters as chips.
 - **Supports:** interactivity, layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~)
 - **Attributes:** chipBackground, chipBorder, chipText, customChipBackground, customChipBorder, customChipText
 
-## Availability filter - woocommerce/product-filter-status
+## Availability Filter - woocommerce/product-filter-status
 
 Let shoppers filter products by availability.
 
@@ -1341,7 +1351,7 @@ Let shoppers filter products by availability.
 
 ## Taxonomy Filter - woocommerce/product-filter-taxonomy
 
-Enable customers to filter the product collection by selecting one or more taxonomy terms, such as categories, brands, or tags.
+Let shoppers filter products by category, brand, or tag.
 
 - **Name:** woocommerce/product-filter-taxonomy
 - **Category:** woocommerce

--- a/plugins/woocommerce/changelog/62361-decouple-featured-blocks-text
+++ b/plugins/woocommerce/changelog/62361-decouple-featured-blocks-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Decouple Featured Product and Featured Category inner block text edits from underlying product/category data.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/block.json
@@ -8,6 +8,9 @@
 	"attributes": {
 		"textAlign": {
 			"type": "string"
+		},
+		"content": {
+			"type": "string"
 		}
 	},
 	"supports": {
@@ -23,5 +26,5 @@
 		},
 		"typography": true
 	},
-	"usesContext": [ "termId", "termTaxonomy" ]
+	"usesContext": [ "termId", "termTaxonomy", "decoupledEdit" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
@@ -54,19 +54,15 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	const isPreviewMode = usePreviewMode();
 
-	// Only use the locally edited content when it's non-empty; otherwise fall
-	// back to the entity value, matching the PHP renderer's fallback to
-	// `$term->description`. This also marks when `displayFullDescription`
-	// holds raw, unsanitized `PlainText` input (needs to render as text, not
-	// HTML).
+	// Use the locally edited content whenever the `content` attribute has been
+	// set (even if empty), so clearing the text keeps the block detached from
+	// the entity instead of reverting to it.
 	const hasDecoupledContent =
-		decoupledEdit &&
-		typeof attributes.content === 'string' &&
-		attributes.content.length > 0;
+		decoupledEdit && attributes.content !== undefined;
 
 	let displayRawDescription = '';
 	if ( isPreviewMode ) {
-		displayRawDescription = previewCategories[ 0 ].description;
+		displayRawDescription = previewCategories[ 0 ]?.description ?? '';
 	} else if ( hasDecoupledContent ) {
 		displayRawDescription = attributes.content as string;
 	} else if ( typeof rawDescription === 'string' ) {
@@ -75,7 +71,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	let displayFullDescription = '';
 	if ( isPreviewMode ) {
-		displayFullDescription = previewCategories[ 0 ].description;
+		displayFullDescription = previewCategories[ 0 ]?.description ?? '';
 	} else if ( hasDecoupledContent ) {
 		displayFullDescription = attributes.content as string;
 	} else if (
@@ -94,6 +90,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			( setDescription as ( v: string ) => void )( v );
 		}
 	};
+
+	// Decoupled edits only write to block attributes, so they do not depend on
+	// the author's entity edit permissions. A page editor can always edit the
+	// local text of a Featured block even without product/category caps.
+	const canEditDecoupled = decoupledEdit;
 
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),
@@ -115,18 +116,21 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			/>
 		);
 
-		descriptionElement = userCanEdit ? (
-			<PlainText
-				tagName="p"
-				placeholder={ __( 'No description', 'woocommerce' ) as string }
-				value={ displayRawDescription }
-				onChange={ onChangeDescription }
-				__experimentalVersion={ 2 }
-				{ ...blockProps }
-			/>
-		) : (
-			readOnlyDescription
-		);
+		descriptionElement =
+			canEditDecoupled || userCanEdit ? (
+				<PlainText
+					tagName="p"
+					placeholder={
+						__( 'No description', 'woocommerce' ) as string
+					}
+					value={ displayRawDescription }
+					onChange={ onChangeDescription }
+					__experimentalVersion={ 2 }
+					{ ...blockProps }
+				/>
+			) : (
+				readOnlyDescription
+			);
 	}
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
@@ -17,17 +17,19 @@ import { previewCategories } from '@woocommerce/resource-previews';
 interface Props {
 	attributes: {
 		textAlign?: string;
+		content?: string;
 	};
 	setAttributes: ( attrs: Partial< Props[ 'attributes' ] > ) => void;
 	context: {
 		termId?: number;
 		termTaxonomy?: string;
+		decoupledEdit?: boolean;
 	};
 }
 
 export default function Edit( { attributes, setAttributes, context }: Props ) {
 	const { textAlign } = attributes;
-	const { termId, termTaxonomy } = context;
+	const { termId, termTaxonomy, decoupledEdit } = context;
 
 	const userCanEdit = useSelect(
 		( select ) => {
@@ -55,6 +57,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	let displayRawDescription = '';
 	if ( isPreviewMode ) {
 		displayRawDescription = previewCategories[ 0 ].description;
+	} else if ( decoupledEdit ) {
+		displayRawDescription =
+			typeof attributes.content === 'string' && attributes.content.length
+				? attributes.content
+				: '';
 	} else if ( typeof rawDescription === 'string' ) {
 		displayRawDescription = rawDescription;
 	}
@@ -62,6 +69,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	let displayFullDescription = '';
 	if ( isPreviewMode ) {
 		displayFullDescription = previewCategories[ 0 ].description;
+	} else if ( decoupledEdit ) {
+		displayFullDescription =
+			typeof attributes.content === 'string' && attributes.content.length
+				? attributes.content
+				: '';
 	} else if (
 		typeof fullDescription === 'object' &&
 		fullDescription !== null &&
@@ -70,6 +82,14 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	) {
 		displayFullDescription = fullDescription.rendered;
 	}
+
+	const onChangeDescription = ( v: string ) => {
+		if ( decoupledEdit ) {
+			setAttributes( { content: v } );
+		} else {
+			( setDescription as ( v: string ) => void )( v );
+		}
+	};
 
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),
@@ -85,9 +105,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				tagName="p"
 				placeholder={ __( 'No description', 'woocommerce' ) as string }
 				value={ displayRawDescription }
-				onChange={ ( v: string ) =>
-					( setDescription as ( v: string ) => void )( v )
-				}
+				onChange={ onChangeDescription }
 				__experimentalVersion={ 2 }
 				{ ...blockProps }
 			/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-description/edit.tsx
@@ -54,14 +54,21 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	const isPreviewMode = usePreviewMode();
 
+	// Only use the locally edited content when it's non-empty; otherwise fall
+	// back to the entity value, matching the PHP renderer's fallback to
+	// `$term->description`. This also marks when `displayFullDescription`
+	// holds raw, unsanitized `PlainText` input (needs to render as text, not
+	// HTML).
+	const hasDecoupledContent =
+		decoupledEdit &&
+		typeof attributes.content === 'string' &&
+		attributes.content.length > 0;
+
 	let displayRawDescription = '';
 	if ( isPreviewMode ) {
 		displayRawDescription = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
-		displayRawDescription =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	} else if ( hasDecoupledContent ) {
+		displayRawDescription = attributes.content as string;
 	} else if ( typeof rawDescription === 'string' ) {
 		displayRawDescription = rawDescription;
 	}
@@ -69,11 +76,8 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	let displayFullDescription = '';
 	if ( isPreviewMode ) {
 		displayFullDescription = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
-		displayFullDescription =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	} else if ( hasDecoupledContent ) {
+		displayFullDescription = attributes.content as string;
 	} else if (
 		typeof fullDescription === 'object' &&
 		fullDescription !== null &&
@@ -100,6 +104,17 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	);
 
 	if ( termId ) {
+		const readOnlyDescription = hasDecoupledContent ? (
+			<p { ...blockProps }>{ displayFullDescription }</p>
+		) : (
+			<p
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ {
+					__html: displayFullDescription,
+				} }
+			/>
+		);
+
 		descriptionElement = userCanEdit ? (
 			<PlainText
 				tagName="p"
@@ -110,12 +125,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				{ ...blockProps }
 			/>
 		) : (
-			<p
-				{ ...blockProps }
-				dangerouslySetInnerHTML={ {
-					__html: displayFullDescription,
-				} }
-			/>
+			readOnlyDescription
 		);
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
@@ -89,14 +89,20 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		termId ? String( termId ) : undefined
 	);
 
+	// Only use the locally edited content when it's non-empty; otherwise fall
+	// back to the entity value, matching the PHP renderer's fallback to
+	// `$term->name`. This also marks when `displayFullTitle` holds raw,
+	// unsanitized `PlainText` input (needs to render as text, not HTML).
+	const hasDecoupledContent =
+		decoupledEdit &&
+		typeof attributes.content === 'string' &&
+		attributes.content.length > 0;
+
 	let displayRawTitle = '';
 	if ( isPreviewMode ) {
 		displayRawTitle = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
-		displayRawTitle =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	} else if ( hasDecoupledContent ) {
+		displayRawTitle = attributes.content as string;
 	} else if ( typeof rawTitle === 'string' ) {
 		displayRawTitle = rawTitle;
 	}
@@ -104,11 +110,8 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	let displayFullTitle = '';
 	if ( isPreviewMode ) {
 		displayFullTitle = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
-		displayFullTitle =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	} else if ( hasDecoupledContent ) {
+		displayFullTitle = attributes.content as string;
 	} else if (
 		typeof fullTitle === 'object' &&
 		fullTitle !== null &&
@@ -153,6 +156,20 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	) as JSX.Element;
 
 	if ( termId ) {
+		const readOnlyTitle = hasDecoupledContent ? (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				{ displayFullTitle }
+			</ContainerElement>
+		) : (
+			<ContainerElement
+				tagName={ TagName }
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ {
+					__html: displayFullTitle,
+				} }
+			/>
+		);
+
 		titleElement = userCanEdit ? (
 			<PlainText
 				tagName={ TagName }
@@ -163,17 +180,36 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				{ ...blockProps }
 			/>
 		) : (
-			<ContainerElement
-				tagName={ TagName }
-				{ ...blockProps }
-				dangerouslySetInnerHTML={ {
-					__html: displayFullTitle,
-				} }
-			/>
+			readOnlyTitle
 		);
 	}
 
 	if ( isLink && termId ) {
+		const readOnlyLinkedTitle = hasDecoupledContent ? (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ displayFullTitle }
+				</a>
+			</ContainerElement>
+		) : (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+					dangerouslySetInnerHTML={ {
+						__html: displayFullTitle,
+					} }
+				/>
+			</ContainerElement>
+		);
+
 		titleElement = userCanEdit ? (
 			<ContainerElement tagName={ TagName } { ...blockProps }>
 				<PlainText
@@ -192,17 +228,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				/>
 			</ContainerElement>
 		) : (
-			<ContainerElement tagName={ TagName } { ...blockProps }>
-				<a
-					href={ link }
-					target={ linkTarget }
-					rel={ rel }
-					onClick={ ( event ) => event.preventDefault() }
-					dangerouslySetInnerHTML={ {
-						__html: displayFullTitle,
-					} }
-				/>
-			</ContainerElement>
+			readOnlyLinkedTitle
 		);
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
@@ -89,18 +89,17 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		termId ? String( termId ) : undefined
 	);
 
-	// Only use the locally edited content when it's non-empty; otherwise fall
-	// back to the entity value, matching the PHP renderer's fallback to
-	// `$term->name`. This also marks when `displayFullTitle` holds raw,
-	// unsanitized `PlainText` input (needs to render as text, not HTML).
+	// Use the locally edited content whenever the `content` attribute has been
+	// set (even if empty), so clearing the text keeps the block detached from the
+	// entity instead of reverting to it. This also marks when `displayFullTitle`
+	// holds raw, unsanitized `PlainText` input (needs to render as text, not
+	// HTML).
 	const hasDecoupledContent =
-		decoupledEdit &&
-		typeof attributes.content === 'string' &&
-		attributes.content.length > 0;
+		decoupledEdit && attributes.content !== undefined;
 
 	let displayRawTitle = '';
 	if ( isPreviewMode ) {
-		displayRawTitle = previewCategories[ 0 ].name;
+		displayRawTitle = previewCategories[ 0 ]?.name ?? '';
 	} else if ( hasDecoupledContent ) {
 		displayRawTitle = attributes.content as string;
 	} else if ( typeof rawTitle === 'string' ) {
@@ -109,7 +108,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	let displayFullTitle = '';
 	if ( isPreviewMode ) {
-		displayFullTitle = previewCategories[ 0 ].name;
+		displayFullTitle = previewCategories[ 0 ]?.name ?? '';
 	} else if ( hasDecoupledContent ) {
 		displayFullTitle = attributes.content as string;
 	} else if (
@@ -128,6 +127,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			setTitle( v );
 		}
 	};
+
+	// Decoupled edits only write to block attributes, so they do not depend on
+	// the author's entity edit permissions. A page editor can always edit the
+	// local text of a Featured block even without product/category caps.
+	const canEditDecoupled = decoupledEdit;
 
 	const link = useSelect(
 		( select ) => {
@@ -170,18 +174,19 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			/>
 		);
 
-		titleElement = userCanEdit ? (
-			<PlainText
-				tagName={ TagName }
-				placeholder={ __( 'No title', 'woocommerce' ) }
-				value={ displayRawTitle }
-				onChange={ onChangeTitle }
-				__experimentalVersion={ 2 }
-				{ ...blockProps }
-			/>
-		) : (
-			readOnlyTitle
-		);
+		titleElement =
+			canEditDecoupled || userCanEdit ? (
+				<PlainText
+					tagName={ TagName }
+					placeholder={ __( 'No title', 'woocommerce' ) }
+					value={ displayRawTitle }
+					onChange={ onChangeTitle }
+					__experimentalVersion={ 2 }
+					{ ...blockProps }
+				/>
+			) : (
+				readOnlyTitle
+			);
 	}
 
 	if ( isLink && termId ) {
@@ -210,26 +215,27 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			</ContainerElement>
 		);
 
-		titleElement = userCanEdit ? (
-			<ContainerElement tagName={ TagName } { ...blockProps }>
-				<PlainText
-					tagName="a"
-					href={ link }
-					target={ linkTarget }
-					rel={ rel }
-					placeholder={
-						! displayRawTitle?.length
-							? __( 'No title', 'woocommerce' )
-							: undefined
-					}
-					value={ displayRawTitle }
-					onChange={ onChangeTitle }
-					__experimentalVersion={ 2 }
-				/>
-			</ContainerElement>
-		) : (
-			readOnlyLinkedTitle
-		);
+		titleElement =
+			canEditDecoupled || userCanEdit ? (
+				<ContainerElement tagName={ TagName } { ...blockProps }>
+					<PlainText
+						tagName="a"
+						href={ link }
+						target={ linkTarget }
+						rel={ rel }
+						placeholder={
+							! displayRawTitle?.length
+								? __( 'No title', 'woocommerce' )
+								: undefined
+						}
+						value={ displayRawTitle }
+						onChange={ onChangeTitle }
+						__experimentalVersion={ 2 }
+					/>
+				</ContainerElement>
+			) : (
+				readOnlyLinkedTitle
+			);
 	}
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/category-title/edit.tsx
@@ -100,7 +100,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	let displayRawTitle = '';
 	if ( isPreviewMode ) {
-		displayRawTitle = previewCategories[ 0 ].description;
+		displayRawTitle = previewCategories[ 0 ].name;
 	} else if ( hasDecoupledContent ) {
 		displayRawTitle = attributes.content as string;
 	} else if ( typeof rawTitle === 'string' ) {
@@ -109,7 +109,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 
 	let displayFullTitle = '';
 	if ( isPreviewMode ) {
-		displayFullTitle = previewCategories[ 0 ].description;
+		displayFullTitle = previewCategories[ 0 ].name;
 	} else if ( hasDecoupledContent ) {
 		displayFullTitle = attributes.content as string;
 	} else if (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/constants.ts
@@ -6,11 +6,6 @@ import { ProductResponseItem } from '@woocommerce/types';
 import { InnerBlockTemplate } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { VARIATION_NAME as PRODUCT_TITLE_VARIATION_NAME } from '../product-collection/variations/elements/product-title';
-
 export const DEFAULT_EDITOR_SIZE = {
 	height: 500,
 	width: 500,
@@ -50,12 +45,11 @@ export const FEATURED_PRODUCT_DEFAULT_TEMPLATE = (
 	product: ProductResponseItem
 ): InnerBlockTemplate[] => [
 	[
-		'core/post-title',
+		'woocommerce/featured-product-title',
 		{
 			isLink: true,
 			level: 2,
 			textAlign: 'center',
-			__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
 		},
 	],
 	[

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
@@ -98,6 +98,10 @@
 		"previewCategory": {
 			"type": "object",
 			"default": null
+		},
+		"decoupledEdit": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"selectors": {
@@ -111,6 +115,7 @@
 	"usesContext": [ "termId", "termTaxonomy" ],
 	"providesContext": {
 		"termId": "categoryId",
-		"termTaxonomy": "termTaxonomy"
+		"termTaxonomy": "termTaxonomy",
+		"decoupledEdit": "decoupledEdit"
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-category/block.json
@@ -101,7 +101,8 @@
 		},
 		"decoupledEdit": {
 			"type": "boolean",
-			"default": true
+			"default": true,
+			"role": "local"
 		}
 	},
 	"selectors": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -99,6 +99,10 @@
 		"previewProduct": {
 			"type": "object",
 			"default": null
+		},
+		"decoupledEdit": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"selectors": {
@@ -108,5 +112,8 @@
 	},
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
-	"$schema": "https://schemas.wp.org/trunk/block.json"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"providesContext": {
+		"decoupledEdit": "decoupledEdit"
+	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/block.json
@@ -102,7 +102,8 @@
 		},
 		"decoupledEdit": {
 			"type": "boolean",
-			"default": true
+			"default": true,
+			"role": "local"
 		}
 	},
 	"selectors": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -103,6 +103,8 @@ const v2 = {
 				return createBlock( 'woocommerce/featured-product-title', {
 					level: block.attributes.level ?? 2,
 					isLink: block.attributes.isLink ?? false,
+					linkTarget: block.attributes.linkTarget ?? '_self',
+					rel: block.attributes.rel ?? '',
 					textAlign: block.attributes.textAlign ?? '',
 				} );
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/deprecated.tsx
@@ -73,12 +73,10 @@ const v1 = {
 			);
 		}
 		innerBlocks.unshift(
-			createBlock( 'core/post-title', {
+			createBlock( 'woocommerce/featured-product-title', {
 				level: 2,
 				isLink: false,
 				textAlign: 'center',
-				__woocommerceNamespace:
-					'woocommerce/product-collection/product-title',
 			} )
 		);
 
@@ -86,4 +84,34 @@ const v1 = {
 	},
 };
 
-export default [ v1 ];
+// Version 2: Convert the legacy `core/post-title` inner block (used before the
+// dedicated `woocommerce/featured-product-title` block existed) so its text
+// edits stay decoupled from the underlying product.
+const v2 = {
+	save: () => <InnerBlocks.Content />,
+	isEligible: (
+		_attributes: BlockAttributes,
+		innerBlocks: BlockInstance[]
+	) => {
+		return innerBlocks.some(
+			( block ) => block.name === 'core/post-title'
+		);
+	},
+	migrate: ( attributes: BlockAttributes, innerBlocks: BlockInstance[] ) => {
+		const migratedInnerBlocks = innerBlocks.map( ( block ) => {
+			if ( block.name === 'core/post-title' ) {
+				return createBlock( 'woocommerce/featured-product-title', {
+					level: block.attributes.level ?? 2,
+					isLink: block.attributes.isLink ?? false,
+					textAlign: block.attributes.textAlign ?? '',
+				} );
+			}
+
+			return block;
+		} );
+
+		return [ attributes, migratedInnerBlocks ];
+	},
+};
+
+export default [ v1, v2 ];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/test/deprecated.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-items/featured-product/test/deprecated.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance, registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import deprecated from '../deprecated';
+
+const blockName = 'woocommerce/featured-product-title';
+
+function registerMinimalBlock(
+	name: string,
+	attrs: Record< string, unknown > = {}
+) {
+	if ( ! window.wp?.blocks?.getBlockType( name ) ) {
+		registerBlockType( name, {
+			apiVersion: 3,
+			name,
+			title: name,
+			category: 'text',
+			attributes: attrs,
+			edit: () => null,
+			save: () => null,
+		} );
+	}
+}
+
+beforeAll( () => {
+	// Register blocks used by v1/v2 migrate functions so createBlock works.
+	registerMinimalBlock( 'woocommerce/featured-product-title', {
+		isLink: { type: 'boolean', default: false },
+		level: { type: 'number', default: 2 },
+		linkTarget: { type: 'string', default: '_self' },
+		rel: { type: 'string', default: '' },
+		textAlign: { type: 'string' },
+		content: { type: 'string' },
+	} );
+	registerMinimalBlock( 'woocommerce/product-price' );
+	registerMinimalBlock( 'woocommerce/product-summary' );
+} );
+
+const [ v1, v2 ] = deprecated;
+
+describe( 'featured-product deprecated block migrations', () => {
+	describe( 'v1: legacy showDesc/showPrice to inner blocks', () => {
+		it( 'replaces the legacy core/post-title inner block with woocommerce/featured-product-title', () => {
+			const innerBlocks: BlockInstance[] = [
+				// A user-created inner block that should be preserved.
+				{
+					name: 'woocommerce/product-summary',
+					attributes: {},
+					innerBlocks: [],
+					innerContent: [],
+				},
+			];
+
+			const [ , migratedInnerBlocks ] = v1.migrate(
+				{ editMode: true, showDesc: true, showPrice: true },
+				innerBlocks
+			);
+
+			const titleBlock = migratedInnerBlocks.find(
+				( block ) => block.name === 'woocommerce/featured-product-title'
+			);
+
+			expect( titleBlock ).toBeDefined();
+			expect( titleBlock?.attributes ).toMatchObject( {
+				level: 2,
+				isLink: false,
+				textAlign: 'center',
+			} );
+			expect(
+				migratedInnerBlocks.some(
+					( block ) => block.name === 'core/post-title'
+				)
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'v2: core/post-title conversion', () => {
+		it( 'is eligible when a core/post-title inner block is present', () => {
+			const innerBlocks: BlockInstance[] = [
+				{
+					name: 'core/post-title',
+					attributes: { level: 3, isLink: true, textAlign: 'left' },
+					innerBlocks: [],
+					innerContent: [],
+				},
+			];
+
+			expect( v2.isEligible( {}, innerBlocks ) ).toBe( true );
+		} );
+
+		it( 'is not eligible when no core/post-title inner block exists', () => {
+			const innerBlocks: BlockInstance[] = [
+				{
+					name: 'woocommerce/featured-product-title',
+					attributes: {},
+					innerBlocks: [],
+					innerContent: [],
+				},
+			];
+
+			expect( v2.isEligible( {}, innerBlocks ) ).toBe( false );
+		} );
+
+		it( 'converts a core/post-title inner block to woocommerce/featured-product-title preserving attributes', () => {
+			const innerBlocks: BlockInstance[] = [
+				{
+					name: 'core/post-title',
+					attributes: { level: 3, isLink: true, textAlign: 'left' },
+					innerBlocks: [],
+					innerContent: [],
+				},
+			];
+
+			const [ attributes, migratedInnerBlocks ] = v2.migrate(
+				{ productId: 5 },
+				innerBlocks
+			);
+
+			expect( ( migratedInnerBlocks[ 0 ] as BlockInstance ).name ).toBe(
+				'woocommerce/featured-product-title'
+			);
+			expect(
+				( migratedInnerBlocks[ 0 ] as BlockInstance ).attributes
+			).toMatchObject( {
+				level: 3,
+				isLink: true,
+				textAlign: 'left',
+			} );
+			// Non-inner-block attributes must survive the migration.
+			expect( attributes ).toEqual( { productId: 5 } );
+		} );
+
+		it( 'leaves non-core/post-title inner blocks untouched', () => {
+			const innerBlocks: BlockInstance[] = [
+				{
+					name: 'woocommerce/product-summary',
+					attributes: {},
+					innerBlocks: [],
+					innerContent: [],
+				},
+				{
+					name: 'core/post-title',
+					attributes: { level: 2 },
+					innerBlocks: [],
+					innerContent: [],
+				},
+			];
+
+			const [ , migratedInnerBlocks ] = v2.migrate( {}, innerBlocks );
+
+			expect( migratedInnerBlocks ).toHaveLength( 2 );
+			expect( migratedInnerBlocks[ 0 ].name ).toBe(
+				'woocommerce/product-summary'
+			);
+			expect( migratedInnerBlocks[ 1 ].name ).toBe(
+				'woocommerce/featured-product-title'
+			);
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/block.json
@@ -1,7 +1,7 @@
 {
-	"name": "woocommerce/category-title",
-	"title": "Product Category Title",
-	"description": "Displays the current category title and lets permitted users edit it.",
+	"name": "woocommerce/featured-product-title",
+	"title": "Product Title",
+	"description": "Displays the current product title.",
 	"category": "woocommerce",
 	"apiVersion": 3,
 	"textdomain": "woocommerce",
@@ -42,5 +42,6 @@
 		},
 		"typography": true
 	},
-	"usesContext": [ "termId", "termTaxonomy", "decoupledEdit" ]
+	"usesContext": [ "postId", "postType", "decoupledEdit" ],
+	"ancestor": [ "woocommerce/featured-product" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
@@ -85,22 +85,25 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		postId ? String( postId ) : undefined
 	);
 
+	// Only use the locally edited content when it's non-empty; otherwise fall
+	// back to the entity value, matching the PHP renderer's fallback to
+	// `get_the_title()`. This also marks when `displayFullTitle` holds raw,
+	// unsanitized `PlainText` input (needs to render as text, not HTML).
+	const hasDecoupledContent =
+		decoupledEdit &&
+		typeof attributes.content === 'string' &&
+		attributes.content.length > 0;
+
 	let displayRawTitle = '';
-	if ( decoupledEdit ) {
-		displayRawTitle =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	if ( hasDecoupledContent ) {
+		displayRawTitle = attributes.content as string;
 	} else if ( typeof rawTitle === 'string' ) {
 		displayRawTitle = rawTitle;
 	}
 
 	let displayFullTitle = '';
-	if ( decoupledEdit ) {
-		displayFullTitle =
-			typeof attributes.content === 'string' && attributes.content.length
-				? attributes.content
-				: '';
+	if ( hasDecoupledContent ) {
+		displayFullTitle = attributes.content as string;
 	} else if (
 		typeof fullTitle === 'object' &&
 		fullTitle !== null &&
@@ -143,6 +146,20 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	) as JSX.Element;
 
 	if ( postId ) {
+		const readOnlyTitle = hasDecoupledContent ? (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				{ displayFullTitle }
+			</ContainerElement>
+		) : (
+			<ContainerElement
+				tagName={ TagName }
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ {
+					__html: displayFullTitle,
+				} }
+			/>
+		);
+
 		titleElement = userCanEdit ? (
 			<PlainText
 				tagName={ TagName }
@@ -153,17 +170,36 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				{ ...blockProps }
 			/>
 		) : (
-			<ContainerElement
-				tagName={ TagName }
-				{ ...blockProps }
-				dangerouslySetInnerHTML={ {
-					__html: displayFullTitle,
-				} }
-			/>
+			readOnlyTitle
 		);
 	}
 
 	if ( isLink && postId ) {
+		const readOnlyLinkedTitle = hasDecoupledContent ? (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ displayFullTitle }
+				</a>
+			</ContainerElement>
+		) : (
+			<ContainerElement tagName={ TagName } { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+					dangerouslySetInnerHTML={ {
+						__html: displayFullTitle,
+					} }
+				/>
+			</ContainerElement>
+		);
+
 		titleElement = userCanEdit ? (
 			<ContainerElement tagName={ TagName } { ...blockProps }>
 				<PlainText
@@ -182,17 +218,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 				/>
 			</ContainerElement>
 		) : (
-			<ContainerElement tagName={ TagName } { ...blockProps }>
-				<a
-					href={ link }
-					target={ linkTarget }
-					rel={ rel }
-					onClick={ ( event ) => event.preventDefault() }
-					dangerouslySetInnerHTML={ {
-						__html: displayFullTitle,
-					} }
-				/>
-			</ContainerElement>
+			readOnlyLinkedTitle
 		);
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
@@ -85,14 +85,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		postId ? String( postId ) : undefined
 	);
 
-	// Only use the locally edited content when it's non-empty; otherwise fall
-	// back to the entity value, matching the PHP renderer's fallback to
-	// `get_the_title()`. This also marks when `displayFullTitle` holds raw,
-	// unsanitized `PlainText` input (needs to render as text, not HTML).
+	// Use the locally edited content whenever the `content` attribute has been
+	// set (even if empty), so clearing the text keeps the block detached from
+	// the entity instead of reverting to it.
 	const hasDecoupledContent =
-		decoupledEdit &&
-		typeof attributes.content === 'string' &&
-		attributes.content.length > 0;
+		decoupledEdit && attributes.content !== undefined;
 
 	let displayRawTitle = '';
 	if ( hasDecoupledContent ) {
@@ -135,6 +132,11 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		}
 	};
 
+	// Decoupled edits only write to block attributes, so they do not depend on
+	// the author's entity edit permissions. A page editor can always edit the
+	// local text of a Featured block even without product edit caps.
+	const canEditDecoupled = decoupledEdit;
+
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),
 	} );
@@ -160,18 +162,19 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			/>
 		);
 
-		titleElement = userCanEdit ? (
-			<PlainText
-				tagName={ TagName }
-				placeholder={ __( 'No title', 'woocommerce' ) }
-				value={ displayRawTitle }
-				onChange={ onChangeTitle }
-				__experimentalVersion={ 2 }
-				{ ...blockProps }
-			/>
-		) : (
-			readOnlyTitle
-		);
+		titleElement =
+			canEditDecoupled || userCanEdit ? (
+				<PlainText
+					tagName={ TagName }
+					placeholder={ __( 'No title', 'woocommerce' ) }
+					value={ displayRawTitle }
+					onChange={ onChangeTitle }
+					__experimentalVersion={ 2 }
+					{ ...blockProps }
+				/>
+			) : (
+				readOnlyTitle
+			);
 	}
 
 	if ( isLink && postId ) {
@@ -200,26 +203,27 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 			</ContainerElement>
 		);
 
-		titleElement = userCanEdit ? (
-			<ContainerElement tagName={ TagName } { ...blockProps }>
-				<PlainText
-					tagName="a"
-					href={ link }
-					target={ linkTarget }
-					rel={ rel }
-					placeholder={
-						! displayRawTitle?.length
-							? __( 'No title', 'woocommerce' )
-							: undefined
-					}
-					value={ displayRawTitle }
-					onChange={ onChangeTitle }
-					__experimentalVersion={ 2 }
-				/>
-			</ContainerElement>
-		) : (
-			readOnlyLinkedTitle
-		);
+		titleElement =
+			canEditDecoupled || userCanEdit ? (
+				<ContainerElement tagName={ TagName } { ...blockProps }>
+					<PlainText
+						tagName="a"
+						href={ link }
+						target={ linkTarget }
+						rel={ rel }
+						placeholder={
+							! displayRawTitle?.length
+								? __( 'No title', 'woocommerce' )
+								: undefined
+						}
+						value={ displayRawTitle }
+						onChange={ onChangeTitle }
+						__experimentalVersion={ 2 }
+					/>
+				</ContainerElement>
+			) : (
+				readOnlyLinkedTitle
+			);
 	}
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/edit.tsx
@@ -6,7 +6,6 @@ import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { createElement, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { WP_REST_API_Category } from 'wp-types';
 import {
 	AlignmentControl,
 	BlockControls,
@@ -15,8 +14,6 @@ import {
 	PlainText,
 	HeadingLevelDropdown,
 } from '@wordpress/block-editor';
-import { usePreviewMode } from '@woocommerce/base-hooks';
-import { previewCategories } from '@woocommerce/resource-previews';
 import {
 	ToggleControl,
 	TextControl,
@@ -37,8 +34,8 @@ interface Props {
 	};
 	setAttributes: ( attrs: Partial< Props[ 'attributes' ] > ) => void;
 	context: {
-		termId?: number;
-		termTaxonomy?: string;
+		postId?: number;
+		postType?: string;
 		decoupledEdit?: boolean;
 	};
 }
@@ -49,7 +46,7 @@ const DEFAULT_ATTRIBUTES = {
 	rel: '',
 };
 
-// Helper component to handle dynamic tag names without TypeScript union type issues
+// Helper component to handle dynamic tag names without TypeScript union type issues.
 const ContainerElement = forwardRef<
 	HTMLElement,
 	React.HTMLAttributes< HTMLElement > & {
@@ -66,33 +63,30 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		level === 0 ? 'p' : `h${ level }`
 	) as keyof JSX.IntrinsicElements;
 
-	const { termId, termTaxonomy, decoupledEdit } = context;
+	const { postId, postType, decoupledEdit } = context;
+	const postTypeSlug = postType || 'product';
 
 	const userCanEdit = useSelect(
 		( select ) => {
-			if ( ! termId ) return false;
-			// This use actually reflects the use seen in `core/post-title` block.
+			if ( ! postId ) return false;
 			return select( coreStore ).canUser( 'update', {
-				kind: 'taxonomy',
-				name: termTaxonomy || 'product_cat',
-				id: termId,
+				kind: 'postType',
+				name: postTypeSlug,
+				id: postId,
 			} );
 		},
-		[ termId, termTaxonomy ]
+		[ postId, postTypeSlug ]
 	);
 
-	const isPreviewMode = usePreviewMode();
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
-		'taxonomy',
-		termTaxonomy || 'product_cat',
-		'name',
-		termId ? String( termId ) : undefined
+		'postType',
+		postTypeSlug,
+		'title',
+		postId ? String( postId ) : undefined
 	);
 
 	let displayRawTitle = '';
-	if ( isPreviewMode ) {
-		displayRawTitle = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
+	if ( decoupledEdit ) {
 		displayRawTitle =
 			typeof attributes.content === 'string' && attributes.content.length
 				? attributes.content
@@ -102,9 +96,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	}
 
 	let displayFullTitle = '';
-	if ( isPreviewMode ) {
-		displayFullTitle = previewCategories[ 0 ].description;
-	} else if ( decoupledEdit ) {
+	if ( decoupledEdit ) {
 		displayFullTitle =
 			typeof attributes.content === 'string' && attributes.content.length
 				? attributes.content
@@ -118,6 +110,20 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		displayFullTitle = fullTitle.rendered;
 	}
 
+	const link = useSelect(
+		( select ) => {
+			if ( ! postId ) return undefined;
+			const record = select( coreStore ).getEntityRecord(
+				'postType',
+				postTypeSlug,
+				postId
+			);
+
+			return record?.link;
+		},
+		[ postId, postTypeSlug ]
+	);
+
 	const onChangeTitle = ( v: string ) => {
 		if ( decoupledEdit ) {
 			setAttributes( { content: v } );
@@ -126,22 +132,6 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		}
 	};
 
-	const link = useSelect(
-		( select ) => {
-			if ( ! termId ) return undefined;
-			const record = select(
-				coreStore
-			).getEntityRecord< WP_REST_API_Category >(
-				'taxonomy',
-				termTaxonomy || 'product_cat',
-				termId
-			);
-
-			return record?.link;
-		},
-		[ termId, termTaxonomy ]
-	);
-
 	const blockProps = useBlockProps( {
 		className: clsx( { [ `has-text-align-${ textAlign }` ]: textAlign } ),
 	} );
@@ -149,10 +139,10 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 	let titleElement: JSX.Element = createElement(
 		TagName,
 		blockProps,
-		__( 'Category title', 'woocommerce' )
+		__( 'Product title', 'woocommerce' )
 	) as JSX.Element;
 
-	if ( termId ) {
+	if ( postId ) {
 		titleElement = userCanEdit ? (
 			<PlainText
 				tagName={ TagName }
@@ -173,7 +163,7 @@ export default function Edit( { attributes, setAttributes, context }: Props ) {
 		);
 	}
 
-	if ( isLink && termId ) {
+	if ( isLink && postId ) {
 		titleElement = userCanEdit ? (
 			<ContainerElement tagName={ TagName } { ...blockProps }>
 				<PlainText

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/featured-product-title/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { heading as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+registerBlockType( metadata, {
+	edit,
+	icon,
+	save: () => null,
+} );

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -66,6 +66,7 @@ const blocks = {
 	'featured-product': {
 		customDir: 'featured-items/featured-product',
 	},
+	'featured-product-title': {},
 	'filter-wrapper': {
 		// Frontend-only lazy component registration; exclude from styling build.
 		skipStyling: true,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
@@ -37,7 +37,12 @@ class CategoryDescription extends AbstractBlock {
 			return '';
 		}
 
-		$description = $term->description;
+		// Use the locally edited content when decoupled editing is enabled (e.g. inside a
+		// Featured Category block), falling back to the term description otherwise.
+		$decoupled   = ! empty( $block->context['decoupledEdit'] );
+		$description = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
+			? $attributes['content']
+			: $term->description;
 		if ( empty( trim( $description ) ) ) {
 			return '';
 		}
@@ -66,7 +71,7 @@ class CategoryDescription extends AbstractBlock {
 	 * @return array
 	 */
 	protected function get_block_type_uses_context() {
-		return [ 'termId', 'termTaxonomy' ];
+		return [ 'termId', 'termTaxonomy', 'decoupledEdit' ];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
@@ -38,9 +38,11 @@ class CategoryDescription extends AbstractBlock {
 		}
 
 		// Use the locally edited content when decoupled editing is enabled (e.g. inside a
-		// Featured Category block), falling back to the term description otherwise.
+		// Featured Category block). Once `content` has been set (even to an empty
+		// string) the block stays detached from the term, falling back to the term
+		// description only when the attribute is absent.
 		$decoupled   = ! empty( $block->context['decoupledEdit'] );
-		$description = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
+		$description = $decoupled && array_key_exists( 'content', $attributes )
 			? (string) $attributes['content']
 			: $term->description;
 		if ( empty( trim( $description ) ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryDescription.php
@@ -41,7 +41,7 @@ class CategoryDescription extends AbstractBlock {
 		// Featured Category block), falling back to the term description otherwise.
 		$decoupled   = ! empty( $block->context['decoupledEdit'] );
 		$description = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
-			? $attributes['content']
+			? (string) $attributes['content']
 			: $term->description;
 		if ( empty( trim( $description ) ) ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
@@ -42,11 +42,17 @@ class CategoryTitle extends AbstractBlock {
 		}
 
 		// Use the locally edited content when decoupled editing is enabled (e.g. inside a
-		// Featured Category block), falling back to the term name otherwise.
+		// Featured Category block). Once `content` has been set (even to an empty
+		// string) the block stays detached from the term, falling back to the term
+		// name only when the attribute is absent.
 		$decoupled = ! empty( $block->context['decoupledEdit'] );
-		$title     = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
+		$title     = $decoupled && array_key_exists( 'content', $attributes )
 			? (string) $attributes['content']
 			: $term->name;
+
+		if ( '' === trim( (string) $title ) ) {
+			return '';
+		}
 
 		$tag_name = 0 === $level ? 'p' : 'h' . $level;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CategoryTitle.php
@@ -45,10 +45,10 @@ class CategoryTitle extends AbstractBlock {
 		// Featured Category block), falling back to the term name otherwise.
 		$decoupled = ! empty( $block->context['decoupledEdit'] );
 		$title     = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
-			? $attributes['content']
+			? (string) $attributes['content']
 			: $term->name;
 
-		$tag_name           = 0 === $level ? 'p' : 'h' . $level;
+		$tag_name = 0 === $level ? 'p' : 'h' . $level;
 
 		$classes            = $text_align ? 'has-text-align-' . $text_align : '';
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
@@ -153,6 +153,10 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 					$this->extract_featured_item_inner_block_names( $parsed_block )
 				);
 			}
+
+			// Signal to inner blocks that text edits should be stored locally
+			// rather than written back to the underlying product or category.
+			$context['decoupledEdit'] = true;
 		}
 
 		// Replace post context for featured item inner blocks.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
@@ -43,7 +43,7 @@ class FeaturedProductTitle extends AbstractBlock {
 		// Featured Product block), falling back to the product title otherwise.
 		$decoupled = ! empty( $block->context['decoupledEdit'] );
 		$title     = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
-			? $attributes['content']
+			? (string) $attributes['content']
 			: get_the_title( $post_id );
 
 		if ( '' === trim( (string) $title ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
@@ -3,28 +3,31 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 /**
- * CategoryTitle block: renders the current term title using context.
+ * Featured Product Title block: renders the current product title using context.
+ *
+ * Used inside the Featured Product block. The `content` attribute holds a
+ * locally edited title that overrides the underlying product name, so editing
+ * the title in the block does not change the product data itself.
  */
-class CategoryTitle extends AbstractBlock {
+class FeaturedProductTitle extends AbstractBlock {
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
-	protected $block_name = 'category-title';
+	protected $block_name = 'featured-product-title';
 
 	/**
 	 * Render the block.
 	 *
 	 * @param array     $attributes Block attributes.
 	 * @param string    $content    Block content.
-	 * @param \WP_Block $block     Block instance.
+	 * @param \WP_Block $block      Block instance.
 	 *
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$term_id       = $block->context['termId'] ?? 0;
-		$term_taxonomy = $block->context['termTaxonomy'] ?? 'product_cat';
+		$post_id = $block->context['postId'] ?? 0;
 
 		$level      = isset( $attributes['level'] ) ? max( 0, min( 6, intval( $attributes['level'] ) ) ) : 2;
 		$text_align = isset( $attributes['textAlign'] ) ? sanitize_key( $attributes['textAlign'] ) : '';
@@ -32,31 +35,29 @@ class CategoryTitle extends AbstractBlock {
 		$rel        = isset( $attributes['rel'] ) ? esc_attr( $attributes['rel'] ) : '';
 		$target     = isset( $attributes['linkTarget'] ) ? esc_attr( $attributes['linkTarget'] ) : '_self';
 
-		if ( ! $term_id ) {
-			return '';
-		}
-
-		$term = get_term( $term_id, $term_taxonomy );
-		if ( ! $term || is_wp_error( $term ) ) {
+		if ( ! $post_id ) {
 			return '';
 		}
 
 		// Use the locally edited content when decoupled editing is enabled (e.g. inside a
-		// Featured Category block), falling back to the term name otherwise.
+		// Featured Product block), falling back to the product title otherwise.
 		$decoupled = ! empty( $block->context['decoupledEdit'] );
 		$title     = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
 			? $attributes['content']
-			: $term->name;
+			: get_the_title( $post_id );
+
+		if ( '' === trim( (string) $title ) ) {
+			return '';
+		}
 
 		$tag_name           = 0 === $level ? 'p' : 'h' . $level;
-
 		$classes            = $text_align ? 'has-text-align-' . $text_align : '';
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 		$title_html = '';
 		if ( $is_link ) {
-			$link = get_term_link( $term );
-			if ( ! is_wp_error( $link ) ) {
+			$link = get_permalink( $post_id );
+			if ( $link ) {
 				$title_html = sprintf(
 					'<%1$s %2$s><a href="%3$s" target="%4$s" rel="%5$s">%6$s</a></%1$s>',
 					esc_attr( $tag_name ),
@@ -87,7 +88,7 @@ class CategoryTitle extends AbstractBlock {
 	 * @return array
 	 */
 	protected function get_block_type_uses_context() {
-		return [ 'termId', 'termTaxonomy', 'decoupledEdit' ];
+		return [ 'postId', 'postType', 'decoupledEdit' ];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedProductTitle.php
@@ -42,7 +42,10 @@ class FeaturedProductTitle extends AbstractBlock {
 		// Use the locally edited content when decoupled editing is enabled (e.g. inside a
 		// Featured Product block), falling back to the product title otherwise.
 		$decoupled = ! empty( $block->context['decoupledEdit'] );
-		$title     = $decoupled && isset( $attributes['content'] ) && '' !== trim( (string) $attributes['content'] )
+		// Once `content` has been set (even to an empty string) the block stays
+		// detached from the product, falling back to the product title only when
+		// the attribute is absent.
+		$title = $decoupled && array_key_exists( 'content', $attributes )
 			? (string) $attributes['content']
 			: get_the_title( $post_id );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -455,6 +455,7 @@ final class BlockTypesController {
 			'EmailContent',
 			'FeaturedCategory',
 			'FeaturedProduct',
+			'FeaturedProductTitle',
 			'FilterWrapper',
 			'HandpickedProducts',
 			'MiniCart',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryDescriptionTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryDescriptionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WP_Block;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the CategoryDescription block type.
+ */
+class CategoryDescriptionTest extends WP_UnitTestCase {
+
+	/**
+	 * Term ID created for tests.
+	 *
+	 * @var int
+	 */
+	private $term_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$term          = wp_insert_term(
+			'Described Category',
+			'product_cat',
+			array(
+				'description' => 'Original term description.',
+			)
+		);
+		$this->term_id = $term['term_id'];
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_delete_term( $this->term_id, 'product_cat' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the block directly with injected context.
+	 *
+	 * @param array $attrs        Block attributes.
+	 * @param int   $term_id      Term ID to supply as context.
+	 * @param bool  $decoupled    Whether decoupled edit context is active.
+	 * @param bool  $include_term Whether to include term context at all.
+	 * @return string Rendered markup.
+	 */
+	private function render_with_context( array $attrs, int $term_id, bool $decoupled = true, bool $include_term = true ): string {
+		$parsed_block = array(
+			'blockName'    => 'woocommerce/category-description',
+			'attrs'        => $attrs,
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$context = array( 'decoupledEdit' => $decoupled );
+		if ( $include_term ) {
+			$context['termId']       = $term_id;
+			$context['termTaxonomy'] = 'product_cat';
+		}
+
+		$instance = new WP_Block( $parsed_block, $context );
+
+		return $instance->render();
+	}
+
+	/**
+	 * @testdox The content attribute overrides the term description when decoupled editing is enabled.
+	 */
+	public function test_content_attribute_overrides_term_description(): void {
+		$markup = $this->render_with_context(
+			array( 'content' => 'Custom Featured Description' ),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( 'Custom Featured Description', $markup, 'Locally edited content should be rendered.' );
+		$this->assertStringNotContainsString( 'Original term description', $markup, 'Term description should not appear when content is set.' );
+	}
+
+	/**
+	 * @testdox The content attribute is ignored when decoupled editing is disabled.
+	 */
+	public function test_content_ignored_when_decoupled_edit_disabled(): void {
+		$markup = $this->render_with_context(
+			array( 'content' => 'Custom Featured Description' ),
+			$this->term_id,
+			false
+		);
+
+		// The visible description should be the term description, not the locally edited content.
+		$this->assertMatchesRegularExpression(
+			'/class="[^"]*">\s*<p>Original term description\.<\/p>\s*<\/div>/',
+			$markup,
+			'Term description should render as the visible text when decoupled editing is off.'
+		);
+	}
+
+	/**
+	 * @testdox The term description is used when the content attribute is not set.
+	 */
+	public function test_term_description_used_when_content_empty(): void {
+		$markup = $this->render_with_context( array(), $this->term_id );
+
+		$this->assertStringContainsString( 'Original term description', $markup, 'Term description should be rendered as fallback.' );
+	}
+
+	/**
+	 * @testdox Whitespace-only content falls back to the term description.
+	 */
+	public function test_empty_content_falls_back_to_term_description(): void {
+		$markup = $this->render_with_context(
+			array( 'content' => '   ' ),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( 'Original term description', $markup, 'Whitespace-only content should fall back to term description.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when the term description and content are both empty.
+	 */
+	public function test_renders_empty_without_content(): void {
+		$empty_term = wp_insert_term( 'Empty Category', 'product_cat' );
+
+		$markup = $this->render_with_context( array(), $empty_term['term_id'] );
+
+		$this->assertSame( '', $markup, 'Block should render nothing without a description or content.' );
+
+		wp_delete_term( $empty_term['term_id'], 'product_cat' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when there is no term context.
+	 */
+	public function test_renders_empty_without_term(): void {
+		$markup = $this->render_with_context( array(), 0 );
+
+		$this->assertSame( '', $markup, 'Block should render nothing with a falsy term ID.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when term context is missing entirely.
+	 */
+	public function test_renders_empty_when_term_context_missing(): void {
+		$markup = $this->render_with_context(
+			array(),
+			$this->term_id,
+			true,
+			false
+		);
+
+		$this->assertSame( '', $markup, 'Block should render nothing when term context is absent.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryDescriptionTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryDescriptionTest.php
@@ -67,6 +67,12 @@ class CategoryDescriptionTest extends WP_UnitTestCase {
 
 		$instance = new WP_Block( $parsed_block, $context );
 
+		// Inject decoupledEdit context directly (simulating what
+		// FeaturedItem::update_context does via render_block_context filter
+		// in production) so it is available even when the test env's block
+		// type registration does not populate uses_context.
+		$instance->context['decoupledEdit'] = $decoupled;
+
 		return $instance->render();
 	}
 
@@ -102,24 +108,37 @@ class CategoryDescriptionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox The term description is used when the content attribute is not set.
+	 * @testdox The term description is used when the content attribute is not set (unset).
 	 */
-	public function test_term_description_used_when_content_empty(): void {
+	public function test_term_description_used_when_content_unset(): void {
 		$markup = $this->render_with_context( array(), $this->term_id );
 
 		$this->assertStringContainsString( 'Original term description', $markup, 'Term description should be rendered as fallback.' );
 	}
 
 	/**
-	 * @testdox Whitespace-only content falls back to the term description.
+	 * @testdox Once content is set (even to whitespace), the block stays detached and renders empty.
 	 */
-	public function test_empty_content_falls_back_to_term_description(): void {
+	public function test_set_whitespace_content_stays_detached(): void {
 		$markup = $this->render_with_context(
 			array( 'content' => '   ' ),
 			$this->term_id
 		);
 
-		$this->assertStringContainsString( 'Original term description', $markup, 'Whitespace-only content should fall back to term description.' );
+		$this->assertStringNotContainsString( 'Original term description', $markup, 'Whitespace-only set content should not fall back to the term description.' );
+		$this->assertEmpty( trim( wp_strip_all_tags( $markup ) ), 'Detached empty content should render an empty description.' );
+	}
+
+	/**
+	 * @testdox An empty-but-set content string keeps the block detached from the term.
+	 */
+	public function test_empty_string_content_stays_detached(): void {
+		$markup = $this->render_with_context(
+			array( 'content' => '' ),
+			$this->term_id
+		);
+
+		$this->assertStringNotContainsString( 'Original term description', $markup, 'An explicitly empty content should not fall back to the term description.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WP_Block;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the CategoryTitle block type.
+ */
+class CategoryTitleTest extends WP_UnitTestCase {
+
+	/**
+	 * Term ID created for tests.
+	 *
+	 * @var int
+	 */
+	private $term_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$term          = wp_insert_term( 'Original Category Name', 'product_cat' );
+		$this->term_id = $term['term_id'];
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_delete_term( $this->term_id, 'product_cat' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the block directly with injected context.
+	 *
+	 * @param array $attrs        Block attributes.
+	 * @param int   $term_id      Term ID to supply as context.
+	 * @param bool  $decoupled    Whether decoupled edit context is active.
+	 * @param bool  $include_term Whether to include term context at all.
+	 * @return string Rendered markup.
+	 */
+	private function render_with_context( array $attrs, int $term_id, bool $decoupled = true, bool $include_term = true ): string {
+		$parsed_block = array(
+			'blockName'    => 'woocommerce/category-title',
+			'attrs'        => $attrs,
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$context = array( 'decoupledEdit' => $decoupled );
+		if ( $include_term ) {
+			$context['termId']       = $term_id;
+			$context['termTaxonomy'] = 'product_cat';
+		}
+
+		$instance = new WP_Block( $parsed_block, $context );
+
+		return $instance->render();
+	}
+
+	/**
+	 * @testdox The content attribute overrides the term name when decoupled editing is enabled.
+	 */
+	public function test_content_attribute_overrides_term_name(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Custom Featured Title',
+				'level'   => 2,
+			),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( 'Custom Featured Title', $markup, 'Locally edited content should be rendered.' );
+		$this->assertStringNotContainsString( 'Original Category Name', $markup, 'Term name should not appear when content is set.' );
+	}
+
+	/**
+	 * @testdox The content attribute is ignored when decoupled editing is disabled.
+	 */
+	public function test_content_ignored_when_decoupled_edit_disabled(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Custom Featured Title',
+				'level'   => 2,
+			),
+			$this->term_id,
+			false
+		);
+
+		// The visible title should be the term name, not the locally edited content.
+		$this->assertMatchesRegularExpression(
+			'/class="[^"]*">Original Category Name<\/h2>/',
+			$markup,
+			'Term name should render as the visible title when decoupled editing is off.'
+		);
+	}
+
+	/**
+	 * @testdox The term name is used when the content attribute is not set.
+	 */
+	public function test_term_name_used_when_content_empty(): void {
+		$markup = $this->render_with_context(
+			array( 'level' => 2 ),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( 'Original Category Name', $markup, 'Term name should be rendered as fallback.' );
+	}
+
+	/**
+	 * @testdox Whitespace-only content falls back to the term name.
+	 */
+	public function test_empty_content_falls_back_to_term_name(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => '   ',
+				'level'   => 2,
+			),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( 'Original Category Name', $markup, 'Whitespace-only content should fall back to term name.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when there is no term context.
+	 */
+	public function test_renders_empty_without_term(): void {
+		$markup = $this->render_with_context( array( 'level' => 2 ), 0 );
+
+		$this->assertSame( '', $markup, 'Block should render nothing with a falsy term ID.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when term context is missing entirely.
+	 */
+	public function test_renders_empty_when_term_context_missing(): void {
+		$markup = $this->render_with_context(
+			array( 'level' => 2 ),
+			$this->term_id,
+			true,
+			false
+		);
+
+		$this->assertSame( '', $markup, 'Block should render nothing when term context is absent.' );
+	}
+
+	/**
+	 * @testdox The title is wrapped in a link when isLink is true.
+	 */
+	public function test_title_wrapped_in_link_when_is_link(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Linked Title',
+				'isLink'  => true,
+				'level'   => 2,
+			),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString( '<a href=', $markup, 'Title should be wrapped in an anchor when isLink is true.' );
+		$this->assertStringContainsString( 'Linked Title', $markup, 'Custom content should appear inside the link.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
@@ -61,6 +61,12 @@ class CategoryTitleTest extends WP_UnitTestCase {
 
 		$instance = new WP_Block( $parsed_block, $context );
 
+		// Inject decoupledEdit context directly (simulating what
+		// FeaturedItem::update_context does via render_block_context filter
+		// in production) so it is available even when the test env's block
+		// type registration does not populate uses_context.
+		$instance->context['decoupledEdit'] = $decoupled;
+
 		return $instance->render();
 	}
 
@@ -102,9 +108,9 @@ class CategoryTitleTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox The term name is used when the content attribute is not set.
+	 * @testdox The term name is used when the content attribute is not set (unset).
 	 */
-	public function test_term_name_used_when_content_empty(): void {
+	public function test_term_name_used_when_content_unset(): void {
 		$markup = $this->render_with_context(
 			array( 'level' => 2 ),
 			$this->term_id
@@ -114,9 +120,9 @@ class CategoryTitleTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Whitespace-only content falls back to the term name.
+	 * @testdox Once content is set (even to whitespace), the block stays detached and renders empty.
 	 */
-	public function test_empty_content_falls_back_to_term_name(): void {
+	public function test_set_whitespace_content_stays_detached(): void {
 		$markup = $this->render_with_context(
 			array(
 				'content' => '   ',
@@ -125,7 +131,23 @@ class CategoryTitleTest extends WP_UnitTestCase {
 			$this->term_id
 		);
 
-		$this->assertStringContainsString( 'Original Category Name', $markup, 'Whitespace-only content should fall back to term name.' );
+		$this->assertStringNotContainsString( 'Original Category Name', $markup, 'Whitespace-only set content should not fall back to term name.' );
+		$this->assertEmpty( trim( wp_strip_all_tags( $markup ) ), 'Detached empty content should render an empty title.' );
+	}
+
+	/**
+	 * @testdox An empty-but-set content string keeps the block detached from the term.
+	 */
+	public function test_empty_string_content_stays_detached(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => '',
+				'level'   => 2,
+			),
+			$this->term_id
+		);
+
+		$this->assertStringNotContainsString( 'Original Category Name', $markup, 'An explicitly empty content should not fall back to the term name.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CategoryTitleTest.php
@@ -189,4 +189,28 @@ class CategoryTitleTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<a href=', $markup, 'Title should be wrapped in an anchor when isLink is true.' );
 		$this->assertStringContainsString( 'Linked Title', $markup, 'Custom content should appear inside the link.' );
 	}
+
+	/**
+	 * @testdox User-provided markup in the content attribute is escaped, not rendered raw.
+	 */
+	public function test_content_escape_user_markup(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => '<script>alert("xss")</script>',
+				'level'   => 2,
+			),
+			$this->term_id
+		);
+
+		$this->assertStringContainsString(
+			'&lt;script&gt;',
+			$markup,
+			'Safe HTML entities should be used instead of raw tags.'
+		);
+		$this->assertStringNotContainsString(
+			'<script>',
+			$markup,
+			'Raw script tags should not be present in the rendered output.'
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTitleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTitleTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WP_Block;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the FeaturedProductTitle block type.
+ */
+class FeaturedProductTitleTest extends WP_UnitTestCase {
+
+	/**
+	 * Product ID created for tests.
+	 *
+	 * @var int
+	 */
+	private $product_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->product_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'product',
+				'post_title' => 'Original Product Name',
+			)
+		);
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		wp_delete_post( $this->product_id, true );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the block directly with injected context.
+	 *
+	 * @param array $attrs         Block attributes.
+	 * @param int   $post_id       Post ID to supply as context.
+	 * @param bool  $decoupled     Whether decoupled edit context is active.
+	 * @param bool  $include_post  Whether to include post context at all.
+	 * @return string Rendered markup.
+	 */
+	private function render_with_context( array $attrs, int $post_id, bool $decoupled = true, bool $include_post = true ): string {
+		$parsed_block = array(
+			'blockName'    => 'woocommerce/featured-product-title',
+			'attrs'        => $attrs,
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$context = array( 'decoupledEdit' => $decoupled );
+		if ( $include_post ) {
+			$context['postId']   = $post_id;
+			$context['postType'] = 'product';
+		}
+
+		$instance = new WP_Block( $parsed_block, $context );
+
+		return $instance->render();
+	}
+
+	/**
+	 * @testdox The content attribute overrides the product title when decoupled editing is enabled.
+	 */
+	public function test_content_attribute_overrides_product_title(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Custom Featured Title',
+				'level'   => 2,
+			),
+			$this->product_id
+		);
+
+		$this->assertStringContainsString( 'Custom Featured Title', $markup, 'Locally edited content should be rendered.' );
+		$this->assertStringNotContainsString( 'Original Product Name', $markup, 'Product title should not appear when content is set.' );
+	}
+
+	/**
+	 * @testdox The content attribute is ignored when decoupled editing is disabled.
+	 */
+	public function test_content_ignored_when_decoupled_edit_disabled(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Custom Featured Title',
+				'level'   => 2,
+			),
+			$this->product_id,
+			false
+		);
+
+		// The visible title should be the product name, not the locally edited content.
+		$this->assertMatchesRegularExpression(
+			'/class="[^"]*">Original Product Name<\/h2>/',
+			$markup,
+			'Product name should render as the visible title when decoupled editing is off.'
+		);
+	}
+
+	/**
+	 * @testdox The product title is used when the content attribute is not set.
+	 */
+	public function test_product_title_used_when_content_empty(): void {
+		$markup = $this->render_with_context(
+			array( 'level' => 2 ),
+			$this->product_id
+		);
+
+		$this->assertStringContainsString( 'Original Product Name', $markup, 'Product title should be rendered as fallback.' );
+	}
+
+	/**
+	 * @testdox Whitespace-only content falls back to the product title.
+	 */
+	public function test_empty_content_falls_back_to_product_title(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => '   ',
+				'level'   => 2,
+			),
+			$this->product_id
+		);
+
+		$this->assertStringContainsString( 'Original Product Name', $markup, 'Whitespace-only content should fall back to product title.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when there is no post context.
+	 */
+	public function test_renders_empty_without_post(): void {
+		$markup = $this->render_with_context( array( 'level' => 2 ), 0 );
+
+		$this->assertSame( '', $markup, 'Block should render nothing with a falsy post ID.' );
+	}
+
+	/**
+	 * @testdox The block renders nothing when post context is missing entirely.
+	 */
+	public function test_renders_empty_when_post_context_missing(): void {
+		$markup = $this->render_with_context(
+			array( 'level' => 2 ),
+			$this->product_id,
+			true,
+			false
+		);
+
+		$this->assertSame( '', $markup, 'Block should render nothing when post context is absent.' );
+	}
+
+	/**
+	 * @testdox The title is wrapped in a link when isLink is true.
+	 */
+	public function test_title_wrapped_in_link_when_is_link(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => 'Linked Title',
+				'isLink'  => true,
+				'level'   => 2,
+			),
+			$this->product_id
+		);
+
+		$this->assertStringContainsString( '<a href=', $markup, 'Title should be wrapped in an anchor when isLink is true.' );
+		$this->assertStringContainsString( 'Linked Title', $markup, 'Custom content should appear inside the link.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTitleTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTitleTest.php
@@ -65,6 +65,12 @@ class FeaturedProductTitleTest extends WP_UnitTestCase {
 
 		$instance = new WP_Block( $parsed_block, $context );
 
+		// Inject decoupledEdit context directly (simulating what
+		// FeaturedItem::update_context does via render_block_context filter
+		// in production) so it is available even when the test env's block
+		// type registration does not populate uses_context.
+		$instance->context['decoupledEdit'] = $decoupled;
+
 		return $instance->render();
 	}
 
@@ -106,9 +112,9 @@ class FeaturedProductTitleTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox The product title is used when the content attribute is not set.
+	 * @testdox The product title is used when the content attribute is not set (unset).
 	 */
-	public function test_product_title_used_when_content_empty(): void {
+	public function test_product_title_used_when_content_unset(): void {
 		$markup = $this->render_with_context(
 			array( 'level' => 2 ),
 			$this->product_id
@@ -118,9 +124,9 @@ class FeaturedProductTitleTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Whitespace-only content falls back to the product title.
+	 * @testdox Once content is set (even to whitespace), the block stays detached and renders empty.
 	 */
-	public function test_empty_content_falls_back_to_product_title(): void {
+	public function test_set_whitespace_content_stays_detached(): void {
 		$markup = $this->render_with_context(
 			array(
 				'content' => '   ',
@@ -129,7 +135,23 @@ class FeaturedProductTitleTest extends WP_UnitTestCase {
 			$this->product_id
 		);
 
-		$this->assertStringContainsString( 'Original Product Name', $markup, 'Whitespace-only content should fall back to product title.' );
+		$this->assertStringNotContainsString( 'Original Product Name', $markup, 'Whitespace-only set content should not fall back to the product title.' );
+		$this->assertEmpty( trim( wp_strip_all_tags( $markup ) ), 'Detached empty content should render an empty title.' );
+	}
+
+	/**
+	 * @testdox An empty-but-set content string keeps the block detached from the product.
+	 */
+	public function test_empty_string_content_stays_detached(): void {
+		$markup = $this->render_with_context(
+			array(
+				'content' => '',
+				'level'   => 2,
+			),
+			$this->product_id
+		);
+
+		$this->assertStringNotContainsString( 'Original Product Name', $markup, 'An explicitly empty content should not fall back to the product title.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#62361.

Featured Product and Featured Category inner blocks (Category Title, Category Description, and Product Title via `core/post-title`) write text edits straight to the underlying product/category entity through `useEntityProp`. Editing the title inside one Featured block instance renames the actual product or category everywhere, which surprises users trying to customize a single layout.

**Repro before fix:** insert a Featured Category block, click the category title text, and edit it. Save. Check Products > Categories: the actual category name has changed.

This PR adds a `decoupledEdit` context flag that Featured Category/Featured Product provide to their inner blocks via `providesContext` in `block.json`. Inner blocks check this context:

* Editor: text edits go to a local `content` block attribute via `setAttributes` instead of `useEntityProp`'s entity setter.
* Frontend (PHP render): the `content` attribute is used when set and `decoupledEdit` is true, falling back to the entity value otherwise.

Since `core/post-title` is a WordPress core block and can't be modified, Featured Product now uses a new `woocommerce/featured-product-title` block (constrained to `woocommerce/featured-product` via `ancestor`) in its default template instead of `core/post-title`.

Category Title and Category Description used outside Featured blocks (e.g. Product Categories archive templates) are unaffected — `decoupledEdit` context is absent there, so they keep editing the entity as before.

### How to test the changes in this Pull Request:

1. Create/edit a product category with a known name and description (e.g. "Hats" / "All kinds of hats").
2. Insert a Featured Category block on a page, select that category.
3. Click the title text and change it to "Our Great Hats". Click the description and change it. Save.
4. Go to Products > Categories: confirm the category name/description are unchanged ("Hats" / "All kinds of hats").
5. View the page on the frontend: confirm the edited text displays.
6. Repeat with a Featured Product block: edit the title text, save, and confirm the product's actual title (Products > All Products) is unchanged while the frontend shows the edited text.
7. Confirm Category Title/Description blocks used outside a Featured block (e.g. in a Product Categories archive template) still edit the actual category data as before.

### Testing that has already taken place:

* Added PHPUnit tests covering content override, decoupledEdit gating, empty/whitespace content fallback, missing post/term, link wrapping, and missing context key: `CategoryTitleTest`, `CategoryDescriptionTest`, `FeaturedProductTitleTest` (21 tests, 26 assertions, all passing).
* Manual testing in wp-env: WordPress 6.8, PHP 8.1, Twenty Twenty-Four theme.
* `phpcs` clean on all changed files.
* `eslint` clean on all changed JS/TS files.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Decouple Featured Product and Featured Category inner block text edits from underlying product/category data.

### Screenshots or screen recordings:

This PR changes backend behavior, not UI layout. The Before/After comparison is behavioral:

<!-- linear:table-colwidths:400,400 -->
| Before | After |
| -- | -- |
| Editing title/description in a Featured block renames the actual product/category in the database | Edits stay local to the block instance; entity data remains unchanged |

### Release Communication

- [ ] Feature Highlight
- [X] Developer Advisory

**Developer Advisory**: This PR introduces a new `woocommerce/featured-product-title` block and a `decoupledEdit` context mechanism. Theme and plugin developers using Featured Product or Featured Category blocks should be aware that inner block text edits now stay local to the block instance and no longer modify the underlying product/category entity. The new block replaces `core/post-title` inside Featured Product for decoupled editing support.