### PR TITLE
Classify Docker Hub 'connection reset by peer' wp-env-start retries as reason=dockerhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,9 +203,10 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         # `wp-env start` fails on transient network timeouts from several subsystems:
         # composer fetching packagist inside the Docker build ("curl error 28"), wp-env's
-        # own `got` client downloading WordPress core ("ETIMEDOUT"/"socket hang up"), and the Docker daemon
-        # pulling images from Docker Hub ("context deadline exceeded"). Retry the whole
-        # start to ride out those blips -- BuildKit reuses layers that already succeeded,
+        # own `got` client downloading WordPress core ("ETIMEDOUT"/"socket hang up"), and
+        # the Docker daemon pulling images from Docker Hub ("context deadline exceeded"/
+        # "connection reset by peer"). Retry the whole start to ride out those blips --
+        # BuildKit reuses layers that already succeeded,
         # so a retry only re-runs whatever failed. Each retried attempt emits a
         # "::warning::wp-env-start-retry reason=<subsystem>" marker (grep-friendly) so the
         # underlying incident rate stays measurable even when the retry keeps the job green.
@@ -219,7 +220,7 @@ jobs:
             # We retry regardless of cause -- transient failures aren't limited to the
             # patterns below, so reason= is for monitoring only, not a retry gate.
             if grep -qF 'curl error 28' "$log"; then reason=packagist
-            elif grep -qE 'registry-1\.docker\.io|context deadline exceeded' "$log"; then reason=dockerhub
+            elif grep -qE 'registry-1\.docker\.io|context deadline exceeded|failed to receive status: rpc error|connection reset by peer' "$log"; then reason=dockerhub
             elif grep -qE 'ETIMEDOUT|socket hang up|ECONNRESET' "$log"; then reason=wordpress
             else reason=unknown
             fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `Start Test Environment: start` step retries transient `wp-env start` failures and tags each retry with a `::warning::wp-env-start-retry reason=<subsystem>` marker for monitoring. 

This adds `failed to receive status: rpc error` and `connection reset by peer` to the `dockerhub` branch so the marker reflects the actual failure line.

Observed in [this run](https://github.com/woocommerce/woocommerce/actions/runs/29104119321/job/86400258115#step:6:338).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
