### PR TITLE
e2e test: Fix command palette test modifier detection

### DIFF
--- a/plugins/woocommerce/changelog/66364-fix-command-palette-e2e-modifier-detection
+++ b/plugins/woocommerce/changelog/66364-fix-command-palette-e2e-modifier-detection
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fix command palette E2E test modifier-key detection under Playwright 1.61 (test-only; no merchant-facing change).

--- a/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/editor/command-palette.spec.ts
@@ -23,19 +23,29 @@ const clickOnCommandPaletteOption = async ( {
 		/Search (?:commands(?: and settings)?|for commands)/
 	);
 
-	// Playwright's browser reports a non-Apple platform even on macOS, so picking the combo from
-	// reports a non-Apple platform even on macOS, so picking the combo from
-	// `process.platform` would send Meta+K while WordPress listens for Ctrl+K and
-	// the palette would never open. Derive the modifier from the page instead.
-	const isApplePlatform = await page.evaluate( () =>
-		/Mac|iPhone|iPod|iPad/i.test(
-			(
-				navigator as Navigator & {
-					userAgentData?: { platform?: string };
-				}
-			 ).userAgentData?.platform || navigator.platform
-		)
-	);
+	// WordPress registers the command-palette shortcut via @wordpress/keycodes'
+	// `isAppleOS()`, which inspects `navigator.platform` only. In Playwright's
+	// Chromium on macOS these two disagree: `navigator.platform` is "MacIntel"
+	// (Apple → Cmd+K) while `navigator.userAgentData.platform` is "Windows".
+	// Deriving the modifier from `userAgentData` therefore sends Ctrl+K and the
+	// palette never opens. Reuse `isAppleOS()` so the test always matches whatever
+	// modifier WordPress actually registered (falling back to its logic if the
+	// keycodes package is unavailable).
+	const isApplePlatform = await page.evaluate( () => {
+		const isAppleOS = (
+			window as Window & {
+				wp?: { keycodes?: { isAppleOS?: () => boolean } };
+			}
+		 ).wp?.keycodes?.isAppleOS;
+		if ( typeof isAppleOS === 'function' ) {
+			return isAppleOS();
+		}
+		const { platform } = navigator;
+		return (
+			platform.indexOf( 'Mac' ) !== -1 ||
+			[ 'iPad', 'iPhone' ].includes( platform )
+		);
+	} );
 	const cmdKeyCombo = isApplePlatform ? 'Meta+k' : 'Control+k';
 
 	// Press `Ctrl`/`Cmd` + `K` to open the command palette.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`command-palette.spec.ts` picks the keyboard modifier (Ctrl vs Cmd) to open the WP command palette. It derived that from `navigator.userAgentData.platform`, but WordPress registers the shortcut via `@wordpress/keycodes`' `isAppleOS()`, which reads `navigator.platform` only. Under the `Desktop Chrome` preset these two disagree on macOS — the preset pins a Windows UA (so `userAgentData.platform` is `"Windows"`) while `navigator.platform` leaks the real host value `"MacIntel"`. The test therefore sent Ctrl+K while WordPress was listening for Cmd+K, and the palette never opened (all 6 tests failed locally on Mac).

### How to test the changes in this Pull Request:

1. On a macOS machine, check out this branch.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:core-parallel command-palette.spec.ts`.
3. Confirm all 6 command-palette tests pass. On `trunk` (with Playwright 1.61.1) they fail with `locator.fill: Timeout ... waiting for getByPlaceholder(/Search .../)` because the palette never opens.
4. CI is green

### Testing that has already taken place:

- Ran the spec locally on macOS (Apple Silicon) against wp-env with Playwright 1.61.1 / WordPress 7.0: 6/6 passing (previously 6/6 failing).


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
