### PR TITLE
Fix: Prevent Webflow migrator from clearing weight on field-filtered re-runs

### DIFF
--- a/plugins/woocommerce/changelog/66315-fix-webflow-migrator-weight-clobber
+++ b/plugins/woocommerce/changelog/66315-fix-webflow-migrator-weight-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Migrator: stop the Webflow product mapper from clearing an existing product's weight on a re-run that excludes the weight field.

--- a/plugins/woocommerce/changelog/66315-fix-webflow-migrator-weight-clobber
+++ b/plugins/woocommerce/changelog/66315-fix-webflow-migrator-weight-clobber
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Migrator: stop the Webflow product mapper from clearing an existing product's weight on a re-run that excludes the weight field.

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Webflow/WebflowMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Webflow/WebflowMapper.php
@@ -375,7 +375,6 @@ class WebflowMapper implements PlatformMapperInterface {
 			'manage_stock'   => false,
 			'stock_quantity' => null,
 			'stock_status'   => 'instock',
-			'weight'         => null,
 			'tax_status'     => 'taxable',
 		);
 
@@ -488,7 +487,6 @@ class WebflowMapper implements PlatformMapperInterface {
 				'manage_stock'      => false,
 				'stock_quantity'    => null,
 				'stock_status'      => 'instock',
-				'weight'            => null,
 				'tax_status'        => 'taxable',
 				'attributes'        => array(),
 				'image_original_id' => null,

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Webflow/WebflowMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Webflow/WebflowMapperTest.php
@@ -212,6 +212,43 @@ class WebflowMapperTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Simple product omits the weight key entirely when weight is excluded from the fields to process.
+	 */
+	public function test_simple_product_omits_weight_key_when_field_excluded(): void {
+		$mapper = new WebflowMapper( array( 'fields' => array( 'price', 'sku' ) ) );
+
+		$result = $mapper->map_product_data( MockWebflowData::simple_product_item() );
+
+		// The importer only touches weight when the key is present (array_key_exists), so an
+		// excluded field must leave the key absent rather than null — a null would clear the
+		// existing product's weight on a field-filtered re-run.
+		$this->assertArrayNotHasKey( 'weight', $result, 'Excluded weight field must not leave a null weight key.' );
+	}
+
+	/**
+	 * @testdox Simple product includes the weight key when weight is among the fields to process.
+	 */
+	public function test_simple_product_includes_weight_key_by_default(): void {
+		$result = $this->mapper->map_product_data( MockWebflowData::simple_product_item() );
+
+		$this->assertArrayHasKey( 'weight', $result, 'Weight key must be present when the field is processed.' );
+	}
+
+	/**
+	 * @testdox Variations omit the weight key entirely when weight is excluded from the fields to process.
+	 */
+	public function test_variation_omits_weight_key_when_field_excluded(): void {
+		$mapper = new WebflowMapper( array( 'fields' => array( 'price', 'sku' ) ) );
+
+		$result = $mapper->map_product_data( MockWebflowData::variable_product_item() );
+
+		$this->assertNotEmpty( $result['variations'], 'Fixture should produce variations.' );
+		foreach ( $result['variations'] as $variation ) {
+			$this->assertArrayNotHasKey( 'weight', $variation, 'Excluded weight field must not leave a null weight key on variations.' );
+		}
+	}
+
+	/**
 	 * Test SEO fields land in metafields.
 	 */
 	public function test_simple_product_seo_metafields(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Webflow product mapper seeded `'weight' => null` in its base array literals (both simple products and variations), _before_ the `should_process( 'weight' )` guard runs. On a field-filtered re-run that excludes weight (e.g. `--fields=price,sku` or `--exclude-fields=weight`), the key was still present as `null` — so the importer's `array_key_exists( 'weight', … )` guard passed and `set_weight( null ?? '' )` silently cleared the existing product's weight.

The importer's guard is specifically designed to leave a value untouched when the mapper omits the key. The mapper was defeating that guard for the one field it pre-seeded. The fix just drops `'weight' => null` from the two literals, so weight now behaves like `sku`, price, and dimensions — it's only added when `should_process( 'weight' )` is true, and absent otherwise.

Worth noting: dimensions were already safe (only merged in inside the `should_process( 'dimensions' )` block), so `weight` was the only affected key.

Closes #66315.

(For Bug Fixes) Bug introduced in PR #64866.

### How to test the changes in this Pull Request:

1. On a store with the CLI migrator configured for Webflow, run a full product import so products land with a non-empty weight.
2. Re-run the import scoped to exclude weight, e.g. `wp wc migrate products --fields=price,sku` (or `--exclude-fields=weight`).
3. **Before this fix:** the previously-imported products have their weight cleared to empty.
4. **After this fix:** the existing weight is preserved on re-run; a run that _includes_ weight still updates it as expected.

### Testing that has already taken place:

- Added regression tests in `WebflowMapperTest.php` covering the simple and variation paths: when weight is excluded from the fields to process, the `weight` key is now absent (not `null`) — plus a positive control asserting the key is present when the field _is_ processed.
- Confirmed the tests actually bite: re-introducing the `'weight' => null` seeds makes both new tests fail (`Failures: 2`); with the fix in place all pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>