### PR TITLE
Update Product Filters overlay setting

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -1240,7 +1240,7 @@ Add a set of filters shoppers can use.
 - **Name:** woocommerce/product-filters
 - **Category:** woocommerce
 - **Supports:** align, color (background, button, heading, text, ~~enableContrastChecker~~), inserter, interactivity, layout (default, ~~allowEditing~~), spacing (blockGap), typography (fontSize)
-- **Attributes:** isPreview, showFilterDrawer
+- **Attributes:** isPreview, overlayMenu, showFilterDrawer
 
 ## Active Filters - woocommerce/product-filter-active
 

--- a/plugins/woocommerce/changelog/product-filters-overlay-setting
+++ b/plugins/woocommerce/changelog/product-filters-overlay-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Product Filters overlay setting to match the Navigation block overlay options.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/block.json
@@ -40,6 +40,9 @@
 			"type": "boolean",
 			"default": false
 		},
+		"overlayMenu": {
+			"type": "string"
+		},
 		"showFilterDrawer": {
 			"type": "boolean",
 			"default": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/edit.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
@@ -7,7 +8,11 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { BlockEditProps, InnerBlockTemplate } from '@wordpress/blocks';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
@@ -19,8 +24,9 @@ import clsx from 'clsx';
  * Internal dependencies
  */
 import './editor.scss';
-import { type BlockAttributes } from './types';
+import { type BlockAttributes, type OverlayMenu } from './types';
 import { getColorsFromBlockSupports } from './utils/get-colors-from-block-supports';
+import { getOverlayMenu } from './utils/overlay-menu';
 import { presetToCssVariable } from './utils/preset-to-css-variable';
 
 const TEMPLATE: InnerBlockTemplate[] = [
@@ -46,7 +52,9 @@ const TEMPLATE: InnerBlockTemplate[] = [
 export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 	const { attributes, setAttributes } = props;
 	const { isPreview } = attributes;
-	const showFilterDrawer = attributes.showFilterDrawer !== false;
+	const overlayMenu = getOverlayMenu( attributes );
+	const hasOverlay = overlayMenu !== 'never';
+	const isOverlayAlways = overlayMenu === 'always';
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const globalColors = getSetting< { background?: string; text?: string } >(
@@ -65,7 +73,8 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filters', {
 			'is-overlay-opened': isOpen,
-			'is-filter-drawer-disabled': ! showFilterDrawer,
+			'is-filter-drawer-disabled': ! hasOverlay,
+			'is-overlay-always': isOverlayAlways,
 		} ),
 		style: {
 			'--wc-product-filters-background-color':
@@ -86,7 +95,7 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 				<InnerBlocks templateLock={ false } template={ TEMPLATE } />
 			</div>
 		);
-	} else if ( showFilterDrawer ) {
+	} else if ( hasOverlay ) {
 		filtersContent = (
 			<>
 				<button
@@ -147,27 +156,40 @@ export const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
-					<ToggleControl
-						label={ __(
-							'Collapse filters on small screens',
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Overlay menu', 'woocommerce' ) }
+						aria-label={ __(
+							'Configure overlay menu',
 							'woocommerce'
 						) }
-						help={
-							showFilterDrawer
-								? __(
-										'Shoppers tap a button to open filters.',
-										'woocommerce'
-								  )
-								: __(
-										'Filters are shown directly on the page.',
-										'woocommerce'
-								  )
-						}
-						checked={ showFilterDrawer }
+						value={ overlayMenu }
+						help={ __(
+							'Collapses filters into a menu icon that opens an overlay.',
+							'woocommerce'
+						) }
 						onChange={ ( value ) =>
-							setAttributes( { showFilterDrawer: value } )
+							setAttributes( {
+								overlayMenu: value as OverlayMenu,
+								showFilterDrawer: undefined,
+							} )
 						}
-					/>
+						isBlock
+					>
+						<ToggleGroupControlOption
+							value="never"
+							label={ __( 'Off', 'woocommerce' ) }
+						/>
+						<ToggleGroupControlOption
+							value="mobile"
+							label={ __( 'Mobile', 'woocommerce' ) }
+						/>
+						<ToggleGroupControlOption
+							value="always"
+							label={ __( 'Always', 'woocommerce' ) }
+						/>
+					</ToggleGroupControl>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>{ filtersContent }</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/save.tsx
@@ -9,15 +9,18 @@ import clsx from 'clsx';
  */
 import './editor.scss';
 import { type BlockAttributes } from './types';
+import { getOverlayMenu } from './utils/overlay-menu';
 
 export const Save = ( {
 	attributes,
 }: {
 	attributes: BlockAttributes;
 } ): JSX.Element => {
+	const overlayMenu = getOverlayMenu( attributes );
 	const blockProps = useBlockProps.save( {
 		className: clsx( 'wc-block-product-filters', {
-			'is-filter-drawer-disabled': attributes.showFilterDrawer === false,
+			'is-filter-drawer-disabled': overlayMenu === 'never',
+			'is-overlay-always': overlayMenu === 'always',
 		} ),
 	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -1,5 +1,5 @@
 :where(.wc-block-product-filters) {
-	--top-padding: var(--wp-admin--admin-bar--height);
+	--top-padding: var(--wp-admin--admin-bar--height, 0);
 	@include breakpoint("<782px") {
 		--top-padding: var(--adminbar-mobile-padding, 0);
 	}
@@ -116,8 +116,8 @@
 	}
 
 	@include breakpoint(">600px") {
-		&,
-		&.is-overlay-opened {
+		&:not(.is-overlay-always),
+		&:not(.is-overlay-always).is-overlay-opened {
 			display: flex;
 
 			.wc-block-product-filters__overlay-header,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -51,9 +51,12 @@ export type ProductFiltersContext = {
 // ----------------------------------------
 // Block props
 // ----------------------------------------
+export type OverlayMenu = 'never' | 'mobile' | 'always';
+
 export type BlockAttributes = {
 	productId?: string;
 	isPreview: boolean;
+	overlayMenu?: OverlayMenu;
 	showFilterDrawer?: boolean;
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/overlay-menu/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/overlay-menu/index.ts
@@ -1,0 +1,25 @@
+import { type BlockAttributes, type OverlayMenu } from '../../types';
+
+export const DEFAULT_OVERLAY_MENU: OverlayMenu = 'mobile';
+
+const OVERLAY_MENU_VALUES: OverlayMenu[] = [ 'never', 'mobile', 'always' ];
+
+const isOverlayMenu = ( value: unknown ): value is OverlayMenu =>
+	OVERLAY_MENU_VALUES.includes( value as OverlayMenu );
+
+export const getOverlayMenu = ( attributes: BlockAttributes ): OverlayMenu => {
+	if (
+		isOverlayMenu( attributes.overlayMenu ) &&
+		attributes.overlayMenu !== DEFAULT_OVERLAY_MENU
+	) {
+		return attributes.overlayMenu;
+	}
+
+	if ( attributes.showFilterDrawer === false ) {
+		return 'never';
+	}
+
+	return isOverlayMenu( attributes.overlayMenu )
+		? attributes.overlayMenu
+		: DEFAULT_OVERLAY_MENU;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/overlay-menu/test/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/overlay-menu/test/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { getOverlayMenu } from '../';
+
+describe( 'getOverlayMenu', () => {
+	it( 'defaults to mobile', () => {
+		expect( getOverlayMenu( { isPreview: false } ) ).toBe( 'mobile' );
+	} );
+
+	it( 'returns explicit overlay menu settings', () => {
+		expect(
+			getOverlayMenu( { isPreview: false, overlayMenu: 'always' } )
+		).toBe( 'always' );
+		expect(
+			getOverlayMenu( { isPreview: false, overlayMenu: 'never' } )
+		).toBe( 'never' );
+	} );
+
+	it( 'maps the legacy disabled drawer setting to never', () => {
+		expect(
+			getOverlayMenu( {
+				isPreview: false,
+				overlayMenu: 'mobile',
+				showFilterDrawer: false,
+			} )
+		).toBe( 'never' );
+	} );
+
+	it( 'prioritizes explicit non-default overlay settings over legacy settings', () => {
+		expect(
+			getOverlayMenu( {
+				isPreview: false,
+				overlayMenu: 'always',
+				showFilterDrawer: false,
+			} )
+		).toBe( 'always' );
+	} );
+} );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -111,10 +111,14 @@ class ProductFilters extends AbstractBlock {
 			'forcePageReload' => isset( $block->context['forcePageReload'] ) ? (bool) $block->context['forcePageReload'] : null,
 		);
 
-		$show_filter_drawer = ! isset( $attributes['showFilterDrawer'] ) || false !== $attributes['showFilterDrawer'];
-		$wrapper_classes    = array( 'wc-block-product-filters' );
-		if ( ! $show_filter_drawer ) {
+		$overlay_menu    = $this->get_overlay_menu( $attributes, $block );
+		$has_overlay     = 'never' !== $overlay_menu;
+		$wrapper_classes = array( 'wc-block-product-filters' );
+		if ( ! $has_overlay ) {
 			$wrapper_classes[] = 'is-filter-drawer-disabled';
+		}
+		if ( 'always' === $overlay_menu ) {
+			$wrapper_classes[] = 'is-overlay-always';
 		}
 
 		$wrapper_attributes = array(
@@ -126,7 +130,7 @@ class ProductFilters extends AbstractBlock {
 			'style'                         => $this->get_css_variables( $attributes ),
 		);
 
-		if ( $show_filter_drawer ) {
+		if ( $has_overlay ) {
 			$wrapper_attributes['data-wp-watch--scrolling']         = 'callbacks.scrollLimit';
 			$wrapper_attributes['data-wp-on--keyup']                = 'actions.closeOverlayOnEscape';
 			$wrapper_attributes['data-wp-class--is-overlay-opened'] = 'context.isOverlayOpened';
@@ -140,7 +144,7 @@ class ProductFilters extends AbstractBlock {
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<?php if ( $show_filter_drawer ) : ?>
+			<?php if ( $has_overlay ) : ?>
 				<button
 					type="button"
 					class="wc-block-product-filters__open-overlay"
@@ -192,6 +196,58 @@ class ProductFilters extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get overlay menu behavior from block attributes.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Overlay menu behavior.
+	 */
+	private function get_overlay_menu( array $attributes, WP_Block $block ): string {
+		$parsed_attributes   = $block->parsed_block['attrs'] ?? array();
+		$parsed_overlay_menu = $this->get_valid_overlay_menu_value( $parsed_attributes['overlayMenu'] ?? null );
+
+		if ( null !== $parsed_overlay_menu && 'mobile' !== $parsed_overlay_menu ) {
+			return $parsed_overlay_menu;
+		}
+
+		if ( false === ( $parsed_attributes['showFilterDrawer'] ?? null ) ) {
+			return 'never';
+		}
+
+		if ( null !== $parsed_overlay_menu ) {
+			return $parsed_overlay_menu;
+		}
+
+		$overlay_menu = $this->get_valid_overlay_menu_value( $attributes['overlayMenu'] ?? null );
+
+		if ( null !== $overlay_menu && 'mobile' !== $overlay_menu ) {
+			return $overlay_menu;
+		}
+
+		if ( false === ( $attributes['showFilterDrawer'] ?? null ) ) {
+			return 'never';
+		}
+
+		return $overlay_menu ?? 'mobile';
+	}
+
+	/**
+	 * Get a valid overlay menu value.
+	 *
+	 * @param mixed $overlay_menu Overlay menu value.
+	 * @return string|null Valid overlay menu value.
+	 */
+	private function get_valid_overlay_menu_value( $overlay_menu ): ?string {
+		$overlay_values = array( 'never', 'mobile', 'always' );
+
+		if ( ! is_string( $overlay_menu ) ) {
+			return null;
+		}
+
+		return in_array( $overlay_menu, $overlay_values, true ) ? $overlay_menu : null;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilters.php
@@ -37,6 +37,13 @@ class ProductFilters extends \WP_UnitTestCase {
 	private $canonical_method;
 
 	/**
+	 * Reflection method used to invoke the private get_overlay_menu method.
+	 *
+	 * @var \ReflectionMethod
+	 */
+	private $overlay_menu_method;
+
+	/**
 	 * Set up the test subject and dependencies.
 	 *
 	 * @return void
@@ -58,6 +65,9 @@ class ProductFilters extends \WP_UnitTestCase {
 
 		$this->canonical_method = new \ReflectionMethod( ProductFiltersBlock::class, 'get_canonical_url_no_pagination' );
 		$this->canonical_method->setAccessible( true );
+
+		$this->overlay_menu_method = new \ReflectionMethod( ProductFiltersBlock::class, 'get_overlay_menu' );
+		$this->overlay_menu_method->setAccessible( true );
 	}
 
 	/**
@@ -104,6 +114,27 @@ class ProductFilters extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Convenience wrapper for invoking the private overlay menu helper.
+	 *
+	 * @param array $attributes        Block attributes after defaults are applied.
+	 * @param array $parsed_attributes Raw parsed block attributes.
+	 * @return string
+	 */
+	private function invoke_overlay_menu_helper( array $attributes, array $parsed_attributes = array() ): string {
+		$block = new \WP_Block(
+			array(
+				'blockName'    => 'woocommerce/product-filters',
+				'attrs'        => $parsed_attributes,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			)
+		);
+
+		return (string) $this->overlay_menu_method->invoke( $this->product_filters, $attributes, $block );
+	}
+
+	/**
 	 * Ensures get_pagenum_link filters receive the expected argument types.
 	 *
 	 * @param mixed $link    Base URL from WordPress.
@@ -123,6 +154,56 @@ class ProductFilters extends \WP_UnitTestCase {
 		$this->assertTrue(
 			null === $escape || is_bool( $escape ),
 			'The get_pagenum_link filter must receive a null or boolean escape flag as the third argument.'
+		);
+	}
+
+	/**
+	 * @testdox Should resolve overlay menu settings.
+	 *
+	 * @param array  $attributes        Block attributes after defaults are applied.
+	 * @param array  $parsed_attributes Raw parsed block attributes.
+	 * @param string $expected          Expected overlay menu setting.
+	 * @return void
+	 *
+	 * @dataProvider overlay_menu_provider
+	 */
+	public function test_resolves_overlay_menu( array $attributes, array $parsed_attributes, string $expected ): void {
+		$this->assertSame(
+			$expected,
+			$this->invoke_overlay_menu_helper( $attributes, $parsed_attributes ),
+			'Overlay menu should match the configured or legacy setting.'
+		);
+	}
+
+	/**
+	 * Provides Product Filters overlay menu settings.
+	 *
+	 * @return array[]
+	 */
+	public function overlay_menu_provider(): array {
+		return array(
+			'default'                 => array( array(), array(), 'mobile' ),
+			'parsed mobile'           => array( array(), array( 'overlayMenu' => 'mobile' ), 'mobile' ),
+			'parsed always'           => array( array(), array( 'overlayMenu' => 'always' ), 'always' ),
+			'parsed never'            => array( array(), array( 'overlayMenu' => 'never' ), 'never' ),
+			'legacy disabled'         => array(
+				array(
+					'overlayMenu'      => 'mobile',
+					'showFilterDrawer' => false,
+				),
+				array( 'showFilterDrawer' => false ),
+				'never',
+			),
+			'parsed explicit always'  => array(
+				array( 'showFilterDrawer' => false ),
+				array(
+					'overlayMenu'      => 'always',
+					'showFilterDrawer' => false,
+				),
+				'always',
+			),
+			'attribute fallback'      => array( array( 'overlayMenu' => 'always' ), array(), 'always' ),
+			'invalid parsed fallback' => array( array(), array( 'overlayMenu' => 'desktop' ), 'mobile' ),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Updates Product Filters to use the same Overlay menu choices as the Navigation block: Off, Mobile, and Always.

Also keeps legacy `showFilterDrawer` blocks compatible and adds test coverage for the overlay setting resolver.

### Screenshots or screen recordings:

Not included.

### How to test the changes in this Pull Request:

1. Open the Site Editor and select a Product Filters block.
2. In block settings, verify the Overlay menu control has Off, Mobile, and Always options.
3. Set Off and confirm filters render inline.
4. Set Mobile and confirm the overlay button appears on small screens and filters render inline on desktop.
5. Set Always and confirm the overlay button appears on desktop and mobile, and opens/closes the filters overlay.

### Testing that has already taken place:

- `pnpm --filter=@woocommerce/block-library test:js -- assets/js/blocks/product-filters/utils/overlay-menu/test/index.ts --runInBand`
- `pnpm --filter=@woocommerce/block-library exec eslint assets/js/blocks/product-filters/edit.tsx assets/js/blocks/product-filters/save.tsx assets/js/blocks/product-filters/types.ts assets/js/blocks/product-filters/utils/overlay-menu/index.ts assets/js/blocks/product-filters/utils/overlay-menu/test/index.ts --ext=js,jsx,ts,tsx`
- `pnpm --filter=@woocommerce/block-library exec stylelint assets/js/blocks/product-filters/style.scss`
- `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter ProductFilters`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `pnpm --filter=@woocommerce/plugin-woocommerce exec composer exec -- phpstan analyse src/Blocks/BlockTypes/ProductFilters.php --memory-limit=2G`
- `pnpm --filter=@woocommerce/plugin-woocommerce changelog validate`

### Milestone

- [x] Automatically assign milestone for the [next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)

### Changelog entry

Manual changelog entry added: `plugins/woocommerce/changelog/product-filters-overlay-setting`.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

- [ ] Feature Highlight - For user-facing features (what changed, user impact)
- [ ] Developer Advisory - For developer-facing changes (what changed, how to detect, actions needed)
