### PR TITLE
php tests: fix flaky variation-gallery "feature off" test

### DIFF
--- a/plugins/woocommerce/changelog/testops-217-fix-flaky-variation-gallery-feature-off-test
+++ b/plugins/woocommerce/changelog/testops-217-fix-flaky-variation-gallery-feature-off-test
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fix flaky variation-gallery "feature off" unit test by setting the enable option to 'no' explicitly instead of deleting it, so is_enabled() short-circuits before the canary-cohort path; test-only, no changes to shipped code.

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -1157,7 +1157,11 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	 * @testdox Variable add-to-cart skips the gallery snapshot when the feature is off.
 	 */
 	public function test_woocommerce_variable_add_to_cart_skips_gallery_snapshot_when_feature_off() {
-		delete_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME );
+		// Set the option to 'no' explicitly rather than deleting it: an empty option makes
+		// Package::is_enabled() fall through to the canary cohort, which reads a separate
+		// option (woocommerce_remote_variant_assignment) that other tests in the same worker
+		// may have left set, non-deterministically re-enabling the feature. 'no' short-circuits.
+		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'no' );
 
 		$inline_js = $this->capture_variable_add_to_cart_inline_js();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`test_woocommerce_variable_add_to_cart_skips_gallery_snapshot_when_feature_off` flaked on some shard orderings because it deleted the enable option, letting `Package::is_enabled()` fall through to `is_in_canary_cohort()`. That path reads a separate option (`woocommerce_remote_variant_assignment`) which other tests in the same worker can leave set, non-deterministically re-enabling the feature and failing the "feature off" assertion.

This sets the enable option to `'no'` explicitly so `is_enabled()` short-circuits before the canary path, making the test deterministic.

Closes TESTOPS-217

### How to test the changes in this Pull Request:

1. Run the two affected tests: `pnpm test:php:env -- --filter 'test_woocommerce_variable_add_to_cart_(attaches_gallery_snapshot|skips_gallery_snapshot_when_feature_off)'`
2. Confirm both pass.
3. Optionally, set `woocommerce_remote_variant_assignment` to a canary value (1–6) before the run and confirm the "feature off" test still passes.
4. CI should be green.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->