### PR TITLE
Remove redundant changelog entry for PR #66477

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
+++ b/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update customer list e2e selectors to match the colon-less Show filter label.


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request:

#66477 shipped with two `plugin-woocommerce` changelog entries for the same change: a manually added `dev` entry about the e2e selector update, and the auto-generated `tweak` entry from the PR template. This removes the redundant `dev` entry, keeping the user-facing `tweak` one, so the change appears once in the compiled release notes.

Changelog-only change; no code affected.

> [!NOTE]
> Milestoned 11.0.0 with the `cherry pick to frozen release` label so 11.0's compiled changelog is also deduplicated. Best applied after the cherry-pick of #66477 itself (#66482) lands on `release/11.0` — before that, the file this PR deletes doesn't exist there yet.

### How to test the changes in this Pull Request:

1. Confirm `plugins/woocommerce/changelog/dev-e2e-filter-label-colon` is deleted and `plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon` remains.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog-only cleanup; no new entry needed.
