### PR TITLE
fix: replace deprecated jQuery focus() shorthand across legacy JS files

### DIFF
--- a/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
+++ b/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Replace deprecated jQuery .focus() shorthand with .trigger( 'focus' ) across multiple checkout, cart, and account JS files.
+Replace deprecated jQuery .focus() shorthand with .trigger( 'focus' ) / .on( 'focus' ) across legacy JS files.

--- a/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
+++ b/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Replace deprecated jQuery .focus() shorthand with .trigger( 'focus' ) in checkout.js.
+Replace deprecated jQuery .focus() shorthand with .trigger( 'focus' ) across multiple checkout, cart, and account JS files.

--- a/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
+++ b/plugins/woocommerce/changelog/60501-fix-jquery-focus-deprecated-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace deprecated jQuery .focus() shorthand with .trigger( 'focus' ) in checkout.js.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -437,7 +437,7 @@
 				},
 				highlightOnFocus: function( query ) {
 					const inputs = $( query );
-					inputs.focus( function() {
+					inputs.on( 'focus', function() {
 						$( this ).select();
 					} );
 				},

--- a/plugins/woocommerce/client/legacy/js/frontend/account-i18n.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/account-i18n.js
@@ -14,7 +14,7 @@ jQuery( function( $ ) {
          * in between.
          */
         setTimeout(function() {
-            $(notices[0]).attr('tabindex', '-1').focus();
+            $(notices[0]).attr('tabindex', '-1').trigger( 'focus' );
         });
     }
 });

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -155,7 +155,7 @@ jQuery( function ( $ ) {
 				$new_coupon_field.val( $old_coupon_field_val );
 				// The coupon input with error needs to be focused before adding the live region
 				// with the error message, otherwise the screen reader won't read it.
-				$new_coupon_field.focus();
+				$new_coupon_field.trigger( 'focus' );
 				show_coupon_error( $old_coupon_error_msg, $new_coupon_field_wrapper, true );
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -1087,7 +1087,7 @@ jQuery( function ( $ ) {
 				.find(
 					'.woocommerce-error[tabindex="-1"], .wc-block-components-notice-banner.is-error[tabindex="-1"]'
 				)
-				.focus();
+				.trigger( 'focus' );
 			$( document.body ).trigger( 'checkout_error', [ error_message ] );
 		},
 		wrapMessagesInsideLink: function ( $msgs ) {
@@ -1198,7 +1198,7 @@ jQuery( function ( $ ) {
 
 			$target
 				.find( '#coupon_code' )
-				.focus()
+				.trigger( 'focus' )
 				.addClass( 'has-error' )
 				.attr( 'aria-invalid', 'true' )
 				.attr( 'aria-describedby', 'coupon-error-notice' );

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -107,7 +107,7 @@ jQuery( function( $ ) {
 				targetIndex = 0;
 			}
 
-			$tabs.eq( targetIndex ).focus();
+			$tabs.eq( targetIndex ).trigger( 'focus' );
 		} )
 		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {
@@ -187,12 +187,12 @@ jQuery( function( $ ) {
 			e.stopPropagation();
 
 			if ( next.includes( direction ) ) {
-				$( this ).next().focus().click();
+				$( this ).next().trigger( 'focus' ).click();
 
 				return;
 			}
 
-			$( this ).prev().focus().click();
+			$( this ).prev().trigger( 'focus' ).click();
 		} );
 
 	// Init Tabs and Star Ratings

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -157,7 +157,7 @@ jQuery( function ( $ ) {
 				.prop( 'type', 'password' );
 		}
 
-		$( this ).siblings( 'input' ).focus();
+		$( this ).siblings( 'input' ).trigger( 'focus' );
 	} );
 
 	$( 'a.coming-soon-footer-banner-dismiss' ).on( 'click', function ( e ) {


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#60501.

`checkout.js` uses `.focus()` as a jQuery event-trigger shorthand in `submit_error()` and `show_coupon_error()`. jQuery Migrate flags this shorthand as deprecated (only `.trigger(focus)` / `.on(focus, fn)` stay supported going forward). This shows up in the browser console as:

```
JQMIGRATE: jQuery.fn.focus() event shorthand is deprecated
```

on shortcode/classic checkout whenever a checkout error or coupon error triggers a focus call. Replaced all deprecated jQuery `.focus()` shorthand calls across the legacy JS files with `.trigger( focus )` (for the programmatic focus calls) or `.on( focus, fn )` (for the event-handler shorthand), matching patterns already used elsewhere in the same files. No behavior change.

Files changed:
- `plugins/woocommerce/client/legacy/js/frontend/checkout.js` — `.focus()` → `.trigger( focus )`
- `plugins/woocommerce/client/legacy/js/frontend/cart.js` — `.focus()` → `.trigger( focus )`
- `plugins/woocommerce/client/legacy/js/frontend/account-i18n.js` — `.focus()` → `.trigger( focus )`
- `plugins/woocommerce/client/legacy/js/frontend/single-product.js` — `.focus()` → `.trigger( focus )`
- `plugins/woocommerce/client/legacy/js/frontend/woocommerce.js` — `.focus()` → `.trigger( focus )`
- `plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js` — `.focus(fn)` event shorthand → `.on( focus, fn )`

### Screenshots or screen recordings:

N/A — no UI change.

### How to test the changes in this Pull Request:

1. Set up a shortcode/classic checkout page with browser dev tools open on the Console tab.
2. Trigger a checkout error (e.g. submit with a gateway configured to fail, or leave a required field empty) — confirm the error notice still gets focus and no JQMIGRATE warning appears.
3. On the coupon form, apply an invalid coupon code — confirm the coupon field still gets focus and the error state still shows, with no JQMIGRATE warning.
4. Open the shipping zone methods admin screen, focus a shipping cost/rate input — confirm the input text is selected and no JQMIGRATE warning appears.

### Testing that has already taken place:

Verified the diff is limited to deprecated jQuery `.focus()` shorthand calls (left native DOM `HTMLElement.focus()` calls untouched). Ran eslint on all changed files, only pre-existing unrelated warnings. Built classic assets and full plugin zip successfully.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Replace deprecated jQuery .focus() shorthand with .trigger( focus ) / .on( focus ) across legacy JS files.

### Release Communication