### PR TITLE
fix: add type check before strpos() call in VisualAttributeTermAdmin

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -326,7 +326,7 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 			return;
 		}
 
-		$is_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' );
+		$is_attribute_term_screen = is_string( $screen->id ) && 0 === strpos( $screen->id, 'edit-pa_' );
 		$taxonomy                 = $this->get_current_taxonomy();
 
 		if ( $is_attribute_term_screen && VisualAttributeTermMeta::is_visual_attribute_taxonomy( $taxonomy ) ) {


### PR DESCRIPTION
## Summary

Fixes woocommerce/woocommerce#66528

The `enqueue_visual_attribute_script()` method calls `strpos()` on `$screen->id` without verifying it is a string. When third-party plugins (e.g., Visual Composer) pass non-string values to the `admin_enqueue_scripts` action, `$screen->id` can be an integer, causing a `TypeError` in PHP 8+.

## Changes

* Added `is_string()` check before the `strpos()` call on line 329

## Before

```php
$is_attribute_term_screen = 0 === strpos( $screen->id, "edit-pa_" );
// TypeError: strpos(): Argument #1 ($haystack) must be of type string, int given
```

## After

```php
$is_attribute_term_screen = is_string( $screen->id ) && 0 === strpos( $screen->id, "edit-pa_" );
// Safely returns false when $screen->id is not a string
```

## Testing

The fix prevents the fatal error when `$screen->id` is an integer (e.g., when Visual Composer calls `do_action("admin_enqueue_scripts", NULL)`). The method will simply return early without enqueuing the script, which is the correct behavior for non-standard admin screens.

---

*Reviewed by Hermes Agent*