### PR TITLE
Add "Send test email" action to the emails listing page

### DIFF
--- a/plugins/woocommerce/changelog/65128-add-send-test-email-to-emails-listing
+++ b/plugins/woocommerce/changelog/65128-add-send-test-email-to-emails-listing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a "Send test email" action to the emails listing page (block email editor).

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
@@ -218,6 +218,31 @@ describe( 'useSendTestEmail + SendTestEmailForm', () => {
 		);
 	} );
 
+	it( 'submits the form when Enter is pressed in the email field, but not while the email is invalid', async () => {
+		apiFetchMock.mockResolvedValue( { success: true, result: true } );
+
+		render( <Harness target={ editorTarget } source="email_listing" /> );
+
+		const emailField = screen.getByLabelText( 'Send to' );
+
+		fireEvent.change( emailField, {
+			target: { value: 'not-an-email' },
+		} );
+		fireEvent.submit( emailField );
+		expect( apiFetchMock ).not.toHaveBeenCalled();
+
+		fireEvent.change( emailField, {
+			target: { value: 'merchant@example.com' },
+		} );
+		fireEvent.submit( emailField );
+
+		await waitFor( () =>
+			expect(
+				screen.getByText( 'Test email sent successfully!' )
+			).toBeInTheDocument()
+		);
+	} );
+
 	it( 'invokes onCancel when the cancel button is clicked', () => {
 		const onCancel = jest.fn();
 		render(

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
@@ -191,6 +191,33 @@ describe( 'useSendTestEmail + SendTestEmailForm', () => {
 		);
 	} );
 
+	it( 'shows the busy "Sending…" state while the request is in flight', async () => {
+		let resolveRequest: ( value: unknown ) => void = () => {};
+		apiFetchMock.mockImplementation(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveRequest = resolve;
+				} )
+		);
+
+		render( <Harness target={ editorTarget } source="email_listing" /> );
+
+		enterEmailAndSend( 'merchant@example.com' );
+
+		const sendingButton = await screen.findByRole( 'button', {
+			name: 'Sending…',
+		} );
+		expect( sendingButton ).toBeDisabled();
+
+		resolveRequest( { success: true, result: true } );
+
+		await waitFor( () =>
+			expect(
+				screen.getByRole( 'button', { name: 'Send test email' } )
+			).toBeEnabled()
+		);
+	} );
+
 	it( 'invokes onCancel when the cancel button is clicked', () => {
 		const onCancel = jest.fn();
 		render(

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for the shared "Send a test email" flow (useSendTestEmail +
+ * SendTestEmailForm) used by both the email preview page and the emails list.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import {
+	SendTestEmailForm,
+	useSendTestEmail,
+	type SendTestEmailSource,
+	type SendTestEmailTarget,
+} from '../settings-email-send-test';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const recordEventMock = jest.fn();
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: ( name: string, payload: Record< string, unknown > ) =>
+		recordEventMock( name, payload ),
+} ) );
+
+jest.mock( '~/utils/admin-settings', () => ( {
+	getAdminSetting: () => 'test-nonce',
+} ) );
+
+const apiFetchMock = apiFetch as unknown as jest.Mock;
+
+const Harness = ( {
+	target,
+	source,
+	onCancel = () => {},
+}: {
+	target: SendTestEmailTarget;
+	source: SendTestEmailSource;
+	onCancel?: () => void;
+} ) => {
+	const { email, setEmail, isSending, notice, noticeType, sendEmail } =
+		useSendTestEmail( target, source );
+
+	return (
+		<SendTestEmailForm
+			email={ email }
+			onEmailChange={ setEmail }
+			isSending={ isSending }
+			notice={ notice }
+			noticeType={ noticeType }
+			onSend={ sendEmail }
+			onCancel={ onCancel }
+		/>
+	);
+};
+
+const editorTarget: SendTestEmailTarget = {
+	endpoint: 'editor',
+	postId: 123,
+	emailType: 'new_order',
+};
+
+const settingsTarget: SendTestEmailTarget = {
+	endpoint: 'settings',
+	emailType: 'WC_Email_New_Order',
+};
+
+const enterEmailAndSend = ( address: string ) => {
+	fireEvent.change( screen.getByLabelText( 'Send to' ), {
+		target: { value: address },
+	} );
+	fireEvent.click(
+		screen.getByRole( 'button', { name: 'Send test email' } )
+	);
+};
+
+describe( 'useSendTestEmail + SendTestEmailForm', () => {
+	beforeEach( () => {
+		apiFetchMock.mockReset();
+		recordEventMock.mockClear();
+	} );
+
+	it( 'disables the send button until a valid email is entered', () => {
+		render( <Harness target={ editorTarget } source="email_listing" /> );
+
+		const sendButton = screen.getByRole( 'button', {
+			name: 'Send test email',
+		} );
+		expect( sendButton ).toBeDisabled();
+
+		fireEvent.change( screen.getByLabelText( 'Send to' ), {
+			target: { value: 'not-an-email' },
+		} );
+		expect( sendButton ).toBeDisabled();
+
+		fireEvent.change( screen.getByLabelText( 'Send to' ), {
+			target: { value: 'merchant@example.com' },
+		} );
+		expect( sendButton ).toBeEnabled();
+	} );
+
+	it( 'editor target: posts the post ID to the email editor endpoint and shows the success notice', async () => {
+		apiFetchMock.mockResolvedValue( { success: true, result: true } );
+
+		render( <Harness target={ editorTarget } source="email_listing" /> );
+
+		enterEmailAndSend( 'merchant@example.com' );
+
+		await waitFor( () =>
+			expect(
+				screen.getByText( 'Test email sent successfully!' )
+			).toBeInTheDocument()
+		);
+
+		expect( apiFetchMock ).toHaveBeenCalledWith( {
+			path: '/woocommerce-email-editor/v1/send_preview_email',
+			method: 'POST',
+			data: {
+				email: 'merchant@example.com',
+				postId: 123,
+			},
+		} );
+		expect( recordEventMock ).toHaveBeenCalledWith(
+			'settings_emails_preview_test_sent_successful',
+			{
+				email_type: 'new_order',
+				source: 'email_listing',
+			}
+		);
+	} );
+
+	it( 'settings target: posts the email type class name to the send-preview endpoint and shows the response message', async () => {
+		apiFetchMock.mockResolvedValue( { message: 'Test email sent.' } );
+
+		render( <Harness target={ settingsTarget } source="email_preview" /> );
+
+		enterEmailAndSend( 'merchant@example.com' );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'Test email sent.' ) ).toBeInTheDocument()
+		);
+
+		expect( apiFetchMock ).toHaveBeenCalledWith( {
+			path: 'wc-admin-email/settings/email/send-preview?nonce=test-nonce',
+			method: 'POST',
+			data: {
+				email: 'merchant@example.com',
+				type: 'WC_Email_New_Order',
+			},
+		} );
+		expect( recordEventMock ).toHaveBeenCalledWith(
+			'settings_emails_preview_test_sent_successful',
+			{
+				email_type: 'WC_Email_New_Order',
+				source: 'email_preview',
+			}
+		);
+	} );
+
+	it( 'shows the friendly error message and records the failure with its source', async () => {
+		apiFetchMock.mockRejectedValue( {
+			code: 'rest_cookie_invalid_nonce',
+			message: 'Cookie check failed',
+			data: { status: 403 },
+		} );
+
+		render( <Harness target={ editorTarget } source="email_listing" /> );
+
+		enterEmailAndSend( 'merchant@example.com' );
+
+		await waitFor( () =>
+			expect(
+				screen.getByText(
+					'Your session expired. Refresh the page and try again.'
+				)
+			).toBeInTheDocument()
+		);
+
+		expect( recordEventMock ).toHaveBeenCalledWith(
+			'settings_emails_preview_test_sent_failed',
+			{
+				email_type: 'new_order',
+				error: 'Cookie check failed',
+				error_code: 'rest_cookie_invalid_nonce',
+				source: 'email_listing',
+			}
+		);
+	} );
+
+	it( 'invokes onCancel when the cancel button is clicked', () => {
+		const onCancel = jest.fn();
+		render(
+			<Harness
+				target={ editorTarget }
+				source="email_listing"
+				onCancel={ onCancel }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onCancel ).toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -206,9 +206,10 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				label: __( 'Send test email', 'woocommerce' ),
 				supportsBulk: false,
 				// The editor's send_preview_email endpoint renders the
-				// woo_email post, so a post is required — rows without one
-				// offer the "Recreate email post" action instead.
-				isEligible: ( item: EmailType ) => !! item.post_id,
+				// woo_email post, so a numeric post ID is required — rows
+				// without one offer the "Recreate email post" action instead.
+				isEligible: ( item: EmailType ) =>
+					Number.isFinite( parseInt( item.post_id, 10 ) ),
 				modalHeader: __( 'Send a test email', 'woocommerce' ),
 				RenderModal: ( {
 					items,

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -18,6 +18,38 @@ import { shouldShowReviewUpdate } from './settings-email-listing-update-state';
 import { Status, EMAIL_STATUSES } from './settings-email-listing-status';
 import { RecipientsList } from './settings-email-listing-recipients';
 import { UpdatesCell } from './settings-email-listing-update-cell';
+import {
+	SendTestEmailForm,
+	useSendTestEmail,
+} from './settings-email-send-test';
+
+const SendTestEmailModalContent = ( {
+	postId,
+	emailId,
+	onClose,
+}: {
+	postId: number;
+	emailId: string;
+	onClose: () => void;
+} ) => {
+	const { email, setEmail, isSending, notice, noticeType, sendEmail } =
+		useSendTestEmail(
+			{ endpoint: 'editor', postId, emailType: emailId },
+			'email_listing'
+		);
+
+	return (
+		<SendTestEmailForm
+			email={ email }
+			onEmailChange={ setEmail }
+			isSending={ isSending }
+			notice={ notice }
+			noticeType={ noticeType }
+			onSend={ sendEmail }
+			onCancel={ onClose }
+		/>
+	);
+};
 
 export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 	const [ view, setView ] = useState< View >( {
@@ -172,11 +204,25 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 			{
 				id: 'test',
 				label: __( 'Send test email', 'woocommerce' ),
-				disabled: true,
 				supportsBulk: false,
-				callback: () => {
-					return true; // TODO: Implement send test email
-				},
+				// The editor's send_preview_email endpoint renders the
+				// woo_email post, so a post is required — rows without one
+				// offer the "Recreate email post" action instead.
+				isEligible: ( item: EmailType ) => !! item.post_id,
+				modalHeader: __( 'Send a test email', 'woocommerce' ),
+				RenderModal: ( {
+					items,
+					closeModal,
+				}: {
+					items: EmailType[];
+					closeModal?: () => void;
+				} ) => (
+					<SendTestEmailModalContent
+						postId={ parseInt( items[ 0 ].post_id, 10 ) }
+						emailId={ items[ 0 ].id }
+						onClose={ closeModal ?? ( () => {} ) }
+					/>
+				),
 			},
 			{
 				id: 'change-status',

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -40,6 +40,11 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 		'email_preview'
 	);
 
+	const closeModal = () => {
+		setIsModalOpen( false );
+		setIsSending( false );
+	};
+
 	return (
 		<div className="wc-settings-email-preview-send">
 			<Button
@@ -52,10 +57,7 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 			{ isModalOpen && (
 				<Modal
 					title={ __( 'Send a test email', 'woocommerce' ) }
-					onRequestClose={ () => {
-						setIsModalOpen( false );
-						setIsSending( false );
-					} }
+					onRequestClose={ closeModal }
 					className="wc-settings-email-preview-send-modal"
 				>
 					<SendTestEmailForm
@@ -65,7 +67,7 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 						notice={ notice }
 						noticeType={ noticeType }
 						onSend={ sendEmail }
-						onCancel={ () => setIsModalOpen( false ) }
+						onCancel={ closeModal }
 					/>
 				</Modal>
 			) }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -1,144 +1,44 @@
 /**
  * External dependencies
  */
-import { Button, Modal, TextControl } from '@wordpress/components';
-import { Icon, check, cautionFilled } from '@wordpress/icons';
-import apiFetch from '@wordpress/api-fetch';
+import { Button, Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
-import { emailPreviewNonce } from './settings-email-preview-nonce';
+import {
+	SendTestEmailForm,
+	useSendTestEmail,
+} from './settings-email-send-test';
 
-const isValidEmail = ( email: string ) => {
-	const re =
-		/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-	return re.test( String( email ).toLowerCase() );
-};
+// Re-exported so existing consumers (and tests) keep working after the send
+// logic moved to settings-email-send-test.tsx.
+export {
+	friendlyEmailSendError,
+	isValidEmail,
+	type WPError,
+} from './settings-email-send-test';
 
 type EmailPreviewSendProps = {
 	type: string;
 };
 
-type EmailPreviewSendResponse = {
-	message: string;
-};
-
-export type WPError = {
-	message: string;
-	code: string;
-	data: {
-		status: number;
-	};
-};
-
-/**
- * Maps an apiFetch error into merchant-friendly copy.
- *
- * Where possible we match on stable backend error codes rather than English
- * message strings, so the mapping still works on localized sites. The two
- * branches that still rely on message matches are flagged inline — they don't
- * have stable codes to match against.
- */
-export function friendlyEmailSendError( wpError: WPError ): string {
-	// apiFetch can reject with non-WPError shapes (native TypeError, wrapped middleware errors); unshaped errors fall through to the generic fallback.
-	const code = wpError?.code ?? '';
-	const message = wpError?.message ?? '';
-
-	// Covers both WP core (rest_cookie_invalid_nonce) and Woo's own
-	// EmailPreviewRestController check (invalid_nonce).
-	if ( code === 'rest_cookie_invalid_nonce' || code === 'invalid_nonce' ) {
-		return __(
-			'Your session expired. Refresh the page and try again.',
-			'woocommerce'
-		);
-	}
-
-	// Stable WP core code for a non-JSON response body.
-	if ( code === 'rest_invalid_json' ) {
-		return __(
-			'The server returned unexpected output. Check your error log, or disable recently added plugins.',
-			'woocommerce'
-		);
-	}
-
-	// Locale-fragile: WSOD responses don't carry a structured error code,
-	// so we fall back to matching the English phrase PHP prints.
-	if ( message.includes( 'critical error' ) ) {
-		return __(
-			'A PHP error stopped the send. Check your error log or contact your host.',
-			'woocommerce'
-		);
-	}
-
-	// Stable Woo code emitted by EmailPreviewRestController when the preview
-	// template fails to render.
-	if ( code === 'woocommerce_rest_email_preview_not_rendered' ) {
-		return __(
-			"The email couldn't be rendered. Try resetting the template in Settings → Emails.",
-			'woocommerce'
-		);
-	}
-
-	// Locale-fragile: this apiFetch client fallback has no stable code, so
-	// we compare against the English message directly.
-	if ( message === 'Could not get a valid response from the server.' ) {
-		return __(
-			'Your server timed out. If it keeps happening, ask your host to check PHP execution limits.',
-			'woocommerce'
-		);
-	}
-
-	return __(
-		"Couldn't send the test email. Check your email settings and try again.",
-		'woocommerce'
-	);
-}
-
 export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const [ email, setEmail ] = useState( '' );
-	const [ isSending, setIsSending ] = useState( false );
-	const [ notice, setNotice ] = useState( '' );
-	const [ noticeType, setNoticeType ] = useState( '' );
-
-	const nonce = emailPreviewNonce();
-
-	const handleSendEmail = async () => {
-		setIsSending( true );
-		setNotice( '' );
-
-		try {
-			const response: EmailPreviewSendResponse = await apiFetch( {
-				path: `wc-admin-email/settings/email/send-preview?nonce=${ nonce }`,
-				method: 'POST',
-				data: { email, type },
-			} );
-
-			setNotice( response.message );
-			setNoticeType( 'success' );
-
-			recordEvent( 'settings_emails_preview_test_sent_successful', {
-				email_type: type,
-			} );
-		} catch ( e ) {
-			const wpError = e as WPError;
-
-			setNotice( friendlyEmailSendError( wpError ) );
-			setNoticeType( 'error' );
-
-			recordEvent( 'settings_emails_preview_test_sent_failed', {
-				email_type: type,
-				error: wpError.message,
-				error_code: wpError.code,
-			} );
-		}
-
-		setIsSending( false );
-	};
+	const {
+		email,
+		setEmail,
+		isSending,
+		setIsSending,
+		notice,
+		noticeType,
+		sendEmail,
+	} = useSendTestEmail(
+		{ endpoint: 'settings', emailType: type },
+		'email_preview'
+	);
 
 	return (
 		<div className="wc-settings-email-preview-send">
@@ -158,55 +58,15 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 					} }
 					className="wc-settings-email-preview-send-modal"
 				>
-					<p>
-						{ __(
-							'Send yourself a test email to check how your email looks in different email apps.',
-							'woocommerce'
-						) }
-					</p>
-
-					<TextControl
-						label={ __( 'Send to', 'woocommerce' ) }
-						type="email"
-						value={ email }
-						placeholder={ __( 'Enter an email', 'woocommerce' ) }
-						onChange={ setEmail }
+					<SendTestEmailForm
+						email={ email }
+						onEmailChange={ setEmail }
+						isSending={ isSending }
+						notice={ notice }
+						noticeType={ noticeType }
+						onSend={ sendEmail }
+						onCancel={ () => setIsModalOpen( false ) }
 					/>
-
-					{ notice && (
-						<div
-							className={ `wc-settings-email-preview-send-modal-notice wc-settings-email-preview-send-modal-notice-${ noticeType }` }
-						>
-							<Icon
-								icon={
-									noticeType === 'success'
-										? check
-										: cautionFilled
-								}
-							/>
-							<span>{ notice }</span>
-						</div>
-					) }
-
-					<div className="wc-settings-email-preview-send-modal-buttons">
-						<Button
-							variant="tertiary"
-							onClick={ () => setIsModalOpen( false ) }
-						>
-							{ __( 'Cancel', 'woocommerce' ) }
-						</Button>
-
-						<Button
-							variant="primary"
-							onClick={ handleSendEmail }
-							isBusy={ isSending }
-							disabled={ ! isValidEmail( email ) || isSending }
-						>
-							{ isSending
-								? __( 'Sending…', 'woocommerce' )
-								: __( 'Send test email', 'woocommerce' ) }
-						</Button>
-					</div>
 				</Modal>
 			) }
 		</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
@@ -167,8 +167,10 @@ export const useSendTestEmail = (
 
 			recordEvent( 'settings_emails_preview_test_sent_failed', {
 				email_type: target.emailType,
-				error: wpError.message,
-				error_code: wpError.code,
+				// apiFetch can reject with non-WPError shapes (e.g. a native
+				// TypeError), so guard against missing fields.
+				error: wpError?.message ?? '',
+				error_code: wpError?.code ?? '',
 				source,
 			} );
 		}
@@ -229,6 +231,7 @@ export const SendTestEmailForm = ( {
 
 			{ notice && (
 				<div
+					role={ noticeType === 'error' ? 'alert' : 'status' }
 					className={ `wc-settings-email-preview-send-modal-notice wc-settings-email-preview-send-modal-notice-${ noticeType }` }
 				>
 					<Icon

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
@@ -1,0 +1,261 @@
+/**
+ * External dependencies
+ */
+import { Button, TextControl } from '@wordpress/components';
+import { Icon, check, cautionFilled } from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { emailPreviewNonce } from './settings-email-preview-nonce';
+
+export const isValidEmail = ( email: string ) => {
+	const re =
+		/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+	return re.test( String( email ).toLowerCase() );
+};
+
+type SendTestEmailResponse = {
+	message: string;
+};
+
+export type WPError = {
+	message: string;
+	code: string;
+	data: {
+		status: number;
+	};
+};
+
+/**
+ * Maps an apiFetch error into merchant-friendly copy.
+ *
+ * Where possible we match on stable backend error codes rather than English
+ * message strings, so the mapping still works on localized sites. The two
+ * branches that still rely on message matches are flagged inline — they don't
+ * have stable codes to match against.
+ */
+export function friendlyEmailSendError( wpError: WPError ): string {
+	// apiFetch can reject with non-WPError shapes (native TypeError, wrapped middleware errors); unshaped errors fall through to the generic fallback.
+	const code = wpError?.code ?? '';
+	const message = wpError?.message ?? '';
+
+	// Covers both WP core (rest_cookie_invalid_nonce) and Woo's own
+	// EmailPreviewRestController check (invalid_nonce).
+	if ( code === 'rest_cookie_invalid_nonce' || code === 'invalid_nonce' ) {
+		return __(
+			'Your session expired. Refresh the page and try again.',
+			'woocommerce'
+		);
+	}
+
+	// Stable WP core code for a non-JSON response body.
+	if ( code === 'rest_invalid_json' ) {
+		return __(
+			'The server returned unexpected output. Check your error log, or disable recently added plugins.',
+			'woocommerce'
+		);
+	}
+
+	// Locale-fragile: WSOD responses don't carry a structured error code,
+	// so we fall back to matching the English phrase PHP prints.
+	if ( message.includes( 'critical error' ) ) {
+		return __(
+			'A PHP error stopped the send. Check your error log or contact your host.',
+			'woocommerce'
+		);
+	}
+
+	// Stable Woo code emitted by EmailPreviewRestController when the preview
+	// template fails to render.
+	if ( code === 'woocommerce_rest_email_preview_not_rendered' ) {
+		return __(
+			"The email couldn't be rendered. Try resetting the template in Settings → Emails.",
+			'woocommerce'
+		);
+	}
+
+	// Locale-fragile: this apiFetch client fallback has no stable code, so
+	// we compare against the English message directly.
+	if ( message === 'Could not get a valid response from the server.' ) {
+		return __(
+			'Your server timed out. If it keeps happening, ask your host to check PHP execution limits.',
+			'woocommerce'
+		);
+	}
+
+	return __(
+		"Couldn't send the test email. Check your email settings and try again.",
+		'woocommerce'
+	);
+}
+
+/**
+ * Where the send-test-email UI was opened from. Added to the Tracks payload so
+ * sends from the email preview and from the emails list can be told apart.
+ */
+export type SendTestEmailSource = 'email_preview' | 'email_listing';
+
+/**
+ * Which backend renders and sends the test email.
+ *
+ * - `settings`: the wc-admin-email send-preview endpoint, driven by the exact
+ *   WC_Email class name (`emailType`). Used by the legacy email preview page.
+ * - `editor`: the email editor's send_preview_email endpoint, driven by the
+ *   `woo_email` post ID — the exact pipeline the block email editor's own
+ *   "Send a test email" modal uses. `emailType` is only used for Tracks.
+ */
+export type SendTestEmailTarget =
+	| { endpoint: 'settings'; emailType: string }
+	| { endpoint: 'editor'; postId: number; emailType: string };
+
+/**
+ * State and send logic for the "Send a test email" flow, shared between the
+ * email preview page and the emails list.
+ *
+ * @param target Backend to send through, see SendTestEmailTarget.
+ * @param source Where the UI was opened from, for Tracks.
+ */
+export const useSendTestEmail = (
+	target: SendTestEmailTarget,
+	source: SendTestEmailSource
+) => {
+	const [ email, setEmail ] = useState( '' );
+	const [ isSending, setIsSending ] = useState( false );
+	const [ notice, setNotice ] = useState( '' );
+	const [ noticeType, setNoticeType ] = useState( '' );
+
+	const sendEmail = async () => {
+		setIsSending( true );
+		setNotice( '' );
+
+		try {
+			if ( target.endpoint === 'editor' ) {
+				await apiFetch( {
+					path: '/woocommerce-email-editor/v1/send_preview_email',
+					method: 'POST',
+					data: { email, postId: target.postId },
+				} );
+
+				setNotice(
+					__( 'Test email sent successfully!', 'woocommerce' )
+				);
+			} else {
+				const response: SendTestEmailResponse = await apiFetch( {
+					path: `wc-admin-email/settings/email/send-preview?nonce=${ emailPreviewNonce() }`,
+					method: 'POST',
+					data: { email, type: target.emailType },
+				} );
+
+				setNotice( response.message );
+			}
+			setNoticeType( 'success' );
+
+			recordEvent( 'settings_emails_preview_test_sent_successful', {
+				email_type: target.emailType,
+				source,
+			} );
+		} catch ( e ) {
+			const wpError = e as WPError;
+
+			setNotice( friendlyEmailSendError( wpError ) );
+			setNoticeType( 'error' );
+
+			recordEvent( 'settings_emails_preview_test_sent_failed', {
+				email_type: target.emailType,
+				error: wpError.message,
+				error_code: wpError.code,
+				source,
+			} );
+		}
+
+		setIsSending( false );
+	};
+
+	return {
+		email,
+		setEmail,
+		isSending,
+		setIsSending,
+		notice,
+		noticeType,
+		sendEmail,
+	};
+};
+
+type SendTestEmailFormProps = {
+	email: string;
+	onEmailChange: ( email: string ) => void;
+	isSending: boolean;
+	notice: string;
+	noticeType: string;
+	onSend: () => void;
+	onCancel: () => void;
+};
+
+/**
+ * Modal body of the "Send a test email" flow: recipient field, result notice,
+ * and Cancel/Send buttons. Controlled — pair with `useSendTestEmail`.
+ */
+export const SendTestEmailForm = ( {
+	email,
+	onEmailChange,
+	isSending,
+	notice,
+	noticeType,
+	onSend,
+	onCancel,
+}: SendTestEmailFormProps ) => {
+	return (
+		<>
+			<p>
+				{ __(
+					'Send yourself a test email to check how your email looks in different email apps.',
+					'woocommerce'
+				) }
+			</p>
+
+			<TextControl
+				label={ __( 'Send to', 'woocommerce' ) }
+				type="email"
+				value={ email }
+				placeholder={ __( 'Enter an email', 'woocommerce' ) }
+				onChange={ onEmailChange }
+			/>
+
+			{ notice && (
+				<div
+					className={ `wc-settings-email-preview-send-modal-notice wc-settings-email-preview-send-modal-notice-${ noticeType }` }
+				>
+					<Icon
+						icon={
+							noticeType === 'success' ? check : cautionFilled
+						}
+					/>
+					<span>{ notice }</span>
+				</div>
+			) }
+
+			<div className="wc-settings-email-preview-send-modal-buttons">
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+
+				<Button
+					variant="primary"
+					onClick={ onSend }
+					isBusy={ isSending }
+					disabled={ ! isValidEmail( email ) || isSending }
+				>
+					{ isSending
+						? __( 'Sending…', 'woocommerce' )
+						: __( 'Send test email', 'woocommerce' ) }
+				</Button>
+			</div>
+		</>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-send-test.tsx
@@ -213,7 +213,15 @@ export const SendTestEmailForm = ( {
 	onCancel,
 }: SendTestEmailFormProps ) => {
 	return (
-		<>
+		<form
+			onSubmit={ ( e ) => {
+				e.preventDefault();
+				if ( ! isValidEmail( email ) || isSending ) {
+					return;
+				}
+				onSend();
+			} }
+		>
 			<p>
 				{ __(
 					'Send yourself a test email to check how your email looks in different email apps.',
@@ -249,8 +257,8 @@ export const SendTestEmailForm = ( {
 				</Button>
 
 				<Button
+					type="submit"
 					variant="primary"
-					onClick={ onSend }
 					isBusy={ isSending }
 					disabled={ ! isValidEmail( email ) || isSending }
 				>
@@ -259,6 +267,6 @@ export const SendTestEmailForm = ( {
 						: __( 'Send test email', 'woocommerce' ) }
 				</Button>
 			</div>
-		</>
+		</form>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a "Send test email" action to the emails list's three-dot menu when block email editor is enabled.

The modal posts the row's `woo_email` post ID to the block email editor's existing `send_preview_email` REST endpoint, so the test email is rendered exactly like sending a test from the email editor itself.

Closes #65128, closes WOOPLUG-6716.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|     <img width="1265" height="598" alt="Screenshot 2026-07-08 at 11 45 40" src="https://github.com/user-attachments/assets/39ca0956-4914-4a2d-a868-c1e1eea0a151" />   |   <img width="1243" height="830" alt="Screenshot 2026-07-08 at 14 00 31" src="https://github.com/user-attachments/assets/0e400b48-6b0f-4c14-9315-9c66c748e5d0" /> <img width="735" height="790" alt="Screenshot 2026-07-08 at 14 00 59" src="https://github.com/user-attachments/assets/6badafe0-82d0-4ae4-ac6a-222390ff313f" />  |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable **Block Email Editor (alpha)** in **WooCommerce → Settings → Advanced → Features**.
2. Go to **WooCommerce → Settings → Emails**, open the three-dot menu on any email row, and click **Send test email**.
3. Send test email and confirm you received it (actually, or e.g. via WP Mail Logging) and it uses the same template as block email editor and not when the feature is disabled (they are slightly different).
4. Check that sending email continues working from email editor, and also when block-email editor feature is disabled.

<!-- End testing instructions -->

### Testing that has already taken place:

- New Jest suite for the shared hook/form covering: send button disabled until a valid address is entered, editor-endpoint payload (`postId`), settings-endpoint payload (`type`), success and error notices, friendly error mapping, Tracks events with the new `source` property, and cancel handling.
- All pre-existing `client/settings-email` Jest suites pass unchanged (34 tests total).
- `pnpm run ts:check`, ESLint on changed files, and branch-level lint are clean.
- Static analysis of the REST endpoint's permission model (`edit_posts` + `edit_post` + REST cookie nonce); no backend changes were needed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
