### PR TITLE
Fix plugin-check CI job to use the E2E env after wp-env config split

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7014-fix-plugin-check-job-env
+++ b/plugins/woocommerce/changelog/wooplug-7014-fix-plugin-check-job-env
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Point the nightly/release 'Checks from plugin-check plugin' CI job at the full E2E wp-env config, which provisions the plugin-check plugin, so `wp plugin check` no longer fails as an unregistered subcommand after the wp-env test config split.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -104,7 +104,7 @@
 		"test:php:env": "sh ./client/blocks/bin/copy-blocks-json.sh && pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli vendor/bin/phpunit -c phpunit.xml --verbose",
 		"test:php:env:hpos-off": "sh ./client/blocks/bin/copy-blocks-json.sh && pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli env DISABLE_HPOS=1 vendor/bin/phpunit -c phpunit.xml --verbose",
 		"test:php:env:watch": "sh ./client/blocks/bin/copy-blocks-json.sh && pnpm wp-env:test run --env-cwd='wp-content/plugins/woocommerce' cli vendor/bin/phpunit-watcher watch --verbose",
-		"test:plugincheck": "pnpm wp-env:test run cli wp plugin check ${PLUGIN_SLUG:-woocommerce}",
+		"test:plugincheck": "pnpm wp-env:e2e run cli wp plugin check ${PLUGIN_SLUG:-woocommerce}",
 		"test:unit": "pnpm test:php",
 		"test:unit:watch": "pnpm test:php:watch",
 		"test:unit:env": "pnpm test:php:env",
@@ -276,7 +276,7 @@
 					"optional": true,
 					"changes": [],
 					"testEnv": {
-						"start": "env:test --debug"
+						"start": "env:e2e --debug"
 					},
 					"events": [
 						"nightly-checks",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a CI regression introduced by the wp-env test config split (#66401).

This PR points the plugin-check job (and its `test:plugincheck` script) at the **E2E** config, which already provisions plugin-check — keeping the lean PHP-unit env lean rather than re-adding E2E-only tooling to it.

- `package.json` → `test:plugincheck` now runs via `wp-env:e2e`
- `package.json` → the job's `testEnv.start` is now `env:e2e --debug`

This is a CI-only change: the job is `optional: true` and fires only on nightly/release events, so it is invisible to PR/push CI (which is why it slipped through review of #66401).

Closes WOOPLUG-7014.

### How to test the changes in this Pull Request:

Since the affected job only runs on `nightly-checks` / `release-checks`, verify locally:

1. `cd plugins/woocommerce`
2. `pnpm env:e2e` (starts the E2E wp-env; its lifecycle installs + activates plugin-check).
3. `PLUGIN_SLUG=woocommerce pnpm test:plugincheck` — confirm `wp plugin check` runs (does **not** error with *"'check' is not a registered subcommand"*).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
