### PR TITLE
Fix: Allow both messages and errors to be shown simultaneously on settings pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-53397-settings-show-both-messages-and-errors
+++ b/plugins/woocommerce/changelog/fix-53397-settings-show-both-messages-and-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow both success messages and errors to be displayed simultaneously on WooCommerce settings pages.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -161,7 +161,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				foreach ( self::$errors as $error ) {
 					echo '<div id="message" class="error inline"><p><strong>' . esc_html( $error ) . '</strong></p></div>';
 				}
-			} elseif ( count( self::$messages ) > 0 ) {
+			}
+
+			if ( count( self::$messages ) > 0 ) {
 				foreach ( self::$messages as $message ) {
 					echo '<div id="message" class="updated inline"><p><strong>' . esc_html( $message ) . '</strong></p></div>';
 				}


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#53397

`WC_Admin_Settings::show_messages()` used an `elseif` condition, meaning that when errors were present, success messages were never displayed. This made it impossible to show both error and success notices on the same settings page — for example, when a settings save succeeds with a warning, or when an external API call returns partial results.

The fix changes `elseif` to a separate `if` block so both errors and messages render independently.

## Testing instructions

1. Go to WooCommerce > Settings > any tab
2. Use `WC_Admin_Settings::add_message('Success message')` and `WC_Admin_Settings::add_error('Error message')` in a settings save handler
3. Before fix: only the error is shown
4. After fix: both the error and success message are shown

## Changelog entry

```
Significance: patch
Type: fix

Allow both success messages and errors to be displayed simultaneously on WooCommerce settings pages.
```