### PR TITLE
Fix email_type Tracks format mismatch in test email sends

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-listview.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-listview.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import type { ComponentType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ListView } from '../settings-email-listing-listview';
+import type { EmailType } from '../settings-email-listing-slotfill';
+import { useSendTestEmail } from '../settings-email-send-test';
+
+jest.mock( '@wordpress/dataviews/wp', () => ( {
+	DataViews: ( {
+		actions,
+		data,
+	}: {
+		actions: Array< {
+			id: string;
+			RenderModal?: ComponentType< {
+				items: EmailType[];
+				closeModal?: () => void;
+			} >;
+		} >;
+		data: EmailType[];
+	} ) => {
+		const SendTestEmailModal = actions.find(
+			( action ) => action.id === 'test'
+		)?.RenderModal;
+
+		return SendTestEmailModal ? (
+			<SendTestEmailModal items={ data } closeModal={ () => {} } />
+		) : null;
+	},
+} ) );
+
+jest.mock( '../settings-email-listing-data', () => ( {
+	useTransactionalEmails: ( emailTypes: EmailType[] ) => ( {
+		emails: emailTypes,
+		total: emailTypes.length,
+		updateEmailEnabledStatus: jest.fn(),
+		recreateEmailPost: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '../settings-email-send-test', () => ( {
+	useSendTestEmail: jest.fn( () => ( {
+		email: '',
+		setEmail: jest.fn(),
+		isSending: false,
+		notice: '',
+		noticeType: '',
+		sendEmail: jest.fn(),
+	} ) ),
+	SendTestEmailForm: () => null,
+} ) );
+
+const useSendTestEmailMock = useSendTestEmail as jest.MockedFunction<
+	typeof useSendTestEmail
+>;
+
+const emailType: EmailType = {
+	title: 'New order',
+	description: 'New order notification',
+	id: 'new_order',
+	email_key: 'wc_email_new_order',
+	email_class_name: 'WC_Email_New_Order',
+	post_id: '123',
+	recipients: {
+		to: 'admin@example.com',
+		cc: '',
+		bcc: '',
+	},
+	enabled: true,
+	manual: false,
+	templateStatus: null,
+	templateVersion: null,
+	currentVersion: null,
+	wasBackfilled: false,
+};
+
+describe( 'ListView', () => {
+	beforeEach( () => {
+		useSendTestEmailMock.mockClear();
+	} );
+
+	it( 'uses the email class name when tracking a test send', () => {
+		render( <ListView emailTypes={ [ emailType ] } /> );
+
+		expect( useSendTestEmailMock ).toHaveBeenCalledWith(
+			{
+				endpoint: 'editor',
+				postId: 123,
+				emailType: 'WC_Email_New_Order',
+			},
+			'email_listing'
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
@@ -51,6 +51,7 @@ const baseEmail: EmailType = {
 	enabled: true,
 	manual: false,
 	email_key: 'new_order',
+	email_class_name: 'WC_Email_New_Order',
 	recipients: { to: '', cc: '', bcc: '' },
 	status: 'enabled',
 	templateStatus: null,
@@ -180,6 +181,7 @@ describe( 'normalizeEmailTypePayload — regression for eligible_count=0', () =>
 		enabled: true,
 		manual: false,
 		email_key: 'customer_processing_order',
+		email_class_name: 'WC_Email_Customer_Processing_Order',
 		recipients: { to: '', cc: '', bcc: '' },
 		status: 'enabled',
 		template_status: 'core_updated_customized',
@@ -222,6 +224,9 @@ describe( 'normalizeEmailTypePayload — regression for eligible_count=0', () =>
 		expect( normalized.templateVersion ).toBe( '9.4.0-test' );
 		expect( normalized.currentVersion ).toBe( '10.7.0' );
 		expect( normalized.wasBackfilled ).toBe( false );
+		expect( normalized.email_class_name ).toBe(
+			'WC_Email_Customer_Processing_Order'
+		);
 
 		render(
 			<EmailListingFill

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-update-cell.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-update-cell.test.tsx
@@ -40,6 +40,7 @@ const baseEmail: EmailType = {
 	enabled: true,
 	manual: false,
 	email_key: 'new_order',
+	email_class_name: 'WC_Email_New_Order',
 	recipients: { to: '', cc: '', bcc: '' },
 	status: 'enabled',
 	templateStatus: null,

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-send-test.test.tsx
@@ -61,7 +61,7 @@ const Harness = ( {
 const editorTarget: SendTestEmailTarget = {
 	endpoint: 'editor',
 	postId: 123,
-	emailType: 'new_order',
+	emailType: 'WC_Email_New_Order',
 };
 
 const settingsTarget: SendTestEmailTarget = {
@@ -127,7 +127,7 @@ describe( 'useSendTestEmail + SendTestEmailForm', () => {
 		expect( recordEventMock ).toHaveBeenCalledWith(
 			'settings_emails_preview_test_sent_successful',
 			{
-				email_type: 'new_order',
+				email_type: 'WC_Email_New_Order',
 				source: 'email_listing',
 			}
 		);
@@ -183,7 +183,7 @@ describe( 'useSendTestEmail + SendTestEmailForm', () => {
 		expect( recordEventMock ).toHaveBeenCalledWith(
 			'settings_emails_preview_test_sent_failed',
 			{
-				email_type: 'new_order',
+				email_type: 'WC_Email_New_Order',
 				error: 'Cookie check failed',
 				error_code: 'rest_cookie_invalid_nonce',
 				source: 'email_listing',

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -25,16 +25,16 @@ import {
 
 const SendTestEmailModalContent = ( {
 	postId,
-	emailId,
+	emailClassName,
 	onClose,
 }: {
 	postId: number;
-	emailId: string;
+	emailClassName: string;
 	onClose: () => void;
 } ) => {
 	const { email, setEmail, isSending, notice, noticeType, sendEmail } =
 		useSendTestEmail(
-			{ endpoint: 'editor', postId, emailType: emailId },
+			{ endpoint: 'editor', postId, emailType: emailClassName },
 			'email_listing'
 		);
 
@@ -220,7 +220,7 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				} ) => (
 					<SendTestEmailModalContent
 						postId={ parseInt( items[ 0 ].post_id, 10 ) }
-						emailId={ items[ 0 ].id }
+						emailClassName={ items[ 0 ].email_class_name }
 						onClose={ closeModal ?? ( () => {} ) }
 					/>
 				),

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -40,6 +40,7 @@ export type EmailType = {
 	description: string;
 	id: string;
 	email_key: string;
+	email_class_name: string;
 	post_id: string;
 	recipients: Recipients;
 	enabled: boolean;

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-update-cell.story.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-update-cell.story.tsx
@@ -12,6 +12,7 @@ const baseEmail: EmailType = {
 	enabled: true,
 	manual: false,
 	email_key: 'new_order',
+	email_class_name: 'WC_Email_New_Order',
 	recipients: { to: '', cc: '', bcc: '' },
 	templateStatus: null,
 	templateVersion: null,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -624,6 +624,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'description'      => $email->get_description(),
 				'id'               => $email->id,
 				'email_key'        => strtolower( $email_key ),
+				'email_class_name' => get_class( $email ),
 				'post_id'          => $post_id,
 				'enabled'          => $email->is_enabled(),
 				'manual'           => $email->is_manual(),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Test-email sends from the emails list and from the preview page reported `email_type` in different formats (`new_order` vs `WC_Email_New_Order`) in the same Tracks events, splitting one email into two values in analytics. This unifies both on the `WC_Email` class name.

Closes #66450, closes WOOPLUG-7022.

(For Bug Fixes) Bug introduced in PR #66405.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor (WooCommerce → Settings → Advanced → Features → "Block email editor").
2. Go to WooCommerce → Settings → Emails, open the ⋯ menu on the "New order" row, choose "Send test email", enter an address, and send. With Tracks debugging enabled (`localStorage.setItem( 'debug', 'wc-admin:*' )` in the browser console), verify the `settings_emails_preview_test_sent_successful` event fires with `email_type: 'WC_Email_New_Order'` and `source: 'email_listing'`.
3. From the same settings page, open the "New order" email, use the "Send a test email" button on the preview page, and verify the event fires with the same `email_type: 'WC_Email_New_Order'` value (`source: 'email_preview'`).
4. Confirm the test email is received in both cases (send behavior unchanged).

<!-- End testing instructions -->

### Testing that has already taken place:



### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Tracks-only analytics fix — it unifies the `email_type` property format in an existing internal telemetry event. There is no merchant- or developer-facing behavior change, so there is nothing meaningful to surface in the changelog.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
