### PR TITLE
Update WooPayments onboarding troubleshooting link

### DIFF
--- a/plugins/woocommerce/changelog/update-woopayments-onboarding-troubleshooting-link
+++ b/plugins/woocommerce/changelog/update-woopayments-onboarding-troubleshooting-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Link WooPayments onboarding failures to the onboarding troubleshooting guide.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/embedded-kyc.tsx
@@ -37,7 +37,7 @@ type EmbeddedKycLoadFailure = {
 
 const embeddedKycLoadTimeoutMs = 20000;
 const embeddedKycTroubleshootingUrl =
-	'https://woocommerce.com/document/woopayments/startup-guide/#requirements';
+	'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/#onboarding';
 const embeddedKycFailureMessage = __(
 	"We couldn't load this step. This can happen when your site's security or server settings block a required connection to Stripe. Check the setup requirements, or contact support if the error persists.",
 	'woocommerce'

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx
@@ -135,7 +135,7 @@ describe( 'EmbeddedKyc', () => {
 			screen.getByRole( 'link', { name: 'Learn more' } )
 		).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/startup-guide/#requirements'
+			'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/#onboarding'
 		);
 		expect(
 			screen.queryByTestId( 'embedded-account-onboarding' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WooPayments onboarding configuration failures currently link to the startup guide requirements. The dedicated onboarding section in the testing and troubleshooting guide is a better destination for merchants investigating CSP, firewall, or server configuration problems.

Update the failure banner's Learn more URL and its existing test assertion. Error handling and user-facing copy remain unchanged.

Follow-up to #65863.

### Screenshots or screen recordings:

Not applicable. This changes the Learn more link destination only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run:
   ```sh
   pnpm --dir plugins/woocommerce/client/admin test:js -- client/settings-payments/onboarding/providers/woopayments/steps/business-verification/test/embedded-kyc.test.tsx --runInBand
   ```
2. Confirm all eight tests pass, including the assertion that Learn more points to `https://woocommerce.com/document/woopayments/testing-and-troubleshooting/#onboarding`.
3. Check the link leads to a valid doc page and looks good.

<!-- End testing instructions -->

### Testing that has already taken place:

- The targeted Jest suite passes with eight tests.
- TypeScript checking and the admin production build pass.
- Targeted ESLint reports no errors. It still reports the existing `LoadError` named-import warning.
- Branch lint and `git diff --check` pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
