### PR TITLE
feat(blocks): add filter to disable default checkout payment selection

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/test/set-default-payment-method.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/test/set-default-payment-method.ts
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { select, dispatch } from '@wordpress/data';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -23,6 +24,10 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
+jest.mock( '@woocommerce/blocks-checkout', () => ( {
+	applyCheckoutFilter: jest.fn( ( { defaultValue } ) => defaultValue ),
+} ) );
+
 jest.mock( '@woocommerce/utils', () => {
 	return {
 		isSiteEditorPage: jest.fn().mockReturnValue( true ),
@@ -30,6 +35,12 @@ jest.mock( '@woocommerce/utils', () => {
 } );
 
 describe( 'setDefaultPaymentMethod', () => {
+	beforeEach( () => {
+		( applyCheckoutFilter as jest.Mock ).mockImplementation(
+			( { defaultValue } ) => defaultValue
+		);
+	} );
+
 	afterEach( () => {
 		jest.resetAllMocks();
 		jest.resetModules();
@@ -43,6 +54,30 @@ describe( 'setDefaultPaymentMethod', () => {
 			name: 'wc-payment-gateway-2',
 		},
 	};
+
+	it( 'does not set a default payment method when default selection is disabled via checkout filter', async () => {
+		( applyCheckoutFilter as jest.Mock ).mockReturnValue( false );
+
+		const setPaymentIdleMock = jest.fn();
+		const setActivePaymentMethodMock = jest.fn();
+		( dispatch as jest.Mock ).mockImplementation( ( storeName ) => {
+			const originalStore = originalDispatch( storeName );
+			if ( storeName === paymentStore ) {
+				return {
+					...originalStore,
+					__internalSetPaymentIdle: setPaymentIdleMock,
+					__internalSetActivePaymentMethod:
+						setActivePaymentMethodMock,
+				};
+			}
+			return originalStore;
+		} );
+
+		await setDefaultPaymentMethod( paymentMethods );
+
+		expect( setPaymentIdleMock ).toHaveBeenCalled();
+		expect( setActivePaymentMethodMock ).toHaveBeenCalledWith( '', {} );
+	} );
 
 	it( 'correctly sets the first payment method in the list of available payment methods', async () => {
 		const setActivePaymentMethodMock = jest.fn();

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/utils/set-default-payment-method.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/utils/set-default-payment-method.ts
@@ -3,6 +3,7 @@
  */
 import { select, dispatch } from '@wordpress/data';
 import { PlainPaymentMethods } from '@woocommerce/types';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -12,6 +13,17 @@ import { store as paymentStore } from '../index';
 export const setDefaultPaymentMethod = async (
 	paymentMethods: PlainPaymentMethods
 ) => {
+	const shouldSelectDefaultPaymentMethod = applyCheckoutFilter( {
+		filterName: 'defaultPaymentMethodSelection',
+		defaultValue: true,
+	} );
+
+	if ( ! shouldSelectDefaultPaymentMethod ) {
+		dispatch( paymentStore ).__internalSetPaymentIdle();
+		dispatch( paymentStore ).__internalSetActivePaymentMethod( '', {} );
+		return;
+	}
+
 	const paymentMethodKeys = Object.keys( paymentMethods );
 	const expressPaymentMethodKeys = Object.keys(
 		select( paymentStore ).getAvailableExpressPaymentMethods()


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Checkout block currently auto-selects a payment method on load, with no extension point to require explicit shopper choice. This change adds a checkout filter to opt out of default selection and keep all methods unselected until the customer picks one.

* **Behavior change in default-selection flow**
  * Added a new checkout filter: `defaultPaymentMethodSelection` (default: `true`).
  * Applied the filter in `setDefaultPaymentMethod` before saved/first-method fallback logic runs.
* **Unselected-state handling**
  * When the filter returns `false`, checkout now:
    * sets payment state to idle
    * clears `activePaymentMethod`
    * skips selecting saved/default gateway automatically
* **Coverage updates**
  * Extended payment default-selection unit tests to assert the opt-out path and ensure active method is cleared when preselection is disabled.

```ts
const shouldSelectDefaultPaymentMethod = applyCheckoutFilter( {
    filterName: 'defaultPaymentMethodSelection',
    defaultValue: true,
} );

if ( ! shouldSelectDefaultPaymentMethod ) {
    dispatch( paymentStore ).__internalSetPaymentIdle();
    dispatch( paymentStore ).__internalSetActivePaymentMethod( '', {} );
    return;
}
```

Closes woocommerce/woocommerce#65938

## How to test the changes in this Pull Request

1. Ensure your WooCommerce store is active and configured with at least two payment gateways (e.g., Direct Bank Transfer and Cash on Delivery).
2. Navigate to the frontend Checkout block page. Confirm the legacy behavior: the first available payment method is selected automatically on load.
3. Hook into the newly created filter to disable preselection. You can do this by registering a script in a test plugin/theme or by executing the following in your browser's developer console on the checkout page:

```js
wp.hooks.addFilter(
	'woocommerce_blocks_default_payment_method_selection', // Adjust to match the exact string prefix your applyCheckoutFilter resolves to
	'test-extension/disable-preselect',
	() => false
);
```

4. Reload the checkout page (or trigger a cart update if testing via console).
5. Verify that no payment method is selected by default (the radio buttons should all be empty/unselected).
6. Attempt to click **Place Order** and verify that standard validation prevents submission and prompts you to select a payment method.
7. Select a payment method manually and verify that the order processes successfully.

---

## Testing that has already taken place

* Executed unit tests for `set-default-payment-method.ts` to ensure the false return value successfully clears the active payment method and sets the store to idle.
* Manually tested in a local WordPress environment with multiple payment gateways enabled to verify the UI correctly reflects the unselected state without throwing React hydration or rendering errors.

---

## Milestone

- [X] Automatically assign milestone for the next WooCommerce version

---

## Changelog entry

- [X] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Significance

- [ ] Patch
- [X] Minor
- [ ] Major

### Type

- [ ] Fix - Fixes an existing bug
- [X] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

### Message

Added the `defaultPaymentMethodSelection` checkout filter to allow extensions and merchants to disable the automatic pre-selection of payment methods in the Checkout Block.

### Comment

Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] Feature Highlight - For user-facing features (what changed, user impact)
- [X] Developer Advisory - For developer-facing changes (what changed, how to detect, actions needed)