### PR TITLE
Enable WP_DEBUG in the wp-env test config

### DIFF
--- a/plugins/woocommerce/.wp-env.test.json
+++ b/plugins/woocommerce/.wp-env.test.json
@@ -14,7 +14,7 @@
 	"themes": [],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,
-		"WP_DEBUG": false,
+		"WP_DEBUG": true,
 		"SCRIPT_DEBUG": false,
 		"WP_DEBUG_LOG": true,
 		"WP_DEBUG_DISPLAY": false,

--- a/plugins/woocommerce/changelog/wooplug-6991-test-env-wp-debug
+++ b/plugins/woocommerce/changelog/wooplug-6991-test-env-wp-debug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Re-enable WP_DEBUG in the wp-env test config so PHP notices and deprecations are captured in debug.log again (with WP_DEBUG_DISPLAY kept off); test-only tooling change, no merchant-facing impact.


### PR DESCRIPTION

### Changes proposed in this Pull Request:

The single-container wp-env migration in #66243 introduced `plugins/woocommerce/.wp-env.test.json` with `WP_DEBUG: false`. The previous dual-container config had no explicit `WP_DEBUG` key, so the test environment inherited wp-env's default of `WP_DEBUG: true`. As a result, PHP notices and deprecations the test suite used to surface were silently suppressed, and the `WP_DEBUG_LOG: true` line became dead config (WordPress only writes `debug.log` when `WP_DEBUG` is on).

This flips `WP_DEBUG` back to `true` while keeping `WP_DEBUG_DISPLAY: false` and `WP_DEBUG_LOG: true`. Deprecations are captured in `debug.log` again, but — unlike the pre-migration env, which had `WP_DEBUG_DISPLAY: true` — notices are never rendered inline into page/REST/AJAX output, so E2E assertions stay safe. `SCRIPT_DEBUG` is left untouched (orthogonal to PHP notice logging).

Closes #66340.

### How to test the changes in this Pull Request:

1. Check out this branch and build the plugin (`pnpm --filter='@woocommerce/plugin-woocommerce' build`).
2. `cd plugins/woocommerce && pnpm env:test` to start the test container.
3. Confirm the running container has debug logging on but display off: `pnpm exec wp-env --config .wp-env.test.json run cli wp config get WP_DEBUG` prints `1`, and `... wp config get WP_DEBUG_DISPLAY` prints an empty value (false).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
