### PR TITLE
Don't fail backport workflow when a reviewer isn't a repo collaborator

### DIFF
--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -390,12 +390,24 @@ jobs:
                 body: prBody
               });
               
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: newPr.number,
-                reviewers: [context.actor, originalPr.user.login]
-              });
+              core.setOutput('pr_number', newPr.number.toString());
+              core.setOutput('original_author', originalPr.user?.login || '');
+              core.setOutput('original_merger', originalPr.merged_by?.login || '');
+              core.info(`Created PR #${newPr.number}: ${newPr.html_url}`);
+
+              // Request reviewers separately so an outside collaborator doesn't fail PR creation.
+              for (const reviewer of [context.actor, originalPr.user.login]) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: newPr.number,
+                    reviewers: [reviewer]
+                  });
+                } catch (error) {
+                  core.warning(`Failed to request review from ${reviewer}: ${error.message}`);
+                }
+              }
 
               // Add label if there are conflicts
               if (hasConflicts) {
@@ -411,12 +423,6 @@ jobs:
                   core.warning(`Failed to add conflicts label: ${error.message}`);
                 }
               }
-
-              core.setOutput('pr_number', newPr.number.toString());
-              core.setOutput('original_author', originalPr.user?.login || '');
-              core.setOutput('original_merger', originalPr.merged_by?.login || '');
-
-              core.info(`Created PR #${newPr.number}: ${newPr.html_url}`);
 
             } catch (error) {
               core.setOutput('error_message', `Failed to create PR: ${error.message}`);

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -396,7 +396,7 @@ jobs:
               core.info(`Created PR #${newPr.number}: ${newPr.html_url}`);
 
               // Request reviewers separately so an outside collaborator doesn't fail PR creation.
-              for (const reviewer of [context.actor, originalPr.user.login]) {
+              for (const reviewer of [context.actor, originalPr.user?.login].filter(Boolean)) {
                 try {
                   await github.rest.pulls.requestReviewers({
                     owner: context.repo.owner,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a milestoned PR from an outside collaborator is backported, the "Create cherry-pick pull request" step requests the original author as a reviewer. GitHub rejects review requests for non-collaborators, so the whole step fails and the backport PR is created with no reviewer assigned. Notifications are still triggered (both to Slack and in the original PR) so the backport isn't lost, but this is a condition we can easily protect against.

This PR makes sure that the PR is always created and that at least one reviewer (excluding the non-collaborator) gets correctly assigned.

Some examples of recent backports that failed because of this:

-   https://github.com/woocommerce/woocommerce/actions/runs/28620703108
-   https://github.com/woocommerce/woocommerce/actions/runs/27195602154

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I ran a test backport using PR #66280 as source, which is from an outside collaborator (`faisalahammad`):

- When running from `trunk`'s version of this workflow, you can see [the job fail](https://github.com/woocommerce/woocommerce/actions/runs/29103763555/job/86400245536#step:4:111) despite having created [the backport PR](https://github.com/woocommerce/woocommerce/pull/66502).
- When running from this branch, [the job succeeds](https://github.com/woocommerce/woocommerce/actions/runs/29104347529) and [the backport PR](https://github.com/woocommerce/woocommerce/pull/66503) has a reviewer assigned.

If desired, the above can be replicated as follows:

1.  In the Actions tab, open the ["Shared Cherry Pick"](https://github.com/woocommerce/woocommerce/actions/workflows/shared-cherry-pick.yml) workflow and use "Run workflow" from this branch (`fix-backport-assignee-failure`).
2.  Set `pr_number` to `66280` and `target_branch` to `release/11.0`.
3.  Confirm the run succeeds and creates a backport PR. Because `faisalahammad` is not a repo collaborator, the review request for them is skipped while you are still requested as reviewer.
4.  Delete the generated backport PR and its associated branch.

<!-- End testing instructions -->

### Milestone

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI workflow change, not shipped.

</details>