### PR TITLE
Fix several RTL layout issues in the WooCommerce admin

### DIFF
--- a/plugins/woocommerce/changelog/65429-fix-rtl-admin-layout
+++ b/plugins/woocommerce/changelog/65429-fix-rtl-admin-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix right-to-left (RTL) layout issues in the admin: the sample product import overlay position and its list chevrons, and the Customize Your Store banner illustration placement.

--- a/plugins/woocommerce/client/admin/client/customize-store/style.scss
+++ b/plugins/woocommerce/client/admin/client/customize-store/style.scss
@@ -202,7 +202,7 @@
 
 		.woocommerce-banner-visual {
 			position: absolute;
-			right: 0;
+			inset-inline-end: 0;
 			top: 50%;
 			transform: translateY(-50%);
 			display: flex;
@@ -262,7 +262,7 @@
 				ul {
 					flex: 1 1 50%;
 					list-style: disc;
-					padding-left: 1rem;
+					padding-inline-start: 1rem;
 
 					li {
 						margin-bottom: 0;

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/components/load-sample-product-confirm-modal.scss
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/components/load-sample-product-confirm-modal.scss
@@ -1,13 +1,13 @@
 .woocommerce-products-load-sample-product-confirm-modal-overlay {
 	@media (min-width: 783px ) {
 		& {
-			left: 35px;
+			inset-inline-start: 35px;
 		}
 	}
 
 	@include break-large {
 		& {
-			left: 160px;
+			inset-inline-start: 160px;
 		}
 	}
 }
@@ -23,7 +23,7 @@
 		margin-top: $gap;
 
 		button {
-			margin-left: $gap;
+			margin-inline-start: $gap;
 		}
 	}
 }

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/components/load-sample-product-modal.scss
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/components/load-sample-product-modal.scss
@@ -4,14 +4,14 @@
 
 	@media (min-width: 783px ) {
 		& {
-			left: 35px;
+			inset-inline-start: 35px;
 		}
 	}
 
 
 	@include break-large {
 		& {
-			left: 160px;
+			inset-inline-start: 160px;
 		}
 	}
 

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/products/constants.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import ProductIcon from 'gridicons/dist/product';
 import CloudOutlineIcon from 'gridicons/dist/cloud-outline';
 import TypesIcon from 'gridicons/dist/types';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 import { recordEvent } from '@woocommerce/tracks';
 import { getAdminLink } from '@woocommerce/settings';
 
@@ -18,6 +18,10 @@ import LightBulb from './icon/lightbulb_24px.js';
 import PrintfulIcon from './icon/printful.png';
 import Upload from './icon/upload_40px.js';
 
+// The "after" chevron points in the reading direction (forward), so it must
+// flip for RTL locales instead of always pointing right.
+const listItemChevron = <Icon icon={ isRTL() ? chevronLeft : chevronRight } />;
+
 export const productTypes = Object.freeze( [
 	{
 		key: 'physical' as const,
@@ -27,7 +31,7 @@ export const productTypes = Object.freeze( [
 			'woocommerce'
 		),
 		before: <ProductIcon />,
-		after: <Icon icon={ chevronRight } />,
+		after: listItemChevron,
 	},
 	{
 		key: 'digital' as const,
@@ -37,7 +41,7 @@ export const productTypes = Object.freeze( [
 			'woocommerce'
 		),
 		before: <CloudOutlineIcon />,
-		after: <Icon icon={ chevronRight } />,
+		after: listItemChevron,
 	},
 	{
 		key: 'variable' as const,
@@ -47,21 +51,21 @@ export const productTypes = Object.freeze( [
 			'woocommerce'
 		),
 		before: <TypesIcon />,
-		after: <Icon icon={ chevronRight } />,
+		after: listItemChevron,
 	},
 	{
 		key: 'grouped' as const,
 		title: __( 'Grouped product', 'woocommerce' ),
 		content: __( 'A collection of related products.', 'woocommerce' ),
 		before: <Widget />,
-		after: <Icon icon={ chevronRight } />,
+		after: listItemChevron,
 	},
 	{
 		key: 'external' as const,
 		title: __( 'External product', 'woocommerce' ),
 		content: __( 'Link a product to an external website.', 'woocommerce' ),
 		before: <Link />,
-		after: <Icon icon={ chevronRight } />,
+		after: listItemChevron,
 	},
 ] );
 
@@ -73,7 +77,7 @@ export const LoadSampleProductType = {
 		'woocommerce'
 	),
 	before: <LightBulb />,
-	after: <Icon icon={ chevronRight } />,
+	after: listItemChevron,
 	className: 'woocommerce-products-list__item-load-sample-product',
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/shared-components/settings-modal/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/shared-components/settings-modal/index.tsx
@@ -57,12 +57,12 @@ const StyledFooter = styled.div`
 
 	> * {
 		&:not( :first-of-type ) {
-			margin-left: 8px;
+			margin-inline-start: 8px;
 		}
 	}
 
 	.button-link-delete {
-		margin-right: auto;
+		margin-inline-end: auto;
 		color: #d63638;
 	}
 `;

--- a/plugins/woocommerce/client/blocks/changelog/65429-fix-rtl-settings-modal-buttons
+++ b/plugins/woocommerce/client/blocks/changelog/65429-fix-rtl-settings-modal-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix right-to-left (RTL) button spacing in the shipping settings modal, where action buttons (for example in Local Pickup) were stuck together.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Several admin screens render incorrectly in right-to-left (RTL) locales because the layout relies on physical CSS properties (and, in one case, `@emotion/styled` CSS-in-JS, which rtlcss cannot flip). This fixes the three RTL issues reported in #65429 by switching to direction-aware logical properties and a reading-direction chevron:

-   **Local Pickup settings modal** — the shared `SettingsModal` footer used physical `margin-left`/`margin-right` inside an `@emotion/styled` block that rtlcss never processes, so the action buttons were stuck together in RTL. Now uses `margin-inline-start`/`margin-inline-end`.
-   **Customize Your Store banners** — the banner illustration was `position: absolute; right: 0`. This screen's styles ship in a lazily-loaded webpack chunk that has no generated `-rtl.css` counterpart (unlike the other admin areas), so the physical `right` was never flipped for RTL: the illustration stayed pinned to the right, overlapping the heading and button and leaving the leading side empty. Now `inset-inline-end: 0`, which resolves to the correct side at paint time regardless of whether an RTL stylesheet exists.
-   **Sample product import** — the loading overlay used physical `left` offsets, and the product-type list chevrons were hard-coded to `chevronRight`. The overlay now uses `inset-inline-start`, and the chevron flips with `isRTL()` (matching the pattern already used elsewhere in the admin client).

LTR rendering is unchanged: logical properties resolve to the same physical side under `direction: ltr`, and `isRTL()` returns `false`.

Closes #65429.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

All captured from a live RTL (`fa_IR`) build running this branch.

| Area | Before | After |
| ---- | ------ | ----- |
| **Local Pickup** settings modal | see the annotated shot in [#65429](https://github.com/woocommerce/woocommerce/issues/65429) | <img src="https://raw.githubusercontent.com/vismaytiwari/woocommerce/pr-65429-screenshots/pr-screenshots/bug1-after-localpickup-modal.png" width="380" alt="Local Pickup modal, RTL, after: action buttons spaced"> |
| **Customize Your Store** banner | <img src="https://raw.githubusercontent.com/vismaytiwari/woocommerce/pr-65429-screenshots/pr-screenshots/bug2-before-banner.png" width="380" alt="Customize Your Store banner, RTL, before: illustration pinned right, overlapping the text"> | <img src="https://raw.githubusercontent.com/vismaytiwari/woocommerce/pr-65429-screenshots/pr-screenshots/bug2-after-banner.png" width="380" alt="Customize Your Store banner, RTL, after: illustration on the leading side, no overlap"> |
| **Sample products** chevrons | see the annotated shot in [#65429](https://github.com/woocommerce/woocommerce/issues/65429) | <img src="https://raw.githubusercontent.com/vismaytiwari/woocommerce/pr-65429-screenshots/pr-screenshots/bug3-after-chevrons.png" width="380" alt="Product-type list, RTL, after: chevrons point in the reading direction (left)"> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set the site language to a right-to-left locale (for example Persian / فارسی) so the admin renders with `dir="rtl"`.
2. **Local Pickup:** WooCommerce → Settings → Shipping → Local pickup → add or edit a pickup location. Confirm the "Cancel" and "Done" buttons have a gap between them, and "Delete location" sits on the far side.
3. **Customize Your Store:** open the "Customize your store" screen from the admin home, using a viewport at least ~1024px wide (the illustration is intentionally hidden on narrower screens via a responsive rule). Confirm each banner's illustration sits on the leading side and the card fills the row — no empty gap, and no illustration overlapping the heading/button.
4. **Sample products:** on the Products task, choose to import sample products. Confirm the loading overlay is positioned over the content area (not skewed), and the chevrons on the product-type rows and "Load sample products" point in the reading direction (left in RTL).
5. Repeat in an LTR locale and confirm nothing changed.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified in a live RTL environment: WooCommerce built from this branch and run in `wp-env` with the site locale set to Persian (`fa_IR`) so the admin renders `dir="rtl"`. Each area was confirmed visually — the Local Pickup modal action buttons are spaced, the Customize Your Store banner illustration sits on the leading side without overlapping the text, and the sample-product overlay is positioned over the content with the product-type chevrons pointing in the reading direction. The fix follows the physical→logical-property pattern already established across the admin client, and LTR was spot-checked to confirm no change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entries were created manually, one per affected package: `plugins/woocommerce/changelog/65429-fix-rtl-admin-layout` (`@woocommerce/plugin-woocommerce`) and `plugins/woocommerce/client/blocks/changelog/65429-fix-rtl-settings-modal-buttons` (`@woocommerce/block-library`).

</details>
