### PR TITLE
Fix: wc_no_js inline script breaks Content Security Policy nonce support

### DIFF
--- a/plugins/woocommerce/changelog/fix-61141-wc-no-js-csp-nonce
+++ b/plugins/woocommerce/changelog/fix-61141-wc-no-js-csp-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Output wc_no_js via wp_add_inline_script instead of wp_footer for Content Security Policy nonce compatibility.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -386,7 +386,7 @@ function wc_body_class( $classes ) {
 
 	$classes[] = 'woocommerce-no-js';
 
-	add_action( 'wp_footer', 'wc_no_js' );
+	add_action( 'wp_enqueue_scripts', 'wc_no_js' );
 
 	return array_unique( $classes );
 }
@@ -398,16 +398,13 @@ function wc_body_class( $classes ) {
  * @return void
  */
 function wc_no_js() {
-	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
-	?>
-	<script<?php echo $type_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		(function () {
-			var c = document.body.className;
-			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
-			document.body.className = c;
-		})();
-	</script>
-	<?php
+	$script  = "(function () {\n";
+	$script .= "\tvar c = document.body.className;\n";
+	$script .= "\tc = c.replace(/woocommerce-no-js/, 'woocommerce-js');\n";
+	$script .= "\tdocument.body.className = c;\n";
+	$script .= "})();";
+
+	wp_add_inline_script( 'woocommerce', $script, 'after' );
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#61141

The `wc_no_js()` function output its inline script via `wp_footer` action, directly echoing a `<script>` tag. This bypasses WordPress's `wp_inline_script_attributes` filter, meaning CSP nonces are never added. Sites with Content Security Policy must use `unsafe-inline` in `script-src`, which weakens security.

This PR changes the approach:

* Hook `wc_no_js` to `wp_enqueue_scripts` instead of `wp_footer`
* Use `wp_add_inline_script('woocommerce', , 'after')` to attach the no-js handler after the main WooCommerce script

This allows the `wp_inline_script_attributes` filter to add nonces, enabling strict CSP compliance.

## Testing instructions

1. Visit any WooCommerce frontend page
2. Inspect the page source — verify the `woocommerce-no-js` → `woocommerce-js` class replacement script appears in the footer
3. Verify the script is now wrapped with proper attributes (including nonce if a CSP is configured)
4. Test with a CSP plugin that adds nonces to inline scripts — should work without `unsafe-inline`

## Changelog entry

```
Significance: patch
Type: fix

Output wc_no_js via wp_add_inline_script instead of wp_footer for Content Security Policy nonce compatibility.
```