### PR TITLE
Fix: Release reserved stock when order transitions to failed status

### DIFF
--- a/plugins/woocommerce/changelog/fix-55396-release-stock-on-failed-order-status
+++ b/plugins/woocommerce/changelog/fix-55396-release-stock-on-failed-order-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Release reserved stock when an order transitions to failed status.

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -486,6 +486,7 @@ function wc_release_stock_for_order( $order ) {
 add_action( 'woocommerce_checkout_order_exception', 'wc_release_stock_for_order' );
 add_action( 'woocommerce_payment_complete', 'wc_release_stock_for_order', 11 );
 add_action( 'woocommerce_order_status_cancelled', 'wc_release_stock_for_order', 11 );
+add_action( 'woocommerce_order_status_failed', 'wc_release_stock_for_order', 11 );
 add_action( 'woocommerce_order_status_completed', 'wc_release_stock_for_order', 11 );
 add_action( 'woocommerce_order_status_processing', 'wc_release_stock_for_order', 11 );
 add_action( 'woocommerce_order_status_on-hold', 'wc_release_stock_for_order', 11 );


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#55396

When an order moves to `failed` status (e.g., payment declined after a `pending` status), the stock reservation was never released. The `wc_reserved_stock` row remained until the `expires` timestamp, artificially reducing available stock for other customers.

**Root cause:** `wc_release_stock_for_order()` was hooked to `woocommerce_order_status_cancelled`, `_completed`, `_processing`, and `_on-hold`, but `woocommerce_order_status_failed` was missing.

**Fix:** Added the missing hook so reserved stock is released when an order transitions to `failed`.

## Testing instructions

1. Enable stock reservation (WooCommerce > Settings > Products > Inventory > Hold Stock)
2. Add a product to cart and start checkout (creates a checkout-draft order, reserves stock)
3. Let the payment fail, transitioning the order to `failed` status
4. **Before fix:** The reserved stock row remains in `wp_wc_reserved_stock` until expiry
5. **After fix:** The reserved stock is immediately released

## Changelog entry

```
Significance: patch
Type: fix

Release reserved stock when an order transitions to failed status.
```