### PR TITLE
Fix: Revenue report double-counts refunds when order has both partial and full refunds

### DIFF
--- a/plugins/woocommerce/changelog/fix-66217-revenue-report-double-counts-refunds
+++ b/plugins/woocommerce/changelog/fix-66217-revenue-report-double-counts-refunds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix revenue report double-counting refund amounts when an order has both partial and full refunds.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -606,10 +606,19 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 					|| self::should_split_full_refund_using_parent_order( $order, $parent_order )
 				);
 				if ( $use_parent_refund_amounts ) {
+					// Subtract amounts already stored by prior partial refund rows for the same parent.
+					$prior = $wpdb->get_row(
+						$wpdb->prepare(
+							"SELECT COALESCE(SUM(net_total), 0) AS net, COALESCE(SUM(tax_total), 0) AS tax, COALESCE(SUM(shipping_total), 0) AS shipping FROM {$table_name} WHERE parent_id = %d AND order_id != %d",
+							$parent_order->get_id(),
+							$order->get_id()
+						)
+					);
+
 					$data['num_items_sold'] = -1 * self::get_num_items_sold( $parent_order );
-					$data['tax_total']      = -1 * $parent_order->get_total_tax();
-					$data['net_total']      = -1 * self::get_net_total( $parent_order );
-					$data['shipping_total'] = -1 * $parent_order->get_shipping_total();
+					$data['tax_total']      = -1 * $parent_order->get_total_tax() - (float) ( $prior->tax ?? 0 );
+					$data['net_total']      = -1 * self::get_net_total( $parent_order ) - (float) ( $prior->net ?? 0 );
+					$data['shipping_total'] = -1 * $parent_order->get_shipping_total() - (float) ( $prior->shipping ?? 0 );
 				}
 			}
 			/**


### PR DESCRIPTION
## Description

Fixes #66217

When an order has a partial refund followed by a full refund, the Revenue report double-counts the refund amounts. The full-refund row in `wc_order_stats` stored the entire negative order total without accounting for amounts already captured by prior partial refund rows for the same parent order.

This PR subtracts prior partial refund amounts from the full-refund row before storing it, so that `SUM()` in the Revenue report produces correct totals.

## How the fix works

Before storing the full-refund row, we query `wc_order_stats` for existing refund rows with the same `parent_id` (excluding the current refund order). The prior partial refund totals (net, tax, shipping) are subtracted from the full-refund values, producing incremental amounts that sum correctly.

## Testing instructions

1. Create an order with multiple line items (total $33.83)
2. Issue a partial refund on one item ($16.13)
3. Issue a full refund for the remaining order
4. Go to Analytics > Revenue, view the date range covering both refunds
5. **Before fix:** Returns = $49.96 (double-counted)
6. **After fix:** Returns = $33.83 (correct)
7. Run `wp wc tool run clear_woocommerce_analytics_cache --user=1` if testing on existing data

## Changelog entry

```
Significance: patch
Type: fix

Fix revenue report double-counting refund amounts when an order has both partial and full refunds.
```