### PR TITLE
Fix: CSV exporter default fopen mode breaks S3 stream wrappers + add error logging

### DIFF
--- a/plugins/woocommerce/changelog/fix-63835-csv-exporter-s3-stream-and-error-logging
+++ b/plugins/woocommerce/changelog/fix-63835-csv-exporter-s3-stream-and-error-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change CSV batch exporter default fopen mode from a+ to a for S3 stream wrapper compatibility and add error logging when file open fails.

--- a/plugins/woocommerce/changelog/fix-63835-csv-exporter-s3-stream-and-error-logging
+++ b/plugins/woocommerce/changelog/fix-63835-csv-exporter-s3-stream-and-error-logging
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Change CSV batch exporter default fopen mode from a+ to a for S3 stream wrapper compatibility and add error logging when file open fails.
+Change CSV batch exporter default fopen mode from a+ to a for S3 stream wrapper compatibility and add error logging when opening, writing to, or closing the export file fails.

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -128,21 +128,24 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 */
 	protected function write_csv_data( $data ) {
 
+		$log_context = array( 'source' => 'wc-csv-exporter' );
+
 		if ( ! file_exists( $this->get_file_path() ) || ! is_writeable( $this->get_file_path() ) ) {
 			wc_get_logger()->error(
 				sprintf(
 					/* translators: %s is file path. */
 					__( 'Unable to create or write to %s during CSV export. Please check file permissions.', 'woocommerce' ),
 					esc_html( $this->get_file_path() )
-				)
+				),
+				$log_context
 			);
 			return false;
 		}
 
 		/**
 		 * Filters the mode parameter which specifies the type of access you require to the stream (used during file
-		 * writing for CSV exports). Defaults to 'a+' (which supports both reading and writing, and places the file
-		 * pointer at the end of the file).
+		 * writing for CSV exports). Defaults to 'a' (append, write-only, placing the file pointer at the end of the
+		 * file), which is all CSV export needs and is supported by the widest range of stream wrappers.
 		 *
 		 * @see   https://www.php.net/manual/en/function.fopen.php
 		 * @since 6.8.0
@@ -153,8 +156,22 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		$fp         = fopen( $this->get_file_path(), $fopen_mode );
 
 		if ( $fp ) {
-			fwrite( $fp, $data );
-			fclose( $fp );
+			// WP_Filesystem has no streaming write API, so it would mean rewriting the whole export on every batch.
+			$bytes_written = fwrite( $fp, $data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+
+			// Append-mode stream wrappers may buffer locally and only transfer the data on close, so closing can fail too.
+			$closed = fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+			if ( false === $bytes_written || strlen( $data ) !== $bytes_written || ! $closed ) {
+				wc_get_logger()->error(
+					sprintf(
+						/* translators: %s: file path */
+						__( 'Failed to write CSV export data to %s. The exported file may be incomplete.', 'woocommerce' ),
+						$this->get_file_path()
+					),
+					$log_context
+				);
+			}
 		} else {
 			wc_get_logger()->error(
 				sprintf(
@@ -162,7 +179,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 					__( 'Unable to open file for writing: %s', 'woocommerce' ),
 					$this->get_file_path()
 				),
-				array( 'source' => 'wc_csv_exporter' )
+				$log_context
 			);
 		}
 

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -135,7 +135,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 				sprintf(
 					/* translators: %s is file path. */
 					__( 'Unable to create or write to %s during CSV export. Please check file permissions.', 'woocommerce' ),
-					esc_html( $this->get_file_path() )
+					$this->get_file_path()
 				),
 				$log_context
 			);
@@ -150,7 +150,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		 * @see   https://www.php.net/manual/en/function.fopen.php
 		 * @since 6.8.0
 		 *
-		 * @param string $fopen_mode, either (r, r+, w, w+, a, a+, x, x+, c, c+, e). Defaults to "a" (append, write-only) for broad stream-wrapper compatibility.
+		 * @param string $fopen_mode One of (r, r+, w, w+, a, a+, x, x+, c, c+), optionally followed by flags such as "b", "t" or "e". Defaults to "a" (append, write-only) for broad stream-wrapper compatibility.
 		 */
 		$fopen_mode = apply_filters( 'woocommerce_csv_exporter_fopen_mode', 'a' );
 		$fp         = fopen( $this->get_file_path(), $fopen_mode );
@@ -173,11 +173,17 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 				);
 			}
 		} else {
+			// fopen() raises a warning when it fails, so the last PHP error usually explains why (permissions, an
+			// invalid mode, or a stream wrapper that doesn't support the requested mode).
+			$last_error = error_get_last();
+
 			wc_get_logger()->error(
 				sprintf(
-					/* translators: %s: file path */
-					__( 'Unable to open file for writing: %s', 'woocommerce' ),
-					$this->get_file_path()
+					/* translators: 1: file path, 2: fopen mode, 3: last PHP error message */
+					__( 'Unable to open file for writing: %1$s (mode: %2$s). Last PHP error: %3$s', 'woocommerce' ),
+					$this->get_file_path(),
+					$fopen_mode,
+					isset( $last_error['message'] ) ? $last_error['message'] : 'n/a'
 				),
 				$log_context
 			);

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -147,14 +147,23 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		 * @see   https://www.php.net/manual/en/function.fopen.php
 		 * @since 6.8.0
 		 *
-		 * @param string $fopen_mode, either (r, r+, w, w+, a, a+, x, x+, c, c+, e)
+		 * @param string $fopen_mode, either (r, r+, w, w+, a, a+, x, x+, c, c+, e). Defaults to "a" (append, write-only) for broad stream-wrapper compatibility.
 		 */
-		$fopen_mode = apply_filters( 'woocommerce_csv_exporter_fopen_mode', 'a+' );
+		$fopen_mode = apply_filters( 'woocommerce_csv_exporter_fopen_mode', 'a' );
 		$fp         = fopen( $this->get_file_path(), $fopen_mode );
 
 		if ( $fp ) {
 			fwrite( $fp, $data );
 			fclose( $fp );
+		} else {
+			wc_get_logger()->error(
+				sprintf(
+					/* translators: %s: file path */
+					__( 'Unable to open file for writing: %s', 'woocommerce' ),
+					$this->get_file_path()
+				),
+				array( 'source' => 'wc_csv_exporter' )
+			);
 		}
 
 		// Add all columns when finished.

--- a/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
+++ b/plugins/woocommerce/tests/php/includes/exporter/class-wc-product-csv-exporter-test.php
@@ -161,4 +161,46 @@ class WC_Product_CSV_Exporter_Test extends \WC_Unit_Test_Case {
 			);
 		}
 	}
+
+	/**
+	 * @testdox CSV data is written with an append-only fopen mode so write-only stream wrappers are supported.
+	 */
+	public function test_write_csv_data_uses_append_only_fopen_mode(): void {
+		$exporter = new WC_Product_CSV_Exporter();
+		$exporter->set_filename( 'wc-csv-exporter-fopen-mode-test' );
+
+		// Creates the file so write_csv_data() gets past its writability check.
+		$exporter->get_file();
+
+		$captured_mode = null;
+		$capture_mode  = function ( $fopen_mode ) use ( &$captured_mode ) {
+			$captured_mode = $fopen_mode;
+			return $fopen_mode;
+		};
+
+		add_filter( 'woocommerce_csv_exporter_fopen_mode', $capture_mode );
+
+		$reflected_exporter = new ReflectionClass( WC_Product_CSV_Exporter::class );
+		$write_csv_data     = $reflected_exporter->getMethod( 'write_csv_data' );
+		$write_csv_data->setAccessible( true );
+		$get_file_path = $reflected_exporter->getMethod( 'get_file_path' );
+		$get_file_path->setAccessible( true );
+		$get_headers_row_file_path = $reflected_exporter->getMethod( 'get_headers_row_file_path' );
+		$get_headers_row_file_path->setAccessible( true );
+
+		try {
+			$write_csv_data->invoke( $exporter, "sku,name\n" );
+
+			$this->assertSame( 'a', $captured_mode, 'The default fopen mode must be append-only; "a+" is rejected by stream wrappers that cannot seek.' );
+			$this->assertStringContainsString( "sku,name\n", $exporter->get_file(), 'Data passed to write_csv_data() should reach the export file.' );
+		} finally {
+			remove_filter( 'woocommerce_csv_exporter_fopen_mode', $capture_mode );
+
+			foreach ( array( $get_file_path->invoke( $exporter ), $get_headers_row_file_path->invoke( $exporter ) ) as $path ) {
+				if ( file_exists( $path ) ) {
+					wp_delete_file( $path );
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#63835

Two issues addressed:

1. **Default fopen mode incompatibility:** `WC_CSV_Batch_Exporter::write_csv_data()` used `a+` as the default fopen mode. S3 stream wrappers (e.g. [S3-Uploads](<https://github.com/humanmade/S3-Uploads>)) don't support `+` mode variants because S3 objects aren't seekable. The `fopen` call fails silently, data is never written, but the Action Scheduler job reports success. Changed default to `a` (append, write-only) which is what CSV export actually needs.
2. **No error logging on fopen failure:** The existing permission check logs errors via `wc_get_logger()->error()`, but a failed `fopen` had no `else` branch. Added logging to help diagnose write failures.

**Backward compatibility:** The `woocommerce_csv_exporter_fopen_mode` filter still allows overriding the mode, so any code relying on `a+` can restore it.

## Testing instructions

1. Run a CSV export (Products > Export) and verify it completes successfully
2. Verify the exported CSV file contains data
3. Test with a stream wrapper that doesn't support `a+` mode — should now work
4. Temporarily make the export directory unwritable — verify an error log entry is created

## Changelog entry

```
Significance: patch
Type: fix

Change CSV batch exporter default fopen mode from a+ to a for S3 stream wrapper compatibility and add error logging when file open fails.
```