### PR TITLE
Fix fatal TypeError when get_term_link() returns WP_Error in wc_display_product_attributes()

### DIFF
--- a/plugins/woocommerce/changelog/66478-fix-guard-get-term-link-wp-error
+++ b/plugins/woocommerce/changelog/66478-fix-guard-get-term-link-wp-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal TypeError on the product page when get_term_link() returns a WP_Error for an attribute term that can no longer be resolved; render the value as plain text instead.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4259,7 +4259,16 @@ function wc_display_product_attributes( $product ) {
 				$value_name = esc_html( $attribute_value->name );
 
 				if ( $attribute_taxonomy->attribute_public ) {
-					$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
+					$term_link = get_term_link( $attribute_value->term_id, $attribute->get_name() );
+
+					// get_term_link() returns WP_Error when the term cannot be resolved (for
+					// example when a cached term list outlives the term). Passing that to
+					// esc_url() would raise a TypeError, so fall back to the plain value.
+					if ( is_wp_error( $term_link ) ) {
+						$values[] = $value_name;
+					} else {
+						$values[] = '<a href="' . esc_url( $term_link ) . '" rel="tag">' . $value_name . '</a>';
+					}
 				} else {
 					$values[] = $value_name;
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

- [X] I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
- [X] I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
- [X] I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

`wc_display_product_attributes()` passed the return value of `get_term_link()` straight into `esc_url()`. `get_term_link()` is documented to return `WP_Error` when the term cannot be resolved, and `esc_url()` hands its argument to `ltrim()`, so on PHP 8 a `WP_Error` raises:

```
TypeError: ltrim(): Argument #1 ($string) must be of type string, WP_Error given
```

That turns a missing archive link into a white screen on the whole single-product page.

It is reachable without any third-party code. `wc_get_product_terms()` → `_wc_get_cached_product_terms()` caches a product's attribute terms in the `product_<id>` cache group, and that group is only invalidated when the **product** is saved (`WC_Cache_Helper::invalidate_cache_group()` from the product data store). Deleting an attribute term does not invalidate it — `WC_Post_Data::handle_attribute_term_deleted()` only regenerates variation summaries, and `WC_Cache_Helper::clean_term_cache()` only touches the `product_cat` hierarchy cache. With a persistent object cache the stale term therefore survives across requests, `get_term_link()` returns `WP_Error`, and every affected product page fatals until the product is re-saved or the cache is flushed.

This PR guards the call and falls back to the plain value — the same output the `! $attribute_taxonomy->attribute_public` branch already produces — so a term that cannot be linked is simply rendered as text.

Note there are other unguarded `get_term_link()` call sites under `includes/` (e.g. `woocommerce_template_loop_category_link_open()` at line 1318). I kept this PR to the one path I could reproduce end to end; happy to extend it if you'd like.

Closes woocommerce/woocommerce#66478.

### How to test the changes in this Pull Request:

1. Create a global attribute with archives enabled under **Products → Attributes** (e.g. `Bug Test` → `pa_bug-test`), and add a term to it (e.g. `Test Value`).
2. Create a published simple product, add that attribute with the `Test Value` term, tick **Visible on the product page**, and save.
3. Enable a persistent object cache (Redis/Memcached), then load the product page once so `_wc_get_cached_product_terms()` is warmed.
4. Delete the term `Test Value` under **Products → Attributes → Bug Test → Configure terms**.
5. Reload the product page.

**Before this PR:** the product page dies with `Uncaught TypeError: ltrim(): Argument #1 ($string) must be of type string, WP_Error given`, thrown from `esc_url()` at `wc-template-functions.php:4262`.

**After this PR:** the product page renders normally and the attribute row shows `Test Value` as plain text instead of a link.

The same thing can be verified in a single request without a persistent object cache (this is how I verified it, with **only WooCommerce active** and no theme, via `wp eval-file repro.php --skip-plugins=<all-others> --skip-themes`):

```php
$p = wc_get_product( $product_id );
$GLOBALS['product'] = $p;

// What a product page view does: warm WooCommerce's per-product term cache.
wc_get_product_terms( $product_id, $taxonomy, [ 'fields' => 'all' ] );

// What the shop owner does in wp-admin.
wp_delete_term( $term_id, $taxonomy );

// WooCommerce's cache is stale and still returns the deleted term:
var_dump( count( wc_get_product_terms( $product_id, $taxonomy, [ 'fields' => 'all' ] ) ) ); // int(1)
var_dump( is_wp_error( get_term_link( $term_id, $taxonomy ) ) );                            // bool(true)

wc_display_product_attributes( $p ); // fatal before this PR, renders fine after
```

Alternatively, since `wc_get_product_terms()` applies the public `woocommerce_get_product_terms` filter, this also reproduces it:

```php
add_filter( 'woocommerce_get_product_terms', function ( $terms ) {
    foreach ( $terms as $t ) { $t->term_id = 999999999; }
    return $terms;
} );
```

### Changelog entry

Added: `plugins/woocommerce/changelog/66478-fix-guard-get-term-link-wp-error` (`Significance: patch`, `Type: fix`).

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)