### PR TITLE
Fix wp-env start retry masking failures due to missing pipefail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
         # "::warning::wp-env-start-retry reason=<subsystem>" marker (grep-friendly) so the
         # underlying incident rate stays measurable even when the retry keeps the job green.
         run: |
+          set -o pipefail
           attempt=1
           max_attempts=3
           log="$(mktemp)"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `Start Test Environment: start` retry loop from #66491 never runs — and masks failed startups as green.

The step has no `shell:` key, so it runs under GitHub's implicit default `bash -e {0}`, which does **not** enable `pipefail` (only an explicit `shell: bash` does). Without `pipefail`, `pnpm ... | tee "$log"` returns `tee`'s exit code (0), so the `until` condition passes on the first iteration regardless of whether `wp-env start` failed: no retry, and a failed start exits 0 instead of failing the step.

Fix: `set -o pipefail` as the first line of the run block.

Bug introduced in PR #66491.

Closes #66494

### How to test the changes in this Pull Request:

Verifiable under the step's real shell (`bash -e`, no pipefail) with a stub that exits non-zero:

1. Before the fix: the loop exits immediately, prints no `wp-env-start-retry` warning, exits **0** (failure masked as success).
2. After the fix: the loop retries 3× then exits **1**; a successful start still runs once and exits **0**.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
