### PR TITLE
Fix CSV importer image unit tests broken by concurrent merge

### DIFF
--- a/plugins/woocommerce/changelog/fix-csv-importer-image-tests
+++ b/plugins/woocommerce/changelog/fix-csv-importer-image-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix CSV importer image unit tests that referenced an importer property removed by a concurrent change.

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -245,8 +245,9 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$product->set_gallery_image_ids( array( $gallery_id ) );
 		$product->save();
 
-		$expanded = $this->invoke_protected( $this->sut, 'expand_data', array( array( 'images' => array( $new_url ) ) ) );
-		$this->invoke_protected( $this->sut, 'set_image_data', array( &$product, $expanded ) );
+		$importer = new WC_Product_CSV_Importer( $this->csv_file, array( 'parse' => false ) );
+		$expanded = $this->invoke_protected( $importer, 'expand_data', array( array( 'images' => array( $new_url ) ) ) );
+		$this->invoke_protected( $importer, 'set_image_data', array( &$product, $expanded ) );
 
 		$this->assertEquals( $new_id, $product->get_image_id(), 'Featured image should be replaced with the new image.' );
 		$this->assertEquals( array(), $product->get_gallery_image_ids(), 'Removed gallery images should be cleared.' );
@@ -267,8 +268,9 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$product->set_gallery_image_ids( array( $gallery_id ) );
 		$product->save();
 
-		$expanded = $this->invoke_protected( $this->sut, 'expand_data', array( array( 'images' => array() ) ) );
-		$this->invoke_protected( $this->sut, 'set_image_data', array( &$product, $expanded ) );
+		$importer = new WC_Product_CSV_Importer( $this->csv_file, array( 'parse' => false ) );
+		$expanded = $this->invoke_protected( $importer, 'expand_data', array( array( 'images' => array() ) ) );
+		$this->invoke_protected( $importer, 'set_image_data', array( &$product, $expanded ) );
 
 		$this->assertEquals( $featured_id, $product->get_image_id(), 'Featured image should be preserved.' );
 		$this->assertEquals( array( $gallery_id ), $product->get_gallery_image_ids(), 'Existing gallery should be preserved.' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`WC_Tests_Product_CSV_Importer::test_reducing_images_clears_removed_gallery_images` and `test_empty_images_column_preserves_existing_images` are red on trunk, failing every PHP unit job with `ReflectionException: The parameter class is expected to be either a string or an object` (PHP 7.4/8.1) or `Undefined property: ...::$sut` (PHP 8.5).

Both tests were added by #66213 and relied on a `$this->sut` importer property that existed on that PR's base. Concurrently, #66522 removed that property (switching to an on-demand `get_importer()` helper) and landed on trunk after #66213's base. 

### How to test the changes in this Pull Request:

1. Run the affected tests:
   `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Product_CSV_Importer`
2. Repeat with HPOS disabled (`DISABLE_HPOS=1`) and confirm it still passes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
