### PR TITLE
fix: show billing name for guest orders in Home Orders panel

### DIFF
--- a/plugins/woocommerce/changelog/59959-fix-guest-order-name-home-orders-panel
+++ b/plugins/woocommerce/changelog/59959-fix-guest-order-name-home-orders-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the billing name for guest orders in the WooCommerce Home Orders activity panel instead of leaving the name blank.

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/index.js
@@ -74,9 +74,7 @@ function renderOrders( orders, customers, getFormattedOrderTotal ) {
 		return renderEmptyCard();
 	}
 
-	const getCustomerString = ( customer ) => {
-		const { name } = customer || {};
-
+	const getCustomerString = ( name ) => {
 		if ( ! name ) {
 			return '';
 		}
@@ -89,6 +87,7 @@ function renderOrders( orders, customers, getFormattedOrderTotal ) {
 			id: orderId,
 			number: orderNumber,
 			customer_id: customerId,
+			billing,
 		} = order;
 		const customer =
 			customers.find( ( c ) => c.user_id === customerId ) || {};
@@ -102,11 +101,22 @@ function renderOrders( orders, customers, getFormattedOrderTotal ) {
 				: getAdminLink( 'user-edit.php?user_id=' + customer.id );
 		}
 
+		// Guest orders (customer_id 0) have no customer record to look up,
+		// fall back to the billing name stored on the order itself. Strip
+		// angle brackets so a billing name can't be mistaken for markup by
+		// createInterpolateElement below.
+		const guestName = billing
+			? `${ billing.first_name || '' } ${ billing.last_name || '' }`
+					.trim()
+					.replace( /[<>]/g, '' )
+			: '';
+		const customerName = customer.name || guestName;
+
 		const formattedString = sprintf(
 			/* translators: 1: order number, 2: customer name */
 			__( '<orderLink>Order #%1$s</orderLink> %2$s', 'woocommerce' ),
 			orderNumber,
-			getCustomerString( customer )
+			getCustomerString( customerName )
 		);
 
 		return (
@@ -218,6 +228,7 @@ function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 				'status',
 				'total',
 				'customer',
+				'billing',
 				'line_items',
 				'customer_id',
 				'date_created_gmt',

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/index.js
@@ -101,16 +101,15 @@ function renderOrders( orders, customers, getFormattedOrderTotal ) {
 				: getAdminLink( 'user-edit.php?user_id=' + customer.id );
 		}
 
-		// Guest orders (customer_id 0) have no customer record to look up,
-		// fall back to the billing name stored on the order itself. Strip
-		// angle brackets so a billing name can't be mistaken for markup by
-		// createInterpolateElement below.
+		// Guest orders have no customer record; fall back to the billing name.
+		// createInterpolateElement parses <word> as a token, so strip angle
+		// brackets from the name to keep it from being read as markup.
+		const sanitizeName = ( name ) =>
+			( name || '' ).replace( /[<>]/g, '' ).trim();
 		const guestName = billing
 			? `${ billing.first_name || '' } ${ billing.last_name || '' }`
-					.trim()
-					.replace( /[<>]/g, '' )
 			: '';
-		const customerName = customer.name || guestName;
+		const customerName = sanitizeName( customer?.name || guestName );
 
 		const formattedString = sprintf(
 			/* translators: 1: order number, 2: customer name */

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
@@ -200,4 +200,27 @@ describe( 'OrdersPanel', () => {
 		expect( screen.getByText( 'Registered Customer' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Jane Doe' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'should strip angle brackets from a guest billing name', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					customer_id: 0,
+					billing: {
+						first_name: '<b>script</b>',
+						last_name: 'Doe',
+					},
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+
+		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } /> );
+		expect( screen.getByText( 'bscriptb Doe' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /</ ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
@@ -220,7 +220,7 @@ describe( 'OrdersPanel', () => {
 		} );
 
 		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } /> );
-		expect( screen.getByText( 'bscriptb Doe' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'bscript/b Doe' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /</ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/test/index.js
@@ -130,4 +130,74 @@ describe( 'OrdersPanel', () => {
 		);
 		expect( getByText( 'BTC123' ) ).toBeInTheDocument();
 	} );
+
+	it( 'should show the billing name for a guest order', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					customer_id: 0,
+					billing: {
+						first_name: 'Jane',
+						last_name: 'Doe',
+					},
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+
+		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } /> );
+		expect( screen.getByText( 'Jane Doe' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show no name for a guest order with a blank billing name', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					customer_id: 0,
+					billing: {
+						first_name: '',
+						last_name: '',
+					},
+				},
+			],
+			isError: false,
+			isRequesting: false,
+		} );
+
+		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } /> );
+		expect( screen.getByText( 'Order #1' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should prefer the registered customer name over the billing name', () => {
+		useSelect.mockReturnValue( {
+			orders: [
+				{
+					total: 123,
+					id: 1,
+					number: 1,
+					customer_id: 5,
+					billing: {
+						first_name: 'Jane',
+						last_name: 'Doe',
+					},
+				},
+			],
+			customerItems: new Map( [
+				[ 5, { id: 5, user_id: 5, name: 'Registered Customer' } ],
+			] ),
+			isError: false,
+			isRequesting: false,
+		} );
+
+		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 1 } /> );
+		expect( screen.getByText( 'Registered Customer' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Jane Doe' ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #59959.
Closes WOOPLUG-5166
Closes #55480 
Closes WOOPLUG-3174

On WooCommerce → Home, the Orders activity panel shows "Order #123 Customer Name" for each actionable order. Guest orders (`customer_id` is `0`) have no customer record to look up, so the name segment was always blank.

Repro: place a guest checkout order with a billing name, open `wp-admin/admin.php?page=wc-admin`, expand the Orders panel. The row shows "Order #123" with no name after it, even though the order has billing details.

The order response already carries the billing address, it just wasn't requested or used. This PR adds `billing` to the orders query fields and falls back to `billing.first_name`/`billing.last_name` when there is no matching registered customer. Registered customer name still takes priority and still links to the customer profile, guests just show as plain text same as the rest of the row.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| `Order #123` (no name shown for guest order) | `Order #123 Jane Doe` |

### How to test the changes in this Pull Request:

1. Place an order as a guest (logged out, or "Create account" unchecked) with a billing first/last name, e.g. Jane Doe.
2. Make sure the order status is one of your actionable statuses, or one of your 5 most recent matching orders.
3. Go to WooCommerce → Home, expand the Orders panel.
4. Before this fix: row reads "Order #123" with no name. After: "Order #123 Jane Doe".
5. Regression check: a registered customer's order still shows their name as a link to their profile/analytics page.
6. Regression check: a guest order with no billing name still renders with no name, no crash.

### Testing that has already taken place:

Added 3 Jest tests covering guest order with billing name, guest order with blank billing name, and registered customer name taking priority over billing name. Manually verified on wp-env with a guest checkout order.

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

- [ ] This Pull Request does not require a changelog entry.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Show the billing name for guest orders in the WooCommerce Home Orders activity panel instead of leaving the name blank.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)