### PR TITLE
Restore generic blank-state icon style at the refreshed 32px scale

### DIFF
--- a/plugins/woocommerce/changelog/66481-sprinkle-blank-state-generic-icon-fallback
+++ b/plugins/woocommerce/changelog/66481-sprinkle-blank-state-generic-icon-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-<!-- Add a changelog message here --> Restore a generic blank-state icon style so extension-supplied icon glyphs render at the refreshed 32px scale.

--- a/plugins/woocommerce/changelog/66481-sprinkle-blank-state-generic-icon-fallback
+++ b/plugins/woocommerce/changelog/66481-sprinkle-blank-state-generic-icon-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+<!-- Add a changelog message here --> Restore a generic blank-state icon style so extension-supplied icon glyphs render at the refreshed 32px scale.

--- a/plugins/woocommerce/changelog/tweak-blank-state-generic-icon-fallback
+++ b/plugins/woocommerce/changelog/tweak-blank-state-generic-icon-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Restore a generic blank-state icon style so extension-supplied icon glyphs render at the refreshed 32px scale.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7696,6 +7696,16 @@ table.bar_chart {
 		font-size: 13px;
 		font-weight: 400;
 		max-width: 500px;
+
+		// Sizes icon-font glyphs supplied by extension blank states to
+		// match the core mask icons below.
+		&::before {
+			display: block;
+			font-size: 32px;
+			line-height: 1;
+			margin: 0 auto 12px;
+			color: $gray-400;
+		}
 	}
 
 	.woocommerce-BlankState-buttons {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request:

#64645 refreshed the legacy admin empty states, scoping the new mask-icon styles to six core-only modifier classes and removing the old generic `.woocommerce-BlankState-message::before` base rule. Extensions that reuse the blank-state markup pattern and supply their own icon-font glyph relied on that generic rule for icon sizing — without it, their glyph renders at text size, inline with the message.

This PR reintroduces a generic `::before` rule that renders extension-supplied glyphs at the refreshed design's scale — 32px, centered, `$gray-400`, 12px below-margin — matching the core mask icons rather than restoring the old 8em treatment. The six core screens set explicit `content`, `width`/`height`, and mask properties on top of it, so they are unaffected (verified: compiled CSS diff against trunk is exactly this one additive rule, and the orders blank state renders identically with and without it).

The removed `.woocommerce-BlankState-cta` rule is intentionally **not** restored: core's own CTAs are now standard `button button-secondary`, so extension CTAs falling back to standard WP button styles match the refreshed design.

Bug introduced in PR #64645.

Closes #65673.

<img width="937" height="531" alt="image" src="https://github.com/user-attachments/assets/24157901-7bca-43b5-a995-22bf98f973d9" />



> [!NOTE]
> #64645 ships in 11.0.0, so this PR is milestoned 11.0.0 and labeled `cherry pick to frozen release` to follow it into `release/11.0`.

#### Notes for extension authors

- **Blank states that supply their own icon glyph** (e.g. a dashicon or icon-font character via `.woocommerce-BlankState-message::before { content: ... }`) now render that glyph at 32px, centered above the message — consistent with the refreshed core empty states, instead of the previous 8em treatment.
- **`.woocommerce-BlankState-cta` no longer applies enlarged button styles.** Extension CTAs fall back to standard WP admin button styling, which is what the refreshed core empty states use as well. The button variant remains the extension's own choice via its markup classes; note that core's refreshed empty states now use `button button-secondary`, so extensions that want to visually match can switch their CTA from `button-primary` to `button-secondary`.

### How to test the changes in this Pull Request:

1. Add a test blank state with a custom glyph to any admin page, e.g.:
   ```html
   <div class="woocommerce-BlankState woocommerce-BlankState--my-extension">
     <h2 class="woocommerce-BlankState-message">Nothing here yet.</h2>
     <a class="woocommerce-BlankState-cta button button-primary" href="#">Get started</a>
   </div>
   <style>.woocommerce-BlankState--my-extension .woocommerce-BlankState-message::before { content: "\2605"; }</style>
   ```
2. Confirm the glyph renders at 32px, gray, centered above the message (on trunk it renders text-sized, inline).
3. Go to WooCommerce → Orders on a store with no orders and confirm the core empty state is unchanged.

### Testing that has already taken place:

- Compiled `admin.scss` on this branch and on trunk; the compiled CSS diff is exactly the one new rule.
- Rendered three cases against the compiled CSS in a browser: extension blank state with its own glyph (now 32px centered), the core `--orders` blank state (pixel-identical to trunk), and a blank state with no glyph (no phantom gap, since a `::before` without `content` generates no box).

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually: `plugins/woocommerce/changelog/tweak-blank-state-generic-icon-fallback`.

<details>

#### Significance
<!-- Choose only one -->
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
<!-- Choose only one -->
- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [x] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message
<!-- Add a changelog message here -->
Restore a generic blank-state icon style so extension-supplied icon glyphs render at the refreshed 32px scale.

</details>


