### PR TITLE
Fix: Analytics export progress overwritten by out-of-order Action Scheduler batches

### DIFF
--- a/plugins/woocommerce/changelog/fix-66311-analytics-export-progress-monotonic
+++ b/plugins/woocommerce/changelog/fix-66311-analytics-export-progress-monotonic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent analytics report export progress from moving backwards when Action Scheduler batches complete out of order.

--- a/plugins/woocommerce/src/Admin/ReportExporter.php
+++ b/plugins/woocommerce/src/Admin/ReportExporter.php
@@ -148,7 +148,10 @@ class ReportExporter {
 		$exports_status = get_option( self::EXPORT_STATUS_OPTION, array() );
 		$status_key     = self::get_status_key( $report_type, $export_id );
 
-		$exports_status[ $status_key ] = $percentage;
+		// Use max() to ensure progress never moves backwards when export batch
+		// actions complete out of order via Action Scheduler.
+		$current                 = isset( $exports_status[ $status_key ] ) ? (int) $exports_status[ $status_key ] : 0;
+		$exports_status[ $status_key ] = max( $current, (int) $percentage );
 
 		update_option( self::EXPORT_STATUS_OPTION, $exports_status );
 	}


### PR DESCRIPTION
## Description

Fixes woocommerce/woocommerce#66311

WooCommerce Analytics CSV report exports can complete all `woocommerce_admin_report_export` Action Scheduler jobs, but the report download email is never sent. This happens because `woocommerce_admin_report_export_status` can be overwritten with a lower percentage when export batch actions complete out of order.

Action Scheduler processes export pages in parallel. If page 39 of 290 completes AFTER page 290, the stored progress drops from \~100% back to \~13%. When the email action runs, it checks `if ( 100 === $percent_complete )` — since the value is 13, the email is silently skipped.

**Root cause:** `ReportExporter::update_export_percentage_complete()` unconditionally overwrites the stored percentage:

```php
$exports_status[ $status_key ] = $percentage;
```

**Fix:** Made progress monotonic — it can never move backwards:

```php
$current = isset( $exports_status[ $status_key ] ) ? (int) $exports_status[ $status_key ] : 0;
$exports_status[ $status_key ] = max( $current, (int) $percentage );
```

## Testing instructions

1. Trigger a large analytics export (e.g., Orders export with 290+ pages of data)
2. Due to Action Scheduler parallelism, some batch pages may complete out of order
3. Verify the final stored `woocommerce_admin_report_export_status` value is `100`
4. Verify the export download email is sent successfully
5. **Before fix:** Final value could be as low as 13, email silently skipped

## Changelog entry

```
Significance: patch
Type: fix

Prevent analytics report export progress from moving backwards when Action Scheduler batches complete out of order.
```

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed analytics export progress so the percentage no longer moves backward when export batches finish out of order.
  * Improved the reliability of report export status updates during long-running exports.
* **Chores**
  * Added a changelog entry for the analytics export progress fix.