### PR TITLE
Fix command palette E2E modifier detection under Playwright 1.61

### DIFF
--- a/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
@@ -23,19 +23,29 @@ const clickOnCommandPaletteOption = async ( {
 		/Search (?:commands(?: and settings)?|for commands)/
 	);
 
-	// Playwright's browser reports a non-Apple platform even on macOS, so picking the combo from
-	// reports a non-Apple platform even on macOS, so picking the combo from
-	// `process.platform` would send Meta+K while WordPress listens for Ctrl+K and
-	// the palette would never open. Derive the modifier from the page instead.
-	const isApplePlatform = await page.evaluate( () =>
-		/Mac|iPhone|iPod|iPad/i.test(
-			(
-				navigator as Navigator & {
-					userAgentData?: { platform?: string };
-				}
-			 ).userAgentData?.platform || navigator.platform
-		)
-	);
+	// WordPress registers the command-palette shortcut via @wordpress/keycodes'
+	// `isAppleOS()`, which inspects `navigator.platform` only. In Playwright's
+	// Chromium on macOS these two disagree: `navigator.platform` is "MacIntel"
+	// (Apple → Cmd+K) while `navigator.userAgentData.platform` is "Windows".
+	// Deriving the modifier from `userAgentData` therefore sends Ctrl+K and the
+	// palette never opens. Reuse `isAppleOS()` so the test always matches whatever
+	// modifier WordPress actually registered (falling back to its logic if the
+	// keycodes package is unavailable).
+	const isApplePlatform = await page.evaluate( () => {
+		const isAppleOS = (
+			window as Window & {
+				wp?: { keycodes?: { isAppleOS?: () => boolean } };
+			}
+		 ).wp?.keycodes?.isAppleOS;
+		if ( typeof isAppleOS === 'function' ) {
+			return isAppleOS();
+		}
+		const { platform } = navigator;
+		return (
+			platform.indexOf( 'Mac' ) !== -1 ||
+			[ 'iPad', 'iPhone' ].includes( platform )
+		);
+	} );
 	const cmdKeyCombo = isApplePlatform ? 'Meta+k' : 'Control+k';
 
 	// Press `Ctrl`/`Cmd` + `K` to open the command palette.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`command-palette.spec.ts` picks the keyboard modifier (Ctrl vs Cmd) to open the WP command palette. It derived that from `navigator.userAgentData.platform`, but WordPress registers the shortcut via `@wordpress/keycodes`' `isAppleOS()`, which reads `navigator.platform` only. Under the `Desktop Chrome` preset these two disagree on macOS — the preset pins a Windows UA (so `userAgentData.platform` is `"Windows"`) while `navigator.platform` leaks the real host value `"MacIntel"`. The test therefore sent Ctrl+K while WordPress was listening for Cmd+K, and the palette never opened (all 6 tests failed locally on Mac).

This surfaced after the Playwright `1.57.0 → 1.61.1` bump in #66097: earlier Playwright pinned `navigator.platform` to the preset's OS too (so both sources agreed), and newer Playwright no longer does. The fix reads `window.wp.keycodes.isAppleOS()` directly — the exact function WordPress uses to register the shortcut — so the test always presses whatever modifier WordPress actually registered, regardless of how Playwright emulates `navigator.platform` vs `userAgentData.platform`. A fallback replicates `isAppleOS()`'s `navigator.platform`-only logic if the keycodes package isn't present.

Bug introduced in PR #66097.

### How to test the changes in this Pull Request:

1. On a macOS machine, check out this branch.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:core-parallel command-palette.spec.ts`.
3. Confirm all 6 command-palette tests pass. On `trunk` (with Playwright 1.61.1) they fail with `locator.fill: Timeout ... waiting for getByPlaceholder(/Search .../)` because the palette never opens.

### Testing that has already taken place:

- Ran the spec locally on macOS (Apple Silicon) against wp-env with Playwright 1.61.1 / WordPress 7.0: 6/6 passing (previously 6/6 failing).
- Verified the root cause empirically with a throwaway diagnostic spec using the commands store: `Control+k` left `wp.data.select('core/commands').isOpen()` false; `Meta+k` set it true; `wp.keycodes.isAppleOS()` returned `true` with `navigator.platform === "MacIntel"` and `navigator.userAgentData.platform === "Windows"`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

E2E test-only change (`tests/e2e/`), not shipped to merchants.

</details>