### PR TITLE
Fix: Declare internal-build dependency in tools/storybook

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4409,6 +4409,9 @@ importers:
       '@woocommerce/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/js/eslint-plugin
+      '@woocommerce/internal-build':
+        specifier: workspace:*
+        version: link:../../packages/js/internal-build
       '@wordpress/base-styles':
         specifier: catalog:wp-bundled
         version: 6.9.1

--- a/tools/storybook/package.json
+++ b/tools/storybook/package.json
@@ -49,6 +49,7 @@
 		"@woocommerce/admin-library": "workspace:*",
 		"@woocommerce/block-library": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
+		"@woocommerce/internal-build": "workspace:*",
 		"@wordpress/base-styles": "catalog:wp-bundled",
 		"react": "18.3.x",
 		"react-dom": "18.3.x",


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`tools/storybook/webpack.config.js` requires `@woocommerce/internal-build/style-build`, but the package was never declared in `tools/storybook/package.json`. It only resolved through incidental pnpm hoisting via the `@woocommerce/admin-library` and `@woocommerce/block-library` workspace packages. On a clean, strictly isolated install (as the nightly Storybook build performs), that hoisting is not guaranteed, so the require can fail with `MODULE_NOT_FOUND`.

This PR declares `@woocommerce/internal-build` explicitly as a workspace `devDependency` of `tools/storybook`, matching how every other consumer in the monorepo declares it (for example the admin client and `@woocommerce/components`), and adds the corresponding `pnpm-lock.yaml` importer entry.

Closes #66426.

(For Bug Fixes) Bug introduced in PR #65651.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. From the repo root, run a clean/isolated install so hoisting can't mask the missing declaration, e.g. `pnpm install --frozen-lockfile` (the lockfile now includes the declared dependency).
3. Build Storybook: `pnpm --filter='@woocommerce/storybook' build`.
4. Confirm the build resolves `@woocommerce/internal-build/style-build` and completes without a `MODULE_NOT_FOUND` error.

### Testing that has already taken place:

- Verified `tools/storybook/webpack.config.js:13` imports `@woocommerce/internal-build/style-build` and that the subpath resolves to `packages/js/internal-build/src/style-build/index.cjs` via the package's `exports` map (`require` condition), which exports `WebpackRTLPlugin`.
- Confirmed `@woocommerce/internal-build` was absent from `tools/storybook/package.json` and is declared as `workspace:*` by other consumers in the monorepo.
- Ran `pnpm install --lockfile-only`; it converged with exactly the added importer entry and no other drift, confirming the lockfile is consistent.
- LLM/AI-based review (multi-agent) of the diff returned no findings.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Manually assigned to `11.1.0` to match the PR that introduced the issue (65651).

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Development-tooling only. The change touches `tools/storybook` (a private, unpublished package that does not participate in the changelogger system) and the root `pnpm-lock.yaml`. No user- or developer-facing WooCommerce package is affected, so no changelog entry is required.

</details>
