### PR TITLE
Fix: Coupon line items don't respect dp parameter in REST API

### DIFF
--- a/plugins/woocommerce/changelog/fix-35821-coupon-line-items-dp-parameter
+++ b/plugins/woocommerce/changelog/fix-35821-coupon-line-items-dp-parameter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect dp parameter when formatting coupon line item discount and discount_tax values in REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -215,7 +215,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	protected function get_order_item_data( $item ) {
 		$data           = $item->get_data();
-		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total' );
+		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total', 'discount', 'discount_tax' );
 
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {


### PR DESCRIPTION
## Description

Addresses part of #35821

When retrieving orders via the REST API with the `dp` (decimal places) parameter, coupon line item values (`discount` and `discount_tax`) were not formatted with the requested precision. They always used the shop's default decimal places.

**Root cause:** `get_order_item_data()` in `WC_REST_Orders_V2_Controller` had a `` array listing which fields to format with `wc_format_decimal( , ->request['dp'] )`. This array included `subtotal`, `total`, `tax_total`, etc., but was missing `discount` and `discount_tax` — the two fields specific to coupon line items.

**Fix:** Added `'discount'` and `'discount_tax'` to the `` array.

## Testing instructions

1. Set WooCommerce > Settings > General > Number of decimals = 2
2. Create an order with a coupon that has a discount like 10.12345
3. Fetch the order via REST API: `GET /wp-json/wc/v3/orders/{id}?dp=5`
4. Check the `coupon_lines` array — `discount` and `discount_tax` should show 5 decimal places
5. **Before fix:** Values show only 2 decimal places regardless of `dp`

## Changelog entry

```
Significance: patch
Type: fix

Respect dp parameter when formatting coupon line item discount and discount_tax values in REST API.
```