### PR TITLE
Analytics: remove trailing colon from FilterPicker labels

### DIFF
--- a/packages/js/components/changelog/66477-sprinkle-filter-picker-colon
+++ b/packages/js/components/changelog/66477-sprinkle-filter-picker-colon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-<!-- Add a changelog message here --> Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.
+Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/packages/js/components/changelog/66477-sprinkle-filter-picker-colon
+++ b/packages/js/components/changelog/66477-sprinkle-filter-picker-colon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+<!-- Add a changelog message here --> Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/packages/js/components/changelog/tweak-filter-picker-label-colon
+++ b/packages/js/components/changelog/tweak-filter-picker-label-colon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/packages/js/components/changelog/tweak-filter-picker-label-colon
+++ b/packages/js/components/changelog/tweak-filter-picker-label-colon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/packages/js/components/src/filter-picker/index.js
+++ b/packages/js/components/src/filter-picker/index.js
@@ -289,7 +289,7 @@ class FilterPicker extends Component {
 			<div className="woocommerce-filters-filter">
 				{ config.label && (
 					<span className="woocommerce-filters-label">
-						{ config.label }:
+						{ config.label }
 					</span>
 				) }
 				<Dropdown

--- a/packages/js/components/src/filter-picker/test/index.js
+++ b/packages/js/components/src/filter-picker/test/index.js
@@ -53,6 +53,17 @@ describe( 'FilterPicker', () => {
 			};
 		} );
 
+		it( 'should render the label without a trailing colon', () => {
+			const { container } = render(
+				<FilterPicker path="/foo/bar" config={ config } />
+			);
+
+			const label = container.querySelector(
+				'.woocommerce-filters-label'
+			);
+			expect( label.textContent ).toBe( 'Show' );
+		} );
+
 		it( 'should render the Search component', async () => {
 			const path = '/foo/bar';
 

--- a/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
+++ b/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-<!-- Add a changelog message here --> Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.
+Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
+++ b/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+<!-- Add a changelog message here --> Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
+++ b/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update customer list e2e selectors to match the colon-less Show filter label.

--- a/plugins/woocommerce/tests/e2e/tests/customer/customer-list.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/customer/customer-list.spec.ts
@@ -196,7 +196,7 @@ test.describe( 'Merchant > Customer List', () => {
 			await page.getByRole( 'menu' ).getByText( 'Total spend' ).click();
 
 			// click to close the menu
-			await page.getByText( 'Show:' ).click();
+			await page.getByText( 'Show', { exact: true } ).click();
 
 			await expect(
 				page.getByRole( 'columnheader', { name: 'Username' } )
@@ -219,7 +219,7 @@ test.describe( 'Merchant > Customer List', () => {
 			await page.getByRole( 'menu' ).getByText( 'Total spend' ).click();
 
 			// click to close the menu
-			await page.getByText( 'Show:' ).click();
+			await page.getByText( 'Show', { exact: true } ).click();
 
 			await expect(
 				page.getByRole( 'columnheader', { name: 'Username' } )


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request:

#64846 removed the trailing colon from the "Date range" and "Data status" labels on analytics report pages to match WordPress 7.0 form-field labeling, but the sibling `FilterPicker` component in the same filter row still renders `{ config.label }:` with a hardcoded colon. The result is mixed label punctuation on every analytics report page — "Date range" next to "Show:".

This PR removes the hardcoded colon from `FilterPicker` so all filter labels in the row are consistent ("Show", "Comparison", "Advanced filters", etc.), updates the two e2e selectors that clicked on the "Show:" text, and adds a unit test asserting the label renders without a trailing colon.

Bug introduced in PR #64846.

Closes #65626.

> [!NOTE]
> The bug-introducing PR #64846 ships in 11.0.0, so this PR is milestoned 11.0.0 and labeled `cherry pick to frozen release` to follow it into `release/11.0` — otherwise the analytics filter row ships one release with mixed label punctuation.

### How to test the changes in this Pull Request:

1. Go to Analytics → Orders (or any analytics report).
2. Look at the filter row above the chart.
3. Confirm the "Show" label (and any other filter labels) render without a trailing colon, consistent with the "Date range" label next to them.
4. Confirm the filter dropdown still opens and filters still apply.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance
<!-- Choose only one -->
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
<!-- Choose only one -->
- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [x] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message
<!-- Add a changelog message here -->
Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

</details>

