### PR TITLE
php tests: Balance output buffers in WC_AJAX order-add-meta nonce test

### DIFF
--- a/plugins/woocommerce/changelog/php-tests-unbalanced-output-buffers-risky-test
+++ b/plugins/woocommerce/changelog/php-tests-unbalanced-output-buffers-risky-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Balance the output-buffer level in the WC_AJAX order-add-meta nonce test so it is no longer reported as risky.

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -683,13 +683,15 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$output_buffering_level = ob_get_level();
 
 		try {
-			// Note that _handleAjax makes use of output buffering...
+			// Note that _handleAjax makes use of output buffering, which the die
+			// handler usually cleans up; the finally block below closes only any
+			// buffer it leaves dangling so the buffer level stays balanced.
 			$this->_handleAjax( $ajax_action );
 		} catch ( Exception $e ) {
-			// ...However, if an exception is raised, it may not be able to clean-up,
-			// which can lead to PhpUnit emitting risky test warnings.
-			if ( ob_get_level() === $output_buffering_level + 1 ) {
-				ob_get_clean();
+			unset( $e );
+		} finally {
+			while ( ob_get_level() > $output_buffering_level ) {
+				ob_end_clean();
 			}
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -650,10 +650,19 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$_POST['metakeyinput']         = 'my_test_key';
 		$_POST['metavalue']            = 'my_test_value';
 
+		$output_buffering_level = ob_get_level();
+
 		try {
+			// Note that _handleAjax makes use of output buffering, which the die
+			// handler usually cleans up; the finally block below closes only any
+			// buffer it leaves dangling so the buffer level stays balanced.
 			$this->_handleAjax( 'woocommerce_order_add_meta' );
 		} catch ( WPAjaxDieContinueException $e ) {
-			ob_end_clean();
+			unset( $e );
+		} finally {
+			while ( ob_get_level() > $output_buffering_level ) {
+				ob_end_clean();
+			}
 		}
 
 		$this->assertStringContainsString(

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -107,11 +107,18 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$_POST['permissions'] = 'read';
 		$_POST['description'] = $description;
 
+		$output_buffering_level = ob_get_level();
+
 		try {
 			$this->_handleAjax( 'woocommerce_update_api_key' );
 		} catch ( WPAjaxDieContinueException $e ) {
-			// wp_die() doesn't actually occur, so we need to clean up WC_AJAX::update_api_key's output buffer.
-			ob_end_clean();
+			unset( $e );
+		} finally {
+			// wp_die() doesn't actually occur, so clean up any output buffer
+			// WC_AJAX::update_api_key leaves open, keeping the level balanced.
+			while ( ob_get_level() > $output_buffering_level ) {
+				ob_end_clean();
+			}
 		}
 
 		$response = json_decode( $this->_last_response, true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_AJAX_Test::test_order_add_meta_delete_button_uses_name_value_nonce` called `ob_end_clean()` unconditionally, over-closing a buffer WordPress's AJAX die handler had already closed. 
It now records the buffer level on entry and closes only dangling buffers in a `finally` block, keeping the level balanced on every path.

### How to test the changes in this Pull Request:

1. Run: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_order_add_meta_delete_button_uses_name_value_nonce`
2. Confirm it passes and is no longer reported under "There was 1 risky test".
3. CI should be green

### Testing that has already taken place:

Ran the filtered test in wp-env (PHP 8.1.34, PHPUnit 9.6.29): passes with no risky-test warning. `phpcs-changed` reports no issues on the changed lines.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->