### PR TITLE
Fix analytics legacy admin disable filters

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics-legacy-admin-disable-filters
+++ b/plugins/woocommerce/changelog/fix-analytics-legacy-admin-disable-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect legacy WooCommerce Admin filters when disabling analytics.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -324,6 +324,8 @@ class Features {
 		/**
 		 * Filter allowing WooCommerce Admin optional features to be disabled.
 		 *
+		 * @since 4.0.0
+		 *
 		 * @param bool $disabled False.
 		 */
 		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
@@ -529,6 +531,26 @@ class Features {
 		 * @param array $features Array of feature slugs.
 		 */
 		return apply_filters( 'woocommerce_admin_features', array_keys( self::get_legacy_feature_compatibility_defaults() ) );
+	}
+
+	/**
+	 * Checks if Analytics was disabled by legacy WooCommerce Admin filters.
+	 *
+	 * @return bool True if Analytics was disabled by legacy filters.
+	 */
+	public static function is_analytics_disabled_by_legacy_filters(): bool {
+		/**
+		 * Filter allowing WooCommerce Admin optional features to be disabled.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param bool $disabled False.
+		 */
+		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
+			return true;
+		}
+
+		return ! in_array( 'analytics', self::get_features_with_legacy_compatibility_defaults(), true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -542,7 +542,7 @@ class Features {
 		 *
 		 * @param bool $disabled False.
 		 */
-		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
+		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) { // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -324,8 +324,6 @@ class Features {
 		/**
 		 * Filter allowing WooCommerce Admin optional features to be disabled.
 		 *
-		 * @since 4.0.0
-		 *
 		 * @param bool $disabled False.
 		 */
 		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
@@ -541,8 +539,6 @@ class Features {
 	public static function is_analytics_disabled_by_legacy_filters(): bool {
 		/**
 		 * Filter allowing WooCommerce Admin optional features to be disabled.
-		 *
-		 * @since 4.0.0
 		 *
 		 * @param bool $disabled False.
 		 */

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use WC_Tracks;
 use WC_Site_Tracking;
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\Features as WCAdminFeatures;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Internal\Caches\ProductCacheController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
@@ -933,6 +934,10 @@ class FeaturesController {
 		// Handle deprecated features - return the backwards-compatible value.
 		if ( ! empty( $feature['deprecated_since'] ) ) {
 			return (bool) ( $feature['deprecated_value'] ?? false );
+		}
+
+		if ( 'analytics' === $feature_id && WCAdminFeatures::is_analytics_disabled_by_legacy_filters() ) {
+			return false;
 		}
 
 		if ( $this->is_preview_email_improvements_enabled( $feature_id ) ) {

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Analytics/FeatureEnabledTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Analytics/FeatureEnabledTest.php
@@ -19,6 +19,8 @@ class FeatureEnabledTest extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_analytics_enabled' );
 		delete_option( RemoteInboxNotifications::TOGGLE_OPTION_NAME );
 		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_analytics_feature' ) );
+		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_analytics_feature' ), PHP_INT_MAX );
+		remove_filter( 'woocommerce_admin_disabled', '__return_true', PHP_INT_MAX );
 		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_launch_your_store_feature' ) );
 		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_customize_store_feature' ) );
 
@@ -35,6 +37,38 @@ class FeatureEnabledTest extends WC_Unit_Test_Case {
 			FeaturesUtil::feature_is_enabled( 'analytics' ),
 			'Analytics should be disabled when the feature option is disabled.'
 		);
+	}
+
+	/**
+	 * @testdox Should disable analytics when removed from the legacy admin feature list.
+	 */
+	public function test_should_be_disabled_when_removed_from_legacy_admin_features(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'disable_analytics_feature' ), PHP_INT_MAX );
+
+		try {
+			$this->assertFalse(
+				FeaturesUtil::feature_is_enabled( 'analytics' ),
+				'Analytics should be disabled when removed from the legacy admin feature list.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_admin_features', array( $this, 'disable_analytics_feature' ), PHP_INT_MAX );
+		}
+	}
+
+	/**
+	 * @testdox Should disable analytics when WooCommerce Admin is disabled by legacy filter.
+	 */
+	public function test_should_be_disabled_when_woocommerce_admin_is_disabled(): void {
+		add_filter( 'woocommerce_admin_disabled', '__return_true', PHP_INT_MAX );
+
+		try {
+			$this->assertFalse(
+				FeaturesUtil::feature_is_enabled( 'analytics' ),
+				'Analytics should be disabled when WooCommerce Admin is disabled.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_admin_disabled', '__return_true', PHP_INT_MAX );
+		}
 	}
 
 	/**
@@ -151,6 +185,16 @@ class FeatureEnabledTest extends WC_Unit_Test_Case {
 		$features[] = 'analytics';
 
 		return array_unique( $features );
+	}
+
+	/**
+	 * Disable the analytics feature in the legacy admin feature list.
+	 *
+	 * @param array $features Feature slugs.
+	 * @return array
+	 */
+	public function disable_analytics_feature( array $features ): array {
+		return array_values( array_diff( $features, array( 'analytics' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


#65472 cleaned up several legacy feature flags. Of those, Analytics is the only feature that can still be intentionally toggled on and off. We migrated it to the new system, but #66442 pointed out that Analytics can also be disabled via the woocommerce_admin_features filter, and I noticed this pattern is used in the wild.

For this reason, I think that, at least for now, it makes sense to reintroduce this possibility.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66442.

(For Bug Fixes) Bug introduced in PR #65472.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a snippet to disable Analytics via code snippet:

```php
add_filter(
	'woocommerce_admin_features',
	function ( $features ) {
		return array_values( array_diff( $features, array( 'analytics' ) ) );
	},
	PHP_INT_MAX
);
```
2. Ensure that Analytics is disabled.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
