### PR TITLE
[Performance] Fix ordering products performance (N-query pattern)

### DIFF
--- a/plugins/woocommerce/changelog/performance-products-reordering-ajax
+++ b/plugins/woocommerce/changelog/performance-products-reordering-ajax
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Fixed ordering products performance (N-query pattern).

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2351,53 +2351,117 @@ class WC_AJAX {
 		}
 
 		$sorting_id  = absint( $_POST['id'] );
-		$previd      = absint( isset( $_POST['previd'] ) ? $_POST['previd'] : 0 );
-		$nextid      = absint( isset( $_POST['nextid'] ) ? $_POST['nextid'] : 0 );
-		$menu_orders = wp_list_pluck( $wpdb->get_results( "SELECT ID, menu_order FROM {$wpdb->posts} WHERE post_type = 'product' ORDER BY menu_order ASC, post_title ASC" ), 'menu_order', 'ID' );
-		$index       = 0;
+		$previous_id = absint( $_POST['previd'] ?? 0 );
+		$next_id     = absint( $_POST['nextid'] ?? 0 );
 
-		foreach ( $menu_orders as $id => $menu_order ) {
-			$id = absint( $id );
+		// Performance note: fetch positions of the three anchor points; fetch by PK is nearly instant.
+		$anchor_positions  = wp_list_pluck(
+			$wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, menu_order FROM {$wpdb->posts} WHERE ID IN (%d, %d, %d) ORDER BY menu_order ASC",
+					$sorting_id,
+					$previous_id,
+					$next_id
+				)
+			),
+			'menu_order',
+			'ID'
+		);
+		$sorting_position  = (int) ( $anchor_positions[ $sorting_id ] ?? 0 );
+		$previous_position = (int) ( $anchor_positions[ $previous_id ] ?? 0 );
+		$next_position     = (int) ( $anchor_positions[ $next_id ] ?? 0 );
 
-			if ( $sorting_id === $id ) {
-				continue;
-			}
-			if ( $nextid === $id ) {
-				++$index;
-			}
-			++$index;
-			$menu_orders[ $id ] = $index;
-
-			if ( $wpdb->update( $wpdb->posts, array( 'menu_order' => $index ), array( 'ID' => $id ) ) ) {
-				// We only need to clean the cache if the menu order was actually modified.
-				clean_post_cache( $id );
-			}
-
-			/**
-			 * When a single product has gotten it's ordering updated.
-			 * $id The product ID
-			 * $index The new menu order
-			*/
-			do_action( 'woocommerce_after_single_product_ordering', $id, $index );
+		// Bail out early if no positioning adjustments are necessary.
+		if ( array_keys( $anchor_positions ) === array_values( array_filter( array( $previous_id, $sorting_id, $next_id ) ) ) ) {
+			wp_send_json( array() );
 		}
 
-		if ( isset( $menu_orders[ $previd ] ) ) {
-			$menu_orders[ $sorting_id ] = $menu_orders[ $previd ] + 1;
-		} elseif ( isset( $menu_orders[ $nextid ] ) ) {
-			$menu_orders[ $sorting_id ] = $menu_orders[ $nextid ] - 1;
+		// Identify the affected range which needs to be updated.
+		if ( $previous_position > $sorting_position ) {
+			// Moving forward: products between current and new position shift down.
+			$range_from   = $sorting_position + 1;
+			$range_to     = $previous_position;
+			$range_delta  = -1;
+			$new_position = $previous_position;
 		} else {
-			$menu_orders[ $sorting_id ] = 0;
+			// Moving backward: products between new and current position shift up.
+			$range_from   = $next_position;
+			$range_to     = $sorting_position - 1;
+			$range_delta  = +1;
+			$new_position = $next_position;
 		}
 
-		if ( $wpdb->update( $wpdb->posts, array( 'menu_order' => $menu_orders[ $sorting_id ] ), array( 'ID' => $sorting_id ) ) ) {
-			// We only need to clean the cache if the menu order was actually modified.
-			clean_post_cache( $sorting_id );
-		}
+		// Performance note: pre-fetch range IDs — no index on menu_order, but re-injecting PKs keeps all follow-up queries instant.
+		$range_positions    = wp_list_pluck(
+			$wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, menu_order FROM {$wpdb->posts} WHERE post_type = 'product' AND menu_order BETWEEN %d AND %d",
+					$range_from,
+					$range_to
+				)
+			),
+			'menu_order',
+			'ID'
+		);
+		$range_ids          = array_merge( array( $sorting_id ), array_keys( $range_positions ) );
+		$range_placeholders = implode( ',', array_fill( 0, count( $range_ids ), '%d' ) );
 
+		// Shift positions in bulk and followup with targeted update for the re-positioned product; update by PK is nearly instant.
+		$wpdb->query(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			$wpdb->prepare(
+				"UPDATE {$wpdb->posts} SET menu_order = menu_order + %d WHERE ID IN ( {$range_placeholders} )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$range_delta,
+				...$range_ids
+			)
+		);
+		$wpdb->update( $wpdb->posts, array( 'menu_order' => $new_position ), array( 'ID' => $sorting_id ) );
+
+		// Fetch updated positions for cache invalidation, hooks, and response; fetch by PK is nearly instant.
+		$updated_positions = wp_list_pluck(
+			$wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, menu_order FROM {$wpdb->posts} WHERE ID IN ( {$range_placeholders} ) ORDER BY menu_order ASC, post_title ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+					$range_ids
+				)
+			),
+			'menu_order',
+			'ID'
+		);
+		foreach ( $updated_positions as $id => $position ) {
+			clean_post_cache( $id );
+			/**
+			 * When a single product has gotten its ordering updated.
+			 *
+			 * @param int $id       The product ID.
+			 * @param int $position The new sort position.
+			 *
+			 * @since 11.1.0 fires for updated entries only; see woocommerce_after_product_ordering for all positions.
+			 * @since 3.1.0
+			 */
+			do_action( 'woocommerce_after_single_product_ordering', $id, $position );
+		}
 		WC_Post_Data::delete_product_query_transients();
 
-		do_action( 'woocommerce_after_product_ordering', $sorting_id, $menu_orders );
-		wp_send_json( $menu_orders );
+		// Performance note: hook below loads all products — no covering index on menu_order, degrades with catalog size; avoid hooking it on large catalogs.
+		if ( has_action( 'woocommerce_after_product_ordering' ) ) {
+			$all_positions = wp_list_pluck(
+				$wpdb->get_results( "SELECT ID, menu_order FROM {$wpdb->posts} WHERE post_type = 'product' ORDER BY menu_order ASC, post_title ASC" ),
+				'menu_order',
+				'ID'
+			);
+			/**
+			 * When products ordering update completed.
+			 *
+			 * @param int            $sorting_id    The product ID that was repositioned.
+			 * @param array<int,int> $all_positions All product sort positions (product ID → actual menu_order value).
+			 *
+			 * @since 3.1.0
+			 */
+			do_action( 'woocommerce_after_product_ordering', $sorting_id, $all_positions );
+		}
+
+		wp_send_json( $updated_positions );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -680,6 +680,113 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for test_product_ordering.
+	 *
+	 * Columns: sorting_idx, previd_idx (-1 = none), nextid_idx (-1 = none), expected menu_orders [P1..P5].
+	 */
+	public function product_ordering_provider(): array {
+		return array(
+			'last to first'             => array( 4, -1, 0, array( 2, 3, 4, 5, 1 ) ),
+			'first to last'             => array( 0, 4, -1, array( 5, 1, 2, 3, 4 ) ),
+			'middle one position left'  => array( 2, 0, 1, array( 1, 3, 2, 4, 5 ) ),
+			'middle one position right' => array( 2, 3, 4, array( 1, 2, 4, 3, 5 ) ),
+			'middle to first'           => array( 2, -1, 0, array( 2, 3, 1, 4, 5 ) ),
+			'middle to last'            => array( 2, 4, -1, array( 1, 2, 5, 3, 4 ) ),
+			'drop in place'             => array( 2, 1, 3, array( 1, 2, 3, 4, 5 ) ),
+		);
+	}
+
+	/**
+	 * @testdox 'product_ordering' moves a product to the correct position and shifts the affected range.
+	 * @dataProvider product_ordering_provider
+	 *
+	 * @param int   $sorting_idx     Index (0-based) of the product being dragged.
+	 * @param int   $previd_idx      Index of the product immediately before the drop target, or -1 if dropped at the top.
+	 * @param int   $nextid_idx      Index of the product immediately after the drop target, or -1 if dropped at the bottom.
+	 * @param int[] $expected_orders Expected menu_order values indexed by original product position [P1..P5].
+	 */
+	public function test_product_ordering( int $sorting_idx, int $previd_idx, int $nextid_idx, array $expected_orders ): void {
+		global $wpdb;
+
+		$this->_setRole( 'administrator' );
+
+		$products = array();
+		for ( $i = 1; $i <= 5; ++$i ) {
+			$product                 = WC_Helper_Product::create_simple_product();
+			$product_id              = $product->get_id();
+			$products[ $product_id ] = $product;
+			wp_update_post(
+				array(
+					'ID'         => $product_id,
+					'menu_order' => $i,
+				)
+			);
+		}
+		$product_ids = array_keys( $products );
+
+		$_POST['security'] = wp_create_nonce( 'product-ordering' );
+		$_POST['id']       = $product_ids[ $sorting_idx ];
+		$_POST['previd']   = $previd_idx >= 0 ? $product_ids[ $previd_idx ] : 0;
+		$_POST['nextid']   = $nextid_idx >= 0 ? $product_ids[ $nextid_idx ] : 0;
+
+		$this->do_ajax( 'woocommerce_product_ordering' );
+
+		unset( $_POST['security'], $_POST['id'], $_POST['previd'], $_POST['nextid'] );
+		foreach ( $product_ids as $idx => $product_id ) {
+			$actual = (int) $wpdb->get_var( $wpdb->prepare( "SELECT menu_order FROM {$wpdb->posts} WHERE ID = %d", $product_id ) );
+			$this->assertSame( $expected_orders[ $idx ], $actual, "Product at index {$idx} has wrong menu_order." );
+			$products[ $product_id ]->delete( true );
+		}
+	}
+
+	/**
+	 * @testdox 'product_ordering' fires 'woocommerce_after_product_ordering' with the moved product ID and full positions map.
+	 */
+	public function test_product_ordering_fires_after_product_ordering_action(): void {
+		$this->_setRole( 'administrator' );
+
+		$products = array();
+		for ( $i = 1; $i <= 2; ++$i ) {
+			$product                 = WC_Helper_Product::create_simple_product();
+			$product_id              = $product->get_id();
+			$products[ $product_id ] = $product;
+			wp_update_post(
+				array(
+					'ID'         => $product_id,
+					'menu_order' => $i,
+				)
+			);
+		}
+		$product_ids = array_keys( $products );
+
+		$hook_fired = false;
+		$hook       = function ( $sorting_id, $all_positions ) use ( &$hook_fired, $product_ids ) {
+			$hook_fired = true;
+			$this->assertSame( $product_ids[1], $sorting_id );
+			$this->assertSame( '1', $all_positions[ $product_ids[1] ] );
+			$this->assertSame( '2', $all_positions[ $product_ids[0] ] );
+		};
+		add_action( 'woocommerce_after_product_ordering', $hook, 10, 2 );
+
+		// Move the last one to the front.
+		$_POST['security'] = wp_create_nonce( 'product-ordering' );
+		$_POST['id']       = $product_ids[1];
+		$_POST['previd']   = 0;
+		$_POST['nextid']   = $product_ids[0];
+
+		$this->do_ajax( 'woocommerce_product_ordering' );
+
+		unset( $_POST['security'], $_POST['id'], $_POST['previd'], $_POST['nextid'] );
+		remove_action( 'woocommerce_after_product_ordering', $hook, 10 );
+
+		$this->assertTrue( $hook_fired, 'woocommerce_after_product_ordering was not fired.' );
+
+		foreach ( $product_ids as $product_id ) {
+			$products[ $product_id ]->delete( true );
+		}
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #30995, WOOPLUG-495.

Reworks `\WC_AJAX::product_ordering` implementation: targeted updates for the product range affected by reordering; accounts for no index covering search/order by on `menu_order`.

The previous approach fetched ALL products, iterated over them to modify the ordering index, and returned all entries (N-update SQLs and N returned items).

The approach revisited is the following:
- 2 SQL queries to identify the affected range and product IDs for this range (one of them is slow - similar to the original one)
- 2 SQL queries to bulk-update the range and the rearranged product (both using PKs)
- 1 SQL query to bulk-fetch updated range data (using PKs)
- Additional slow SQL will be executed if `woocommerce_after_product_ordering` has hooks, but I added a performance note to not use it on larger catalogs.
- Return the updated range data

This approach guarantees, in a standard setup:
- a constant 5 SQL queries (4 of them operate on PKs) for rearranging the product across any catalog size.
- minimal response size necessary to update the admin page

> One of the SQL queries will degrade with catalog size: linear degradation, but not breaking the reorder functionality.

> `woocommerce_after_single_product_ordering` now fires for the modified products range; previously, it fired for all products, since they were iterated (a bug; should be gated, similar to `clean_post_cache`). The contract is narrowed to the modified range (no red flags from regression analysis), but it's something where reviewers' feedback will be handy.

### How to test the changes in this Pull Request:

- Using this branch, navigate to admin: `Products -> All products.`
- Click on the 'Sorting' link in the product status counters area.
- Perform exploratory testing by moving products to different positions across multiple pages.
- Verify the changes being applied by reloading the page after position adjustments.
