### PR TITLE
Preserve correct aspect ratio on Product Images with imageSizing set to cropped

### DIFF
--- a/plugins/woocommerce/changelog/fix-66338-66331-cropped-image-sizing
+++ b/plugins/woocommerce/changelog/fix-66338-66331-cropped-image-sizing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Preserve correct aspect ratio on Product Images with imageSizing set to cropped
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/test/utils.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/test/utils.test.ts
@@ -33,6 +33,17 @@ describe( 'resolveAspectRatio', () => {
 		).toBe( '4/3' );
 	} );
 
+	it( 'falls back to store aspect ratio when no block override is set and imageSizing is cropped', () => {
+		expect(
+			resolveAspectRatio(
+				undefined,
+				undefined,
+				'4/3',
+				ImageSizing.CROPPED
+			)
+		).toBe( '4/3' );
+	} );
+
 	it( 'returns undefined when store aspect ratio is null (uncropped)', () => {
 		expect(
 			resolveAspectRatio(

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/types.ts
@@ -6,6 +6,8 @@ import { ProductQueryContext } from '@woocommerce/blocks/product-query/types';
 export enum ImageSizing {
 	SINGLE = 'single',
 	THUMBNAIL = 'thumbnail',
+	// Deprecated synonym for THUMBNAIL.
+	CROPPED = 'cropped',
 }
 
 export type AspectRatioStyle = {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/utils.ts
@@ -39,7 +39,11 @@ export const resolveAspectRatio = (
 		return aspectRatio;
 	}
 
-	if ( imageSizing && imageSizing === ImageSizing.THUMBNAIL ) {
+	if (
+		imageSizing &&
+		( imageSizing === ImageSizing.THUMBNAIL ||
+			imageSizing === ImageSizing.CROPPED )
+	) {
 		return storeAspectRatio ?? undefined;
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -164,7 +164,8 @@ class ProductImage extends AbstractBlock {
 
 		// For backwards compatibility, we interpret "thumbnail" as following
 		// the store thumbnail cropping settings.
-		if ( 'thumbnail' === $attributes['imageSizing'] ) {
+		// "cropped" was used as a synonym for "thumbnail" in the past, but it's now deprecated.
+		if ( 'thumbnail' === $attributes['imageSizing'] || 'cropped' === $attributes['imageSizing'] ) {
 			return $this->get_store_thumbnail_aspect_ratio();
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/66331.
Closes https://github.com/woocommerce/woocommerce/issues/66338.
Closes WOOPLUG-6985.
Closes WOOPLUG-6990.

Legacy instances of the Related Products pattern might be using `imageSizing: "cropped"` instead of `imageSizing: "thumbnail"`. This PR adds the necessary checks so the aspect ratio doesn't change unexpectedly in the frontend.

### How to test the changes in this Pull Request:

1. Insert the legacy Related Products pattern in the Single Product template. You can checkout this commit 62bf7e4b708d83488ac97f6561044ad7440424c2 and remove `inserter: false` from the [block.json file](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/related-products/block.json#L13) or simply copy and paste this code:

```HTML
<!-- wp:woocommerce/related-products -->
<div class="wp-block-woocommerce-related-products"><!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"woocommerce/related-products","lock":{"remove":true,"move":true}} -->
<div class="wp-block-query"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} -->
<h2 class="wp-block-heading" style="margin-top:1rem;margin-bottom:1rem">Related products</h2>
<!-- /wp:heading -->

<!-- wp:post-template {"layout":{"type":"grid","columnCount":5},"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"cropped","isDescendentOfQueryLoop":true} /-->

<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->

<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->

<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
<!-- /wp:post-template --></div>
<!-- /wp:query --></div>
<!-- /wp:woocommerce/related-products -->
```

2. Visit the page in the frontend.
3. Verify the aspect ratio that you have set up in the _Customizer_ (`/wp-admin/customize.php`) is applied to the product image.

Before | After
--- | ---
<img width="890" height="550" alt="imatge" src="https://github.com/user-attachments/assets/6bfb48ae-8d36-4be5-8067-e7d32fde3f07" /> | <img width="890" height="550" alt="imatge" src="https://github.com/user-attachments/assets/22ed65f4-1c93-4254-ae32-1fe619c62a5c" />