### PR TITLE
fix(orders): snapshot regular and sale price on order line items

### DIFF
--- a/plugins/woocommerce/changelog/fix-30308-order-line-item-regular-sale-price-snapshot
+++ b/plugins/woocommerce/changelog/fix-30308-order-line-item-regular-sale-price-snapshot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add regular_price, sale_price and on_sale (snapshot at order time) to order line items in the REST API.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1800,6 +1800,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$item = wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Order_Item_Product::class );
 		$item->set_props( $args );
+		if ( $product ) {
+			$item->set_product_price_snapshot( $product );
+		}
 		$item->set_backorder_meta();
 		$item->set_order_id( $this->get_id() );
 		$item->save();

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -837,8 +837,7 @@ class WC_Checkout {
 							break;
 						case 'password':
 							if ( $data['createaccount'] && 'account_password' === $key ) {
-								$value = wp_slash( $value );
-								// Passwords are encrypted with slashes on account creation, so we need to slash here too.
+								$value = wp_slash( $value ); // Passwords are encrypted with slashes on account creation, so we need to slash here too.
 							}
 							break;
 						default:

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -588,6 +588,10 @@ class WC_Checkout {
 				);
 			}
 
+			if ( $product ) {
+				$item->set_product_price_snapshot( $product );
+			}
+
 			$item->set_backorder_meta();
 
 			/**
@@ -833,7 +837,8 @@ class WC_Checkout {
 							break;
 						case 'password':
 							if ( $data['createaccount'] && 'account_password' === $key ) {
-								$value = wp_slash( $value ); // Passwords are encrypted with slashes on account creation, so we need to slash here too.
+								$value = wp_slash( $value );
+								// Passwords are encrypted with slashes on account creation, so we need to slash here too.
 							}
 							break;
 						default:

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -170,6 +170,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Set regular price (snapshot at order time).
 	 *
+	 * @since 11.0.0
 	 * @param string $value Regular price.
 	 */
 	public function set_regular_price( $value ) {
@@ -179,6 +180,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Set sale price (snapshot at order time).
 	 *
+	 * @since 11.0.0
 	 * @param string $value Sale price.
 	 */
 	public function set_sale_price( $value ) {
@@ -287,6 +289,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Snapshot the product's regular and sale price at order time.
 	 *
+	 * @since 11.0.0
 	 * @param WC_Product $product Product instance.
 	 * @return void
 	 */
@@ -408,6 +411,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Get regular price (snapshot at order time).
 	 *
+	 * @since 11.0.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
 	 * @return string
 	 */
@@ -418,6 +422,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Get sale price (snapshot at order time).
 	 *
+	 * @since 11.0.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
 	 * @return string
 	 */

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -42,18 +42,20 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @var array
 	 */
 	protected $extra_data = array(
-		'product_id'   => 0,
-		'variation_id' => 0,
-		'quantity'     => 1,
-		'tax_class'    => '',
-		'subtotal'     => 0,
-		'subtotal_tax' => 0,
-		'total'        => 0,
-		'total_tax'    => 0,
-		'taxes'        => array(
+		'product_id'    => 0,
+		'variation_id'  => 0,
+		'quantity'      => 1,
+		'tax_class'     => '',
+		'subtotal'      => 0,
+		'subtotal_tax'  => 0,
+		'total'         => 0,
+		'total_tax'     => 0,
+		'taxes'         => array(
 			'subtotal' => array(),
 			'total'    => array(),
 		),
+		'regular_price' => '',
+		'sale_price'    => '',
 	);
 
 	/*
@@ -166,6 +168,24 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	}
 
 	/**
+	 * Set regular price (snapshot at order time).
+	 *
+	 * @param string $value Regular price.
+	 */
+	public function set_regular_price( $value ) {
+		$this->set_prop( 'regular_price', wc_format_decimal( $value ) );
+	}
+
+	/**
+	 * Set sale price (snapshot at order time).
+	 *
+	 * @param string $value Sale price.
+	 */
+	public function set_sale_price( $value ) {
+		$this->set_prop( 'sale_price', wc_format_decimal( $value ) );
+	}
+
+	/**
 	 * Set line taxes and totals for passed in taxes.
 	 *
 	 * @since 10.5.0 Handles legacy scalar tax values by converting to arrays.
@@ -262,6 +282,20 @@ class WC_Order_Item_Product extends WC_Order_Item {
 		}
 		$this->set_name( $product->get_name() );
 		$this->set_tax_class( $product->get_tax_class() );
+	}
+
+	/**
+	 * Snapshot the product's regular and sale price at order time.
+	 *
+	 * @param WC_Product $product Product instance.
+	 * @return void
+	 */
+	public function set_product_price_snapshot( $product ) {
+		if ( ! ( $product instanceof \WC_Product ) ) {
+			$this->error( 'order_item_product_invalid_product', __( 'Invalid product', 'woocommerce' ) );
+		}
+		$this->set_regular_price( $product->get_regular_price() );
+		$this->set_sale_price( $product->get_sale_price() );
 	}
 
 	/**
@@ -369,6 +403,26 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 */
 	public function get_total_tax( $context = 'view' ) {
 		return $this->get_prop( 'total_tax', $context );
+	}
+
+	/**
+	 * Get regular price (snapshot at order time).
+	 *
+	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return string
+	 */
+	public function get_regular_price( $context = 'view' ) {
+		return $this->get_prop( 'regular_price', $context );
+	}
+
+	/**
+	 * Get sale price (snapshot at order time).
+	 *
+	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return string
+	 */
+	public function get_sale_price( $context = 'view' ) {
+		return $this->get_prop( 'sale_price', $context );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
@@ -22,7 +22,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 	 * @since 3.0.0
 	 * @var array
 	 */
-	protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data' );
+	protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data', '_line_regular_price', '_line_sale_price' );
 
 	/**
 	 * Read/populate data properties specific to this order item.
@@ -35,13 +35,15 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 		$id = $item->get_id();
 		$item->set_props(
 			array(
-				'product_id'   => get_metadata( 'order_item', $id, '_product_id', true ),
-				'variation_id' => get_metadata( 'order_item', $id, '_variation_id', true ),
-				'quantity'     => get_metadata( 'order_item', $id, '_qty', true ),
-				'tax_class'    => get_metadata( 'order_item', $id, '_tax_class', true ),
-				'subtotal'     => get_metadata( 'order_item', $id, '_line_subtotal', true ),
-				'total'        => get_metadata( 'order_item', $id, '_line_total', true ),
-				'taxes'        => get_metadata( 'order_item', $id, '_line_tax_data', true ),
+				'product_id'    => get_metadata( 'order_item', $id, '_product_id', true ),
+				'variation_id'  => get_metadata( 'order_item', $id, '_variation_id', true ),
+				'quantity'      => get_metadata( 'order_item', $id, '_qty', true ),
+				'tax_class'     => get_metadata( 'order_item', $id, '_tax_class', true ),
+				'subtotal'      => get_metadata( 'order_item', $id, '_line_subtotal', true ),
+				'total'         => get_metadata( 'order_item', $id, '_line_total', true ),
+				'taxes'         => get_metadata( 'order_item', $id, '_line_tax_data', true ),
+				'regular_price' => get_metadata( 'order_item', $id, '_line_regular_price', true ),
+				'sale_price'    => get_metadata( 'order_item', $id, '_line_sale_price', true ),
 			)
 		);
 		$item->set_object_read( true );
@@ -58,15 +60,17 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 		$id                = $item->get_id();
 		$changes           = $item->get_changes();
 		$meta_key_to_props = array(
-			'_product_id'        => 'product_id',
-			'_variation_id'      => 'variation_id',
-			'_qty'               => 'quantity',
-			'_tax_class'         => 'tax_class',
-			'_line_subtotal'     => 'subtotal',
-			'_line_subtotal_tax' => 'subtotal_tax',
-			'_line_total'        => 'total',
-			'_line_tax'          => 'total_tax',
-			'_line_tax_data'     => 'taxes',
+			'_product_id'         => 'product_id',
+			'_variation_id'       => 'variation_id',
+			'_qty'                => 'quantity',
+			'_tax_class'          => 'tax_class',
+			'_line_subtotal'      => 'subtotal',
+			'_line_subtotal_tax'  => 'subtotal_tax',
+			'_line_total'         => 'total',
+			'_line_tax'           => 'total_tax',
+			'_line_tax_data'      => 'taxes',
+			'_line_regular_price' => 'regular_price',
+			'_line_sale_price'    => 'sale_price',
 		);
 		$props_to_update   = $this->get_props_to_update( $item, $meta_key_to_props, 'order_item' );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -215,7 +215,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	protected function get_order_item_data( $item ) {
 		$data           = $item->get_data();
-		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total' );
+		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total', 'regular_price', 'sale_price' );
 
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {
@@ -230,9 +230,15 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 			$data['sku']              = $product ? $product->get_sku() : null;
 			$data['global_unique_id'] = $product ? $product->get_global_unique_id() : null;
-			$data['price']            = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['price']       = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
 
-			$image_id = $product ? $product->get_image_id() : 0;
+				if ( $item instanceof WC_Order_Item_Product ) {
+					$regular         = $item->get_regular_price();
+					$sale            = $item->get_sale_price();
+					$data['on_sale'] = ( '' !== $sale && $sale !== $regular );
+				}
+
+				$image_id = $product ? $product->get_image_id() : 0;
 
 			$data['image'] = array(
 				'id'  => $image_id,
@@ -322,11 +328,13 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	private function merge_meta_item_with_formatted_meta_display_attributes( $meta_item, $formatted_meta_data ) {
 		$result = array(
-			'id'            => $meta_item->id,
-			'key'           => $meta_item->key,
-			'value'         => $meta_item->value,
-			'display_key'   => $meta_item->key,   // Default to original key, in case a formatted key is not available.
-			'display_value' => $meta_item->value, // Default to original value, in case a formatted value is not available.
+			'id'                            => $meta_item->id,
+			'key'                           => $meta_item->key,
+			'value'                         => $meta_item->value,
+			'display_key'                   => $meta_item->key,
+			// Default to original key, in case a formatted key is not available.
+							'display_value' => $meta_item->value,
+		// Default to original value, in case a formatted value is not available.
 		);
 
 		if ( $meta_item->id && array_key_exists( $meta_item->id, $formatted_meta_data ) ) {
@@ -949,10 +957,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 				$total    = wc_get_price_excluding_tax( $product, array( 'qty' => $quantity ) );
 				$item->set_total( $total );
 				$item->set_subtotal( $total );
+				$item->set_product_price_snapshot( $product );
 			}
 		}
 
-		$this->maybe_set_item_props( $item, array( 'name', 'quantity', 'total', 'subtotal', 'tax_class' ), $posted );
+			$this->maybe_set_item_props( $item, array( 'name', 'quantity', 'total', 'subtotal', 'tax_class' ), $posted );
 		$this->maybe_set_item_meta_data( $item, $posted );
 
 		return $item;
@@ -1628,6 +1637,24 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							'price'            => array(
 								'description' => __( 'Product price.', 'woocommerce' ),
 								'type'        => 'number',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'regular_price'    => array(
+								'description' => __( 'Product regular price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'sale_price'       => array(
+								'description' => __( 'Product sale price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'on_sale'          => array(
+								'description' => __( 'Product is on sale.', 'woocommerce' ),
+								'type'        => 'boolean',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -230,15 +230,15 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 			$data['sku']              = $product ? $product->get_sku() : null;
 			$data['global_unique_id'] = $product ? $product->get_global_unique_id() : null;
-			$data['price']       = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['price']            = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
 
-				if ( $item instanceof WC_Order_Item_Product ) {
-					$regular         = $item->get_regular_price();
-					$sale            = $item->get_sale_price();
-					$data['on_sale'] = ( '' !== $sale && $sale !== $regular );
-				}
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$regular         = isset( $data['regular_price'] ) ? $data['regular_price'] : '';
+				$sale            = isset( $data['sale_price'] ) ? $data['sale_price'] : '';
+				$data['on_sale'] = ( '' !== $sale && $sale !== $regular );
+			}
 
-				$image_id = $product ? $product->get_image_id() : 0;
+			$image_id = $product ? $product->get_image_id() : 0;
 
 			$data['image'] = array(
 				'id'  => $image_id,
@@ -328,13 +328,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	private function merge_meta_item_with_formatted_meta_display_attributes( $meta_item, $formatted_meta_data ) {
 		$result = array(
-			'id'                            => $meta_item->id,
-			'key'                           => $meta_item->key,
-			'value'                         => $meta_item->value,
-			'display_key'                   => $meta_item->key,
-			// Default to original key, in case a formatted key is not available.
-							'display_value' => $meta_item->value,
-		// Default to original value, in case a formatted value is not available.
+			'id'            => $meta_item->id,
+			'key'           => $meta_item->key,
+			'value'         => $meta_item->value,
+			'display_key'   => $meta_item->key,   // Default to original key, in case a formatted key is not available.
+			'display_value' => $meta_item->value, // Default to original value, in case a formatted value is not available.
 		);
 
 		if ( $meta_item->id && array_key_exists( $meta_item->id, $formatted_meta_data ) ) {
@@ -961,7 +959,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			}
 		}
 
-			$this->maybe_set_item_props( $item, array( 'name', 'quantity', 'total', 'subtotal', 'tax_class' ), $posted );
+		$this->maybe_set_item_props( $item, array( 'name', 'quantity', 'total', 'subtotal', 'tax_class' ), $posted );
 		$this->maybe_set_item_meta_data( $item, $posted );
 
 		return $item;

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -622,4 +622,50 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		// Clean up order.
 		$order->delete( true );
 	}
+
+	/**
+	 * Test regular and sale price snapshot at order item creation time.
+	 */
+	public function test_product_price_snapshot_is_persisted_and_not_affected_by_later_product_changes() {
+		// Arrange: set regular and sale prices on the product.
+		$this->product->set_regular_price( '20.00' );
+		$this->product->set_sale_price( '15.00' );
+		$this->product->save();
+
+		// Act: create a fresh order item using the snapshot helper.
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_quantity( 1 );
+		$item->set_order_id( $this->order->get_id() );
+		$item->set_product_price_snapshot( $this->product );
+		$item->save();
+
+		// Assert snapshot captured at set time.
+		$this->assertEquals( '20.00', $item->get_regular_price() );
+		$this->assertEquals( '15.00', $item->get_sale_price() );
+
+		// Change live product prices (simulates price change after order).
+		$this->product->set_regular_price( '25.00' );
+		$this->product->set_sale_price( '12.00' );
+		$this->product->save();
+
+		// Reload the item from DB to ensure persistence.
+		$reloaded = new WC_Order_Item_Product( $item->get_id() );
+
+		// Snapshot must remain the original captured values, not the new live ones.
+		$this->assertEquals( '20.00', $reloaded->get_regular_price() );
+		$this->assertEquals( '15.00', $reloaded->get_sale_price() );
+	}
+
+	/**
+	 * Test direct getter/setter for regular and sale price.
+	 */
+	public function test_regular_and_sale_price_getters_setters() {
+		$item = new WC_Order_Item_Product();
+		$item->set_regular_price( '99.99' );
+		$item->set_sale_price( '79.99' );
+
+		$this->assertEquals( '99.99', $item->get_regular_price() );
+		$this->assertEquals( '79.99', $item->get_sale_price() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1023,4 +1023,65 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assert_incomplete_meta_data_handled_correctly( wc_get_order( $order->get_id() ) );
 	}
+
+	/**
+	 * @testdox Order line items expose regular_price, sale_price and on_sale as a snapshot at creation time.
+	 */
+	public function test_order_line_item_includes_regular_and_sale_price_snapshot(): void {
+		// Create a product with regular and sale price.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '20.00' );
+		$product->set_sale_price( '15.00' );
+		$product->save();
+
+		// Create order via REST with the sale-priced product.
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'status'     => 'pending',
+					'line_items' => array(
+						array(
+							'product_id' => $product->get_id(),
+							'quantity'   => 2,
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotEmpty( $data['line_items'] );
+		$line = $data['line_items'][0];
+
+		$this->assertEquals( '20.00', $line['regular_price'] );
+		$this->assertEquals( '15.00', $line['sale_price'] );
+		$this->assertTrue( $line['on_sale'] );
+
+		$order_id = $data['id'];
+
+		// Mutate the product's current prices (should not affect the persisted snapshot).
+		$product->set_sale_price( '10.00' );
+		$product->save();
+
+		// Re-fetch the order and verify snapshot is unchanged.
+		$get_req  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order_id );
+		$get_resp = $this->server->dispatch( $get_req );
+		$this->assertEquals( 200, $get_resp->get_status() );
+
+		$get_data = $get_resp->get_data();
+		$line2    = $get_data['line_items'][0];
+
+		$this->assertEquals( '20.00', $line2['regular_price'] );
+		$this->assertEquals( '15.00', $line2['sale_price'] );
+		$this->assertTrue( $line2['on_sale'] );
+
+		// Cleanup.
+		$product->delete( true );
+		wc_get_order( $order_id )->delete( true );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce#30308.

Order line items in the REST API only expose the final unit `price` (`total / quantity`). There is no way to tell if a product was on sale, or what its regular price was at order time. Two prior PRs tried to fix this ([#51999](<https://github.com/woocommerce/woocommerce/issues/51999>), [#60156](<https://github.com/woocommerce/woocommerce/issues/60156>)) by computing a `_line_discount` from the *current* product price at API-call time, which drifts once the sale price changes after the order is placed (this is exactly what got both PRs closed).

This PR instead snapshots `regular_price` and `sale_price` at order-item creation time, in `WC_Order_Item_Product`, and persists them as item meta. The snapshot is taken in the three places an order line item is created from a product: checkout, `WC_Order::add_product()`, and the REST API's `prepare_line_items()`. The values never change after that, even if the product's price changes later.

Also adds a derived `on_sale` boolean to the line item response so integrators don't have to compare `regular_price`/`sale_price` themselves.

### How to test the changes in this Pull Request:

1. Create a product with regular price 20.00 and sale price 15.00.
2. Create an order for it, either through checkout or `POST /wp-json/wc/v3/orders`.
3. `GET /wp-json/wc/v3/orders/<id>` — the line item shows `regular_price: "20.00"`, `sale_price: "15.00"`, `on_sale: true`.
4. Change the product's sale price to 10.00 and save.
5. `GET` the same order again — line item values are unchanged (20.00 / 15.00 / true), proving it's a snapshot and not a live lookup.

### Testing that has already taken place:

Added unit tests covering:

* Getter/setter roundtrip for `regular_price`/`sale_price` on `WC_Order_Item_Product`.
* Snapshot persists across reload and is unaffected by later product price changes.
* Full REST flow: create order with a sale-priced product, verify response fields, mutate the product, re-fetch the order, verify values are still pinned to the original snapshot.

Ran `php -l` on all changed files and `phpcbf` for coding standards. CodeRabbit review passed with no remaining findings after applying its one suggestion (guard the new fields behind `instanceof WC_Order_Item_Product` so non-product line items, like shipping or fees, don't break).

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

**Changelog Entry Details**

#### Significance

- [X] Minor

#### Type

- [X] Enhancement - Improvement to existing functionality

#### Message

Add regular_price, sale_price and on_sale (snapshot at order time) to order line items in the REST API.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [X] **Developer Advisory** - For developer-facing changes (hooks, deprecations, REST API)