### PR TITLE
fix: make get_term() return same product count as get_terms()

### DIFF
--- a/plugins/woocommerce/changelog/fix-61452-get-term-count-mismatch
+++ b/plugins/woocommerce/changelog/fix-61452-get-term-count-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix get_term() returning a different product count than get_terms() for product categories, tags and brands on the frontend.

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -632,6 +632,8 @@ add_filter( 'get_terms', 'wc_change_term_counts', 10, 2 );
  * Overrides the original term count for a single product category/tag/brand term with the
  * product count that takes catalog visibility into account, so get_term() matches get_terms().
  *
+ * @since 11.1.0
+ *
  * @param WP_Term $term     Term object.
  * @param string  $taxonomy Taxonomy slug.
  * @return WP_Term
@@ -641,36 +643,27 @@ function wc_change_term_count( $term, $taxonomy ) {
 		return $term;
 	}
 
-	/**
-	 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param array $valid_taxonomies List of taxonomy slugs.
-	 */
-	$valid_taxonomies = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
+	static $valid_taxonomies = null;
+	if ( null === $valid_taxonomies ) {
+		/**
+		 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
+		 *
+		 * @since 11.1.0
+		 *
+		 * @param array $valid_taxonomies List of taxonomy slugs.
+		 */
+		$valid_taxonomies = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
+	}
 
 	if ( ! in_array( $taxonomy, $valid_taxonomies, true ) ) {
 		return $term;
 	}
 
-	// Read fresh rather than caching across calls in a static: _wc_term_recount() can delete
-	// this transient mid-request, and a stale in-memory copy would then serve outdated counts.
-	$o_term_counts = get_transient( 'wc_term_counts' );
-	$term_counts   = false === $o_term_counts ? array() : $o_term_counts;
-
-	$key = $term->term_id . '_' . $taxonomy;
-
-	if ( ! isset( $term_counts[ $key ] ) ) {
-		$count               = get_term_meta( $term->term_id, 'product_count_' . $taxonomy, true );
-		$term_counts[ $key ] = '' !== $count ? absint( $count ) : 0;
-
-		if ( $term_counts !== $o_term_counts ) {
-			set_transient( 'wc_term_counts', $term_counts, MONTH_IN_SECONDS );
-		}
-	}
-
-	$term->count = $term_counts[ $key ];
+	// Read the count directly from term meta rather than the wc_term_counts transient. The
+	// transient amortizes a read+write across many terms in wc_change_term_counts(), but here
+	// there is a single term, so a direct read is as cheap and avoids a per-call transient write.
+	$count       = get_term_meta( $term->term_id, 'product_count_' . $taxonomy, true );
+	$term->count = '' !== $count ? absint( $count ) : 0;
 
 	return $term;
 }

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -629,6 +629,54 @@ function wc_change_term_counts( $terms, $taxonomies ) {
 add_filter( 'get_terms', 'wc_change_term_counts', 10, 2 );
 
 /**
+ * Overrides the original term count for a single product category/tag/brand term with the
+ * product count that takes catalog visibility into account, so get_term() matches get_terms().
+ *
+ * @param WP_Term $term     Term object.
+ * @param string  $taxonomy Taxonomy slug.
+ * @return WP_Term
+ */
+function wc_change_term_count( $term, $taxonomy ) {
+	if ( is_admin() || wp_doing_ajax() || ! $term instanceof WP_Term ) {
+		return $term;
+	}
+
+	/**
+	 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array $valid_taxonomies List of taxonomy slugs.
+	 */
+	$valid_taxonomies = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
+
+	if ( ! in_array( $taxonomy, $valid_taxonomies, true ) ) {
+		return $term;
+	}
+
+	// Read fresh rather than caching across calls in a static: _wc_term_recount() can delete
+	// this transient mid-request, and a stale in-memory copy would then serve outdated counts.
+	$o_term_counts = get_transient( 'wc_term_counts' );
+	$term_counts   = false === $o_term_counts ? array() : $o_term_counts;
+
+	$key = $term->term_id . '_' . $taxonomy;
+
+	if ( ! isset( $term_counts[ $key ] ) ) {
+		$count               = get_term_meta( $term->term_id, 'product_count_' . $taxonomy, true );
+		$term_counts[ $key ] = '' !== $count ? absint( $count ) : 0;
+
+		if ( $term_counts !== $o_term_counts ) {
+			set_transient( 'wc_term_counts', $term_counts, MONTH_IN_SECONDS );
+		}
+	}
+
+	$term->count = $term_counts[ $key ];
+
+	return $term;
+}
+add_filter( 'get_term', 'wc_change_term_count', 10, 2 );
+
+/**
  * Return products in a given term, and cache value.
  *
  * To keep in sync, product_count will be cleared on "set_object_terms".

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -643,17 +643,17 @@ function wc_change_term_count( $term, $taxonomy ) {
 		return $term;
 	}
 
-	static $valid_taxonomies = null;
-	if ( null === $valid_taxonomies ) {
-		/**
-		 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
-		 *
-		 * @since 11.1.0
-		 *
-		 * @param array $valid_taxonomies List of taxonomy slugs.
-		 */
-		$valid_taxonomies = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
-	}
+	/**
+	 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
+	 *
+	 * Evaluated on every call (not cached) so context changes such as switch_to_blog() are reflected,
+	 * mirroring the plural wc_change_term_counts() which does not cache either.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $valid_taxonomies List of taxonomy slugs.
+	 */
+	$valid_taxonomies = (array) apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag', 'product_brand' ) );
 
 	if ( ! in_array( $taxonomy, $valid_taxonomies, true ) ) {
 		return $term;

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -76,6 +76,29 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Asserts that get_term() returns the same count as get_terms() for every term given.
+	 *
+	 * @param array $expected_counts Counts keyed by term_id, as returned by get_terms().
+	 * @return void
+	 */
+	private function assert_get_term_counts_match( array $expected_counts ): void {
+		$taxonomies_by_key = array(
+			'parent' => 'product_cat',
+			'child1' => 'product_cat',
+			'child2' => 'product_cat',
+			'tag1'   => 'product_tag',
+			'tag2'   => 'product_tag',
+		);
+
+		foreach ( $taxonomies_by_key as $key => $taxonomy ) {
+			$term_id = $this->terms[ $key ]['term_id'];
+			$fetched = get_term( $term_id, $taxonomy );
+
+			$this->assertEquals( $expected_counts[ $term_id ], $fetched->count, "get_term() count mismatch for term {$term_id}" );
+		}
+	}
+
+	/**
 	 * @testdox Term product counts with default settings.
 	 */
 	public function test_term_count_baseline(): void {
@@ -92,6 +115,8 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+
+		$this->assert_get_term_counts_match( $term_counts );
 	}
 
 	/**
@@ -117,6 +142,8 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 1, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+
+		$this->assert_get_term_counts_match( $term_counts );
 	}
 
 	/**
@@ -141,6 +168,8 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 0, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 1, $term_counts[ $this->terms['tag2']['term_id'] ] );
+
+		$this->assert_get_term_counts_match( $term_counts );
 
 		delete_option( 'woocommerce_hide_out_of_stock_items' );
 	}

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -120,6 +120,33 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The woocommerce_change_term_counts filter is evaluated on every get_term() call, not cached.
+	 *
+	 * Ensures context-dependent filter results (such as a callback that varies by blog via switch_to_blog())
+	 * are reflected, mirroring the plural wc_change_term_counts() which does not cache the filter result.
+	 */
+	public function test_change_term_counts_filter_not_cached(): void {
+		$parent_id = $this->terms['parent']['term_id'];
+
+		// Default: product_cat is in the allowlist, so the parent count is rolled up with children (3).
+		$this->assertSame( 3, get_term( $parent_id, 'product_cat' )->count );
+
+		// Filter product_cat out of the allowlist on a later call: the change must take effect immediately.
+		$remove_product_cat = static function ( $taxonomies ) {
+			return array_values( array_diff( $taxonomies, array( 'product_cat' ) ) );
+		};
+		add_filter( 'woocommerce_change_term_counts', $remove_product_cat );
+
+		// With product_cat excluded, get_term() returns the raw WP count (1, the product assigned directly to parent).
+		$this->assertSame( 1, get_term( $parent_id, 'product_cat' )->count );
+
+		remove_filter( 'woocommerce_change_term_counts', $remove_product_cat );
+
+		// After removing the filter, the override applies again on the next call.
+		$this->assertSame( 3, get_term( $parent_id, 'product_cat' )->count );
+	}
+
+	/**
 	 * @testdox Term product counts when a product is hidden from the catalog.
 	 */
 	public function test_product_visibility(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#61452.

WooCommerce hooks into the plural `get_terms` filter (`wc_change_term_counts()`) to override `product_cat`/`product_tag`/`product_brand` term counts so they account for hidden/out-of-stock products and roll up child category counts into parents. It never did the same for the singular `get_term()`, so the two functions return different counts for the same term.

This is easy to reproduce on any site with a hierarchical category or a hidden/out-of-stock product:

```php
$term_id  = 123; // a product_cat term with a hidden or out-of-stock product, or with children
$by_term  = get_term( $term_id, 'product_cat' );
$by_terms = get_terms( array( 'taxonomy' => 'product_cat', 'include' => array( $term_id ), 'hide_empty' => false ) );

var_dump( $by_term->count, $by_terms[0]->count ); // different before this fix
```

This causes real inconsistencies, for example the Gutenberg Term Count block shows different totals in the editor (uses `get_terms()`) versus the frontend (uses `get_term()`).

This PR adds `wc_change_term_count()`, hooked into core's `get_term` filter, mirroring the existing `wc_change_term_counts()` logic (same taxonomy allowlist via `woocommerce_change_term_counts`, same admin/ajax skip, same `product_count_{taxonomy}` term meta source and `wc_term_counts` transient cache). Kept as a separate function instead of refactoring the existing one, to avoid touching already-tested code for a narrow, well isolated addition.

**Backward compatibility:** this changes the value returned by `get_term()->count` for `product_cat`/`product_tag`/`product_brand` on the frontend — it now matches what `get_terms()` already returns. Any third-party code relying on the old (inconsistent) raw count from `get_term()` will see a different number, but this is a consistency fix aligning with existing `get_terms()` behavior, not new custom behavior.

### How to test the changes in this Pull Request:

1. Create a parent product category (e.g. "Clothing") with a child category (e.g. "Hoodies"), add products to the child, and set one of them to "Hidden" catalog visibility.
2. Run the repro snippet above (or `wp eval`) comparing `get_term()` and `get_terms()` counts for the child category.
3. Before this fix: counts differ. After: they match.
4. Repeat with "Hide out of stock items from the catalog" enabled and an out-of-stock product instead of a hidden one, same expected result.

### Testing that has already taken place:

Extended `WC_Term_Functions_Tests` (`tests/php/includes/wc-term-functions-tests.php`) to assert `get_term()` matches `get_terms()` in the baseline, hidden-product, and out-of-stock-excluded scenarios. Ran the full class via `pnpm run test:php:env -- --filter WC_Term_Functions_Tests`, 6 tests / 36 assertions, all pass. Also ran `lint:php:changes` and PHPStan on the modified file, both clean.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Fix get_term() returning a different product count than get_terms() for product categories, tags and brands on the frontend.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
