### PR TITLE
Fix order edit AJAX error and prevent `autosave.js` from loading on WC screens

### DIFF
--- a/plugins/woocommerce/changelog/66411-fix-order-edit-sample-permalink-403
+++ b/plugins/woocommerce/changelog/66411-fix-order-edit-sample-permalink-403
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix failing AJAX requests and false unsaved-changes warnings on the order edit screen, and make the connection-lost notice consistent between HPOS on and off

--- a/plugins/woocommerce/changelog/66411-fix-order-edit-sample-permalink-403
+++ b/plugins/woocommerce/changelog/66411-fix-order-edit-sample-permalink-403
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix failing AJAX requests and false unsaved-changes warnings on the order edit screen, and make the connection-lost notice consistent between HPOS on and off
+Improve lost connection detection on WooCommerce admin screens

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4002,6 +4002,13 @@ mark.notice {
 	margin: 0 0 0 10px;
 }
 
+// Mirrors the WP core rule for #lost-connection-notice.
+#wc-lost-connection-notice .spinner {
+	visibility: visible;
+	float: left;
+	margin: 0 5px 0 0;
+}
+
 a.export_rates,
 a.import_rates {
 	float: right;

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -5,6 +5,19 @@
 			return;
 		}
 
+		// Toggle #wc-lost-connection-notice via WP core's heartbeat events (see WC_Admin_Assets::render_lost_connection_notice()).
+		if ( woocommerce_admin.show_lost_connection_notice ) {
+			$( document )
+				.on( 'heartbeat-connection-lost.wc-lost-connection-notice', function ( event, error, status ) {
+					if ( 'timeout' === error || 603 === status ) {
+						$( '#wc-lost-connection-notice' ).show();
+					}
+				} )
+				.on( 'heartbeat-connection-restored.wc-lost-connection-notice', function () {
+					$( '#wc-lost-connection-notice' ).hide();
+				} );
+		}
+
 		// Add buttons to product screen.
 		var $product_screen = $( '.edit-php.post-type-product' ),
 			$title_action = $product_screen.find( '.page-title-action:first' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -42,21 +42,39 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		}
 
 		/**
-		 * Render a #wc-lost-connection-notice on Woo admin screens that don't already get an accurate one.
-		 * Skipped on classic post edit and wc-admin React pages, except classic order edit: core's own notice
-		 * there wrongly claims local autosave backups are running, which disable_autosave() has turned off.
+		 * Whether the current screen should get the #wc-lost-connection-notice markup and toggle handler.
+		 * Limited to Woo admin screens, minus wc-admin React pages and classic post edit screens, which get WP
+		 * core's own notice. Classic order edit is the exception: core's notice there wrongly claims local
+		 * autosave backups are running, which disable_autosave() has turned off.
+		 *
+		 * @param WP_Screen|null $screen The current screen.
+		 * @return bool Whether to render and toggle the notice.
+		 */
+		private function should_show_lost_connection_notice( $screen ) {
+			if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
+				return false;
+			}
+
+			$is_wc_admin_page = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
+				&& \Automattic\WooCommerce\Admin\PageController::is_admin_page();
+			if ( $is_wc_admin_page ) {
+				return false;
+			}
+
+			$is_classic_order_edit_screen = 'post' === $screen->base
+				&& in_array( $screen->post_type, wc_get_order_types( 'order-meta-boxes' ), true );
+
+			return 'post' !== $screen->base || $is_classic_order_edit_screen;
+		}
+
+		/**
+		 * Render a #wc-lost-connection-notice mirroring WP core's own notice on post edit screens.
+		 * See should_show_lost_connection_notice() for which screens get it.
 		 *
 		 * @return void
 		 */
 		public function render_lost_connection_notice() {
-			$screen                       = get_current_screen();
-			$is_wc_admin_page             = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
-				&& \Automattic\WooCommerce\Admin\PageController::is_admin_page();
-			$is_classic_order_edit_screen = $screen && 'post' === $screen->base
-				&& in_array( $screen->post_type, wc_get_order_types( 'order-meta-boxes' ), true );
-
-			if ( ! $screen || $is_wc_admin_page || ! in_array( $screen->id, wc_get_screen_ids(), true )
-				|| ( 'post' === $screen->base && ! $is_classic_order_edit_screen ) ) {
+			if ( ! $this->should_show_lost_connection_notice( get_current_screen() ) ) {
 				return;
 			}
 			?>
@@ -444,12 +462,12 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'woocommerce_admin' );
 				wp_enqueue_script( 'wc-enhanced-select' );
 
-				$is_wc_admin_page = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
-					&& \Automattic\WooCommerce\Admin\PageController::is_admin_page();
+				$show_lost_connection_notice = $this->should_show_lost_connection_notice( $screen );
 
-				// Matches render_lost_connection_notice()'s own classic-order-edit exception.
-				$is_classic_order_edit_screen = 'post' === ( $screen->base ?? '' )
-					&& in_array( $screen->post_type ?? '', wc_get_order_types( 'order-meta-boxes' ), true );
+				// The notice is toggled via heartbeat events (see woocommerce_admin.js), so ensure the emitter is loaded.
+				if ( $show_lost_connection_notice ) {
+					wp_enqueue_script( 'heartbeat' );
+				}
 
 				wp_enqueue_script( 'jquery-ui-sortable' );
 				wp_enqueue_script( 'jquery-ui-autocomplete' );
@@ -487,8 +505,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),
-					'show_lost_connection_notice'       => ! $is_wc_admin_page
-						&& ( 'post' !== ( $screen->base ?? '' ) || $is_classic_order_edit_screen ),
+					'show_lost_connection_notice'       => $show_lost_connection_notice,
 				);
 
 				wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -42,47 +42,25 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		}
 
 		/**
-		 * Render WordPress core's #lost-connection-notice markup on Woo admin
-		 * screens that don't already get it for free.
-		 *
-		 * WP core renders this element on classic post-type edit pages (via
-		 * edit-form-advanced.php), and wp-autosave.js toggles it in response
-		 * to Heartbeat events. By echoing the same markup here and enqueueing
-		 * the `autosave` script (see admin_scripts()), Woo admin screens
-		 * inherit the same offline awareness without any new copy, styling,
-		 * or behavior.
-		 *
-		 * Translation strings use the 'default' text domain so WP core's
-		 * existing translations apply.
-		 *
-		 * Skipped on:
-		 * - Classic post-type edit screens (WP core already renders the notice).
-		 * - wc-admin React pages (they use their own layout rather than the
-		 *   standard admin_notices position).
+		 * Render a #wc-lost-connection-notice on Woo admin screens that don't already get an accurate one.
+		 * Skipped on classic post edit and wc-admin React pages, except classic order edit: core's own notice
+		 * there wrongly claims local autosave backups are running, which disable_autosave() has turned off.
 		 *
 		 * @return void
 		 */
 		public function render_lost_connection_notice() {
-			$screen = get_current_screen();
-			if ( ! $screen ) {
-				return;
-			}
-
-			if ( 'post' === $screen->base ) {
-				return;
-			}
-
-			$is_wc_admin_page = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
+			$screen                       = get_current_screen();
+			$is_wc_admin_page             = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
 				&& \Automattic\WooCommerce\Admin\PageController::is_admin_page();
-			if ( $is_wc_admin_page ) {
-				return;
-			}
+			$is_classic_order_edit_screen = $screen && 'post' === $screen->base
+				&& in_array( $screen->post_type, wc_get_order_types( 'order-meta-boxes' ), true );
 
-			if ( ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
+			if ( ! $screen || $is_wc_admin_page || ! in_array( $screen->id, wc_get_screen_ids(), true )
+				|| ( 'post' === $screen->base && ! $is_classic_order_edit_screen ) ) {
 				return;
 			}
 			?>
-			<div id="lost-connection-notice" class="notice error hidden">
+			<div id="wc-lost-connection-notice" class="notice error hidden">
 				<p>
 					<span class="spinner"></span>
 					<strong><?php esc_html_e( 'Connection lost.' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- Reusing WP core translation. */ ?></strong>
@@ -466,13 +444,12 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'woocommerce_admin' );
 				wp_enqueue_script( 'wc-enhanced-select' );
 
-				// Pair the #lost-connection-notice markup with core's autosave script.
-				// See render_lost_connection_notice() for scoping rationale.
 				$is_wc_admin_page = class_exists( '\Automattic\WooCommerce\Admin\PageController' )
 					&& \Automattic\WooCommerce\Admin\PageController::is_admin_page();
-				if ( 'post' !== ( $screen->base ?? '' ) && ! $is_wc_admin_page ) {
-					wp_enqueue_script( 'autosave' );
-				}
+
+				// Matches render_lost_connection_notice()'s own classic-order-edit exception.
+				$is_classic_order_edit_screen = 'post' === ( $screen->base ?? '' )
+					&& in_array( $screen->post_type ?? '', wc_get_order_types( 'order-meta-boxes' ), true );
 
 				wp_enqueue_script( 'jquery-ui-sortable' );
 				wp_enqueue_script( 'jquery-ui-autocomplete' );
@@ -510,6 +487,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),
+					'show_lost_connection_notice'       => ! $is_wc_admin_page
+						&& ( 'post' !== ( $screen->base ?? '' ) || $is_classic_order_edit_screen ),
 				);
 
 				wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -47,10 +47,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * core's own notice. Classic order edit is the exception: core's notice there wrongly claims local
 		 * autosave backups are running, which disable_autosave() has turned off.
 		 *
-		 * @param WP_Screen|null $screen The current screen.
 		 * @return bool Whether to render and toggle the notice.
 		 */
-		private function should_show_lost_connection_notice( $screen ) {
+		private function should_show_lost_connection_notice() {
+			$screen = get_current_screen();
+
 			if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
 				return false;
 			}
@@ -74,7 +75,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * @return void
 		 */
 		public function render_lost_connection_notice() {
-			if ( ! $this->should_show_lost_connection_notice( get_current_screen() ) ) {
+			if ( ! $this->should_show_lost_connection_notice() ) {
 				return;
 			}
 			?>
@@ -462,7 +463,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'woocommerce_admin' );
 				wp_enqueue_script( 'wc-enhanced-select' );
 
-				$show_lost_connection_notice = $this->should_show_lost_connection_notice( $screen );
+				$show_lost_connection_notice = $this->should_show_lost_connection_notice();
 
 				// The notice is toggled via heartbeat events (see woocommerce_admin.js), so ensure the emitter is loaded.
 				if ( $show_lost_connection_notice ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -665,8 +665,8 @@ class WC_Meta_Box_Order_Data {
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) :
 								?>
 								<p class="form-field form-field-wide">
-									<label for="customer_note"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
-									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="customer_note" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array( 'br' => array() ) ); ?></textarea>
+									<label for="excerpt"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
+									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array( 'br' => array() ) ); ?></textarea>
 								</p>
 							<?php endif; ?>
 						</div>

--- a/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
@@ -426,29 +426,21 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 		const notice = page.locator( '#wc-lost-connection-notice' );
 		await expect( notice ).toBeHidden();
 
-		// Make the next heartbeat request fail the way this notice specifically checks for.
-		await page.route( '**/admin-ajax.php', async ( route ) => {
-			const postData = route.request().postData() ?? '';
-			if ( postData.includes( 'action=heartbeat' ) ) {
-				await route.fulfill( { status: 603, body: '{}' } );
-			} else {
-				await route.continue();
-			}
-		} );
-
+		// Dispatch the same event heartbeat.js fires on a real timeout.
 		await page.evaluate( () =>
-			// @ts-expect-error wp.heartbeat isn't typed here.
-			window.wp.heartbeat.connectNow()
+			// @ts-expect-error jQuery isn't typed here.
+			jQuery( document ).trigger( 'heartbeat-connection-lost', [
+				'timeout',
+				0,
+			] )
 		);
 
 		await expect( notice ).toBeVisible();
 		await expect( notice ).toContainText( 'Connection lost.' );
-		await expect( notice ).not.toContainText( 'backed up in your browser' );
 
-		await page.unroute( '**/admin-ajax.php' );
 		await page.evaluate( () =>
-			// @ts-expect-error wp.heartbeat isn't typed here.
-			window.wp.heartbeat.connectNow()
+			// @ts-expect-error jQuery isn't typed here.
+			jQuery( document ).trigger( 'heartbeat-connection-restored' )
 		);
 
 		await expect( notice ).toBeHidden();

--- a/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-edit.spec.ts
@@ -198,6 +198,35 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 		);
 	} );
 
+	test( 'saving an order does not trigger a false unsaved-changes warning', async ( {
+		page,
+	} ) => {
+		if ( process.env.DISABLE_HPOS === '1' ) {
+			await page.goto(
+				`wp-admin/post.php?post=${ orderId }&action=edit`
+			);
+		} else {
+			await page.goto(
+				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+			);
+		}
+
+		const dialogMessages: string[] = [];
+		page.on( 'dialog', async ( dialog ) => {
+			dialogMessages.push( dialog.message() );
+			await dialog.accept();
+		} );
+
+		await page.locator( 'button.save_order' ).click();
+		await expect(
+			page
+				.locator( 'div.notice-success > p' )
+				.filter( { hasText: 'Order updated.' } )
+		).toBeVisible();
+
+		expect( dialogMessages ).toEqual( [] );
+	} );
+
 	test( 'can add and delete order notes', async ( { page } ) => {
 		// open order we created
 		await page.goto(
@@ -379,6 +408,50 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 				)
 			).toBeVisible();
 		} );
+	} );
+
+	test( 'shows the lost connection notice when the heartbeat request fails', async ( {
+		page,
+	} ) => {
+		if ( process.env.DISABLE_HPOS === '1' ) {
+			await page.goto(
+				`wp-admin/post.php?post=${ orderId }&action=edit`
+			);
+		} else {
+			await page.goto(
+				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+			);
+		}
+
+		const notice = page.locator( '#wc-lost-connection-notice' );
+		await expect( notice ).toBeHidden();
+
+		// Make the next heartbeat request fail the way this notice specifically checks for.
+		await page.route( '**/admin-ajax.php', async ( route ) => {
+			const postData = route.request().postData() ?? '';
+			if ( postData.includes( 'action=heartbeat' ) ) {
+				await route.fulfill( { status: 603, body: '{}' } );
+			} else {
+				await route.continue();
+			}
+		} );
+
+		await page.evaluate( () =>
+			// @ts-expect-error wp.heartbeat isn't typed here.
+			window.wp.heartbeat.connectNow()
+		);
+
+		await expect( notice ).toBeVisible();
+		await expect( notice ).toContainText( 'Connection lost.' );
+		await expect( notice ).not.toContainText( 'backed up in your browser' );
+
+		await page.unroute( '**/admin-ajax.php' );
+		await page.evaluate( () =>
+			// @ts-expect-error wp.heartbeat isn't typed here.
+			window.wp.heartbeat.connectNow()
+		);
+
+		await expect( notice ).toBeHidden();
 	} );
 } );
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
@@ -1,0 +1,107 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Admin_Assets.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Admin_Assets
+	 */
+	private $sut;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new WC_Admin_Assets();
+		$this->sut->register_scripts();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		unset( $_GET['page'] );
+		wp_dequeue_script( 'woocommerce_admin' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should set up the lost connection notice correctly per screen, and never re-enqueue autosave.
+	 * @testWith ["woocommerce_page_wc-orders", "woocommerce_page_wc-orders", "", false, true]
+	 *           ["shop_order", "post", "shop_order", false, true]
+	 *           ["product", "post", "product", false, false]
+	 *           ["toplevel_page_woocommerce", "toplevel_page_woocommerce", "", true, false]
+	 *
+	 * @param string $screen_id   Screen id.
+	 * @param string $base        Screen base.
+	 * @param string $post_type   Screen post type, if any.
+	 * @param bool   $is_wc_admin Whether to simulate a wc-admin React page.
+	 * @param bool   $expected    Expected show_lost_connection_notice value.
+	 */
+	public function test_admin_scripts_lost_connection_notice_setup( string $screen_id, string $base, string $post_type, bool $is_wc_admin, bool $expected ): void {
+		set_current_screen();
+		$screen            = get_current_screen();
+		$screen->id        = $screen_id;
+		$screen->base      = $base;
+		$screen->post_type = $post_type;
+		$_GET['page']      = $is_wc_admin ? 'wc-admin' : '';
+
+		$this->sut->admin_scripts();
+
+		$localized = wp_scripts()->get_data( 'woocommerce_admin', 'data' );
+		$this->assertIsString( $localized, 'woocommerce_admin should be localized on this screen' );
+		$this->assertStringContainsString(
+			'"show_lost_connection_notice":' . ( $expected ? 'true' : 'false' ),
+			$localized,
+			'show_lost_connection_notice should be ' . ( $expected ? 'true' : 'false' ) . " for screen '{$screen_id}'"
+		);
+
+		$this->assertFalse(
+			wp_scripts()->query( 'autosave', 'enqueued' ),
+			'autosave arms unrelated post.js handlers and must never be enqueued, on any screen'
+		);
+	}
+
+	/**
+	 * @testdox Should render the lost connection notice markup only where expected, with accurate copy.
+	 * @testWith ["woocommerce_page_wc-orders", "woocommerce_page_wc-orders", "", true]
+	 *           ["shop_order", "post", "shop_order", true]
+	 *           ["product", "post", "product", false]
+	 *
+	 * @param string $screen_id     Screen id.
+	 * @param string $base          Screen base.
+	 * @param string $post_type     Screen post type, if any.
+	 * @param bool   $should_render Whether the markup should render at all.
+	 */
+	public function test_render_lost_connection_notice_markup( string $screen_id, string $base, string $post_type, bool $should_render ): void {
+		set_current_screen();
+		$screen            = get_current_screen();
+		$screen->id        = $screen_id;
+		$screen->base      = $base;
+		$screen->post_type = $post_type;
+
+		ob_start();
+		$this->sut->render_lost_connection_notice();
+		$output = ob_get_clean();
+
+		if ( ! $should_render ) {
+			$this->assertSame( '', $output, "No notice should render for screen '{$screen_id}'" );
+			return;
+		}
+
+		$this->assertStringContainsString( 'id="wc-lost-connection-notice"', $output );
+		$this->assertStringNotContainsString(
+			'backed up in your browser',
+			$output,
+			'Local autosave backups never run for orders, so the notice must not claim otherwise'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
@@ -59,19 +59,19 @@ class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
 		$localized = wp_scripts()->get_data( 'woocommerce_admin', 'data' );
 		$this->assertIsString( $localized, 'woocommerce_admin should be localized on this screen' );
 		$this->assertStringContainsString(
-			'"show_lost_connection_notice":' . ( $expected ? 'true' : 'false' ),
+			'"show_lost_connection_notice":"' . ( $expected ? '1' : '' ) . '"',
 			$localized,
 			'show_lost_connection_notice should be ' . ( $expected ? 'true' : 'false' ) . " for screen '{$screen_id}'"
 		);
 
 		$this->assertFalse(
 			wp_scripts()->query( 'autosave', 'enqueued' ),
-			'autosave arms unrelated post.js handlers and must never be enqueued, on any screen'
+			'autosave must never be enqueued, since it turns on unrelated post.js handlers'
 		);
 	}
 
 	/**
-	 * @testdox Should render the lost connection notice markup only where expected, with accurate copy.
+	 * @testdox Should render the lost connection notice markup only where expected.
 	 * @testWith ["woocommerce_page_wc-orders", "woocommerce_page_wc-orders", "", true]
 	 *           ["shop_order", "post", "shop_order", true]
 	 *           ["product", "post", "product", false]
@@ -98,10 +98,5 @@ class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
 		}
 
 		$this->assertStringContainsString( 'id="wc-lost-connection-notice"', $output );
-		$this->assertStringNotContainsString(
-			'backed up in your browser',
-			$output,
-			'Local autosave backups never run for orders, so the notice must not claim otherwise'
-		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-assets-test.php
@@ -30,11 +30,12 @@ class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		unset( $_GET['page'] );
 		wp_dequeue_script( 'woocommerce_admin' );
+		wp_dequeue_script( 'heartbeat' );
 		parent::tearDown();
 	}
 
 	/**
-	 * @testdox Should set up the lost connection notice correctly per screen, and never re-enqueue autosave.
+	 * @testdox Should set up the lost connection notice and heartbeat correctly per screen, and never re-enqueue autosave.
 	 * @testWith ["woocommerce_page_wc-orders", "woocommerce_page_wc-orders", "", false, true]
 	 *           ["shop_order", "post", "shop_order", false, true]
 	 *           ["product", "post", "product", false, false]
@@ -62,6 +63,12 @@ class WC_Admin_Assets_Test extends WC_Unit_Test_Case {
 			'"show_lost_connection_notice":"' . ( $expected ? '1' : '' ) . '"',
 			$localized,
 			'show_lost_connection_notice should be ' . ( $expected ? 'true' : 'false' ) . " for screen '{$screen_id}'"
+		);
+
+		$this->assertSame(
+			$expected,
+			wp_scripts()->query( 'heartbeat', 'enqueued' ),
+			'heartbeat should be enqueued exactly on the screens that use the notice'
 		);
 
 		$this->assertFalse(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After [#64334](<https://github.com/woocommerce/woocommerce/issues/64334>), WP core `autosave` script started being enqueued on the HPOS order edit screen just to get the "Connection lost" notice to run. This resulted in other hooked code running (such as a failing `sample-permalink` request on every heartbeat tick) and a separate false "unsaved changes" browser warning on save (which was only superficially addressed in woocommerce/woocommerce#66001 by renaming an `id` attribute).

This PR stops depending on `autosave` entirely to ensure no extra code is every hooked or runs. This also means we now toggle our own "lost connection" notice (with id `#wc-lost-connection-notice` instead of `#lost-connection-notice`) which works better outside of the classic editor context.

> \[!NOTE\]<br>It's worth discussing whether the fix in woocommerce/woocommerce#66001 can be considered backwards incompatible given ut changed the `id` of an element that's been on the order edit screen for a long time. After this PR, that rename shouldn't be needed for autosave to not conflict with the update action, so we could in theory revert woocommerce/woocommerce#66001. Thoughts?

Closes woocommerce/woocommerce#66411, woocommerce/woocommerce#65773.

(For Bug Fixes) Bug introduced in PR [#64334](<https://github.com/woocommerce/woocommerce/issues/64334>).

### How to test the changes in this Pull Request:

#### Setup

The "lost connection" notice appears when a timeout occurs while resolving the heartbeat request (> 30s). To replicate this, a mu-plugin artificially extending request time can be used, or we can trigger the event directly using jQuery on the relevant screens.

For following the testing instructions below, the jQuery route is much faster, but either can be used.

##### mu-plugin

```php
<?php
add_action( 'wp_ajax_heartbeat', fn() => sleep( 31 ), 0 );`
```

##### jQuery (browser's console)

```js
// To simulate the timeout:
jQuery(document).trigger('heartbeat-connection-lost', ['timeout', 0])

// To simulate connection restored:
jQuery(document).trigger('heartbeat-connection-restored');
```

#### Instructions

1. Disable HPOS (`wp wc hpos disable`). Run `wp wc hpos sync` if syncing is needed before.
2. Go to **WooCommerce > Orders > Add order**.
3. If using the mu-plugin wait > 30s, otherwise trigger the JS code to simulate the timeout using the browser's console. Confirm a "connection lost" notice appears.
4. Run the JS code to simulate connection restored, and confirm the notice disappears.
5. Enable HPOS on your site (`wp wc hpos enable`). Run `wp wc hpos sync` if needed.
6. Repeat steps 2-4 and confirm results are the same.
7. (`excerpt` regression fixed in woocommerce/woocommerce#66001 no longer exists) Open any order for editing and use the devtools to confirm the id for the customer note field is `excerpt`. Click **Update** and confirm no "unsaved changes" browser alert appears.
8. Go to **WooCommerce > Orders > Add order** again and watch requests in the devtools' Network tab. Confirm no heartbeat request with body `action=sample-permalink` fires.
9. Visit any wc-admin page (e.g. Analytics) or a non-WooCommerce screen (dashboard, plugins, posts) and confirm that no "lost notice" appears even after triggering the connection lost event.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.