### PR TITLE
Restore Blocks shared package bundles

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocks-shared-package-bundles
+++ b/plugins/woocommerce/changelog/fix-blocks-shared-package-bundles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore standalone WooCommerce Blocks shared package bundles for components, shared context, and shared higher-order components used by extensions.

--- a/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-helpers.js
@@ -26,7 +26,7 @@ const wcDepMap = {
 	'@woocommerce/shared-hocs': [ 'wc', 'wcBlocksSharedHocs' ],
 	'@woocommerce/price-format': [ 'wc', 'priceFormat' ],
 	'@woocommerce/blocks-checkout': [ 'wc', 'blocksCheckout' ],
-	'@woocommerce/blocks-components': false, // Bundle; compatibility handle remains registered separately
+	'@woocommerce/blocks-components': [ 'wc', 'blocksComponents' ],
 	'@woocommerce/types': [ 'wc', 'wcTypes' ],
 	'@woocommerce/sanitize': [ 'wc', 'sanitize' ],
 	'@woocommerce/entities': [ 'wc', 'wcEntities' ],
@@ -42,7 +42,7 @@ const wcHandleMap = {
 	'@woocommerce/price-format': 'wc-price-format',
 	'@woocommerce/blocks-checkout': 'wc-blocks-checkout',
 	'@woocommerce/blocks-checkout-events': 'wc-blocks-checkout-events',
-	'@woocommerce/blocks-components': false, // Bundle; compatibility handle remains registered separately
+	'@woocommerce/blocks-components': 'wc-blocks-components',
 	'@woocommerce/types': 'wc-types',
 	'@woocommerce/sanitize': 'wc-sanitize',
 	'@woocommerce/entities': 'wc-entities',
@@ -55,10 +55,13 @@ const editorExternalPackages = [
 	'@woocommerce/block-data',
 	'@woocommerce/blocks-checkout',
 	'@woocommerce/blocks-checkout-events',
+	'@woocommerce/blocks-components',
 	'@woocommerce/blocks-registry',
 	'@woocommerce/data',
 	'@woocommerce/entities',
 	'@woocommerce/price-format',
+	'@woocommerce/shared-context',
+	'@woocommerce/shared-hocs',
 ];
 
 const shouldBundleWooPackageInEditor = ( request ) =>

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md
@@ -29,15 +29,15 @@ This list comes from `editorExternalPackages` in `webpack-helpers.js`. Imports f
 
 ## Compatibility handles
 
-The entries below resolve as bundled editor imports when they are used by WooCommerce editor code, but their script handles remain registered so existing extensions and non-editor scripts can still enqueue or declare them directly. The `wc-blocks-vendors` and `wc-blocks` handles should continue to be registered for backward compatibility, but they are placeholders and no longer load the old vendor or editor bundles.
+The entries below are available as enqueueable package handles for extensions and non-editor scripts. The `wc-blocks-vendors` and `wc-blocks` handles should continue to be registered for backward compatibility, but they are placeholders and no longer load the old vendor or editor bundles.
 
 | Package import | Script handle | Global | Registration owner | Notes |
 | --- | --- | --- | --- | --- |
 | N/A | `wc-blocks-vendors` | N/A | `AssetsController::register_deprecated_package_scripts()` | Compatibility placeholder only; keeps legacy dependencies resolvable but does not print a script, so enqueueing it no longer loads the old vendor bundle. |
 | N/A | `wc-blocks` | N/A | `AssetsController::register_deprecated_package_scripts()` | Compatibility placeholder only; keeps legacy dependencies resolvable but does not print a script. Use `wc-block-library` for the shared editor bundle. |
-| `@woocommerce/blocks-components` | `wc-blocks-components` | `wc.blocksComponents` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
-| `@woocommerce/shared-context` | `wc-blocks-shared-context` | `wc.wcBlocksSharedContext` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
-| `@woocommerce/shared-hocs` | `wc-blocks-shared-hocs` | `wc.wcBlocksSharedHocs` | `AssetsController::register_deprecated_package_scripts()` | Deprecated editor dependency target kept for backward compatibility. |
+| `@woocommerce/blocks-components` | `wc-blocks-components` | `wc.blocksComponents` | `AssetsController::register_deprecated_package_scripts()` | Supported standalone package bundle for shared Blocks components. |
+| `@woocommerce/shared-context` | `wc-blocks-shared-context` | `wc.wcBlocksSharedContext` | `AssetsController::register_deprecated_package_scripts()` | Supported standalone package bundle for shared Blocks context helpers. |
+| `@woocommerce/shared-hocs` | `wc-blocks-shared-hocs` | `wc.wcBlocksSharedHocs` | `AssetsController::register_deprecated_package_scripts()` | Supported standalone package bundle for shared Blocks higher-order components. |
 | `@woocommerce/settings` | `wc-settings` | `wc.wcSettings` | `AssetDataRegistry::register_data_script()` | Still used when scripts need WooCommerce settings data; inline data is only printed when the handle is enqueued. |
 | `@woocommerce/types` | `wc-types` | `wc.wcTypes` | `AssetsController::register_assets()` | Runtime type helpers remain available as a standalone handle. |
 | `@woocommerce/sanitize` | `wc-sanitize` | `wc.sanitize` | `AssetsController::register_assets()` and WooCommerce Admin assets | Sanitization helpers remain available as a standalone handle. |

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -120,34 +120,30 @@ final class AssetsController {
 	}
 
 	/**
-	 * Register deprecated package and aggregate script handles for backward compatibility.
+	 * Register deprecated aggregate handles and standalone package bundles for backward compatibility.
 	 *
-	 * These handles are no longer used by WooCommerce's consolidated editor build, but are still registered
-	 * so extensions that declare them directly do not break. Other package handles in register_assets() are
-	 * intentionally kept at their normal registration sites because they remain supported shared APIs,
-	 * frontend/runtime dependencies, or are registered by another asset controller.
+	 * The aggregate handles are placeholders so extensions that declare them directly do not break.
+	 * The package handles below remain real bundles because WooCommerce's consolidated editor build
+	 * externalizes them as shared dependencies for extension compatibility.
 	 */
 	private function register_deprecated_package_scripts(): void {
 		// Deprecated aggregate handles kept as placeholders for extensions that still declare them.
 		wp_register_script( 'wc-blocks-vendors', false, array(), $this->api->wc_version, true );
 		wp_register_script( 'wc-blocks', false, array(), $this->api->wc_version, true );
 
-		// Deprecated package handle kept for extensions that still declare wc-blocks-shared-context.
+		// Standalone package bundle for extensions that depend on wc-blocks-shared-context.
 		$this->api->register_script( 'wc-blocks-shared-context', 'assets/client/blocks/wc-blocks-shared-context.js' );
 
-		// Deprecated package handle kept for extensions that still declare wc-blocks-shared-hocs.
+		// Standalone package bundle for extensions that depend on wc-blocks-shared-hocs.
 		$this->api->register_script( 'wc-blocks-shared-hocs', 'assets/client/blocks/wc-blocks-shared-hocs.js', array(), false );
 
-		// Deprecated package handle kept for extensions that still declare wc-blocks-components.
+		// Standalone package bundle for extensions that depend on wc-blocks-components.
 		$this->api->register_script( 'wc-blocks-components', 'assets/client/blocks/blocks-components.js' );
 
 		$this->add_deprecated_script_handle_warnings(
 			array(
 				'wc-blocks-vendors',
 				'wc-blocks',
-				'wc-blocks-shared-context',
-				'wc-blocks-shared-hocs',
-				'wc-blocks-components',
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is an alternative compatibility follow-up to the WooCommerce Blocks editor asset consolidation. Rather than folding every shared package into `wc-block-library`, this PR keeps standalone editor dependency bundles for the package globals most likely to be consumed by third-party developers: `wc.wcBlocksSharedContext`, `wc.wcBlocksSharedHocs`, and `wc.blocksComponents`.

The editor build now externalizes `@woocommerce/shared-context`, `@woocommerce/shared-hocs`, and `@woocommerce/blocks-components`, which makes `wc-block-library` enqueue `wc-blocks-shared-context`, `wc-blocks-shared-hocs`, and `wc-blocks-components` as dependencies. Those handles remain real bundles, are no longer listed in the deprecated-handle warning path, and the enqueueable packages documentation describes them as supported standalone package bundles.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch on top of the parent Blocks editor asset consolidation branch.
2. Build Blocks with `pnpm --filter='@woocommerce/block-library' build`.
3. Confirm the generated `wc-block-library.asset.php` dependencies include `wc-blocks-components`, `wc-blocks-shared-context`, and `wc-blocks-shared-hocs`.
4. Confirm these files are present in `plugins/woocommerce/assets/client/blocks`: `blocks-components.js`, `wc-blocks-shared-context.js`, and `wc-blocks-shared-hocs.js`.
5. Confirm only the deprecated aggregate placeholder handles `wc-blocks-vendors` and `wc-blocks` receive deprecated-handle warnings.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter='@woocommerce/block-library' build`
- `pnpm --dir plugins/woocommerce/client/blocks exec wp-scripts lint-js bin/webpack-helpers.js`
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `composer exec -- phpstan analyse src/Blocks/AssetsController.php --memory-limit=2G`
- `pnpm dlx markdownlint-cli -- plugins/woocommerce/client/blocks/docs/internal-developers/enqueueable-packages/README.md`
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-blocks-shared-package-bundles`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
