### PR TITLE
Fix: Zero-cost orders lose renewal metadata when retried via Store API

### DIFF
--- a/plugins/woocommerce/changelog/fix-50328-zero-cost-renewals-draft-order
+++ b/plugins/woocommerce/changelog/fix-50328-zero-cost-renewals-draft-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow zero-cost order retries by checking order status directly instead of needs_payment(), which requires total > 0.

--- a/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -61,7 +61,12 @@ trait DraftOrderTrait {
 		}
 
 		// Pending and failed orders can be retried if the cart hasn't changed.
-		if ( $order_object->needs_payment() && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
+		// We check the status explicitly (rather than using needs_payment()) so that
+		// zero-cost orders (e.g. subscription renewals with a 100% discount) are
+		// also eligible for retry.
+		$valid_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order_object );
+
+		if ( $order_object->has_status( $valid_statuses ) && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/tests/php/src/StoreApi/Utilities/DraftOrderTraitTest.php
+++ b/plugins/woocommerce/tests/php/src/StoreApi/Utilities/DraftOrderTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
+use WC_Unit_Test_Case;
+use WC_Helper_Order;
+
+/**
+ * Tests for DraftOrderTrait.
+ */
+class DraftOrderTraitTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Test class that uses the trait.
+	 *
+	 * @var DraftOrderTraitUser
+	 */
+	private $sut;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new DraftOrderTraitUser();
+	}
+
+	/**
+	 * @testDox Zero-total pending order with matching cart hash is valid for retry.
+	 */
+	public function test_zero_total_pending_order_is_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 0 );
+		$order->set_status( 'pending' );
+		$order->set_cart_hash( wc()->cart->get_cart_hash() );
+		$order->save();
+
+		$this->assertTrue( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Zero-total failed order with matching cart hash is valid for retry.
+	 */
+	public function test_zero_total_failed_order_is_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 0 );
+		$order->set_status( 'failed' );
+		$order->set_cart_hash( wc()->cart->get_cart_hash() );
+		$order->save();
+
+		$this->assertTrue( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Processing order with matching cart hash is NOT valid for retry.
+	 */
+	public function test_processing_order_is_not_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'processing' );
+		$order->set_cart_hash( wc()->cart->get_cart_hash() );
+		$order->save();
+
+		$this->assertFalse( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Completed order with matching cart hash is NOT valid for retry.
+	 */
+	public function test_completed_order_is_not_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_cart_hash( wc()->cart->get_cart_hash() );
+		$order->save();
+
+		$this->assertFalse( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Pending order without matching cart hash is NOT valid for retry.
+	 */
+	public function test_pending_order_wrong_cart_hash_is_not_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 0 );
+		$order->set_status( 'pending' );
+		$order->set_cart_hash( 'non_matching_hash_' . uniqid() );
+		$order->save();
+
+		$this->assertFalse( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Checkout-draft order is always valid regardless of cart hash.
+	 */
+	public function test_draft_order_is_valid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+
+		$this->assertTrue( $this->sut->expose_is_valid_draft_order( $order ) );
+	}
+
+	/**
+	 * @testDox Non-order object is not valid.
+	 */
+	public function test_non_order_is_not_valid() {
+		$this->assertFalse( $this->sut->expose_is_valid_draft_order( null ) );
+	}
+}
+
+/**
+ * Helper class to expose the protected trait method for testing.
+ */
+class DraftOrderTraitUser {
+	use DraftOrderTrait;
+
+	/**
+	 * Expose is_valid_draft_order for testing.
+	 *
+	 * @param mixed $order Order object.
+	 * @return bool
+	 */
+	public function expose_is_valid_draft_order( $order ) {
+		return $this->is_valid_draft_order( $order );
+	}
+}


### PR DESCRIPTION
## Description

Fixes #50328

When a subscription renewal has a 100% discount coupon making it zero-cost, the Store API checkout would create a new draft order instead of reusing the existing pending/failed order. This caused loss of renewal metadata and order type, leaving the subscription on-hold without processing.

**Root cause:** `DraftOrderTrait::is_valid_draft_order()` required `needs_payment()` to return true for pending/failed orders to be eligible for retry. Zero-cost orders return `false` for `needs_payment()`, so the existing order was discarded and a new one created.

**Fix:** Removed the `needs_payment()` requirement. Any pending/failed order with a matching cart hash is valid for retry, regardless of whether payment is needed.

## Testing instructions

1. Set up a subscription product with WooCommerce Subscriptions
2. Create a coupon that brings the renewal cost to /usr/bin/bash
3. Complete the initial purchase
4. When the renewal fires, verify the existing order is reused and subscription metadata is preserved
5. **Before fix:** A new draft order is created, renewal metadata is lost, subscription goes on-hold
6. **After fix:** The existing pending/failed order is retried successfully

## Changelog entry

```
Significance: patch
Type: fix

Allow zero-cost order retries by not requiring needs_payment() check for pending/failed draft orders.
```