### PR TITLE
Add class to payment link on the customer order details and update the template title

### DIFF
--- a/plugins/woocommerce/changelog/66544-66537-order-details-email
+++ b/plugins/woocommerce/changelog/66544-66537-order-details-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add class to payment link on the customer order details and update the template title to "Customer order details email"

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 11.0.0
+ * @version 11.1.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer invoice email
+ * Customer order details email
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-invoice.php.
  *

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -67,7 +67,6 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 				array(
 					'a' => array(
 						'href' => array(),
-						'class' => array(),
 					),
 				)
 			),

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.4.0
+ * @version 11.0.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
@@ -67,11 +67,12 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 				array(
 					'a' => array(
 						'href' => array(),
+						'class' => array(),
 					),
 				)
 			),
 			esc_html( get_bloginfo( 'name', 'display' ) ),
-			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
+			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="email-payment-link">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
 		);
 	}
 	?>

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -57,7 +57,7 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 				)
 			),
 			esc_html( get_bloginfo( 'name', 'display' ) ),
-			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
+			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="email-payment-link">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
 		);
 	} else {
 		printf(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Adds a "email-payment-link" to the payment link `A` tag on the [Customer Order details email](https://github.com/woocommerce/woocommerce/blob/10.9.4/plugins/woocommerce/templates/emails/customer-invoice.php), to allow site owners to style it via CSS.

It also updates the template comment title to "Customer order details email" to align with its "new" name, and drop "invoice" as it's not used on the UX anymore.

Closes #66537

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use the `woocommerce_email_styles` to add a css style to `.email-payment-link`
2. Go to any order needing payment and send the customer order details email using the actions dropdown
3. Check that the CSS style was applied to the payment link

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
- 
<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add class to payment link on the customer order details and update the template title to "Customer order details email"

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>