### PR TITLE
Restore wc-blocks-components editor dependency

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-blocks-components-editor-dependency
+++ b/plugins/woocommerce/changelog/fix-wc-blocks-components-editor-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore wc-blocks-components as a WooCommerce Blocks editor dependency so extensions that use the shared components global continue to load safely.

--- a/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
@@ -26,7 +26,7 @@ const wcDepMap = {
 	'@woocommerce/shared-hocs': [ 'wc', 'wcBlocksSharedHocs' ],
 	'@woocommerce/price-format': [ 'wc', 'priceFormat' ],
 	'@woocommerce/blocks-checkout': [ 'wc', 'blocksCheckout' ],
-	'@woocommerce/blocks-components': false, // Bundle; compatibility handle remains registered separately
+	'@woocommerce/blocks-components': [ 'wc', 'blocksComponents' ],
 	'@woocommerce/types': [ 'wc', 'wcTypes' ],
 	'@woocommerce/sanitize': [ 'wc', 'sanitize' ],
 	'@woocommerce/entities': [ 'wc', 'wcEntities' ],
@@ -42,7 +42,7 @@ const wcHandleMap = {
 	'@woocommerce/price-format': 'wc-price-format',
 	'@woocommerce/blocks-checkout': 'wc-blocks-checkout',
 	'@woocommerce/blocks-checkout-events': 'wc-blocks-checkout-events',
-	'@woocommerce/blocks-components': false, // Bundle; compatibility handle remains registered separately
+	'@woocommerce/blocks-components': 'wc-blocks-components',
 	'@woocommerce/types': 'wc-types',
 	'@woocommerce/sanitize': 'wc-sanitize',
 	'@woocommerce/entities': 'wc-entities',
@@ -55,6 +55,7 @@ const editorExternalPackages = [
 	'@woocommerce/block-data',
 	'@woocommerce/blocks-checkout',
 	'@woocommerce/blocks-checkout-events',
+	'@woocommerce/blocks-components',
 	'@woocommerce/blocks-registry',
 	'@woocommerce/data',
 	'@woocommerce/entities',

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md
@@ -35,7 +35,7 @@ The entries below resolve as bundled editor imports when they are used by WooCom
 | --- | --- | --- | --- | --- |
 | N/A | `wc-blocks-vendors` | N/A | `AssetsController::register_deprecated_package_scripts()` | Compatibility placeholder only; keeps legacy dependencies resolvable but does not print a script, so enqueueing it no longer loads the old vendor bundle. |
 | N/A | `wc-blocks` | N/A | `AssetsController::register_deprecated_package_scripts()` | Compatibility placeholder only; keeps legacy dependencies resolvable but does not print a script. Use `wc-block-library` for the shared editor bundle. |
-| `@woocommerce/blocks-components` | `wc-blocks-components` | `wc.blocksComponents` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
+| `@woocommerce/blocks-components` | `wc-blocks-components` | `wc.blocksComponents` | `AssetsController::register_deprecated_package_scripts()` | Supported editor dependency target for shared Blocks components. |
 | `@woocommerce/shared-context` | `wc-blocks-shared-context` | `wc.wcBlocksSharedContext` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
 | `@woocommerce/shared-hocs` | `wc-blocks-shared-hocs` | `wc.wcBlocksSharedHocs` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
 | `@woocommerce/settings` | `wc-settings` | `wc.wcSettings` | `AssetDataRegistry::register_data_script()` | Still used when scripts need WooCommerce settings data; inline data is only printed when the handle is enqueued. |

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -138,7 +138,7 @@ final class AssetsController {
 		// Deprecated package handle kept for extensions that still declare wc-blocks-shared-hocs.
 		$this->api->register_script( 'wc-blocks-shared-hocs', 'assets/client/blocks/wc-blocks-shared-hocs.js', array(), false );
 
-		// Deprecated package handle kept for extensions that still declare wc-blocks-components.
+		// Supported package handle loaded by the consolidated editor build when components are externalized.
 		$this->api->register_script( 'wc-blocks-components', 'assets/client/blocks/blocks-components.js' );
 
 		$this->add_deprecated_script_handle_warnings(
@@ -147,7 +147,6 @@ final class AssetsController {
 				'wc-blocks',
 				'wc-blocks-shared-context',
 				'wc-blocks-shared-hocs',
-				'wc-blocks-components',
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a safer follow-up to the WooCommerce Blocks editor asset consolidation. The parent PR bundles most WooCommerce Blocks editor code into `wc-block-library`, but `wc-blocks-components` is a known package handle used by third-party developers, including extensions that read `window.wc.blocksComponents`.

Instead of relying on those integrations to change immediately, this PR keeps `@woocommerce/blocks-components` external in the editor build so `wc-block-library` declares and enqueues `wc-blocks-components`. The handle remains registered, no longer receives a deprecated-handle warning, and the enqueueable packages documentation describes it as a supported editor dependency target.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch on top of the parent Blocks editor asset consolidation branch.
2. Build Blocks with `pnpm --filter='@woocommerce/block-library' build`.
3. Confirm the generated `wc-block-library.asset.php` dependencies include `wc-blocks-components`.
4. Confirm `wc-blocks-components` is still registered without the deprecated-handle console warning path.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter='@woocommerce/block-library' build`
- `pnpm --dir plugins/woocommerce/client/blocks exec wp-scripts lint-js bin/webpack-helpers.js`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `composer exec -- phpstan analyse src/Blocks/AssetsController.php --memory-limit=2G`
- `pnpm dlx markdownlint-cli -- plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md`
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-wc-blocks-components-editor-dependency`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
