### PR TITLE
Fix Settings UI select trigger showing placeholder for empty-string option values

### DIFF
--- a/packages/js/experimental-products-app/changelog/dev-correct-selectcontrol-comments
+++ b/packages/js/experimental-products-app/changelog/dev-correct-selectcontrol-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct comments that attributed SelectControl empty-string handling to Radix UI; @wordpress/ui is built on Base UI.

--- a/packages/js/experimental-products-app/src/variation-view/fields/shipping_class/field.tsx
+++ b/packages/js/experimental-products-app/src/variation-view/fields/shipping_class/field.tsx
@@ -19,7 +19,8 @@ interface ProductShippingClass {
 	count: number;
 }
 
-// Radix UI (used by @wordpress/ui SelectControl) rejects empty-string values.
+// Base UI (used by @wordpress/ui SelectControl) treats an empty-string value
+// as "no selection" and shows the placeholder instead of the item label.
 // We use 'parent' as a UI sentinel for the '' API value ("Same as parent").
 const SAME_AS_PARENT = 'parent';
 

--- a/packages/js/experimental-products-app/src/variation-view/fields/tax_class/field.tsx
+++ b/packages/js/experimental-products-app/src/variation-view/fields/tax_class/field.tsx
@@ -10,7 +10,8 @@ import type { Field } from '@wordpress/dataviews';
  */
 import type { ProductEntityRecord } from '../types';
 
-// Radix UI (used by @wordpress/ui SelectControl) rejects empty-string values.
+// Base UI (used by @wordpress/ui SelectControl) treats an empty-string value
+// as "no selection" and shows the placeholder instead of the item label.
 // We use 'parent' as a UI sentinel for the '' API value ("Same as parent").
 const SAME_AS_PARENT = 'parent';
 

--- a/packages/js/settings-ui/changelog/fix-empty-string-option-trigger-label
+++ b/packages/js/settings-ui/changelog/fix-empty-string-option-trigger-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix select and radio fields showing the generic placeholder instead of the selected option label when the option value is an empty string.

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -154,6 +154,10 @@ export const NativeSettingsField = ( {
 				value={ selectedItem }
 				disabled={ field.disabled }
 				onValueChange={ ( item ) => onChange( item?.value ?? '' ) }
+				// Base UI treats a value that stringifies to '' as "no selection"
+				// and shows the placeholder, so pass the label explicitly to keep
+				// empty-string options displaying as selected.
+				triggerContent={ selectedItem?.label }
 			/>
 		);
 	}

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -419,6 +419,46 @@ describe( 'NativeSettingsField', () => {
 		} );
 	} );
 
+	describe( 'select fields', () => {
+		const selectField: SettingsUIField = {
+			id: 'woocommerce_shop_page_id',
+			label: 'Shop page',
+			type: 'select',
+			options: [
+				{ value: '', label: 'Select a page...' },
+				{ value: '5', label: 'Shop' },
+			],
+		};
+
+		const getTrigger = ( container: HTMLElement ) => {
+			const trigger = container.querySelector( '[role="combobox"]' );
+
+			if ( ! ( trigger instanceof HTMLElement ) ) {
+				throw new Error( 'Expected a select trigger.' );
+			}
+
+			return trigger;
+		};
+
+		it( 'renders an empty-string option value without throwing and shows its label as selected', () => {
+			const container = render(
+				<NativeSettingsField { ...makeProps( selectField, '' ) } />
+			);
+
+			expect( getTrigger( container ).textContent ).toContain(
+				'Select a page...'
+			);
+		} );
+
+		it( 'shows the selected option label for non-empty values', () => {
+			const container = render(
+				<NativeSettingsField { ...makeProps( selectField, '5' ) } />
+			);
+
+			expect( getTrigger( container ).textContent ).toContain( 'Shop' );
+		} );
+	} );
+
 	describe( 'text fields', () => {
 		it( 'renders text fields without spin buttons', () => {
 			const container = render(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Pass `triggerContent` to `SelectControl` in the Settings UI select/radio field so the trigger shows the selected option's label when the option value is an empty string. Base UI treats a value that stringifies to `''` as "no selection" and falls back to the generic "Select" placeholder.
- Correct two comments in `experimental-products-app` that attributed this behavior to Radix UI. `@wordpress/ui` is built on Base UI, and the wrong attribution already misled an automated review (#66543).
- Add unit tests covering select fields with empty-string option values.

Follow-up to #66543.

Bug introduced in PR #66461.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Trigger shows the generic "Select" placeholder when "Select a page..." is chosen | Trigger shows "Select a page..." |

### How to test the changes in this Pull Request:

1. Enable the `settings-ui` feature flag (e.g. via the `woocommerce_admin_features` filter).
2. Go to WooCommerce → Settings → Products.
3. Open the "Shop page" dropdown and choose "Select a page...".
4. Confirm the field shows "Select a page..." rather than the generic "Select" placeholder.
5. Choose a real page again and confirm its title still shows as the selected value.

### Testing that has already taken place:

- New unit tests for select fields in `native-fields.test.tsx`; the suite passes (16 tests).
- Manual test on a local site with the `settings-ui` flag enabled: the Products settings page renders as before, and the trigger now shows the empty option's label after selecting it.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entries were created manually and are included in the branch (`packages/js/settings-ui`, `packages/js/experimental-products-app`).
