### PR TITLE
fix: advance NOX test account step on non-recoverable stripe error

### DIFF
--- a/plugins/woocommerce/changelog/59437-nox-non-recoverable-error
+++ b/plugins/woocommerce/changelog/59437-nox-non-recoverable-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Automatically advance the NOX test-account onboarding step when Stripe returns a non-recoverable error

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -67,6 +67,15 @@ class WooPaymentsService {
 	 */
 	const ONBOARDING_STEP_STATUS_BLOCKED = 'blocked';
 
+	/**
+	 * Stripe error types that are non-recoverable for the test account step.
+	 *
+	 * These are errors the merchant has no way to fix on their end (e.g. a validation error
+	 * caused by data we generate automatically), so we shouldn't trap them in a retry loop.
+	 * Instead, we complete the step and let onboarding proceed.
+	 */
+	const NON_RECOVERABLE_TEST_ACCOUNT_ERROR_TYPES = array( 'invalid_request_error' );
+
 	const ACTION_TYPE_REST     = 'REST';
 	const ACTION_TYPE_REDIRECT = 'REDIRECT';
 
@@ -1036,6 +1045,23 @@ class WooPaymentsService {
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {
+			// If the merchant can't do anything to fix this on their end, don't trap them
+			// in a retry loop. Complete the step and let onboarding proceed instead.
+			// Use the internal record path (not mark_onboarding_step_completed()) because the
+			// onboarding lock was already released above; re-checking it here could spuriously
+			// fail if a concurrent request has since acquired it. See record_onboarding_step_completed().
+			if ( $this->is_test_account_error_non_recoverable( $response->get_error_data() ) ) {
+				$this->record_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, false, $source );
+
+				$this->record_event(
+					self::EVENT_PREFIX . 'onboarding_test_account_init_non_recoverable_error',
+					$location,
+					array( 'source' => $source )
+				);
+
+				return array( 'success' => true );
+			}
+
 			// Mark the onboarding step as failed.
 			$this->mark_onboarding_step_failed(
 				self::ONBOARDING_STEP_TEST_ACCOUNT,
@@ -1107,6 +1133,30 @@ class WooPaymentsService {
 		);
 
 		return $response;
+	}
+
+	/**
+	 * Determine if a test account initialization error is non-recoverable for the merchant.
+	 *
+	 * We look for a Stripe error `type` in a few plausible locations of the error data, since
+	 * the shape depends on how the WooPayments extension forwards it to us.
+	 *
+	 * @param mixed $error_data The error data returned alongside the WP_Error.
+	 *
+	 * @return bool
+	 */
+	private function is_test_account_error_non_recoverable( $error_data ): bool {
+		if ( ! is_array( $error_data ) ) {
+			return false;
+		}
+
+		$error_type = $error_data['type']
+			?? $error_data['error']['type']
+			?? $error_data['data']['type']
+			?? $error_data['data']['error']['type']
+			?? null;
+
+		return is_string( $error_type ) && in_array( $error_type, self::NON_RECOVERABLE_TEST_ACCOUNT_ERROR_TYPES, true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -7230,6 +7230,157 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test onboarding_test_account_init completes the step when the error is non-recoverable.
+	 *
+	 * @return void
+	 */
+	public function test_onboarding_test_account_init_completes_step_on_non_recoverable_error() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
+		// Arrange the NOX profile.
+		$step_id                 = WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT;
+		$stored_profile          = array();
+		$updated_stored_profiles = array();
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option'    => function ( $option_name, $default_value = null ) use ( &$updated_stored_profiles, $stored_profile ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						return ! empty( $updated_stored_profiles ) ? end( $updated_stored_profiles ) : $stored_profile;
+					}
+
+					return $default_value;
+				},
+				'update_option' => function ( $option_name, $value ) use ( &$updated_stored_profiles ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						$updated_stored_profiles[] = $value;
+						return true;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		// Arrange the REST API request to fail with a non-recoverable Stripe error type.
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) {
+						// Avoid parameter not used PHPCS errors.
+						unset( $params );
+						if ( '/wc/v3/payments/onboarding/test_drive_account/init' === $endpoint ) {
+							return new WP_Error(
+								'bad_request',
+								"The statement descriptor matches a common term or website URL, and can't be used.",
+								array( 'type' => 'invalid_request_error' )
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		// Act.
+		$result = $this->sut->onboarding_test_account_init( $location );
+
+		// Assert - the step is completed instead of throwing, so onboarding can proceed.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertTrue( $result['success'] );
+
+		$this->assertNotEmpty( $updated_stored_profiles );
+		$final_profile = end( $updated_stored_profiles );
+		$this->assertArrayHasKey(
+			WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+			$final_profile['onboarding'][ $location ]['steps'][ $step_id ]['statuses']
+		);
+	}
+
+	/**
+	 * Test onboarding_test_account_init still throws for a recoverable (non-matching) error type.
+	 *
+	 * @return void
+	 */
+	public function test_onboarding_test_account_init_throws_on_recoverable_error_type() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
+		// Arrange the NOX profile.
+		$stored_profile = array();
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option'    => function ( $option_name, $default_value = null ) use ( $stored_profile ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						return $stored_profile;
+					}
+
+					return $default_value;
+				},
+				'update_option' => function ( $option_name, $value ) {
+					// Avoid parameter not used PHPCS errors.
+					unset( $option_name, $value );
+					return true;
+				},
+			)
+		);
+
+		// Arrange the REST API request to fail with an error type that is not non-recoverable.
+		$expected_error = array(
+			'code'    => 'bad_request',
+			'message' => 'Your card was declined.',
+		);
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint, array $params = array() ) use ( $expected_error ) {
+						// Avoid parameter not used PHPCS errors.
+						unset( $params );
+						if ( '/wc/v3/payments/onboarding/test_drive_account/init' === $endpoint ) {
+							return new WP_Error(
+								$expected_error['code'],
+								$expected_error['message'],
+								array( 'type' => 'card_error' )
+							);
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		// Assert.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( $expected_error['message'] );
+
+		// Act.
+		$this->sut->onboarding_test_account_init( $location );
+	}
+
+	/**
 	 * Test that error sanitization moves extra keys to context when storing a step error.
 	 *
 	 * When an error has keys beyond 'code', 'message', and 'context', those extra keys


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #59437.

When a merchant hits the NOX test account onboarding step, WooPayments calls Stripe to create a test-drive account. Some Stripe failures are non-recoverable on the merchant's side, the issue's example is Stripe's `invalid_request_error` for a bad statement descriptor, which is generated by WooCommerce/WooPayments, not typed in by the merchant. Right now any failure from that call marks the step `failed` and the merchant is stuck on a "Try Again" loop they can never win.

This PR adds detection for non-recoverable error types in `WooPaymentsService::onboarding_test_account_init()`. When the error type matches a known non-recoverable list (currently just `invalid_request_error`), the step is marked `completed` instead, so onboarding proceeds normally. Any other error keeps the existing behavior (marked `failed`, retry available).

**Dependency note:** the actual Stripe call happens in the WooPayments plugin (`Automattic/woocommerce-payments`), which today catches the Stripe exception generically and returns a `WP_Error` with just a message, no structured error `type`. This PR implements the consuming side in WooCommerce core, it's inert (no behavior change) until WooPayments is updated to forward a `type` field in its `test_drive_account/init` response. Safe to merge ahead of that change since it doesn't alter any current code path.

### How to test the changes in this Pull Request:

1. Run the automated tests below, both new tests confirm the step completes on a non-recoverable error and still fails/retries on any other error.
2. Since WooPayments doesn't send the error `type` yet, the new path can't be triggered end to end from the UI today. To verify manually, temporarily force a non-recoverable `WP_Error` (with `type => invalid_request_error`) right before the `is_wp_error( $response )` check in `onboarding_test_account_init()`, then trigger the test account step in wp-admin (Payments settings, WooPayments onboarding, test account step). Expected: instead of the "Try Again" error screen, the step completes and onboarding advances to the next step. Revert the temporary change after.
3. Confirm regression: any other error type (e.g. `card_error`) or no `type` at all still marks the step failed and shows the retry screen, same as before this change.

### Testing that has already taken place:

Ran the full `WooPaymentsServiceTest` suite via `wp-env` (PHP 8.1, PHPUnit 9.6.24), 317 tests / 679 assertions passing, including 2 new tests covering the non-recoverable and recoverable error paths. Also ran `phpcs-changed` (clean) and PHPStan on the modified file (no errors, no baseline additions needed).

### Milestone

- [x] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Automatically advance the NOX test-account onboarding step when Stripe returns a non-recoverable error.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)
