### PR TITLE
Fix: Preserve customer's chosen shipping method on rate recalculation for all methods, not just local pickup

### DIFF
--- a/plugins/woocommerce/changelog/fix-64558-preserve-chosen-shipping-method
+++ b/plugins/woocommerce/changelog/fix-64558-preserve-chosen-shipping-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve customer's chosen shipping method when rates are recalculated, not just local pickup methods.

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -534,17 +534,16 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 	}
 
 	/**
-	 * If the customer has selected local pickup, keep it selected if it's still in the package. We don't want to auto
-	 * toggle between shipping and pickup even if available shipping methods are changed.
+	 * If the customer has selected a shipping method, keep it selected if it's still in the package. We don't want to
+	 * silently change the customer's selection when unrelated rates change.
 	 *
-	 * This is important for block-based checkout where there is an explicit toggle between shipping and pickup.
+	 * Previously this was limited to local pickup methods (for block-based checkout toggle), but the same logic applies
+	 * to any chosen method — if it's still available, it should stay selected.
 	 */
-	$chosen_method_id       = current( explode( ':', $chosen_method ) );
 	$chosen_method_exists   = in_array( $chosen_method, $rate_keys, true );
-	$is_local_pickup_chosen = in_array( $chosen_method_id, $local_pickup_method_ids, true );
 
-	// Default to local pickup if its chosen already.
-	if ( $chosen_method_exists && $is_local_pickup_chosen ) {
+	// Preserve the customer's chosen method if it's still available.
+	if ( $chosen_method_exists ) {
 		$default = $chosen_method;
 
 	} else {


### PR DESCRIPTION
## Description

Fixes #64558

When shipping rates are recalculated (e.g., customer changes quantity, or a table-rate rule changes), `wc_get_default_shipping_method_for_package()` only preserved the customer's chosen method if it was a local_pickup method. For any other carrier — DPD, GLS, Box Now, table-rate carriers, custom methods — the selection was silently reset to the first available rate.

**Root cause:** The condition at line 547 checked both `$chosen_method_exists` AND `$is_local_pickup_chosen`, so non-pickup choices were dropped into the `else` branch which only looks for free shipping coupons.

**Fix:** Changed the condition to preserve any still-valid chosen method regardless of type. This is what users expect — their selection shouldn't change unless the method is no longer available.

## Testing instructions

1. Configure shipping with multiple methods (e.g., Flat Rate + Table Rate + DPD)
2. As a customer, select a non-default carrier (e.g., DPD which is position 3)
3. Change cart contents to trigger rate recalculation
4. **Before fix:** selection silently moves to first available rate
5. **After fix:** DPD stays selected

## Changelog entry

```
Significance: patch
Type: fix

Preserve customer's chosen shipping method when rates are recalculated, not just local pickup methods.
```