### PR TITLE
Document Settings UI native controls

### DIFF
--- a/docs/extensions/settings-and-config/settings-ui.md
+++ b/docs/extensions/settings-and-config/settings-ui.md
@@ -179,25 +179,29 @@ $schema['shell']['sectionNavigation'] = array(
 
 ## Native field migration
 
-The legacy adapter converts the existing `get_settings()` array into a canonical schema for React. It supports common settings fields:
+The legacy adapter converts the existing `get_settings()` array into a canonical schema for React. Native schemas can use canonical types directly. The first column lists legacy types accepted by the adapter, including aliases that it normalizes before rendering.
 
--   `text`
--   `password`
--   `email`
--   `url`
--   `tel`
--   `number`
--   `textarea`
--   `checkbox`
--   `select`
--   `radio`
--   `multiselect`
--   `multi_select_countries`
--   `single_select_country`
--   `single_select_page`
--   `info`
+### Native controls
 
-Fields before the first `title` marker are placed into a default group automatically.
+| Legacy type | Canonical type | Native control | Typical schema value |
+| ------------ | -------------- | -------------- | -------------------- |
+| `text`, `password`, `email`, `url`, `tel` | Same as the legacy type | Single-line input using the corresponding HTML input type | `string` |
+| `date`, `time`, `datetime-local` | Same as the legacy type | Date or time input using the corresponding HTML input type | `string` |
+| `number` | `number` | Number input with increment and decrement buttons | `string` or `number` |
+| `textarea` | `textarea` | Multi-line text input | `string` |
+| `checkbox` | `checkbox` | Checkbox | `boolean` |
+| `select`, `single_select_country`, `single_select_page` | `select` | Single-choice dropdown | `string` |
+| `radio` | `radio` | Single-choice dropdown (current renderer) | `string` |
+| `multiselect`, `multi_select_countries` | `array` | Multiple-selection list | `string[]` |
+| `info` | `info` | Read-only informational content | No editable value |
+
+The `options` array supplies choices for `select`, `radio`, and `array` fields. Use `placeholder` and `disabled` where the control supports them. Text and number inputs also accept HTML input attributes such as `min`, `max`, and `step` through the legacy `custom_attributes` key or canonical `customAttributes` key.
+
+Only the types in the table have dedicated native renderers. Other legacy or plugin-specific types fall back to a text input and log a browser warning unless the extension registers a custom component, field override, or type renderer. Use a custom renderer when the fallback would change the field's intended interaction.
+
+Native control implementations can change without changing the schema contract. Custom renderers should use the [WordPress component reference](https://developer.wordpress.org/block-editor/reference-guides/components/) and [Gutenberg Storybook](https://wordpress.github.io/gutenberg/) rather than depending on the native renderer's generated markup.
+
+The `title` and `sectionend` types define groups rather than controls. Fields before the first `title` marker are placed into a default group automatically.
 
 The default save adapter is `form_post`, which serializes hidden inputs so `WC_Admin_Settings::save_fields()` continues to save the submitted values.
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Settings UI guide lists common legacy field types but does not explain how they map to native controls and canonical schema values.

Replace the list with a compact reference table covering supported controls, legacy aliases, value shapes, the current `radio` renderer, and unsupported-type fallback behaviour. Link custom renderer authors to the WordPress component reference and Gutenberg Storybook without changing the Settings UI API or runtime behaviour.

### Screenshots or screen recordings:

Not applicable. This is a documentation-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Read the Native field migration section in `docs/extensions/settings-and-config/settings-ui.md`.
2. Confirm the table documents each native field type, legacy aliases, control behaviour, and typical value shape.
3. Confirm the guidance explains unsupported-type fallback and links to custom renderer resources.
4. Run:
   ```sh
   pnpm dlx markdownlint-cli -- docs/extensions/settings-and-config/settings-ui.md
   ```
5. Confirm markdownlint reports no errors.

<!-- End testing instructions -->

### Testing that has already taken place:

- Checked the table against `NativeSettingsField` and the legacy schema type normalisation.
- Markdown lint and `git diff --check` pass.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation only, not shipped in the plugin package.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
