### PR TITLE
fix: respect cleared actionable order statuses in Activity Panel counts

### DIFF
--- a/plugins/woocommerce/changelog/fix-66480-empty-actionable-order-statuses
+++ b/plugins/woocommerce/changelog/fix-66480-empty-actionable-order-statuses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Activity Panel counts endpoint now respects an explicitly-empty actionable order statuses setting instead of falling back to the defaults, so a cleared setting reports zero orders to fulfill.

--- a/plugins/woocommerce/src/Admin/API/ActivityPanelCounts.php
+++ b/plugins/woocommerce/src/Admin/API/ActivityPanelCounts.php
@@ -173,14 +173,10 @@ class ActivityPanelCounts extends \WC_REST_Data_Controller {
 	private function get_default_order_statuses() {
 		$actionable = get_option( 'woocommerce_actionable_order_statuses', false );
 
-		// A missing option means actionable statuses were never configured, so fall
-		// back to the store's built-in defaults. An explicitly empty array means the
-		// merchant intentionally cleared all statuses, which we respect (nothing to
-		// fulfill) to match the previous client-side behaviour.
-		if ( false === $actionable ) {
-			return array( 'processing', 'on-hold' );
-		}
-
+		// Any array is respected as-is, including an explicitly empty one: the merchant
+		// intentionally cleared all actionable statuses, so there is nothing to fulfill,
+		// matching the previous client-side behaviour. A missing (never configured) or
+		// malformed option falls back to the built-in defaults.
 		return is_array( $actionable ) ? $actionable : array( 'processing', 'on-hold' );
 	}
 

--- a/plugins/woocommerce/src/Admin/API/ActivityPanelCounts.php
+++ b/plugins/woocommerce/src/Admin/API/ActivityPanelCounts.php
@@ -59,17 +59,27 @@ class ActivityPanelCounts extends \WC_REST_Data_Controller {
 	 * @return \WP_REST_Response
 	 */
 	public function get_counts( $request ) {
+		$order_statuses = (array) $request->get_param( 'order_statuses' );
+
+		// When a merchant has cleared every actionable order status there is nothing
+		// "to fulfill". Short-circuit to 0 rather than querying: an empty status list
+		// would otherwise count every order, and the previous client-side
+		// getUnreadOrders() returned 0 in this case.
+		$orders_to_fulfill_count = empty( $order_statuses )
+			? 0
+			: $this->get_count_via(
+				'/wc-analytics/orders',
+				array(
+					'page'     => 1,
+					'per_page' => 1,
+					'status'   => $order_statuses,
+					'_fields'  => array( 'id' ),
+				)
+			);
+
 		return rest_ensure_response(
 			array(
-				'orders_to_fulfill_count'     => $this->get_count_via(
-					'/wc-analytics/orders',
-					array(
-						'page'     => 1,
-						'per_page' => 1,
-						'status'   => $request->get_param( 'order_statuses' ),
-						'_fields'  => array( 'id' ),
-					)
-				),
+				'orders_to_fulfill_count'     => $orders_to_fulfill_count,
 				'reviews_to_moderate_count'   => $this->get_count_via(
 					'/wc-analytics/products/reviews',
 					array(
@@ -161,8 +171,17 @@ class ActivityPanelCounts extends \WC_REST_Data_Controller {
 	 * @return array
 	 */
 	private function get_default_order_statuses() {
-		$actionable = get_option( 'woocommerce_actionable_order_statuses', array() );
-		return is_array( $actionable ) && ! empty( $actionable ) ? $actionable : array( 'processing', 'on-hold' );
+		$actionable = get_option( 'woocommerce_actionable_order_statuses', false );
+
+		// A missing option means actionable statuses were never configured, so fall
+		// back to the store's built-in defaults. An explicitly empty array means the
+		// merchant intentionally cleared all statuses, which we respect (nothing to
+		// fulfill) to match the previous client-side behaviour.
+		if ( false === $actionable ) {
+			return array( 'processing', 'on-hold' );
+		}
+
+		return is_array( $actionable ) ? $actionable : array( 'processing', 'on-hold' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
@@ -16,6 +16,7 @@ use WC_Helper_Product;
 use WC_REST_Unit_Test_Case;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Server;
 
 /**
  * ActivityPanelCounts API controller test.
@@ -180,5 +181,36 @@ class ActivityPanelCountsTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertNull( $data['products_low_in_stock_count'] );
 		$this->assertEquals( 1, $data['orders_to_fulfill_count'] );
+	}
+
+	/**
+	 * Test that clearing all actionable order statuses yields a 0 orders-to-fulfill count,
+	 * matching the previous client-side getUnreadOrders() behaviour, rather than falling back
+	 * to the default statuses. Mirrors the client, which calls the endpoint without passing
+	 * order_statuses and relies on the endpoint default.
+	 */
+	public function test_cleared_actionable_statuses_yield_zero_orders_to_fulfill() {
+		wp_set_current_user( $this->user );
+
+		WC_Helper_Order::create_order( 1, null, array( 'status' => OrderStatus::PROCESSING ) );
+
+		// Merchant cleared every actionable status. Re-register routes so the endpoint's
+		// default order_statuses reflects the updated option, as it would on a real request.
+		update_option( 'woocommerce_actionable_order_statuses', array() );
+		$this->server              = new WP_REST_Server();
+		$GLOBALS['wp_rest_server'] = $this->server;
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Re-firing a core hook to re-register routes in the test, not defining one.
+		do_action( 'rest_api_init' );
+
+		try {
+			$request  = new WP_REST_Request( 'GET', self::ENDPOINT );
+			$response = $this->server->dispatch( $request );
+			$data     = $response->get_data();
+		} finally {
+			delete_option( 'woocommerce_actionable_order_statuses' );
+		}
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 0, $data['orders_to_fulfill_count'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
@@ -184,33 +184,64 @@ class ActivityPanelCountsTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Re-register REST routes on a fresh server. The endpoint's order_statuses default is
+	 * computed at registration time (which setUp() has already run), so tests that change
+	 * the actionable statuses option must re-register routes for the default to pick it up,
+	 * as it would on a real request.
+	 */
+	private function reregister_routes() {
+		$this->server              = new WP_REST_Server();
+		$GLOBALS['wp_rest_server'] = $this->server;
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Re-firing a core hook to re-register routes in the test, not defining one.
+		do_action( 'rest_api_init' );
+	}
+
+	/**
 	 * Test that clearing all actionable order statuses yields a 0 orders-to-fulfill count,
 	 * matching the previous client-side getUnreadOrders() behaviour, rather than falling back
 	 * to the default statuses. Mirrors the client, which calls the endpoint without passing
 	 * order_statuses and relies on the endpoint default.
+	 *
+	 * Option changes are rolled back by the per-test DB transaction, so no manual cleanup.
 	 */
 	public function test_cleared_actionable_statuses_yield_zero_orders_to_fulfill() {
 		wp_set_current_user( $this->user );
 
 		WC_Helper_Order::create_order( 1, null, array( 'status' => OrderStatus::PROCESSING ) );
 
-		// Merchant cleared every actionable status. Re-register routes so the endpoint's
-		// default order_statuses reflects the updated option, as it would on a real request.
+		// Merchant cleared every actionable status.
 		update_option( 'woocommerce_actionable_order_statuses', array() );
-		$this->server              = new WP_REST_Server();
-		$GLOBALS['wp_rest_server'] = $this->server;
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Re-firing a core hook to re-register routes in the test, not defining one.
-		do_action( 'rest_api_init' );
+		$this->reregister_routes();
 
-		try {
-			$request  = new WP_REST_Request( 'GET', self::ENDPOINT );
-			$response = $this->server->dispatch( $request );
-			$data     = $response->get_data();
-		} finally {
-			delete_option( 'woocommerce_actionable_order_statuses' );
-		}
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame( 0, $data['orders_to_fulfill_count'] );
+	}
+
+	/**
+	 * Test that a merchant's custom (non-empty) actionable statuses selection drives the
+	 * endpoint's default orders-to-fulfill count when the client passes no order_statuses
+	 * param. Counts are asymmetric (2 completed vs 1 processing) so falling back to the
+	 * built-in processing/on-hold defaults would fail the assertion.
+	 */
+	public function test_custom_actionable_statuses_option_drives_default_count() {
+		wp_set_current_user( $this->user );
+
+		WC_Helper_Order::create_order( 1, null, array( 'status' => OrderStatus::PROCESSING ) );
+		WC_Helper_Order::create_order( 1, null, array( 'status' => OrderStatus::COMPLETED ) );
+		WC_Helper_Order::create_order( 1, null, array( 'status' => OrderStatus::COMPLETED ) );
+
+		update_option( 'woocommerce_actionable_order_statuses', array( OrderStatus::COMPLETED ) );
+		$this->reregister_routes();
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 2, $data['orders_to_fulfill_count'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The new `GET /wc-analytics/activity-panel/counts` endpoint (added in #66276) computes the orders-to-fulfill count from `get_default_order_statuses()`, which used `is_array( $actionable ) && ! empty( $actionable )`. That conflates two distinct states: the option being **unset** (never configured) and the option being an **explicitly-empty array** (the merchant deliberately unchecked every "Actionable statuses" checkbox in Analytics → Settings, which persists `woocommerce_actionable_order_statuses = []`).

Because the client sends no `order_statuses` param, this default always governs the count. Before #66276 the client-side `getUnreadOrders()` short-circuited to `0` when the status list was empty, so a merchant who had cleared all actionable statuses saw no orders-to-fulfill indicator. After #66276 the endpoint falls back to `['processing','on-hold']`, so the badge / homescreen count reports processing/on-hold orders again — while the OrdersPanel list below (still driven by the JS setting → `[]`) stays empty. The count and the list disagree.

This PR:

- `get_default_order_statuses()` now distinguishes "unset" (→ built-in default `['processing','on-hold']`) from "explicitly empty" (→ respected as-is) using a `false` sentinel default from `get_option()`.
- `get_counts()` short-circuits `orders_to_fulfill_count` to `0` when the resolved status list is empty, rather than querying — passing an empty status list to `/wc-analytics/orders` would otherwise count **every** order.

This restores the pre-#66276 behaviour for the cleared-setting case and keeps the count in agreement with the OrdersPanel list. The common case (default statuses, or any non-empty selection) is unchanged, since the server reads the same option the client does.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66480 .

(For Bug Fixes) Bug introduced in PR #66276 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

No UI changes. Backend-only fix to the count returned by the endpoint.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create at least one order in `processing` or `on-hold` status.
2. Go to **Analytics → Settings**, uncheck **every** "Actionable statuses" checkbox, and save (this persists `woocommerce_actionable_order_statuses = []`).
3. Load any wp-admin page and open the header bell icon, plus the WooCommerce Home "Things to do next" panel.
4. **Expected:** "Orders to fulfill" shows **no count / 0**, matching the (empty) Orders panel list. On `trunk` without this fix, the badge/homescreen count instead reports the processing/on-hold orders while the list stays empty.
5. Re-check one or more actionable statuses and save; confirm the count returns and matches the list.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Added regression test `ActivityPanelCountsTest::test_cleared_actionable_statuses_yield_zero_orders_to_fulfill`, which persists an empty option, re-registers routes (so the endpoint default reflects the update as it would on a real request), and asserts `orders_to_fulfill_count === 0`. Full `ActivityPanelCountsTest` suite passes (6 tests, 13 assertions) on `wp-env`.
- Verified end-to-end against a running `wp-env` instance: with the option unset → count reflects the query (1 for a seeded processing order); with the option `[]` → count is `0`; with the option deleted → count restored. Also confirmed via the settings REST endpoint that saving an all-unchecked selection persists `[]` (no server-side coercion to the default), so the edge case is reachable through the normal UI.
- Ran PHPCS and PHPStan on the changed files — both clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Activity Panel counts endpoint now respects an explicitly-empty actionable order statuses setting instead of falling back to the defaults, so a cleared setting reports zero orders to fulfill.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry created manually (`plugins/woocommerce/changelog/fix-66480-empty-actionable-order-statuses`).

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
