### PR TITLE
[Email Editor] Fix gallery block ignoring aspect ratio crop

### DIFF
--- a/packages/php/email-editor/changelog/fix-nl-738-gallery-aspect-ratio-crop
+++ b/packages/php/email-editor/changelog/fix-nl-738-gallery-aspect-ratio-crop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor the gallery block aspect ratio (crop) when rendering emails. Cropped images now fall back to CSS cropping and expose the `woocommerce_email_editor_gallery_cropped_image_url` filter so integrations can serve server-side-cropped images that render the crop in every email client.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -98,8 +98,12 @@ class Gallery extends Abstract_Block_Renderer {
 		$image_count = count( $image_blocks );
 
 		foreach ( $image_blocks as $index => $block ) {
-			$image_attrs  = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
-			$aspect_ratio = isset( $image_attrs['aspectRatio'] ) && is_string( $image_attrs['aspectRatio'] ) ? $image_attrs['aspectRatio'] : $gallery_aspect_ratio;
+			$image_attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+
+			// Use the per-image override only when it is a valid ratio; a malformed override falls
+			// back to the gallery ratio instead of silently disabling the crop for that image.
+			$image_ratio  = isset( $image_attrs['aspectRatio'] ) && is_string( $image_attrs['aspectRatio'] ) ? $image_attrs['aspectRatio'] : null;
+			$aspect_ratio = ( null !== $image_ratio && null !== $this->parse_aspect_ratio( $image_ratio ) ) ? $image_ratio : $gallery_aspect_ratio;
 
 			$cell_width      = $this->get_cell_width( $index, $image_count, $columns, $layout_width );
 			$extracted_image = $this->extract_image_from_html( $block['innerHTML'], $aspect_ratio, $cell_width, $image_attrs );
@@ -205,9 +209,10 @@ class Gallery extends Abstract_Block_Renderer {
 			return $img_html;
 		}
 
-		// Derive the target display dimensions from the cell width and the requested ratio.
+		// Derive the target display dimensions from the cell width and the requested ratio. Clamp the
+		// height to at least 1px so a very wide ratio can't round down to a 0-height (unusable) crop.
 		$width  = $cell_width > 0 ? $cell_width : 0;
-		$height = $width > 0 ? (int) round( $width / $ratio_value ) : 0;
+		$height = $width > 0 ? max( 1, (int) round( $width / $ratio_value ) ) : 0;
 
 		/** @var string $image_url */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort -- used for phpstan
 		$image_url = $html->get_attribute( 'src' ) ?? '';

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -214,8 +214,10 @@ class Gallery extends Abstract_Block_Renderer {
 		$width  = $cell_width > 0 ? $cell_width : 0;
 		$height = $width > 0 ? max( 1, (int) round( $width / $ratio_value ) ) : 0;
 
-		/** @var string $image_url */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort -- used for phpstan
-		$image_url = $html->get_attribute( 'src' ) ?? '';
+		// get_attribute() can return a string, null (absent), or bool true (valueless attribute);
+		// coerce anything that isn't a real URL string to an empty string.
+		$src_attribute = $html->get_attribute( 'src' );
+		$image_url     = is_string( $src_attribute ) ? $src_attribute : '';
 
 		/**
 		 * Filters the URL of an image inside an email gallery so integrations can serve a
@@ -241,6 +243,10 @@ class Gallery extends Abstract_Block_Renderer {
 
 		$is_server_cropped = '' !== $image_url && '' !== $cropped_url && $cropped_url !== $image_url;
 
+		// These crop styles are appended after Html_Processing_Helper::sanitize_image_html() has run
+		// (its style allowlist would otherwise strip object-fit), so they intentionally bypass that
+		// sanitizer. Only the regex-validated $aspect_ratio may be interpolated here — every other
+		// token is a literal. Do not add dynamic values to $crop_styles without validating them.
 		if ( $is_server_cropped ) {
 			// The file is already cropped to the requested ratio, so we can give it concrete
 			// dimensions. This renders the crop correctly even in clients without CSS crop support.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -28,8 +28,13 @@ class Gallery extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		// The number of columns determines how wide each cropped image is displayed, which we pass to
+		// the crop so an image CDN can serve an appropriately sized (and cropped) file.
+		$columns    = $this->get_columns_from_attributes( $parsed_block['attrs'] ?? array() );
+		$cell_width = $this->get_cell_width( $columns, $rendering_context );
+
 		// Extract images directly from the block content (more efficient than re-rendering).
-		$gallery_images = $this->extract_images_from_gallery_content( $block_content, $parsed_block );
+		$gallery_images = $this->extract_images_from_gallery_content( $block_content, $parsed_block, $cell_width );
 
 		// If we don't have any images, return empty.
 		if ( empty( $gallery_images ) ) {
@@ -41,20 +46,44 @@ class Gallery extends Abstract_Block_Renderer {
 	}
 
 	/**
+	 * Estimate the display width (in px) of a single gallery cell.
+	 *
+	 * Used to size cropped images so an image CDN can serve a file that matches the cell instead of
+	 * the full-size original.
+	 *
+	 * @param int               $columns Number of gallery columns.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return int Cell width in px (at least 1).
+	 */
+	private function get_cell_width( int $columns, Rendering_Context $rendering_context ): int {
+		$layout_width = Styles_Helper::parse_value( $rendering_context->get_layout_width_without_padding() );
+		$columns      = max( 1, $columns );
+
+		return (int) max( 1, floor( $layout_width / $columns ) );
+	}
+
+	/**
 	 * Extract all images from gallery content with their links and captions.
 	 *
 	 * @param string $block_content The rendered gallery block HTML.
 	 * @param array  $parsed_block The parsed block data.
+	 * @param int    $cell_width Estimated display width of a gallery cell in px.
 	 * @return array Array of sanitized image HTML strings.
 	 */
-	private function extract_images_from_gallery_content( string $block_content, array $parsed_block ): array {
+	private function extract_images_from_gallery_content( string $block_content, array $parsed_block, int $cell_width ): array {
 		$gallery_images = array();
 		$inner_blocks   = $parsed_block['innerBlocks'] ?? array();
+
+		// The gallery can request a crop (aspect ratio) for all of its images. Individual images
+		// may override it with their own aspectRatio attribute.
+		$gallery_aspect_ratio = $parsed_block['attrs']['aspectRatio'] ?? null;
 
 		// Extract images from inner blocks data where the actual image HTML is stored.
 		foreach ( $inner_blocks as $block ) {
 			if ( 'core/image' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
-				$extracted_image = $this->extract_image_from_html( $block['innerHTML'] );
+				$aspect_ratio    = $block['attrs']['aspectRatio'] ?? $gallery_aspect_ratio;
+				$image_attrs     = $block['attrs'] ?? array();
+				$extracted_image = $this->extract_image_from_html( $block['innerHTML'], $aspect_ratio, $cell_width, $image_attrs );
 				if ( ! empty( $extracted_image ) ) {
 					$gallery_images[] = $extracted_image;
 				}
@@ -68,10 +97,13 @@ class Gallery extends Abstract_Block_Renderer {
 	 * Extract and sanitize image with optional link and caption from HTML content.
 	 * This is the unified method that handles all image extraction scenarios.
 	 *
-	 * @param string $html_content HTML content containing the image.
+	 * @param string      $html_content HTML content containing the image.
+	 * @param string|null $aspect_ratio Optional aspect ratio (e.g. "1" or "4/3") to crop the image to.
+	 * @param int         $cell_width Estimated display width of the gallery cell in px.
+	 * @param array       $image_attrs Parsed attributes of the core/image block (id, sizeSlug, ...).
 	 * @return string Sanitized image HTML with proper link and caption handling.
 	 */
-	private function extract_image_from_html( string $html_content ): string {
+	private function extract_image_from_html( string $html_content, ?string $aspect_ratio = null, int $cell_width = 0, array $image_attrs = array() ): string {
 		$result = '';
 
 		// First, try to find a linked image (most common case).
@@ -79,20 +111,20 @@ class Gallery extends Abstract_Block_Renderer {
 			// Validate and sanitize the link URL.
 			$sanitized_url = esc_url( $link_matches[2] );
 			if ( ! empty( $sanitized_url ) ) {
-				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
+				$sanitized_img = $this->apply_aspect_ratio_crop( Html_Processing_Helper::sanitize_image_html( $link_matches[3] ), $aspect_ratio, $cell_width, $image_attrs );
 				if ( '' !== $sanitized_img ) {
 					$result .= '<a href="' . $sanitized_url . '">' . $sanitized_img . '</a>';
 				}
 			} else {
 				// If URL is invalid, extract just the image without link.
-				$sanitized_img = Html_Processing_Helper::sanitize_image_html( $link_matches[3] );
+				$sanitized_img = $this->apply_aspect_ratio_crop( Html_Processing_Helper::sanitize_image_html( $link_matches[3] ), $aspect_ratio, $cell_width, $image_attrs );
 				if ( '' !== $sanitized_img ) {
 					$result .= $sanitized_img;
 				}
 			}
 		} elseif ( preg_match( '/<img[^>]*>/', $html_content, $img_matches ) ) {
 			// Image is not linked - just extract the img element with sanitization.
-			$sanitized_img = Html_Processing_Helper::sanitize_image_html( $img_matches[0] );
+			$sanitized_img = $this->apply_aspect_ratio_crop( Html_Processing_Helper::sanitize_image_html( $img_matches[0] ), $aspect_ratio, $cell_width, $image_attrs );
 			if ( '' !== $sanitized_img ) {
 				$result .= $sanitized_img;
 			}
@@ -115,6 +147,115 @@ class Gallery extends Abstract_Block_Renderer {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Apply an aspect-ratio crop to a sanitized <img> tag.
+	 *
+	 * Email clients can't crop client-side reliably (`object-fit`/`aspect-ratio` are unsupported in
+	 * Gmail), so the only way to truly honor the crop everywhere is to serve an already-cropped image
+	 * file. This method exposes the {@see 'woocommerce_email_editor_gallery_cropped_image_url'} filter
+	 * so integrations (e.g. Jetpack/Photon on WordPress.com) can rewrite the image URL to a
+	 * server-cropped version. When that happens, the image is given concrete `width`/`height`
+	 * dimensions so it renders correctly even in clients without CSS crop support.
+	 *
+	 * When no integration crops the URL (e.g. self-hosted sites with no image CDN), the method falls
+	 * back to inline `aspect-ratio` + `object-fit: cover` CSS. Clients that support it (Apple Mail,
+	 * iOS Mail, modern webmail) render the crop; the rest fall back to the natural aspect ratio,
+	 * matching the previous behavior with no regression.
+	 *
+	 * @param string      $img_html Sanitized <img> HTML.
+	 * @param string|null $aspect_ratio Aspect ratio to apply (e.g. "1" or "4/3").
+	 * @param int         $cell_width Estimated display width of the gallery cell in px.
+	 * @param array       $image_attrs Parsed attributes of the core/image block (id, sizeSlug, ...).
+	 * @return string Image HTML with the crop applied, or the input unchanged when no valid ratio.
+	 */
+	private function apply_aspect_ratio_crop( string $img_html, ?string $aspect_ratio, int $cell_width = 0, array $image_attrs = array() ): string {
+		if ( null === $aspect_ratio || '' === $img_html ) {
+			return $img_html;
+		}
+
+		// Only accept simple numeric ratios such as "1", "1.5" or "4/3" to avoid injecting anything unexpected.
+		$aspect_ratio = trim( $aspect_ratio );
+		$ratio_value  = $this->parse_aspect_ratio( $aspect_ratio );
+		if ( null === $ratio_value ) {
+			return $img_html;
+		}
+
+		$html = new \WP_HTML_Tag_Processor( $img_html );
+		if ( ! $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			return $img_html;
+		}
+
+		// Derive the target display dimensions from the cell width and the requested ratio.
+		$width  = $cell_width > 0 ? $cell_width : 0;
+		$height = $width > 0 ? (int) round( $width / $ratio_value ) : 0;
+
+		/** @var string $image_url */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort -- used for phpstan
+		$image_url = $html->get_attribute( 'src' ) ?? '';
+
+		/**
+		 * Filters the URL of an image inside an email gallery so integrations can serve a
+		 * server-side-cropped file that honors the block's aspect ratio.
+		 *
+		 * Email can't crop client-side reliably, so returning an already-cropped URL (e.g. an image
+		 * CDN URL with resize/crop parameters) is the only way to honor the crop in every client.
+		 * Return the URL unchanged to leave the image uncropped (the renderer then falls back to
+		 * best-effort CSS cropping).
+		 *
+		 * @param string $image_url    The original image URL.
+		 * @param string $aspect_ratio The requested aspect ratio (e.g. "1", "4/3").
+		 * @param int    $width        Target display width of the image in px (0 if unknown).
+		 * @param int    $height       Target display height derived from the aspect ratio in px (0 if unknown).
+		 * @param array  $image_attrs  Parsed attributes of the core/image block (id, sizeSlug, ...).
+		 */
+		$cropped_url = (string) apply_filters( 'woocommerce_email_editor_gallery_cropped_image_url', $image_url, $aspect_ratio, $width, $height, $image_attrs );
+
+		$is_server_cropped = '' !== $image_url && '' !== $cropped_url && $cropped_url !== $image_url;
+
+		if ( $is_server_cropped ) {
+			// The file is already cropped to the requested ratio, so we can give it concrete
+			// dimensions. This renders the crop correctly even in clients without CSS crop support.
+			$html->set_attribute( 'src', esc_url( $cropped_url ) );
+			if ( $width > 0 && $height > 0 ) {
+				$html->set_attribute( 'width', esc_attr( (string) $width ) );
+				$html->set_attribute( 'height', esc_attr( (string) $height ) );
+			}
+			$crop_styles = sprintf( 'aspect-ratio: %s; object-fit: cover; width: 100%%; height: auto; max-width: 100%%; display: block;', $aspect_ratio );
+		} else {
+			// No server-side crop available: fall back to best-effort CSS cropping. We avoid concrete
+			// dimensions here so the natural image isn't distorted in clients that ignore object-fit.
+			$crop_styles = sprintf( 'aspect-ratio: %s; object-fit: cover; width: 100%%; height: auto; display: block;', $aspect_ratio );
+		}
+
+		/** @var string $existing_style */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort -- used for phpstan
+		$existing_style = $html->get_attribute( 'style' ) ?? '';
+		$existing_style = '' !== $existing_style ? ( rtrim( $existing_style, ';' ) . '; ' ) : '';
+		$html->set_attribute( 'style', esc_attr( $existing_style . $crop_styles ) );
+
+		return $html->get_updated_html();
+	}
+
+	/**
+	 * Parse an aspect ratio attribute value (e.g. "1", "1.5", "4/3") into a numeric width/height ratio.
+	 *
+	 * @param string $aspect_ratio Aspect ratio value.
+	 * @return float|null The ratio (width divided by height), or null when the value is invalid.
+	 */
+	private function parse_aspect_ratio( string $aspect_ratio ): ?float {
+		// Only accept simple numeric ratios to avoid injecting anything unexpected into the markup.
+		if ( ! preg_match( '/^(\d+(?:\.\d+)?)(?:\s*\/\s*(\d+(?:\.\d+)?))?$/', trim( $aspect_ratio ), $matches ) ) {
+			return null;
+		}
+
+		$numerator   = (float) $matches[1];
+		$denominator = isset( $matches[2] ) ? (float) $matches[2] : 1.0;
+
+		if ( $numerator <= 0 || $denominator <= 0 ) {
+			return null;
+		}
+
+		return $numerator / $denominator;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -28,13 +28,14 @@ class Gallery extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
-		// The number of columns determines how wide each cropped image is displayed, which we pass to
-		// the crop so an image CDN can serve an appropriately sized (and cropped) file.
-		$columns    = $this->get_columns_from_attributes( $parsed_block['attrs'] ?? array() );
-		$cell_width = $this->get_cell_width( $columns, $rendering_context );
+		// The number of columns and the available layout width determine how wide each cropped image
+		// is displayed. We pass that per-image width to the crop so an image CDN can serve an
+		// appropriately sized (and cropped) file.
+		$columns      = $this->get_columns_from_attributes( $parsed_block['attrs'] ?? array() );
+		$layout_width = (int) Styles_Helper::parse_value( $rendering_context->get_layout_width_without_padding() );
 
 		// Extract images directly from the block content (more efficient than re-rendering).
-		$gallery_images = $this->extract_images_from_gallery_content( $block_content, $parsed_block, $cell_width );
+		$gallery_images = $this->extract_images_from_gallery_content( $block_content, $parsed_block, $columns, $layout_width );
 
 		// If we don't have any images, return empty.
 		if ( empty( $gallery_images ) ) {
@@ -46,20 +47,25 @@ class Gallery extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Estimate the display width (in px) of a single gallery cell.
+	 * Estimate the rendered width (in px) of the gallery cell that holds a given image.
 	 *
-	 * Used to size cropped images so an image CDN can serve a file that matches the cell instead of
-	 * the full-size original.
+	 * The gallery packs images into rows of `$columns`. A complete row splits the layout width
+	 * evenly, but an incomplete final row is distributed across only its remaining images — a lone
+	 * trailing image spans the full width (see {@see build_gallery_row_table()}). Sizing the crop to
+	 * the actual cell keeps an image CDN from serving an undersized file for such images.
 	 *
-	 * @param int               $columns Number of gallery columns.
-	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @param int $index Zero-based index of the image among the rendered images.
+	 * @param int $image_count Total number of rendered images.
+	 * @param int $columns Number of gallery columns.
+	 * @param int $layout_width Available layout width in px.
 	 * @return int Cell width in px (at least 1).
 	 */
-	private function get_cell_width( int $columns, Rendering_Context $rendering_context ): int {
-		$layout_width = Styles_Helper::parse_value( $rendering_context->get_layout_width_without_padding() );
-		$columns      = max( 1, $columns );
+	private function get_cell_width( int $index, int $image_count, int $columns, int $layout_width ): int {
+		$columns       = max( 1, $columns );
+		$row_start     = intdiv( $index, $columns ) * $columns;
+		$images_in_row = max( 1, min( $columns, $image_count - $row_start ) );
 
-		return (int) max( 1, floor( $layout_width / $columns ) );
+		return (int) max( 1, floor( $layout_width / $images_in_row ) );
 	}
 
 	/**
@@ -67,26 +73,38 @@ class Gallery extends Abstract_Block_Renderer {
 	 *
 	 * @param string $block_content The rendered gallery block HTML.
 	 * @param array  $parsed_block The parsed block data.
-	 * @param int    $cell_width Estimated display width of a gallery cell in px.
+	 * @param int    $columns Number of gallery columns.
+	 * @param int    $layout_width Available layout width in px.
 	 * @return array Array of sanitized image HTML strings.
 	 */
-	private function extract_images_from_gallery_content( string $block_content, array $parsed_block, int $cell_width ): array {
+	private function extract_images_from_gallery_content( string $block_content, array $parsed_block, int $columns, int $layout_width ): array {
 		$gallery_images = array();
 		$inner_blocks   = $parsed_block['innerBlocks'] ?? array();
 
 		// The gallery can request a crop (aspect ratio) for all of its images. Individual images
-		// may override it with their own aspectRatio attribute.
-		$gallery_aspect_ratio = $parsed_block['attrs']['aspectRatio'] ?? null;
+		// may override it with their own aspectRatio attribute. Guard against malformed input so a
+		// non-string ratio can't throw a TypeError and abort rendering.
+		$gallery_attrs        = isset( $parsed_block['attrs'] ) && is_array( $parsed_block['attrs'] ) ? $parsed_block['attrs'] : array();
+		$gallery_aspect_ratio = isset( $gallery_attrs['aspectRatio'] ) && is_string( $gallery_attrs['aspectRatio'] ) ? $gallery_attrs['aspectRatio'] : null;
 
-		// Extract images from inner blocks data where the actual image HTML is stored.
+		// Collect the image blocks first so we know how many land in each rendered row and can size
+		// each crop to its actual cell (incomplete final rows are wider — see get_cell_width()).
+		$image_blocks = array();
 		foreach ( $inner_blocks as $block ) {
 			if ( 'core/image' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
-				$aspect_ratio    = $block['attrs']['aspectRatio'] ?? $gallery_aspect_ratio;
-				$image_attrs     = $block['attrs'] ?? array();
-				$extracted_image = $this->extract_image_from_html( $block['innerHTML'], $aspect_ratio, $cell_width, $image_attrs );
-				if ( ! empty( $extracted_image ) ) {
-					$gallery_images[] = $extracted_image;
-				}
+				$image_blocks[] = $block;
+			}
+		}
+		$image_count = count( $image_blocks );
+
+		foreach ( $image_blocks as $index => $block ) {
+			$image_attrs  = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+			$aspect_ratio = isset( $image_attrs['aspectRatio'] ) && is_string( $image_attrs['aspectRatio'] ) ? $image_attrs['aspectRatio'] : $gallery_aspect_ratio;
+
+			$cell_width      = $this->get_cell_width( $index, $image_count, $columns, $layout_width );
+			$extracted_image = $this->extract_image_from_html( $block['innerHTML'], $aspect_ratio, $cell_width, $image_attrs );
+			if ( ! empty( $extracted_image ) ) {
+				$gallery_images[] = $extracted_image;
 			}
 		}
 
@@ -209,14 +227,19 @@ class Gallery extends Abstract_Block_Renderer {
 		 * @param int    $height       Target display height derived from the aspect ratio in px (0 if unknown).
 		 * @param array  $image_attrs  Parsed attributes of the core/image block (id, sizeSlug, ...).
 		 */
-		$cropped_url = (string) apply_filters( 'woocommerce_email_editor_gallery_cropped_image_url', $image_url, $aspect_ratio, $width, $height, $image_attrs );
+		$filtered_url = apply_filters( 'woocommerce_email_editor_gallery_cropped_image_url', $image_url, $aspect_ratio, $width, $height, $image_attrs );
+
+		// Extensions can return anything (arrays, WP_Error, objects). Only accept a string, and
+		// sanitize it before we compare or use it so an invalid value can't emit a warning, be
+		// misclassified as a server crop, or become an empty src.
+		$cropped_url = is_string( $filtered_url ) ? esc_url( $filtered_url ) : '';
 
 		$is_server_cropped = '' !== $image_url && '' !== $cropped_url && $cropped_url !== $image_url;
 
 		if ( $is_server_cropped ) {
 			// The file is already cropped to the requested ratio, so we can give it concrete
 			// dimensions. This renders the crop correctly even in clients without CSS crop support.
-			$html->set_attribute( 'src', esc_url( $cropped_url ) );
+			$html->set_attribute( 'src', $cropped_url );
 			if ( $width > 0 && $height > 0 ) {
 				$html->set_attribute( 'width', esc_attr( (string) $width ) );
 				$html->set_attribute( 'height', esc_attr( (string) $height ) );

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -457,7 +457,7 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$filter = function ( $url, $aspect_ratio, $width, $height ) {
 			return $url . '?resize=' . $width . ',' . $height . '&crop=1';
 		};
-		add_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10, 5 );
+		add_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10, 4 );
 		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
 		remove_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10 );
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -465,11 +465,20 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'crop=1', $rendered );
 		$this->assertSame( 3, substr_count( $rendered, 'crop=1' ), 'Every image URL is rewritten.' );
 
-		// A square crop gets equal, concrete width/height attributes so it renders everywhere.
-		$this->assertSame( 1, preg_match( '/<img\b[^>]*>/', $rendered, $img ), 'The rendered output contains an image tag.' );
-		$this->assertSame( 1, preg_match( '/\bwidth="(\d+)"/', $img[0], $width_match ), 'The image has a concrete width.' );
-		$this->assertSame( 1, preg_match( '/\bheight="(\d+)"/', $img[0], $height_match ), 'The image has a concrete height.' );
-		$this->assertSame( $width_match[1], $height_match[1], 'A square crop has equal width and height.' );
+		// Every image (not just the first) gets equal, positive, concrete width/height attributes so
+		// a square crop renders everywhere.
+		$image_count = 0;
+		$html        = new \WP_HTML_Tag_Processor( $rendered );
+		while ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			++$image_count;
+			$width  = $html->get_attribute( 'width' );
+			$height = $html->get_attribute( 'height' );
+			$this->assertIsString( $width, 'Each server-cropped image has a concrete width.' );
+			$this->assertIsString( $height, 'Each server-cropped image has a concrete height.' );
+			$this->assertGreaterThan( 0, (int) $width, 'The width is positive.' );
+			$this->assertSame( (int) $width, (int) $height, 'A square crop has equal width and height.' );
+		}
+		$this->assertSame( 3, $image_count, 'All three images are present.' );
 	}
 
 	/**
@@ -483,6 +492,54 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 
 		// Without a cropping integration, images keep CSS cropping and are not given fixed dimensions.
 		$this->assertStringContainsString( 'object-fit: cover', $rendered );
-		$this->assertDoesNotMatchRegularExpression( '/<img[^>]*\bheight="/', $rendered, 'Uncropped images must not get a fixed height that would distort them.' );
+
+		$image_count = 0;
+		$html        = new \WP_HTML_Tag_Processor( $rendered );
+		while ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			++$image_count;
+			$this->assertNull( $html->get_attribute( 'height' ), 'Uncropped images must not get a fixed height that would distort them.' );
+		}
+		$this->assertSame( 3, $image_count, 'All three images are present.' );
+	}
+
+	/**
+	 * Test the crop is sized to the actual rendered cell width, so an incomplete final row
+	 * (e.g. a lone trailing image spanning the full width) is not served an undersized file.
+	 */
+	public function testItSizesCropToTheRenderedRowWidthForIncompleteRows(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+		$parsed_gallery['attrs']['columns']     = 3;
+		// Add a fourth image so the final row holds a single, full-width image.
+		$parsed_gallery['innerBlocks'][3] = array(
+			'blockName'    => 'core/image',
+			'attrs'        => array(
+				'id'              => 4,
+				'sizeSlug'        => 'large',
+				'linkDestination' => 'none',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '<figure class="wp-block-image size-large"><img src="https://example.com/image4.jpg" alt="Image 4" class="wp-image-4"/></figure>',
+			'innerContent' => array(
+				0 => '<figure class="wp-block-image size-large"><img src="https://example.com/image4.jpg" alt="Image 4" class="wp-image-4"/></figure>',
+			),
+		);
+
+		$widths = array();
+		$filter = function ( $url, $aspect_ratio, $width ) use ( &$widths ) {
+			$widths[] = $width;
+			return $url;
+		};
+		add_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10, 3 );
+		$this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		remove_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10 );
+
+		$this->assertCount( 4, $widths, 'The filter runs once per gallery image.' );
+		// The first three images share a full row (one-third width each); the fourth is alone in the
+		// final row and spans the full width.
+		$this->assertSame( $widths[0], $widths[1], 'Images in the same full row share a width.' );
+		$this->assertSame( $widths[1], $widths[2], 'Images in the same full row share a width.' );
+		$this->assertGreaterThan( $widths[0], $widths[3], 'A lone trailing image is sized to the full row width.' );
+		$this->assertGreaterThanOrEqual( 2 * $widths[0], $widths[3], 'The full-width cell is substantially wider than a one-third cell.' );
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -392,6 +392,23 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test an invalid per-image aspect ratio falls back to the gallery ratio rather than
+	 * disabling the crop for that image.
+	 */
+	public function testItFallsBackToGalleryRatioWhenPerImageOverrideIsInvalid(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+		$parsed_gallery['innerBlocks'][0]['attrs']['aspectRatio'] = 'not-a-ratio';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		// All three images (including the one with the malformed override) use the gallery ratio.
+		$this->assertSame( 3, substr_count( $rendered, 'aspect-ratio: 1;' ), 'The malformed override falls back to the gallery ratio.' );
+		$this->assertSame( 3, substr_count( $rendered, 'object-fit: cover' ), 'Every image is still cropped.' );
+		$this->assertStringNotContainsString( 'not-a-ratio', $rendered, 'The invalid value is never emitted into the markup.' );
+	}
+
+	/**
 	 * Test galleries without an aspect ratio are left uncropped (no regression).
 	 */
 	public function testItDoesNotCropWhenNoAspectRatioIsSet(): void {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -360,4 +360,129 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'blocks-gallery-caption', $rendered );
 		$this->assertStringContainsString( 'text-align: center', $rendered );
 	}
+
+	/**
+	 * Test it applies a gallery-level aspect ratio crop to every image.
+	 */
+	public function testItAppliesGalleryLevelAspectRatioCrop(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		// Every image should be cropped square via inline CSS the sanitizer would otherwise strip.
+		$this->assertSame( 3, substr_count( $rendered, 'object-fit: cover' ), 'Each image should get object-fit: cover.' );
+		$this->assertSame( 3, substr_count( $rendered, 'aspect-ratio: 1' ), 'Each image should get the gallery aspect ratio.' );
+	}
+
+	/**
+	 * Test a per-image aspect ratio overrides the gallery-level one.
+	 */
+	public function testItLetsPerImageAspectRatioOverrideGalleryLevel(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+		$parsed_gallery['innerBlocks'][0]['attrs']['aspectRatio'] = '4/3';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		// The overriding image uses its own ratio, the others fall back to the gallery ratio.
+		$this->assertStringContainsString( 'aspect-ratio: 4/3', $rendered );
+		$this->assertSame( 2, substr_count( $rendered, 'aspect-ratio: 1;' ), 'The two non-overridden images keep the gallery ratio.' );
+		$this->assertSame( 3, substr_count( $rendered, 'object-fit: cover' ), 'All three images are still cropped.' );
+	}
+
+	/**
+	 * Test galleries without an aspect ratio are left uncropped (no regression).
+	 */
+	public function testItDoesNotCropWhenNoAspectRatioIsSet(): void {
+		$rendered = $this->gallery_renderer->render( '', $this->parsed_gallery, $this->rendering_context );
+
+		$this->assertStringNotContainsString( 'object-fit', $rendered );
+		$this->assertStringNotContainsString( 'aspect-ratio', $rendered );
+	}
+
+	/**
+	 * Test an invalid aspect ratio value is ignored rather than injected into the markup.
+	 */
+	public function testItIgnoresInvalidAspectRatioValues(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = 'cover; background:url(javascript:alert(1))';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		$this->assertStringNotContainsString( 'object-fit', $rendered );
+		$this->assertStringNotContainsString( 'aspect-ratio', $rendered );
+		$this->assertStringNotContainsString( 'javascript:', $rendered );
+	}
+
+	/**
+	 * Test the crop filter receives the image URL, ratio and target dimensions.
+	 */
+	public function testItPassesCropContextToTheImageUrlFilter(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+		$parsed_gallery['attrs']['columns']     = 3;
+
+		$received = array();
+		$filter   = function ( $url, $aspect_ratio, $width, $height, $attrs ) use ( &$received ) {
+			$received[] = array(
+				'url'          => $url,
+				'aspect_ratio' => $aspect_ratio,
+				'width'        => $width,
+				'height'       => $height,
+				'attrs'        => $attrs,
+			);
+			return $url;
+		};
+		add_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10, 5 );
+		$this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		remove_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10 );
+
+		$this->assertCount( 3, $received, 'The filter runs once per gallery image.' );
+		$this->assertSame( 'https://example.com/image1.jpg', $received[0]['url'] );
+		$this->assertSame( '1', $received[0]['aspect_ratio'] );
+		// Square crop: derived height equals the target width.
+		$this->assertSame( $received[0]['width'], $received[0]['height'] );
+		$this->assertGreaterThan( 0, $received[0]['width'], 'A concrete cell width is passed for CDN sizing.' );
+		$this->assertSame( 1, $received[0]['attrs']['id'], 'The image block attributes are forwarded.' );
+	}
+
+	/**
+	 * Test a server-cropped URL is used with concrete width/height dimensions.
+	 */
+	public function testItUsesServerCroppedUrlWithConcreteDimensions(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+
+		$filter = function ( $url, $aspect_ratio, $width, $height ) {
+			return $url . '?resize=' . $width . ',' . $height . '&crop=1';
+		};
+		add_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10, 5 );
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+		remove_filter( 'woocommerce_email_editor_gallery_cropped_image_url', $filter, 10 );
+
+		// The rewritten (cropped) URL is used.
+		$this->assertStringContainsString( 'crop=1', $rendered );
+		$this->assertSame( 3, substr_count( $rendered, 'crop=1' ), 'Every image URL is rewritten.' );
+
+		// A square crop gets equal, concrete width/height attributes so it renders everywhere.
+		$this->assertSame( 1, preg_match( '/<img\b[^>]*>/', $rendered, $img ), 'The rendered output contains an image tag.' );
+		$this->assertSame( 1, preg_match( '/\bwidth="(\d+)"/', $img[0], $width_match ), 'The image has a concrete width.' );
+		$this->assertSame( 1, preg_match( '/\bheight="(\d+)"/', $img[0], $height_match ), 'The image has a concrete height.' );
+		$this->assertSame( $width_match[1], $height_match[1], 'A square crop has equal width and height.' );
+	}
+
+	/**
+	 * Test an unchanged URL from the filter falls back to CSS-only cropping (no dimensions).
+	 */
+	public function testItFallsBackToCssCropWhenFilterLeavesUrlUnchanged(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		// Without a cropping integration, images keep CSS cropping and are not given fixed dimensions.
+		$this->assertStringContainsString( 'object-fit: cover', $rendered );
+		$this->assertDoesNotMatchRegularExpression( '/<img[^>]*\bheight="/', $rendered, 'Uncropped images must not get a fixed height that would distort them.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `core/gallery` email renderer extracted each raw `<img>` and dropped it into a table cell without reading the block's `aspectRatio`, so galleries that request a crop (e.g. 1:1) rendered at the images' natural aspect ratio. Email clients can't crop reliably client-side (`object-fit`/`aspect-ratio` are unsupported in Gmail), so the only way to honor the crop everywhere is to serve an already-cropped file.

This makes the gallery renderer aspect-ratio aware:

-   Reads the per-image `aspectRatio` attribute, falling back to the gallery-level one, and supports any ratio (`1`, `4/3`, `16/9`, `3/4`, …).
-   Exposes a new filter, `woocommerce_email_editor_gallery_cropped_image_url`, passing the image URL, the requested ratio, the target cell width/height (for CDN sizing), and the image block attributes. Integrations (e.g. Jetpack/Photon on WordPress.com) can hook it to return a server-side-cropped URL. The package ships no CDN-specific behavior, so self-hosted sites are unaffected.
-   When the URL is rewritten (server-cropped), the image is given concrete `width`/`height` dimensions so the crop renders correctly even in clients without CSS crop support (e.g. Gmail).
-   When the URL is left unchanged, it falls back to inline `aspect-ratio` + `object-fit: cover` CSS. Supporting clients (Apple Mail, iOS Mail, modern webmail) render the crop; the rest fall back to the natural ratio, matching the previous behavior — no regression, and no fixed dimensions that would distort an uncropped image.

Before | After
--- | ---
<img width="657" height="575" alt="Screenshot 2026-07-16 at 10 11 50 AM" src="https://github.com/user-attachments/assets/9b256311-af2e-4c1f-bb28-3fceb1d5f085" /> | <img width="662" height="495" alt="Screenshot 2026-07-16 at 10 13 51 AM" src="https://github.com/user-attachments/assets/0181bfb3-db54-4dc8-92c6-a8be9c141ba2" />


### How to test the changes in this Pull Request:

**Note the gallery block isn't available in the email editor. This needs to be tested from Jetpack newsletters.**

1.  In the editor, add a Gallery block with several images of differing natural aspect ratios (mix portrait and landscape).
2.  Set the gallery to crop — e.g. select a 1:1 (square) aspect ratio.
3.  Send/preview the email and open it in a client that supports CSS cropping (Apple Mail / iOS Mail): the images render square. The crop won't yet work in Gmail.
5.  Confirm a gallery with **no** aspect ratio set is unchanged (no `object-fit`, no fixed dimensions).

### Testing that has already taken place:

-   Added integration tests to `Gallery_Test` covering: gallery-level crop, per-image override of the gallery ratio, the filter receiving the URL/ratio/target dimensions, the server-cropped URL path setting equal `width`/`height`, the CSS-only fallback avoiding fixed dimensions, no-op when no ratio is set, and invalid ratio values being ignored.
-   Full Core renderer block suite passes (237 tests). PHPCS and PHPStan (level 9) are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `packages/php/email-editor/changelog/`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)