### PR TITLE
Add errored_coupon and errored_coupon_in_checkout JS events

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-59489-coupon-error-event
+++ b/plugins/woocommerce/changelog/wooplug-59489-coupon-error-event
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add coupon_error and coupon_error_in_checkout JS events fired when a coupon fails to apply on the classic cart and checkout pages.
+Add errored_coupon and errored_coupon_in_checkout JS events fired when a coupon fails to apply on the classic cart and checkout pages.

--- a/plugins/woocommerce/changelog/wooplug-59489-coupon-error-event
+++ b/plugins/woocommerce/changelog/wooplug-59489-coupon-error-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add coupon_error and coupon_error_in_checkout JS events fired when a coupon fails to apply on the classic cart and checkout pages.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -643,7 +643,7 @@ jQuery( function ( $ ) {
 							show_coupon_error( response, $coupon_wrapper, false );
 						}
 
-						$( document.body ).trigger( 'coupon_error', [
+						$( document.body ).trigger( 'errored_coupon', [
 							coupon_code,
 							response,
 						] );

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -642,6 +642,11 @@ jQuery( function ( $ ) {
 						if ( $coupon_wrapper.length > 0 ) {
 							show_coupon_error( response, $coupon_wrapper, false );
 						}
+
+						$( document.body ).trigger( 'coupon_error', [
+							coupon_code,
+							response,
+						] );
 					}
 
 					$( document.body ).trigger( 'applied_coupon', [

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -1296,7 +1296,7 @@ jQuery( function ( $ ) {
 							);
 
 							$( document.body ).trigger(
-								'coupon_error_in_checkout',
+								'errored_coupon_in_checkout',
 								[ data.coupon_code, response ]
 							);
 						}

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -1294,6 +1294,11 @@ jQuery( function ( $ ) {
 								response,
 								$coupon_field.parent()
 							);
+
+							$( document.body ).trigger(
+								'coupon_error_in_checkout',
+								[ data.coupon_code, response ]
+							);
 						}
 
 						$( document.body ).trigger(

--- a/plugins/woocommerce/tests/e2e/tests/coupons/cart-checkout-restricted-coupons.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/coupons/cart-checkout-restricted-coupons.spec.ts
@@ -51,27 +51,6 @@ const expandCouponForm = async ( page: Page ) => {
 	await expect( page.getByPlaceholder( 'Coupon code' ) ).toBeVisible();
 };
 
-// Arms a listener for the given jQuery event on document.body, stashing the
-// result on window for later retrieval. Await this before applyCoupon() so
-// the listener is attached before the AJAX response can trigger the event,
-// then read the result back with getCouponErrorEvent() once the action
-// that's expected to fire it has completed.
-const armCouponErrorEvent = ( page: Page, eventName: string ) =>
-	page.evaluate( ( name ) => {
-		( window as any ).__couponErrorPromise = new Promise< string >(
-			( resolve ) => {
-				( window as any )
-					.jQuery( document.body )
-					.one( name, ( _event: unknown, couponCode: string ) =>
-						resolve( couponCode )
-					);
-			}
-		);
-	}, eventName );
-
-const getCouponErrorEvent = ( page: Page ) =>
-	page.evaluate( () => ( window as any ).__couponErrorPromise );
-
 const fillBillingDetails = async ( page: Page, email: string ) => {
 	await page.getByLabel( 'First name' ).first().fill( 'Homer' );
 	await page.getByLabel( 'Last name' ).first().fill( 'Simpson' );
@@ -194,16 +173,12 @@ test.describe(
 			await test.step( 'cart', async () => {
 				await addAProductToCart( page, firstProductId );
 				await page.goto( CLASSIC_CART_PAGE.slug );
-				await armCouponErrorEvent( page, 'coupon_error' );
 				await applyCoupon( page, EXPIRED_COUPON );
 				await expect(
 					page.getByText(
 						`Coupon "${ EXPIRED_COUPON }" has expired.`
 					)
 				).toBeVisible();
-				expect( await getCouponErrorEvent( page ) ).toBe(
-					EXPIRED_COUPON
-				);
 			} );
 
 			await context.clearCookies();
@@ -212,16 +187,12 @@ test.describe(
 				await addAProductToCart( page, firstProductId );
 				await page.goto( CLASSIC_CHECKOUT_PAGE.slug );
 				await expandCouponForm( page );
-				await armCouponErrorEvent( page, 'coupon_error_in_checkout' );
 				await applyCoupon( page, EXPIRED_COUPON );
 				await expect(
 					page.getByText(
 						`Coupon "${ EXPIRED_COUPON }" has expired.`
 					)
 				).toBeVisible();
-				expect( await getCouponErrorEvent( page ) ).toBe(
-					EXPIRED_COUPON
-				);
 			} );
 		} );
 

--- a/plugins/woocommerce/tests/e2e/tests/coupons/cart-checkout-restricted-coupons.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/coupons/cart-checkout-restricted-coupons.spec.ts
@@ -51,6 +51,27 @@ const expandCouponForm = async ( page: Page ) => {
 	await expect( page.getByPlaceholder( 'Coupon code' ) ).toBeVisible();
 };
 
+// Arms a listener for the given jQuery event on document.body, stashing the
+// result on window for later retrieval. Await this before applyCoupon() so
+// the listener is attached before the AJAX response can trigger the event,
+// then read the result back with getCouponErrorEvent() once the action
+// that's expected to fire it has completed.
+const armCouponErrorEvent = ( page: Page, eventName: string ) =>
+	page.evaluate( ( name ) => {
+		( window as any ).__couponErrorPromise = new Promise< string >(
+			( resolve ) => {
+				( window as any )
+					.jQuery( document.body )
+					.one( name, ( _event: unknown, couponCode: string ) =>
+						resolve( couponCode )
+					);
+			}
+		);
+	}, eventName );
+
+const getCouponErrorEvent = ( page: Page ) =>
+	page.evaluate( () => ( window as any ).__couponErrorPromise );
+
 const fillBillingDetails = async ( page: Page, email: string ) => {
 	await page.getByLabel( 'First name' ).first().fill( 'Homer' );
 	await page.getByLabel( 'Last name' ).first().fill( 'Simpson' );
@@ -173,12 +194,16 @@ test.describe(
 			await test.step( 'cart', async () => {
 				await addAProductToCart( page, firstProductId );
 				await page.goto( CLASSIC_CART_PAGE.slug );
+				await armCouponErrorEvent( page, 'coupon_error' );
 				await applyCoupon( page, EXPIRED_COUPON );
 				await expect(
 					page.getByText(
 						`Coupon "${ EXPIRED_COUPON }" has expired.`
 					)
 				).toBeVisible();
+				expect( await getCouponErrorEvent( page ) ).toBe(
+					EXPIRED_COUPON
+				);
 			} );
 
 			await context.clearCookies();
@@ -187,12 +212,16 @@ test.describe(
 				await addAProductToCart( page, firstProductId );
 				await page.goto( CLASSIC_CHECKOUT_PAGE.slug );
 				await expandCouponForm( page );
+				await armCouponErrorEvent( page, 'coupon_error_in_checkout' );
 				await applyCoupon( page, EXPIRED_COUPON );
 				await expect(
 					page.getByText(
 						`Coupon "${ EXPIRED_COUPON }" has expired.`
 					)
 				).toBeVisible();
+				expect( await getCouponErrorEvent( page ) ).toBe(
+					EXPIRED_COUPON
+				);
 			} );
 		} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#59489.

Right now `applied_coupon` (cart) and `applied_coupon_in_checkout` (checkout) fire regardless of whether the coupon actually applied. The AJAX success handlers already string-match the response for `woocommerce-error`/`is-error` to decide whether to show the inline error notice, but that outcome was never exposed as an event, so extensions had no way to react to a failed coupon attempt without duplicating that same check.

This adds two new events fired from inside the existing error branch, using the detection that's already there:

* `errored_coupon` on the cart page, fired with `(couponCode, response)`.
* `errored_coupon_in_checkout` on the checkout page, fired with `(couponCode, response)`.

`response` is the raw AJAX HTML fragment already used for the inline error. `applied_coupon` / `applied_coupon_in_checkout` are unchanged, still fire on both outcomes as before. No PHP changes, purely additive JS.

### How to test the changes in this Pull Request:

1. Create a coupon with an expiry date in the past.
2. Add a product to cart, go to the Cart page, open the browser console and run:

   ```js
   jQuery( document.body ).on( 'errored_coupon', function ( e, couponCode, response ) {
       console.log( 'errored_coupon fired for', couponCode );
   } );
   ```
3. Enter the expired coupon code, click Apply coupon. Console logs the event and the "has expired" notice appears under the field.
4. Repeat on the Checkout page (expand the coupon form), listening for `errored_coupon_in_checkout` instead.
5. Sanity check: apply a valid coupon, confirm `applied_coupon` / `applied_coupon_in_checkout` still fire and no `errored_coupon` fires.

### Testing that has already taken place:

Manually verified in a local build (WP + WC classic cart/checkout, no blocks) that `errored_coupon` (cart) and `errored_coupon_in_checkout` (checkout) fire on an expired coupon and that `applied_coupon` / `applied_coupon_in_checkout` remain unchanged. E2E coverage for the error events was removed per maintainer review.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Minor

#### Type

- [X] Add - Adds functionality

#### Message

Add errored_coupon and errored_coupon_in_checkout JS events fired when a coupon fails to apply on the classic cart and checkout pages.

### Screenshots

<img src="https://github.com/user-attachments/assets/f6388cf9-d512-4d98-8a4e-87b7aea70680 " alt="SCR-20260705-ojcx" width="1169" data-linear-height="498" />

<img src="https://github.com/user-attachments/assets/bc2db2f9-0812-49a1-9a54-eb9d5ca13163 " alt="SCR-20260705-ojha" width="857" data-linear-height="497" />

<img src="https://github.com/user-attachments/assets/d312764e-bc03-448e-8099-f98579f420bc " alt="SCR-20260705-ojta" width="858" data-linear-height="509" />