### PR TITLE
Prime post caches in count_matching_variations()

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6986-prime-variation-count-caches
+++ b/plugins/woocommerce/changelog/wooplug-6986-prime-variation-count-caches
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Prime post caches in structured data variation counting to avoid a database query per child variation.

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -830,8 +830,14 @@ class WC_Structured_Data {
 	 */
 	private function count_matching_variations( $product, $match_attributes ) {
 		$match_count = 0;
+		$child_ids   = $product->get_children();
 
-		foreach ( $product->get_children() as $variation_id ) {
+		if ( ! empty( $child_ids ) ) {
+			// Prime caches to reduce future queries.
+			_prime_post_caches( $child_ids );
+		}
+
+		foreach ( $child_ids as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
 
 			if ( ! $variation instanceof WC_Product_Variation ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`WC_Structured_Data::count_matching_variations()` iterated `$product->get_children()` calling `wc_get_product()` per child **without** priming the post caches first. On variation-specific product URLs (attribute selection present in the query string) this could trigger a separate database query for every child variation.

This PR primes the post caches once up front with `_prime_post_caches()`, mirroring the existing grouped-product branch in `generate_product_data()` which already does this before its `wc_get_product()` loop.

Introduced in PR #66043.

Closes #66334, closes WOOPLUG-6986.

### How to test the changes in this Pull Request:

1. Create a variable product with several variations and give each a price.
2. Enable a query-log / query-count tool (e.g. Query Monitor).
3. Visit a variation-specific URL, e.g. `?attribute_pa_color=blue`, on the single product page.
4. Inspect the generated Product structured data (`<script type="application/ld+json">` in the page source) — the emitted Offer/AggregateOffer output must be identical to before this change.
5. Confirm the number of database queries during structured-data generation no longer scales with the number of child variations.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean.
- Verified `_prime_post_caches()` is already used the same way in the sibling grouped-product branch of the same file.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Performance - Address performance issues

#### Message

Prime post caches in structured data variation counting to avoid a database query per child variation.

</details>
