### PR TITLE
[Settings UI] Fix value matching for extension-supplied schemas

### DIFF
--- a/packages/js/settings-ui/changelog/fix-select-option-value-coercion
+++ b/packages/js/settings-ui/changelog/fix-select-option-value-coercion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix select and radio fields rendering a blank selection for numeric option values, and badge intents matching Object.prototype keys.

--- a/packages/js/settings-ui/changelog/fix-select-option-value-coercion
+++ b/packages/js/settings-ui/changelog/fix-select-option-value-coercion
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix select and radio fields rendering a blank selection for numeric option values, and badge intents matching Object.prototype keys.
+Keep settings field values consistent across controls, dirty tracking, visibility, and form posts, and harden badge intent matching.

--- a/packages/js/settings-ui/src/checkbox-values.ts
+++ b/packages/js/settings-ui/src/checkbox-values.ts
@@ -1,0 +1,31 @@
+import type { SettingsValue } from './types';
+
+export const isCheckboxChecked = (
+	value: SettingsValue | undefined
+): boolean => value === true || value === 1 || value === 'yes' || value === '1';
+
+export const toCheckboxValue = (
+	checked: boolean,
+	initialValue: SettingsValue | undefined
+): SettingsValue => {
+	if (
+		typeof initialValue !== 'undefined' &&
+		checked === isCheckboxChecked( initialValue )
+	) {
+		return initialValue;
+	}
+
+	if ( typeof initialValue === 'boolean' ) {
+		return checked;
+	}
+
+	if ( initialValue === 1 || initialValue === 0 ) {
+		return checked ? 1 : 0;
+	}
+
+	if ( initialValue === '1' || initialValue === '0' ) {
+		return checked ? '1' : '0';
+	}
+
+	return checked ? 'yes' : 'no';
+};

--- a/packages/js/settings-ui/src/hidden-inputs.tsx
+++ b/packages/js/settings-ui/src/hidden-inputs.tsx
@@ -6,6 +6,7 @@ import { createElement, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { isCheckboxChecked } from './checkbox-values';
 import { error } from './diagnostics';
 import type { SettingsUIField, SettingsValue } from './types';
 
@@ -40,10 +41,7 @@ export const getHiddenInputs = (
 		return [
 			{
 				name,
-				value:
-					value === true || value === 'yes' || value === '1'
-						? 'yes'
-						: 'no',
+				value: isCheckboxChecked( value ) ? 'yes' : 'no',
 			},
 		];
 	}

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -109,7 +109,10 @@ export const NativeSettingsField = ( {
 				className="wc-settings-ui__control"
 				label={ field.label }
 				help={ getHelp( field.description ) }
-				checked={ value === true || value === 'yes' || value === '1' }
+				checked={
+					value === true ||
+					[ 'yes', '1' ].includes( toStringValue( value ) )
+				}
 				disabled={ field.disabled }
 				onChange={ onChange }
 				__nextHasNoMarginBottom
@@ -137,8 +140,10 @@ export const NativeSettingsField = ( {
 	}
 
 	if ( field.type === 'select' || field.type === 'radio' ) {
+		// Stringify option values so numeric values from extension-supplied
+		// schemas still match, as they did with the native <select>.
 		const items = ( field.options || [] ).map( ( option ) => ( {
-			value: option.value,
+			value: toStringValue( option.value ),
 			label: option.label,
 		} ) );
 		const selectedItem =

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -8,6 +8,7 @@ import { Field, InputControl, SelectControl, Textarea } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import { isCheckboxChecked, toCheckboxValue } from './checkbox-values';
 import { warn } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
 import { NumberSpinControl } from './number-spin-control';
@@ -88,6 +89,7 @@ const getHelp = ( description?: string ) =>
 export const NativeSettingsField = ( {
 	field,
 	value,
+	initialValues,
 	onChange,
 }: SettingsFieldComponentProps ) => {
 	if ( field.type === 'info' ) {
@@ -109,12 +111,13 @@ export const NativeSettingsField = ( {
 				className="wc-settings-ui__control"
 				label={ field.label }
 				help={ getHelp( field.description ) }
-				checked={
-					value === true ||
-					[ 'yes', '1' ].includes( toStringValue( value ) )
-				}
+				checked={ isCheckboxChecked( value ) }
 				disabled={ field.disabled }
-				onChange={ onChange }
+				onChange={ ( checked: boolean ) =>
+					onChange(
+						toCheckboxValue( checked, initialValues[ field.id ] )
+					)
+				}
 				__nextHasNoMarginBottom
 			/>
 		);
@@ -140,9 +143,8 @@ export const NativeSettingsField = ( {
 	}
 
 	if ( field.type === 'select' || field.type === 'radio' ) {
-		// Stringify option values so numeric values from extension-supplied
-		// schemas still match, as they did with the native <select>.
-		const items = ( field.options || [] ).map( ( option ) => ( {
+		const options = field.options || [];
+		const items = options.map( ( option ) => ( {
 			value: toStringValue( option.value ),
 			label: option.label,
 		} ) );
@@ -158,7 +160,13 @@ export const NativeSettingsField = ( {
 				items={ items }
 				value={ selectedItem }
 				disabled={ field.disabled }
-				onValueChange={ ( item ) => onChange( item?.value ?? '' ) }
+				onValueChange={ ( item ) => {
+					const option = options.find(
+						( candidate ) =>
+							toStringValue( candidate.value ) === item?.value
+					);
+					onChange( option?.value ?? '' );
+				} }
 			/>
 		);
 	}

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -90,6 +90,35 @@ const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	return a === b;
 };
 
+// Restore the schema representation when a control emits an equivalent value.
+const preserveInitialRepresentation = (
+	value: SettingsValue,
+	initialValue: SettingsValue | undefined
+): SettingsValue => {
+	if ( typeof initialValue === 'undefined' || value === initialValue ) {
+		return value;
+	}
+
+	if (
+		typeof value === 'string' &&
+		typeof initialValue !== 'string' &&
+		! Array.isArray( initialValue ) &&
+		( initialValue === null ? '' : String( initialValue ) ) === value
+	) {
+		return initialValue;
+	}
+
+	if (
+		Array.isArray( value ) &&
+		value.length === 0 &&
+		( initialValue === '' || initialValue === null )
+	) {
+		return initialValue;
+	}
+
+	return value;
+};
+
 const getChangedValues = (
 	values: SettingsValues,
 	initialValues: SettingsValues
@@ -631,10 +660,13 @@ export const SettingsUIPage = ( {
 		( fieldId: string, nextValue: SettingsValue ) => {
 			setValuesState( ( currentValues ) => ( {
 				...currentValues,
-				[ fieldId ]: nextValue,
+				[ fieldId ]: preserveInitialRepresentation(
+					nextValue,
+					initialValues[ fieldId ]
+				),
 			} ) );
 		},
-		[]
+		[ initialValues ]
 	);
 
 	const allowNavigation = useCallback( () => {
@@ -676,7 +708,11 @@ export const SettingsUIPage = ( {
 				Object.entries( nextValues ).forEach(
 					( [ fieldId, value ] ) => {
 						if ( typeof value !== 'undefined' ) {
-							mergedValues[ fieldId ] = value;
+							mergedValues[ fieldId ] =
+								preserveInitialRepresentation(
+									value,
+									initialValues[ fieldId ]
+								);
 						}
 					}
 				);
@@ -684,7 +720,7 @@ export const SettingsUIPage = ( {
 				return mergedValues;
 			} );
 		},
-		[]
+		[ initialValues ]
 	);
 
 	const handleCustomSave = useCallback( async () => {

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -129,7 +129,7 @@ const BADGE_INTENTS: Record<
 const getBadgeIntent = (
 	intent?: string
 ): ComponentProps< typeof Badge >[ 'intent' ] =>
-	intent && intent in BADGE_INTENTS
+	intent && Object.prototype.hasOwnProperty.call( BADGE_INTENTS, intent )
 		? BADGE_INTENTS[ intent as SettingsUIShellBadgeIntent ]
 		: BADGE_INTENTS.default;
 

--- a/packages/js/settings-ui/src/test/header-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/header-fields.test.tsx
@@ -185,6 +185,32 @@ describe( 'settings UI shell header fields', () => {
 		container.remove();
 	} );
 
+	it( 'falls back to the default intent for Object.prototype key intent values', () => {
+		const { container, root } = renderElement(
+			<SettingsUIPage
+				schema={ baseSchema( {
+					title: 'Test page',
+					// 'constructor' exists on Object.prototype, so an `in` check
+					// would wrongly resolve it to a function instead of an intent.
+					badges: [
+						{
+							label: 'Mystery',
+							intent: 'constructor' as never,
+						},
+					],
+				} ) }
+				page="test_page"
+			/>
+		);
+
+		const badge = container.querySelector( '[data-testid="shell-badge"]' );
+		expect( badge ).not.toBeNull();
+		expect( badge?.getAttribute( 'data-intent' ) ).toBe( 'draft' );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
 	it( 'omits subtitle and badges when not provided', () => {
 		const { container, root } = renderElement(
 			<SettingsUIPage

--- a/packages/js/settings-ui/src/test/hidden-inputs.test.ts
+++ b/packages/js/settings-ui/src/test/hidden-inputs.test.ts
@@ -4,7 +4,16 @@
 import { getHiddenInputs } from '../hidden-inputs';
 
 describe( 'getHiddenInputs', () => {
-	it( 'serializes checkbox values for legacy form posts', () => {
+	it.each( [
+		[ true, 'yes' ],
+		[ 'yes', 'yes' ],
+		[ '1', 'yes' ],
+		[ 1, 'yes' ],
+		[ false, 'no' ],
+		[ 'no', 'no' ],
+		[ '0', 'no' ],
+		[ 0, 'no' ],
+	] )( 'serializes checkbox value %p as %s', ( value, serialized ) => {
 		expect(
 			getHiddenInputs(
 				{
@@ -13,9 +22,9 @@ describe( 'getHiddenInputs', () => {
 					type: 'checkbox',
 					save: { adapter: 'form_post', name: 'enabled' },
 				},
-				true
+				value
 			)
-		).toEqual( [ { name: 'enabled', value: 'yes' } ] );
+		).toEqual( [ { name: 'enabled', value: serialized } ] );
 	} );
 
 	it( 'serializes array values with bracketed field names', () => {

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -23,6 +23,44 @@ jest.mock( '@wordpress/admin-ui', () => ( {
 	),
 } ) );
 
+jest.mock( '@wordpress/ui', () => ( {
+	...jest.requireActual( '@wordpress/ui' ),
+	SelectControl: ( {
+		label,
+		items = [],
+		value,
+		onValueChange,
+	}: {
+		label: string;
+		items?: Array< { label: string; value: string } >;
+		value?: { label: string; value: string } | null;
+		onValueChange: (
+			item: { label: string; value: string } | null
+		) => void;
+	} ) => (
+		<div>
+			<span>{ label }</span>
+			<select
+				aria-label={ label }
+				value={ value?.value ?? '' }
+				onChange={ ( event ) =>
+					onValueChange(
+						items.find(
+							( item ) => item.value === event.target.value
+						) ?? null
+					)
+				}
+			>
+				{ items.map( ( item ) => (
+					<option key={ item.value } value={ item.value }>
+						{ item.label }
+					</option>
+				) ) }
+			</select>
+		</div>
+	),
+} ) );
+
 /**
  * Internal dependencies
  */
@@ -103,6 +141,37 @@ const expectUnsafeMarkupRemoved = ( container: HTMLElement ) => {
 	expect( container.innerHTML ).not.toContain( 'onerror' );
 	expect( container.innerHTML ).not.toContain( 'onclick' );
 	expect( container.innerHTML ).not.toContain( 'javascript:' );
+};
+
+const getSaveButton = ( container: HTMLElement ) => {
+	const button = container.querySelector< HTMLButtonElement >(
+		'.woocommerce-save-button'
+	);
+
+	if ( ! button ) {
+		throw new Error( 'Expected a save button.' );
+	}
+
+	return button;
+};
+
+const clickCheckbox = ( container: HTMLElement ) => {
+	const checkbox = container.querySelector< HTMLInputElement >(
+		'input[type="checkbox"]'
+	);
+
+	if ( ! checkbox ) {
+		throw new Error( 'Expected a checkbox.' );
+	}
+
+	act( () => checkbox.click() );
+};
+
+const changeSelect = ( select: HTMLSelectElement, value: string ) => {
+	act( () => {
+		select.value = value;
+		select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+	} );
 };
 
 describe( 'settings HTML rendering', () => {
@@ -232,6 +301,289 @@ describe( 'settings HTML rendering', () => {
 		);
 
 		expectUnsafeMarkupRemoved( container );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	it.each( [ 'select', 'radio' ] )(
+		'keeps numeric %s values consistent across interaction and dirty tracking',
+		( type ) => {
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					dependent: ( { values } ) => values.numeric_choice === 2,
+				},
+			} );
+
+			const schema: SettingsUISchema = {
+				id: 'test-page',
+				title: 'Test page',
+				save: { adapter: 'form_post' },
+				groups: {
+					general: {
+						id: 'general',
+						fields: [
+							{
+								id: 'numeric_choice',
+								label: 'Numeric choice',
+								type,
+								value: 1,
+								options: [
+									{
+										label: 'One',
+										value: 1 as unknown as string,
+									},
+									{
+										label: 'Two',
+										value: 2 as unknown as string,
+									},
+								],
+							},
+							{
+								id: 'dependent',
+								label: 'Numeric value is two',
+								type: 'text',
+								value: '',
+							},
+						],
+					},
+				},
+			};
+
+			const { container, root } = renderElement(
+				<SettingsUIPage schema={ schema } page="test-page" />
+			);
+			const select = container.querySelector< HTMLSelectElement >(
+				'select[aria-label="Numeric choice"]'
+			);
+			const hiddenInput = container.querySelector< HTMLInputElement >(
+				'input[type="hidden"][name="numeric_choice"]'
+			);
+
+			if ( ! select ) {
+				throw new Error( 'Expected a select control.' );
+			}
+
+			expect( select.value ).toBe( '1' );
+			expect( hiddenInput?.value ).toBe( '1' );
+			expect( container.textContent ).not.toContain(
+				'Numeric value is two'
+			);
+			expect( getSaveButton( container ).disabled ).toBe( true );
+
+			changeSelect( select, '2' );
+			expect( hiddenInput?.value ).toBe( '2' );
+			expect( container.textContent ).toContain( 'Numeric value is two' );
+			expect( getSaveButton( container ).disabled ).toBe( false );
+
+			changeSelect( select, '1' );
+			expect( hiddenInput?.value ).toBe( '1' );
+			expect( container.textContent ).not.toContain(
+				'Numeric value is two'
+			);
+			expect( getSaveButton( container ).disabled ).toBe( true );
+
+			act( () => root.unmount() );
+			container.remove();
+		}
+	);
+
+	it( 'keeps numeric checkbox values consistent across rendering, visibility, and form posts', () => {
+		registerSettingsExtension( {
+			scope: { page: 'test-page' },
+			fieldVisibility: {
+				dependent: ( { values } ) => values.numeric_checkbox === 1,
+			},
+		} );
+
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'numeric_checkbox',
+							label: 'Numeric checkbox',
+							type: 'checkbox',
+							value: 1,
+						},
+						{
+							id: 'dependent',
+							label: 'Numeric checkbox is enabled',
+							type: 'text',
+							value: '',
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } page="test-page" />
+		);
+		const hiddenInput = container.querySelector< HTMLInputElement >(
+			'input[type="hidden"][name="numeric_checkbox"]'
+		);
+
+		expect( hiddenInput?.value ).toBe( 'yes' );
+		expect( container.textContent ).toContain(
+			'Numeric checkbox is enabled'
+		);
+		expect( getSaveButton( container ).disabled ).toBe( true );
+
+		clickCheckbox( container );
+		expect( hiddenInput?.value ).toBe( 'no' );
+		expect( container.textContent ).not.toContain(
+			'Numeric checkbox is enabled'
+		);
+		expect( getSaveButton( container ).disabled ).toBe( false );
+
+		clickCheckbox( container );
+		expect( hiddenInput?.value ).toBe( 'yes' );
+		expect( container.textContent ).toContain(
+			'Numeric checkbox is enabled'
+		);
+		expect( getSaveButton( container ).disabled ).toBe( true );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	it( 'restores numeric and null representations when native fields revert', () => {
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'threshold',
+							label: 'Threshold',
+							type: 'number',
+							value: 5,
+							customAttributes: { step: 1 },
+						},
+						{
+							id: 'nullable',
+							label: 'Nullable',
+							type: 'text',
+							value: null,
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } />
+		);
+		const increment = container.querySelector< HTMLButtonElement >(
+			'button[aria-label="Increment Threshold"]'
+		);
+		const decrement = container.querySelector< HTMLButtonElement >(
+			'button[aria-label="Decrement Threshold"]'
+		);
+		const textInput =
+			container.querySelector< HTMLInputElement >( 'input[type="text"]' );
+
+		act( () => increment?.click() );
+		expect( getSaveButton( container ).disabled ).toBe( false );
+		act( () => decrement?.click() );
+		expect( getSaveButton( container ).disabled ).toBe( true );
+
+		if ( ! textInput ) {
+			throw new Error( 'Expected a text input.' );
+		}
+		act( () => changeTextInput( textInput, 'changed' ) );
+		expect( getSaveButton( container ).disabled ).toBe( false );
+		act( () => changeTextInput( textInput, '' ) );
+		expect( getSaveButton( container ).disabled ).toBe( true );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	it( 'preserves initial representations for custom setValue and setValues writes', () => {
+		registerSettingsExtension( {
+			scope: { page: 'test-page' },
+			fieldOverrides: {
+				tags: ( { setValue, setValues } ) => (
+					<div>
+						<button
+							type="button"
+							onClick={ () => setValue( 'tags', [] ) }
+						>
+							Clear tags
+						</button>
+						<button
+							type="button"
+							onClick={ () => setValue( 'tags', [ 'featured' ] ) }
+						>
+							Add tag
+						</button>
+						<button
+							type="button"
+							onClick={ () =>
+								setValues( { tags: [], threshold: '5' } )
+							}
+						>
+							Reset fields
+						</button>
+					</div>
+				),
+			},
+		} );
+
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'tags',
+							label: 'Tags',
+							type: 'array',
+							value: '',
+						},
+						{
+							id: 'threshold',
+							label: 'Threshold',
+							type: 'number',
+							value: 5,
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIPage schema={ schema } page="test-page" />
+		);
+		const clickButton = ( label: string ) => {
+			const button = [
+				...container.querySelectorAll< HTMLButtonElement >( 'button' ),
+			].find( ( candidate ) => candidate.textContent === label );
+
+			act( () => button?.click() );
+		};
+
+		clickButton( 'Clear tags' );
+		expect( getSaveButton( container ).disabled ).toBe( true );
+
+		clickButton( 'Add tag' );
+		expect( getSaveButton( container ).disabled ).toBe( false );
+
+		clickButton( 'Reset fields' );
+		expect( getSaveButton( container ).disabled ).toBe( true );
 
 		act( () => root.unmount() );
 		container.remove();

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -419,6 +419,117 @@ describe( 'NativeSettingsField', () => {
 		} );
 	} );
 
+	describe( 'select and radio fields', () => {
+		// TS unions erase at runtime: extension-supplied PHP schemas can carry
+		// numeric option values, which must still match the saved value.
+		const numericOptions = [
+			{ label: 'One', value: 1 as unknown as string },
+			{ label: 'Two', value: 2 as unknown as string },
+		];
+
+		it( 'selects a numeric option value matching a numeric saved value', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_select',
+							label: 'Amount',
+							type: 'select',
+							options: numericOptions,
+						},
+						1
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'button[role="combobox"]' )
+					?.textContent
+			).toBe( 'One' );
+		} );
+
+		it( 'selects a numeric option value matching a string saved value', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_radio',
+							label: 'Amount',
+							type: 'radio',
+							options: numericOptions,
+						},
+						'2'
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'button[role="combobox"]' )
+					?.textContent
+			).toBe( 'Two' );
+		} );
+
+		it( 'selects a string option value matching the saved value', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_select',
+							label: 'Country',
+							type: 'select',
+							options: [
+								{ label: 'Sweden', value: 'SE' },
+								{ label: 'Norway', value: 'NO' },
+							],
+						},
+						'NO'
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'button[role="combobox"]' )
+					?.textContent
+			).toBe( 'Norway' );
+		} );
+	} );
+
+	describe( 'checkbox fields', () => {
+		const checkboxField: SettingsUIField = {
+			id: 'wc_test_checkbox',
+			label: 'Enable feature',
+			type: 'checkbox',
+		};
+
+		const getCheckbox = ( container: HTMLElement ) => {
+			const input = container.querySelector( 'input[type="checkbox"]' );
+
+			if ( ! ( input instanceof HTMLInputElement ) ) {
+				throw new Error( 'Expected a checkbox input.' );
+			}
+
+			return input;
+		};
+
+		it.each( [
+			[ true, true ],
+			[ 'yes', true ],
+			[ '1', true ],
+			[ 1, true ],
+			[ 0, false ],
+			[ 'no', false ],
+			[ '', false ],
+		] )( 'renders saved value %p as checked=%p', ( value, checked ) => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps( checkboxField, value as SettingsValue ) }
+				/>
+			);
+
+			expect( getCheckbox( container ).checked ).toBe( checked );
+		} );
+	} );
+
 	describe( 'text fields', () => {
 		it( 'renders text fields without spin buttons', () => {
 			const container = render(

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -516,7 +516,9 @@ describe( 'NativeSettingsField', () => {
 			[ 'yes', true ],
 			[ '1', true ],
 			[ 1, true ],
+			[ false, false ],
 			[ 0, false ],
+			[ '0', false ],
 			[ 'no', false ],
 			[ '', false ],
 		] )( 'renders saved value %p as checked=%p', ( value, checked ) => {
@@ -528,6 +530,36 @@ describe( 'NativeSettingsField', () => {
 
 			expect( getCheckbox( container ).checked ).toBe( checked );
 		} );
+
+		it.each( [
+			[ false, true, true ],
+			[ true, false, false ],
+			[ 'no', true, 'yes' ],
+			[ 'yes', false, 'no' ],
+			[ '0', true, '1' ],
+			[ '1', false, '0' ],
+			[ 0, true, 1 ],
+			[ 1, false, 0 ],
+		] )(
+			'changes initial value %p to %p as %p',
+			( initialValue, checked, expected ) => {
+				const onChange = jest.fn();
+				const container = render(
+					<NativeSettingsField
+						{ ...makeProps(
+							checkboxField,
+							initialValue as SettingsValue,
+							onChange
+						) }
+					/>
+				);
+
+				const checkbox = getCheckbox( container );
+				expect( checkbox.checked ).not.toBe( checked );
+				clickButton( checkbox );
+				expect( onChange ).toHaveBeenCalledWith( expected );
+			}
+		);
 	} );
 
 	describe( 'text fields', () => {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Settings UI controls use strings or booleans at the browser and `@wordpress/ui` boundaries, while extension-supplied schemas can contain other representations. This mismatch caused numeric selections to render blank, checkboxes to change value format, reverted edits to remain dirty, visibility rules to receive unexpected values, and numeric checkboxes to submit the wrong form value.

- Stringify select and radio values only at the `@wordpress/ui` boundary, then map a selection back to the original schema option value.
- Keep checkbox changes in the initial boolean, numeric, numeric-string, or `yes`/`no` format.
- Use the same checkbox interpretation for rendering and hidden form inputs, which submit WooCommerce-compatible `yes` or `no` values.
- Restore the initial representation when a native control or custom component emits an equivalent reverted value through `setValue` or `setValues`.
- Use an own-property check for badge intents so values such as `constructor` fall back to the neutral style.

This supersedes #66232, which was closed in favour of keeping the overlapping value-consistency fixes together.

**Notes:**

- No public types or signatures change. `SettingsUIOption.value` remains string-based, and numeric option handling is defensive runtime support for extension-supplied schemas.
- A genuinely changed free-form value can still use the browser control's string representation. The initial schema representation is restored when the value reverts to an equivalent encoding.
- Checkbox form posts intentionally use WooCommerce's `yes` and `no` values, regardless of the page-state representation.
- The `settings-ui` feature flag is off by default, so this is not reachable in a release yet.
- PR #66461 was backported to `release/11.0` in #66542, so this fix needs the same backport.

Closes #66558.

(For Bug Fixes) Bug introduced in PR #66461.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Automated tests**

1. Run `pnpm --filter @woocommerce/settings-ui test:js`.
2. Run `pnpm --filter @woocommerce/settings-ui lint`.
3. Run `pnpm --filter @woocommerce/settings-ui build`.

**Browser smoke test**

1. On a development site running this branch, add the mu-plugin below. It enables `settings-ui` and registers a form-post settings tab with numeric schema values.
2. Build the admin client with `pnpm --filter=@woocommerce/admin-library build`.
3. Go to WooCommerce > Settings > SUI value smoke.
4. Confirm the initial values are Numeric one, Radio two, a checked numeric checkbox, and numeric threshold 5. The checkbox-dependent message should be visible and Save should be disabled.
5. Confirm the Prototype-key fallback badge uses the neutral style.
6. Change and revert the select, radio, checkbox, number, text, and textarea fields. Save should enable after each change and disable after each revert. The checkbox-dependent message should follow the checkbox state.
7. Change only the text field and save. Reload the page and confirm the text change persisted without changing the checkbox.
8. Change the select, radio, checkbox, and number fields, then save and reload. Confirm each changed value persisted.

<details>
<summary>Test mu-plugin</summary>

```php
<?php
/**
 * Plugin Name: Settings UI value smoke test
 */

add_filter(
	'woocommerce_admin_features',
	static function ( array $features ): array {
		$features[] = 'settings-ui';
		return array_values( array_unique( $features ) );
	}
);

add_filter(
	'woocommerce_get_settings_pages',
	static function ( array $pages ): array {
		$ui_page = new class() implements \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
			public function get_page_id(): string {
				return 'sui_value_smoke';
			}

			public function get_schema( string $section ): array {
				$checkbox_value = get_option( 'sui_smoke_checkbox', 1 );
				$is_checked     = in_array( $checkbox_value, array( true, 1, '1', 'yes' ), true );

				return array(
					'id'      => 'sui_value_smoke',
					'title'   => 'Settings UI value smoke test',
					'section' => 'default',
					'save'    => array( 'adapter' => 'form_post' ),
					'shell'   => array(
						'title'  => 'Settings UI value smoke test',
						'badges' => array(
							array( 'label' => 'Valid intent', 'intent' => 'success' ),
							array( 'label' => 'Prototype-key fallback', 'intent' => 'constructor' ),
						),
					),
					'groups'  => array(
						'values' => array(
							'id'          => 'values',
							'title'       => 'Value consistency',
							'description' => 'Exercise numeric values, dirty tracking, visibility, and form-post persistence.',
							'fields'      => array(
								array(
									'id'      => 'sui_smoke_select',
									'label'   => 'Numeric select',
									'type'    => 'select',
									'value'   => (int) get_option( 'sui_smoke_select', 1 ),
									'options' => array(
										array( 'label' => 'Numeric one', 'value' => 1 ),
										array( 'label' => 'Numeric two', 'value' => 2 ),
									),
								),
								array(
									'id'      => 'sui_smoke_radio',
									'label'   => 'Numeric radio',
									'type'    => 'radio',
									'value'   => (int) get_option( 'sui_smoke_radio', 2 ),
									'options' => array(
										array( 'label' => 'Radio one', 'value' => 1 ),
										array( 'label' => 'Radio two', 'value' => 2 ),
									),
								),
								array(
									'id'    => 'sui_smoke_checkbox',
									'label' => 'Numeric checkbox',
									'type'  => 'checkbox',
									'value' => $is_checked ? 1 : 0,
								),
								array(
									'id'          => 'sui_smoke_dependent',
									'label'       => 'Numeric checkbox value is 1',
									'type'        => 'info',
									'description' => 'This message should follow the numeric checkbox value.',
									'value'       => '',
									'visibility'  => array(
										'controller' => 'sui_smoke_checkbox',
										'value'      => 1,
									),
									'save'        => array( 'adapter' => 'none' ),
								),
								array(
									'id'               => 'sui_smoke_number',
									'label'            => 'Numeric threshold',
									'type'             => 'number',
									'value'            => (int) get_option( 'sui_smoke_number', 5 ),
									'customAttributes' => array( 'min' => 0, 'step' => 1 ),
								),
								array(
									'id'    => 'sui_smoke_text',
									'label' => 'Smoke text',
									'type'  => 'text',
									'value' => (string) get_option( 'sui_smoke_text', 'Initial text' ),
								),
								array(
									'id'    => 'sui_smoke_textarea',
									'label' => 'Smoke textarea',
									'type'  => 'textarea',
									'value' => (string) get_option( 'sui_smoke_textarea', 'Initial textarea' ),
								),
							),
						),
					),
				);
			}

			public function get_script_handles( string $section ): array {
				return array();
			}

			public function get_save_adapter( string $section ): string {
				return 'form_post';
			}
		};

		$pages[] = new class( $ui_page ) extends WC_Settings_Page {
			private $ui_page;

			public function __construct( $ui_page ) {
				$this->id      = 'sui_value_smoke';
				$this->label   = 'SUI value smoke';
				$this->ui_page = $ui_page;
				parent::__construct();
			}

			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
				return $this->ui_page;
			}

			protected function get_settings_for_default_section() {
				return array(
					array( 'type' => 'title', 'id' => 'sui_smoke_values' ),
					array(
						'id'      => 'sui_smoke_select',
						'type'    => 'select',
						'options' => array( 1 => 'Numeric one', 2 => 'Numeric two' ),
					),
					array(
						'id'      => 'sui_smoke_radio',
						'type'    => 'radio',
						'options' => array( 1 => 'Radio one', 2 => 'Radio two' ),
					),
					array( 'id' => 'sui_smoke_checkbox', 'type' => 'checkbox' ),
					array( 'id' => 'sui_smoke_number', 'type' => 'number' ),
					array( 'id' => 'sui_smoke_text', 'type' => 'text' ),
					array( 'id' => 'sui_smoke_textarea', 'type' => 'textarea' ),
					array( 'type' => 'sectionend', 'id' => 'sui_smoke_values' ),
				);
			}
		};

		return $pages;
	}
);
```

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

- The `@woocommerce/settings-ui` Jest suite passes with 70 tests.
- Package lint, type checking, and build pass.
- The full repository build and `git diff --check` pass.
- Browser smoke testing covered numeric select, radio, checkbox, and number values; dirty-state reverts; checkbox visibility; hidden inputs; unrelated-field saves; persistence after reload; and badge fallback.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
