### PR TITLE
Validate mail callback return type

### DIFF
--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1233,7 +1233,18 @@ class WC_Email extends WC_Settings_API {
 		$message              = apply_filters( 'woocommerce_mail_content', $this->style_inline( $message ) );
 		$mail_callback        = apply_filters( 'woocommerce_mail_callback', 'wp_mail', $this );
 		$mail_callback_params = apply_filters( 'woocommerce_mail_callback_params', array( $to, wp_specialchars_decode( $subject ), $message, $headers, $attachments ), $this );
-		$return               = (bool) $mail_callback( ...$mail_callback_params );
+		$return               = $mail_callback( ...$mail_callback_params );
+		if ( ! is_bool( $return ) ) {
+			wc_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					'The callback registered to the woocommerce_mail_callback filter should return a boolean; %s returned.',
+					gettype( $return )
+				),
+				'11.1.0'
+			);
+			$return = false;
+		}
 
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1235,15 +1235,18 @@ class WC_Email extends WC_Settings_API {
 		$mail_callback_params = apply_filters( 'woocommerce_mail_callback_params', array( $to, wp_specialchars_decode( $subject ), $message, $headers, $attachments ), $this );
 		$return               = $mail_callback( ...$mail_callback_params );
 		if ( ! is_bool( $return ) ) {
+			$original_type = gettype( $return );
+
+			$return = is_scalar( $return ) ? wc_string_to_bool( (string) $return ) : false;
+
 			wc_doing_it_wrong(
 				__METHOD__,
 				sprintf(
 					'The callback registered to the woocommerce_mail_callback filter should return a boolean; %s returned.',
-					gettype( $return )
+					$original_type
 				),
 				'11.1.0'
 			);
-			$return = false;
 		}
 
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -910,14 +910,14 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox send() returns false and warns when the mail callback returns a non-bool.
+	 * @testdox send() returns false and warns when the mail callback returns a non-scalar.
 	 */
-	public function test_send_returns_false_and_warns_when_mail_callback_returns_non_bool(): void {
+	public function test_send_returns_false_and_warns_when_mail_callback_returns_non_scalar(): void {
 		add_filter(
 			'woocommerce_mail_callback',
 			function () {
 				return static function () {
-					return 1;
+					return new \WP_Error( 'failed', 'Mail failed' );
 				};
 			}
 		);
@@ -942,11 +942,69 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 		}
 
-		$this->assertFalse( $result, 'A non-bool callback return should resolve to false' );
+		$this->assertFalse( $result, 'A non-scalar callback return should resolve to false' );
 		$this->assertNotEmpty( $notices );
 		$this->assertSame( 'WC_Email::send', $notices[0]['function_name'] );
-		$this->assertStringContainsString( 'woocommerce_mail_callback filter should return a boolean; integer returned.', $notices[0]['message'] );
+		$this->assertStringContainsString( 'woocommerce_mail_callback filter should return a boolean; object returned.', $notices[0]['message'] );
 		$this->assertSame( '11.1.0', $notices[0]['version'] );
+	}
+
+	/**
+	 * @testdox send() coerces a scalar mail callback return to bool and warns.
+	 *
+	 * @dataProvider provider_scalar_callback_returns
+	 *
+	 * @param mixed  $callback_return Value returned by the mail callback.
+	 * @param bool   $expected        Expected coerced send result.
+	 * @param string $expected_type   gettype() of the returned value, as reported in the notice.
+	 */
+	public function test_send_coerces_scalar_callback_return_and_warns( $callback_return, bool $expected, string $expected_type ): void {
+		add_filter(
+			'woocommerce_mail_callback',
+			function () use ( $callback_return ) {
+				return static function () use ( $callback_return ) {
+					return $callback_return;
+				};
+			}
+		);
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Email::send' );
+
+		$notices = array();
+		$action  = function ( $function_name, $message, $version ) use ( &$notices ) {
+			$notices[] = array(
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			);
+		};
+		add_action( 'doing_it_wrong_run', $action, 10, 3 );
+
+		try {
+			$email  = new \WC_Email();
+			$result = $email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+		} finally {
+			remove_action( 'doing_it_wrong_run', $action, 10 );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$this->assertSame( $expected, $result );
+		$this->assertNotEmpty( $notices );
+		$this->assertStringContainsString( "woocommerce_mail_callback filter should return a boolean; {$expected_type} returned.", $notices[0]['message'] );
+	}
+
+	/**
+	 * Scalar mail callback return values and their expected coercion.
+	 *
+	 * @return array<string, array<mixed>>
+	 */
+	public function provider_scalar_callback_returns(): array {
+		return array(
+			'integer 1 is a success'     => array( 1, true, 'integer' ),
+			'string yes is a success'    => array( 'yes', true, 'string' ),
+			'integer 0 is a failure'     => array( 0, false, 'integer' ),
+			'random string is a failure' => array( 'sent', false, 'string' ),
+		);
 	}
 
 	/**
@@ -957,7 +1015,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			'woocommerce_mail_callback',
 			function () {
 				return static function () {
-					return 1;
+					return new \WP_Error( 'failed', 'Mail failed' );
 				};
 			}
 		);
@@ -984,7 +1042,7 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 			'woocommerce_mail_callback',
 			function () {
 				return static function () {
-					return 1;
+					return new \WP_Error( 'failed', 'Mail failed' );
 				};
 			}
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailLoggerTest.php
@@ -910,23 +910,43 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox send() coerces a non-bool return from the mail callback into a bool.
+	 * @testdox send() returns false and warns when the mail callback returns a non-bool.
 	 */
-	public function test_send_coerces_non_bool_mail_callback_return_to_bool(): void {
+	public function test_send_returns_false_and_warns_when_mail_callback_returns_non_bool(): void {
 		add_filter(
 			'woocommerce_mail_callback',
 			function () {
-					return static function () {
-							return null;
-					};
+				return static function () {
+					return 1;
+				};
 			}
 		);
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Email::send' );
 
-		$email  = new \WC_Email();
-		$result = $email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+		$notices = array();
+		$action  = function ( $function_name, $message, $version ) use ( &$notices ) {
+			$notices[] = array(
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			);
+		};
+		add_action( 'doing_it_wrong_run', $action, 10, 3 );
 
-		$this->assertIsBool( $result, 'send() should always return a bool, even if the mail callback does not' );
-		$this->assertFalse( $result, 'A non-bool (null) callback return should coerce to false' );
+		try {
+			$email  = new \WC_Email();
+			$result = $email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+		} finally {
+			remove_action( 'doing_it_wrong_run', $action, 10 );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$this->assertFalse( $result, 'A non-bool callback return should resolve to false' );
+		$this->assertNotEmpty( $notices );
+		$this->assertSame( 'WC_Email::send', $notices[0]['function_name'] );
+		$this->assertStringContainsString( 'woocommerce_mail_callback filter should return a boolean; integer returned.', $notices[0]['message'] );
+		$this->assertSame( '11.1.0', $notices[0]['version'] );
 	}
 
 	/**
@@ -936,32 +956,40 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_mail_callback',
 			function () {
-					return static function () {
-							return null;
-					};
+				return static function () {
+					return 1;
+				};
 			}
 		);
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Email::send' );
 
 		$email = $this->create_testable_email( 'my_email', 'admin@example.com', true, false, true );
 
-		$result = $email->run_send_notification();
+		try {
+			$result = $email->run_send_notification();
+		} finally {
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
 
 		$this->assertIsBool( $result, 'send_notification() should return a bool instead of fataling' );
-		$this->assertFalse( $result, 'Should resolve to false when the underlying mail callback returns null' );
+		$this->assertFalse( $result, 'Should resolve to false when the underlying mail callback returns a non-bool' );
 	}
 
 	/**
-	 * @testdox send() casts the mail callback return to bool before firing woocommerce_email_sent.
+	 * @testdox send() passes false to woocommerce_email_sent when the mail callback returns a non-bool.
 	 */
 	public function test_send_fires_email_sent_action_with_bool_when_callback_returns_non_bool(): void {
 		add_filter(
 			'woocommerce_mail_callback',
 			function () {
-					return static function () {
-							return null;
-					};
+				return static function () {
+					return 1;
+				};
 			}
 		);
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Email::send' );
 
 		$received_return = null;
 		add_action(
@@ -974,9 +1002,13 @@ class EmailLoggerTest extends WC_Unit_Test_Case {
 		);
 
 		$email = new \WC_Email();
-		$email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+		try {
+			$email->send( 'test@example.com', 'Subject', 'Message', '', array() );
+		} finally {
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
 
-		$this->assertIsBool( $received_return, 'woocommerce_email_sent should receive a bool even when the mail callback returns null' );
+		$this->assertIsBool( $received_return, 'woocommerce_email_sent should receive a bool even when the mail callback returns a non-bool' );
 		$this->assertFalse( $received_return );
 
 		remove_all_actions( 'woocommerce_email_sent' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follows up on #66186 (as discussed in https://github.com/woocommerce/woocommerce/pull/66186#discussion_r3523191230) by tightening the `woocommerce_mail_callback` return handling.

When the callback returns a non-boolean value, WooCommerce now triggers `wc_doing_it_wrong()` with the returned type and treats the email as not sent unless the callback returns boolean `true`.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a `woocommerce_mail_callback` callback that returns a non-boolean value, such as `1`.
2. Call `WC_Email::send()`.
3. Confirm the send result is `false`, `WC_Email::send` triggers an incorrect-usage notice, and `woocommerce_email_sent` receives `false`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Focused PHPUnit coverage, PHP linting, branch linting, and PHPStan on the production file passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Code improvement only; no merchant-facing changelog entry needed.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
