### PR TITLE
Fix false "unsaved changes"/"Leave site?" warning on the order edit screen

### DIFF
--- a/plugins/woocommerce/changelog/66418-fix-order-edit-unsaved-changes-warning
+++ b/plugins/woocommerce/changelog/66418-fix-order-edit-unsaved-changes-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a false "unsaved changes" warning when leaving the order edit screen without making any changes.

--- a/plugins/woocommerce/changelog/fix-66308-order-edit-unsaved-changes-warning
+++ b/plugins/woocommerce/changelog/fix-66308-order-edit-unsaved-changes-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix false "unsaved changes"/"Leave site?" warning shown when clicking Update on the order edit screen after editing notes.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -25,8 +25,13 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
+			$( '#woocommerce-order-actions button, #woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
 				window.onbeforeunload = '';
+				// Also detach WordPress core's unsaved-changes guard. When the `autosave` script is
+				// enqueued on the order screen, post.js registers a namespaced jQuery beforeunload
+				// handler, so clearing window.onbeforeunload alone does not remove it. This mirrors
+				// what post.js itself does on its own form submit.
+				$( window ).off( 'beforeunload.edit-post' );
 			});
 			$( 'a.edit_address' ).on( 'click', this.edit_address );
 			$( 'a.billing-same-as-shipping' ).on( 'click', this.copy_billing_to_shipping );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -25,7 +25,9 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( '#woocommerce-order-actions button, #woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
+			var orderActionsSelector = '#woocommerce-order-actions button, ' +
+				'#woocommerce-order-actions input, #woocommerce-order-actions a';
+			$( orderActionsSelector ).on( 'click', function() {
 				window.onbeforeunload = '';
 				// Also detach WordPress core's unsaved-changes guard. When the `autosave` script is
 				// enqueued on the order screen, post.js registers a namespaced jQuery beforeunload


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On the order edit screen the browser shows a false "Changes that you made may not be saved." / "Leave site?" prompt when clicking **Update**, even though the order saves.

Root cause: WP core's `post.js` registers a namespaced jQuery guard `$( window ).on( 'beforeunload.edit-post', … )` that fires whenever `wp.autosave.server.postChanged()` reports a diff on the tracked fields (`#title`/`#content`/`#excerpt`). That guard became active on the order screen once the `autosave` script started being enqueued there. WooCommerce already tries to suppress the prompt on intentional saves in `meta-boxes-order.js`, but that code never worked:

1. The click selector matched only `input`/`a`, so it never fired on the `<button>` **Update** and **Apply** controls in the Order actions box.
2. `window.onbeforeunload = ''` (a DOM property) cannot detach a jQuery-bound handler.

This PR adds `button` to the selector and detaches WP core's guard with `$( window ).off( 'beforeunload.edit-post' )` on intentional order actions — mirroring what `post.js` does on its own form submit. It repairs the suppression for any dirty-state source on the order screen, complementing #66001 (which removed the specific `#excerpt`/customer-note collision, so the reporter's exact repro no longer triggers on trunk — this change hardens the intended suppression against any remaining or extension-added tracked-field collision).

Closes #66308
Closes #65773
Closes #66310


(For Bug Fixes) Bug introduced in PR #64334 (enqueued `autosave` on the order screen, arming WP core's dirty-state guard).

### How to test the changes in this Pull Request:

1. On a clean site (only WooCommerce active, Storefront/TT theme), enable HPOS (WooCommerce → Settings → Advanced → Features → High-Performance Order Storage).
2. Create at least one order (WooCommerce → Orders → Add order → set a customer → Create).
3. Open the order for editing (`admin.php?page=wc-orders&action=edit&id=…`).
4. To see the pre-#66001 behavior, temporarily give any order-screen field one of the WP-tracked ids (e.g. set the customer-note textarea id back to `excerpt`), edit it, then click **Update**. Without this patch: the browser shows "Changes that you made may not be saved." / "Leave site?". With this patch: the order saves with **no** prompt.
5. Regression check — genuine unsaved changes are still protected on accidental navigation: edit such a field, then click a browser link / the back button (not Update); the prompt should still appear.
6. Confirm normal saves are unaffected: edit a billing field and click Update — the order saves with no prompt.

### Testing that has already taken place:

- `node --check` passes on the edited file and the change conforms to the legacy ESLint config (`max-len: 140`).
- Mechanism traced through WP core `wp-includes/js/autosave.js` and `wp-admin/js/post.js` to confirm the tracked fields, the `beforeunload.edit-post` registration, and that `post.js` itself detaches the same namespaced handler on its own submit.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

A changelog file is included in the PR: `plugins/woocommerce/changelog/fix-66308-order-edit-unsaved-changes-warning` (`Significance: patch`, `Type: fix`).

