### PR TITLE
Use ExternalLink for WooCommerce external links

### DIFF
--- a/packages/js/components/changelog/update-link-external-indicator
+++ b/packages/js/components/changelog/update-link-external-indicator
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Render `Link type="external"` with WordPress' `ExternalLink` component so WooCommerce external links use the standard external-link indicator.

--- a/packages/js/components/src/link/index.tsx
+++ b/packages/js/components/src/link/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { partial } from 'lodash';
+import { ExternalLink } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getHistory } from '@woocommerce/navigation';
 
@@ -76,6 +77,14 @@ export const Link = ( {
 
 	if ( type === 'wc-admin' ) {
 		passProps.onClick = partial( wcAdminLinkHandler, passProps.onClick );
+	}
+
+	if ( type === 'external' ) {
+		return (
+			<ExternalLink href={ href } { ...passProps }>
+				{ children }
+			</ExternalLink>
+		);
 	}
 
 	return (

--- a/packages/js/components/src/link/test/index.tsx
+++ b/packages/js/components/src/link/test/index.tsx
@@ -29,7 +29,9 @@ describe( 'Link', () => {
 		expect( testLink.getAttribute( 'target' ) ).toBe( '_blank' );
 		expect( testLink.getAttribute( 'rel' ) ).toContain( 'noopener' );
 		expect( testLink.getAttribute( 'rel' ) ).toContain( 'noreferrer' );
-		expect( testLink.querySelector( 'svg' ) ).not.toBeNull();
+		expect(
+			testLink.querySelector( '.components-external-link__icon' )
+		).not.toBeNull();
 	} );
 
 	it( 'should render `wp-admin` links', () => {

--- a/packages/js/components/src/link/test/index.tsx
+++ b/packages/js/components/src/link/test/index.tsx
@@ -10,21 +10,26 @@ import { createElement } from '@wordpress/element';
 import { Link } from '..';
 
 describe( 'Link', () => {
-	it( 'should render `external` links', () => {
-		const { container } = render(
+	it( 'should render `external` links using WordPress ExternalLink', () => {
+		render(
 			<Link href="https://woocommerce.com" type="external">
 				WooCommerce.com
 			</Link>
 		);
 
-		expect( container.firstChild ).toMatchInlineSnapshot( `
-			<a
-			  data-link-type="external"
-			  href="https://woocommerce.com"
-			>
-			  WooCommerce.com
-			</a>
-		` );
+		const testLink = screen.getByRole( 'link', {
+			name: 'WooCommerce.com (opens in a new tab)',
+		} );
+
+		expect( testLink.className ).toContain( 'components-external-link' );
+		expect( testLink.getAttribute( 'data-link-type' ) ).toBe( 'external' );
+		expect( testLink.getAttribute( 'href' ) ).toBe(
+			'https://woocommerce.com'
+		);
+		expect( testLink.getAttribute( 'target' ) ).toBe( '_blank' );
+		expect( testLink.getAttribute( 'rel' ) ).toContain( 'noopener' );
+		expect( testLink.getAttribute( 'rel' ) ).toContain( 'noreferrer' );
+		expect( testLink.querySelector( 'svg' ) ).not.toBeNull();
 	} );
 
 	it( 'should render `wp-admin` links', () => {
@@ -82,27 +87,25 @@ describe( 'Link', () => {
 	} );
 
 	it( 'should allow custom props to be passed through', () => {
-		const { container } = render(
+		render(
 			<Link
 				href="https://woocommerce.com"
 				type="external"
 				className="foo"
-				target="bar"
+				title="bar"
 			>
 				WooCommerce.com
 			</Link>
 		);
 
-		expect( container.firstChild ).toMatchInlineSnapshot( `
-			<a
-			  class="foo"
-			  data-link-type="external"
-			  href="https://woocommerce.com"
-			  target="bar"
-			>
-			  WooCommerce.com
-			</a>
-		` );
+		const testLink = screen.getByRole( 'link', {
+			name: 'WooCommerce.com (opens in a new tab)',
+		} );
+
+		expect( testLink.className ).toContain( 'components-external-link' );
+		expect( testLink.className ).toContain( 'foo' );
+		expect( testLink.getAttribute( 'data-link-type' ) ).toBe( 'external' );
+		expect( testLink.getAttribute( 'title' ) ).toBe( 'bar' );
 	} );
 
 	it( 'should support `onClick`', () => {

--- a/plugins/woocommerce/changelog/update-settings-marketplace-external-link
+++ b/plugins/woocommerce/changelog/update-settings-marketplace-external-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Render settings marketplace external links with the WordPress components external-link indicator.

--- a/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
@@ -6,7 +6,7 @@ import { Text } from '@woocommerce/experimental';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
-import { Icon, chevronRight, page } from '@wordpress/icons';
+import { Icon, page } from '@wordpress/icons';
 import { partial } from 'lodash';
 import { List, Section } from '@woocommerce/components';
 import {
@@ -351,7 +351,6 @@ function getListItems( props ) {
 			</Text>
 		),
 		before: <Icon icon={ page } />,
-		after: <Icon icon={ chevronRight } />,
 		linkType: item.linkType ?? 'external',
 		target: item.target ?? '_blank',
 		href: item.link,

--- a/plugins/woocommerce/client/admin/client/activity-panel/style.scss
+++ b/plugins/woocommerce/client/admin/client/activity-panel/style.scss
@@ -256,3 +256,17 @@
 .woocommerce-layout__notice-list-hide {
 	display: none;
 }
+
+.woocommerce-quick-links__list {
+	.woocommerce-list__item-inner {
+		align-items: center;
+	}
+
+	.woocommerce-list__item-text,
+	.woocommerce-list__item-title,
+	.woocommerce-list__item-title > div,
+	.components-external-link__contents {
+		display: inline-flex;
+		align-items: center;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/activity-panel/test/help-panel.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/test/help-panel.js
@@ -311,6 +311,22 @@ describe( 'Activity Panels', () => {
 			homescreenLinkTitles.forEach( ( title ) => {
 				expect( homescreen.getByText( title ) ).toBeDefined();
 			} );
+
+			const quickLinks = homescreen.container.querySelectorAll(
+				'.woocommerce-quick-links__list .woocommerce-list__item-inner'
+			);
+
+			quickLinks.forEach( ( quickLink ) => {
+				expect(
+					quickLink.querySelector( '.woocommerce-list__item-before' )
+				).toBeDefined();
+				expect(
+					quickLink.querySelector( '.components-external-link__icon' )
+				).toBeDefined();
+				expect(
+					quickLink.querySelector( '.woocommerce-list__item-after' )
+				).toBeNull();
+			} );
 		} );
 
 		describe( 'Filters', () => {

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-terms-of-service/test/__snapshots__/index.tsx.snap
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-terms-of-service/test/__snapshots__/index.tsx.snap
@@ -10,11 +10,23 @@ exports[`PluginsTermsOfService should render TOS message when Jetpack is selecte
   </span>
    plugin for free you agree to our 
   <a
+    class="components-external-link"
     data-link-type="external"
     href="https://wordpress.com/tos/"
+    rel="external noreferrer noopener"
     target="_blank"
   >
-    Terms of Service
+    <span
+      class="components-external-link__contents"
+    >
+      Terms of Service
+    </span>
+    <span
+      aria-label="(opens in a new tab)"
+      class="components-external-link__icon"
+    >
+      ↗
+    </span>
   </a>
   .
 </p>
@@ -38,11 +50,23 @@ exports[`PluginsTermsOfService should render TOS message with multiple plugins w
   </span>
    plugins for free you agree to our 
   <a
+    class="components-external-link"
     data-link-type="external"
     href="https://wordpress.com/tos/"
+    rel="external noreferrer noopener"
     target="_blank"
   >
-    Terms of Service
+    <span
+      class="components-external-link__contents"
+    >
+      Terms of Service
+    </span>
+    <span
+      aria-label="(opens in a new tab)"
+      class="components-external-link__icon"
+    >
+      ↗
+    </span>
   </a>
   .
 </p>
@@ -66,11 +90,23 @@ exports[`PluginsTermsOfService should render TOS message with multiple plugins w
   </span>
    plugins for free you agree to our 
   <a
+    class="components-external-link"
     data-link-type="external"
     href="https://wordpress.com/tos/"
+    rel="external noreferrer noopener"
     target="_blank"
   >
-    Terms of Service
+    <span
+      class="components-external-link__contents"
+    >
+      Terms of Service
+    </span>
+    <span
+      aria-label="(opens in a new tab)"
+      class="components-external-link__icon"
+    >
+      ↗
+    </span>
   </a>
   .
 </p>

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -397,11 +397,6 @@
 	.more-payment-options-link {
 		padding: 0;
 		text-decoration: none;
-
-		img {
-			height: $grid-unit-20;
-			margin-right: $grid-unit-05;
-		}
 	}
 
 	.more-payment-options {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -13,7 +13,7 @@ import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import React, { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
-import { Button } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -40,7 +40,6 @@ import {
 } from '~/settings-payments/utils';
 import { WooPaymentsPostSandboxAccountSetupModal } from '~/settings-payments/components/modals';
 import WooPaymentsModal from '~/settings-payments/onboarding/providers/woopayments';
-import { getAdminSetting } from '~/utils/admin-settings';
 import { wooPaymentsOnboardingSessionEntrySettings } from '~/settings-payments/constants';
 
 /**
@@ -72,8 +71,6 @@ export const SettingsPaymentsMain = () => {
 
 	const [ isOnboardingModalOpen, setIsOnboardingModalOpen ] =
 		useState( false );
-
-	const assetUrl = getAdminSetting( 'wcAdminAssetUrl' );
 
 	useEffect( () => {
 		// Record the page view event.
@@ -476,17 +473,13 @@ export const SettingsPaymentsMain = () => {
 	};
 
 	const morePaymentOptionsLink = (
-		<Button
-			variant={ 'link' }
-			target="_blank"
-			rel="noopener noreferrer"
+		<ExternalLink
 			href="https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations"
 			className="more-payment-options-link"
 			onClick={ trackMorePaymentsOptionsClicked }
 		>
-			<img src={ assetUrl + '/icons/external-link.svg' } alt="" />
 			{ __( 'More payment options', 'woocommerce' ) }
-		</Button>
+		</ExternalLink>
 	);
 
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
@@ -62,31 +62,37 @@ describe( 'SettingsPaymentsMain', () => {
 			</Router>
 		);
 
-		const morePaymentOptionsLink = screen.getByText(
-			'More payment options'
-		);
+		const morePaymentOptionsLink = screen
+			.getByText( 'More payment options' )
+			.closest( 'a' );
 
 		// Verify the link has the correct href attribute for external navigation
-		expect( morePaymentOptionsLink.closest( 'a' ) ).toHaveAttribute(
+		expect( morePaymentOptionsLink ).toHaveAttribute(
 			'href',
 			'https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations'
 		);
 
 		// Verify the link opens in a new tab
-		expect( morePaymentOptionsLink.closest( 'a' ) ).toHaveAttribute(
-			'target',
-			'_blank'
-		);
+		expect( morePaymentOptionsLink ).toHaveAttribute( 'target', '_blank' );
 
 		// Verify security attributes are present for external links
-		expect( morePaymentOptionsLink.closest( 'a' ) ).toHaveAttribute(
+		expect( morePaymentOptionsLink ).toHaveAttribute(
 			'rel',
 			expect.stringContaining( 'noopener' )
 		);
 
-		expect( morePaymentOptionsLink.closest( 'a' ) ).toHaveAttribute(
+		expect( morePaymentOptionsLink ).toHaveAttribute(
 			'rel',
 			expect.stringContaining( 'noreferrer' )
 		);
+
+		expect( morePaymentOptionsLink ).toHaveClass(
+			'components-external-link'
+		);
+		expect(
+			morePaymentOptionsLink?.querySelector(
+				'.components-external-link__icon'
+			)
+		).not.toBeNull();
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/store-management-links/quick-link/index.js
+++ b/plugins/woocommerce/client/admin/client/store-management-links/quick-link/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from '@wordpress/element';
-import { external, Icon } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
 
@@ -37,7 +37,6 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 				>
 					{ title }
 				</Text>
-				{ isExternal && <Icon icon={ external } /> }
 			</Link>
 		</div>
 	);

--- a/plugins/woocommerce/client/admin/client/store-management-links/quick-link/style.scss
+++ b/plugins/woocommerce/client/admin/client/store-management-links/quick-link/style.scss
@@ -13,6 +13,12 @@
 		text-decoration: none;
 		padding: 16px 27px 16px 24px;
 
+		.components-external-link__contents {
+			display: flex;
+			align-items: center;
+			flex: 1;
+		}
+
 		.woocommerce-quick-links__item-link__icon {
 			fill: var(--wp-admin-theme-color);
 		}

--- a/plugins/woocommerce/client/admin/client/store-management-links/quick-link/style.scss
+++ b/plugins/woocommerce/client/admin/client/store-management-links/quick-link/style.scss
@@ -16,7 +16,10 @@
 		.components-external-link__contents {
 			display: flex;
 			align-items: center;
-			flex: 1;
+		}
+
+		.components-external-link__icon {
+			margin-left: 0.5ch;
 		}
 
 		.woocommerce-quick-links__item-link__icon {
@@ -25,7 +28,6 @@
 
 		.woocommerce-quick-links__item-link__text {
 			margin-left: 16px;
-			flex: 1;
 			line-height: 16px;
 			font-size: 13px;
 		}

--- a/plugins/woocommerce/client/admin/client/store-management-links/quick-link/test/index.js
+++ b/plugins/woocommerce/client/admin/client/store-management-links/quick-link/test/index.js
@@ -29,6 +29,25 @@ describe( 'QuickLink', () => {
 		);
 	} );
 
+	it( 'uses the WordPress external link indicator for external links', () => {
+		const { container, queryByRole } = render(
+			<QuickLink
+				linkType="external"
+				title="hello world"
+				icon={ brush }
+				href="https://example.com"
+			/>
+		);
+
+		expect( queryByRole( 'link' ) ).toHaveClass(
+			'components-external-link'
+		);
+		expect(
+			container.querySelector( '.components-external-link__icon' )
+		).toBeDefined();
+		expect( container.querySelectorAll( 'svg' ) ).toHaveLength( 1 );
+	} );
+
 	it( 'attaches a click handler to the link if it is passed', () => {
 		const clickHandler = jest.fn();
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9612,9 +9612,8 @@ body.woocommerce_page_wc-settings {
 		border-top: 1px solid #c3c4c7;
 		color: #50575e;
 
-		a img {
-			margin-right: 4px;
-			vertical-align: text-bottom;
+		.components-external-link__icon {
+			margin-left: 0.5ch;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1065,12 +1065,11 @@ $default-line-height: 18px;
 
 		a {
 			text-decoration: none;
+		}
 
-			&[target="_blank"]::after {
-				content: url("../images/icons/external-link.svg");
-				margin-left: 2px;
-				vertical-align: sub;
-			}
+		.components-external-link__icon {
+			margin-left: 0.5ch;
+			vertical-align: text-bottom;
 		}
 
 		.add-attributes-message {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1067,6 +1067,11 @@ $default-line-height: 18px;
 			text-decoration: none;
 		}
 
+		.variations-learn-more-link::after {
+			content: none;
+			display: none;
+		}
+
 		.components-external-link__icon {
 			margin-left: 0.5ch;
 			vertical-align: text-bottom;

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -27,6 +27,18 @@ if ( Features::exists( ProductVariationsClassicRedesign::FEATURE_ID ) ) {
 $add_attributes_img_url = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/info.svg';
 $background_img_url     = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variation-background-image.svg';
 $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variation-arrow.svg';
+$external_link_icon     = is_rtl() ? '&#8598;' : '&#8599;';
+$attributes_link_open   = '<a class="variations-add-attributes-link" href="'
+	. esc_url( '#product_attributes' )
+	. '">';
+$learn_more_link_open   = '<a class="variations-learn-more-link components-external-link" href="'
+	. esc_url( 'https://woocommerce.com/document/variable-product/' )
+	. '" target="_blank" rel="external noreferrer noopener"><span class="components-external-link__contents">';
+$learn_more_link_close  = '</span><span class="components-external-link__icon wp-exclude-emoji" aria-label="'
+	. esc_attr__( '(opens in a new tab)', 'woocommerce' )
+	. '">'
+	. $external_link_icon
+	. '</span></a>';
 ?>
 <div id="variable_product_options" class="panel wc-metaboxes-wrapper hidden">
 	<div id="variable_product_options_inner">
@@ -37,12 +49,27 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 				<img src="<?php echo esc_url( $add_attributes_img_url ); ?>" />
 				<p>
 					<?php
-						echo wp_kses_post(
+						echo wp_kses(
 							sprintf(
-								/* translators: %1$s: url for attributes tab, %2$s: url for variable product documentation */
-								__( 'Add some attributes in the <a class="variations-add-attributes-link" href="%1$s">Attributes</a> tab to generate variations. Make sure to check the <b>Used for variations</b> box. <a class="variations-learn-more-link" href="%2$s" target="_blank" rel="noreferrer">Learn more</a>', 'woocommerce' ),
-								esc_url( '#product_attributes' ),
-								esc_url( 'https://woocommerce.com/document/variable-product/' )
+								/* translators: %1$s: opening attributes tab link, %2$s: closing attributes tab link, %3$s: opening learn more link, %4$s: closing learn more link */
+								__( 'Add some attributes in the %1$sAttributes%2$s tab to generate variations. Make sure to check the <b>Used for variations</b> box. %3$sLearn more%4$s', 'woocommerce' ),
+								$attributes_link_open,
+								'</a>',
+								$learn_more_link_open,
+								$learn_more_link_close
+							),
+							array(
+								'a'    => array(
+									'class'  => true,
+									'href'   => true,
+									'target' => true,
+									'rel'    => true,
+								),
+								'b'    => array(),
+								'span' => array(
+									'class'      => true,
+									'aria-label' => true,
+								),
 							)
 						);
 					?>

--- a/plugins/woocommerce/includes/admin/views/html-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-settings.php
@@ -152,13 +152,12 @@ $marketplace_links = array(
 				$link_config = $marketplace_links[ $current_tab ];
 
 				if ( $link_config['is_external'] ) {
-					$utm_source    = 'settings_' . $current_tab . ( $current_section ? '_' . $current_section : '' );
-					$link_url      = add_query_arg( 'utm_source', $utm_source, $link_config['url'] );
-					$icon_url      = WC()->plugin_url() . '/assets/images/icons/external-link.svg';
-					$external_icon = '<img src="' . esc_url( $icon_url ) . '" alt="" />';
-					$screen_reader = '<span class="screen-reader-text">' . esc_html__( '(opens in a new tab)', 'woocommerce' ) . '</span>';
-					$link_open     = '<a href="' . esc_url( $link_url ) . '" target="_blank" rel="noopener noreferrer">' . $external_icon;
-					$link_close    = $screen_reader . '</a>';
+					$utm_source          = 'settings_' . $current_tab . ( $current_section ? '_' . $current_section : '' );
+					$link_url            = add_query_arg( 'utm_source', $utm_source, $link_config['url'] );
+					$external_icon_arrow = is_rtl() ? '&#8598;' : '&#8599;';
+					$external_icon       = '<span class="components-external-link__icon wp-exclude-emoji" aria-label="' . esc_attr__( '(opens in a new tab)', 'woocommerce' ) . '">' . $external_icon_arrow . '</span>';
+					$link_open           = '<a class="components-external-link" href="' . esc_url( $link_url ) . '" target="_blank" rel="external noreferrer noopener"><span class="components-external-link__contents">';
+					$link_close          = '</span>' . $external_icon . '</a>';
 				} else {
 					$link_open  = '<a href="' . esc_url( $link_config['url'] ) . '">';
 					$link_close = '</a>';
@@ -170,16 +169,14 @@ $marketplace_links = array(
 					sprintf( $link_config['message'], $link_open, $link_close ),
 					array(
 						'a'    => array(
+							'class'  => array(),
 							'href'   => array(),
 							'target' => array(),
 							'rel'    => array(),
 						),
-						'img'  => array(
-							'src' => array(),
-							'alt' => array(),
-						),
 						'span' => array(
-							'class' => array(),
+							'class'      => array(),
+							'aria-label' => array(),
 						),
 					)
 				);


### PR DESCRIPTION
_In the Sprinkle spirit with Codex_

### Changes proposed in this Pull Request

Fixes #32236.

This updates `@woocommerce/components` so `Link type="external"` renders through WordPress' `ExternalLink` component. That brings WooCommerce external links in line with the WordPress component by adding the standard external-link visual indicator, accessible "opens in a new tab" text, and the expected `_blank`/safe `rel` handling.

This keeps the change focused on the shared component and its unit tests, instead of changing every existing call site. It follows the technical direction explored in #40025 while making the behavior change easier to review in isolation.

The settings-page marketplace footer links, payments settings "More payment options" link, help drawer documentation links, Woo Home store-management "View my store" quick link, and classic product variations empty-state "Learn more" link were also updated to use the same WordPress external-link indicator treatment. The help drawer rows keep the page icon and link text on one line and no longer render the trailing caret icon. The store-management quick link no longer renders its previous extra external-link SVG, and the indicator sits immediately after the link text. The variations empty state no longer injects the legacy external-link SVG via CSS.

### How to test the changes in this Pull Request

1. In a WooCommerce admin screen or component using `@woocommerce/components`, render a `Link` with `type="external"`.
2. Confirm the rendered link includes the WordPress external-link icon and announces that it opens in a new tab.
3. Confirm `type="wp-admin"`, `type="wc-admin"`, and omitted `type` links still render as plain anchors with their existing `data-link-type` behavior.

For focused component testing, run:

```sh
pnpm --filter='@woocommerce/components' test:js -- src/link/test/index.tsx
```

For visual review, run Storybook and open `Components / Link / External`:

```sh
pnpm --filter='@woocommerce/storybook' watch:build
```

### Screenshots

Woo Home

<img width="532" height="613" alt="Screenshot 2026-07-03 at 8 51 19 PM" src="https://github.com/user-attachments/assets/ea8cdd2d-5afc-449b-badd-9999d857014d" />
<img width="1006" height="751" alt="Screenshot 2026-07-03 at 8 50 36 PM" src="https://github.com/user-attachments/assets/5843da6f-16f9-4f9c-a635-fb3a3e854c25" />

Help panel
<img width="1468" height="1021" alt="Screenshot 2026-07-03 at 8 19 31 PM" src="https://github.com/user-attachments/assets/94a9c083-fd71-4f49-9552-9a185214398f" />

Task list - Taxes
<img width="1469" height="867" alt="Screenshot 2026-07-03 at 8 22 44 PM" src="https://github.com/user-attachments/assets/1c2735f0-75fd-4f02-8ffb-a18489549629" />

Products
<img width="853" height="457" alt="Screenshot 2026-07-03 at 8 43 13 PM" src="https://github.com/user-attachments/assets/5855718a-7338-4989-90d1-08d072d4dfe8" />

Marketplace "Explore solutions" and "More payment options" links
<img width="1466" height="1088" alt="Screenshot 2026-07-03 at 8 07 53 PM" src="https://github.com/user-attachments/assets/716ef50c-4ea1-4d90-967d-343f486a760b" />
<img width="1464" height="1120" alt="Screenshot 2026-07-03 at 8 08 04 PM" src="https://github.com/user-attachments/assets/2767ea83-c893-4756-aa24-c1d388e3d433" />
<img width="572" height="50" alt="Screenshot 2026-07-03 at 8 08 10 PM" src="https://github.com/user-attachments/assets/d5e3899f-a741-4fc1-9c5a-ce8fd3e72810" />
<img width="512" height="44" alt="Screenshot 2026-07-03 at 8 08 27 PM" src="https://github.com/user-attachments/assets/c73fe4e9-c8f5-4c6d-9e7d-d2ebb677bc53" />
<img width="741" height="42" alt="Screenshot 2026-07-03 at 8 08 37 PM" src="https://github.com/user-attachments/assets/9118070f-a1d8-4c51-ad46-803d9bc37f69" />

In-app marketplace
<img width="1852" height="171" alt="Screenshot 2026-07-03 at 6 33 11 PM" src="https://github.com/user-attachments/assets/e4435aeb-2041-4c24-b0be-2426c85013a9" />
<img width="1853" height="154" alt="Screenshot 2026-07-03 at 6 33 03 PM" src="https://github.com/user-attachments/assets/005989c0-a974-48f5-98a9-94af72c52147" />
<img width="1854" height="185" alt="Screenshot 2026-07-03 at 6 32 53 PM" src="https://github.com/user-attachments/assets/bce30fb4-a4e6-432c-8688-885a943a0da2" />
<img width="1850" height="1123" alt="Screenshot 2026-07-03 at 6 32 42 PM" src="https://github.com/user-attachments/assets/7138acaf-ffbf-450c-b3c4-84a3c8ea4614" />

### Design impact

This is intentionally marked as a major package change because external links gain a visible icon and `ExternalLink` controls the target/rel behavior. That visual change was the main review concern in #40025, so this PR is opened as a draft for design confirmation.

### Testing performed

- Component tests: `pnpm --filter='@woocommerce/components' test:js -- src/link/test/index.tsx` passed with 6 tests and 3 snapshots.
- Admin tests: payments settings, help panel, store-management quick-link, and plugin terms-of-service focused Jest suites passed.
- Lint checks: focused ESLint checks passed for touched admin JS files; focused Stylelint checks passed for touched admin SCSS files.
- PHP checks: `php -l` passed for the touched settings footer and product variations template files.
- Builds: `pnpm wc:build:admin` and `pnpm wc:build:classic-assets` passed. Classic asset builds emitted existing Autoprefixer warnings.
- Storybook: ran `pnpm --filter='@woocommerce/storybook' watch:build`; Storybook selected `http://localhost:6008/` because `6007` was occupied. Confirmed `Components / Link / External` renders the WordPress external-link indicator.
- Visual/manual checks: confirmed the Settings “Explore solutions” footer link, Payments “More payment options” link, Woo Home help drawer links, Woo Home “View my store” quick link, and classic product variations empty-state “Learn more” link use the updated indicator treatment.
- Generated markup/CSS checks: confirmed settings and variations PHP output uses `components-external-link`, `components-external-link__contents`, and `components-external-link__icon wp-exclude-emoji`; confirmed generated LTR/RTL classic admin CSS suppresses the legacy variations `::after` icon.
- Known local lint limitations: `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` could not run because `phpcs-changed` is missing in this workspace. `pnpm --filter='@woocommerce/classic-assets' lint:lang:css` fails broadly across existing SCSS files because that legacy stylelint task is not configured with SCSS syntax here.
