### PR TITLE
Store API: restore billing address fallback when checkout omits the shipping address

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-checkout-shipping-address-fallback
+++ b/plugins/woocommerce/changelog/fix-store-api-checkout-shipping-address-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: fall back to the billing address when a checkout request omits the shipping address and the cart needs shipping.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -69964,7 +69964,7 @@ parameters:
 		-
 			message: '#^Expression on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.expr
-			count: 3
+			count: 2
 			path: src/StoreApi/Routes/V1/Checkout.php
 
 		-

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -902,11 +902,9 @@ class Checkout extends AbstractCartRoute {
 			$additional_fields = $this->additional_fields_controller->get_contextual_fields_for_location( $context_data['location'], $document_object );
 
 			if ( 'shipping_address' === $context_data['param'] ) {
-				$field_values = (array) $request['shipping_address'] ?? ( $request['billing_address'] ?? [] );
-
-				if ( ! WC()->cart->needs_shipping() ) {
-					$field_values = $request['billing_address'] ?? [];
-				}
+				$field_values = WC()->cart->needs_shipping()
+					? (array) ( $request['shipping_address'] ?? $request['billing_address'] ?? [] )
+					: (array) ( $request['billing_address'] ?? [] );
 			} else {
 				$field_values = (array) $request[ $context_data['param'] ] ?? [];
 			}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -214,6 +214,135 @@ class Checkout extends MockeryTestCase {
 	}
 
 	/**
+	 * Billing address used by the shipping address fallback tests.
+	 *
+	 * @return array
+	 */
+	private function get_fallback_billing_address() {
+		return array(
+			'first_name' => 'Billing',
+			'last_name'  => 'Person',
+			'company'    => '',
+			'address_1'  => '10 Billing Street',
+			'address_2'  => '',
+			'city'       => 'Cambridge',
+			'state'      => '',
+			'postcode'   => 'cb241ab',
+			'country'    => 'GB',
+			'phone'      => '01223 000000',
+			'email'      => 'testaccount@test.com',
+		);
+	}
+
+	/**
+	 * Shipping address used by the shipping address fallback tests.
+	 *
+	 * @return array
+	 */
+	private function get_fallback_shipping_address() {
+		return array(
+			'first_name' => 'Shipping',
+			'last_name'  => 'Person',
+			'company'    => '',
+			'address_1'  => '20 Shipping Street',
+			'address_2'  => '',
+			'city'       => 'Oxford',
+			'state'      => '',
+			'postcode'   => 'ox11aa',
+			'country'    => 'GB',
+			'phone'      => '01865 000000',
+		);
+	}
+
+	/**
+	 * When the cart needs shipping and the request omits the shipping address, the billing address is used as the
+	 * shipping address.
+	 *
+	 * Regression test: the fallback never ran because `(array)` binds tighter than `??`, so the null coalesce
+	 * operated on an already-cast empty array instead of on the missing `shipping_address` param. That left the
+	 * order without a shipping address, which then failed pre-payment validation.
+	 */
+	public function test_omitted_shipping_address_falls_back_to_billing_address() {
+		$this->assertTrue( WC()->cart->needs_shipping(), 'Test cart is expected to need shipping.' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address' => (object) $this->get_fallback_billing_address(),
+				'payment_method'  => WC_Gateway_BACS::ID,
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+
+		$order = wc_get_order( $response->get_data()['order_id'] );
+		$this->assertInstanceOf( \WC_Order::class, $order );
+		$this->assertEquals( 'Billing', $order->get_shipping_first_name() );
+		$this->assertEquals( 'Person', $order->get_shipping_last_name() );
+		$this->assertEquals( '10 Billing Street', $order->get_shipping_address_1() );
+		$this->assertEquals( 'Cambridge', $order->get_shipping_city() );
+		$this->assertEquals( 'CB24 1AB', $order->get_shipping_postcode() );
+		$this->assertEquals( 'GB', $order->get_shipping_country() );
+	}
+
+	/**
+	 * When the cart needs shipping and a shipping address is provided, it is used as-is rather than being overwritten
+	 * by the billing address fallback.
+	 */
+	public function test_provided_shipping_address_is_used_when_cart_needs_shipping() {
+		$this->assertTrue( WC()->cart->needs_shipping(), 'Test cart is expected to need shipping.' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) $this->get_fallback_billing_address(),
+				'shipping_address' => (object) $this->get_fallback_shipping_address(),
+				'payment_method'   => WC_Gateway_BACS::ID,
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+
+		$order = wc_get_order( $response->get_data()['order_id'] );
+		$this->assertInstanceOf( \WC_Order::class, $order );
+		$this->assertEquals( 'Shipping', $order->get_shipping_first_name() );
+		$this->assertEquals( '20 Shipping Street', $order->get_shipping_address_1() );
+		$this->assertEquals( 'Oxford', $order->get_shipping_city() );
+	}
+
+	/**
+	 * When the cart does not need shipping, the provided shipping address is ignored in favour of the billing address.
+	 */
+	public function test_shipping_address_is_ignored_when_cart_does_not_need_shipping() {
+		wc_empty_cart();
+		WC()->cart->add_to_cart( $this->products[2]->get_id(), 1 );
+		$this->assertFalse( WC()->cart->needs_shipping(), 'Test cart is expected to not need shipping.' );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) $this->get_fallback_billing_address(),
+				'shipping_address' => (object) $this->get_fallback_shipping_address(),
+				'payment_method'   => WC_Gateway_BACS::ID,
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+
+		$order = wc_get_order( $response->get_data()['order_id'] );
+		$this->assertInstanceOf( \WC_Order::class, $order );
+		$this->assertEquals( 'Billing', $order->get_shipping_first_name() );
+		$this->assertEquals( '10 Billing Street', $order->get_shipping_address_1() );
+		$this->assertEquals( 'Cambridge', $order->get_shipping_city() );
+	}
+
+	/**
 	 * Ensure that orders can be placed with virtual products.
 	 */
 	public function test_virtual_product_post_data() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`(array)` binds tighter than `??`, so this line never falls back:

```php
$field_values = (array) $request['shipping_address'] ?? ( $request['billing_address'] ?? [] );
```

`(array) null` is `[]`, not `null`. The coalesce never fires. So when a cart needs shipping and the request leaves out `shipping_address`, nothing gets persisted, the order is saved with no shipping address, and pre-payment validation rejects it with `woocommerce_rest_invalid_address`. Web checkout always sends a shipping address, so nobody has hit this in practice.

The fallback was deliberate when it landed in woocommerce-blocks#6050, and broke in #55570 when the block moved to contextual additional fields. 

PHPStan has been pointing at it the whole time (`Expression on left side of ?? is not nullable`, baselined for this file); the fix takes that count from 3 to 2. The other two are the same shape but harmless, so I left them.

Found while reading the code, not reported, so there's no issue to close.

(For Bug Fixes) Bug introduced in PR #55570.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Green CI is sufficient — the regression test covers it.

1.  `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter Checkout`
2.  To see the bug: revert the `src/StoreApi/Routes/V1/Checkout.php` hunk and re-run. `test_omitted_shipping_address_falls_back_to_billing_address` fails with a 400.

<!-- End testing instructions -->

### Testing that has already taken place:

-   Before + After regression unit test

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

The changelog entry is already committed to the branch as `plugins/woocommerce/changelog/fix-store-api-checkout-shipping-address-fallback`, so neither box above is checked.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Store API: fall back to the billing address when a checkout request omits the shipping address and the cart needs shipping.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

Neither: this is a patch-level edge-case fix on a path web checkout never hits, and it changes no promised surface.
