### PR TITLE
Stop redundant error_log noise from handled settings-UI fallbacks

### DIFF
--- a/plugins/woocommerce/changelog/php-tests-settings-ui-fallback-error-log-noise
+++ b/plugins/woocommerce/changelog/php-tests-settings-ui-fallback-error-log-noise
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stop redundant error_log noise from handled settings-UI resolution fallbacks; the recovered condition is already recorded via the logger.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -367,7 +367,7 @@ class SettingsUIRequestContext {
 		try {
 			$registered_section = SettingsSectionRegistry::get_instance()->get_registered( $settings_page->get_id(), $section );
 		} catch ( \Throwable $e ) {
-			self::log_resolution_failure( 'Registered settings section', $settings_page->get_id(), $section, $e, __METHOD__ );
+			self::log_resolution_failure( 'Registered settings section', $settings_page->get_id(), $section, $e );
 			$registered_section = null;
 		}
 
@@ -379,7 +379,7 @@ class SettingsUIRequestContext {
 						return $settings_ui_page;
 					}
 				} catch ( \Throwable $e ) {
-					self::log_resolution_failure( 'Native Settings UI page', $settings_page->get_id(), $section, $e, __METHOD__ );
+					self::log_resolution_failure( 'Native Settings UI page', $settings_page->get_id(), $section, $e );
 
 					// Raise a developer notice here only: this failure still
 					// renders through the registered-section adapter, so
@@ -423,7 +423,7 @@ class SettingsUIRequestContext {
 		} catch ( \Throwable $e ) {
 			$this->script_handles_failed = true;
 
-			self::log_resolution_failure( 'Settings UI script handles', $this->get_page_id(), $this->section, $e, __METHOD__ );
+			self::log_resolution_failure( 'Settings UI script handles', $this->get_page_id(), $this->section, $e );
 
 			if ( $e instanceof \Exception ) {
 				$this->script_handles_failure_reason = sprintf(
@@ -451,7 +451,7 @@ class SettingsUIRequestContext {
 		} catch ( \Throwable $e ) {
 			$this->schema_failed = true;
 
-			self::log_resolution_failure( 'Settings UI schema', $this->get_page_id(), $this->section, $e, __METHOD__ );
+			self::log_resolution_failure( 'Settings UI schema', $this->get_page_id(), $this->section, $e );
 		}
 	}
 
@@ -462,9 +462,8 @@ class SettingsUIRequestContext {
 	 * @param string     $page_id Settings page id.
 	 * @param string     $section Section id. Empty string means the default section.
 	 * @param \Throwable $e The resolution failure.
-	 * @param string     $caller Calling method, for exception tracking.
 	 */
-	private static function log_resolution_failure( string $subject, string $page_id, string $section, \Throwable $e, string $caller ): void {
+	private static function log_resolution_failure( string $subject, string $page_id, string $section, \Throwable $e ): void {
 		wc_get_logger()->debug(
 			sprintf(
 				'%1$s could not be resolved for page "%2$s" section "%3$s": %4$s: %5$s',
@@ -476,10 +475,6 @@ class SettingsUIRequestContext {
 			),
 			array( 'source' => 'settings-ui' )
 		);
-
-		if ( $e instanceof \Exception ) {
-			wc_caught_exception( $e, $caller );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
@@ -242,30 +242,28 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should report exceptions from a registered section native Settings UI page provider and fall back to the default adapter.
+	 * @testdox Should fall back to the default adapter when a registered section native Settings UI page provider throws an exception.
 	 */
 	public function test_falls_back_to_default_adapter_when_registered_section_native_settings_ui_page_provider_throws_exception(): void {
 		$this->setExpectedIncorrectUsage( SettingsUIRequestContext::class . '::resolve_settings_ui_page' );
-
-		$caught   = array();
-		$listener = static function ( $exception ) use ( &$caught ): void {
-			$caught[] = $exception;
-		};
-		add_action( 'woocommerce_caught_exception', $listener );
 
 		$page      = $this->get_parent_page();
 		$exception = new \RuntimeException( 'Unable to resolve native settings UI page.' );
 		SettingsSectionRegistry::get_instance()->register( $this->get_registered_section( 'acme_payments', $exception ) );
 
-		try {
-			$settings_ui_page = SettingsUIRequestContext::for_settings_page( $page, 'acme_payments' )->get_settings_ui_page();
-		} finally {
-			remove_action( 'woocommerce_caught_exception', $listener );
-		}
+		$settings_ui_page = SettingsUIRequestContext::for_settings_page( $page, 'acme_payments' )->get_settings_ui_page();
 
+		// Mirrors the `\Error` case above with a thrown `\Exception`: both must
+		// fall back to the default adapter (signalled by the doing_it_wrong notice
+		// asserted above) so the schema still resolves. Keeping both throwable
+		// types guards against a regression that narrows the provider's catch from
+		// `\Throwable` to `\Exception`, which would let an `\Error` escape and
+		// fatal — caught by the sibling test, but not by this one.
 		$this->assertInstanceOf( SettingsUIPageInterface::class, $settings_ui_page );
 		$this->assertSame( 'checkout', $settings_ui_page->get_page_id() );
-		$this->assertSame( array( $exception ), $caught, 'Provider exceptions should be reported through wc_caught_exception().' );
+
+		$schema = $settings_ui_page->get_schema( 'acme_payments' );
+		$this->assertSame( 'registered_acme_payments_setting', $schema['groups']['default']['fields'][0]['id'] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`SettingsUIRequestContext::log_resolution_failure()` fired an unconditional `wc_caught_exception()` → `error_log()` on *handled, recovered* settings-UI fallbacks, printing `Exception caught in …resolve_settings_ui_page. …. Args: Array` on every CI run.

This removes that `error_log`. The fallback is still recorded via `wc_get_logger()->debug()`, and `resolve_settings_ui_page()` still raises `wc_doing_it_wrong()` where user-facing. The now-unused `$caller` parameter is dropped, and the fallback test that asserted the removed side effect now asserts the recovery outcome instead.

**BC note:** `wc_caught_exception()` also fires the `woocommerce_caught_exception` action, so that action no longer fires for these four recovered fallbacks (it still fires everywhere else). Intentional, but observable for any third-party listener.

### How to test the changes in this Pull Request:

1. Check out this branch and start the PHP test environment.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'SettingsSectionRegistryTest|SettingsUIFeatureFlagTest'`.
3. Confirm tests pass and no `Exception caught in …SettingsUIRequestContext…` lines appear in the output.

### Testing that has already taken place:

- `SettingsSectionRegistryTest` + `SettingsUIFeatureFlagTest`: 29 tests, 87 assertions, OK; 0 `Exception caught in` lines (was noisy before).
- PHPStan on the changed file: no errors. `phpcs`: clean.
- Environment: `wp-env` PHP-unit config, PHP 8.1, PHPUnit 9.6.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
