### PR TITLE
Keep the subscriptions-engine Core zone WordPress-free in BillingPolicy

### DIFF
--- a/packages/php/woocommerce-subscriptions-engine/changelog/fix-billing-policy-core-zone-purity
+++ b/packages/php/woocommerce-subscriptions-engine/changelog/fix-billing-policy-core-zone-purity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Keep the WordPress-free Core zone pure: use gettype() instead of wp_json_encode() in the BillingPolicy trial_duration validation message, and cover the previously-untested error branch with a unit test.

--- a/packages/php/woocommerce-subscriptions-engine/src/Core/ValueObject/BillingPolicy.php
+++ b/packages/php/woocommerce-subscriptions-engine/src/Core/ValueObject/BillingPolicy.php
@@ -115,7 +115,7 @@ final class BillingPolicy {
 		$trial = $data['trial_duration'] ?? null;
 		if ( null !== $trial && ! is_array( $trial ) ) {
 			throw new DomainException(
-				sprintf( 'BillingPolicy: trial_duration must be null or an array, got %s.', wp_json_encode( $trial ) )
+				sprintf( 'BillingPolicy: trial_duration must be null or an array, got %s.', gettype( $trial ) )
 			);
 		}
 

--- a/packages/php/woocommerce-subscriptions-engine/tests/unit/Core/ValueObject/BillingPolicyTest.php
+++ b/packages/php/woocommerce-subscriptions-engine/tests/unit/Core/ValueObject/BillingPolicyTest.php
@@ -128,6 +128,19 @@ class BillingPolicyTest extends TestCase {
 		$policy->compute_next_renewal_from( new DateTimeImmutable( '2026-01-01', new DateTimeZone( 'UTC' ) ) );
 	}
 
+	public function test_non_array_trial_duration_throws(): void {
+		$this->expectException( DomainException::class );
+		$this->expectExceptionMessage( 'BillingPolicy: trial_duration must be null or an array, got string.' );
+
+		BillingPolicy::from_array(
+			array(
+				'period'         => 'month',
+				'interval'       => 1,
+				'trial_duration' => 'P7D',
+			)
+		);
+	}
+
 	/**
 	 * @dataProvider provide_min_and_max_cycles_validation_cases
 	 * @param string|null $expected_exception_message The expected exception message, or null if no exception is expected.


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`BillingPolicy::from_array()` lives in the subscriptions-engine's WordPress-free `Core/` zone, but its `trial_duration` error branch built the exception message with `wp_json_encode()` - the only WordPress symbol in the entire `Core/` zone. On that branch, in a WordPress-free context (the Core unit tests deliberately stub no WordPress functions), the call fatals with "Call to undefined function wp_json_encode()" instead of throwing the intended `DomainException`.

This replaces `wp_json_encode( $trial )` with `gettype( $trial )`, which:

- removes the WordPress dependency, restoring `Core/` zone purity, and
- matches every sibling validation in the same file (`period`, `interval`, and the nested `trial_duration` fields all report `gettype()`).

It also adds a unit test for the previously-untested branch so the WordPress-free test bootstrap enforces the zone rule here going forward - that branch being untested is why the violation reached trunk in the first place.

No merchant-facing behavior change: in a live WordPress runtime `wp_json_encode()` is always defined, so production was unaffected. This is a code-purity and test-coverage cleanup.

Closes #65843.

(For Bug Fixes) Bug introduced in PR #65767.

### How to test the changes in this Pull Request:

1. From `packages/php/woocommerce-subscriptions-engine/`, run the WordPress-free unit suite: `composer test:unit` (or `vendor/bin/phpunit`). All tests pass.
2. Confirm the new coverage: `vendor/bin/phpunit --filter test_non_array_trial_duration_throws` passes and asserts the `DomainException` message `BillingPolicy: trial_duration must be null or an array, got string.`
3. Regression guard: temporarily change `gettype( $trial )` back to `wp_json_encode( $trial )` at `src/Core/ValueObject/BillingPolicy.php` and re-run step 2 - the test fails with `Call to undefined function ...\wp_json_encode() at BillingPolicy.php`, proving the branch is now guarded. Restore the fix afterwards.

### Testing that has already taken place:

- `composer test:unit`: 232 tests, 490 assertions, all pass.
- `vendor/bin/phpcs -s -p` on both changed files: clean.
- Mutation check (step 3 above) confirms the new test catches reintroduction of a WordPress symbol on this branch.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
