### PR TITLE
fix: restrict address autocomplete to allowed sell/ship-to countries

### DIFF
--- a/plugins/woocommerce/changelog/62111-address-autocomplete-ship-to-countries
+++ b/plugins/woocommerce/changelog/62111-address-autocomplete-ship-to-countries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address autocomplete now only searches/selects countries the store actually sells or ships to

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/address-autocomplete.tsx
@@ -22,6 +22,7 @@ import { ValidatedTextInputProps } from '../../../../../../packages/components/t
 import './style.scss';
 import { Suggestions } from './suggestions';
 import { useUpdatePreferredAutocompleteProvider } from '../../../hooks/use-update-preferred-autocomplete-provider';
+import { getAutocompleteCountry } from './utils';
 
 // Maximum gap (ms) between a keydown event and the resulting React onChange.
 // After this window, userIsTypingRef resets to false so that programmatic
@@ -167,10 +168,15 @@ export const AddressAutocomplete = ( {
 				addressType as 'shipping' | 'billing'
 			];
 
-		if ( provider ) {
+		const autocompleteCountry = getAutocompleteCountry(
+			country,
+			addressType
+		);
+
+		if ( provider && autocompleteCountry ) {
 			const generation = ++searchGenerationRef.current;
 			provider
-				.search( searchValue, country )
+				.search( searchValue, autocompleteCountry )
 				.then( ( results ) => {
 					// Discard stale results from a superseded search.
 					if ( generation !== searchGenerationRef.current ) {
@@ -371,14 +377,18 @@ export const AddressAutocomplete = ( {
 					window?.wc?.addressAutocomplete?.activeProvider?.[
 						addressType
 					];
-				if ( provider ) {
+				const autocompleteCountry = getAutocompleteCountry(
+					country,
+					addressType
+				);
+				if ( provider && autocompleteCountry ) {
 					setIsSettingAddress( true );
 					// Immediately suppress search to prevent any change events from triggering search
 					suppressSearchTimeoutRef.current = setTimeout( () => {
 						suppressSearchTimeoutRef.current = null;
 					}, 1000 );
 					provider
-						.select( selected.id, country )
+						.select( selected.id, autocompleteCountry )
 						.then( ( address ) => {
 							if ( addressType === 'shipping' ) {
 								setShippingAddress( address );
@@ -409,14 +419,21 @@ export const AddressAutocomplete = ( {
 	const handleSuggestionClick = async ( suggestionId: string ) => {
 		const provider =
 			window?.wc?.addressAutocomplete?.activeProvider?.[ addressType ];
-		if ( provider ) {
+		const autocompleteCountry = getAutocompleteCountry(
+			country,
+			addressType
+		);
+		if ( provider && autocompleteCountry ) {
 			setIsSettingAddress( true );
 			// Immediately suppress search to prevent any change events from triggering search
 			suppressSearchTimeoutRef.current = setTimeout( () => {
 				suppressSearchTimeoutRef.current = null;
 			}, 1000 );
 			try {
-				const address = await provider.select( suggestionId, country );
+				const address = await provider.select(
+					suggestionId,
+					autocompleteCountry
+				);
 				if ( addressType === 'shipping' ) {
 					setShippingAddress( address );
 					if ( useShippingAsBilling ) {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/browser-autofill.tsx
@@ -40,8 +40,10 @@ wpData.useSelect.mockImplementation(
 				return {
 					getCartData() {
 						return {
-							shippingAddress: { country: 'DE' },
-							billingAddress: { country: 'DE' },
+							// CA is allowed for billing/shipping in the global test
+							// settings mock, so autocomplete is eligible to search for it.
+							shippingAddress: { country: 'CA' },
+							billingAddress: { country: 'CA' },
 						};
 					},
 				};

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/test/utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { getAutocompleteCountry } from '../utils';
+
+jest.mock( '@woocommerce/block-settings', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@woocommerce/block-settings' ),
+	// Billing allows several countries; shipping is locked to one. Together
+	// these cover every branch of getAutocompleteCountry().
+	ALLOWED_COUNTRIES: {
+		US: 'United States',
+		CA: 'Canada',
+		GB: 'United Kingdom',
+	},
+	SHIPPING_COUNTRIES: {
+		US: 'United States',
+	},
+} ) );
+
+describe( 'getAutocompleteCountry', () => {
+	it( 'returns the country as-is when it is allowed for the address type', () => {
+		expect( getAutocompleteCountry( 'CA', 'billing' ) ).toBe( 'CA' );
+		expect( getAutocompleteCountry( 'US', 'shipping' ) ).toBe( 'US' );
+	} );
+
+	it( 'falls back to the single allowed country when the current one is not allowed', () => {
+		expect( getAutocompleteCountry( 'DE', 'shipping' ) ).toBe( 'US' );
+		expect( getAutocompleteCountry( '', 'shipping' ) ).toBe( 'US' );
+	} );
+
+	it( 'returns an empty string when multiple countries are allowed and none match', () => {
+		expect( getAutocompleteCountry( 'DE', 'billing' ) ).toBe( '' );
+		expect( getAutocompleteCountry( '', 'billing' ) ).toBe( '' );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/address-autocomplete/utils.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import {
+	ALLOWED_COUNTRIES,
+	SHIPPING_COUNTRIES,
+} from '@woocommerce/block-settings';
+import type { AddressFormType } from '@woocommerce/settings';
+
+/**
+ * Resolves the country to use for address autocomplete requests, constrained
+ * to the countries the store actually allows for the given address type.
+ *
+ * The address's own country value can be stale, geolocated, or otherwise
+ * unrelated to the store's "sell to"/"ship to" settings, so it isn't safe to
+ * forward as-is to the autocomplete provider.
+ *
+ * @param country     Country code currently on the address.
+ * @param addressType Type of address ('billing' or 'shipping').
+ * @return The country to search/select with, or an empty string when there's
+ *         no unambiguous allowed country to use yet.
+ */
+export function getAutocompleteCountry(
+	country: string,
+	addressType: AddressFormType
+): string {
+	const allowedCountries =
+		addressType === 'shipping' ? SHIPPING_COUNTRIES : ALLOWED_COUNTRIES;
+	const allowedCodes = Object.keys( allowedCountries );
+
+	if ( allowedCodes.includes( country ) ) {
+		return country;
+	}
+
+	// Store locked to a single country: use it, regardless of whatever
+	// (stale/mismatched) country is currently on the address.
+	if ( allowedCodes.length === 1 ) {
+		return allowedCodes[ 0 ];
+	}
+
+	// Ambiguous: more than one allowed country and none currently selected
+	// matches. Callers should treat this as "no usable country yet".
+	return '';
+}

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-update-preferred-autocomplete-provider.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/test/use-update-preferred-autocomplete-provider.ts
@@ -18,6 +18,16 @@ jest.mock( '@wordpress/data', () => ( {
  */
 import { useUpdatePreferredAutocompleteProvider } from '../use-update-preferred-autocomplete-provider';
 
+// This test exercises canSearch()-driven provider switching between DE and
+// US, independent of the ship-to/sell-to country restriction feature, so
+// give it its own allow-list rather than relying on the global test fixture.
+jest.mock( '@woocommerce/block-settings', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@woocommerce/block-settings' ),
+	ALLOWED_COUNTRIES: { DE: 'Germany', US: 'United States' },
+	SHIPPING_COUNTRIES: { DE: 'Germany', US: 'United States' },
+} ) );
+
 // Mock settings
 jest.mock( '@woocommerce/settings', () => ( {
 	...jest.requireActual( '@woocommerce/settings' ),

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-update-preferred-autocomplete-provider.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-update-preferred-autocomplete-provider.ts
@@ -16,6 +16,7 @@ import type {
  */
 import { type CheckoutStoreDescriptor } from '../../data/checkout';
 import { type CartStoreDescriptor } from '../../data/cart';
+import { getAutocompleteCountry } from '../components/cart-checkout/address-autocomplete/utils';
 
 // Get server providers configuration
 const serverProviders = getSettingWithCoercion<
@@ -76,13 +77,30 @@ export function useUpdatePreferredAutocompleteProvider(
 	) as ActionCreatorsOf< ConfigOf< CheckoutStoreDescriptor > >;
 
 	useEffect( () => {
-		// Check if window.wc.addressAutocomplete.providers exists
-		if ( ! window?.wc?.addressAutocomplete?.providers ) {
+		const clearActiveProvider = () => {
 			setActiveAddressAutocompleteProvider( '', addressType );
 			if ( window?.wc?.addressAutocomplete?.activeProvider ) {
 				window.wc.addressAutocomplete.activeProvider[ addressType ] =
 					null;
 			}
+		};
+
+		// Check if window.wc.addressAutocomplete.providers exists
+		if ( ! window?.wc?.addressAutocomplete?.providers ) {
+			clearActiveProvider();
+			return;
+		}
+
+		// Constrain the country to what the store actually allows for this
+		// address type. An empty result means there's no country the
+		// shopper can eligibly search/select yet.
+		const autocompleteCountry = getAutocompleteCountry(
+			country || '',
+			addressType
+		);
+
+		if ( ! autocompleteCountry ) {
+			clearActiveProvider();
 			return;
 		}
 
@@ -93,7 +111,7 @@ export function useUpdatePreferredAutocompleteProvider(
 					serverProvider.id
 				];
 
-			if ( provider && provider.canSearch( country ) ) {
+			if ( provider && provider.canSearch( autocompleteCountry ) ) {
 				setActiveAddressAutocompleteProvider(
 					provider.id,
 					addressType
@@ -107,11 +125,7 @@ export function useUpdatePreferredAutocompleteProvider(
 		}
 
 		// No provider supports this country, clear the active provider
-		setActiveAddressAutocompleteProvider( '', addressType );
-		// Set globally as this is going to be the source of truth where the actual provider objects are stored.
-		if ( window?.wc?.addressAutocomplete?.activeProvider ) {
-			window.wc.addressAutocomplete.activeProvider[ addressType ] = null;
-		}
+		clearActiveProvider();
 	}, [
 		addressType,
 		country,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #62111.

The checkout/cart block's Address Autocomplete field sends whatever country is currently on the address to the autocomplete provider's `search()`/`select()` calls, with no check against the store's "sell to specific countries" / "ship to specific countries" settings. That address country can be a stale or geolocated value unrelated to what the store actually allows, so a shopper can get suggestions for, and autofill, a country the store doesn't sell/ship to. The address fills in, but then fails postcode/country validation, which is confusing since the country selector looks locked to the allowed country.

Repro: set "Ship to specific countries" to a single country (e.g. United States only), open block Checkout as a guest so no address is saved yet, and start typing in the Address field. Suggestions returned aren't limited to the locked country, and picking one that isn't in the allowed list produces a mismatched address that trips validation on submit.

Fix: added `getAutocompleteCountry()` which resolves the country to actually pass to the provider, constrained to `ALLOWED_COUNTRIES` (billing) / `SHIPPING_COUNTRIES` (shipping) — the same allow-lists already used by `validate-country.ts`. It falls back to the store's single allowed country when the address's current country isn't one of them, and disables search/select entirely when there's no unambiguous allowed country yet (mirrors the existing "select a country first" requirement for city/state/postcode). Wired into `address-autocomplete.tsx` (search + both select call sites) and `use-update-preferred-autocomplete-provider.ts` (provider activation).

No PHP changes — this is client-side only.

### How to test the changes in this Pull Request:

1. WooCommerce → Settings → General → set "Sell to specific countries" and "Ship to specific countries" to a single country (e.g. United States only).
2. Go to the block Checkout page as a guest (no saved address).
3. Type 3+ characters of a real address into the Address field.
4. Suggestions returned are for the locked country only; selecting one fills the address with a matching country and no validation error appears afterward.
5. Repeat with several allowed countries configured and picking one of them — behavior is unchanged (no regression).
6. Repeat with several allowed countries configured and no valid country selected yet — no suggestions appear until a valid country is chosen.

### Testing that has already taken place:

Added/updated Jest unit tests covering `getAutocompleteCountry()` (valid passthrough, single-country fallback, ambiguous multi-country case) and the existing autocomplete/provider-activation suites, run via `pnpm --filter=@woocommerce/block-library test:js`. Also ran ESLint and `ts:check` on the changed files — no new errors or warnings introduced (verified against trunk baseline).

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Address autocomplete now only searches/selects countries the store actually sells or ships to.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
