### PR TITLE
Fix: Increase download directory URL column from VARCHAR(256) to VARCHAR(1000)

### DIFF
--- a/plugins/woocommerce/changelog/fix-53964-download-directories-url-length
+++ b/plugins/woocommerce/changelog/fix-53964-download-directories-url-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Increase the URL column length in wc_product_download_directories from 256 to 1000 characters to accommodate valid URLs.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -341,6 +341,7 @@ class WC_Install {
 		),
 		'11.0.0'   => array(
 			'wc_update_1100_enable_point_of_sale_feature',
+		'wc_update_1100_increase_download_directories_url_length',
 		),
 	);
 
@@ -2026,7 +2027,7 @@ CREATE TABLE {$wpdb->prefix}wc_rate_limits (
 $product_attributes_lookup_table_creation_sql
 CREATE TABLE {$wpdb->prefix}wc_product_download_directories (
 	url_id bigint(20) unsigned NOT NULL auto_increment,
-	url varchar(256) NOT NULL,
+	url varchar(1000) NOT NULL,
 	enabled tinyint(1) NOT NULL DEFAULT 0,
 	PRIMARY KEY (url_id),
 	KEY url (url($max_index_length))

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3581,3 +3581,22 @@ function wc_update_10902_remove_deprecated_push_notifications_option(): void {
 function wc_update_1100_enable_point_of_sale_feature() {
 	update_option( 'woocommerce_feature_point_of_sale_enabled', 'yes' );
 }
+
+/**
+ * Increase the URL column length in wc_product_download_directories from 256 to 1000.
+ *
+ * Domains can be up to 256 characters (RFC 1035), meaning a URL like https://{domain}
+ * exceeds the previous limit. This update alters the column to varchar(1000).
+ *
+ * @since 11.0.0
+ *
+ * @return void
+ */
+function wc_update_1100_increase_download_directories_url_length() {
+	global $wpdb;
+
+	$table_name = $wpdb->prefix . 'wc_product_download_directories';
+
+	// phpcs:ignore WordPress.DB.PreparedSQL
+	$wpdb->query( "ALTER TABLE {$table_name} MODIFY url varchar(1000) NOT NULL" );
+}

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -296,8 +296,8 @@ class Register {
 	private function prepare_url_for_upsert( string $url ): string {
 		$url = trailingslashit( $this->normalize_url( $url ) );
 
-		if ( mb_strlen( $url ) > 256 ) {
-			throw new ApprovedDirectoriesException( __( 'Approved directory URLs cannot be longer than 256 characters.', 'woocommerce' ), ApprovedDirectoriesException::INVALID_URL );
+		if ( mb_strlen( $url ) > 1000 ) {
+			throw new ApprovedDirectoriesException( __( 'Approved directory URLs cannot be longer than 1000 characters.', 'woocommerce' ), ApprovedDirectoriesException::INVALID_URL );
 		}
 
 		return $url;


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#53964

The `wc_product_download_directories` table used `VARCHAR(256)` for the `url` column. Per [RFC 1035](<https://www.ietf.org/rfc/rfc1035.txt>), a domain name can be up to 256 characters, meaning any valid URL (e.g. `https://{256-char-domain}`) exceeds the column limit and gets truncated.

This PR:

* Changes the schema from `varchar(256)` to `varchar(1000)`
* Adds an `ALTER TABLE` migration in the 11.0.0 update routine
* Updates the validation check in `Register::prepare_url_for_upsert()` from 256 to 1000

## Testing instructions

1. On a fresh install, verify the `wc_product_download_directories` table has `url varchar(1000)`
2. On an existing install (pre-11.0.0), trigger the update and confirm the column is altered
3. Try adding an approved directory URL longer than 256 characters — should now succeed
4. Try adding a URL longer than 1000 characters — should show the validation error

## Changelog entry

```
Significance: patch
Type: fix

Increase the URL column length in wc_product_download_directories from 256 to 1000 characters to accommodate valid URLs.
```