### PR TITLE
Release: Remove 11.0.0-beta.1 change files from trunk

### DIFF
--- a/plugins/woocommerce/changelog/28798-fix-import-pending-review-products
+++ b/plugins/woocommerce/changelog/28798-fix-import-pending-review-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Preserve the "Pending review" product status when exporting and re-importing products via CSV, instead of importing them as drafts.

--- a/plugins/woocommerce/changelog/31365-add-backorder-notification-setting
+++ b/plugins/woocommerce/changelog/31365-add-backorder-notification-setting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a setting to enable or disable backorder stock notification emails, plus a woocommerce_should_send_backorder_notification filter, mirroring the existing low stock and out of stock notifications.

--- a/plugins/woocommerce/changelog/32831-fix-regenerate-attributes-lookup-table-via-rest-api
+++ b/plugins/woocommerce/changelog/32831-fix-regenerate-attributes-lookup-table-via-rest-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow the "Regenerate the product attributes lookup table" tool (and the related abort and resume tools) to run via the REST API instead of failing with an "Invalid nonce" error.

--- a/plugins/woocommerce/changelog/36702-fix-restore-stock-on-failed
+++ b/plugins/woocommerce/changelog/36702-fix-restore-stock-on-failed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Restore reduced stock when an order transitions to failed, so inventory held by an order that reduced stock while on-hold (e.g. an accepted-but-pending SEPA/ACH payment) is released instead of staying reduced indefinitely.

--- a/plugins/woocommerce/changelog/46099-fix-geolocation-https
+++ b/plugins/woocommerce/changelog/46099-fix-geolocation-https
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use HTTPS for all geolocation IP-lookup and geo-IP requests. Switch the IP-lookup services (ipify, ipecho, ident, tnedi) to HTTPS and replace the HTTP-only ip-api.com geo-IP provider with the HTTPS-based country.is, so visitor IP addresses are never sent over unencrypted connections.

--- a/plugins/woocommerce/changelog/49120-remove-async-product-editor-category-field
+++ b/plugins/woocommerce/changelog/49120-remove-async-product-editor-category-field
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove unused async product editor category field feature flag and deprecate its AJAX callback.

--- a/plugins/woocommerce/changelog/54584-fix-order-status-key-length
+++ b/plugins/woocommerce/changelog/54584-fix-order-status-key-length
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Warn when an order status key is too long and can't be stored.

--- a/plugins/woocommerce/changelog/55864-fix-hpos-custom-fields-delete-nonce
+++ b/plugins/woocommerce/changelog/55864-fix-hpos-custom-fields-delete-nonce
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix deleting a newly added custom field on the order edit screen with HPOS enabled.

--- a/plugins/woocommerce/changelog/58214-fix-backslash-address-store-api
+++ b/plugins/woocommerce/changelog/58214-fix-backslash-address-store-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix silent backslash corruption in Store API (block checkout) address fields. Calling wp_unslash() on JSON body data that is never magic-quoted was stripping real backslashes from address_1, address_2, and other address fields.

--- a/plugins/woocommerce/changelog/61018-cart-short-desc-format
+++ b/plugins/woocommerce/changelog/61018-cart-short-desc-format
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Normalize heading formatting in Cart and Checkout product short descriptions so an H1-styled short description no longer renders oversized.

--- a/plugins/woocommerce/changelog/61900-update-offline-payment-forms-dataform
+++ b/plugins/woocommerce/changelog/61900-update-offline-payment-forms-dataform
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate offline payment settings forms to DataForm.

--- a/plugins/woocommerce/changelog/62695-remove-nvm-from-blocks-build-notice
+++ b/plugins/woocommerce/changelog/62695-remove-nvm-from-blocks-build-notice
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove the obsolete `nvm use` step from the WooCommerce Blocks development build admin notice, since PNPM now manages the Node version automatically.

--- a/plugins/woocommerce/changelog/63146-feat-63009-public-taxonomy
+++ b/plugins/woocommerce/changelog/63146-feat-63009-public-taxonomy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Updates the `product_shipping_class` taxonomy to be private.

--- a/plugins/woocommerce/changelog/63517-fix-duplicate-scheduled-sale-events
+++ b/plugins/woocommerce/changelog/63517-fix-duplicate-scheduled-sale-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent duplicate wc_product_start_scheduled_sale and wc_product_end_scheduled_sale actions from piling up in Action Scheduler when concurrent processes schedule sale events for the same product.

--- a/plugins/woocommerce/changelog/63744-fix-adjust-non-base-location-prices-manual-orders
+++ b/plugins/woocommerce/changelog/63744-fix-adjust-non-base-location-prices-manual-orders
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix: woocommerce_adjust_non_base_location_prices not respected for manual backend orders

--- a/plugins/woocommerce/changelog/63792-fix-placeholder-contrast
+++ b/plugins/woocommerce/changelog/63792-fix-placeholder-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix insufficient color contrast on attribute placeholder text to meet WCAG 2.2 AA requirements.

--- a/plugins/woocommerce/changelog/63793-fix-wcag-metabox-delete-contrast
+++ b/plugins/woocommerce/changelog/63793-fix-wcag-metabox-delete-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix: Improve color contrast for delete link in .wc-metabox to meet WCAG 2.2 AA requirements (SC 1.4.3)

--- a/plugins/woocommerce/changelog/63967-fix-order-totals-mobile-width
+++ b/plugins/woocommerce/changelog/63967-fix-order-totals-mobile-width
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix order totals only filling half the width on the admin order screen at mobile widths.

--- a/plugins/woocommerce/changelog/64009-37525-image-size-restapi
+++ b/plugins/woocommerce/changelog/64009-37525-image-size-restapi
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add image_size query parameter to the products and product variations REST API endpoints, allowing consumers to request a specific registered WordPress image size.

--- a/plugins/woocommerce/changelog/64564-sprinkle-order-edit-wp7-alignment
+++ b/plugins/woocommerce/changelog/64564-sprinkle-order-edit-wp7-alignment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Align the Order Edit meta boxes with WordPress 7.0 admin design and preserve the legacy order trash action surface with sentence-case copy.

--- a/plugins/woocommerce/changelog/64634-fix-variation-bulk-sale-schedule-end-before-start
+++ b/plugins/woocommerce/changelog/64634-fix-variation-bulk-sale-schedule-end-before-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Variation bulk action "Set scheduled sale dates": block submission when the sale end date is earlier than the sale start date, and clear sale dates submitted as blank instead of storing 1970-01-01.

--- a/plugins/woocommerce/changelog/65334-woomob-2684-refund-preview-helpers
+++ b/plugins/woocommerce/changelog/65334-woomob-2684-refund-preview-helpers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add internal helper methods on Refunds\DataUtils to support the upcoming refund preview endpoint.

--- a/plugins/woocommerce/changelog/65335-woomob-2684-refund-preview-endpoint
+++ b/plugins/woocommerce/changelog/65335-woomob-2684-refund-preview-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add refund preview endpoint (POST /wc/v4/refunds/preview) for server-side refund calculation

--- a/plugins/woocommerce/changelog/65338-composer-psr4-upgrade-fallback
+++ b/plugins/woocommerce/changelog/65338-composer-psr4-upgrade-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Register a WooCommerce-scoped Composer PSR-4 fallback autoloader so that future in-place upgrades can resolve newly-added first-party Automattic\WooCommerce classes under src/ that the in-memory Jetpack classmap snapshot would otherwise miss, preventing "class not found" fatals during the upgrade request.

--- a/plugins/woocommerce/changelog/65368-fix-null-safety-and-security-bugs
+++ b/plugins/woocommerce/changelog/65368-fix-null-safety-and-security-bugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix exception message info leak to non-admin API callers, null dereferences on missing parent product and order, and duplicate date query key in OrdersTableQuery.

--- a/plugins/woocommerce/changelog/65385-update-algeria-provinces
+++ b/plugins/woocommerce/changelog/65385-update-algeria-provinces
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update Algeria states from 48 to 58 wilayas; also correct DZ-11 spelling.

--- a/plugins/woocommerce/changelog/65389-dev-product-shape-mapper-interface
+++ b/plugins/woocommerce/changelog/65389-dev-product-shape-mapper-interface
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add delivery-agnostic ProductShapeMapperInterface to the ProductFeed framework, deprecating ProductMapperInterface in its favor.

--- a/plugins/woocommerce/changelog/65390-fix-log-dir-size-fatal
+++ b/plugins/woocommerce/changelog/65390-fix-log-dir-size-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent fatal error on System Status page when log directory does not exist (e.g. when logging is disabled).

--- a/plugins/woocommerce/changelog/65417-fix-storeapi-create-order-default-order-status-filter-leak
+++ b/plugins/woocommerce/changelog/65417-fix-storeapi-create-order-default-order-status-filter-leak
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Store API: ensure the woocommerce_default_order_status filter is always removed after OrderController::create_order_from_cart(), even if order creation throws.

--- a/plugins/woocommerce/changelog/65420-fix-store-api-collection-data-dos
+++ b/plugins/woocommerce/changelog/65420-fix-store-api-collection-data-dos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Store API: limit and de-duplicate the attribute and taxonomy count requests accepted by the products/collection-data endpoint to prevent a single request from triggering an excessive number of database queries.

--- a/plugins/woocommerce/changelog/65426-security-unserialize-allowed-classes
+++ b/plugins/woocommerce/changelog/65426-security-unserialize-allowed-classes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Security hardening: pass allowed_classes => false to unserialize() in LookupDataStore to prevent PHP Object Injection via crafted cached data.

--- a/plugins/woocommerce/changelog/65436-performance-batch-prime-product-collection-images
+++ b/plugins/woocommerce/changelog/65436-performance-batch-prime-product-collection-images
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Batch-prime product image attachment caches across the products collection endpoints (Store API, REST v3, v4) and reuse the shared helper in the Store API cart.

--- a/plugins/woocommerce/changelog/65439-woomob-2685-simplify-refund-creation
+++ b/plugins/woocommerce/changelog/65439-woomob-2685-simplify-refund-creation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Make per-line `refund_total` optional on POST /wc/v4/refunds. When omitted, the backend computes the tax-inclusive refund total from the order line item's unit price × quantity. The legacy explicit form (refund_total without quantity) is preserved for v3-style callers.

--- a/plugins/woocommerce/changelog/65452-fix-batch-processing-concurrency
+++ b/plugins/woocommerce/changelog/65452-fix-batch-processing-concurrency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Serialize mutations of the wc_pending_batch_processes option in BatchProcessingController with a short-lived database lock and a fresh re-read, so concurrent enqueue/dequeue/remove requests no longer clobber each other and silently drop or resurrect batch processors.

--- a/plugins/woocommerce/changelog/65460-add-theme-json-support-to-breadcrumb-block
+++ b/plugins/woocommerce/changelog/65460-add-theme-json-support-to-breadcrumb-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add theme.json support to breadcrumbs block

--- a/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
+++ b/plugins/woocommerce/changelog/65468-performance-prime-analytics-extended-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Improve the performance of the analytics Products and Variations reports by batch-priming product caches.

--- a/plugins/woocommerce/changelog/65496-wooplug-6699-variation-parent-int-cast
+++ b/plugins/woocommerce/changelog/65496-wooplug-6699-variation-parent-int-cast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix fatal TypeError in ProductVersionStringInvalidator when a persistent object cache returns the cached variation parent ID as a string.

--- a/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
+++ b/plugins/woocommerce/changelog/65541-fix-checkout-shipping-cache-homeboy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent non-rate package metadata from invalidating cached shipping rates.

--- a/plugins/woocommerce/changelog/65544-65104-stale-user-meta
+++ b/plugins/woocommerce/changelog/65544-65104-stale-user-meta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fixes checkout flow to not save shipping_method in customer meta

--- a/plugins/woocommerce/changelog/65552-fix-layered-nav-count-cache-bound
+++ b/plugins/woocommerce/changelog/65552-fix-layered-nav-count-cache-bound
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Limit layered navigation count cache growth for product attributes and brands.

--- a/plugins/woocommerce/changelog/65565-wooplug-6146-log-context-json
+++ b/plugins/woocommerce/changelog/65565-wooplug-6146-log-context-json
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the log entry context being written and displayed as invalid JSON (e.g. with backtraces or namespaced class names) in WooCommerce > Status > Logs.

--- a/plugins/woocommerce/changelog/65591-fix-rest-batch-transient-coalescing
+++ b/plugins/woocommerce/changelog/65591-fix-rest-batch-transient-coalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Coalesce repeated product transient deletion during REST variation batch writes.

--- a/plugins/woocommerce/changelog/65614-site-visibility-badge-toggle
+++ b/plugins/woocommerce/changelog/65614-site-visibility-badge-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Move the "Display site visibility badge in admin bar" toggle into the Site Visibility settings tab and align the toggle with its label.

--- a/plugins/woocommerce/changelog/65637-wooplug-4673-product-collection-block-several-inner-blocks-dont-work
+++ b/plugins/woocommerce/changelog/65637-wooplug-4673-product-collection-block-several-inner-blocks-dont-work
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Product Collection inner blocks when rendered inside Query Loop post content.

--- a/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
+++ b/plugins/woocommerce/changelog/65682-64660-image-no-link-archive
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Updates anchor rendering logic to not show an anchor tag when product image link is disabled

--- a/plugins/woocommerce/changelog/65701-add-wc-cli-debug-group
+++ b/plugins/woocommerce/changelog/65701-add-wc-cli-debug-group
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add the WooCommerce debug group to HPOS CLI debug messages.

--- a/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
+++ b/plugins/woocommerce/changelog/65706-fix-order-items-null-tax-rate-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent PHP 8.5 deprecation notices when an order tax item has no matching tax rate.

--- a/plugins/woocommerce/changelog/65723-fix-site-health-upload-loopback
+++ b/plugins/woocommerce/changelog/65723-fix-site-health-upload-loopback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Avoid a critical Site Health warning when WooCommerce cannot verify uploads directory protection.

--- a/plugins/woocommerce/changelog/65725-56586-variation-cart
+++ b/plugins/woocommerce/changelog/65725-56586-variation-cart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes 0 value attributes from being skipped when variation is added to cart directly

--- a/plugins/woocommerce/changelog/65749-fix-blocks-build-warnings
+++ b/plugins/woocommerce/changelog/65749-fix-blocks-build-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix a Sass build error in the Cart proceed-to-checkout block and remove an invalid script module declaration from the Product Price block.

--- a/plugins/woocommerce/changelog/65766-56335-stale-attribute-meta
+++ b/plugins/woocommerce/changelog/65766-56335-stale-attribute-meta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Remove stale variation attribute meta on updates

--- a/plugins/woocommerce/changelog/65786-tax-settings-recommendations
+++ b/plugins/woocommerce/changelog/65786-tax-settings-recommendations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Added Tax extensions recommendations.

--- a/plugins/woocommerce/changelog/65860-feature-pos-catalog-chunked-generation
+++ b/plugins/woocommerce/changelog/65860-feature-pos-catalog-chunked-generation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Generate the POS catalog feed in chunks across several Action Scheduler actions so large catalogs no longer exceed the host request timeout or Action Scheduler's failure period mid-generation, and detect and restart stuck generation jobs that would otherwise stay pinned in progress forever.

--- a/plugins/woocommerce/changelog/65864-34487-different-border
+++ b/plugins/woocommerce/changelog/65864-34487-different-border
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Match orders and stock home panel border with other cards

--- a/plugins/woocommerce/changelog/65867-customer-history-cpt-order
+++ b/plugins/woocommerce/changelog/65867-customer-history-cpt-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent customer history metabox warnings for CPT-backed orders.

--- a/plugins/woocommerce/changelog/65879-40653-country-code
+++ b/plugins/woocommerce/changelog/65879-40653-country-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix tax country code autocomplete to not be based on full country name

--- a/plugins/woocommerce/changelog/65881-state-code
+++ b/plugins/woocommerce/changelog/65881-state-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix tax state code autocomplete: allow searching by state code and scope suggestions to the selected country

--- a/plugins/woocommerce/changelog/66014-fix-extension-cart-update-shipping-mode-sync
+++ b/plugins/woocommerce/changelog/66014-fix-extension-cart-update-shipping-mode-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Checkout block shipping method UI after extension cart updates change the selected shipping rate.

--- a/plugins/woocommerce/changelog/66043-wooplug-472-variable-product-schema-single-variation-offer
+++ b/plugins/woocommerce/changelog/66043-wooplug-472-variable-product-schema-single-variation-offer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Structured data: emit a single Offer with the exact variation price (and `inProductGroupWithID`) when a variation-specific URL is requested, instead of the parent AggregateOffer price range, fixing Google Merchant "price mismatch" disapprovals.

--- a/plugins/woocommerce/changelog/66097-bump-wp-env-and-playwright
+++ b/plugins/woocommerce/changelog/66097-bump-wp-env-and-playwright
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Bump @wordpress/env to 11.9.0 and @playwright/test to 1.61.1 (dev dependencies; no merchant-facing change).

--- a/plugins/woocommerce/changelog/66148-fix-billing-address-response-checkout-block
+++ b/plugins/woocommerce/changelog/66148-fix-billing-address-response-checkout-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Sanitize instead of texturize the email address in the StoreAPI response

--- a/plugins/woocommerce/changelog/66168-fix-65686-transient-deferrer-shutdown-order
+++ b/plugins/woocommerce/changelog/66168-fix-65686-transient-deferrer-shutdown-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix deferred product transient shutdown ordering before parent product sync.

--- a/plugins/woocommerce/changelog/66233-fix-account-display-name-description
+++ b/plugins/woocommerce/changelog/66233-fix-account-display-name-description
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Remove "and in reviews" from the display name description in My Account if product reviews are not active

--- a/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
+++ b/plugins/woocommerce/changelog/66477-sprinkle-filter-picker-colon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Remove the trailing colon from FilterPicker labels to match WordPress 7.0 form-field labeling.

--- a/plugins/woocommerce/changelog/66508-fix-hpos-legacy-meta-cache-self-heal
+++ b/plugins/woocommerce/changelog/66508-fix-hpos-legacy-meta-cache-self-heal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Invalidate the correct meta cache group when the HPOS order meta corruption guard fires, so a corrupt legacy object-cache entry is re-read from the database instead of persisting across reads.

--- a/plugins/woocommerce/changelog/abandoned-cart-recovery-auto-send
+++ b/plugins/woocommerce/changelog/abandoned-cart-recovery-auto-send
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Schedule the abandoned cart recovery email to send 2 hours after a pending order is created, and cancel the pending send when the order leaves the pending status.

--- a/plugins/woocommerce/changelog/abandoned-cart-recovery-email
+++ b/plugins/woocommerce/changelog/abandoned-cart-recovery-email
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a new transactional abandoned cart recovery email that prompts customers to complete a pending checkout, behind the new `abandoned_cart_recovery` feature flag.

--- a/plugins/woocommerce/changelog/abandoned-cart-recovery-experimental-optin
+++ b/plugins/woocommerce/changelog/abandoned-cart-recovery-experimental-optin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Make the Abandoned cart recovery feature experimental and opt-in only; it is no longer enabled automatically on new installs.

--- a/plugins/woocommerce/changelog/abandoned-cart-recovery-recommendations
+++ b/plugins/woocommerce/changelog/abandoned-cart-recovery-recommendations
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a recommendation card on the Abandoned cart recovery email settings page.

--- a/plugins/woocommerce/changelog/accessibility-cart-table-headers
+++ b/plugins/woocommerce/changelog/accessibility-cart-table-headers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add proper ARIA roles and scope attributes to cart table headers for screen reader accessibility (WCAG 1.3.1)

--- a/plugins/woocommerce/changelog/add-65454-list-failed-order-imports
+++ b/plugins/woocommerce/changelog/add-65454-list-failed-order-imports
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Analytics: list failed order imports in the Import historical data section with a retry action.

--- a/plugins/woocommerce/changelog/add-admin-email-verified-field
+++ b/plugins/woocommerce/changelog/add-admin-email-verified-field
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a user profile control so admins can view and set a customer's email-confirmation status.

--- a/plugins/woocommerce/changelog/add-currency-position-enum
+++ b/plugins/woocommerce/changelog/add-currency-position-enum
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add CurrencyPosition enum class for woocommerce_currency_pos option values and adopt it in the Store API and Marketing Campaigns REST API.

--- a/plugins/woocommerce/changelog/add-customer-email-verification-order-linking
+++ b/plugins/woocommerce/changelog/add-customer-email-verification-order-linking
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add customer email verification, letting shoppers securely link past guest orders to their account once they confirm ownership of their email address.

--- a/plugins/woocommerce/changelog/add-dimension-unit-enum
+++ b/plugins/woocommerce/changelog/add-dimension-unit-enum
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add DimensionUnit enum class for woocommerce_dimension_unit option values and implement it across the codebase.

--- a/plugins/woocommerce/changelog/add-eslint-restrict-wp-components-storefront
+++ b/plugins/woocommerce/changelog/add-eslint-restrict-wp-components-storefront
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Adds an ESLint rule to prevent `@wordpress/components` from being imported in storefront-bound files in the Cart and Checkout blocks, and refactors the Place Order button icon to use an inline SVG instead.
-

--- a/plugins/woocommerce/changelog/add-filter-for-variable-product-taxes-influence-price
+++ b/plugins/woocommerce/changelog/add-filter-for-variable-product-taxes-influence-price
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add the `woocommerce_variable_product_taxes_influence_price` filter.

--- a/plugins/woocommerce/changelog/add-new-functions-check-script
+++ b/plugins/woocommerce/changelog/add-new-functions-check-script
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Add a CI check that prevents new standalone functions from being added to the includes and src directories.

--- a/plugins/woocommerce/changelog/add-orders-screen-marketplace-promo
+++ b/plugins/woocommerce/changelog/add-orders-screen-marketplace-promo
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a contextual Marketplace recommendation card to the WooCommerce Orders screen, shown to eligible stores based on locally-evaluated promotion rules.

--- a/plugins/woocommerce/changelog/add-pos-catalog-feed-file-access
+++ b/plugins/woocommerce/changelog/add-pos-catalog-feed-file-access
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Allow POS catalog product feed files to be served by enabling file access on the feed directory while preventing directory listing.

--- a/plugins/woocommerce/changelog/add-pos-staff-foundation
+++ b/plugins/woocommerce/changelog/add-pos-staff-foundation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add the foundation for POS staff management: an experimental `point_of_sale_staff` feature flag (off by default), a flag-gated orchestrator, and the `pos_*` capability access model that keys POS access on holding any `pos_*` WP capability. No runtime surface yet; the staff endpoint, attribution, and admin UI register behind the flag in follow-up changes.

--- a/plugins/woocommerce/changelog/add-pos-staff-presets
+++ b/plugins/woocommerce/changelog/add-pos-staff-presets
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add the POS preset layer to the capability model: capability bundles for the Cashier, Manager, and Admin presets, assigned or cleared per user via `woocommerce_pos_*` capabilities (never WP roles), with the assigned preset recorded in user meta and cleaned up on uninstall. Behind the off-by-default `point_of_sale_staff` feature flag.

--- a/plugins/woocommerce/changelog/add-product-filters-disable-responsive
+++ b/plugins/woocommerce/changelog/add-product-filters-disable-responsive
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add option disabling filter drawer on smaller screens.

--- a/plugins/woocommerce/changelog/add-resend-set-password-link
+++ b/plugins/woocommerce/changelog/add-resend-set-password-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a resend action to the temporary-password notice on My Account so customers can request a fresh change-password email.

--- a/plugins/woocommerce/changelog/add-search-list-control-depth-fixes
+++ b/plugins/woocommerce/changelog/add-search-list-control-depth-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix hierarchical selection and expansion in SearchListControl for multi-level categories

--- a/plugins/woocommerce/changelog/add-settings-section-ui-page-provider
+++ b/plugins/woocommerce/changelog/add-settings-section-ui-page-provider
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add a native Settings UI page provider path for registered settings sections.

--- a/plugins/woocommerce/changelog/add-settings-ui-default-section-navigation
+++ b/plugins/woocommerce/changelog/add-settings-ui-default-section-navigation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Inject default sibling-section navigation into native Settings UI page schemas that omit shell.sectionNavigation.

--- a/plugins/woocommerce/changelog/add-settings-ui-shell-header-fields
+++ b/plugins/woocommerce/changelog/add-settings-ui-shell-header-fields
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add styling for settings UI shell header badges.

--- a/plugins/woocommerce/changelog/add-shopper-lists-privacy-exporter-eraser
+++ b/plugins/woocommerce/changelog/add-shopper-lists-privacy-exporter-eraser
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Register a GDPR privacy exporter and eraser for shopper lists so admin Export/Erase Personal Data tools cover saved-for-later and wishlist data.

--- a/plugins/woocommerce/changelog/add-tax-display-mode-enum
+++ b/plugins/woocommerce/changelog/add-tax-display-mode-enum
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add TaxDisplayMode enum class for woocommerce_tax_display_shop/cart option values and implement it across the codebase.

--- a/plugins/woocommerce/changelog/add-webflow-products-migrator
+++ b/plugins/woocommerce/changelog/add-webflow-products-migrator
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add Webflow platform to the CLI products migrator.

--- a/plugins/woocommerce/changelog/add-weight-unit-enum
+++ b/plugins/woocommerce/changelog/add-weight-unit-enum
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add WeightUnit enum class for woocommerce_weight_unit option values and implement it across the codebase.

--- a/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce-format-phone-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a woocommerce_format_phone_number filter and a WC_Validation::is_phone_format() method.

--- a/plugins/woocommerce/changelog/add-woocommerce_validate_phone-filter-phone-validation
+++ b/plugins/woocommerce/changelog/add-woocommerce_validate_phone-filter-phone-validation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add woocommerce_validate_phone filter to allow customizing phone number validation

--- a/plugins/woocommerce/changelog/billow-69-add-to-cart-cart-line-identity
+++ b/plugins/woocommerce/changelog/billow-69-add-to-cart-cart-line-identity
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Block add to cart: adding a product that is in the cart only inside a bundle (or only as a booking, add-on configuration, or recipient-differentiated line) now adds a new standalone line instead of showing an error or changing the existing line's quantity.

--- a/plugins/woocommerce/changelog/checkout-recovery-manual-send
+++ b/plugins/woocommerce/changelog/checkout-recovery-manual-send
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a "Send checkout recovery email" action to the order actions dropdown so merchants can manually send the Checkout Recovery email for pending or checkout-draft orders past the 1-hour abandonment threshold.

--- a/plugins/woocommerce/changelog/checkout-recovery-unsubscribe
+++ b/plugins/woocommerce/changelog/checkout-recovery-unsubscribe
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Customers can now unsubscribe from Checkout Recovery emails via a one-click link in the email footer.

--- a/plugins/woocommerce/changelog/codex-fix-65992-non-null-assertions
+++ b/plugins/woocommerce/changelog/codex-fix-65992-non-null-assertions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Harden Blocks non-null assertion lint rule to error.

--- a/plugins/woocommerce/changelog/codex-hide-gallery-arrows-single-image
+++ b/plugins/woocommerce/changelog/codex-hide-gallery-arrows-single-image
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide Product Gallery arrows and thumbnails for products with one or no images in the editor.

--- a/plugins/woocommerce/changelog/codex-remove-create-product-editor-block
+++ b/plugins/woocommerce/changelog/codex-remove-create-product-editor-block
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Remove @woocommerce/create-product-editor-block package

--- a/plugins/woocommerce/changelog/codex-remove-integrate-plugin
+++ b/plugins/woocommerce/changelog/codex-remove-integrate-plugin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Remove @woocommerce/integrate-plugin package

--- a/plugins/woocommerce/changelog/defer-payment-gateway-init
+++ b/plugins/woocommerce/changelog/defer-payment-gateway-init
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Store API: skip initializing the available payment gateways on checkout requests that do not provide a payment method.

--- a/plugins/woocommerce/changelog/dev-65710-stricter-types-control-in-tax-class
+++ b/plugins/woocommerce/changelog/dev-65710-stricter-types-control-in-tax-class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Harden types handling in WC_Tax class get-methods.

--- a/plugins/woocommerce/changelog/dev-actions-scheduler-api-usage-audit
+++ b/plugins/woocommerce/changelog/dev-actions-scheduler-api-usage-audit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Audit Action Scheduler APIs usage.

--- a/plugins/woocommerce/changelog/disable-playwright-report-on-failure
+++ b/plugins/woocommerce/changelog/disable-playwright-report-on-failure
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-

--- a/plugins/woocommerce/changelog/e2e-marketing-overview-remove-redundant-learning-test
+++ b/plugins/woocommerce/changelog/e2e-marketing-overview-remove-redundant-learning-test
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove redundant marketing learning section E2E test (covered by unit tests) and harden the introduction dismissal test using addLocatorHandler.

--- a/plugins/woocommerce/changelog/enable-product-object-caching-new-installs
+++ b/plugins/woocommerce/changelog/enable-product-object-caching-new-installs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Enable the product object caching feature by default for newly installed stores. Existing stores are unaffected and keep the opt-in default.

--- a/plugins/woocommerce/changelog/env-restart-force-destroy
+++ b/plugins/woocommerce/changelog/env-restart-force-destroy
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Add --force to the env:restart script so wp-env destroy skips the interactive confirmation prompt.

--- a/plugins/woocommerce/changelog/fix-30454-disable-continue-button-no-file
+++ b/plugins/woocommerce/changelog/fix-30454-disable-continue-button-no-file
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Disable the "Continue" button on the product CSV import page until a file is selected or a server path is entered.

--- a/plugins/woocommerce/changelog/fix-30612-stock-reservation-default
+++ b/plugins/woocommerce/changelog/fix-30612-stock-reservation-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use the checkout hold stock setting only for core checkout stock reservations.

--- a/plugins/woocommerce/changelog/fix-34827-shop-page-queried_object
+++ b/plugins/woocommerce/changelog/fix-34827-shop-page-queried_object
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix 'current-menu-item' class not being added to the Shop page in the Page List block

--- a/plugins/woocommerce/changelog/fix-39289
+++ b/plugins/woocommerce/changelog/fix-39289
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-For better compat, use order caps for HPOS placeholder posts.

--- a/plugins/woocommerce/changelog/fix-39366
+++ b/plugins/woocommerce/changelog/fix-39366
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow users with the `view_woocommerce_reports` capability to access the Analytics Leaderboards REST endpoint and view leaderboard data.

--- a/plugins/woocommerce/changelog/fix-43332-decode-pattern-titles
+++ b/plugins/woocommerce/changelog/fix-43332-decode-pattern-titles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Decode HTML entities in PTK pattern titles

--- a/plugins/woocommerce/changelog/fix-46349-asset-data-registry-deprecated-argument
+++ b/plugins/woocommerce/changelog/fix-46349-asset-data-registry-deprecated-argument
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Warn when deprecated AssetDataRegistry key check arguments are explicitly provided.

--- a/plugins/woocommerce/changelog/fix-59238-product-collection-reset-all
+++ b/plugins/woocommerce/changelog/fix-59238-product-collection-reset-all
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent Product Collection filter resets from clearing lifted collection controls.

--- a/plugins/woocommerce/changelog/fix-59464-migrate-reviews-panelbody-to-toolspanel
+++ b/plugins/woocommerce/changelog/fix-59464-migrate-reviews-panelbody-to-toolspanel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Replace PanelBody with ToolsPanel in All Reviews, Reviews by Category, and Reviews by Product inspector controls.

--- a/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-stock-filter
+++ b/plugins/woocommerce/changelog/fix-59464-use-toolspanel-in-stock-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Replace PanelBody with ToolsPanel in Stock Filter inspector controls.

--- a/plugins/woocommerce/changelog/fix-63238-email-order-item-alignment
+++ b/plugins/woocommerce/changelog/fix-63238-email-order-item-alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Align email order item names consistently after product thumbnails.

--- a/plugins/woocommerce/changelog/fix-63757-variation-custom-order
+++ b/plugins/woocommerce/changelog/fix-63757-variation-custom-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Respect the attribute's custom term order when creating all product variations.

--- a/plugins/woocommerce/changelog/fix-63892-legacy-shim-loading-strategy
+++ b/plugins/woocommerce/changelog/fix-63892-legacy-shim-loading-strategy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix strategy mismatch between legacy alias scripts and their real counterparts. Scripts with legacy handles now use blocking strategy consistently, since WordPress discards loading strategies on alias scripts (src=false) since 6.3.

--- a/plugins/woocommerce/changelog/fix-64009-get-images-signature-bc
+++ b/plugins/woocommerce/changelog/fix-64009-get-images-signature-bc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Follow-up to unreleased #64009: restore the original get_images()/get_image() signatures on product REST controllers so third-party subclasses do not fatal on PHP 8; the image_size parameter is now read from the current request.
-
-

--- a/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
+++ b/plugins/woocommerce/changelog/fix-64338-order-customer-name-method-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix fatal error in Analytics Customers DataStore when a plain WC_Order (rather than the Overrides\Order subclass) is passed to get_or_create_customer_from_order(), and harden date_last_active against a missing date_created by cascading through date_modified and date_paid before falling back to null.

--- a/plugins/woocommerce/changelog/fix-64744-product-id-contrast
+++ b/plugins/woocommerce/changelog/fix-64744-product-id-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve contrast for product IDs in the Products list row actions.

--- a/plugins/woocommerce/changelog/fix-65094-grouped-product-a11y
+++ b/plugins/woocommerce/changelog/fix-65094-grouped-product-a11y
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Mark grouped products add to cart table as presentational

--- a/plugins/woocommerce/changelog/fix-65095-checkout-payment-methods-a11y-grouping
+++ b/plugins/woocommerce/changelog/fix-65095-checkout-payment-methods-a11y-grouping
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Add aria-label to payment methods list for improved screen reader accessibility

--- a/plugins/woocommerce/changelog/fix-65378-sku-duplication-hyphen
+++ b/plugins/woocommerce/changelog/fix-65378-sku-duplication-hyphen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix SKU duplication corrupting hyphenated SKUs. Duplicating a product with SKU `SKU-123` now correctly produces `SKU-123-1` instead of `SKU-124`.

--- a/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
+++ b/plugins/woocommerce/changelog/fix-65424-order-edit-unsaved-changes-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix false "unsaved changes" warning when editing orders with customer notes

--- a/plugins/woocommerce/changelog/fix-65618
+++ b/plugins/woocommerce/changelog/fix-65618
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed quantity selector plus button size mismatch in Cart and Mini-Cart by replacing the fullwidth plus glyph with a standard plus.

--- a/plugins/woocommerce/changelog/fix-65946-uninstall-experimental-user-meta
+++ b/plugins/woocommerce/changelog/fix-65946-uninstall-experimental-user-meta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove the push notification preferences, shopper list, and customer email verification user meta when uninstalling with WC_REMOVE_ALL_DATA.

--- a/plugins/woocommerce/changelog/fix-66031-settings-ui-registry-resolution-guard
+++ b/plugins/woocommerce/changelog/fix-66031-settings-ui-registry-resolution-guard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Tolerate settings section registry failures when resolving the Settings UI request context, preventing update-time fatals.

--- a/plugins/woocommerce/changelog/fix-66046-add-to-cart-with-options-unit-tests-to-e2e
+++ b/plugins/woocommerce/changelog/fix-66046-add-to-cart-with-options-unit-tests-to-e2e
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add to Cart + Options: add extra e2e tests to cover skipped unit tests

--- a/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
+++ b/plugins/woocommerce/changelog/fix-66103-duplicate-password-changed-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix duplicate "Password Changed" admin notification email sent when a customer resets their password.

--- a/plugins/woocommerce/changelog/fix-66160-list-table-prepare-items-cache-gate
+++ b/plugins/woocommerce/changelog/fix-66160-list-table-prepare-items-cache-gate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed incorrect order counts when custom query_args are added via the order list table prepare_items query args filter.

--- a/plugins/woocommerce/changelog/fix-66338-66331-cropped-image-sizing
+++ b/plugins/woocommerce/changelog/fix-66338-66331-cropped-image-sizing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Preserve correct aspect ratio on Product Images with imageSizing set to cropped
-
-

--- a/plugins/woocommerce/changelog/fix-add-variation-id-to-add-to-cart-quantity-filter
+++ b/plugins/woocommerce/changelog/fix-add-variation-id-to-add-to-cart-quantity-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-`woocommerce_add_to_cart_quantity` filter now receives `$variation_id`.

--- a/plugins/woocommerce/changelog/fix-analytics-data-e2e-scheduled-import
+++ b/plugins/woocommerce/changelog/fix-analytics-data-e2e-scheduled-import
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Force immediate analytics import mode in the analytics-data E2E spec so its orders import deterministically regardless of the store's scheduled-import default; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/fix-attribute-slug-length-multibyte
+++ b/plugins/woocommerce/changelog/fix-attribute-slug-length-multibyte
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Reject attribute slugs whose taxonomy name (with the "pa_" prefix) exceeds WordPress's 32-byte limit, instead of incorrectly counting characters. This lets users create attributes with multibyte slugs (Cyrillic, Chinese, etc.) that fit within the limit, and shows a live byte count next to the slug input so users can see how close they are to the limit before submitting.

--- a/plugins/woocommerce/changelog/fix-block-templates-compat
+++ b/plugins/woocommerce/changelog/fix-block-templates-compat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add compatibility shims for the removed block templates PHP API to avoid third-party extension fatals.

--- a/plugins/woocommerce/changelog/fix-blocks-e2e-nightly-sample-data-path
+++ b/plugins/woocommerce/changelog/fix-blocks-e2e-nightly-sample-data-path
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix the Blocks e2e nightly suite: mount the released plugin at the canonical `woocommerce` folder via a wp-env mapping, instead of letting wp-env name the plugin folder after the release zip (e.g. `woocommerce-trunk-nightly`), which broke the test setup's plugin-path assumptions. The generated test translations are mapped into the plugin's languages directory the same way. Also resolve the active plugin path (WC_ABSPATH) for the sample product import.

--- a/plugins/woocommerce/changelog/fix-blocks-e2e-provisioning-log-errors
+++ b/plugins/woocommerce/changelog/fix-blocks-e2e-provisioning-log-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove benign errors from the Blocks e2e build log: make provisioning idempotent (customer user and Test Helper APIs plugin) across the Core and Blocks setup paths, drop a redundant `--fields=id` from the product attribute listing, and navigate the page away before the per-test DB reset so late Store API requests stop logging false "not a valid JSON response" errors.

--- a/plugins/woocommerce/changelog/fix-blocks-site-editor-save-panel
+++ b/plugins/woocommerce/changelog/fix-blocks-site-editor-save-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Stabilize Blocks E2E site editor saves when the save panel opens with multiple dirty entities.

--- a/plugins/woocommerce/changelog/fix-blocks-use-collection-non-error-handling
+++ b/plugins/woocommerce/changelog/fix-blocks-use-collection-non-error-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Blocks: Fix JS crash when the store returns a non-Error value in useCollection; convert it to a proper Error instance so the error boundary handles it gracefully.

--- a/plugins/woocommerce/changelog/fix-breadcrumbs-block-custom-font-size
+++ b/plugins/woocommerce/changelog/fix-breadcrumbs-block-custom-font-size
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fix custom font sizes not working on the Breadcrumbs block
-
-

--- a/plugins/woocommerce/changelog/fix-cartupdateitem-truncates-float-quantities
+++ b/plugins/woocommerce/changelog/fix-cartupdateitem-truncates-float-quantities
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix/normalize the Store API cart/update-item route truncating decimal quantities when dispatching the cart item updated hook.

--- a/plugins/woocommerce/changelog/fix-checkout-address-fill-idempotent
+++ b/plugins/woocommerce/changelog/fix-checkout-address-fill-idempotent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Use idempotent checkout address helpers in checkout e2e tests.

--- a/plugins/woocommerce/changelog/fix-coming-soon-banner-colors
+++ b/plugins/woocommerce/changelog/fix-coming-soon-banner-colors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use fixed colors for the coming soon footer banner instead of inheriting them from the active theme.

--- a/plugins/woocommerce/changelog/fix-count-badge-styles
+++ b/plugins/woocommerce/changelog/fix-count-badge-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove unnecessary font-weight override on the mini-cart quantity badge and use a theme-resolvable color for the count text in the checkout order summary item badge.

--- a/plugins/woocommerce/changelog/fix-customer-session-empty-field-persistence
+++ b/plugins/woocommerce/changelog/fix-customer-session-empty-field-persistence
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix: allow empty customer session fields to override prior values in WC_Customer_Data_Store_Session

--- a/plugins/woocommerce/changelog/fix-do_deferred_product_sync-undefined-behavior
+++ b/plugins/woocommerce/changelog/fix-do_deferred_product_sync-undefined-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix undefined behavior and potential infinite loop in WC_Post_Data::do_deferred_product_sync when more products are deferred for sync while a deferred sync is running.

--- a/plugins/woocommerce/changelog/fix-drawer-overlay-color
+++ b/plugins/woocommerce/changelog/fix-drawer-overlay-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use a fixed black overlay color for the drawer instead of inheriting the theme palette.

--- a/plugins/woocommerce/changelog/fix-e2e-core-parallel-customer-order-flakiness
+++ b/plugins/woocommerce/changelog/fix-e2e-core-parallel-customer-order-flakiness
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Stabilize two e2e specs in the core-parallel pool against concurrent-worker pollution: customer-list (pin the customers report page size on the URL so the list assertions and CSV download stay deterministic regardless of how many customers other workers create) and create-order (wait for the line item to render before saving so the order is never persisted with a 0-quantity line).

--- a/plugins/woocommerce/changelog/fix-e2e-helper-plugin-mounts
+++ b/plugins/woocommerce/changelog/fix-e2e-helper-plugin-mounts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Mount E2E helper plugins as a directory and provision wp-cli.yml in-container so single-file Docker mounts no longer surface as empty files under gRPC FUSE.

--- a/plugins/woocommerce/changelog/fix-e2e-replace-dead-demo-image-urls
+++ b/plugins/woocommerce/changelog/fix-e2e-replace-dead-demo-image-urls
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: E2E test-only change. Replace dead demo.woothemes.com image URLs with local media library lookups. No user-facing change.

--- a/plugins/woocommerce/changelog/fix-email-preview-downloadable-items
+++ b/plugins/woocommerce/changelog/fix-email-preview-downloadable-items
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent email previews from showing unrelated dummy products as downloadable items.

--- a/plugins/woocommerce/changelog/fix-embedded-kyc-loader-failure-hardening
+++ b/plugins/woocommerce/changelog/fix-embedded-kyc-loader-failure-hardening
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent embedded WooPayments business verification from hanging when the Stripe loader fails.

--- a/plugins/woocommerce/changelog/fix-express-payment-focus-outline
+++ b/plugins/woocommerce/changelog/fix-express-payment-focus-outline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix express payment buttons missing a visible focus outline in Cart and Checkout.

--- a/plugins/woocommerce/changelog/fix-flaky-non-utc-refund-report-test
+++ b/plugins/woocommerce/changelog/fix-flaky-non-utc-refund-report-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Stabilize the non-UTC refund sales report unit test so it no longer fails depending on the time of day CI runs; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/fix-get-variation-parent-visibility
+++ b/plugins/woocommerce/changelog/fix-get-variation-parent-visibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Check parent product visibility in get_variation AJAX endpoint before returning variation data

--- a/plugins/woocommerce/changelog/fix-hardcoded-wp-content-paths
+++ b/plugins/woocommerce/changelog/fix-hardcoded-wp-content-paths
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Resolve downloadable file paths and Mini Cart lazy-loaded script URLs against the configured content directory and site URL instead of a hardcoded /wp-content location, so they work on non-default WordPress directory layouts (e.g. Bedrock or a custom WP_CONTENT_DIR).

--- a/plugins/woocommerce/changelog/fix-has-block-in-page-recursive-search
+++ b/plugins/woocommerce/changelog/fix-has-block-in-page-recursive-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix - Make WC_Blocks_Utils::has_block_in_page() search nested blocks recursively.

--- a/plugins/woocommerce/changelog/fix-highlight-template-analyzer-checkout
+++ b/plugins/woocommerce/changelog/fix-highlight-template-analyzer-checkout
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Internal CI workflow change; no merchant-facing impact.

--- a/plugins/woocommerce/changelog/fix-hpos-data-cache-corrupt-entry-fatal
+++ b/plugins/woocommerce/changelog/fix-hpos-data-cache-corrupt-entry-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent a fatal TypeError on the HPOS Orders screen when a persistent object cache returns a corrupt order or meta cache entry: invalid entries are now discarded and re-read from the database instead of breaking the page.

--- a/plugins/woocommerce/changelog/fix-line-item-subtotal-display
+++ b/plugins/woocommerce/changelog/fix-line-item-subtotal-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the order admin Items Subtotal incorrectly subtracting fee tax for stores with fixed end-prices.

--- a/plugins/woocommerce/changelog/fix-log-cleanup-20-file-cap
+++ b/plugins/woocommerce/changelog/fix-log-cleanup-20-file-cap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the daily log cleanup so it deletes all expired log files, not just the first 20.

--- a/plugins/woocommerce/changelog/fix-non-persistable-preview-state-products-collection
+++ b/plugins/woocommerce/changelog/fix-non-persistable-preview-state-products-collection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Product Collection block from marking the post as dirty when the editor loads.

--- a/plugins/woocommerce/changelog/fix-order-admin-color-contrast
+++ b/plugins/woocommerce/changelog/fix-order-admin-color-contrast
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve text color contrast on the admin order edit screen so order data, line-item details, and column headers meet WCAG AA accessibility standards.

--- a/plugins/woocommerce/changelog/fix-order-attribution-banner-unscoped-button-styles
+++ b/plugins/woocommerce/changelog/fix-order-attribution-banner-unscoped-button-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Scope the order attribution install banner button styles to the banner, so they no longer center the content of every icon+text components button rendered on WooCommerce admin pages.

--- a/plugins/woocommerce/changelog/fix-orders-endpoint-title-cart
+++ b/plugins/woocommerce/changelog/fix-orders-endpoint-title-cart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix My Account endpoint page titles showing the page title instead of the endpoint heading (e.g. "Orders") in block themes when the cart is not empty.

--- a/plugins/woocommerce/changelog/fix-orders-query-sqlite-limit
+++ b/plugins/woocommerce/changelog/fix-orders-query-sqlite-limit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Omit the LIMIT clause in OrdersTableQuery when an unlimited (-1) row count is requested, matching WP_Query nopaging behavior. Fixes a datatype mismatch error when the orders query runs against a SQLite database.

--- a/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
+++ b/plugins/woocommerce/changelog/fix-pos-catalog-stuck-in-progress
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Recover POS catalog feed generation jobs that were killed (server timeout or out of memory) and left stuck in the in_progress state, and raise the execution time and memory limits during generation.

--- a/plugins/woocommerce/changelog/fix-pos-feed-htaccess-write-logging
+++ b/plugins/woocommerce/changelog/fix-pos-feed-htaccess-write-logging
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Log when the POS product feed directory's .htaccess cannot be updated, and avoid overwriting an unreadable or custom file during the legacy upgrade.

--- a/plugins/woocommerce/changelog/fix-product-block-editor-block-registry-compat
+++ b/plugins/woocommerce/changelog/fix-product-block-editor-block-registry-compat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add a compatibility shim for the removed product block editor block registry to avoid third-party extension fatals.

--- a/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
+++ b/plugins/woocommerce/changelog/fix-product-collection-upsells-null-deref
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix PHP fatal in the Product Collection upsells handler when the product reference is unresolved (editor preview), and stop the cross-sells handler from leaking unresolved product references into its results.

--- a/plugins/woocommerce/changelog/fix-product-description-editor-alignment
+++ b/plugins/woocommerce/changelog/fix-product-description-editor-alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix product description editor alignment in the classic product editor.

--- a/plugins/woocommerce/changelog/fix-product-filters-e2e-template-path
+++ b/plugins/woocommerce/changelog/fix-product-filters-e2e-template-path
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Move the Product Filters multiple-instance e2e content template to the Core blocks template directory.

--- a/plugins/woocommerce/changelog/fix-product-query-fixes
+++ b/plugins/woocommerce/changelog/fix-product-query-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Rename Products (Beta) block to Products (Deprecated)

--- a/plugins/woocommerce/changelog/fix-product-rating-e2e-tab-race
+++ b/plugins/woocommerce/changelog/fix-product-rating-e2e-tab-race
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Set the product's comment_status via WP-CLI in the product-rating E2E specs instead of clicking product-data tabs that race against admin JS initialization; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/fix-promo-card-styling
+++ b/plugins/woocommerce/changelog/fix-promo-card-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Align Woo Home in-app promo banner styling with updated admin card patterns.

--- a/plugins/woocommerce/changelog/fix-psr4-fallback-degrade-guards
+++ b/plugins/woocommerce/changelog/fix-psr4-fallback-degrade-guards
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Harden the in-place-upgrade PSR-4 fallback autoloader so its remaining unguarded paths degrade gracefully: a foreign Composer ClassLoader shape and a torn/partially-written class file mid-upgrade now leave the class unresolved instead of fataling, so a defensive class_exists() probe during an upgrade returns false rather than raising an error.

--- a/plugins/woocommerce/changelog/fix-psr4-fallback-validate-getprefixespsr4
+++ b/plugins/woocommerce/changelog/fix-psr4-fallback-validate-getprefixespsr4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the PSR-4 upgrade fallback fataling when a foreign Composer ClassLoader returns a non-array from getPrefixesPsr4() or a non-string from findFile(); validate both shapes so it degrades to no fallback instead.

--- a/plugins/woocommerce/changelog/fix-quantity-selector-styles-outside-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-quantity-selector-styles-outside-add-to-cart-with-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Quantity Selector block styles when outside the Add to Cart + Options block

--- a/plugins/woocommerce/changelog/fix-random-product-collection-pagination
+++ b/plugins/woocommerce/changelog/fix-random-product-collection-pagination
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Keep random Product Collection pagination consistent across pages.

--- a/plugins/woocommerce/changelog/fix-refund-amount-validation-message
+++ b/plugins/woocommerce/changelog/fix-refund-amount-validation-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix refund amount validation message positioning

--- a/plugins/woocommerce/changelog/fix-rsmapgj-338
+++ b/plugins/woocommerce/changelog/fix-rsmapgj-338
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow decimal stock quantities below 1 to remain in stock when the `woocommerce_stock_amount` filter is overridden with `floatval`. The integer cast inside `WC_Abstract_Product::validate_props()` truncated values like `0.5` to `0`, incorrectly flipping the product to "Out of stock".

--- a/plugins/woocommerce/changelog/fix-settings-ui-save-and-continue
+++ b/plugins/woocommerce/changelog/fix-settings-ui-save-and-continue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Preserve Settings UI pending navigation after form-post saves.

--- a/plugins/woocommerce/changelog/fix-settings-ui-tabs-horizontal-overflow
+++ b/plugins/woocommerce/changelog/fix-settings-ui-tabs-horizontal-overflow
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix horizontal page overflow caused by the Settings UI tab bar including its padding outside the declared width.

--- a/plugins/woocommerce/changelog/fix-shop-page-permalink-rewrite
+++ b/plugins/woocommerce/changelog/fix-shop-page-permalink-rewrite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Refresh product archive rewrite rules after the Shop page permalink changes.

--- a/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
+++ b/plugins/woocommerce/changelog/fix-simplify-compatibility-layer-checks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Move logic to enable or disable the compatibility layer in block templates from 'template_redirect' to 'template_include' to be more accurate with the resolved template

--- a/plugins/woocommerce/changelog/fix-store-api-checkout-order-address-validation
+++ b/plugins/woocommerce/changelog/fix-store-api-checkout-order-address-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Store API: validate address data on the checkout-order endpoint before it is persisted, so a rejected request can no longer modify an existing order's address or totals.

--- a/plugins/woocommerce/changelog/fix-store-api-non-public-product-visibility
+++ b/plugins/woocommerce/changelog/fix-store-api-non-public-product-visibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hardens Store API product/review endpoints checks.

--- a/plugins/woocommerce/changelog/fix-storeapi-order-auth-refund-guard
+++ b/plugins/woocommerce/changelog/fix-storeapi-order-auth-refund-guard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Reject refund IDs in Store API order authorization to prevent a fatal when wc_get_order() returns a WC_Order_Refund.

--- a/plugins/woocommerce/changelog/fix-storeapi-order-tax-location-from-order
+++ b/plugins/woocommerce/changelog/fix-storeapi-order-tax-location-from-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Resolve the local pickup tax location from the order's own shipping line instead of attaching a per-call closure to woocommerce_order_get_tax_location during cart sync.

--- a/plugins/woocommerce/changelog/fix-synced-product-filters-instances
+++ b/plugins/woocommerce/changelog/fix-synced-product-filters-instances
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix: Sync active filters across multiple Product Filters blocks on the same page.

--- a/plugins/woocommerce/changelog/fix-update-pnpm-lock
+++ b/plugins/woocommerce/changelog/fix-update-pnpm-lock
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Update pnpm-lock.yaml
-
-

--- a/plugins/woocommerce/changelog/fix-wc-update-10802-missing-orders-meta-table-check
+++ b/plugins/woocommerce/changelog/fix-wc-update-10802-missing-orders-meta-table-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix fatal DB errors during upgrade on sites where HPOS was never enabled by adding a table existence check before attempting to restore the meta_key_value index on wp_wc_orders_meta.

--- a/plugins/woocommerce/changelog/fix-woopayments-activate-payments-lock
+++ b/plugins/woocommerce/changelog/fix-woopayments-activate-payments-lock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the WooPayments test account activation flow requiring a second click when switching to live payments.

--- a/plugins/woocommerce/changelog/fix-woopayments-optional-business-structure
+++ b/plugins/woocommerce/changelog/fix-woopayments-optional-business-structure
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide unnecessary WooPayments business structure selection during onboarding.

--- a/plugins/woocommerce/changelog/fix-wooplug-104-sales-report-refunds
+++ b/plugins/woocommerce/changelog/fix-wooplug-104-sales-report-refunds
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add per-period `refunds` field to the legacy REST sales report so consumers can compute net sales per day or month (fixes #27552, #42694).

--- a/plugins/woocommerce/changelog/fix-wooplug-6319-blueprint-import-table-prefix
+++ b/plugins/woocommerce/changelog/fix-wooplug-6319-blueprint-import-table-prefix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Blueprint: export SQL steps using a table prefix placeholder instead of the source site's database prefix, so settings can be imported on sites that use a different table prefix.

--- a/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
+++ b/plugins/woocommerce/changelog/fix-wooplug-6446-remove-all-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove additional WooCommerce data when uninstalling with WC_REMOVE_ALL_DATA: the product_visibility taxonomy terms, the placeholder image attachment, and additional WooCommerce user meta. The Action Scheduler tables can also be removed by additionally defining the WC_REMOVE_ACTION_SCHEDULER constant.

--- a/plugins/woocommerce/changelog/fix-wooplug-6639-analytics-division-by-zero
+++ b/plugins/woocommerce/changelog/fix-wooplug-6639-analytics-division-by-zero
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Analytics: prevent a Division by zero error when syncing monetary-only refunds on stores that use decimal item quantities.

--- a/plugins/woocommerce/changelog/fix-wooplug-6719-property-exists-false-php8
+++ b/plugins/woocommerce/changelog/fix-wooplug-6719-property-exists-false-php8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix fatal TypeError in wc_modify_map_meta_cap() on PHP 8+ when get_userdata() returns false for an invalid user ID.

--- a/plugins/woocommerce/changelog/fix-wooprd-3552-offline-payments-header-font-size
+++ b/plugins/woocommerce/changelog/fix-wooprd-3552-offline-payments-header-font-size
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix oversized heading on the offline payment settings pages by setting the header font size explicitly instead of relying on the floating-header-scoped rule.

--- a/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
+++ b/plugins/woocommerce/changelog/hpos-orders-status-union-rewrite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-HPOS: speed up the order admin list on large stores by rewriting multi-status order queries as per-status UNIONs.

--- a/plugins/woocommerce/changelog/improve-woocommerce-analytics-settings-label
+++ b/plugins/woocommerce/changelog/improve-woocommerce-analytics-settings-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Improve the label and description of the WooCommerce Analytics setting on the Features settings screen.

--- a/plugins/woocommerce/changelog/issue-64592-checkout-fields-textdomain-too-early
+++ b/plugins/woocommerce/changelog/issue-64592-checkout-fields-textdomain-too-early
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Warn when additional checkout fields are registered before the woocommerce_init action, which can load translations too early.

--- a/plugins/woocommerce/changelog/order-resume-item-loss-WOOPLUG-6382
+++ b/plugins/woocommerce/changelog/order-resume-item-loss-WOOPLUG-6382
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent order items from being lost when order resume fails between removing items and saving the order.

--- a/plugins/woocommerce/changelog/patch-1
+++ b/plugins/woocommerce/changelog/patch-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add unique CSS classes to the order data meta-box columns: order_data_column_general, order_data_column_billing, and order_data_column_shipping.

--- a/plugins/woocommerce/changelog/pcb-201-harden-cart-item-product-guards
+++ b/plugins/woocommerce/changelog/pcb-201-harden-cart-item-product-guards
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent a fatal error in the mini-cart and checkout review-order templates when a filter hooked on woocommerce_cart_item_product returns a truthy non-product value.

--- a/plugins/woocommerce/changelog/perf-lazy-block-patterns
+++ b/plugins/woocommerce/changelog/perf-lazy-block-patterns
@@ -1,3 +1,0 @@
-Significance: patch
-Type: performance
-Comment: Load WooCommerce block pattern content lazily via core's `filePath` mechanism instead of including all pattern files on every request, saving ~7-8 ms on requests that do not consume patterns.

--- a/plugins/woocommerce/changelog/performance-64471-jetpack-connection-status
+++ b/plugins/woocommerce/changelog/performance-64471-jetpack-connection-status
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Optimized JetPack connection status retrieval on admin pages.

--- a/plugins/woocommerce/changelog/performance-65313-stock-reservation-bottleneck
+++ b/plugins/woocommerce/changelog/performance-65313-stock-reservation-bottleneck
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Optimized the stock reservation SQL to prevent blocking order status updates.

--- a/plugins/woocommerce/changelog/performance-audit-wc_product_dropdown_categories-usages-in-admin
+++ b/plugins/woocommerce/changelog/performance-audit-wc_product_dropdown_categories-usages-in-admin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Audit wc_product_dropdown_categories usages in admin

--- a/plugins/woocommerce/changelog/performance-centralize-wp_count_posts-invocation
+++ b/plugins/woocommerce/changelog/performance-centralize-wp_count_posts-invocation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Centralize wp_count_posts invocations towards products.

--- a/plugins/woocommerce/changelog/performance-features-and-gateways-options-priming
+++ b/plugins/woocommerce/changelog/performance-features-and-gateways-options-priming
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Reduced the number of SQL queries on the cart and checkout pages in the store, as well as on admin pages, by adding cache priming.

--- a/plugins/woocommerce/changelog/performance-isolate-wp_count_posts-in-admin-take1
+++ b/plugins/woocommerce/changelog/performance-isolate-wp_count_posts-in-admin-take1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Harden the conditions required to invoke \Automattic\WooCommerce\Internal\Utilities\ProductUtil::get_counts_for_type throughout the codebase.

--- a/plugins/woocommerce/changelog/performance-product-collection-inspector-import
+++ b/plugins/woocommerce/changelog/performance-product-collection-inspector-import
@@ -1,4 +1,0 @@
-Significance: patch
-Type: performance
-
-Product Collection: Reduce editor bundle cost

--- a/plugins/woocommerce/changelog/performance-product-status-counters-components
+++ b/plugins/woocommerce/changelog/performance-product-status-counters-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Update the admin to use persistent product status counters to improve performance with large product catalogs.

--- a/plugins/woocommerce/changelog/performance-products-instance-caching-groundwork
+++ b/plugins/woocommerce/changelog/performance-products-instance-caching-groundwork
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Addressed cache invalidation gaps for product instance caching refresh.

--- a/plugins/woocommerce/changelog/performance-slow-sql-on-admin-products-page
+++ b/plugins/woocommerce/changelog/performance-slow-sql-on-admin-products-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Disabled counters in the category filter on the admin products page to address performance issues with large product catalogs.

--- a/plugins/woocommerce/changelog/performance-tax-rates-sqls-number
+++ b/plugins/woocommerce/changelog/performance-tax-rates-sqls-number
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Reduced the number of SQL queries required to fetch tax rates in the cart and during checkout.

--- a/plugins/woocommerce/changelog/pos-catalog-feed-file-lock
+++ b/plugins/woocommerce/changelog/pos-catalog-feed-file-lock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Lock the POS catalog feed file exclusively while writing so two overlapping generation processes can no longer interleave output into a corrupt feed.

--- a/plugins/woocommerce/changelog/pr-64362
+++ b/plugins/woocommerce/changelog/pr-64362
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Cast refund amount values to float for PHP 8.1 TypeError fix.

--- a/plugins/woocommerce/changelog/pr-64374
+++ b/plugins/woocommerce/changelog/pr-64374
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add woocommerce_term_recount_product_count filter to _wc_term_recount.

--- a/plugins/woocommerce/changelog/qao-402-blocks-e2e-page-object-utils
+++ b/plugins/woocommerce/changelog/qao-402-blocks-e2e-page-object-utils
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate Blocks e2e page-object utils (admin, editor, frontend, local-pickup, mini-cart, performance, shipping) into the Core e2e suite under utils/blocks/; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/qao-403-blocks-e2e-leaf-utils-content-templates
+++ b/plugins/woocommerce/changelog/qao-403-blocks-e2e-leaf-utils-content-templates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate Blocks e2e leaf utils (constants, test, types, wp-cli, get-test-translation, request-utils, navigation) and content-templates into the Core e2e suite under a blocks/ namespace; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/qao-404-blocks-e2e-specs-core-isolation-guard
+++ b/plugins/woocommerce/changelog/qao-404-blocks-e2e-specs-core-isolation-guard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate Blocks e2e specs into the Core e2e suite under tests/blocks and add a core testIgnore guard so the core e2e project does not collect them; the Blocks suite keeps running them from the new location. Test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/qao-405-blocks-e2e-non-module-assets
+++ b/plugins/woocommerce/changelog/qao-405-blocks-e2e-non-module-assets
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate Blocks e2e non-module assets (themes, test plugins, test data, lint rules) into the Core e2e suite under a blocks/ namespace; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/qao-408-rename-e2e-pw-to-e2e
+++ b/plugins/woocommerce/changelog/qao-408-rename-e2e-pw-to-e2e
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Rename the e2e test directory from e2e-pw to e2e and repoint all references; test-only, no changes to shipped code.

--- a/plugins/woocommerce/changelog/refactor-59464-use-toolspanel-in-page-selector
+++ b/plugins/woocommerce/changelog/refactor-59464-use-toolspanel-in-page-selector
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Replace PanelBody with ToolsPanel in the PageSelector component.

--- a/plugins/woocommerce/changelog/remove-block-templates-package
+++ b/plugins/woocommerce/changelog/remove-block-templates-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove the unused block templates admin package and PHP API.

--- a/plugins/woocommerce/changelog/remove-brands-beta-product-editor
+++ b/plugins/woocommerce/changelog/remove-brands-beta-product-editor
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Remove WC Brands code related to the deprecated product editor
-
-

--- a/plugins/woocommerce/changelog/remove-buildkite-analytics-ci
+++ b/plugins/woocommerce/changelog/remove-buildkite-analytics-ci
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-

--- a/plugins/woocommerce/changelog/remove-coming-soon-newsletter-template-flag
+++ b/plugins/woocommerce/changelog/remove-coming-soon-newsletter-template-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove the unused coming soon newsletter template feature flag.

--- a/plugins/woocommerce/changelog/remove-deprecated-blocks-bootstrap-dependencies
+++ b/plugins/woocommerce/changelog/remove-deprecated-blocks-bootstrap-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove deprecated Blocks bootstrap dependencies.

--- a/plugins/woocommerce/changelog/remove-product-block-editor
+++ b/plugins/woocommerce/changelog/remove-product-block-editor
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove the deprecated product block editor feature, package, routes, assets, and extension APIs.

--- a/plugins/woocommerce/changelog/remove-product-filters-store-locks
+++ b/plugins/woocommerce/changelog/remove-product-filters-store-locks
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove Interactivity API locks from the Product Filters store.

--- a/plugins/woocommerce/changelog/remove-products-catalog-api
+++ b/plugins/woocommerce/changelog/remove-products-catalog-api
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove unused `products-catalog-api` feature flag and its mock `WC_REST_Products_Catalog_Controller`, superseded by the `wc/pos/v1/catalog` endpoint.

--- a/plugins/woocommerce/changelog/remove-redundant-basic-e2e-spec
+++ b/plugins/woocommerce/changelog/remove-redundant-basic-e2e-spec
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove redundant basic E2E smoke test; its checks are implicitly covered by other specs.

--- a/plugins/woocommerce/changelog/remove-render_block_with_context_util
+++ b/plugins/woocommerce/changelog/remove-render_block_with_context_util
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Remove no longer needed render_block_with_context() util
-
-

--- a/plugins/woocommerce/changelog/remove-use-wp-horizon-flag
+++ b/plugins/woocommerce/changelog/remove-use-wp-horizon-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Remove the disabled use-wp-horizon feature flag.

--- a/plugins/woocommerce/changelog/revert-65595-product-create-meta-fast-path
+++ b/plugins/woocommerce/changelog/revert-65595-product-create-meta-fast-path
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Revert #65595 (product-create meta fast-path). Added and reverted within the 11.0 cycle, so no net user-facing change to document.

--- a/plugins/woocommerce/changelog/site-health-admin-notice-migration
+++ b/plugins/woocommerce/changelog/site-health-admin-notice-migration
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Move several WooCommerce admin status notices to Site Health and show regeneration progress in status tools; deprecate the related WC_Admin_Notices/WC_Regenerate_Images notice callbacks and stop honoring the woocommerce_hide_* notice dismissal filters

--- a/plugins/woocommerce/changelog/sprinkle-analytics-date-range-alignment
+++ b/plugins/woocommerce/changelog/sprinkle-analytics-date-range-alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Align the Data status box with the Date range filter at mid-range viewports, drop the trailing colons on both labels, use a consistent "M j at H:i" date format, and pick up WP component defaults for the Update now button and bar typography.

--- a/plugins/woocommerce/changelog/sprinkle-orders-empty-state
+++ b/plugins/woocommerce/changelog/sprinkle-orders-empty-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Reduce the visual weight of legacy admin empty states to align with WordPress admin styling.

--- a/plugins/woocommerce/changelog/testops-139-woocommerce-core-move-redundant-coupon-e2e-down-to-php
+++ b/plugins/woocommerce/changelog/testops-139-woocommerce-core-move-redundant-coupon-e2e-down-to-php
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-tests: move coupons test coverage from e2e to php unit

--- a/plugins/woocommerce/changelog/testops-181-coupon-e2e-downgrade-move-discount-arithmetic-to-phpunit
+++ b/plugins/woocommerce/changelog/testops-181-coupon-e2e-downgrade-move-discount-arithmetic-to-phpunit
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Move coupon discount-arithmetic coverage from e2e to PHPUnit; reduce coupon cart e2e to a single wiring smoke.

--- a/plugins/woocommerce/changelog/testops-183-right-size-create-order-spec
+++ b/plugins/woocommerce/changelog/testops-183-right-size-create-order-spec
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove redundant tax-amount assertions from create-order E2E spec; tax calculation logic is already covered by API and PHPUnit tests.

--- a/plugins/woocommerce/changelog/testops-185-restricted-coupon-e2e-downgrade
+++ b/plugins/woocommerce/changelog/testops-185-restricted-coupon-e2e-downgrade
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Move restricted-coupon validation-rule coverage from e2e to PHPUnit; reduce restricted-coupon cart/checkout e2e to wiring + order-placement tests; fix the excluded-coupon test that never applied its coupon.

--- a/plugins/woocommerce/changelog/testops-189-product-reviews-delete-flake
+++ b/plugins/woocommerce/changelog/testops-189-product-reviews-delete-flake
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix product-reviews "can delete a product review" E2E flake by waiting for the trash AJAX to commit before navigating to the Trash view.

--- a/plugins/woocommerce/changelog/testops-199-fix-flaky-create-product-attributes-e2e
+++ b/plugins/woocommerce/changelog/testops-199-fix-flaky-create-product-attributes-e2e
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: E2E test only change.

--- a/plugins/woocommerce/changelog/tweak-blank-state-generic-icon-fallback
+++ b/plugins/woocommerce/changelog/tweak-blank-state-generic-icon-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Restore a generic blank-state icon style so extension-supplied icon glyphs render at the refreshed 32px scale.

--- a/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
+++ b/plugins/woocommerce/changelog/tweak-dashboard-setup-post-launch-widgets
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Show WooCommerce Status and Recent Reviews dashboard widgets during store setup.

--- a/plugins/woocommerce/changelog/update-47865-orders-table-query-build
+++ b/plugins/woocommerce/changelog/update-47865-orders-table-query-build
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Optimized SQL generation in \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery by removing 'group by' and 'limit' clauses when they are not required.

--- a/plugins/woocommerce/changelog/update-action-scheduler-via-automation
+++ b/plugins/woocommerce/changelog/update-action-scheduler-via-automation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update the Action Scheduler package to version 4.0.0.

--- a/plugins/woocommerce/changelog/update-blocks-e2e-core-cutover
+++ b/plugins/woocommerce/changelog/update-blocks-e2e-core-cutover
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Merge the Blocks Playwright e2e suite into the Core e2e suite; no functional change to the plugin.
-
-

--- a/plugins/woocommerce/changelog/update-cart-checkout-slotfill-wp68
+++ b/plugins/woocommerce/changelog/update-cart-checkout-slotfill-wp68
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Update the cart/checkout Slot Fill to source from the WordPress 6.8 @wordpress/components package, removing the separately pinned wp-6.5 copy.

--- a/plugins/woocommerce/changelog/update-cssmin-clean-css-5
+++ b/plugins/woocommerce/changelog/update-cssmin-clean-css-5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump grunt-contrib-cssmin to 4.x (clean-css 5) so the admin CSS pipeline preserves @container at-rules.

--- a/plugins/woocommerce/changelog/update-e2e-core-serial-parallel-projects
+++ b/plugins/woocommerce/changelog/update-e2e-core-serial-parallel-projects
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Split the core E2E Playwright suite into core-serial and core-parallel projects to enable parallel test runs. Test-only change, no production impact.

--- a/plugins/woocommerce/changelog/update-email-verification-magic-link
+++ b/plugins/woocommerce/changelog/update-email-verification-magic-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Customer email verification now confirms via a one-time login-gated link instead of a 6-digit code.

--- a/plugins/woocommerce/changelog/update-product-filter-copy
+++ b/plugins/woocommerce/changelog/update-product-filter-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Standardize copy for Product Filters descriptions.

--- a/plugins/woocommerce/changelog/update-product-filter-status-availability
+++ b/plugins/woocommerce/changelog/update-product-filter-status-availability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update Product Filter Status block labels to use availability wording.

--- a/plugins/woocommerce/changelog/update-product-image-use-larger-thumbnails
+++ b/plugins/woocommerce/changelog/update-product-image-use-larger-thumbnails
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Updated Product Image block to use larger thumbnails

--- a/plugins/woocommerce/changelog/update-product-publish-panel-catalog-visibility
+++ b/plugins/woocommerce/changelog/update-product-publish-panel-catalog-visibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update product publish panel catalog visibility layout and extension row ordering.

--- a/plugins/woocommerce/changelog/update-products-control-ts
+++ b/plugins/woocommerce/changelog/update-products-control-ts
@@ -1,3 +1,0 @@
-Significance: patch
-Type: update
-Comment: Convert ProductsControl component to TS

--- a/plugins/woocommerce/changelog/update-rename-visual-attribute-picker
+++ b/plugins/woocommerce/changelog/update-rename-visual-attribute-picker
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Rename visual-attribute-color-picker script to visual-attribute-picker

--- a/plugins/woocommerce/changelog/update-settings-ui-wpds-cards
+++ b/plugins/woocommerce/changelog/update-settings-ui-wpds-cards
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Render settings UI section cards with WordPress Design System components behind the settings-ui feature flag.

--- a/plugins/woocommerce/changelog/update-settings-ui-wpds-token-delivery
+++ b/plugins/woocommerce/changelog/update-settings-ui-wpds-token-delivery
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Load the WordPress Design System tokens stylesheet on WooCommerce settings pages so Settings UI styles consume real design tokens.

--- a/plugins/woocommerce/changelog/update-swatches-improvements
+++ b/plugins/woocommerce/changelog/update-swatches-improvements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Minor enhancements to product swatches and editing Color attributes in the editor

--- a/plugins/woocommerce/changelog/update-tell-agents-not-to-write-jquery
+++ b/plugins/woocommerce/changelog/update-tell-agents-not-to-write-jquery
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Update AGENTS.md to avoid agents adding more jQuery code
-
-

--- a/plugins/woocommerce/changelog/update-wordpress-package-catalog-wp-6-9
+++ b/plugins/woocommerce/changelog/update-wordpress-package-catalog-wp-6-9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update the WordPress package catalog to WordPress 6.9 package versions.

--- a/plugins/woocommerce/changelog/use-public-postcode-validator-api
+++ b/plugins/woocommerce/changelog/use-public-postcode-validator-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Use the public postcode-validator API instead of reaching into the package's internal CJS regex map.

--- a/plugins/woocommerce/changelog/wccom-2623-marketplace-react-19-compatibility
+++ b/plugins/woocommerce/changelog/wccom-2623-marketplace-react-19-compatibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Prepare Marketplace JSX and ref types for React 19 compatibility.

--- a/plugins/woocommerce/changelog/woomob-2683-remove-pos-feature-flag
+++ b/plugins/woocommerce/changelog/woomob-2683-remove-pos-feature-flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Deprecate the Point of Sale feature flag and remove its toggle from WooCommerce settings; POS-related functionality (settings page, product visibility, and transactional emails) is now always enabled. The flag setting remains readable via the REST API for mobile app compatibility.

--- a/plugins/woocommerce/changelog/woomob-3176-partial-refunds-by-amount
+++ b/plugins/woocommerce/changelog/woomob-3176-partial-refunds-by-amount
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-POST /wc/v4/refunds/preview: accept refund_total per line item for partial-amount previews (quantity now optional when refund_total is provided). For the quantity and tax-inclusive refund_total forms, preview and create split tax by the line's stored total/tax ratio and round amounts identically, so a previewed amount matches the created refund to the cent.

--- a/plugins/woocommerce/changelog/wooplug-3697-deprecate-queryfilters-class
+++ b/plugins/woocommerce/changelog/wooplug-3697-deprecate-queryfilters-class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Deprecate the Automattic\WooCommerce\Blocks\QueryFilters class.

--- a/plugins/woocommerce/changelog/wooplug-5748-add-referrerpolicy-to-address-autocomplete-request
+++ b/plugins/woocommerce/changelog/wooplug-5748-add-referrerpolicy-to-address-autocomplete-request
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add referrerPolicy to address autocomplete fetch requests to ensure Referer header is sent even with restrictive site policies.

--- a/plugins/woocommerce/changelog/wooplug-5971-order-item-meta
+++ b/plugins/woocommerce/changelog/wooplug-5971-order-item-meta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Order editing: skip reserved internal meta keys when saving order items, so they cannot be added via the "Add meta" button and stored as invisible meta.

--- a/plugins/woocommerce/changelog/wooplug-6190-order-util-data-sync-enabled-accessor
+++ b/plugins/woocommerce/changelog/wooplug-6190-order-util-data-sync-enabled-accessor
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add OrderUtil::custom_orders_table_data_sync_is_enabled() so extensions can cheaply check whether HPOS data sync is enabled without running the expensive is_custom_order_tables_in_sync() query.

--- a/plugins/woocommerce/changelog/wooplug-6248-express-payment-incompatible-notice
+++ b/plugins/woocommerce/changelog/wooplug-6248-express-payment-incompatible-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix false "incompatible extension" notice shown in the block editor for express payment methods whose client-side `name` differs from their server-side gateway ID. The compatibility check now matches on `paymentMethodId` (falling back to `name`).

--- a/plugins/woocommerce/changelog/wooplug-6536-email-reply-to-always-visible
+++ b/plugins/woocommerce/changelog/wooplug-6536-email-reply-to-always-visible
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Always show the email Reply-to settings, regardless of whether the email block editor feature is enabled.

--- a/plugins/woocommerce/changelog/wooplug-6656-uploads-direct-filesystem
+++ b/plugins/woocommerce/changelog/wooplug-6656-uploads-direct-filesystem
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use a direct filesystem instance for log, import, product feed, and transient file operations inside the uploads directory, so they no longer fail on sites that have FS_METHOD set to an FTP-based method without complete credentials.

--- a/plugins/woocommerce/changelog/wooplug-6663-fix-typeerror-formatted-order-total
+++ b/plugins/woocommerce/changelog/wooplug-6663-fix-typeerror-formatted-order-total
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix TypeError: string - string in get_formatted_order_total() on PHP 8.3 with refunded orders

--- a/plugins/woocommerce/changelog/wooplug-6670-untrash-customer-emails
+++ b/plugins/woocommerce/changelog/wooplug-6670-untrash-customer-emails
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Stop re-sending customer order email notifications when restoring orders from the trash.

--- a/plugins/woocommerce/changelog/wooplug-6829-can-be-refunded-fee-shipping-parity
+++ b/plugins/woocommerce/changelog/wooplug-6829-can-be-refunded-fee-shipping-parity
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-v4 Orders API: align fee/shipping `can_be_refunded` with the refund validator — compare on a tax-inclusive absolute basis (so discount/negative fee lines report refundable) and round to currency precision (so a fully-refunded line is not reported refundable on a sub-cent float residue).

--- a/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
+++ b/plugins/woocommerce/changelog/wooplug-6831-cart-rowheader-grid-aria
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve cart table accessibility and spacing so screen readers announce line items as rows with the correct column headers.

--- a/plugins/woocommerce/changelog/wooplug-6842-email-preview-shipping-details-filter
+++ b/plugins/woocommerce/changelog/wooplug-6842-email-preview-shipping-details-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add a filter to hide shipping details in email previews.

--- a/plugins/woocommerce/changelog/wooplug-6866-fix-backslash-agentic-checkout
+++ b/plugins/woocommerce/changelog/wooplug-6866-fix-backslash-agentic-checkout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix silent backslash corruption in Agentic Checkout buyer/address fields and Store API checkout field validation. Calling wp_unslash() on JSON request body data that is never magic-quoted was stripping real backslashes typed by the buyer.

--- a/plugins/woocommerce/changelog/wooplug-6880-pending-cancelled-admin-email
+++ b/plugins/woocommerce/changelog/wooplug-6880-pending-cancelled-admin-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Send cancelled order admin emails when pending orders are cancelled.

--- a/plugins/woocommerce/changelog/wooplug-6883-email-preview-download-file-object
+++ b/plugins/woocommerce/changelog/wooplug-6883-email-preview-download-file-object
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix email previews for orders with downloadable products.

--- a/plugins/woocommerce/changelog/wooplug-6930-adopt-import-order
+++ b/plugins/woocommerce/changelog/wooplug-6930-adopt-import-order
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove obsolete @woocommerce/dependency-group eslint-disable directives following the switch to import/order in @woocommerce/eslint-plugin.

--- a/plugins/woocommerce/changelog/wooplug-6930-prettier-ignore-decouple
+++ b/plugins/woocommerce/changelog/wooplug-6930-prettier-ignore-decouple
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Decouple the blocks reformat-files script from .eslintignore by using a dedicated .prettierignore.

--- a/plugins/woocommerce/changelog/wooplug-6950-product-filters-category-in-taxonomy-term-labels-is-double
+++ b/plugins/woocommerce/changelog/wooplug-6950-product-filters-category-in-taxonomy-term-labels-is-double
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix encoded character in filter option label.

--- a/plugins/woocommerce/changelog/wooplug-7021-ai-regression-reviewrelease110-decoding-term-names-upstream
+++ b/plugins/woocommerce/changelog/wooplug-7021-ai-regression-reviewrelease110-decoding-term-names-upstream
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix: ensure the dropdown inside Add to Cart + Options block render special character correctly.

--- a/plugins/woocommerce/changelog/woopmnt-6250-custom-place-order-button
+++ b/plugins/woocommerce/changelog/woopmnt-6250-custom-place-order-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix custom place order button (shortcode checkout) never submitting the order when a shipping address block is present. Client-side validation now only counts visible invalid fields, so the collapsed "Ship to a different address?" shipping fields no longer block submission.

--- a/plugins/woocommerce/changelog/wooprd-3212-wp-ui-payment-method-notice
+++ b/plugins/woocommerce/changelog/wooprd-3212-wp-ui-payment-method-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Use the standard WordPress UI Notice for payment method eligibility notices in WooPayments onboarding.

--- a/plugins/woocommerce/changelog/wooprd-3555-settings-container-radius
+++ b/plugins/woocommerce/changelog/wooprd-3555-settings-container-radius
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update the Settings UI section card border radius to match DataForm styling.


### PR DESCRIPTION
This pull request removes the changefiles from 11.0.0-beta.1 that are compiled into the `trunk` branch via #66563.

Created manually by the release lead: the automated step of `Release: Compile changelog` failed on modify/delete conflicts caused by #66410's trailing-newline sweep (run https://github.com/woocommerce/woocommerce/actions/runs/29268836942). Deletion set = the 298 changefiles removed from `release/11.0` by #66563, all present on trunk at base `16fa8cce`.