### PR TITLE
Fix: Orders list report overwrites refund data when multiple refunds exist

### DIFF
--- a/plugins/woocommerce/changelog/fix-66217-orders-report-multiple-refund-parent-overwrite
+++ b/plugins/woocommerce/changelog/fix-66217-orders-report-multiple-refund-parent-overwrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Orders list report overwriting refund data when multiple refunds exist for one order.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -406,9 +406,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$mapped_data[ $product['order_id'] ]['products'][] = $product_data;
 
-			// If this product's order has another related order, it will be added to our mapped_data.
+			// If this product's order has related refund orders, add product data to each refund.
 			if ( isset( $related_orders [ $product['order_id'] ] ) ) {
-				$mapped_data[ $related_orders[ $product['order_id'] ]['order_id'] ] ['products'] [] = $product_data;
+				foreach ( $related_orders[ $product['order_id'] ] as $refund_order ) {
+					$mapped_data[ $refund_order['order_id'] ]['products'][] = $product_data;
+				}
 			}
 		}
 
@@ -453,7 +455,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$related_orders = array();
 		foreach ( $orders as $order ) {
 			if ( '0' !== $order['parent_id'] ) {
-				$related_orders[ $order['parent_id'] ] = $order;
+				$related_orders[ $order['parent_id'] ][] = $order;
 			}
 		}
 		return $related_orders;


### PR DESCRIPTION
## Description

Fixes #66217 (second part)

When an order has multiple refunds (e.g., a partial refund followed by a full refund), the Orders list report's extended info only showed product details for the last refund. The first refund row had empty product details.

**Root cause:** `get_orders_with_parent_id()` used `$related_orders[ $order['parent_id'] ] = $order` which overwrote previous refund data when multiple refunds had the same parent_id.

**Fix:**
1. Changed `get_orders_with_parent_id()` to store an array of refund orders per parent_id
2. Updated the consumer loop to iterate all refunds when adding product details

## Testing instructions

1. Create an order with multiple line items
2. Issue a partial refund (refund one line item)
3. Issue a full refund for the remaining order
4. Go to Analytics > Orders — **Before fix:** first refund row shows empty products
5. **After fix:** both refund rows show correct product details

## Changelog entry

```
Significance: patch
Type: fix

Fix Orders list report overwriting refund data when multiple refunds exist for one order.
```