### PR TITLE
e2e tests: close two race windows in blocks save helper

### DIFF
--- a/plugins/woocommerce/changelog/fix-65677-e2e-save-helper-races
+++ b/plugins/woocommerce/changelog/fix-65677-e2e-save-helper-races
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Close two race windows in the blocks E2E saveSiteEditorEntities helper: gate the top-bar button pick on a rendered Save/Publish button, and converge the stale save-notice sweep to zero before saving so a leftover notice cannot report a false save success. Test-only, no changes to shipped code.

--- a/plugins/woocommerce/tests/e2e/utils/blocks/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/editor/editor-utils.page.ts
@@ -262,14 +262,25 @@ export class Editor extends CoreEditor {
 			.getByRole( 'button', { name: 'Dismiss this notice' } )
 			.filter( { hasText: /(updated|published)\./ } );
 
-		const staleSaveNoticeCount = await saveNoticeDismissButton.count();
-		for ( let i = 0; i < staleSaveNoticeCount; i++ ) {
-			const staleSaveNotice = saveNoticeDismissButton.first();
-			if ( ! ( await staleSaveNotice.isVisible() ) ) {
-				break;
-			}
-			await staleSaveNotice.click();
+		// Dismiss any save notices left over from earlier saves. The success
+		// assertion at the end reuses this same locator, so a leftover notice
+		// must not survive into it — converge to zero instead of snapshotting
+		// the count once and breaking on the first invisible notice. The loop
+		// is bounded so a notice that regenerates or refuses to dismiss fails
+		// via the assertion below rather than spinning.
+		for (
+			let i = 0;
+			i < 10 && ( await saveNoticeDismissButton.first().isVisible() );
+			i++
+		) {
+			await saveNoticeDismissButton.first().click();
 		}
+		await expect( saveNoticeDismissButton ).toHaveCount( 0 );
+
+		// Wait for the top bar to render its primary action before the
+		// instantaneous pick below; otherwise an unrendered bar falls through
+		// to a Publish button that never exists in the site editor.
+		await expect( saveButton.or( publishButton ).first() ).toBeVisible();
 
 		const buttonToClick = ( await saveButton.isVisible() )
 			? saveButton


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The blocks E2E `saveSiteEditorEntities` helper (used by ~29 spec files) had two confirmed race windows that undermined the very deflaking it exists to provide:

1. **Non-waiting button pick.** `( await saveButton.isVisible() ) ? saveButton : publishButton` was an instantaneous check. When the top bar had not rendered yet, it fell through to a `Publish` button that does not exist in the site editor, producing a hard timeout. 
This PR gates the pick on a rendered Save/Publish button via a retrying `expect( saveButton.or( publishButton ).first() ).toBeVisible()`.

2. **Stale-notice sweep never converged.** The sweep snapshotted `count()` once and broke on the first invisible notice, never asserting the notices reached zero. Because the final success assertion reuses the same locator, a leftover `updated./published.` notice could report save success while entities were actually unsaved. 
This PR replaces the sweep with a bounded dismiss loop followed by `expect( saveNoticeDismissButton ).toHaveCount( 0 )`, so the success assertion can only be satisfied by a genuinely fresh post-save notice.

Closes #65677.

### How to test the changes in this Pull Request:

A. locally:
1. Run a selection of blocks E2E specs that call `saveSiteEditorEntities`, e.g. `checkout-block.merchant.block_theme.spec.ts` and `product-collection.block_theme.spec.ts`.
2. Confirm the site-editor save flows still pass and no longer intermittently time out on a missing `Publish` button.
4. Confirm specs that run several saves in sequence (leaving prior "updated." notices on screen) still pass — the sweep now clears leftovers before asserting success.

B. CI should be green

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->