### PR TITLE
ci: bump peter-evans comment actions to Node 24 releases

### DIFF
--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -114,7 +114,7 @@ jobs:
               echo "TEAMS=$teams" >> $GITHUB_ENV
 
         - name: Find the comment by github-actions[bot] asking for reviewing the testing instructions
-          uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
+          uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
           id: find-comment
           with:
               issue-number: ${{ github.event.pull_request.number }}
@@ -122,7 +122,7 @@ jobs:
               body-includes: Apart from reviewing the code changes
 
         - name: Create or update PR comment asking for reviewers to review the testing instructions and test coverage
-          uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+          uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
           with:
               comment-id: ${{ steps.find-comment.outputs.comment-id }}
               issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to the Node 20 → Node 24 deprecation sweeps (#66434, #66571), which left these two `peter-evans` actions out of scope because they were still on **node16** and needed major-version bumps.

- `peter-evans/find-comment`: v2.3.0 → **v4.0.0**, pinned to peeled commit `b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad`.
- `peter-evans/create-or-update-comment`: v2.1.1 → **v5.0.0**, pinned to peeled commit `e8674b075228eee787fea43ef493e45ece1004c9`.

This gets both actions off the deprecated Node 16 runtime.

No breaking changes: all inputs/outputs the workflow uses were confirmed present and unchanged at the target versions.

Closes TESTOPS-221

### How to test the changes in this Pull Request:

1. Confirm the two `uses:` pins in `.github/workflows/automate-team-review-assignment.yml` resolve to the commit SHAs above and carry the matching `# vX.Y.Z` comment.
2. Request a review on a PR (or mark it ready for review) so the `review_requested` event fires the `add-testing-instructions-review-comment` job. Note: the updated pins only take effect once this workflow is on `trunk`, so exercise it on the next PR after merge.
3. Verify the job succeeds: `find-comment` locates any prior bot testing-instructions comment and `create-or-update-comment` posts/updates the "Testing Guidelines" comment — with no Node 16 deprecation warnings in the workflow logs.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
