### PR TITLE
Fix: Use field_name instead of id when retrieving option values in admin settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-48254-settings-field-name-option-retrieval
+++ b/plugins/woocommerce/changelog/fix-48254-settings-field-name-option-retrieval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use field_name instead of id when retrieving option values to correctly support array options.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -296,7 +296,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					$value['suffix'] = '';
 				}
 				if ( ! isset( $value['value'] ) ) {
-					$value['value'] = self::get_option( $value['id'], $value['default'] );
+					$value['value'] = self::get_option( $value['field_name'], $value['default'] );
 				}
 
 				if ( ! is_null( $value['fixed_value'] ?? null ) ) {


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#48254

In `WC_Admin_Settings::output_fields()`, the `get_option()` call on line 299 was passing `$value['id']` as the option name, even when a `field_name` was explicitly defined. When field settings use array options (e.g., `field_name='section[setting]'`), using `id` instead of `field_name` causes incorrect option retrieval.

Note: `field_name` already defaults to `id` when not explicitly set (lines 267-268), so this change is backward-compatible.

## Testing instructions

1. Define a setting with both `id` and `field_name` where `field_name` points to an array option key
2. Visit the settings page — the field should now display the correct saved value
3. Verify standard settings (without `field_name`) still work correctly

## Changelog entry

```
Significance: patch
Type: fix

Use field_name instead of id when retrieving option values to correctly support array options.
```