### PR TITLE
e2e tests: Fix product-delete list-table quick-delete

### DIFF
--- a/plugins/woocommerce/changelog/testops-179-fix-product-delete-quick-delete-flake
+++ b/plugins/woocommerce/changelog/testops-179-fix-product-delete-quick-delete-flake
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky product-delete list-table quick-delete E2E test by scrolling the product row into view before clicking the hover-revealed Trash / Delete Permanently row action.

--- a/plugins/woocommerce/tests/e2e/tests/product/product-delete.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-delete.spec.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { Page } from '@playwright/test';
 import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 
 /**
@@ -9,6 +10,29 @@ import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { getFakeProduct } from '../../utils/data';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+/**
+ * Clicks the hover-revealed Trash / Delete Permanently row action for a product
+ * in the WP list table.
+ *
+ * The matched product row can render near the bottom of the list table, where
+ * the revealed action link ends up below the fold or obscured by the table
+ * footer, so a plain click is intercepted and times out. Scrolling the row into
+ * view before hovering keeps the action inside the viewport and clickable.
+ */
+async function deleteProductViaRowAction( page: Page, productId: number ) {
+	const row = page.locator( `#post-${ productId }` );
+
+	// Bring the row (and its always-present row-actions) fully into view before
+	// hovering, so the Trash link isn't outside the viewport or under the footer.
+	await row.scrollIntoViewIfNeeded();
+
+	// Mouse over the product row to reveal the quick actions.
+	await row.hover();
+
+	// Trigger the delete row action.
+	await row.locator( '.submitdelete' ).click();
+}
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -81,11 +105,7 @@ test( 'can quick delete a product from product list', async ( {
 	} );
 
 	await test.step( 'Move product to trash', async () => {
-		// mouse over the product row to display the quick actions
-		await page.locator( `#post-${ product.id }` ).hover();
-
-		// move product to trash
-		await page.locator( `#post-${ product.id } .submitdelete` ).click();
+		await deleteProductViaRowAction( page, product.id );
 	} );
 
 	await test.step( 'Verify product was trashed', async () => {
@@ -127,11 +147,7 @@ test( 'can permanently delete a product from trash list', async ( {
 	} );
 
 	await test.step( 'Permanently delete the product', async () => {
-		// mouse over the product row to display the quick actions
-		await page.locator( `#post-${ product.id }` ).hover();
-
-		// delete the product
-		await page.locator( `#post-${ product.id } .submitdelete` ).click();
+		await deleteProductViaRowAction( page, product.id );
 	} );
 
 	await test.step( 'Verify product was permanently deleted', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The tests hover a product row and click the revealed Trash / Delete Permanently action, but when the matched row renders near the bottom of the WP list table the link lands below the fold or under the table footer. 

This extracts a shared `deleteProductViaRowAction` helper that scrolls the row into view *before* hovering — keeping the action inside the viewport and clickable — and applies it to both the quick-delete and permanent-delete list-table paths.

Fixes TESTOPS-179.

### How to test the changes in this Pull Request:


1. Check out this branch and start the E2E environment.
2. From `plugins/woocommerce`, run the product dir under the parallel project a few times to apply concurrent load: `pnpm test:e2e:core-parallel product/`
3. Confirm `can quick delete a product from product list` and `can permanently delete a product from trash list` pass on every run (they no longer time out on the hover-revealed Trash action).

### Testing that has already taken place:

- Ran the full `core-parallel` suite (196 tests × 7 workers) **10 consecutive times** locally. Both fixed tests passed **10/10** — the flake never reproduced.
- Also ran a product-dir-only loop **5/5 green**.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
