### PR TITLE
Fix: Remove invalid label for= attribute on radio settings fields

### DIFF
--- a/plugins/woocommerce/changelog/fix-55669-radio-settings-invalid-label-for
+++ b/plugins/woocommerce/changelog/fix-55669-radio-settings-invalid-label-for
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove invalid label for= attribute from radio button settings fields where no matching input id exists.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -519,7 +519,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						?>
 						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+								<?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?>
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<fieldset>


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#55669

When a WooCommerce settings field uses `type => 'radio'`, the `<th>` element outputs a `<label for="{id}">` but the individual radio inputs inside the `<fieldset>` don't have matching `id` attributes. This creates invalid HTML — the `for` attribute points to a non-existent element. The fix replaces the `<label>` in the `<th>` with plain text, since the radio inputs already have their own per-option labels wrapping them. ## Testing instructions 1. Go to WooCommerce > Settings (any page with radio settings, e.g. Shipping > Local Pickup) 2. Inspect the HTML for radio button fields 3. Before: `<th><label for="some_id">Label</label></th>` with no matching input id<br>4. After: `<th>Label</th>` — no orphaned label

## Changelog entry

```
Significance: patch
Type: fix

Remove invalid label for= attribute from radio button settings fields where no matching input id exists.
```