### PR TITLE
Allow classic themes to opt into a11y labels for orderby dropdown

### DIFF
--- a/plugins/woocommerce/changelog/66476-feature-orderby-label-legacy-optin
+++ b/plugins/woocommerce/changelog/66476-feature-orderby-label-legacy-optin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `woocommerce_catalog_orderby_use_label` filter to opt into more accessible orderby dropdowns

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1670,6 +1670,8 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 			return;
 		}
 
+		$use_label = apply_filters( 'woocommerce_catalog_orderby_use_label', isset( $attributes ) && isset( $attributes['useLabel'] ) ? $attributes['useLabel'] : false );
+
 		/**
 		 * Filter the default catalog orderby.
 		 *
@@ -1679,7 +1681,7 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 		 */
 		$show_default_orderby = 'menu_order' === apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby', 'menu_order' ) );
 
-		if ( isset( $attributes ) && isset( $attributes['useLabel'] ) && $attributes['useLabel'] ) {
+		if ( $use_label ) {
 			/**
 			 * Filters the catalog orderby options.
 			 *
@@ -1745,7 +1747,7 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 				'catalog_orderby_options' => $catalog_orderby_options,
 				'orderby'                 => $orderby,
 				'show_default_orderby'    => $show_default_orderby,
-				'use_label'               => isset( $attributes['useLabel'] ) ? $attributes['useLabel'] : false,
+				'use_label'               => $use_label,
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1670,6 +1670,13 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 			return;
 		}
 
+		/**
+		 * Filter the use of a visible label for the orderby dropdown.
+		 * 
+		 * @since x.y.z
+		 * 
+		 * @param bool $use_label Whether to use a visible label for the orderby dropdown. Default is whatever was passed in the block attributes or false.
+		 */
 		$use_label = apply_filters( 'woocommerce_catalog_orderby_use_label', isset( $attributes ) && isset( $attributes['useLabel'] ) ? $attributes['useLabel'] : false );
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Adds a new filter and consolidation of array access checks in the args passed to the orderby rendering function, allowing classic themes to opt into a more accessible orderby dropdown with label.

Closes woocommerce/woocommerce#66475.

### Screenshots or screen recordings:

See PR that originally introduced this UI change for blocks for screenshots of the final product.

### How to test the changes in this Pull Request:

1. Test against a classic theme, such as Storefront
2. Add `add_filter('woocommerce_catalog_orderby_use_label', '__return_true');` to plugin/theme
3. Open a WooCommerce archive page
4. See the dropdown for ordering now has a label and updated option values

### Testing that has already taken place:

Automated tests have been run locally. Observing results of GHA tests.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [X] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [X] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [X] Enhancement - Improvement to existing functionality

#### Message

Add `woocommerce_catalog_orderby_use_label` filter to opt into more accessible orderby dropdowns

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>