### PR TITLE
Fix undefined array key warning in [products] shortcode with no global post

### DIFF
--- a/plugins/woocommerce/changelog/fix-products-shortcode-missing-global-post
+++ b/plugins/woocommerce/changelog/fix-products-shortcode-missing-global-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent an undefined array key warning from the [products] shortcode when it renders without a global post, such as in AJAX or REST requests, and restore the prior post state correctly.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
@@ -637,7 +637,7 @@ class WC_Shortcode_Products {
 				)
 			);
 
-			$original_post = $GLOBALS['post'];
+			$original_post = $GLOBALS['post'] ?? null;
 
 			do_action( "woocommerce_shortcode_before_{$this->type}_loop", $this->attributes );
 
@@ -669,7 +669,11 @@ class WC_Shortcode_Products {
 				}
 			}
 
-			$GLOBALS['post'] = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			if ( null !== $original_post ) {
+				$GLOBALS['post'] = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			} else {
+				unset( $GLOBALS['post'] );
+			}
 			woocommerce_product_loop_end();
 
 			if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/shortcodes/products.php
@@ -644,6 +644,22 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_content() restores the global post when there was none.
+	 *
+	 * Regression for #30073: product_loop() read $GLOBALS['post'] without a guard, so in a
+	 * context with no global post (an AJAX or REST request) it raised an undefined-key warning
+	 * and left $GLOBALS['post'] set to null instead of restoring the prior unset state.
+	 */
+	public function test_get_content_without_global_post() {
+		unset( $GLOBALS['post'] );
+
+		$shortcode = new WC_Shortcode_Products();
+		$shortcode->get_content();
+
+		$this->assertArrayNotHasKey( 'post', $GLOBALS, 'The global post should be restored to its prior unset state.' );
+	}
+
+	/**
 	 * Test: WC_Shortcode_Products::set_product_as_visible.
 	 */
 	public function test_set_product_as_visible() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_Shortcode_Products::product_loop()` saves and restores the global `$post` around its render loop, but it read `$GLOBALS['post']` directly. In any context with no global post (an AJAX or REST request, or a nested render) that read hits an unset key and raises `Undefined array key "post"` on PHP 8 (or `Undefined index: post` on PHP 7), and it left `$GLOBALS['post']` set to `null` afterwards instead of restoring the prior unset state.

This null-coalesces the read and guards the restore, unsetting the global again when there was no original post, so the prior state is faithfully restored.

Closes woocommerce/woocommerce#30073.

This supersedes the stale [#45254](<https://github.com/woocommerce/woocommerce/issues/45254>), which attempted the same fix.

### How to test the changes in this Pull Request:

1. In a context with no global post, render the shortcode, for example `wp eval 'unset($GLOBALS["post"]); echo do_shortcode("[products limit=1]");'`, or from an AJAX or REST callback.
2. On trunk you see an `Undefined array key "post"` warning.
3. With this change the warning is gone and `$GLOBALS['post']` is restored to its prior (unset) state.

### Testing that has already taken place:

Added `WC_Test_Shortcode_Products::test_get_content_without_global_post`: it unsets the global post, renders the shortcode, and asserts the global is restored to its prior unset state. The assertion fails on trunk (the bug leaves the key set to `null`) and passes with this change.

### Changelog entry

Added under `plugins/woocommerce/changelog/` (Significance: patch, Type: fix).

### Milestone

- [X] Automatically assign milestone for the next WooCommerce version.

🤖 Prepared by Claude, on behalf of Daniel.