### PR TITLE
Add low stock filter to Products list

### DIFF
--- a/plugins/woocommerce/changelog/add-products-low-stock-filter
+++ b/plugins/woocommerce/changelog/add-products-low-stock-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a Low stock option to the Products list stock status filter.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -876,7 +876,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				( wc_low_stock_amount.meta_value > '' AND wc_product_meta_lookup.stock_quantity <= CAST( wc_low_stock_amount.meta_value AS SIGNED ) )
 				OR ( ( wc_low_stock_amount.meta_value IS NULL OR wc_low_stock_amount.meta_value <= '' ) AND wc_product_meta_lookup.stock_quantity <= %d )
 			) ",
-			get_option( 'woocommerce_notify_low_stock_amount', 2 )
+			absint( max( get_option( 'woocommerce_notify_low_stock_amount', 2 ), 1 ) )
 		);
 
 		return $args;

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -509,7 +509,12 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	public function render_products_stock_status_filter() {
 		$current_stock_status = isset( $_REQUEST['stock_status'] ) ? wc_clean( wp_unslash( $_REQUEST['stock_status'] ) ) : false; // WPCS: input var ok, sanitization ok.
 		$stock_statuses       = wc_get_product_stock_status_options();
-		$output               = '<select name="stock_status"><option value="">' . esc_html__( 'Filter by stock status', 'woocommerce' ) . '</option>';
+
+		// Low stock is a derived quantity condition, not a stored stock status, so it's appended here
+		// rather than in wc_get_product_stock_status_options() which is used in other contexts too.
+		$stock_statuses['lowstock'] = __( 'Low stock', 'woocommerce' );
+
+		$output = '<select name="stock_status"><option value="">' . esc_html__( 'Filter by stock status', 'woocommerce' ) . '</option>';
 
 		foreach ( $stock_statuses as $status => $label ) {
 			$output .= '<option ' . selected( $status, $current_stock_status, false ) . ' value="' . esc_attr( $status ) . '">' . esc_html( $label ) . '</option>';
@@ -618,7 +623,11 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 
 		// Stock status filter.
 		if ( ! empty( $_GET['stock_status'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			add_filter( 'posts_clauses', array( $this, 'filter_stock_status_post_clauses' ) );
+			if ( 'lowstock' === wc_clean( wp_unslash( $_GET['stock_status'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				add_filter( 'posts_clauses', array( $this, 'filter_low_stock_post_clauses' ) );
+			} else {
+				add_filter( 'posts_clauses', array( $this, 'filter_stock_status_post_clauses' ) );
+			}
 		}
 
 		// Shipping class taxonomy.
@@ -671,6 +680,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		remove_filter( 'posts_clauses', array( $this, 'filter_downloadable_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_virtual_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_stock_status_post_clauses' ) );
+		remove_filter( 'posts_clauses', array( $this, 'filter_low_stock_post_clauses' ) );
 		if ( $this->use_cogs_lookup_column ) {
 			remove_filter( 'posts_clauses', array( $this, 'order_by_cogs_value_asc_post_clauses' ) );
 			remove_filter( 'posts_clauses', array( $this, 'order_by_cogs_value_desc_post_clauses' ) );
@@ -842,6 +852,33 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 				$args['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.stock_status=%s ', $stock_status );
 			}
 		}
+		return $args;
+	}
+
+	/**
+	 * Filter by low stock: quantity at or below the product's own low stock amount,
+	 * falling back to the sitewide "woocommerce_notify_low_stock_amount" option.
+	 * Mirrors the threshold logic used by the Analytics low-in-stock report.
+	 *
+	 * @param array $args Query args.
+	 * @return array
+	 */
+	public function filter_low_stock_post_clauses( $args ) {
+		global $wpdb;
+
+		$args['join']  = $this->append_product_sorting_table_join( $args['join'] );
+		$args['join'] .= " LEFT JOIN {$wpdb->postmeta} AS wc_low_stock_amount ON {$wpdb->posts}.ID = wc_low_stock_amount.post_id AND wc_low_stock_amount.meta_key = '_low_stock_amount' ";
+
+		$args['where'] .= $wpdb->prepare(
+			" AND wc_product_meta_lookup.stock_status = 'instock'
+			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+			AND (
+				( wc_low_stock_amount.meta_value > '' AND wc_product_meta_lookup.stock_quantity <= CAST( wc_low_stock_amount.meta_value AS SIGNED ) )
+				OR ( ( wc_low_stock_amount.meta_value IS NULL OR wc_low_stock_amount.meta_value <= '' ) AND wc_product_meta_lookup.stock_quantity <= %d )
+			) ",
+			get_option( 'woocommerce_notify_low_stock_amount', 2 )
+		);
+
 		return $args;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
@@ -26,11 +26,19 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	private $original_manage_stock;
 
 	/**
+	 * Previous value of the sitewide low stock amount option, restored in tearDown.
+	 *
+	 * @var string
+	 */
+	private $previous_low_stock_amount_option;
+
+	/**
 	 * Set up.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->original_manage_stock = get_option( 'woocommerce_manage_stock' );
+		$this->original_manage_stock             = get_option( 'woocommerce_manage_stock' );
+		$this->previous_low_stock_amount_option = get_option( 'woocommerce_notify_low_stock_amount', 2 );
 	}
 
 	/**
@@ -42,6 +50,9 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 		} else {
 			update_option( 'woocommerce_manage_stock', $this->original_manage_stock );
 		}
+
+		update_option( 'woocommerce_notify_low_stock_amount', $this->previous_low_stock_amount_option );
+		unset( $_GET['stock_status'] );
 
 		parent::tearDown();
 	}
@@ -116,6 +127,123 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 			array( $simple_out_of_stock->get_id() ),
 			array_values( array_intersect( $this->query_product_ids_for_stock_status( ProductStockStatus::OUT_OF_STOCK, 'filter_virtual_post_clauses' ), $fixture_ids ) )
 		);
+	}
+
+	/**
+	 * @testdox Should include a "Low stock" option in the stock status filter dropdown.
+	 */
+	public function test_render_products_stock_status_filter_includes_low_stock_option() {
+		$list_table = new WC_Admin_List_Table_Products();
+
+		ob_start();
+		$list_table->render_products_stock_status_filter();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'value="lowstock"', $output );
+	}
+
+	/**
+	 * @testdox Should hook the low stock clause, not the exact-match stock status clause, when stock_status=lowstock.
+	 */
+	public function test_query_filters_hooks_low_stock_clause_for_lowstock_status() {
+		$_GET['stock_status'] = 'lowstock'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$list_table = new WC_Admin_List_Table_Products();
+		$this->call_query_filters( $list_table, array() );
+
+		$this->assertNotFalse( has_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) ) );
+		$this->assertFalse( has_filter( 'posts_clauses', array( $list_table, 'filter_stock_status_post_clauses' ) ) );
+
+		$list_table->remove_ordering_args();
+	}
+
+	/**
+	 * @testdox Should return only in-stock products at or below their low stock threshold.
+	 */
+	public function test_filter_low_stock_post_clauses_returns_expected_products() {
+		update_option( 'woocommerce_notify_low_stock_amount', 5 );
+
+		$low_stock_custom_threshold = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'     => true,
+				'stock_quantity'   => 3,
+				'low_stock_amount' => 4,
+				'stock_status'     => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$above_custom_threshold = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'     => true,
+				'stock_quantity'   => 10,
+				'low_stock_amount' => 4,
+				'stock_status'     => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$low_stock_sitewide_threshold = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 5,
+				'stock_status'   => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$well_stocked = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 50,
+				'stock_status'   => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		// Stock status is recalculated from quantity on save (see WC_Product::validate_props()),
+		// so a quantity of 0 with default backorders is what actually produces "out of stock".
+		$out_of_stock = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'     => true,
+				'stock_quantity'   => 0,
+				'low_stock_amount' => 4,
+			)
+		);
+
+		$list_table = new WC_Admin_List_Table_Products();
+		add_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
+
+		$query     = new WP_Query(
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'fields'      => 'ids',
+			)
+		);
+		$found_ids = $query->posts;
+
+		remove_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
+
+		$this->assertContains( $low_stock_custom_threshold->get_id(), $found_ids, 'Product under its custom low stock amount should be included' );
+		$this->assertContains( $low_stock_sitewide_threshold->get_id(), $found_ids, 'Product under the sitewide threshold should be included' );
+		$this->assertNotContains( $above_custom_threshold->get_id(), $found_ids, 'Product above its custom low stock amount should be excluded' );
+		$this->assertNotContains( $well_stocked->get_id(), $found_ids, 'Well stocked product should be excluded' );
+		$this->assertNotContains( $out_of_stock->get_id(), $found_ids, 'Out of stock product should be excluded even if under threshold' );
+	}
+
+	/**
+	 * Call the protected query_filters() method.
+	 *
+	 * @param WC_Admin_List_Table_Products $list_table List table instance.
+	 * @param array                        $query_vars Query vars.
+	 * @return array
+	 */
+	private function call_query_filters( $list_table, $query_vars ) {
+		$method = new ReflectionMethod( $list_table, 'query_filters' );
+		$method->setAccessible( true );
+		return $method->invoke( $list_table, $query_vars );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
@@ -247,6 +247,38 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should treat an empty sitewide low stock amount option as a threshold of 1, matching the Analytics low-in-stock report, rather than 0.
+	 */
+	public function test_filter_low_stock_post_clauses_normalizes_empty_sitewide_threshold() {
+		update_option( 'woocommerce_notify_low_stock_amount', '' );
+
+		$low_stock_no_amount = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 1,
+				'stock_status'   => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		$list_table = new WC_Admin_List_Table_Products();
+		add_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
+
+		$query     = new WP_Query(
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'fields'      => 'ids',
+			)
+		);
+		$found_ids = $query->posts;
+
+		remove_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
+
+		$this->assertContains( $low_stock_no_amount->get_id(), $found_ids, 'Quantity of 1 with an empty sitewide option should still be treated as low stock (threshold normalized to 1, not 0)' );
+	}
+
+	/**
 	 * Create a variable product with children that use the supplied stock statuses.
 	 *
 	 * @param array $stock_statuses Child variation stock statuses.

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
@@ -37,7 +37,7 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->original_manage_stock             = get_option( 'woocommerce_manage_stock' );
+		$this->original_manage_stock            = get_option( 'woocommerce_manage_stock' );
 		$this->previous_low_stock_amount_option = get_option( 'woocommerce_notify_low_stock_amount', 2 );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-products-test.php
@@ -28,7 +28,7 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	/**
 	 * Previous value of the sitewide low stock amount option, restored in tearDown.
 	 *
-	 * @var string
+	 * @var string|false
 	 */
 	private $previous_low_stock_amount_option;
 
@@ -38,7 +38,7 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->original_manage_stock            = get_option( 'woocommerce_manage_stock' );
-		$this->previous_low_stock_amount_option = get_option( 'woocommerce_notify_low_stock_amount', 2 );
+		$this->previous_low_stock_amount_option = get_option( 'woocommerce_notify_low_stock_amount' );
 	}
 
 	/**
@@ -51,7 +51,11 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 			update_option( 'woocommerce_manage_stock', $this->original_manage_stock );
 		}
 
-		update_option( 'woocommerce_notify_low_stock_amount', $this->previous_low_stock_amount_option );
+		if ( false === $this->previous_low_stock_amount_option ) {
+			delete_option( 'woocommerce_notify_low_stock_amount' );
+		} else {
+			update_option( 'woocommerce_notify_low_stock_amount', $this->previous_low_stock_amount_option );
+		}
 		unset( $_GET['stock_status'] );
 
 		parent::tearDown();
@@ -261,6 +265,15 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 			)
 		);
 
+		$above_normalized_threshold = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 2,
+				'stock_status'   => ProductStockStatus::IN_STOCK,
+			)
+		);
+
 		$list_table = new WC_Admin_List_Table_Products();
 		add_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
 
@@ -276,6 +289,7 @@ class WC_Admin_List_Table_Products_Test extends WC_Unit_Test_Case {
 		remove_filter( 'posts_clauses', array( $list_table, 'filter_low_stock_post_clauses' ) );
 
 		$this->assertContains( $low_stock_no_amount->get_id(), $found_ids, 'Quantity of 1 with an empty sitewide option should still be treated as low stock (threshold normalized to 1, not 0)' );
+		$this->assertNotContains( $above_normalized_threshold->get_id(), $found_ids, 'Quantity of 2 with an empty sitewide option should fall above the normalized threshold of 1' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#61908.

Adds a "Low stock" option to the existing "Filter by stock status" dropdown on the Products list (`wp-admin/edit.php?post_type=product`). Selecting it shows only in-stock products at or below their low stock threshold, so a merchant (or a future dashboard widget) can jump straight to a low-stock view without going through Analytics.

"Low stock" is a derived condition, not a stored stock status, so this reuses the SQL logic already shipped for the Analytics low-in-stock report (`ProductsLowInStock`): a product's own `_low_stock_amount` if set, otherwise the sitewide "Low stock threshold" setting. Out of stock products are excluded even if their quantity is under the threshold, since they're already flagged as out of stock rather than low.

### Screenshots or screen recordings:

No visual layout change. This adds one new option to the existing native "Filter by stock status" dropdown on the Products list screen.

<!-- linear:table-colwidths:400,400 -->
| Before | After |
| -- | -- |
| Filter by stock status ▾  <br>— Any —  <br>In stock  <br>Out of stock  <br>On backorder | Filter by stock status ▾  <br>— Any —  <br>In stock  <br>Out of stock  <br>On backorder  <br>**Low stock** |

Selecting "Low stock" filters the Products list to in-stock products at or below their low stock threshold (product-level `_low_stock_amount` if set, otherwise the sitewide setting), excluding out-of-stock products.

### How to test the changes in this Pull Request:

1. Go to **WooCommerce → Settings → Products → Inventory** and note the "Low stock threshold" value (default 2).
2. Create a product with Manage stock on, quantity below that threshold, and no product-level low stock amount.
3. Create a second product with Manage stock on, its own low stock amount set, and a quantity at or below that amount.
4. Create a well stocked product and an out of stock product for contrast.
5. Go to **Products**, open "Filter by stock status", confirm a "Low stock" option is there.
6. Select it and confirm only the two low-stock products show up, not the well stocked or out of stock ones.
7. Confirm the existing In stock / Out of stock / On backorder filter options still work.

### Testing that has already taken place:

Manual testing in wp-env (WP 6.x, PHP 8.1). Added `WC_Admin_List_Table_Products_Test` covering the dropdown option and the query filtering (custom threshold, sitewide threshold, well stocked, out of stock). All 3 tests pass. PHPCS and PHPStan clean on the changed file.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Minor

#### Type

- [X] Add - Adds functionality

#### Message

Add a Low stock option to the Products list stock status filter.

### Release Communication

- [X] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)