### PR TITLE
Fix: PHP 8.0+ undefined array key warning in PayPal gateway

### DIFF
--- a/plugins/woocommerce/changelog/fix-66309-paypal-undefined-array-key
+++ b/plugins/woocommerce/changelog/fix-66309-paypal-undefined-array-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP 8.0+ undefined array key warning in PayPal gateway add_paypal_sdk_attributes.

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -853,7 +853,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function add_paypal_sdk_attributes( $attrs ) {
-		if ( 'paypal-standard-sdk-js' === $attrs['id'] ) {
+		if ( isset( $attrs['id'] ) && 'paypal-standard-sdk-js' === $attrs['id'] ) {
 			$buttons   = new PayPalButtons( $this );
 			$page_type = $buttons->get_page_type();
 


### PR DESCRIPTION
## Description

Fixes #66309

`WC_Gateway_Paypal::add_paypal_sdk_attributes()` accesses `['id']` without checking if the key exists. On PHP 8.0+, this generates a warning on every request that triggers the PayPal SDK script, flooding error logs.

**Fix:** Added `isset()` check before accessing the array key.

## Testing instructions

1. Enable PayPal Standard gateway
2. Visit checkout page with PHP 8.0+ and WP_DEBUG enabled
3. **Before fix:** `PHP Warning: Undefined array key "id" in class-wc-gateway-paypal.php on line 857`
4. **After fix:** No warning

## Changelog entry

```
Significance: patch
Type: fix

Fix PHP 8.0+ undefined array key warning in PayPal gateway add_paypal_sdk_attributes.
```