### PR TITLE
Restore deprecated product gallery image count helper

### DIFF
--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -50,13 +50,12 @@ class ProductGalleryUtils {
 	 * @deprecated 11.1.0 Use get_product_gallery_media_count instead.
 	 *
 	 * @param \WC_Product $product The product object to retrieve the gallery images for.
-	 * @return int The number of images in the product gallery.
+	 * @return int The number of media items in the product gallery.
 	 */
 	public static function get_product_gallery_image_count( $product ) {
 		wc_deprecated_function( __METHOD__, '11.1.0', 'get_product_gallery_media_count' );
 
-		$all_image_ids = self::get_all_image_ids( $product );
-		return count( $all_image_ids );
+		return self::get_product_gallery_media_count( $product );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -45,6 +45,21 @@ class ProductGalleryUtils {
 	}
 
 	/**
+	 * Get the product gallery image count.
+	 *
+	 * @deprecated 11.1.0 Use get_product_gallery_media_count instead.
+	 *
+	 * @param \WC_Product $product The product object to retrieve the gallery images for.
+	 * @return int The number of images in the product gallery.
+	 */
+	public static function get_product_gallery_image_count( $product ) {
+		wc_deprecated_function( __METHOD__, '11.1.0', 'get_product_gallery_media_count' );
+
+		$all_image_ids = self::get_all_image_ids( $product );
+		return count( $all_image_ids );
+	}
+
+	/**
 	 * Get all media items for the product gallery.
 	 *
 	 * @param \WC_Product $product The product object.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Restores the deprecated `ProductGalleryUtils::get_product_gallery_image_count()` compatibility method after it was renamed to `get_product_gallery_media_count()` in the product gallery videos work (#65396).

The restored method:

- Emits a WooCommerce deprecation notice pointing to `get_product_gallery_media_count()`.
- Preserves the previous image-only count behavior by counting `get_all_image_ids()`.

Closes #66514.

(For Bug Fixes) Bug introduced in PR #65396.

### Screenshots or screen recordings:

Not applicable. This is a PHP compatibility fix with no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch.
2. From plugin or extension code, call `Automattic\WooCommerce\Blocks\Utils\ProductGalleryUtils::get_product_gallery_image_count( $product )` with a valid product.
3. Confirm the call no longer fatals, returns the image-only gallery count, and emits a deprecation notice pointing to `get_product_gallery_media_count()`.

<!-- End testing instructions -->

### Testing that has already taken place:

- `composer exec -- phpstan analyse src/Blocks/Utils/ProductGalleryUtils.php --memory-limit=2G`
- `corepack pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`
- `corepack pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`
- `git diff --check`

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

No changelog entry required because this restores a deprecated compatibility shim for external callers and has no merchant-facing behavior change.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
