### PR TITLE
Fix plugin-check nightly job race via wp-env config provisioning

### DIFF
--- a/plugins/woocommerce/.wp-env.e2e.json
+++ b/plugins/woocommerce/.wp-env.e2e.json
@@ -9,7 +9,8 @@
 		"https://downloads.wordpress.org/plugin/akismet.zip",
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wp-mail-logging.zip",
-		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip"
+		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",
+		"https://downloads.wordpress.org/plugin/plugin-check.zip"
 	],
 	"themes": [],
 	"config": {

--- a/plugins/woocommerce/changelog/fix-plugin-check-env-config
+++ b/plugins/woocommerce/changelog/fix-plugin-check-env-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Install and activate the plugin-check plugin via the E2E wp-env config instead of the e2e test setup script, so it is provisioned before lifecycle scripts run and no longer races with the backgrounded theme install that intermittently left `wp plugin check` unregistered in the nightly CI job.

--- a/plugins/woocommerce/tests/e2e/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e/bin/test-env-setup.sh
@@ -54,9 +54,6 @@ $WP_CLI_PREFIX wp plugin activate e2e-test-helpers/process-waiting-actions.php
 echo -e 'Activate Test Helper APIs utility plugin \n'
 $WP_CLI_PREFIX wp plugin activate e2e-test-helpers/test-helper-apis.php
 
-echo -e 'Install Plugin-check utility plugin \n'
-$WP_CLI_PREFIX wp plugin install plugin-check --activate
-
 echo -e 'Add Customer user \n'
 if ! $WP_CLI_PREFIX wp user get customer --field=ID >/dev/null 2>&1; then
 	$WP_CLI_PREFIX wp user create customer customer@woocommercecoree2etestsuite.com \


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The nightly "Checks from plugin-check plugin" job keeps failing with `Error: 'check' is not a registered subcommand of 'plugin'`. Root cause: `tests/e2e/bin/test-env-setup.sh` installs plugin-check right after a backgrounded `wp theme install ... &`, with no `wait` and no `set -e`. When the theme download is slow, two concurrent `wp` processes race and plugin-check intermittently fails to install/activate, leaving `wp plugin check` unregistered. 

This provisions plugin-check through the `.wp-env.e2e.json` instead, so activation is deterministic and race-free.

### How to test the changes in this Pull Request:

The affected job only runs on `nightly-checks` / `release-checks`, so verify locally:

1. `cd plugins/woocommerce`
2. `pnpm env:e2e` (starts the E2E wp-env).
3. `pnpm wp-env:e2e run cli wp plugin list --status=active | grep plugin-check` — confirm plugin-check is **active** (provisioned by wp-env, not the setup script).
4. `PLUGIN_SLUG=woocommerce pnpm test:plugincheck` — confirm `wp plugin check` runs and does **not** error with *"'check' is not a registered subcommand"*.

Validated with run: https://github.com/woocommerce/woocommerce/actions/runs/29010596308/job/86093157421#step:6:1344

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
