### PR TITLE
Fix stale Algeria wilaya data in onboarding test fixture

### DIFF
--- a/packages/js/onboarding/changelog/fix-dz-states-test-fixture
+++ b/packages/js/onboarding/changelog/fix-dz-states-test-fixture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix stale 'Tamanghasset' spelling and add missing DZ-49 through DZ-58 Algeria wilayas to the onboarding country/state test fixture.

--- a/packages/js/onboarding/src/utils/countries/test/utils/country-options.ts
+++ b/packages/js/onboarding/src/utils/countries/test/utils/country-options.ts
@@ -97,7 +97,7 @@ export const countryStateOptions = [
 	},
 	{
 		key: 'DZ:DZ-11',
-		label: 'Algeria — Tamanghasset',
+		label: 'Algeria — Tamanrasset',
 	},
 	{
 		key: 'DZ:DZ-12',
@@ -246,6 +246,46 @@ export const countryStateOptions = [
 	{
 		key: 'DZ:DZ-48',
 		label: 'Algeria — Relizane',
+	},
+	{
+		key: 'DZ:DZ-49',
+		label: 'Algeria — Timimoun',
+	},
+	{
+		key: 'DZ:DZ-50',
+		label: 'Algeria — Bordj Badji Mokhtar',
+	},
+	{
+		key: 'DZ:DZ-51',
+		label: 'Algeria — Ouled Djellal',
+	},
+	{
+		key: 'DZ:DZ-52',
+		label: 'Algeria — Béni Abbès',
+	},
+	{
+		key: 'DZ:DZ-53',
+		label: 'Algeria — In Salah',
+	},
+	{
+		key: 'DZ:DZ-54',
+		label: 'Algeria — In Guezzam',
+	},
+	{
+		key: 'DZ:DZ-55',
+		label: 'Algeria — Touggourt',
+	},
+	{
+		key: 'DZ:DZ-56',
+		label: 'Algeria — Djanet',
+	},
+	{
+		key: 'DZ:DZ-57',
+		label: 'Algeria — El Meghaier',
+	},
+	{
+		key: 'DZ:DZ-58',
+		label: 'Algeria — El Meniaa',
 	},
 	{
 		key: 'AS',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The onboarding country/state test fixture still had the old `Tamanghasset` spelling for DZ-11 and was missing the 10 wilayas (DZ-49–DZ-58) that were added to `states.php`, leaving it out of sync with the real Algeria subdivision data. This updates the fixture to match `states.php` exactly.

Closes #65839.

(For Bug Fixes) Bug introduced in PR #65385.

### How to test the changes in this Pull Request:

1. Run the onboarding package tests: `pnpm --filter=@woocommerce/onboarding test:js`.
2. Confirm `country-options.ts` DZ-11 reads "Tamanrasset" and includes DZ-49 through DZ-58.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance
#### Type
#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually (packages/js/onboarding/changelog/fix-dz-states-test-fixture).

</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**