### PR TITLE
Fix: encoded character in filter option label

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6950-product-filters-category-in-taxonomy-term-labels-is-double
+++ b/plugins/woocommerce/changelog/wooplug-6950-product-filters-category-in-taxonomy-term-labels-is-double
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix encoded character in filter option label.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -120,10 +120,11 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		foreach ( $attribute_terms as $term_object ) {
 			$attribute_name = str_replace( 'pa_', '', $term_object->taxonomy );
+			$term_name      = wp_specialchars_decode( $term_object->name, ENT_QUOTES );
 			$items[]        = array(
 				'type'               => 'attribute/' . $attribute_name,
 				'value'              => $term_object->slug,
-				'activeLabel'        => sprintf( '%s: %s', $product_attributes_map[ $attribute_name ], $term_object->name ),
+				'activeLabel'        => sprintf( '%s: %s', $product_attributes_map[ $attribute_name ], $term_name ),
 				'attributeQueryType' => $query_types[ $attribute_name ] ?? 'or',
 			);
 		}
@@ -208,11 +209,12 @@ final class ProductFilterAttribute extends AbstractBlock {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
 
-					$type = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
-					$item = array(
+					$term_name = wp_specialchars_decode( $term['name'], ENT_QUOTES );
+					$type      = 'attribute/' . str_replace( 'pa_', '', $product_attribute->slug );
+					$item      = array(
 						'id'                 => $type . '-' . $term['slug'],
-						'label'              => $term['name'],
-						'ariaLabel'          => $term['name'],
+						'label'              => $term_name,
+						'ariaLabel'          => $term_name,
 						'value'              => $term['slug'],
 						'selected'           => in_array( $term['slug'], $selected_terms, true ),
 						'type'               => $type,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -67,10 +67,11 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		foreach ( $terms as $term ) {
 			$taxonomy_object = get_taxonomy( $term->taxonomy );
 			if ( $taxonomy_object ) {
-				$items[] = array(
+				$term_name = wp_specialchars_decode( $term->name, ENT_QUOTES );
+				$items[]   = array(
 					'type'        => 'taxonomy/' . $term->taxonomy,
 					'value'       => $term->slug,
-					'activeLabel' => $taxonomy_object->labels->singular_name . ': ' . $term->name,
+					'activeLabel' => $taxonomy_object->labels->singular_name . ': ' . $term_name,
 				);
 			}//end if
 		}
@@ -243,12 +244,13 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 				function ( $term ) use ( $taxonomy_counts, $selected_terms, $taxonomy, $show_counts ) {
 					$term          = (array) $term;
 					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
+					$term_name     = wp_specialchars_decode( $term['name'], ENT_QUOTES );
 
 					$type   = 'taxonomy/' . $taxonomy;
 					$option = array(
 						'id'        => $type . '-' . $term['slug'],
-						'label'     => $term['name'],
-						'ariaLabel' => $term['name'],
+						'label'     => $term_name,
+						'ariaLabel' => $term_name,
 						'value'     => $term['slug'],
 						'selected'  => in_array( $term['slug'], $selected_terms, true ),
 						'type'      => $type,

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterAttributeTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterAttributeTest.php
@@ -3,17 +3,59 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
+use WC_Unit_Test_Case;
+
 /**
  * Tests for the ProductFilterAttribute block type.
  */
-class ProductFilterAttributeTest extends \WP_UnitTestCase {
+class ProductFilterAttributeTest extends WC_Unit_Test_Case {
 
 	/**
-	 * Test that rendering returns empty string when the attribute ID references a deleted taxonomy.
+	 * Attribute counts returned by the product filter data hook.
 	 *
-	 * Regression test for https://github.com/woocommerce/woocommerce/issues/63791
+	 * @var array
 	 */
-	public function test_render_returns_empty_for_deleted_attribute() {
+	private $attribute_counts = array();
+
+	/**
+	 * Attribute IDs created during tests.
+	 *
+	 * @var array
+	 */
+	private $attribute_ids = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'woocommerce_pre_product_filter_data', array( $this, 'filter_product_filter_data' ), 10, 4 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_pre_product_filter_data', array( $this, 'filter_product_filter_data' ), 10 );
+
+		foreach ( $this->attribute_ids as $attribute_id ) {
+			wc_delete_attribute( $attribute_id );
+		}
+
+		if ( taxonomy_exists( 'pa_material' ) ) {
+			unregister_taxonomy( 'pa_material' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should render empty output when the attribute ID references a deleted taxonomy.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/63791.
+	 */
+	public function test_render_returns_empty_for_deleted_attribute(): void {
 		$non_existent_attribute_id = 999999;
 
 		$block_markup = sprintf(
@@ -27,5 +69,101 @@ class ProductFilterAttributeTest extends \WP_UnitTestCase {
 		$output = render_block( $blocks[0] );
 
 		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * @testdox Should render decoded attribute term labels in checkbox filters.
+	 */
+	public function test_renders_decoded_attribute_term_labels_in_checkbox_filters(): void {
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'Material',
+				'slug' => 'material',
+			)
+		);
+
+		$this->assertIsInt( $attribute_id, 'Attribute should be created.' );
+
+		$this->attribute_ids[] = $attribute_id;
+
+		if ( ! taxonomy_exists( 'pa_material' ) ) {
+			register_taxonomy( 'pa_material', array( 'product' ), array( 'labels' => array( 'name' => 'Material' ) ) );
+		}
+
+		$term = wp_insert_term( 'Cotton & Linen', 'pa_material' );
+
+		$this->assertNotWPError( $term );
+
+		$term_id                       = (int) $term['term_id'];
+		$this->attribute_counts        = array( $term_id => 1 );
+		$stored_term                   = get_term( $term_id, 'pa_material' );
+		$expected_serialized_label     = 'Cotton &amp; Linen';
+		$expected_context_label        = 'Cotton \\u0026 Linen';
+		$double_encoded_serialization  = 'Cotton &amp;amp; Linen';
+		$double_encoded_context_entity = '\\u0026amp;';
+
+		$this->assertSame( 'Cotton &amp; Linen', $stored_term->name, 'Term fixture should use WordPress encoded storage.' );
+
+		$output = $this->render_attribute_filter_with_checkbox_list( $attribute_id );
+
+		$this->assertStringContainsString( $expected_serialized_label, $output, 'Rendered label should be serialized once for HTML output.' );
+		$this->assertStringContainsString( $expected_context_label, $output, 'Interactivity context should contain the decoded label.' );
+		$this->assertStringNotContainsString( $double_encoded_serialization, $output, 'Rendered label should not be double-encoded.' );
+		$this->assertStringNotContainsString( $double_encoded_context_entity, $output, 'Interactivity context should not contain an encoded entity label.' );
+	}
+
+	/**
+	 * Render an attribute filter block with a checkbox list inner block.
+	 *
+	 * @param int $attribute_id Attribute ID.
+	 * @return string
+	 */
+	private function render_attribute_filter_with_checkbox_list( int $attribute_id ): string {
+		$attribute_block = array(
+			'blockName'    => 'woocommerce/product-filter-attribute',
+			'attrs'        => array(
+				'attributeId' => $attribute_id,
+				'hideEmpty'   => false,
+				'queryType'   => 'or',
+				'sortOrder'   => 'name-asc',
+			),
+			'innerBlocks'  => array(
+				array(
+					'blockName'    => 'woocommerce/product-filter-checkbox-list',
+					'attrs'        => array(),
+					'innerBlocks'  => array(),
+					'innerHTML'    => '',
+					'innerContent' => array(),
+				),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+		$parsed_block    = array(
+			'blockName'    => 'woocommerce/product-filters',
+			'attrs'        => array( 'showFilterDrawer' => false ),
+			'innerBlocks'  => array( $attribute_block ),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+
+		return ( new \WP_Block( $parsed_block ) )->render();
+	}
+
+	/**
+	 * Filter product filter data for tests.
+	 *
+	 * @param mixed  $results     Filter data results.
+	 * @param string $filter_type Filter type.
+	 * @param array  $query_vars  Query variables.
+	 * @param array  $extra       Extra filter arguments.
+	 * @return mixed
+	 */
+	public function filter_product_filter_data( $results, string $filter_type, array $query_vars, array $extra ) {
+		if ( 'attribute' === $filter_type ) {
+			return $this->attribute_counts;
+		}
+
+		return $results;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterTaxonomyTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductFilterTaxonomyTest.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the ProductFilterTaxonomy block type.
+ */
+class ProductFilterTaxonomyTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Term counts returned by the product filter data hook.
+	 *
+	 * @var array
+	 */
+	private $taxonomy_counts = array();
+
+	/**
+	 * Term IDs created during tests.
+	 *
+	 * @var array
+	 */
+	private $term_ids = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'woocommerce_pre_product_filter_data', array( $this, 'filter_product_filter_data' ), 10, 4 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_pre_product_filter_data', array( $this, 'filter_product_filter_data' ), 10 );
+
+		foreach ( $this->term_ids as $term_id ) {
+			wp_delete_term( $term_id, 'product_cat' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should render decoded taxonomy term labels in checkbox filters.
+	 */
+	public function test_renders_decoded_taxonomy_term_labels_in_checkbox_filters(): void {
+		$term = wp_insert_term( 'Indoor & Tropical Bonsai', 'product_cat' );
+
+		$this->assertNotWPError( $term );
+
+		$term_id                       = (int) $term['term_id'];
+		$this->term_ids[]              = $term_id;
+		$this->taxonomy_counts         = array( $term_id => 1 );
+		$stored_term                   = get_term( $term_id, 'product_cat' );
+		$expected_serialized_label     = 'Indoor &amp; Tropical Bonsai';
+		$expected_context_label        = 'Indoor \\u0026 Tropical Bonsai';
+		$double_encoded_serialization  = 'Indoor &amp;amp; Tropical Bonsai';
+		$double_encoded_context_entity = '\\u0026amp;';
+
+		$this->assertSame( 'Indoor &amp; Tropical Bonsai', $stored_term->name, 'Term fixture should use WordPress encoded storage.' );
+
+		$output = $this->render_taxonomy_filter_with_checkbox_list();
+
+		$this->assertStringContainsString( $expected_serialized_label, $output, 'Rendered label should be serialized once for HTML output.' );
+		$this->assertStringContainsString( $expected_context_label, $output, 'Interactivity context should contain the decoded label.' );
+		$this->assertStringNotContainsString( $double_encoded_serialization, $output, 'Rendered label should not be double-encoded.' );
+		$this->assertStringNotContainsString( $double_encoded_context_entity, $output, 'Interactivity context should not contain an encoded entity label.' );
+	}
+
+	/**
+	 * Render a taxonomy filter block with a checkbox list inner block.
+	 *
+	 * @return string
+	 */
+	private function render_taxonomy_filter_with_checkbox_list(): string {
+		$taxonomy_block = array(
+			'blockName'    => 'woocommerce/product-filter-taxonomy',
+			'attrs'        => array(
+				'taxonomy'  => 'product_cat',
+				'sortOrder' => 'name-asc',
+			),
+			'innerBlocks'  => array(
+				array(
+					'blockName'    => 'woocommerce/product-filter-checkbox-list',
+					'attrs'        => array(),
+					'innerBlocks'  => array(),
+					'innerHTML'    => '',
+					'innerContent' => array(),
+				),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+		$parsed_block   = array(
+			'blockName'    => 'woocommerce/product-filters',
+			'attrs'        => array( 'showFilterDrawer' => false ),
+			'innerBlocks'  => array( $taxonomy_block ),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+
+		return ( new \WP_Block( $parsed_block ) )->render();
+	}
+
+	/**
+	 * Filter product filter data for tests.
+	 *
+	 * @param mixed  $results     Filter data results.
+	 * @param string $filter_type Filter type.
+	 * @param array  $query_vars  Query variables.
+	 * @param array  $extra       Extra filter arguments.
+	 * @return mixed
+	 */
+	public function filter_product_filter_data( $results, string $filter_type, array $query_vars, array $extra ) {
+		if ( 'taxonomy' === $filter_type && 'product_cat' === ( $extra['taxonomy'] ?? '' ) ) {
+			return $this->taxonomy_counts;
+		}
+
+		return $results;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes the regression where the special character in filter options is shown as the encoded value.

Closes woocommerce/woocommerce#66156

(For Bug Fixes) Bug introduced in PR [#64585](<https://github.com/woocommerce/woocommerce/issues/64585>).

### Screenshots or screen recordings:

<img src="https://github.com/user-attachments/assets/178fbe50-6d1f-4b46-8b8c-2f62f6db18a4 " alt="image" width="1537" data-linear-height="847" />

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Use special characters like `&` in attribute or taxonomy term label, and those attributes/terms have products assigned.
2. Add Product Filters block to the product catalog template, ensuring the corresponding attribute/taxonomy filter blocks are added.
3. On the frontend, see the special character is properly rendered.

### Testing that has already taken place:

### Milestone

- [ ] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>