### PR TITLE
Add warnings for shadowed shipping zones

### DIFF
--- a/plugins/woocommerce/changelog/30340-shipping-zone-order-warning
+++ b/plugins/woocommerce/changelog/30340-shipping-zone-order-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Warn merchants when a higher-priority shipping zone prevents a narrower zone from matching.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -383,7 +383,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			'wc-shipping-zones',
 			'shippingZonesLocalizeScript',
 			array(
-				'zones'                   => WC_Shipping_Zones::get_zones( 'json' ),
+				'zones'                   => WC_Shipping_Zones::get_zones_with_order_conflict_warnings( 'json' ),
 				'default_zone'            => array(
 					'zone_id'    => 0,
 					'zone_name'  => '',

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -105,6 +105,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</td>
 		<td class="wc-shipping-zone-region">
 			{{ data.formatted_zone_location }}
+			<# if ( data.zone_order_conflict_warning ) { #>
+				<div class="notice notice-warning inline wc-shipping-zone-order-conflict-warning">
+					<p>{{ data.zone_order_conflict_warning }}</p>
+				</div>
+			<# } #>
 		</td>
 		<td class="wc-shipping-zone-methods">
 			<div><ul></ul></div>

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3414,7 +3414,7 @@ class WC_AJAX {
 		do_action( 'woocommerce_update_options' );
 		wp_send_json_success(
 			array(
-				'zones' => WC_Shipping_Zones::get_zones( 'json' ),
+				'zones' => WC_Shipping_Zones::get_zones_with_order_conflict_warnings( 'json' ),
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -38,6 +38,215 @@ class WC_Shipping_Zones {
 	}
 
 	/**
+	 * Get shipping zones from the database with admin warnings for zones that may not match because of their order.
+	 *
+	 * @since 11.1.0
+	 * @param string $context Getting shipping methods for what context. Valid values, admin, json.
+	 * @return array Array of arrays.
+	 */
+	public static function get_zones_with_order_conflict_warnings( $context = 'admin' ) {
+		$zones = self::get_zones( $context );
+
+		return self::add_zone_order_conflict_warnings( $zones );
+	}
+
+	/**
+	 * Add warnings to zones that are fully covered by a higher-priority zone.
+	 *
+	 * @since 11.1.0
+	 * @param array $zones Shipping zones.
+	 * @return array Shipping zones with order conflict warnings.
+	 */
+	private static function add_zone_order_conflict_warnings( $zones ) {
+		$ordered_zones         = $zones;
+		$higher_priority_zones = array();
+
+		uasort(
+			$ordered_zones,
+			function ( $zone_a, $zone_b ) {
+				$order_a = absint( $zone_a['zone_order'] ?? 0 );
+				$order_b = absint( $zone_b['zone_order'] ?? 0 );
+
+				if ( $order_a === $order_b ) {
+					return absint( $zone_a['zone_id'] ?? 0 ) <=> absint( $zone_b['zone_id'] ?? 0 );
+				}
+
+				return $order_a <=> $order_b;
+			}
+		);
+
+		foreach ( $ordered_zones as $zone ) {
+			$shadowing_zone = self::get_shadowing_zone( $zone, $higher_priority_zones );
+
+			if ( $shadowing_zone ) {
+				$zones[ $zone['zone_id'] ]['zone_order_conflict_warning'] = sprintf(
+					/* translators: %1$s: Higher-priority shipping zone name. */
+					__( 'This zone will not be matched because "%1$s" covers the same region earlier in the list. Move this zone above "%1$s" to make it available.', 'woocommerce' ),
+					$shadowing_zone['zone_name']
+				);
+			}
+
+			$higher_priority_zones[] = $zone;
+		}
+
+		return $zones;
+	}
+
+	/**
+	 * Get the first higher-priority zone that fully covers a zone.
+	 *
+	 * @since 11.1.0
+	 * @param array $zone Zone to check.
+	 * @param array $higher_priority_zones Higher-priority zones.
+	 * @return array|null Shadowing zone, or null when none exists.
+	 */
+	private static function get_shadowing_zone( $zone, $higher_priority_zones ) {
+		foreach ( $higher_priority_zones as $higher_priority_zone ) {
+			if ( self::zone_covers_zone( $higher_priority_zone, $zone ) ) {
+				return $higher_priority_zone;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether a possible broader zone fully covers another zone.
+	 *
+	 * @since 11.1.0
+	 * @param array $possible_broader_zone Possible broader zone.
+	 * @param array $zone Zone to check.
+	 * @return bool Whether the possible broader zone fully covers the zone.
+	 */
+	private static function zone_covers_zone( $possible_broader_zone, $zone ) {
+		if ( self::zone_has_postcode_locations( $possible_broader_zone ) ) {
+			return false;
+		}
+
+		$broader_locations = self::get_zone_locations_by_type( $possible_broader_zone, array( 'continent', 'country', 'state' ) );
+		$zone_locations    = self::get_zone_locations_by_type( $zone, array( 'continent', 'country', 'state' ) );
+
+		if ( empty( $zone_locations ) ) {
+			return empty( $broader_locations );
+		}
+
+		if ( empty( $broader_locations ) ) {
+			return true;
+		}
+
+		foreach ( $zone_locations as $zone_location ) {
+			$is_location_covered = false;
+
+			foreach ( $broader_locations as $broader_location ) {
+				if ( self::location_covers_location( $broader_location, $zone_location ) ) {
+					$is_location_covered = true;
+					break;
+				}
+			}
+
+			if ( ! $is_location_covered ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a zone has postcode locations.
+	 *
+	 * @since 11.1.0
+	 * @param array $zone Shipping zone.
+	 * @return bool Whether the zone has postcode locations.
+	 */
+	private static function zone_has_postcode_locations( $zone ) {
+		return ! empty( self::get_zone_locations_by_type( $zone, array( 'postcode' ) ) );
+	}
+
+	/**
+	 * Get zone locations for the requested location types.
+	 *
+	 * @since 11.1.0
+	 * @param array $zone Shipping zone.
+	 * @param array $location_types Location types.
+	 * @return array Zone locations.
+	 */
+	private static function get_zone_locations_by_type( $zone, $location_types ) {
+		$locations = $zone['zone_locations'] ?? array();
+
+		return array_values(
+			array_filter(
+				$locations,
+				function ( $location ) use ( $location_types ) {
+					return isset( $location->type ) && in_array( $location->type, $location_types, true );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Check whether one location covers another location.
+	 *
+	 * @since 11.1.0
+	 * @param object $possible_broader_location Possible broader location.
+	 * @param object $location Location to check.
+	 * @return bool Whether the possible broader location covers the location.
+	 */
+	private static function location_covers_location( $possible_broader_location, $location ) {
+		$broader_type = $possible_broader_location->type ?? '';
+		$broader_code = $possible_broader_location->code ?? '';
+		$type         = $location->type ?? '';
+		$code         = $location->code ?? '';
+
+		if ( $broader_type === $type && $broader_code === $code ) {
+			return true;
+		}
+
+		if ( 'continent' === $broader_type ) {
+			return $broader_code === self::get_continent_code_for_location( $location );
+		}
+
+		if ( 'country' === $broader_type ) {
+			return 'state' === $type && $broader_code === self::get_country_code_from_state_code( $code );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the continent code for a country or state location.
+	 *
+	 * @since 11.1.0
+	 * @param object $location Location.
+	 * @return string Continent code, or an empty string.
+	 */
+	private static function get_continent_code_for_location( $location ) {
+		$type = $location->type ?? '';
+		$code = $location->code ?? '';
+
+		if ( 'continent' === $type ) {
+			return $code;
+		}
+
+		$country_code = 'state' === $type ? self::get_country_code_from_state_code( $code ) : $code;
+
+		return WC()->countries->get_continent_code_for_country( $country_code );
+	}
+
+	/**
+	 * Get the country code from a state location code.
+	 *
+	 * @since 11.1.0
+	 * @param string $state_code State location code.
+	 * @return string Country code.
+	 */
+	private static function get_country_code_from_state_code( $state_code ) {
+		$state_code_parts = explode( ':', $state_code );
+
+		return $state_code_parts[0] ?? '';
+	}
+
+	/**
 	 * Retrieve Shipping_Zone data objects for the given zone_ids.
 	 *
 	 * @param array|null $zone_ids The zone_ids of the zones to retrieve. An empty array will return no results. Use null for all zones.

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -123,6 +123,13 @@ class WC_Shipping_Zones {
 			return false;
 		}
 
+		if (
+			self::zone_has_unsupported_non_postcode_locations( $possible_broader_zone ) ||
+			self::zone_has_unsupported_non_postcode_locations( $zone )
+		) {
+			return false;
+		}
+
 		$broader_locations = self::get_zone_locations_by_type( $possible_broader_zone, array( 'continent', 'country', 'state' ) );
 		$zone_locations    = self::get_zone_locations_by_type( $zone, array( 'continent', 'country', 'state' ) );
 
@@ -161,6 +168,26 @@ class WC_Shipping_Zones {
 	 */
 	private static function zone_has_postcode_locations( $zone ) {
 		return ! empty( self::get_zone_locations_by_type( $zone, array( 'postcode' ) ) );
+	}
+
+	/**
+	 * Check whether a zone has non-postcode locations not understood by this warning helper.
+	 *
+	 * @since 11.1.0
+	 * @param array $zone Shipping zone.
+	 * @return bool Whether the zone has unsupported non-postcode locations.
+	 */
+	private static function zone_has_unsupported_non_postcode_locations( $zone ) {
+		$locations                = $zone['zone_locations'] ?? array();
+		$supported_location_types = array( 'continent', 'country', 'state', 'postcode' );
+
+		foreach ( $locations as $location ) {
+			if ( isset( $location->type ) && ! in_array( $location->type, $supported_location_types, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -203,11 +203,11 @@ class WC_Shipping_Zones {
 		}
 
 		if ( 'continent' === $broader_type ) {
-			return $broader_code === self::get_continent_code_for_location( $location );
+			return self::get_continent_code_for_location( $location ) === $broader_code;
 		}
 
 		if ( 'country' === $broader_type ) {
-			return 'state' === $type && $broader_code === self::get_country_code_from_state_code( $code );
+			return 'state' === $type && self::get_country_code_from_state_code( $code ) === $broader_code;
 		}
 
 		return false;

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-zones-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-zones-test.php
@@ -27,6 +27,7 @@ class WC_Shipping_Zones_Test extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		parent::tearDown();
 
+		remove_filter( 'woocommerce_valid_location_types', array( $this, 'add_custom_location_type' ) );
 		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
@@ -81,6 +82,45 @@ class WC_Shipping_Zones_Test extends WC_Unit_Test_Case {
 
 		$this->assertArrayHasKey( $zip_zone->get_id(), $zones );
 		$this->assertArrayNotHasKey( 'zone_order_conflict_warning', $zones[ $zip_zone->get_id() ] );
+	}
+
+	/**
+	 * @testdox Should not warn when a higher-priority zone has only custom locations.
+	 */
+	public function test_does_not_warn_when_higher_priority_zone_has_only_custom_locations(): void {
+		add_filter( 'woocommerce_valid_location_types', array( $this, 'add_custom_location_type' ) );
+
+		$this->create_zone(
+			'Custom Region',
+			0,
+			array(
+				array( 'custom-region', 'custom_location' ),
+			)
+		);
+		$state_zone = $this->create_zone(
+			'Washington State',
+			1,
+			array(
+				array( 'US:WA', 'state' ),
+			)
+		);
+
+		$zones = WC_Shipping_Zones::get_zones_with_order_conflict_warnings( 'json' );
+
+		$this->assertArrayHasKey( $state_zone->get_id(), $zones );
+		$this->assertArrayNotHasKey( 'zone_order_conflict_warning', $zones[ $state_zone->get_id() ] );
+	}
+
+	/**
+	 * Add a custom location type for tests.
+	 *
+	 * @param array $location_types Location types.
+	 * @return array Location types.
+	 */
+	public function add_custom_location_type( array $location_types ): array {
+		$location_types[] = 'custom_location';
+
+		return $location_types;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-zones-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-zones-test.php
@@ -1,0 +1,107 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Class WC_Shipping_Zones_Test file.
+ *
+ * @package WooCommerce\Tests\Shipping
+ */
+
+/**
+ * Tests for the WC_Shipping_Zones class.
+ */
+class WC_Shipping_Zones_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WC_Helper_Shipping_Zones::remove_mock_zones();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		WC_Helper_Shipping_Zones::remove_mock_zones();
+	}
+
+	/**
+	 * @testdox Should warn when a postcode zone is below a broader state zone.
+	 */
+	public function test_warns_when_postcode_zone_is_below_broader_state_zone(): void {
+		$state_zone = $this->create_zone(
+			'Washington State',
+			0,
+			array(
+				array( 'US:WA', 'state' ),
+			)
+		);
+		$zip_zone   = $this->create_zone(
+			'Washington ZIP',
+			1,
+			array(
+				array( 'US:WA', 'state' ),
+				array( '98012', 'postcode' ),
+			)
+		);
+
+		$zones = WC_Shipping_Zones::get_zones_with_order_conflict_warnings( 'json' );
+
+		$this->assertArrayHasKey( $zip_zone->get_id(), $zones );
+		$this->assertArrayHasKey( 'zone_order_conflict_warning', $zones[ $zip_zone->get_id() ] );
+		$this->assertStringContainsString( $state_zone->get_zone_name(), $zones[ $zip_zone->get_id() ]['zone_order_conflict_warning'] );
+	}
+
+	/**
+	 * @testdox Should not warn when a postcode zone is above a broader state zone.
+	 */
+	public function test_does_not_warn_when_postcode_zone_is_above_broader_state_zone(): void {
+		$zip_zone = $this->create_zone(
+			'Washington ZIP',
+			0,
+			array(
+				array( 'US:WA', 'state' ),
+				array( '98012', 'postcode' ),
+			)
+		);
+		$this->create_zone(
+			'Washington State',
+			1,
+			array(
+				array( 'US:WA', 'state' ),
+			)
+		);
+
+		$zones = WC_Shipping_Zones::get_zones_with_order_conflict_warnings( 'json' );
+
+		$this->assertArrayHasKey( $zip_zone->get_id(), $zones );
+		$this->assertArrayNotHasKey( 'zone_order_conflict_warning', $zones[ $zip_zone->get_id() ] );
+	}
+
+	/**
+	 * Create a shipping zone for tests.
+	 *
+	 * @param string $name Zone name.
+	 * @param int    $order Zone order.
+	 * @param array  $locations Zone locations.
+	 * @return WC_Shipping_Zone
+	 */
+	private function create_zone( string $name, int $order, array $locations ): WC_Shipping_Zone {
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( $name );
+		$zone->set_zone_order( $order );
+
+		foreach ( $locations as $location ) {
+			$zone->add_location( $location[0], $location[1] );
+		}
+
+		$zone->save();
+
+		return $zone;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Shipping zones are matched by priority, so a broader zone higher in the list can prevent a narrower lower-priority zone from ever matching. This adds an inline warning to the Shipping zones table when an earlier zone covers the same region as a later zone, prompting merchants to move the narrower zone above the broader one.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #30340.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| A lower-priority postcode zone appears without any indication that it will not match. | The lower-priority postcode zone shows an inline warning explaining which broader zone covers it and that it should be moved higher. |

After
<img width="2298" height="1080" alt="CleanShot 2026-07-07 at 16 29 54@2x" src="https://github.com/user-attachments/assets/aa319f36-0f1c-4c6a-a29a-31928f16f5bf" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Shipping > Shipping zones.
2. Add a shipping zone named `Washington State` with region `United States (US) - Washington` and keep it above other Washington zones.
3. Add a second shipping zone named `Washington ZIP` with region `United States (US) - Washington` and limit it to postcode `98012`.
4. Return to the Shipping zones table and confirm the `Washington ZIP` row shows a warning that `Washington State` covers the same region earlier in the list.
5. Drag `Washington ZIP` above `Washington State` and confirm the warning disappears after the order is saved.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Confirmed the shipping-zone matching query orders by `zone_order ASC` and returns the first matching zone.
- Added PHPUnit coverage for the Washington State / 98012 warning case and the corrected order case.
- Ran PHP syntax checks for all touched PHP files.
- `pnpm run test:php:env -- --filter WC_Shipping_Zones_Test` could not run locally because `wp-env` is not installed in this workspace.
- `pnpm run lint:changes:branch:php` could not run locally because `phpcs-changed` and local `node_modules` are not installed in this workspace.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
