### PR TITLE
e2e tests: fix review order page e2e flakiness from a stale host-page option

### DIFF
--- a/plugins/woocommerce/tests/e2e/tests/order/review-order-page.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/review-order-page.spec.ts
@@ -49,8 +49,14 @@ test.describe(
 				'yes'
 			);
 
-			// First REST call after enabling the flag boots WP with init
-			// firing again; that's when the host page is created.
+			// Drop the stored host-page id so the next request re-adopts the
+			// canonical review-order page and reflushes its rewrite.
+			await deleteOption(
+				request,
+				baseURL || '',
+				'woocommerce_review_order_page_id'
+			);
+
 			const { data } = await restApi.get(
 				`${ WP_API_PATH }/pages?slug=review-order`,
 				{ data: { _fields: [ 'id', 'link' ] } }


### PR DESCRIPTION

### Changes proposed in this Pull Request:

The five "Customer Review Request" scenarios in `review-order-page.spec.ts` fail consistently in the **Core e2e tests (HPOS:off)** job ([example run](https://github.com/woocommerce/woocommerce/actions/runs/29011316121/job/86096268811)) — Scenario 1 hits a strict-mode duplicate `<h1>Review your order</h1>`, and 2/3/6/Variations lose their JS-driven behaviour.

Root cause: this spec runs in the serial pool, which shares one WordPress instance with no DB reset between spec files. Leftover state can leave a second `review-order` page and point `woocommerce_review_order_page_id` at a different page than the `/review-order/{id}/` rewrite actually renders.

The fix deletes `woocommerce_review_order_page_id` in `beforeAll` after enabling the feature, realigning the option, the route, and the rendered page.

### How to test the changes in this Pull Request:

1. Start the e2e environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e:start`.
2. Run the spec in the HPOS-disabled project:
   `DISABLE_HPOS=1 USE_WP_ENV=true pnpm --filter=@woocommerce/plugin-woocommerce exec playwright test --config tests/e2e/envs/default-hpos-disabled/playwright.config.ts --grep "Customer Review Request"`.
3. All nine scenarios pass (one is intentionally skipped).
4. (Optional) To prove the fix matters, recreate the divergent state before the run: with the `customer_review_request` feature enabled, add a second published page (slug `review-order-2`, content `[woocommerce_review_order]`) and set the `woocommerce_review_order_page_id` option to it while leaving the `/review-order/` rewrite pointing at the canonical page. On `trunk` the five scenarios fail with the duplicate heading / missing `order-review.min.js`; with this branch `beforeAll` realigns the state and they pass.

CI should be green.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->