### PR TITLE
Fix flaky product-delete list-table quick-delete E2E test

### DIFF
--- a/plugins/woocommerce/changelog/testops-179-fix-product-delete-quick-delete-flake
+++ b/plugins/woocommerce/changelog/testops-179-fix-product-delete-quick-delete-flake
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky product-delete list-table quick-delete E2E test by scrolling the product row into view before clicking the hover-revealed Trash / Delete Permanently row action.

--- a/plugins/woocommerce/tests/e2e/tests/product/product-delete.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-delete.spec.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { Page } from '@playwright/test';
 import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 
 /**
@@ -9,6 +10,29 @@ import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { getFakeProduct } from '../../utils/data';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+/**
+ * Clicks the hover-revealed Trash / Delete Permanently row action for a product
+ * in the WP list table.
+ *
+ * The matched product row can render near the bottom of the list table, where
+ * the revealed action link ends up below the fold or obscured by the table
+ * footer, so a plain click is intercepted and times out. Scrolling the row into
+ * view before hovering keeps the action inside the viewport and clickable.
+ */
+async function deleteProductViaRowAction( page: Page, productId: number ) {
+	const row = page.locator( `#post-${ productId }` );
+
+	// Bring the row (and its always-present row-actions) fully into view before
+	// hovering, so the Trash link isn't outside the viewport or under the footer.
+	await row.scrollIntoViewIfNeeded();
+
+	// Mouse over the product row to reveal the quick actions.
+	await row.hover();
+
+	// Trigger the delete row action.
+	await row.locator( '.submitdelete' ).click();
+}
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -81,11 +105,7 @@ test( 'can quick delete a product from product list', async ( {
 	} );
 
 	await test.step( 'Move product to trash', async () => {
-		// mouse over the product row to display the quick actions
-		await page.locator( `#post-${ product.id }` ).hover();
-
-		// move product to trash
-		await page.locator( `#post-${ product.id } .submitdelete` ).click();
+		await deleteProductViaRowAction( page, product.id );
 	} );
 
 	await test.step( 'Verify product was trashed', async () => {
@@ -127,11 +147,7 @@ test( 'can permanently delete a product from trash list', async ( {
 	} );
 
 	await test.step( 'Permanently delete the product', async () => {
-		// mouse over the product row to display the quick actions
-		await page.locator( `#post-${ product.id }` ).hover();
-
-		// delete the product
-		await page.locator( `#post-${ product.id } .submitdelete` ).click();
+		await deleteProductViaRowAction( page, product.id );
 	} );
 
 	await test.step( 'Verify product was permanently deleted', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The `product-delete.spec.ts` list-table delete tests hover a product row and click the revealed Trash / Delete Permanently action, but when the matched row renders near the bottom of the WP list table the link lands below the fold or under the table footer, so under `core-parallel` load the click is intercepted and times out (~1 in 5 full-suite runs). This extracts a shared `deleteProductViaRowAction` helper that scrolls the row into view *before* hovering — keeping the action inside the viewport and clickable — and applies it to both the quick-delete and permanent-delete list-table paths.

Fixes TESTOPS-179.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and start the E2E environment.
2. From `plugins/woocommerce`, run the product dir under the parallel project a few times to apply concurrent load: `pnpm test:e2e:core-parallel product/`
3. Confirm `can quick delete a product from product list` and `can permanently delete a product from trash list` pass on every run (they no longer time out on the hover-revealed Trash action).

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Ran the full `core-parallel` suite (196 tests × 7 workers) **10 consecutive times** locally (wp-env, macOS). Both fixed tests passed **10/10** — the flake never reproduced. The loop was set to halt immediately on any failure of the two fixed tests; it never did.
- Also ran a product-dir-only loop **5/5 green**.
- Pre-existing, unrelated failures observed during the runs (`editor/command-palette.spec.ts`, and rare one-off flakes in `product-create-simple`/`product-reviews`) are out of scope for this change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry (`Significance: patch`, `Type: dev`) was added manually in the branch — this is a test-only change (E2E flake fix), not shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
