### PR TITLE
Invalidate the legacy meta cache in the HPOS order meta corruption guard

### DIFF
--- a/plugins/woocommerce/changelog/66508-fix-hpos-legacy-meta-cache-self-heal
+++ b/plugins/woocommerce/changelog/66508-fix-hpos-legacy-meta-cache-self-heal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Invalidate the correct meta cache group when the HPOS order meta corruption guard fires, so a corrupt legacy object-cache entry is re-read from the database instead of persisting across reads.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -676,7 +676,7 @@ abstract class WC_Data {
 	 * misses the cache and re-reads from the database. Used to recover from a corrupt persistent
 	 * object cache entry.
 	 *
-	 * @since 11.1.0
+	 * @since 11.0.0
 	 */
 	public function delete_meta_cache() {
 		if ( empty( $this->cache_group ) || ! $this->get_id() ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -677,8 +677,10 @@ abstract class WC_Data {
 	 * object cache entry.
 	 *
 	 * @since 11.0.0
+	 *
+	 * @return void
 	 */
-	public function delete_meta_cache() {
+	public function delete_meta_cache(): void {
 		if ( empty( $this->cache_group ) || ! $this->get_id() ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -669,6 +669,24 @@ abstract class WC_Data {
 	}
 
 	/**
+	 * Delete this object's cached raw meta data entry, if a cache group is set.
+	 *
+	 * Counterpart to prime_raw_meta_data_cache(): it removes the entry stored under this object's
+	 * own cache group (for example 'orders' for WC_Abstract_Order), so the next read_meta_data()
+	 * misses the cache and re-reads from the database. Used to recover from a corrupt persistent
+	 * object cache entry.
+	 *
+	 * @since 11.1.0
+	 */
+	public function delete_meta_cache() {
+		if ( empty( $this->cache_group ) || ! $this->get_id() ) {
+			return;
+		}
+		$cache_key = self::generate_meta_cache_key( $this->get_id(), $this->cache_group );
+		wp_cache_delete( $cache_key, $this->cache_group );
+	}
+
+	/**
 	 * Read Meta Data from the database. Ignore any internal properties.
 	 * Uses it's own caches because get_metadata does not provide meta_ids.
 	 *

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1520,6 +1520,7 @@ WHERE
 				),
 				array( 'source' => 'hpos-data-cache' )
 			);
+
 			/*
 			 * Invalidate every cache the corrupt value could have come from so the next read
 			 * self-heals from the database. The HPOS meta cache (orders_meta group) is primed by
@@ -1528,6 +1529,7 @@ WHERE
 			 * so without clearing that group the corrupt entry would persist across reads.
 			 */
 			$this->data_store_meta->clear_cached_data( array( $object->get_id() ) );
+
 			/*
 			 * delete_meta_cache() is defined on WC_Data, so $object always has it in a consistent
 			 * deploy. The guard only covers the brief window during a plugin upgrade where this

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1485,19 +1485,25 @@ WHERE
 	public function filter_raw_meta_data( &$object, $raw_meta_data ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 
 		/*
-		 * Defensive last-resort guard. The meta data should always arrive as an array of meta-row
-		 * objects, but a corrupt persistent object cache entry can surface as a scalar, an object,
-		 * or a well-formed array whose elements are not meta rows. Any of these would otherwise
-		 * fatal downstream (array_filter()/array_diff() on a non-array, or $meta->meta_key on a
-		 * non-object element). Drop anything that is not a usable meta row so the order still
-		 * loads, and when corruption is detected invalidate the cached entries so the next read
-		 * self-heals from the database.
+		 * Defensive last-resort guard. The meta data should always arrive as an array of complete
+		 * meta-row objects, but a corrupt persistent object cache entry can surface as a scalar, an
+		 * object, a well-formed array whose elements are not meta rows, or an array of objects that
+		 * are missing required columns. Any of these would otherwise fatal or silently load wrong
+		 * values downstream (array_filter()/array_diff() on a non-array, $meta->meta_key on a
+		 * non-object element, or a real key hydrated with a null value from a partial row). A row is
+		 * only usable when it carries meta_id, meta_key and meta_value - the same completeness check
+		 * OrdersTableDataStoreMeta::is_valid_cached_meta() applies at the HPOS cache boundary. Drop
+		 * anything that is not a usable meta row so the order still loads, and when corruption is
+		 * detected invalidate the cached entries so the next read self-heals from the database.
 		 */
 		$is_corrupt = false;
 		if ( is_array( $raw_meta_data ) ) {
 			$valid_meta_data = array_filter(
 				$raw_meta_data,
-				static fn( $meta ) => is_object( $meta ) && property_exists( $meta, 'meta_key' )
+				static fn( $meta ) => is_object( $meta )
+					&& property_exists( $meta, 'meta_id' )
+					&& property_exists( $meta, 'meta_key' )
+					&& property_exists( $meta, 'meta_value' )
 			);
 			$is_corrupt      = count( $valid_meta_data ) !== count( $raw_meta_data );
 			$raw_meta_data   = $valid_meta_data;
@@ -1522,6 +1528,12 @@ WHERE
 			 * so without clearing that group the corrupt entry would persist across reads.
 			 */
 			$this->data_store_meta->clear_cached_data( array( $object->get_id() ) );
+			/*
+			 * delete_meta_cache() is defined on WC_Data, so $object always has it in a consistent
+			 * deploy. The guard only covers the brief window during a plugin upgrade where this
+			 * (newer) class can be loaded before an opcode-cached, older abstract-wc-data.php gains
+			 * the method, which would otherwise fatal on an undefined method.
+			 */
 			if ( is_callable( array( $object, 'delete_meta_cache' ) ) ) {
 				$object->delete_meta_cache();
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1490,7 +1490,7 @@ WHERE
 		 * or a well-formed array whose elements are not meta rows. Any of these would otherwise
 		 * fatal downstream (array_filter()/array_diff() on a non-array, or $meta->meta_key on a
 		 * non-object element). Drop anything that is not a usable meta row so the order still
-		 * loads, and when corruption is detected invalidate the cached entry so the next read
+		 * loads, and when corruption is detected invalidate the cached entries so the next read
 		 * self-heals from the database.
 		 */
 		$is_corrupt = false;
@@ -1514,7 +1514,17 @@ WHERE
 				),
 				array( 'source' => 'hpos-data-cache' )
 			);
+			/*
+			 * Invalidate every cache the corrupt value could have come from so the next read
+			 * self-heals from the database. The HPOS meta cache (orders_meta group) is primed by
+			 * init_order_record(), while WC_Data::read_meta_data() reads the object's own legacy
+			 * meta cache (the 'orders' group for orders) and, on a cache hit, skips re-caching -
+			 * so without clearing that group the corrupt entry would persist across reads.
+			 */
 			$this->data_store_meta->clear_cached_data( array( $object->get_id() ) );
+			if ( is_callable( array( $object, 'delete_meta_cache' ) ) ) {
+				$object->delete_meta_cache();
+			}
 		}
 
 		$filtered_meta_data = parent::filter_raw_meta_data( $object, $raw_meta_data );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
@@ -634,6 +634,61 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 	}
 
 	/**
+	 * @testdox A corrupt legacy ('orders' group) meta cache entry is invalidated so the next read_meta_data() self-heals from the database.
+	 */
+	public function test_corrupt_legacy_meta_cache_entry_is_invalidated_and_self_heals(): void {
+		$fake_logger = $this->create_fake_logger();
+		add_filter(
+			'woocommerce_logging_class',
+			function () use ( $fake_logger ) {
+				return $fake_logger;
+			}
+		);
+
+		$order = new WC_Order();
+		$order->add_meta_data( 'custom_meta_key', 'custom_value', true );
+		$order->save();
+		$order_id = $order->get_id();
+
+		// Reload a fresh order object so its meta cache key reflects current cache prefixes.
+		$order = wc_get_order( $order_id );
+
+		/*
+		 * Poison the legacy meta cache group that WC_Data::read_meta_data() reads
+		 * (WC_Abstract_Order::$cache_group = 'orders') with a well-formed array whose elements are
+		 * not meta rows. This passes the top-level is_array() check in read_meta_data(), so the
+		 * corruption guard in filter_raw_meta_data() - not the HPOS 'orders_meta' boundary - is the
+		 * layer that must invalidate it.
+		 */
+		$cache_key = $order->get_meta_cache_key();
+		wp_cache_set( $cache_key, array( 'not-a-meta-row' ), 'orders' );
+		$this->assertIsArray( wp_cache_get( $cache_key, 'orders' ), 'Sanity: the legacy meta cache entry should be primed.' );
+
+		// Force the legacy read path directly (init_order_record() primes meta_data, so the normal
+		// wc_get_order() flow does not re-enter read_meta_data()).
+		$order->read_meta_data();
+
+		$this->assert_hpos_cache_warning_logged( $fake_logger, 'Discarded malformed meta data' );
+
+		// The corrupt legacy entry must have been invalidated - otherwise read_meta_data() would keep
+		// loading it (it skips re-caching on a cache hit) and re-log on every read.
+		$this->assertFalse(
+			wp_cache_get( $cache_key, 'orders' ),
+			'The corrupt legacy meta cache entry should be invalidated so the next read re-reads from the database.'
+		);
+
+		// The next read misses the cache, re-reads from the database, and recovers the real value.
+		$order->read_meta_data();
+		$this->assertSame(
+			'custom_value',
+			$order->get_meta( 'custom_meta_key' ),
+			'Meta should self-heal from the database after the corrupt legacy cache entry is invalidated.'
+		);
+
+		remove_all_filters( 'woocommerce_logging_class' );
+	}
+
+	/**
 	 * Assert that a warning with the "hpos-data-cache" source and the given message fragment was logged.
 	 *
 	 * @param object $fake_logger The fake logger capturing log calls.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
@@ -685,7 +685,79 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 			'Meta should self-heal from the database after the corrupt legacy cache entry is invalidated.'
 		);
 
+		// The self-healed read must not re-log: the warning fires once, not on every read.
+		$this->assertSame(
+			1,
+			$this->count_hpos_cache_warnings( $fake_logger, 'Discarded malformed meta data' ),
+			'The corruption warning should fire once and stop once the cache self-heals.'
+		);
+
 		remove_all_filters( 'woocommerce_logging_class' );
+	}
+
+	/**
+	 * @testdox A legacy meta cache array containing an incomplete meta row (missing meta_value) is treated as corrupt, invalidated, and self-heals.
+	 */
+	public function test_incomplete_legacy_meta_row_is_invalidated_and_self_heals(): void {
+		$fake_logger = $this->create_fake_logger();
+		add_filter(
+			'woocommerce_logging_class',
+			function () use ( $fake_logger ) {
+				return $fake_logger;
+			}
+		);
+
+		$order = new WC_Order();
+		$order->add_meta_data( 'custom_meta_key', 'custom_value', true );
+		$order->save();
+		$order_id = $order->get_id();
+
+		$order = wc_get_order( $order_id );
+
+		/*
+		 * Poison the legacy 'orders' meta cache with an object row that has meta_key but is missing
+		 * meta_id and meta_value. This is a valid array of objects with meta_key, so a meta_key-only
+		 * shape check would accept it and hydrate the real key with a null value. The completeness
+		 * check (meta_id + meta_key + meta_value) must treat it as corrupt and self-heal instead.
+		 */
+		$cache_key = $order->get_meta_cache_key();
+		wp_cache_set( $cache_key, array( (object) array( 'meta_key' => 'custom_meta_key' ) ), 'orders' ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+
+		$order->read_meta_data();
+
+		$this->assert_hpos_cache_warning_logged( $fake_logger, 'Discarded malformed meta data' );
+		$this->assertFalse(
+			wp_cache_get( $cache_key, 'orders' ),
+			'The incomplete legacy meta cache entry should be invalidated so the next read re-reads from the database.'
+		);
+
+		$order->read_meta_data();
+		$this->assertSame(
+			'custom_value',
+			$order->get_meta( 'custom_meta_key' ),
+			'The incomplete row should be discarded and the real value re-read from the database, not loaded as null.'
+		);
+
+		remove_all_filters( 'woocommerce_logging_class' );
+	}
+
+	/**
+	 * Count warnings with the "hpos-data-cache" source containing the given message fragment.
+	 *
+	 * @param object $fake_logger The fake logger capturing log calls.
+	 * @param string $needle      A substring expected in the warning message.
+	 *
+	 * @return int Number of matching warnings.
+	 */
+	private function count_hpos_cache_warnings( object $fake_logger, string $needle ): int {
+		$count = 0;
+		foreach ( $fake_logger->warning_calls as $call ) {
+			if ( 'hpos-data-cache' === ( $call['context']['source'] ?? '' ) && false !== strpos( $call['message'], $needle ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
@@ -645,6 +645,12 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 			}
 		);
 
+		// Rebuild the data store so its injected logger (captured in init() via wc_get_logger())
+		// is the fake logger added above, and orders created below use this instance.
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+		$container->get( OrdersTableDataStore::class );
+
 		$order = new WC_Order();
 		$order->add_meta_data( 'custom_meta_key', 'custom_value', true );
 		$order->save();
@@ -706,6 +712,12 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 				return $fake_logger;
 			}
 		);
+
+		// Rebuild the data store so its injected logger (captured in init() via wc_get_logger())
+		// is the fake logger added above, and orders created below use this instance.
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+		$container->get( OrdersTableDataStore::class );
 
 		$order = new WC_Order();
 		$order->add_meta_data( 'custom_meta_key', 'custom_value', true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Closes #66508 .

(For Bug Fixes) Bug introduced in PR #66131 .

The corruption guard added in PR #66131 to `OrdersTableDataStore::filter_raw_meta_data()` invalidates the wrong cache when it fires.

On corruption it calls `$this->data_store_meta->clear_cached_data()`, which clears the HPOS `orders_meta` cache group. But that group is primed by `init_order_record()`, whose meta is already shape-validated at the `OrdersTableDataStoreMeta` cache boundary, so the guard is effectively never reached with a corrupt cached array there.

The one path that *can* feed the guard a corrupt cached array is the legacy `WC_Data::read_meta_data()`, which reads the object's own meta cache group (`WC_Abstract_Order::$cache_group = 'orders'`). Because:

1. the guard clears `orders_meta`, not `orders`, and
2. `read_meta_data()` skips its own re-cache when the value was loaded from cache (`$cache_loaded === true`),

the corrupt `orders` entry is never invalidated. The order keeps loading with empty meta and the `Discarded malformed meta data...` warning re-logs on every read, instead of self-healing from the database as the message promises. This is not a regression (pre-PR #66131 this same input fataled), but the advertised self-heal does not happen in the reachable path.

This PR:

-   Adds `WC_Data::delete_meta_cache()`, a counterpart to the existing `WC_Data::prime_raw_meta_data_cache()`, that removes the object's own legacy meta cache entry (its `cache_group`).
-   Calls it from the corruption guard so the group the corrupt value actually came from is invalidated. The next `read_meta_data()` misses the cache and re-reads from the database. The existing `orders_meta` clear is kept as defense-in-depth for the HPOS path.
-   Tightens the guard's corruption check to require complete meta rows (`meta_id` + `meta_key` + `meta_value`), matching the completeness check `OrdersTableDataStoreMeta::is_valid_cached_meta()` already applies at the HPOS cache boundary. Previously the guard only checked for `meta_key`, so a cached object row missing `meta_id`/`meta_value` slipped past the guard, hydrated the real key with a `null` value, and left the legacy cache poisoned. This asymmetry was surfaced by an adversarial review pass.

**Backward compatibility:** `WC_Data::delete_meta_cache()` is a new public method on the `WC_Data` base class. This is additive (a concrete method on an abstract base, not an interface or abstract method), so no existing subclass fatals on load; it changes no existing signatures or interfaces. The name is unique in-tree. One low-probability residual: a third-party subclass that already declares its own `delete_meta_cache()` with an incompatible signature would emit a PHP "Declaration should be compatible" warning on load. No such subclass is known. The guard call is `is_callable`-guarded to cover the brief plugin-upgrade window where this data store class can load before an opcode-cached older `WC_Data` gains the method.

**`@since`:** the new method is tagged `@since 11.0.0` to match this PR's 11.0.0 milestone (the target release, cherry-picked to `release/11.0`), not trunk's current `11.1.0-dev`. If the fix will not be cherry-picked into 11.0.0, change this to `11.1.0`.

### How to test the changes in this Pull Request:

1. Enable HPOS and HPOS data-store caching on a store with a persistent object cache.
2. Create an order with at least one meta value (for example `custom_meta_key` = `custom_value`).
3. Simulate a corrupt legacy meta cache entry: prime the `orders` object-cache group for the order's meta cache key with a well-formed array whose elements are not meta rows, e.g.
   `wp_cache_set( $order->get_meta_cache_key(), array( 'not-a-meta-row' ), 'orders' );`
4. Trigger the legacy read path: `$order->read_meta_data();`
5. Confirm a `hpos-data-cache` warning `Discarded malformed meta data...` is logged and the order loads (no fatal).
6. **Before this fix:** the `orders`-group cache entry is still present, and a second `read_meta_data()` re-loads the corrupt value (empty meta, warning re-logs).
7. **After this fix:** the `orders`-group entry has been invalidated (`wp_cache_get( $order->get_meta_cache_key(), 'orders' ) === false`), and a second `read_meta_data()` re-reads from the database and recovers `custom_value`.

The added test `OrdersTableDataStoreCacheCrossBleedTest::test_corrupt_legacy_meta_cache_entry_is_invalidated_and_self_heals` automates this.

### Testing that has already taken place:

-   Static analysis and root-cause tracing of both meta read paths (`init_order_record()` and `WC_Data::read_meta_data()`) and the two cache groups (`orders_meta` via `WPCacheEngine`, `orders` via `wp_cache_*`).
-   PHP syntax check (`php -l`) on all three changed files.
-   A regression test was added that fails without the fix (the legacy entry persists) and passes with it (the entry is invalidated and meta self-heals). Note: the full PHPUnit suite was not executed in this workspace because its local dev environment was not provisioned; CI will run it.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Milestone set manually to 11.0.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually in `plugins/woocommerce/changelog/66508-fix-hpos-legacy-meta-cache-self-heal`.
