### PR TITLE
Skip cart fragments AJAX for visitors without a cart session

### DIFF
--- a/plugins/woocommerce/changelog/skip-cart-fragments-refresh-for-empty-carts
+++ b/plugins/woocommerce/changelog/skip-cart-fragments-refresh-for-empty-carts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Skip the cart fragments AJAX request for visitors without a cart session by pre-rendering empty-cart fragments into the script parameters. Disable via the woocommerce_cart_fragments_skip_ajax_for_empty_carts filter.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart-fragments.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart-fragments.js
@@ -68,6 +68,15 @@ jQuery( function( $ ) {
 
 	/* Named callback for refreshing cart fragment */
 	function refresh_cart_fragment() {
+		// Visitors without a cart session can use the pre-rendered empty-cart
+		// fragments instead of requesting them over AJAX.
+		if ( wc_cart_fragments_params.empty_cart_fragments && ! Cookies.get( 'woocommerce_cart_hash' ) ) {
+			$fragment_refresh.success( {
+				fragments: wc_cart_fragments_params.empty_cart_fragments,
+				cart_hash: ''
+			} );
+			return;
+		}
 		$.ajax( $fragment_refresh );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -749,6 +749,22 @@ class WC_Frontend_Scripts {
 					'fragment_name'   => apply_filters( 'woocommerce_cart_fragment_name', 'wc_fragments_' . md5( get_current_blog_id() . '_' . get_site_url( get_current_blog_id(), '/' ) . get_template() ) ),
 					'request_timeout' => 5000,
 				);
+
+				/**
+				 * Filters whether visitors without a cart session skip the initial cart fragments AJAX request.
+				 *
+				 * When enabled, pages rendered while the cart is empty include pre-rendered empty-cart
+				 * fragments, so the frontend can populate the mini cart without an uncacheable
+				 * `wc-ajax=get_refreshed_fragments` request. Disable this if fragments must be generated
+				 * per visitor even for empty carts (e.g. dynamic empty-cart content on cached pages).
+				 *
+				 * @since 11.0.0
+				 *
+				 * @param bool $skip Whether to skip the AJAX request for visitors without a cart session. Default true.
+				 */
+				if ( apply_filters( 'woocommerce_cart_fragments_skip_ajax_for_empty_carts', true ) && WC()->cart instanceof WC_Cart && WC()->cart->is_empty() ) {
+					$params['empty_cart_fragments'] = self::get_empty_cart_fragments();
+				}
 				break;
 			case 'wc-add-to-cart':
 				$params = array(
@@ -808,6 +824,29 @@ class WC_Frontend_Scripts {
 		$params = apply_filters_deprecated( $handle . '_params', array( $params ), '3.0.0', 'woocommerce_get_script_data' );
 
 		return apply_filters( 'woocommerce_get_script_data', $params, $handle );
+	}
+
+	/**
+	 * Get the cart fragments for an empty cart, matching what WC_AJAX::get_refreshed_fragments() returns.
+	 *
+	 * @return array Fragments keyed by replacement selector.
+	 */
+	private static function get_empty_cart_fragments() {
+		ob_start();
+
+		woocommerce_mini_cart();
+
+		$mini_cart = ob_get_clean();
+
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		/** This filter is documented in includes/class-wc-ajax.php */
+		return apply_filters(
+			'woocommerce_add_to_cart_fragments',
+			array(
+				'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
+			)
+		);
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -763,7 +763,12 @@ class WC_Frontend_Scripts {
 				 * @param bool $skip Whether to skip the AJAX request for visitors without a cart session. Default true.
 				 */
 				if ( apply_filters( 'woocommerce_cart_fragments_skip_ajax_for_empty_carts', true ) && WC()->cart instanceof WC_Cart && WC()->cart->is_empty() ) {
-					$params['empty_cart_fragments'] = self::get_empty_cart_fragments();
+					$empty_cart_fragments = self::get_empty_cart_fragments();
+
+					// Omitted entirely on failure: an empty value would suppress the AJAX fallback in the frontend script.
+					if ( ! empty( $empty_cart_fragments ) ) {
+						$params['empty_cart_fragments'] = $empty_cart_fragments;
+					}
 				}
 				break;
 			case 'wc-add-to-cart':
@@ -829,24 +834,42 @@ class WC_Frontend_Scripts {
 	/**
 	 * Get the cart fragments for an empty cart, matching what WC_AJAX::get_refreshed_fragments() returns.
 	 *
-	 * @return array Fragments keyed by replacement selector.
+	 * Third-party fragment callbacks and mini cart templates run during regular page rendering here,
+	 * unlike the AJAX endpoint, so failures are contained: an empty array is returned and the
+	 * frontend falls back to requesting fragments over AJAX.
+	 *
+	 * @return array Fragments keyed by replacement selector, or an empty array on failure.
 	 */
 	private static function get_empty_cart_fragments() {
-		ob_start();
+		$ob_level = ob_get_level();
 
-		woocommerce_mini_cart();
+		try {
+			ob_start();
 
-		$mini_cart = ob_get_clean();
+			woocommerce_mini_cart();
 
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
-		/** This filter is documented in includes/class-wc-ajax.php */
-		return apply_filters(
-			'woocommerce_add_to_cart_fragments',
-			array(
-				'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
-			)
-		);
-		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			$mini_cart = ob_get_clean();
+
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+			/** This filter is documented in includes/class-wc-ajax.php */
+			$fragments = apply_filters(
+				'woocommerce_add_to_cart_fragments',
+				array(
+					'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
+				)
+			);
+			// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+
+			return is_array( $fragments ) ? $fragments : array();
+		} catch ( Throwable $e ) {
+			while ( ob_get_level() > $ob_level ) {
+				ob_end_clean();
+			}
+
+			wc_get_logger()->error( 'Could not pre-render empty cart fragments: ' . $e->getMessage(), array( 'source' => 'cart-fragments' ) );
+
+			return array();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On classic themes, `cart-fragments.js` fires an uncacheable `wc-ajax=get_refreshed_fragments` POST on the first pageview of every tab — even when the visitor has no cart at all. That request boots WordPress + WooCommerce in full, bypasses page caching entirely, and lands on the most common visit in commerce: a first-time visitor with an empty cart. This is the most-documented WooCommerce performance complaint of recent years (entire host/plugin docs exist just to disable cart fragments), and the Interactivity API Mini Cart only replaces fragments for block themes.

This PR skips that request when it provably has nothing to fetch. When a page is rendered while the cart is empty, `wc_cart_fragments_params` now includes pre-rendered empty-cart fragments (built exactly like `WC_AJAX::get_refreshed_fragments()` builds its response, including the `woocommerce_add_to_cart_fragments` filter — so theme fragments such as Storefront's header cart are included). On the client, `refresh_cart_fragment()` applies those inline fragments instead of calling the server when the visitor has no `woocommerce_cart_hash` cookie. Every other path is unchanged: visitors with a cart, add/remove events, cross-tab sync, and back-button restores behave exactly as before. If the inline fragments are absent (e.g. the page was cached for a cart-holding visitor), the code falls back to the AJAX request — behavior degrades to current, never worse.

#### Performance impact (measured)

Environment: wp-env (Docker, PHP 8.1, no page cache), Storefront, 4,003 products. First-time visitor with an empty cart, fresh browser profile, measured via Chrome DevTools performance API (3 runs) and curl (15 runs, cookieless POST).

| Metric | Before | After |
| ------ | ------ | ----- |
| Uncacheable PHP requests per first pageview | **2** (page + fragments AJAX) | **1** (page only) — **-50%** |
| `get_refreshed_fragments` server cost | ~81 ms median full WP boot per call | **0 — request eliminated** |
| Client-observed AJAX duration | 113–124 ms | **0 — request never fires** |
| Mini cart content settles | ~720–780 ms, after the `load` event | at script execution, before `load` |
| Payload trade-off | 708-byte AJAX response | ~0.9 KB inlined in the (cacheable) page |

The eliminated request is the cache-busting one: on real hosting it costs far more than the 81 ms measured locally (zero network latency, warm PHP-FPM). On stores behind full-page caching, every first-visit pageview currently produces one uncached origin request purely for an empty mini cart; with this change those pageviews produce none.

#### Context and prior art

- Issue #30834 proposed exactly this in 2021; a maintainer endorsed the approach with the caveat that it should be toggleable for merchants whose empty-cart fragments are dynamic on cached pages. This PR implements that shape: the `woocommerce_cart_fragments_skip_ajax_for_empty_carts` filter (default `true`) restores the previous behavior when returning `false`.
- Issue #38362 — a maintainer independently suggested the same direction ("loading the script once there is content in the cart") in 2025.
- Issue #60851 — open spike on cart fragments performance.

#### Backward compatibility

- `woocommerce_add_to_cart_fragments` now also runs during regular page rendering (when the cart is empty and the script is enqueued), not only in the AJAX context. Callbacks that assume an AJAX-only context should be unaffected in output but will execute in an additional context.
- Fragments that render per-visitor dynamic content for empty carts will be frozen into cached pages; those setups should return `false` from `woocommerce_cart_fragments_skip_ajax_for_empty_carts`.
- No existing hooks, signatures, or events were changed or removed. The `wc_fragments_refreshed` / `wc_fragments_loaded` events still fire as before.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Activate a classic theme with a header cart (e.g. Storefront) and make sure at least one simple product exists.
2. Open a private/incognito window with DevTools → Network open, filter by `wc-ajax`, and load the shop page.
3. Confirm **no** `get_refreshed_fragments` request fires, and the header cart and cart widget still show the correct empty state ("No products in the cart.", `$0.00 / 0 items` in Storefront).
4. Click an AJAX add-to-cart button. Confirm the mini cart and header cart update to show the product (this exercises the unchanged `added_to_cart` path).
5. Open a second tab on the same site (cart now has an item, sessionStorage empty). Confirm `get_refreshed_fragments` **does** fire and renders the cart contents — visitors with a cart still use the AJAX path.
6. Add `add_filter( 'woocommerce_cart_fragments_skip_ajax_for_empty_carts', '__return_false' );` to a snippet/mu-plugin, clear cookies + site data, reload the shop page, and confirm the request fires again on first view (opt-out restores current behavior).

### Testing that has already taken place:

All six steps above were performed on wp-env (PHP 8.1, no page cache) with Storefront and a 4,003-product catalog, using isolated Chrome browser contexts per run. Measurements in the table were collected with the browser performance API (3 first-visit runs before, verified zero-request state after) and 15 curl timings of the cookieless AJAX POST. `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified file are clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
