### PR TITLE
Fix is_vat_exempt being not correctly applied during block checkout for logged-in users

### DIFF
--- a/plugins/woocommerce/changelog/fix-customer-vat-excempt-save-blocks-checkout
+++ b/plugins/woocommerce/changelog/fix-customer-vat-excempt-save-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix is_vat_exempt being not correctly applied during block checkout for logged-in users.

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -1266,27 +1266,4 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_is_paying_customer( $is_paying_customer ) {
 		$this->set_prop( 'is_paying_customer', (bool) $is_paying_customer );
 	}
-
-	/**
-	 * Overrides the save method to guard against saves with no data changed.
-	 *
-	 * @since 10.9.0
-	 * @return int
-	 */
-	public function save() {
-		$customer_id = $this->get_id();
-		if ( $customer_id ) {
-			$meta_data     = $this->meta_data ?? array();
-			$props_changed = ! empty( $this->password ) || ! empty( $this->changes );
-			$state_changed = $props_changed || ! empty( array_filter( $meta_data, static fn( $meta ) => ! $meta->id || ! empty( $meta->get_changes() ) ) );
-			if ( ! $state_changed ) {
-				// Backward compatibility: e.g. '( new WC_Customer( $customer_id ) )->save()' as means to trigger integrations.
-				do_action( 'woocommerce_update_customer', $customer_id, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
-
-				return $this->get_id();
-			}
-		}
-
-		return parent::save();
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-customer-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-customer-test.php
@@ -1,8 +1,66 @@
 <?php
 /**
+ * Unit tests for WC_Customer class.
+ *
+ * @package WooCommerce\Tests.
+ */
+
+declare( strict_types = 1 );
+
+/**
  * Tests for WC_Customer class.
  */
 class WC_Customer_Test extends \WC_Unit_Test_Case {
+	/**
+	 * Data provider: setters that write directly to a class property instead of going through set_prop().
+	 *
+	 * @return array<string,array>
+	 */
+	public function data_provider_set_prop_bypassing_setters(): array {
+		return array(
+			'password'            => array(
+				false,
+				fn( WC_Customer $customer ) => $customer->set_password( '***' ),
+				fn( int $id ) => wp_check_password( '***', get_user_by( 'id', $id )->user_pass ),
+			),
+			'is_vat_exempt'       => array(
+				true,
+				fn( WC_Customer $customer ) => $customer->set_is_vat_exempt( true ),
+				fn( int $id ) => ( new WC_Customer( $id, true ) )->get_is_vat_exempt(),
+			),
+			'calculated_shipping' => array(
+				true,
+				fn( WC_Customer $customer ) => $customer->set_calculated_shipping( true ),
+				fn( int $id ) => ( new WC_Customer( $id, true ) )->get_calculated_shipping(),
+			),
+		);
+	}
+
+	/**
+	 * @testdox Setters that bypass set_prop() must still persist their value when save() is called on a logged-in customer with no other pending changes.
+	 * @dataProvider data_provider_set_prop_bypassing_setters
+	 *
+	 * @param bool     $use_session True = session data store (Block Checkout); false = DB data store.
+	 * @param callable $set         Mutates the customer (calls the setter under test).
+	 * @param callable $verify      Returns true when the value was persisted after save().
+	 */
+	public function test_set_prop_bypass_is_persisted_on_save( bool $use_session, callable $set, callable $verify ): void {
+		$user_id = WC_Helper_Customer::create_customer()->get_id();
+
+		if ( $use_session ) {
+			WC()->session->init();
+		}
+		$customer = new WC_Customer( $user_id, $use_session );
+
+		// Precondition: no pending WC_Data changes — same state extensions see at checkout.
+		$this->assertEmpty( $customer->get_changes() );
+
+		$set( $customer );
+		$customer->save();
+
+		$this->assertTrue( $verify( $user_id ) );
+	}
+
 	/**
 	 * Test that customer object can be initialized even if wc session is not available.
 	 * There are cases when WC()->session is null but we are reading customer object with $session param set to true, for example, when calling methods from WC_Checkout object.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1783337306131549-slack-C8X6Q7XQU

Resolves an issue where `is_vat_exempt` was not correctly applied during block checkout for logged-in users:
- reverts `\WC_Customer::save` introduced in https://github.com/woocommerce/woocommerce/pull/64392/
- adds test coverage for `\WC_Customer` to prevent this regression in the future

Verified here: p1783351298890999/1783337306.131549-slack-C8X6Q7XQU

Performance impact: minor; the original PR improvements are holding, and we are getting 1 extra customer object save with this PR (I'll re-introduce the save method as a follow-up issue, as it needs a round trip through the review pipeline).

### How to test the changes in this Pull Request:

Pre-requisites:
- Ensure your testing site has `EU VAT Number` extension installed and active
- Use [the Irish entity of A8C](https://wordpress.com/support/automattic-inc/) details to update you addresses and VAT number under `My account` in store
- Ensure the store address is set to Ireland, and Irish VAT is configured in taxes

Testing steps from WOOEUVA-121:
- New private window - add to cart
- On checkout block page - use the "Log in" link to log in and get directed to checkout again
- Place the order using BACS 
- Verify the VAT is validated and deducted
