### PR TITLE
Fix: Correct Indian state code for Chhattisgarh from CT to CG

### DIFF
--- a/plugins/woocommerce/changelog/fix-39651-india-chhattisgarh-state-code
+++ b/plugins/woocommerce/changelog/fix-39651-india-chhattisgarh-state-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct Indian state code for Chhattisgarh from CT to CG per ISO 3166-2:IN, with database migration for existing records.

--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -820,7 +820,7 @@ return array(
 		'AS' => __( 'Assam', 'woocommerce' ),
 		'BR' => __( 'Bihar', 'woocommerce' ),
 		'CH' => __( 'Chandigarh', 'woocommerce' ),
-		'CT' => __( 'Chhattisgarh', 'woocommerce' ),
+		'CG' => __( 'Chhattisgarh', 'woocommerce' ),
 		'DD' => __( 'Daman and Diu', 'woocommerce' ),
 		'DH' => __( 'Dādra and Nagar Haveli and Damān and Diu', 'woocommerce' ),
 		'DL' => __( 'Delhi', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -344,6 +344,7 @@ class WC_Install {
 		),
 		'11.1.0'   => array(
 			'wc_update_1110_delete_dashboard_outofstock_count_transient',
+			'wc_update_1110_migrate_india_chhattisgarh_state_code',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3593,3 +3593,20 @@ function wc_update_1100_enable_point_of_sale_feature() {
 function wc_update_1110_delete_dashboard_outofstock_count_transient() {
 	delete_transient( ProductUtil::OUTOFSTOCK_COUNT_TRANSIENT );
 }
+
+/**
+ * Update the India state code for Chhattisgarh from CT to CG
+ * to match the ISO 3161-2:IN standard.
+ *
+ * @since 11.1.0
+ *
+ * @return bool True if there are more records that need to be migrated, false otherwise.
+ */
+function wc_update_1110_migrate_india_chhattisgarh_state_code() {
+	return MigrationHelper::migrate_country_states(
+		'IN',
+		array(
+			'CT' => 'CG',
+		)
+	);
+}


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#39651

Per ISO 3166-2:IN, the state code for Chhattisgarh is `CG`, not `CT`. The incorrect code caused problems with tax plugins and shipping integrations that rely on ISO standard codes.

**Change:** `'CT' => __( 'Chhattisgarh', ... )` → `'CG' => __( 'Chhattisgarh', ... )`

## Testing instructions

1. Go to WooCommerce > Settings > Tax > Standard rates
2. Add a rate for India > Chhattisgarh
3. **Before fix:** The state code shown is `CT`
4. **After fix:** The state code shown is `CG` (correct per ISO 3166-2:IN)

## Changelog entry

```
Significance: patch
Type: fix

Correct Indian state code for Chhattisgarh from CT to CG per ISO 3166-2:IN.
```