### PR TITLE
fix: skip trunk push prompt when pushing to a fork

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-./bin/pre-push.sh
+./bin/pre-push.sh "$@"

--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
+# Git passes the remote name as $1 and the remote URL as $2 to the pre-push hook.
+REMOTE_URL="$2"
+
+# Only prompt when pushing to the canonical repo, forks have nothing to protect.
+IS_CANONICAL_REMOTE=1
+if [ -n "$REMOTE_URL" ] && ! echo "$REMOTE_URL" | grep -qiE 'github\.com[:/]woocommerce/woocommerce(\.git)?/?$'; then
+	IS_CANONICAL_REMOTE=0
+fi
+
 PROTECTED_BRANCH="trunk"
 CURRENT_BRANCH=$(git branch --show-current)
-if [ $PROTECTED_BRANCH = $CURRENT_BRANCH ]; then
+if [ $PROTECTED_BRANCH = $CURRENT_BRANCH ] && [ $IS_CANONICAL_REMOTE = 1 ]; then
 	if [ "$TERM" = "dumb" ]; then
 		>&2 echo "Sorry, you are unable to push to $PROTECTED_BRANCH using a GUI client! Please use git CLI."
 		exit 1


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#60309.

The `bin/pre-push.sh` hook prompts "You're about to push to trunk, is that what you intended?" whenever the current branch is `trunk`, regardless of the destination remote. This breaks the common fork-sync workflow: `git pull upstream trunk:trunk; git push origin trunk:trunk` still triggers the prompt even though `origin` is the contributor's own fork, not `woocommerce/woocommerce`.

Git passes the remote name and URL to the `pre-push` hook as `$1`/`$2`. This PR reads `$2` and only shows the confirmation prompt when the destination URL actually resolves to `woocommerce/woocommerce` (covers `https://`, `git@host:`, and `ssh://` forms). `.husky/pre-push` was also updated to forward `"$@"` to the script, since it previously dropped git's arguments entirely. If the hook ever runs without those args (e.g. invoked by hand), it falls back to the original always-prompt behavior.

### How to test the changes in this Pull Request:

1. Check out `trunk` and run `TERM=dumb ./bin/pre-push.sh origin https://github.com/woocommerce/woocommerce.git` — expect the existing "unable to push to trunk using a GUI client" refusal (confirms the guard still applies to the canonical repo).
2. On the same `trunk` checkout, run `TERM=dumb ./bin/pre-push.sh origin https://github.com/someone-else/woocommerce.git` — expect no refusal/prompt, script falls through to the rest of the hook.
3. Reproduce the original issue: add a fork remote and `upstream` pointing at `woocommerce/woocommerce`, then `git pull upstream trunk:trunk; git push origin trunk:trunk` — expect no "are you sure" prompt.

### Testing that has already taken place:

Ran the steps above locally with `bash -n` syntax check plus manual invocations covering canonical repo (https, git@, ssh:// forms), a fork URL, a similarly-named repo (`woocommerce-blocks`, to confirm no false match), and the no-args fallback case. All behaved as expected.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

This only touches repo-root dev tooling (`bin/pre-push.sh`, `.husky/pre-push`), not any shipped package, so there's nothing to note in a package changelog.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)