### PR TITLE
Fix: Order not refundable after deleting previous refund due to stale cache

### DIFF
--- a/plugins/woocommerce/changelog/fix-32718-refund-total-cache-invalidation
+++ b/plugins/woocommerce/changelog/fix-32718-refund-total-cache-invalidation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Invalidate cached total_refunded, total_tax_refunded, total_shipping_refunded, and total_shipping_tax_refunded when a refund is deleted.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -56,6 +56,19 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refund_ids' . $parent_order_id;
 		wp_delete_post( $id );
 		wp_cache_delete( $refund_cache_key, 'orders' );
+
+		// Invalidate cached refund totals so the parent order can be refunded again.
+		$cache_prefix = WC_Cache_Helper::get_cache_prefix( 'orders' );
+		$cache_keys   = array(
+			'total_refunded'              . $parent_order_id,
+			'total_tax_refunded'          . $parent_order_id,
+			'total_shipping_refunded'     . $parent_order_id,
+			'total_shipping_tax_refunded' . $parent_order_id,
+		);
+		foreach ( $cache_keys as $key ) {
+			wp_cache_delete( $cache_prefix . $key, 'orders' );
+		}
+
 		$order->set_id( 0 );
 
 		/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -81,6 +81,19 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refund_ids' . $refund->get_parent_id();
 		wp_cache_delete( $refund_cache_key, 'orders' );
 
+		// Invalidate cached refund totals so the parent order can be refunded again.
+		$parent_order_id = $refund->get_parent_id();
+		$cache_prefix    = WC_Cache_Helper::get_cache_prefix( 'orders' );
+		$cache_keys      = array(
+			'total_refunded'              . $parent_order_id,
+			'total_tax_refunded'          . $parent_order_id,
+			'total_shipping_refunded'     . $parent_order_id,
+			'total_shipping_tax_refunded' . $parent_order_id,
+		);
+		foreach ( $cache_keys as $key ) {
+			wp_cache_delete( $cache_prefix . $key, 'orders' );
+		}
+
 		$this->delete_order_data_from_custom_order_tables( $refund_id );
 		$refund->set_id( 0 );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
@@ -272,6 +272,63 @@ class OrdersTableRefundDataStoreTests extends \WC_Unit_Test_Case {
 
 
 	/**
+	 * @testDox Test that deleting a refund invalidates cached refund totals on the parent order.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $hpos_on_or_off True to test with HPOS on, false to test with HPOS off.
+	 */
+	public function test_delete_refund_invalidates_cached_totals( $hpos_on_or_off ) {
+		$this->toggle_cot_authoritative( $hpos_on_or_off );
+
+		$order = OrderHelper::create_order();
+		$order->set_total( 100 );
+		$order->set_shipping_total( 10 );
+		$order->set_shipping_tax( 2 );
+		$order->set_cart_tax( 8 );
+		$order->save();
+
+		// Create a partial refund.
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 50,
+				'line_items' => array(),
+			)
+		);
+		$this->assertNotNull( $refund );
+		$this->assertTrue( $refund->get_id() > 0 );
+
+		// Prime the caches by reading refund totals.
+		$parent = wc_get_order( $order->get_id() );
+		$this->assertEquals( 50, $parent->get_total_refunded() );
+		$this->assertGreaterThan( 0, $parent->get_total_tax_refunded() + $parent->get_total_shipping_refunded() + $parent->get_total_shipping_tax_refunded() );
+
+		// Delete the refund.
+		$parent->remove_refund( $refund->get_id() );
+
+		// Re-read the order and verify totals are no longer stale.
+		$parent_refreshed = wc_get_order( $order->get_id() );
+		$this->assertEquals( 0, $parent_refreshed->get_total_refunded(), 'total_refunded should be 0 after deleting the only refund' );
+		$this->assertEquals( 0, $parent_refreshed->get_total_tax_refunded(), 'total_tax_refunded should be 0 after deleting the only refund' );
+		$this->assertEquals( 0, $parent_refreshed->get_total_shipping_refunded(), 'total_shipping_refunded should be 0 after deleting the only refund' );
+		$this->assertEquals( 0, $parent_refreshed->get_total_shipping_tax_refunded(), 'total_shipping_tax_refunded should be 0 after deleting the only refund' );
+
+		// Verify a new refund for the same amount succeeds.
+		$new_refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 50,
+				'line_items' => array(),
+			)
+		);
+		$this->assertNotNull( $new_refund );
+		$this->assertTrue( $new_refund->get_id() > 0 );
+		$this->assertEquals( 50, wc_get_order( $order->get_id() )->get_total_refunded() );
+	}
+
+	/**
 	 * @testDox  Test that refund hooks are fired as expected.
 	 * @testWith [true]
 	 *           [false]


### PR DESCRIPTION
## Description

Fixes #32718

When a refund is deleted from an order, the parent order's cached `total_refunded` value was never invalidated. This caused `get_total_refunded()` to return the old (higher) amount, making it impossible to create a new refund for the same amount — the system would reject it with "invalid refund amount".

**Root cause:** Both `WC_Order_Refund_Data_Store_CPT::delete()` and `OrdersTableRefundDataStore::delete()` cleared the `refund_ids` cache but NOT the `total_refunded`, `total_tax_refunded`, or `total_shipping_refunded` cache keys.

**Fix:** Added cache deletion for all three refund-related cache keys in both data stores (CPT and HPOS).

## Testing instructions

1. Create an order for $100
2. Refund $50 → verify `get_total_refunded()` returns 50
3. Delete the $50 refund
4. Attempt a new refund for $50
5. **Before fix:** "Invalid refund amount" error because cached total_refunded is still 50
6. **After fix:** Refund succeeds because cache was invalidated

## Changelog entry

```
Significance: patch
Type: fix

Invalidate cached total_refunded, total_tax_refunded, and total_shipping_refunded when a refund is deleted.
```