### PR TITLE
Fix Local Pickup settings save confirmation notice

### DIFF
--- a/plugins/woocommerce/changelog/66404-fix-local-pickup-save-notice
+++ b/plugins/woocommerce/changelog/66404-fix-local-pickup-save-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the Local Pickup settings save confirmation on a successful save (and an error notice on failure), instead of only when the server response matched the sent payload, which suppressed the notice when values were sanitized (e.g. "&" normalized to "&amp;").

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
@@ -12,7 +12,6 @@ import type { UniqueIdentifier } from '@dnd-kit/core';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import fastDeepEqual from 'fast-deep-equal/es6';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -145,32 +144,37 @@ export const SettingsProvider = ( {
 		setIsSaving( true );
 		setIsDirty( false );
 
-		// @todo This should be improved to include error handling in case of API failure, or invalid data being sent that
-		// does not match the schema. This would fail silently on the API side.
+		// A resolved apiFetch means the request succeeded (2xx); the server
+		// sanitizes the payload before echoing it back, so the response will not
+		// necessarily match what we sent. Gate the notice on success, not on the
+		// response matching the payload, otherwise sanitized values (e.g. "&"
+		// normalized to "&amp;") would suppress the confirmation on a save that
+		// actually persisted.
 		apiFetch( {
 			path: '/wc/v3/pickup-locations',
 			method: 'POST',
 			data,
-		} ).then( ( response ) => {
-			setIsSaving( false );
-			if (
-				fastDeepEqual(
-					response.pickup_location_settings,
-					data.pickup_location_settings
-				) &&
-				fastDeepEqual(
-					response.pickup_locations,
-					data.pickup_locations
-				)
-			) {
+		} )
+			.then( () => {
 				dispatch( noticesStore ).createSuccessNotice(
 					__(
 						'Local Pickup settings have been saved.',
 						'woocommerce'
 					)
 				);
-			}
-		} );
+			} )
+			.catch( () => {
+				setIsDirty( true );
+				dispatch( noticesStore ).createErrorNotice(
+					__(
+						'There was an error saving your Local Pickup settings. Please try again.',
+						'woocommerce'
+					)
+				);
+			} )
+			.finally( () => {
+				setIsSaving( false );
+			} );
 	}, [ settings, pickupLocations ] );
 
 	const settingsData = {


### PR DESCRIPTION
In Local pickup settings page when we save, we run the result back compared to what we have in the memory and decide if want to show a success notice or not, this is a bit error prone because if the return value encode certain entities. So this removes the check and just ensure we get 200 back.

Closes #66404

### Testing steps

1. In local pickup settings, add a new location with title "Barn & Nobles" or something similar.
2. Hit save.
3. Ensure you get a success notice.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Changelog file added manually in `plugins/woocommerce/changelog/66404-fix-local-pickup-save-notice`.

</details>
