### PR TITLE
Fix :where() selectors in Brands shortcode

### DIFF
--- a/plugins/woocommerce/changelog/fix-brand-thumbnails-where-selectors
+++ b/plugins/woocommerce/changelog/fix-brand-thumbnails-where-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix :where() selectors in Brands shortcode

--- a/plugins/woocommerce/client/legacy/css/brands.scss
+++ b/plugins/woocommerce/client/legacy/css/brands.scss
@@ -63,9 +63,7 @@ ul.brand-thumbnails:not(.fluid-columns) li.first,
 	clear: both;
 }
 
-ul.brand-thumbnails:not(.fluid-columns) li.last,
-:where(.brand-thumbnails-description li.last),
-:where(.brand-thumbnails-description.columns-1 li) {
+ul.brand-thumbnails:not(.fluid-columns) li.last {
 	margin-right: 0;
 }
 
@@ -129,6 +127,11 @@ ul.brand-thumbnails.columns-6 li {
 	padding: 0;
 	position: relative;
 	text-align: center;
+}
+
+:where(.brand-thumbnails-description li.last),
+:where(.brand-thumbnails-description.columns-1 li) {
+	margin-right: 0;
 }
 
 :where(.brand-thumbnails-description li .term-thumbnail img) {

--- a/plugins/woocommerce/client/legacy/css/brands.scss
+++ b/plugins/woocommerce/client/legacy/css/brands.scss
@@ -33,14 +33,14 @@ ul.brand-thumbnails,
 }
 
 ul.brand-thumbnails:before,
-:where(.brand-thumbnails-description:before) {
+:where(.brand-thumbnails-description)::before {
 	clear: both;
 	content: "";
 	display: table;
 }
 
 ul.brand-thumbnails:after,
-:where(.brand-thumbnails-description:after) {
+:where(.brand-thumbnails-description)::after {
 	clear: both;
 	content: "";
 	display: table;

--- a/plugins/woocommerce/client/legacy/css/brands.scss
+++ b/plugins/woocommerce/client/legacy/css/brands.scss
@@ -33,7 +33,7 @@ ul.brand-thumbnails,
 }
 
 ul.brand-thumbnails:before,
-:where(.brand-thumbnails-description):before {
+:where(.brand-thumbnails-description:before) {
 	clear: both;
 	content: "";
 	display: table;

--- a/plugins/woocommerce/client/legacy/css/brands.scss
+++ b/plugins/woocommerce/client/legacy/css/brands.scss
@@ -40,7 +40,7 @@ ul.brand-thumbnails:before,
 }
 
 ul.brand-thumbnails:after,
-:where(.brand-thumbnails-description):after {
+:where(.brand-thumbnails-description:after) {
 	clear: both;
 	content: "";
 	display: table;
@@ -59,13 +59,13 @@ ul.brand-thumbnails.fluid-columns li {
 }
 
 ul.brand-thumbnails:not(.fluid-columns) li.first,
-:where(.brand-thumbnails-description) li.first {
+:where(.brand-thumbnails-description li.first) {
 	clear: both;
 }
 
 ul.brand-thumbnails:not(.fluid-columns) li.last,
-:where(.brand-thumbnails-description) li.last,
-:where(.brand-thumbnails-description.columns-1) li {
+:where(.brand-thumbnails-description li.last),
+:where(.brand-thumbnails-description.columns-1 li) {
 	margin-right: 0;
 }
 
@@ -123,7 +123,7 @@ ul.brand-thumbnails.columns-6 li {
 }
 
 /* Brand thumbnails description */
-:where(.brand-thumbnails-description) li {
+:where(.brand-thumbnails-description li) {
 	float: left;
 	margin: 0 2% 1em 0;
 	padding: 0;
@@ -131,12 +131,12 @@ ul.brand-thumbnails.columns-6 li {
 	text-align: center;
 }
 
-:where(.brand-thumbnails-description) li .term-thumbnail img {
+:where(.brand-thumbnails-description li .term-thumbnail img) {
 	width: 100%;
 	display: inline;
 }
 
-:where(.brand-thumbnails-description) li .term-description {
+:where(.brand-thumbnails-description li .term-description) {
 	margin-top: 1em;
 	text-align: left;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #66496.
Closes WOOPLUG-7036.

(For Bug Fixes) Bug introduced in PR #66280.

While reviewing https://github.com/woocommerce/woocommerce/pull/66280, I completely missed that `:where()` selectors weren't wrapping the whole selector. Also some of the selectors weren't in the correct order so the margin was not properly reset when there was only one column. This PR solves both issues.

### How to test the changes in this Pull Request:

1. Make sure you have some brands with images, and at least one product assigned to those brands.
2. Insert the `[product_brand_thumbnails_description columns="1"]` shortcode to a post or page.
3. Verify the `.brand-thumbnails-description li` elements don't have right margin.

Before | After
--- | ---
<img width="955" height="781" alt="imatge" src="https://github.com/user-attachments/assets/d0f6c4d5-9c25-45bd-aebd-cd31e0767465" /> | <img width="955" height="781" alt="imatge" src="https://github.com/user-attachments/assets/7e6852f1-a11c-4484-863d-84a162cc4d8b" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
