### PR TITLE
Fix featured image losing 'sizes' metadata when regenerated on the fly

### DIFF
--- a/plugins/woocommerce/changelog/60577-featured-image-sizes-metadata-lost
+++ b/plugins/woocommerce/changelog/60577-featured-image-sizes-metadata-lost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix featured product image losing its 'sizes' metadata when regenerated on the fly with a mismatched thumbnail size.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -324,6 +324,22 @@ class WC_Regenerate_Images {
 	}
 
 	/**
+	 * Only regenerate images for the requested size. `intermediate_image_sizes_advanced` is the
+	 * filter core's image subsize generation actually reads (unlike `intermediate_image_sizes`
+	 * above), so without this every registered size gets regenerated instead of just the one
+	 * we need, which can be slow enough on large images to leave the DB with partial metadata.
+	 *
+	 * @param array $sizes Registered subsizes, keyed by size name.
+	 * @return array
+	 */
+	public static function adjust_intermediate_image_sizes_advanced( $sizes ) {
+		if ( ! isset( $sizes[ self::$regenerate_size ] ) ) {
+			return array();
+		}
+		return array( self::$regenerate_size => $sizes[ self::$regenerate_size ] );
+	}
+
+	/**
 	 * Generate the thumbnail filename and dimensions for a given file.
 	 *
 	 * @param string $fullsizepath Path to full size image.
@@ -412,14 +428,18 @@ class WC_Regenerate_Images {
 			$metadata = array();
 		}
 
-		// We only want to regen a specific image size.
+		// We only want to regen a specific image size. `intermediate_image_sizes_advanced` is what
+		// core's wp_create_image_subsizes()/_wp_make_subsizes() actually reads since WP 5.3, so both
+		// filters are needed to stop it from regenerating every registered size.
 		add_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );
+		add_filter( 'intermediate_image_sizes_advanced', array( __CLASS__, 'adjust_intermediate_image_sizes_advanced' ) );
 
 		// This function will generate the new image sizes.
 		$new_metadata = wp_generate_attachment_metadata( $attachment_id, $fullsizepath );
 
-		// Remove custom filter.
+		// Remove custom filters.
 		remove_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );
+		remove_filter( 'intermediate_image_sizes_advanced', array( __CLASS__, 'adjust_intermediate_image_sizes_advanced' ) );
 
 		// If something went wrong lets just return the original image.
 		if ( is_wp_error( $new_metadata ) || empty( $new_metadata ) ) {

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -333,7 +333,10 @@ class WC_Regenerate_Images {
 	 * @return array
 	 */
 	public static function adjust_intermediate_image_sizes_advanced( $sizes ) {
-		if ( ! isset( $sizes[ self::$regenerate_size ] ) ) {
+		if ( ! is_array( $sizes ) ) {
+				return array();
+			}
+			if ( ! isset( $sizes[ self::$regenerate_size ] ) ) {
 			return array();
 		}
 		return array( self::$regenerate_size => $sizes[ self::$regenerate_size ] );
@@ -428,9 +431,10 @@ class WC_Regenerate_Images {
 			$metadata = array();
 		}
 
-		// We only want to regen a specific image size. `intermediate_image_sizes_advanced` is what
-		// core's wp_create_image_subsizes()/_wp_make_subsizes() actually reads since WP 5.3, so both
-		// filters are needed to stop it from regenerating every registered size.
+		// We only want to regen a specific image size. Both `intermediate_image_sizes` and, since
+		// WP 5.3, `intermediate_image_sizes_advanced` are read by core's subsize generation
+		// (wp_create_image_subsizes()/_wp_make_subsizes()), so both filters are hooked to stop it
+		// from regenerating every registered size.
 		add_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );
 		add_filter( 'intermediate_image_sizes_advanced', array( __CLASS__, 'adjust_intermediate_image_sizes_advanced' ) );
 
@@ -446,10 +450,17 @@ class WC_Regenerate_Images {
 			return $image;
 		}
 
-		if ( isset( $new_metadata['sizes'][ self::$regenerate_size ] ) ) {
+		/*
+		 * Always write the stored metadata back. wp_generate_attachment_metadata() starts by
+		 * persisting an initial metadata array with an empty `sizes` array (wp_create_image_subsizes()),
+		 * which would otherwise wipe the attachment's existing `sizes` whenever the regenerated size
+		 * below is missing from the returned metadata (for example if the image editor fails on it).
+		 * Keep the pre-existing sizes as the base so a partial regen can never truncate them.
+		 */
+		if ( isset( $new_metadata['sizes'] ) && is_array( $new_metadata['sizes'] ) && isset( $new_metadata['sizes'][ self::$regenerate_size ] ) ) {
 			$metadata['sizes'][ self::$regenerate_size ] = $new_metadata['sizes'][ self::$regenerate_size ];
-			wp_update_attachment_metadata( $attachment_id, $metadata );
 		}
+		wp_update_attachment_metadata( $attachment_id, $metadata );
 
 		// Now we've done our regen, attempt to return the new size.
 		$new_image = self::unfiltered_image_downsize( $attachment_id, self::$regenerate_size );

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 /**
  * Class WC_Regenerate_Images_Test file.
  *

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Class WC_Regenerate_Images_Test file.
+ *
+ * @package WooCommerce\Tests\WC_Regenerate_Images.
+ */
+
+/**
+ * Class WC_Regenerate_Images_Test.
+ */
+class WC_Regenerate_Images_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Original value of WC_Regenerate_Images::$regenerate_size, restored in tearDown().
+	 *
+	 * @var string
+	 */
+	private $original_regenerate_size;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$property = $this->get_regenerate_size_property();
+		$this->original_regenerate_size = $property->getValue();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		$this->get_regenerate_size_property()->setValue( null, $this->original_regenerate_size );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Get accessible reflection access to the private static WC_Regenerate_Images::$regenerate_size property.
+	 *
+	 * @return ReflectionProperty
+	 */
+	private function get_regenerate_size_property() {
+		$property = ( new ReflectionClass( WC_Regenerate_Images::class ) )->getProperty( 'regenerate_size' );
+		$property->setAccessible( true );
+
+		return $property;
+	}
+
+	/**
+	 * @testdox adjust_intermediate_image_sizes_advanced() should return only the size being regenerated.
+	 */
+	public function test_adjust_intermediate_image_sizes_advanced_keeps_only_requested_size() {
+		$regenerate_size = $this->get_regenerate_size_property();
+		$regenerate_size->setValue( null, 'woocommerce_thumbnail' );
+
+		$registered_sizes = array(
+			'thumbnail'             => array(
+				'width'  => 150,
+				'height' => 150,
+				'crop'   => true,
+			),
+			'woocommerce_thumbnail' => array(
+				'width'  => 300,
+				'height' => 300,
+				'crop'   => true,
+			),
+			'woocommerce_single'    => array(
+				'width'  => 600,
+				'height' => 600,
+				'crop'   => false,
+			),
+		);
+
+		$result = WC_Regenerate_Images::adjust_intermediate_image_sizes_advanced( $registered_sizes );
+
+		$this->assertSame(
+			array( 'woocommerce_thumbnail' => $registered_sizes['woocommerce_thumbnail'] ),
+			$result,
+			'Only the size being regenerated should remain, so core does not rebuild every registered size.'
+		);
+	}
+
+	/**
+	 * @testdox adjust_intermediate_image_sizes_advanced() should return no sizes when the requested size is not registered.
+	 */
+	public function test_adjust_intermediate_image_sizes_advanced_handles_unregistered_size() {
+		$regenerate_size = $this->get_regenerate_size_property();
+		$regenerate_size->setValue( null, 'woocommerce_gallery_thumbnail' );
+
+		$registered_sizes = array(
+			'thumbnail' => array(
+				'width'  => 150,
+				'height' => 150,
+				'crop'   => true,
+			),
+		);
+
+		$result = WC_Regenerate_Images::adjust_intermediate_image_sizes_advanced( $registered_sizes );
+
+		$this->assertSame( array(), $result, 'No sizes should be regenerated when the requested size is not registered.' );
+	}
+
+	/**
+	 * @testdox The intermediate_image_sizes_advanced filter should stop wp_generate_attachment_metadata() from regenerating every registered size.
+	 */
+	public function test_advanced_filter_restricts_wp_generate_attachment_metadata_to_one_size() {
+		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$fullsizepath  = get_attached_file( $attachment_id );
+
+		$regenerate_size = $this->get_regenerate_size_property();
+		$regenerate_size->setValue( null, 'woocommerce_thumbnail' );
+
+		add_filter( 'intermediate_image_sizes_advanced', array( 'WC_Regenerate_Images', 'adjust_intermediate_image_sizes_advanced' ) );
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $fullsizepath );
+		remove_filter( 'intermediate_image_sizes_advanced', array( 'WC_Regenerate_Images', 'adjust_intermediate_image_sizes_advanced' ) );
+
+		$this->assertSame(
+			array( 'woocommerce_thumbnail' ),
+			array_keys( $metadata['sizes'] ),
+			'Without this filter, core regenerates every registered size (thumbnail, medium, large, ...) instead of just the one requested.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -25,7 +25,7 @@ class WC_Regenerate_Images_Test extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$property = $this->get_regenerate_size_property();
+		$property                       = $this->get_regenerate_size_property();
 		$this->original_regenerate_size = $property->getValue();
 	}
 
@@ -105,23 +105,53 @@ class WC_Regenerate_Images_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The intermediate_image_sizes_advanced filter should stop wp_generate_attachment_metadata() from regenerating every registered size.
+	 * @testdox resize_and_return_image() should preserve pre-existing size entries when the requested size fails to regenerate.
 	 */
-	public function test_advanced_filter_restricts_wp_generate_attachment_metadata_to_one_size() {
-		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
-		$fullsizepath  = get_attached_file( $attachment_id );
+	public function test_resize_and_return_image_preserves_pre_existing_sizes_on_regen_failure() {
+		$attachment_id = $this->factory->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg'
+		);
+
+		$initial_meta = wp_get_attachment_metadata( $attachment_id );
+		$this->assertNotEmpty( $initial_meta, 'Initial attachment metadata must exist.' );
+		$this->assertIsArray( $initial_meta['sizes'], 'Initial _wp_attachment_metadata must carry sizes.' );
+		$this->assertNotEmpty( $initial_meta['sizes'], 'Pre-existing sizes must not be empty before the test runs.' );
+		$initial_size_keys = array_keys( $initial_meta['sizes'] );
+
+		// Simulate a scenario where the requested size is removed from the sizes list
+		// (e.g. _wp_make_subsizes() hits an editor error and produces nothing).
+		// Run with the lowest-possible priority so the callback runs *after* the
+		// resize_and_return_image callbacks added at default priority and overrides
+		// them to an empty array.
+		add_filter( 'intermediate_image_sizes_advanced', '__return_empty_array', PHP_INT_MAX );
 
 		$regenerate_size = $this->get_regenerate_size_property();
 		$regenerate_size->setValue( null, 'woocommerce_thumbnail' );
 
-		add_filter( 'intermediate_image_sizes_advanced', array( 'WC_Regenerate_Images', 'adjust_intermediate_image_sizes_advanced' ) );
-		$metadata = wp_generate_attachment_metadata( $attachment_id, $fullsizepath );
-		remove_filter( 'intermediate_image_sizes_advanced', array( 'WC_Regenerate_Images', 'adjust_intermediate_image_sizes_advanced' ) );
+		$method = ( new \ReflectionClass( WC_Regenerate_Images::class ) )
+			->getMethod( 'resize_and_return_image' );
+		$method->setAccessible( true );
 
-		$this->assertSame(
-			array( 'woocommerce_thumbnail' ),
-			array_keys( $metadata['sizes'] ),
-			'Without this filter, core regenerates every registered size (thumbnail, medium, large, ...) instead of just the one requested.'
+		$image_data = array(
+			wp_get_attachment_url( $attachment_id ),
+			800,
+			600,
 		);
+
+		$method->invoke( null, $attachment_id, $image_data, 'woocommerce_thumbnail', false );
+
+		remove_filter( 'intermediate_image_sizes_advanced', '__return_empty_array', PHP_INT_MAX );
+
+		$stored_meta = wp_get_attachment_metadata( $attachment_id );
+		$this->assertIsArray( $stored_meta, 'Stored metadata must survive a failed regen.' );
+		$this->assertNotEmpty( $stored_meta['sizes'], 'sizes must not be empty after a failed regen — the fix must restore pre-existing sizes.' );
+
+		foreach ( $initial_size_keys as $size_key ) {
+			$this->assertArrayHasKey(
+				$size_key,
+				$stored_meta['sizes'],
+				"Size '{$size_key}' must be preserved after a regen failure."
+			);
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
* I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
* I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#60577.

`WC_Regenerate_Images::resize_and_return_image()` regenerates a single missing/mismatched image size on the fly by filtering `intermediate_image_sizes` down to the requested size, then calling `wp_generate_attachment_metadata()`. Both filters — `intermediate_image_sizes` (read by `get_intermediate_image_sizes()` via `wp_get_registered_image_subsizes()`) and `intermediate_image_sizes_advanced` (read directly in `wp_create_image_subsizes()`) — are effective and restrict core to the one requested size.

However, `wp_create_image_subsizes()` writes an initial metadata record with an empty `sizes` array to the database _before_ generating any subsizes. If the requested sub-size fails to generate (for example an image editor error or an interrupted regen), the returned metadata's `sizes` array lacks the expected key. WooCommerce's corrective merge was gated on `isset( $new_metadata['sizes'][ self::$regenerate_size ] )` — when the key is absent the merge is skipped, leaving the DB with the empty (or partial) `sizes` array from core's initial write. The featured image falls back to the full image.

**Fix:** hook `intermediate_image_sizes_advanced` alongside the existing `intermediate_image_sizes` filter so both filter layers restrict regeneration, and always persist the stored `$metadata` captured before the regen call, so the corrective write back to the DB is never gated on the regenerated size key appearing in the returned metadata.

### How to test the changes in this Pull Request:

1. Register a `woocommerce_thumbnail` size that mismatches the site's stored setting, e.g.:

   ```php
   add_filter( 'woocommerce_get_image_size_thumbnail', function( $size ) {
       $size['width'] = 400;
       return $size;
   } );
   ```
2. Upload a product with a high-resolution featured image, note the attachment ID.
3. View a page that renders it via `wp_get_attachment_image_src( $id, 'woocommerce_thumbnail' )` (product page, shop, or add to cart to trigger `wc-ajax=get_refreshed_fragments`).
4. Check `wp post meta get <id> _wp_attachment_metadata --format=json` — `sizes` should retain all pre-existing sizes plus `woocommerce_thumbnail`, not shrink or come back empty.

### Testing that has already taken place:

Added `WC_Regenerate_Images_Test` covering the `intermediate_image_sizes_advanced` filter callback and a `resize_and_return_image()` integration test confirming that pre-existing size entries are preserved after a regen where the requested size fails to generate. Ran locally against WordPress 6.x / PHP 8.1 via `wp-env`, all 3 tests pass. Also ran `phpcs` and `phpstan` on the changed files with no issues.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Fix featured product image losing its 'sizes' metadata when regenerated on the fly with a mismatched thumbnail size.

### Release Communication

*No response*
