### PR TITLE
Fix CSV importer server paths when wp-content is outside ABSPATH

### DIFF
--- a/plugins/woocommerce/changelog/fix-53676-csv-import-server-path
+++ b/plugins/woocommerce/changelog/fix-53676-csv-import-server-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve server file paths entered in the product CSV importer against the site root and uploads directory (and accept absolute paths), fixing imports on hosts where wp-content lives outside of ABSPATH.

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -471,10 +471,13 @@ class WC_Product_CSV_Importer_Controller {
 	public function handle_upload() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce already verified in WC_Product_CSV_Importer_Controller::upload_form_handler()
 		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
+		if ( ! is_string( $file_url ) ) {
+			$file_url = '';
+		}
 
 		try {
 			if ( ! empty( $file_url ) ) {
-				$path = ABSPATH . $file_url;
+				$path = FilesystemUtil::resolve_upload_file_path( $file_url );
 				self::validate_file_path( $path );
 			} else {
 				$csv_import_util = wc_get_container()->get( Automattic\WooCommerce\Internal\Admin\ImportExport\CSVUploadHelper::class );

--- a/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
@@ -66,8 +66,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</th>
 					<td>
 						<label for="woocommerce-importer-file-url" class="woocommerce-importer-file-url-field-wrapper">
-							<code><?php echo esc_html( ABSPATH ) . ' '; ?></code><input type="text" id="woocommerce-importer-file-url" name="file_url" />
+							<input type="text" id="woocommerce-importer-file-url" name="file_url" />
 						</label>
+						<small><?php esc_html_e( 'Enter the absolute path to the file, or a path relative to your WordPress directory.', 'woocommerce' ); ?></small>
 					</td>
 				</tr>
 				<tr class="woocommerce-importer-advanced hidden">

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -4033,12 +4033,6 @@ parameters:
 			path: includes/admin/helper/views/html-section-notices.php
 
 		-
-			message: '#^Binary operation "\." between string and non\-empty\-array\|non\-falsy\-string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: includes/admin/importers/class-wc-product-csv-importer-controller.php
-
-		-
 			message: '#^Method WC_Product_CSV_Importer_Controller\:\:add_error\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -331,7 +331,7 @@ class FilesystemUtil {
 	 * the uploads directory), so a resolved path may still be rejected — e.g.
 	 * a file sitting at the site root, outside both allowed locations.
 	 *
-	 * @since 11.1.0
+	 * @internal
 	 *
 	 * @param string $file_path The path to resolve, as entered by the user.
 	 * @return string The resolved path. Falls back to the path relative to

--- a/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/FilesystemUtil.php
@@ -314,6 +314,66 @@ class FilesystemUtil {
 	}
 
 	/**
+	 * Resolve a user-supplied file path to an absolute path on the server.
+	 *
+	 * Relative paths are tried against the WordPress root (ABSPATH), the
+	 * directory containing wp-content (the site root on hosts where wp-content
+	 * lives outside of ABSPATH, e.g. installs with a symlinked core), and the
+	 * uploads directory, in that order; the first readable candidate wins.
+	 * Absolute local paths are used as-is when readable. Stream URLs are never
+	 * used as-is: probing a user-supplied stream (e.g. phar://) with
+	 * is_readable() can trigger wrapper side effects, and stream-backed uploads
+	 * (e.g. s3://) are already reachable through the uploads-basedir candidate.
+	 *
+	 * The result is not validated as a permitted location: pass it through
+	 * validate_upload_file_path() before use. Note that the resolution bases
+	 * are intentionally broader than that validation's allowlist (ABSPATH and
+	 * the uploads directory), so a resolved path may still be rejected — e.g.
+	 * a file sitting at the site root, outside both allowed locations.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param string $file_path The path to resolve, as entered by the user.
+	 * @return string The resolved path. Falls back to the path relative to
+	 *                ABSPATH when no candidate is readable, so validation of
+	 *                the returned value fails with the usual error.
+	 */
+	public static function resolve_upload_file_path( string $file_path ): string {
+		$abspath        = (string) Constants::get_constant( 'ABSPATH' );
+		$wp_content_dir = (string) Constants::get_constant( 'WP_CONTENT_DIR' );
+		$candidates     = array();
+
+		// The stream check must come first: path_is_absolute() probes streams
+		// with is_file(), which must not run on user-supplied stream URLs.
+		if ( ! wp_is_stream( $file_path ) && path_is_absolute( $file_path ) ) {
+			$candidates[] = $file_path;
+		}
+
+		$bases = array(
+			$abspath,
+			trailingslashit( dirname( $wp_content_dir ) ),
+		);
+
+		$upload_dir = wp_get_upload_dir();
+		if ( false === $upload_dir['error'] ) {
+			$bases[] = trailingslashit( $upload_dir['basedir'] );
+		}
+
+		foreach ( $bases as $base ) {
+			$candidates[] = $base . $file_path;
+		}
+
+		$wp_filesystem = self::get_wp_filesystem_direct();
+		foreach ( $candidates as $candidate ) {
+			if ( $wp_filesystem->is_readable( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return $abspath . $file_path;
+	}
+
+	/**
 	 * Check if a given file is inside a given directory.
 	 *
 	 * @param string $file_path The full path of the file to check.

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -198,6 +198,67 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test importing a file located in the uploads directory by entering a path
+	 * relative to the uploads directory (e.g. on hosts where wp-content lives
+	 * outside of ABSPATH).
+	 *
+	 * @return void
+	 */
+	public function test_server_file_in_uploads_dir() {
+		$upload_dir = wp_get_upload_dir();
+		$file       = trailingslashit( $upload_dir['basedir'] ) . 'sample-53676.csv';
+		self::file_copy( $this->csv_file, $file );
+
+		$_POST['file_url'] = 'sample-53676.csv';
+		$import_controller = new WC_Product_CSV_Importer_Controller();
+		try {
+			$this->assertEquals( $file, $import_controller->handle_upload() );
+		} finally {
+			wp_delete_file( $file );
+		}
+	}
+
+	/**
+	 * Test importing a file by entering its absolute path.
+	 *
+	 * @return void
+	 */
+	public function test_server_file_absolute_path() {
+		$upload_dir = wp_get_upload_dir();
+		$file       = trailingslashit( $upload_dir['basedir'] ) . 'sample-53676-absolute.csv';
+		self::file_copy( $this->csv_file, $file );
+
+		$_POST['file_url'] = $file;
+		$import_controller = new WC_Product_CSV_Importer_Controller();
+		try {
+			$this->assertEquals( $file, $import_controller->handle_upload() );
+		} finally {
+			wp_delete_file( $file );
+		}
+	}
+
+	/**
+	 * Test that an absolute path outside of ABSPATH and the uploads directory is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_server_file_absolute_path_outside_allowed_locations() {
+		$file = sys_get_temp_dir() . '/sample-53676-outside.csv';
+		self::file_copy( $this->csv_file, $file );
+
+		$_POST['file_url'] = $file;
+		$import_controller = new WC_Product_CSV_Importer_Controller();
+		try {
+			$import_result = $import_controller->handle_upload();
+
+			$this->assertTrue( is_wp_error( $import_result ) );
+			$this->assertEquals( 'woocommerce_product_csv_importer_upload_invalid_file', $import_result->get_error_code() );
+		} finally {
+			wp_delete_file( $file );
+		}
+	}
+
+	/**
 	 * Test get_raw_keys.
 	 * @since 3.1.0
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -259,6 +259,20 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that a non-string file_url value is treated as empty rather than resolved.
+	 *
+	 * @return void
+	 */
+	public function test_server_file_non_string_file_url() {
+		$_POST['file_url'] = array( 'sample.csv' );
+		$import_controller = new WC_Product_CSV_Importer_Controller();
+		$import_result     = $import_controller->handle_upload();
+
+		$this->assertTrue( is_wp_error( $import_result ) );
+		$this->assertEquals( 'woocommerce_product_csv_importer_upload_invalid_file', $import_result->get_error_code() );
+	}
+
+	/**
 	 * Test get_raw_keys.
 	 * @since 3.1.0
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -337,6 +337,79 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'resolve_upload_file_path' resolves a path relative to ABSPATH.
+	 */
+	public function test_resolve_upload_file_path_relative_to_abspath(): void {
+		$this->assertSame( ABSPATH . 'index.php', FilesystemUtil::resolve_upload_file_path( 'index.php' ) );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' returns a readable absolute path as-is.
+	 */
+	public function test_resolve_upload_file_path_absolute(): void {
+		$upload_dir = wp_get_upload_dir();
+		$path       = $this->make_temp_file( $upload_dir['basedir'] );
+
+		$this->assertSame( $path, FilesystemUtil::resolve_upload_file_path( $path ) );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' resolves a path relative to the uploads directory.
+	 */
+	public function test_resolve_upload_file_path_relative_to_uploads(): void {
+		$upload_dir = wp_get_upload_dir();
+		$path       = $this->make_temp_file( $upload_dir['basedir'] );
+
+		$this->assertSame( $path, FilesystemUtil::resolve_upload_file_path( basename( $path ) ) );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' resolves a path relative to the site root when wp-content lives outside ABSPATH (e.g. symlinked-core hosts).
+	 */
+	public function test_resolve_upload_file_path_relative_to_site_root(): void {
+		$site_root = sys_get_temp_dir() . '/wc-fsutil-siteroot-' . wp_generate_uuid4();
+		$path      = $this->make_temp_file( $site_root );
+
+		Constants::set_constant( 'WP_CONTENT_DIR', $site_root . '/wp-content' );
+
+		$this->assertSame( $path, FilesystemUtil::resolve_upload_file_path( basename( $path ) ) );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' never uses a stream URL as-is: probing user-supplied streams (e.g. phar://) with is_readable() could trigger wrapper side effects.
+	 */
+	public function test_resolve_upload_file_path_does_not_use_stream_urls_as_is(): void {
+		$stream_url = 'phar://evil.phar/payload.csv';
+
+		$this->assertSame( ABSPATH . $stream_url, FilesystemUtil::resolve_upload_file_path( $stream_url ) );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' resolution bases are broader than the validation allowlist: a resolved site-root file outside ABSPATH and uploads is still rejected by 'validate_upload_file_path'.
+	 */
+	public function test_resolved_site_root_path_outside_allowed_locations_fails_validation(): void {
+		$site_root = sys_get_temp_dir() . '/wc-fsutil-siteroot-' . wp_generate_uuid4();
+		$path      = $this->make_temp_file( $site_root );
+
+		Constants::set_constant( 'WP_CONTENT_DIR', $site_root . '/wp-content' );
+
+		$resolved = FilesystemUtil::resolve_upload_file_path( basename( $path ) );
+		$this->assertSame( $path, $resolved );
+
+		$this->expectException( \Exception::class );
+		FilesystemUtil::validate_upload_file_path( $resolved );
+	}
+
+	/**
+	 * @testdox 'resolve_upload_file_path' falls back to the ABSPATH-relative path when nothing is readable.
+	 */
+	public function test_resolve_upload_file_path_fallback_when_unreadable(): void {
+		$file_path = 'definitely-does-not-exist-' . wp_generate_uuid4() . '.csv';
+
+		$this->assertSame( ABSPATH . $file_path, FilesystemUtil::resolve_upload_file_path( $file_path ) );
+	}
+
+	/**
 	 * @testdox 'file_is_in_directory' keeps stream-wrapper (e.g. s3://) containment intact for upload paths.
 	 *
 	 * Exercises the non-file:// protocol branch of the containment check. The

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/FilesystemUtilTest.php
@@ -401,6 +401,25 @@ class FilesystemUtilTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'resolve_upload_file_path' prefers the ABSPATH candidate when the same relative path is readable in multiple bases.
+	 */
+	public function test_resolve_upload_file_path_prefers_abspath_over_uploads(): void {
+		$upload_dir   = wp_get_upload_dir();
+		$uploads_file = $this->make_temp_file( $upload_dir['basedir'] );
+		$file_name    = basename( $uploads_file );
+		$abspath_file = ABSPATH . $file_name;
+
+		FilesystemUtil::get_wp_filesystem_direct()->put_contents( $abspath_file, '' );
+		$this->temp_files[] = $abspath_file;
+
+		$this->assertSame(
+			$abspath_file,
+			FilesystemUtil::resolve_upload_file_path( $file_name ),
+			'The ABSPATH candidate must take precedence over the uploads-directory candidate.'
+		);
+	}
+
+	/**
 	 * @testdox 'resolve_upload_file_path' falls back to the ABSPATH-relative path when nothing is readable.
 	 */
 	public function test_resolve_upload_file_path_fallback_when_unreadable(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The product CSV importer prefixed the entered server path with `ABSPATH`, so imports failed on hosts where wp-content lives outside of the WordPress directory (e.g. installs with a symlinked core). This PR adds `FilesystemUtil::resolve_upload_file_path()`, which resolves the entered path against the WordPress root, the site root, and the uploads directory — and accepts absolute paths — while never probing user-supplied stream URLs (e.g. `phar://`). Every resolved path still goes through the existing `validate_upload_file_path()` allowlist (ABSPATH + uploads) and CSV/TXT extension checks, so no new locations become importable.

Closes #53676.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|<img width="758" height="957" alt="advanced-path-before" src="https://github.com/user-attachments/assets/0580d1c9-3174-4e30-9eb0-2b44d7a869da" />|<img width="767" height="985" alt="advanced-path-after" src="https://github.com/user-attachments/assets/43525831-c52c-4c2c-ae3d-b08662f956b2" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Copy a product CSV (e.g. `wp-content/plugins/woocommerce/sample-data/sample_products.csv`) into `wp-content/uploads/`.
2. Go to **Products → Import**, expand the alternative file field, and enter `sample_products.csv` (relative to the uploads directory). Confirm the import proceeds to the column mapping step.
3. Repeat with the absolute path to the same file — it should also work.
4. Enter a path outside ABSPATH and the uploads directory (e.g. `/tmp/foo.csv` with a real file there) — the importer should reject it with "File path provided for import is invalid."
5. For the original issue: on a host where wp-content lives outside ABSPATH (symlinked core), confirm a path relative to the site root or uploads directory now resolves and imports.

<!-- End testing instructions -->

### Testing that has already taken place:

- New and existing unit tests pass in wp-env (`FilesystemUtilTest` — 7 resolver tests including stream-URL and allowlist regressions, `WC_Tests_Product_CSV_Importer` — 15 tests including traversal, precedence, and non-string input).
- Security-focused review of the resolution logic: stream wrappers are never probed, and the validation allowlist is unchanged.
- `lint:php:changes` clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>