### PR TITLE
Fix: Non-taxable cart fees stored as taxable in order items due to missing tax_status

### DIFF
--- a/plugins/woocommerce/changelog/fix-53766-fee-tax_status-non-taxable
+++ b/plugins/woocommerce/changelog/fix-53766-fee-tax_status-non-taxable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set tax_status to 'none' when creating fee order items from non-taxable cart fees.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
 use Automattic\WooCommerce\Internal\Tax\TaxRateDataStore;
@@ -616,7 +617,8 @@ class WC_Checkout {
 			$item->set_props(
 				array(
 					'name'      => $fee->name,
-					'tax_class' => $fee->taxable ? $fee->tax_class : 0,
+					'tax_class' => $fee->taxable ? $fee->tax_class : '',
+					'tax_status' => $fee->taxable ? ProductTaxStatus::TAXABLE : ProductTaxStatus::NONE,
 					'amount'    => $fee->amount,
 					'total'     => $fee->total,
 					'total_tax' => $fee->tax,

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -616,13 +616,13 @@ class WC_Checkout {
 			$item->legacy_fee_key = $fee_key; // @deprecated 4.4.0 For legacy actions.
 			$item->set_props(
 				array(
-					'name'      => $fee->name,
-					'tax_class' => $fee->taxable ? $fee->tax_class : '',
+					'name'       => $fee->name,
+					'tax_class'  => $fee->taxable ? $fee->tax_class : '',
 					'tax_status' => $fee->taxable ? ProductTaxStatus::TAXABLE : ProductTaxStatus::NONE,
-					'amount'    => $fee->amount,
-					'total'     => $fee->total,
-					'total_tax' => $fee->tax,
-					'taxes'     => array(
+					'amount'     => $fee->amount,
+					'total'      => $fee->total,
+					'total_tax'  => $fee->tax,
+					'taxes'      => array(
 						'total' => $fee->tax_data,
 					),
 				)

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -291,6 +291,40 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox create_order_fee_lines sets tax status to 'none' for non-taxable cart fees and 'taxable' for taxable ones.
+	 *
+	 * @testWith [true, "taxable"]
+	 *           [false, "none"]
+	 *
+	 * @param bool   $taxable Whether the cart fee is taxable.
+	 * @param string $expected_tax_status The expected tax status for the created fee order item.
+	 */
+	public function test_create_order_fee_lines_sets_correct_tax_status( $taxable, $expected_tax_status ): void {
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$add_fee = static function ( $cart ) use ( $taxable ) {
+			$cart->add_fee( 'Test fee', 10, $taxable );
+		};
+		add_action( 'woocommerce_cart_calculate_fees', $add_fee );
+
+		try {
+			WC()->cart->calculate_totals();
+			$order = wc_get_order( $this->sut->create_order( array( 'payment_method' => WC_Gateway_BACS::ID ) ) );
+		} finally {
+			remove_action( 'woocommerce_cart_calculate_fees', $add_fee );
+		}
+
+		$fee_items = $order->get_fees();
+
+		$this->assertCount( 1, $fee_items );
+
+		/** @var WC_Order_Item_Fee $fee_item */
+		$fee_item = array_values( $fee_items )[0];
+		$this->assertSame( $expected_tax_status, $fee_item->get_tax_status() );
+	}
+
+	/**
 	 * @testdox Checkout page contains login form for guests.
 	 */
 	public function test_checkout_page_contains_login_form_for_guests() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -293,13 +293,14 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox create_order_fee_lines sets tax status to 'none' for non-taxable cart fees and 'taxable' for taxable ones.
 	 *
-	 * @testWith [true, "taxable"]
-	 *           [false, "none"]
+	 * @testWith [true, "taxable", ""]
+	 *           [false, "none", ""]
 	 *
 	 * @param bool   $taxable Whether the cart fee is taxable.
 	 * @param string $expected_tax_status The expected tax status for the created fee order item.
+	 * @param string $expected_tax_class The expected tax class for the created fee order item.
 	 */
-	public function test_create_order_fee_lines_sets_correct_tax_status( $taxable, $expected_tax_status ): void {
+	public function test_create_order_fee_lines_sets_correct_tax_status( $taxable, $expected_tax_status, $expected_tax_class ): void {
 		$product = WC_Helper_Product::create_simple_product();
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
@@ -322,6 +323,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		/** @var WC_Order_Item_Fee $fee_item */
 		$fee_item = array_values( $fee_items )[0];
 		$this->assertSame( $expected_tax_status, $fee_item->get_tax_status() );
+		$this->assertSame( $expected_tax_class, $fee_item->get_tax_class() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes #53766

When a non-taxable fee is added via `WC_Cart::add_fee()` with `$taxable = false`, the order item created during checkout incorrectly retained `tax_status = 'taxable'` (the default from `WC_Order_Item_Fee`) with `tax_class = '0'` (evaluated as standard tax class). Third-party tax plugins (e.g., TaxJar, Avatax) that read `get_tax_status()` would calculate tax on these fees, despite them being explicitly non-taxable.

**Root cause:** `WC_Checkout::create_order_fee_lines()` passed `'tax_class' => 0` for non-taxable fees in `set_props()`, but never set `tax_status`. Since the default `tax_status` in `WC_Order_Item_Fee` is `ProductTaxStatus::TAXABLE`, the fee was stored as taxable in the database — even though it was not supposed to be.

**Fix:** 
1. Added `tax_status` to `set_props()`: `ProductTaxStatus::TAXABLE` when taxable, `ProductTaxStatus::NONE` when not
2. Changed `tax_class` from `0` to `''` for non-taxable fees (standard tax class slug is empty string, not `0`)

## Testing instructions

1. Add a non-taxable fee via `WC_Cart::add_fee('Test Fee', 10, false)`
2. Complete checkout
3. Verify the fee order item has `tax_status = 'none'` and `tax_class = ''`
4. **Before fix:** `tax_status` was `'taxable'` and `tax_class` was `'0'`
5. Verify tax calculation plugins like TaxJar/Avatax no longer calculate tax on this fee

## Changelog entry

```
Significance: patch
Type: fix

Set tax_status to 'none' when creating fee order items from non-taxable cart fees.
```