### PR TITLE
php tests: Fix same-second timing race in WC_Rate_Limiter unit tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-rate-limiter-test-timing-race
+++ b/plugins/woocommerce/changelog/fix-rate-limiter-test-timing-race
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Remove a same-second timing race in the WC_Rate_Limiter unit tests (test-only change, no runtime impact).

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
@@ -37,7 +37,7 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		$rate_limit_id_1 = $action_identifier . $user_1_id;
 		$rate_limit_id_2 = $action_identifier . $user_2_id;
 
-		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 0 );
+		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, HOUR_IN_SECONDS );
 
 		$this->assertEquals( true, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon allowed action to run too soon before the delay.' );
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user before the delay.' );
@@ -59,7 +59,7 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		$rate_limit_id_1 = $action_identifier . $user_1_id;
 		$rate_limit_id_2 = $action_identifier . $user_2_id;
 
-		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 0 );
+		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, HOUR_IN_SECONDS );
 		// Clear cached value for user 1.
 		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_1 ), WC_Rate_Limiter::CACHE_GROUP );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_Tests_Rate_Limiter::test_rate_limit_limits` intermittently failed in CI (e.g. [this trunk run](https://github.com/woocommerce/woocommerce/actions/runs/29314033822/job/87024470109)) with *"retried_too_soon allowed action to run too soon before the delay."*

This replaces the zero delay with `HOUR_IN_SECONDS` in both `test_rate_limit_limits` and `test_rate_limit_limits_without_cache`, so the "before the delay" expiry sits comfortably in the future and the assertion is deterministic. The later `set_rate_limit( $id, -1 )` calls overwrite the same row, so the "after the delay" assertions are unaffected.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Rate_Limiter`.
2. Confirm both `test_rate_limit_limits` and `test_rate_limit_limits_without_cache` pass.
3. The change removes a timing-boundary flake; repeated runs should stay green.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
