### PR TITLE
Fix CartUpdateItem truncating float quantities in the update hook

### DIFF
--- a/plugins/woocommerce/changelog/fix-cartupdateitem-truncates-float-quantities
+++ b/plugins/woocommerce/changelog/fix-cartupdateitem-truncates-float-quantities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix/normalize the Store API cart/update-item route truncating decimal quantities when dispatching the cart item updated hook.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartAddItem.php
@@ -130,7 +130,7 @@ class CartAddItem extends AbstractCartRoute {
 
 		if ( ! empty( $cart_item ) ) {
 			$product_id = $cart_item['variation_id'] ? $cart_item['variation_id'] : $cart_item['product_id'];
-			$quantity   = $add_to_cart_data['quantity'] ?? $cart_item['quantity'];
+			$quantity   = wc_stock_amount( $add_to_cart_data['quantity'] ?? $cart_item['quantity'] );
 
 			/**
 			 * Fires when an item is added to the cart from a user request.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -72,21 +72,22 @@ class CartUpdateItem extends AbstractCartRoute {
 
 		if ( isset( $request['quantity'] ) ) {
 			$cart_item    = $cart->get_cart_item( $request['key'] );
-			$old_quantity = $cart_item['quantity'] ?? 0;
-			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
+			$old_quantity = wc_stock_amount( $cart_item['quantity'] ?? 0 );
+			$new_quantity = wc_stock_amount( $request['quantity'] );
+			$this->cart_controller->set_cart_item_quantity( $request['key'], $new_quantity );
 
-			if ( $old_quantity !== (int) $request['quantity'] ) {
+			if ( $old_quantity !== $new_quantity ) {
 				/**
 				 * Fires when a cart item quantity is updated from a user request.
 				 *
 				 * @param string    $cart_item_key Cart item key.
-				 * @param int       $quantity      New quantity.
+				 * @param int|float $quantity      New quantity.
 				 * @param int|float $old_quantity  Old quantity.
 				 * @param \WC_Cart  $cart          Cart object.
 				 *
 				 * @since 10.6.0
 				 */
-				do_action( 'internal_woocommerce_cart_item_updated_from_user_request', $request['key'], (int) $request['quantity'], $old_quantity, $cart );
+				do_action( 'internal_woocommerce_cart_item_updated_from_user_request', $request['key'], $new_quantity, $old_quantity, $cart );
 			}
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1315,4 +1315,160 @@ class Cart extends ControllerTestCase {
 
 		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
 	}
+
+	/**
+	 * @testdox Should fire internal_woocommerce_cart_item_updated_from_user_request with untruncated quantities on stores with decimal quantities.
+	 */
+	public function test_update_item_fires_update_action_with_float_quantity(): void {
+		remove_filter( 'woocommerce_stock_amount', 'intval' );
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
+		$multiple_of_callback = function () {
+			return 0.5;
+		};
+		add_filter( 'woocommerce_store_api_product_quantity_multiple_of', $multiple_of_callback );
+
+		wc()->cart->set_quantity( $this->keys[0], 1.5 );
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $cart_item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
+		};
+
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key'      => $this->keys[0],
+				'quantity' => 2.5,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
+		$this->assertSame( 2.5, $captured_args['quantity'], 'The new quantity should not be truncated' );
+		$this->assertSame( 1.5, $captured_args['old_quantity'], 'The old quantity should not be truncated' );
+		$this->assertSame( 2.5, wc()->cart->get_cart_item( $this->keys[0] )['quantity'], 'The cart item quantity should be the untruncated value' );
+
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_filter( 'woocommerce_store_api_product_quantity_multiple_of', $multiple_of_callback );
+		remove_filter( 'woocommerce_stock_amount', 'floatval' );
+		add_filter( 'woocommerce_stock_amount', 'intval' );
+	}
+
+	/**
+	 * @testdox Should not fire internal_woocommerce_cart_item_updated_from_user_request when a decimal quantity is unchanged.
+	 */
+	public function test_update_item_with_same_float_quantity_does_not_fire_update_action(): void {
+		remove_filter( 'woocommerce_stock_amount', 'intval' );
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
+		$multiple_of_callback = function () {
+			return 0.5;
+		};
+		add_filter( 'woocommerce_store_api_product_quantity_multiple_of', $multiple_of_callback );
+
+		wc()->cart->set_quantity( $this->keys[0], 1.5 );
+
+		$action_fired = false;
+		$callback     = function () use ( &$action_fired ) {
+			$action_fired = true;
+		};
+
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key'      => $this->keys[0],
+				'quantity' => 1.5,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertFalse( $action_fired, 'The update action should not fire when a decimal quantity is unchanged' );
+
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
+		remove_filter( 'woocommerce_store_api_product_quantity_multiple_of', $multiple_of_callback );
+		remove_filter( 'woocommerce_stock_amount', 'floatval' );
+		add_filter( 'woocommerce_stock_amount', 'intval' );
+	}
+
+	/**
+	 * @testdox Should fire internal_woocommerce_cart_item_updated_from_user_request with numeric quantities when the cart contains a string quantity.
+	 */
+	public function test_update_item_fires_update_action_with_numeric_quantities_for_string_cart_quantity(): void {
+		$cart_contents                               = wc()->cart->get_cart_contents();
+		$cart_contents[ $this->keys[0] ]['quantity'] = '2';
+		wc()->cart->set_cart_contents( $cart_contents );
+
+		$captured_args = array();
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$callback = function ( $cart_item_key, $quantity, $old_quantity, $cart ) use ( &$captured_args ) {
+			$captured_args = compact( 'cart_item_key', 'quantity', 'old_quantity', 'cart' );
+		};
+
+		add_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback, 10, 4 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'key'      => $this->keys[0],
+				'quantity' => 3,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 200 );
+
+		$this->assertNotEmpty( $captured_args, 'The update action should have been fired' );
+		$this->assertSame( 3, $captured_args['quantity'], 'The new quantity should be a numeric value' );
+		$this->assertSame( 2, $captured_args['old_quantity'], 'The old quantity should be normalized to a numeric value' );
+
+		remove_action( 'internal_woocommerce_cart_item_updated_from_user_request', $callback );
+	}
+
+	/**
+	 * @testdox Should fire internal_woocommerce_cart_item_added_from_user_request with a numeric quantity when a filter sets a string quantity.
+	 */
+	public function test_add_item_fires_add_action_with_numeric_quantity_for_string_quantity(): void {
+		wc_empty_cart();
+
+		$add_to_cart_data_callback = function ( $add_to_cart_data ) {
+			$add_to_cart_data['quantity'] = '2';
+			return $add_to_cart_data;
+		};
+		add_filter( 'woocommerce_store_api_add_to_cart_data', $add_to_cart_data_callback );
+
+		$captured_args = array();
+		$callback      = function ( $product_id, $quantity ) use ( &$captured_args ) {
+			$captured_args = array(
+				'product_id' => $product_id,
+				'quantity'   => $quantity,
+			);
+		};
+
+		add_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback, 10, 2 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => 1,
+			)
+		);
+
+		$this->assertAPIResponse( $request, 201 );
+
+		$this->assertNotEmpty( $captured_args, 'The add action should have been fired' );
+		$this->assertSame( 2, $captured_args['quantity'], 'The quantity should be normalized to a numeric value' );
+
+		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
+		remove_filter( 'woocommerce_store_api_add_to_cart_data', $add_to_cart_data_callback );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Store API `cart/update-item` route (`CartUpdateItem`) casts the requested quantity to `(int)` when dispatching the `internal_woocommerce_cart_item_updated_from_user_request` action, and decides *whether* to dispatch it with a strict comparison between a raw `int|float` and that truncated int. On stores that support decimal quantities (a Core-sanctioned setup: the `intval` callback on the `woocommerce_stock_amount` filter is an explicitly removable default), this causes:

- **Lossy dispatch**: an update to quantity 2.5 is reported to hook consumers as 2, contradicting the route's own arg schema (`'type' => 'number'`, sanitized with `wc_stock_amount`).
- **Broken change detection**: float `2.0 !== int 2` fires the hook when the quantity didn't change, while old `2` → new `2.7` truncates to `2 !== 2` and suppresses a real change.
- **Type leaks**: string quantities (which third-party code can place in cart contents, or inject via the `woocommerce_store_api_add_to_cart_data` filter) can reach hook consumers unnormalized.

This PR normalizes both the old and the new quantity with `wc_stock_amount()` in `CartUpdateItem` and uses the normalized values for both the change check and the hook payload. Since both values pass through the same `woocommerce_stock_amount` filter chain, they always have the same type, making the strict comparison reliable. The quantity dispatched by `internal_woocommerce_cart_item_added_from_user_request` in `CartAddItem` is normalized the same way, so the whole hook family (Store API routes, `WC_AJAX`, `WC_Form_Handler`) now consistently emits `int|float`, never strings.

**Backward-compatibility impact**: no public API or signature changes. The affected actions are `internal_`-prefixed hooks. The documented payload type of the update hook broadens from `int` to `int|float`, matching what the classic-checkout dispatch of the same hook (`class-wc-form-handler.php`) already passes. Behavior on default (integer-quantity) stores is unchanged.

Bug introduced in PR #63371.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Setup: configure a store with non-integer quantities

1. Add the following snippet at the end of `plugins/woocommerce/woocommerce.php` (or via a code snippets plugin). It switches stock amounts from integers to floats, allows quantity steps of 0.5, and logs every dispatch of the cart-item-updated hook:

    ```php
    remove_filter( 'woocommerce_stock_amount', 'intval' );
    add_filter( 'woocommerce_stock_amount', 'floatval' );
    add_filter(
        'woocommerce_store_api_product_quantity_multiple_of',
        function () {
            return 0.5;
        }
    );
    add_filter(
        'woocommerce_quantity_input_args',
        function ( $args ) {
            $args['step']      = 0.5;
            $args['min_value'] = 0.5;
            return $args;
        }
    );
    add_action(
        'internal_woocommerce_cart_item_updated_from_user_request',
        function ( $key, $quantity, $old_quantity ) {
            wc_get_logger()->info(
                sprintf( 'Cart item updated: new=%s (%s), old=%s (%s)', $quantity, gettype( $quantity ), $old_quantity, gettype( $old_quantity ) ),
                array( 'source' => 'quantity-hook-test' )
            );
        },
        10,
        3
    );
    ```

2. Create a simple product and make sure your cart page uses the Cart block (the block updates quantities through the Store API `cart/update-item` route, which is the code path fixed here).

#### Test 1: decimal quantities reach the hook untruncated

1. On the front end, open the product page and add the product to the cart with quantity **1.5** (the quantity input now steps by 0.5).
2. Go to the cart page and use the quantity stepper to change the quantity from 1.5 to **2.5** (click "+" twice; each click issues an update).
3. Go to **WooCommerce → Status → Logs** and open the `quantity-hook-test` log.
4. **Expected**: the last entry shows `new=2.5 (double), old=2 (double)` (and the previous one `new=2 (double), old=1.5 (double)`). **Without this fix**, the new quantity is truncated to an integer (e.g. `new=2 (integer)` after setting 2.5).

#### Test 2: no dispatch when the quantity doesn't change

1. With the item at quantity 2.5, open the browser devtools console on the cart page and re-send the same quantity:

    ```js
    const nonce = JSON.parse( localStorage.getItem( 'storeApiNonce' ) )?.nonce || wcBlocksMiddlewareConfig.storeApiNonce;
    const cart = await ( await fetch( '/wp-json/wc/store/v1/cart' ) ).json();
    await fetch( '/wp-json/wc/store/v1/cart/update-item', {
        method: 'POST',
        credentials: 'same-origin',
        headers: { 'Content-Type': 'application/json', Nonce: nonce },
        body: JSON.stringify( { key: cart.items[ 0 ].key, quantity: 2.5 } ),
    } );
    ```

2. Check the log again.
3. **Expected**: no new entry is added. **Without this fix**, an entry is logged on every request because the truncated comparison (`2.5 !== 2`) always reports a change.

#### Test 3: default integer stores are unaffected

1. Remove the snippet from setup step 1 (keep only the `add_action` logging part if you want to observe the hook).
2. Add a product to the cart, and change its quantity on the cart page from 1 to 2.
3. **Expected**: everything behaves as before this PR; the log shows `new=2 (integer), old=1 (integer)`, and no entry is logged when the quantity doesn't change.

<!-- End testing instructions -->

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry was created manually and is included in this PR (`plugins/woocommerce/changelog/fix-cartupdateitem-truncates-float-quantities`).

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
