### PR TITLE
Remove redundant changelog entry for PR #66477 (#66484) [release/11.0]

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
+++ b/plugins/woocommerce/changelog/dev-e2e-filter-label-colon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update customer list e2e selectors to match the colon-less Show filter label.


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.

### Changes proposed in this Pull Request:

Manual cherry-pick of #66484 to `release/11.0`. The automated cherry-pick was skipped because the PR contains no code changes (changelog-only deletion).

#66477 shipped with two `plugin-woocommerce` changelog entries for the same change: a manually added `dev` entry about the e2e selector update, and the auto-generated `tweak` entry from the PR template. This removes the redundant `dev` entry, keeping the user-facing `tweak` one, so the change appears once in the compiled 11.0 release notes.

Both files are present on `release/11.0` (the cherry-pick of #66477 itself, #66482, has landed), so this cleanup applies cleanly.

Changelog-only change; no code affected.

### How to test the changes in this Pull Request:

1. Confirm `plugins/woocommerce/changelog/dev-e2e-filter-label-colon` is deleted and `plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon` remains on `release/11.0`.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog-only cleanup; no new entry needed.
