### PR TITLE
fix: prevent fatal error activating WooCommerce via symlinked plugin dir

### DIFF
--- a/plugins/woocommerce/changelog/fix-59958-symlink-activation-fatal-error
+++ b/plugins/woocommerce/changelog/fix-59958-symlink-activation-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error activating WooCommerce via a symlinked plugin directory

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -91,7 +91,9 @@ class WC_Admin {
 		}
 
 		// Helper.
-		include_once __DIR__ . '/helper/class-wc-helper.php';
+		if ( ! class_exists( 'WC_Helper', false ) ) {
+			include_once __DIR__ . '/helper/class-wc-helper.php';
+		}
 
 		// Marketplace suggestions & related REST API.
 		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1303,7 +1303,9 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function activated_plugin( $filename ) {
-		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		if ( ! class_exists( 'WC_Helper', false ) ) {
+			include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		}
 
 		if ( '/woocommerce.php' === substr( $filename, -16 ) ) {
 			set_transient( 'woocommerce_activated_plugin', $filename );
@@ -1321,7 +1323,9 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function deactivated_plugin( $filename ) {
-		include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		if ( ! class_exists( 'WC_Helper', false ) ) {
+			include_once __DIR__ . '/admin/helper/class-wc-helper.php';
+		}
 
 		WC_Helper::deactivated_plugin( $filename );
 	}

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
@@ -39,7 +39,9 @@ class WC_WCCOM_Site {
 	 * @since 3.7.0
 	 */
 	protected static function includes() {
-		require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
+		if ( ! class_exists( 'WC_Helper', false ) ) {
+			require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
+		}
 		require_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php';
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -520,7 +520,9 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @return \WP_Error|array Contains success status.
 	 */
 	public function finish_wccom_connect( $rest_request ) {
-		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
+		if ( ! class_exists( 'WC_Helper', false ) ) {
+			include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
+		}
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php';
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';

--- a/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/helper/class-wc-helper-test.php
@@ -291,4 +291,20 @@ class WC_Helper_Test extends \WC_Unit_Test_Case {
 		$this->assertArrayHasKey( $woocommerce_key, $woo_plugins );
 	}
 
+	/**
+	 * @testdox WC_Admin::includes should be safe to run more than once (e.g. when a symlinked
+	 *          plugin directory causes the 'init' hook path and another bootstrap path to both
+	 *          attempt to load class-wc-helper.php).
+	 */
+	public function test_wc_admin_includes_can_run_more_than_once(): void {
+		$this->assertTrue( class_exists( 'WC_Helper' ) );
+
+		// WC_Admin::includes() is normally only reached once (via the 'init' hook), but under
+		// a symlinked plugin install it can be reached via more than one literal path. Running
+		// it again must not attempt to redeclare WC_Helper.
+		( new WC_Admin() )->includes();
+
+		$this->assertTrue( class_exists( 'WC_Helper' ) );
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #59958.

`includes/admin/helper/class-wc-helper.php` is required from five call sites, each building the file path a different way (`__DIR__` vs `WC_ABSPATH`). Under a symlinked plugin directory (e.g. `wp-content/plugins/woocommerce -> /some/path`), PHP can end up compiling the file a second time in the same request, fataling on the `WC_Helper` class redeclaration:

```
PHP Fatal error: Cannot declare class WC_Helper, because the name is already in use
in .../includes/admin/helper/class-wc-helper.php on line 22
```

Each of the five call sites now checks `class_exists( 'WC_Helper', false )` before including the file, so a second attempt is a no-op instead of a fatal:

- `includes/admin/class-wc-admin.php`
- `includes/class-woocommerce.php` (`activated_plugin()`, `deactivated_plugin()`)
- `includes/wccom-site/class-wc-wccom-site.php`
- `src/Admin/API/Plugins.php` (`finish_wccom_connect()`)

### How to test the changes in this Pull Request:

1. Extract WooCommerce into a directory outside `wp-content/plugins` (per the issue's repro steps).
2. `cd wp-content/plugins` and symlink it in: `ln -s /path/to/woocommerce-src woocommerce`.
3. Log into wp-admin, go to Plugins, activate WooCommerce.
4. Before this fix: fatal error, activation fails. After this fix: activates normally.
5. Sanity check a normal (non-symlinked) install still activates/deactivates fine, and Marketplace/Helper (Plugins > WooCommerce > Marketplace) still connects/disconnects as before.

### Testing that has already taken place:

- Added a unit test (`WC_Helper_Test::test_wc_admin_includes_can_run_more_than_once`) that runs `WC_Admin::includes()` twice and asserts `WC_Helper` stays declared with no fatal.
- `pnpm test:php:env -- --filter WC_Helper_Test`: 15/15 pass.
- `pnpm test:php:env -- --filter 'WC_Admin_Test|WooCommerce_Test|Plugins_Test|WC_WCCOM_Site'`: 710/710 pass (4 pre-existing unrelated skips).
- `pnpm lint:php:changes` and PHPStan on all changed files: clean.
- Manual symlink repro per the issue's steps, on WP 6.9-alpha / PHP 8.1.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

**Changelog Entry Details**

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Fix fatal error activating WooCommerce via a symlinked plugin directory.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)