### PR TITLE
Fix Revenue report double-counting returns on partial-then-full refunds

### DIFF
--- a/plugins/woocommerce/changelog/66217-fix-revenue-report-refund-double-count
+++ b/plugins/woocommerce/changelog/66217-fix-revenue-report-refund-double-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Revenue report double-counting returns when an order has a partial refund followed by a full refund.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -113,7 +113,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	protected function assign_report_columns() {
 		$table_name = self::get_db_table_name();
 		// Avoid ambiguous columns in SQL query.
-		$refunds = "ABS( SUM( CASE WHEN {$table_name}.net_total < 0 THEN {$table_name}.net_total + {$table_name}.tax_total + {$table_name}.shipping_total ELSE 0 END ) )";
+		// Identify refund rows by the sign of the whole row (net + tax + shipping), not net alone:
+		// when a prior partial refund already covered the net portion, an incremental full-refund
+		// row can have net_total = 0 while still carrying negative tax or shipping.
+		$refunds = "ABS( SUM( CASE WHEN ( {$table_name}.net_total + {$table_name}.tax_total + {$table_name}.shipping_total ) < 0 THEN {$table_name}.net_total + {$table_name}.tax_total + {$table_name}.shipping_total ELSE 0 END ) )";
 		if ( ! OrderUtil::uses_new_full_refund_data() ) {
 			$refunds = "ABS( SUM( CASE WHEN {$table_name}.net_total < 0 THEN {$table_name}.net_total ELSE 0 END ) )";
 		}
@@ -606,10 +609,26 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 					|| self::should_split_full_refund_using_parent_order( $order, $parent_order )
 				);
 				if ( $use_parent_refund_amounts ) {
+					// A full refund derives its amounts from the parent order so that net, tax
+					// and shipping each zero out — a lump-sum refund carries no line items of its
+					// own, so the parent is the only reliable source for that split.
 					$data['num_items_sold'] = -1 * self::get_num_items_sold( $parent_order );
 					$data['tax_total']      = -1 * $parent_order->get_total_tax();
 					$data['net_total']      = -1 * self::get_net_total( $parent_order );
 					$data['shipping_total'] = -1 * $parent_order->get_shipping_total();
+
+					// If earlier refunds already booked part of the order, subtract what they
+					// recorded so this row only captures the remaining, not-yet-refunded portion.
+					// With no prior refunds this loop is skipped, leaving the totals above intact.
+					foreach ( $parent_order->get_refunds() as $prior_refund ) {
+						if ( $prior_refund->get_id() === $order->get_id() ) {
+							continue;
+						}
+						$data['num_items_sold'] -= self::get_num_items_sold( $prior_refund );
+						$data['tax_total']      -= (float) $prior_refund->get_total_tax();
+						$data['net_total']      -= self::get_net_total( $prior_refund );
+						$data['shipping_total'] -= (float) $prior_refund->get_shipping_total();
+					}
 				}
 			}
 			/**

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
@@ -117,4 +117,83 @@ class DataStoreTest extends WC_Unit_Test_Case {
 
 		WC_Helper_Order::delete_order( $order->get_id() );
 	}
+
+	/**
+	 * @testdox A partial refund followed by a full refund does not double-count the returns amount.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/66217: the full-refund
+	 * row used to store the whole parent order total again, ignoring the amount an earlier partial
+	 * refund had already recorded, so the Revenue report over-counted returns.
+	 */
+	public function test_partial_then_full_refund_does_not_double_count_returns(): void {
+		update_option( 'woocommerce_db_version', '10.2.0' );
+		update_option( 'woocommerce_analytics_uses_old_full_refund_data', 'no' );
+
+		// Order: net 40 (4 x $10 product) + tax 5 + shipping 10 = 55 gross.
+		$order = WC_Helper_Order::create_order();
+		$order->set_cart_tax( 5.00 );
+		$order->set_total( 55.00 );
+		$order->save();
+		$order->update_status( 'completed' );
+
+		$product_item_id = array_key_first( $order->get_items() );
+
+		// Partial refund: 2 of the 4 product units ($20) with a real line-item breakdown.
+		$partial = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 20.00,
+				'line_items' => array(
+					$product_item_id => array(
+						'qty'          => 2,
+						'refund_total' => 20.00,
+					),
+				),
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $partial );
+
+		// Full refund of the remainder as a lump sum (no line items), flagged as a full refund.
+		$remaining = (float) wc_format_decimal( $order->get_total() - $order->get_total_refunded() );
+		$full      = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $remaining,
+				'line_items' => array(),
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $full );
+		$full->update_meta_data( '_refund_type', 'full' );
+		$full->save_meta_data();
+		if ( OrderUtil::orders_cache_usage_is_enabled() ) {
+			wc_get_container()->get( OrderCache::class )->remove( $full->get_id() );
+		}
+
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+		OrdersStatsDataStore::sync_order( $partial->get_id() );
+		OrdersStatsDataStore::sync_order( $full->get_id() );
+
+		global $wpdb;
+
+		// Reported returns = absolute gross (net + tax + shipping) summed over the refund rows.
+		$returns = (float) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ABS( SUM( net_total + tax_total + shipping_total ) ) FROM {$wpdb->prefix}wc_order_stats WHERE parent_id = %d",
+				$order->get_id()
+			)
+		);
+		// Once (the order gross), not the partial refund counted twice ($75 before the fix).
+		$this->assertEqualsWithDelta( 55.00, $returns, 0.02 );
+
+		// The net portion across refunds should reconstruct the order net exactly once.
+		$refunded_net = (float) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM( net_total ) FROM {$wpdb->prefix}wc_order_stats WHERE parent_id = %d",
+				$order->get_id()
+			)
+		);
+		$this->assertEqualsWithDelta( -40.00, $refunded_net, 0.02 );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WooCommerce coding standards](https://github.com/woocommerce/woocommerce/wiki/Coding-Guidelines)?
- [x] Have you added tests where appropriate?

### Changes proposed in this Pull Request:

Fixes #66217, reported by @PypWalters (who also diagnosed the root cause 🙏).

When an order receives a **partial refund followed by a full refund**, the Revenue report's **Returns** metric double-counts the partial amount. The full-refund row in `wc_order_stats` stored `-1 ×` the entire parent order total, ignoring what the earlier partial refund had already recorded, so the report SUM'd both.

**Example:** $50 order → partial refund $15 → full refund of the remainder. Returns showed **$65** instead of **$50** (the $15 partial counted twice).

Changes (both in `Admin/API/Reports/Orders/Stats/DataStore.php`):

1. **`update()`** — the full-refund row starts from the parent-order totals (so a lone full refund still zeroes net/tax/shipping, preserving the behavior from #58744) and then **subtracts what prior refunds already booked**, via `$parent_order->get_refunds()`, so it records only the *remaining, not-yet-refunded* portion.
2. **`assign_report_columns()`** — refund rows are detected by the sign of `net + tax + shipping` rather than `net_total` alone, so an incremental full-refund row whose `net_total` is 0 (net already covered by a prior partial) is still counted for its tax/shipping.

Bug introduced in PR #58744 (the full-refund parent-total path; earlier data already had inconsistent behavior).

> **Scope note:** Two adjacent items were intentionally left out to keep this PR tight and low-risk:
> - The **Analytics → Orders** report shows an empty Products column on all-but-the-last refund row when an order has multiple refunds (`Orders/DataStore::get_orders_with_parent_id()`). It's a separate, cosmetic bug in a different report and touches a `protected` method on a non-`Internal` data store (BC surface) — better handled on its own.
> - A re-import of the parent order when a refund is **deleted** (so the recalculated full-refund row can't be left stale). This turned out not to be cleanly solvable via hooks across all storage backends — see the discussion thread. Tracked as a follow-up.

### How to test the changes in this Pull Request:

1. Create a completed order with a couple of line items and a shipping cost (e.g. gross ~$50).
2. Issue a **partial** refund on one line item.
3. Issue a **full** refund of the remainder (or set the order status to **Refunded**, which creates a full refund for the balance automatically).
4. Ensure analytics has synced (**WooCommerce → Status → Scheduled Actions**, or run the pending actions).
5. Go to **Analytics → Revenue** for a date range covering the refunds.
6. **Before this PR:** Returns = partial + full order total (over-counted). **After:** Returns = the order's gross total, once, and Net Sales / Taxes / Shipping all return to 0 for the fully-refunded order.

For existing affected stores, re-sync after upgrading:
```
wp action-scheduler run
wp wc tool run clear_woocommerce_analytics_cache --user=1
```

### Screenshots or screen recordings

Scenario: a **$50 order** (net $40 + tax $5 + shipping $5) with a **$15 partial refund** on one line item, followed by a **full refund** of the remaining $35 (via status → Refunded).

_Order — the partial ($15) + full ($35) refunds:_

<!-- attach order-refunds.png here -->

_Analytics → Revenue — Returns is **$50.00** (the order gross, once), not $65.00; Net Sales / Taxes / Shipping all $0.00:_

<!-- attach revenue-summary.png here -->

### Testing that has already taken place:

- New regression test `DataStoreTest::test_partial_then_full_refund_does_not_double_count_returns` — fails on trunk (asserts 75.0 vs 55.0), passes with this fix.
- Existing `DataStoreTest` (lump-sum full refund) still passes.
- Legacy REST report suites `WC_Admin_Tests_API_Reports_Orders` and `_Orders_Stats` — 14 tests, 107 assertions, all pass.
- Manual reproduction on wp-env across several refund combinations:
  - **Partial → full** ($33.83 order): Returns $48.83 → **$33.83**.
  - **Two partials → full** and **three partials (each a line item) → full**: Returns equals the order gross. The three-partial case drives the full-refund row's `net_total` to exactly 0 (net fully covered by the partials); Returns is correct only because of change #2 — under the old `net_total < 0` condition it would drop the $15 tax + shipping-only row.
  - **Single full refund** (no prior partial): net / tax / shipping still zero out — #58744 behavior preserved, no regression.
- phpcs (changed lines), branch lint, and PHPStan all clean.

### Changelog entry

- [x] This Pull Request includes a changelog entry (added manually: `plugins/woocommerce/changelog/66217-fix-revenue-report-refund-double-count`).

<!-- MILESTONE -->
- [x] Assign the appropriate milestone (first available, not in the past).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
