### PR TITLE
Fix: Related products limit -1 returns one less product

### DIFF
--- a/plugins/woocommerce/changelog/fix-62257-related-products-limit-minus-one
+++ b/plugins/woocommerce/changelog/fix-62257-related-products-limit-minus-one
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix related products returning one less product when limit is set to -1 (show all).

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1470,7 +1470,7 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 	$related_posts = $transient && is_array( $transient ) && isset( $transient[ $query_args ] ) ? $transient[ $query_args ] : false;
 
 	// We want to query related posts if they are not cached, or we don't have enough.
-	if ( false === $related_posts || count( $related_posts ) < $limit ) {
+	if ( false === $related_posts || ( $limit > 0 && count( $related_posts ) < $limit ) ) {
 
 		$cats_array = apply_filters( 'woocommerce_product_related_posts_relate_by_category', true, $product_id ) ? apply_filters( 'woocommerce_get_related_product_cat_terms', wc_get_product_term_ids( $product_id, 'product_cat' ), $product_id ) : array();
 		$tags_array = apply_filters( 'woocommerce_product_related_posts_relate_by_tag', true, $product_id ) ? apply_filters( 'woocommerce_get_related_product_tag_terms', wc_get_product_term_ids( $product_id, 'product_tag' ), $product_id ) : array();
@@ -1480,7 +1480,8 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 			$related_posts = array();
 		} else {
 			$data_store    = WC_Data_Store::load( 'product' );
-			$related_posts = $data_store->get_related_products( $cats_array, $tags_array, $exclude_ids, $limit + 10, $product_id );
+			$query_limit   = $limit > 0 ? $limit + 10 : $limit;
+			$related_posts = $data_store->get_related_products( $cats_array, $tags_array, $exclude_ids, $query_limit, $product_id );
 		}
 
 		if ( $transient && is_array( $transient ) ) {
@@ -1506,6 +1507,10 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 
 	if ( apply_filters( 'woocommerce_product_related_posts_shuffle', true ) ) {
 		shuffle( $related_posts );
+	}
+
+	if ( $limit < 0 ) {
+		return $related_posts;
 	}
 
 	return array_slice( $related_posts, 0, $limit );

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -1043,6 +1043,10 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		$empty_related_products = wc_get_related_products( $main_product->get_id(), 'non-numeric-limit' );
 		$this->assertEquals( array(), $empty_related_products );
 
+		// Test with limit -1 (show all related products).
+		$all_related_with_unlimited = wc_get_related_products( $main_product->get_id(), -1 );
+		$this->assertCount( 3, $all_related_with_unlimited, 'Limit -1 should return all 3 related products' );
+
 		// Clean up.
 		WC_Helper_Product::delete_product( $main_product->get_id() );
 		WC_Helper_Product::delete_product( $related_product1->get_id() );


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#62257

The `woocommerce_output_related_products_args` filter allows setting `posts_per_page` to `-1` to show all related products. However, when `-1` is passed to `wc_get_related_products()`, the final `array_slice($related_posts, 0, $limit)` uses `-1` as the length, which in PHP returns all elements **except the last one**.

This means requesting "all" related products always drops one.

The fix checks if the limit is negative (meaning unlimited) and returns all related posts without slicing.

## Testing instructions

1. Add a filter: `add_filter('woocommerce_output_related_products_args', function($args) { $args['posts_per_page'] = -1; return $args; });`
2. Create a product with many related products (via shared categories/tags)
3. View the single product page
4. **Before fix:** One related product is missing from the display
5. **After fix:** All related products are displayed

## Changelog entry

```
Significance: patch
Type: fix

Fix related products returning one less product when limit is set to -1 (show all).
```