### PR TITLE
ci: upgrade actions/labeler v3 → v6.2.0 and migrate config

### DIFF
--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -1,70 +1,114 @@
 'package: @woocommerce/e2e-utils-playwright':
-  - packages/js/e2e-utils-playwright/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/e2e-utils-playwright/**/*
 
 'package: @woocommerce/components':
-  - packages/js/components/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/components/**/*
 
 'package: @woocommerce/csv-export':
-  - packages/js/csv-export/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/csv-export/**/*
 
 'package: @woocommerce/currency':
-  - packages/js/currency/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/currency/**/*
 
 'package: @woocommerce/customer-effort-score':
-  - packages/js/customer-effort-score/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/customer-effort-score/**/*
 
 'package: @woocommerce/data':
-  - packages/js/data/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/data/**/*
 
 'package: @woocommerce/date':
-  - packages/js/date/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/date/**/*
 
 'package: dependency-extraction-webpack-plugin':
-  - packages/js/dependency-extraction-webpack-plugin/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/dependency-extraction-webpack-plugin/**/*
 
 'package: @woocommerce/eslint-plugin':
-  - packages/js/eslint-plugin/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/eslint-plugin/**/*
 
 'package: @woocommerce/experimental':
-  - packages/js/experimental/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/experimental/**/*
 
 'package: @woocommerce/explat':
-  - packages/js/explat/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/explat/**/*
 
 'package: @woocommerce/navigation':
-  - packages/js/navigation/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/navigation/**/*
 
 'package: @woocommerce/number':
-  - packages/js/number/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/number/**/*
 
 'package: @woocommerce/onboarding':
-  - packages/js/onboarding/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/onboarding/**/*
 
 'package: @woocommerce/tracks':
-  - packages/js/tracks/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/js/tracks/**/*
 
 'plugin: woocommerce':
-  - plugins/woocommerce/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/woocommerce/**/*
 
 'plugin: woocommerce beta tester':
-  - plugins/woocommerce-beta-tester/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/woocommerce-beta-tester/**/*
 
 'focus: performance tests':
-  - plugins/woocommerce/tests/performance/**/*
-  - plugins/woocommerce/tests/metrics/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/woocommerce/tests/performance/**/*
+          - plugins/woocommerce/tests/metrics/**/*
 
 'focus: api tests':
-  - plugins/woocommerce/tests/e2e/tests/api-tests/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/woocommerce/tests/e2e/tests/api-tests/**/*
 
 'focus: e2e tests':
-  - plugins/woocommerce/tests/e2e/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/woocommerce/tests/e2e/**/*
 
 'Documentation':
-  - docs/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**/*
 
 'focus: monorepo infrastructure':
-  - .github/**/*
-  - bin/**/*
-  - tools/**/*
-  - '**/composer.json'
-  - '**/package.json'
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**/*
+          - bin/**/*
+          - tools/**/*
+          - '**/composer.json'
+          - '**/package.json'

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -16,7 +16,7 @@ jobs:
             contents: read
             pull-requests: write
         steps:
-            - uses: actions/labeler@3d612d72e6784a1a65365cc6d33b5a001c12bf10 # v3.1.0
+            - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   configuration-path: .github/project-pr-labeler.yml


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to the Node 20 deprecation sweep (#66571).

This bumps `actions/labeler` to **v6.2.0** (node24). 
Labeler v5+ replaced the flat-glob config schema with a structured `changed-files:` / `any-glob-to-any-file:` schema so a configuration migration was needed.

### How to test the changes in this Pull Request:

1. Open or reopen a PR touching `plugins/woocommerce/**` and confirm the **`plugin: woocommerce`** label is applied by the "Label Pull Request Project" workflow.
2. Open a PR touching `.github/**` or `**/package.json` and confirm **`focus: monorepo infrastructure`** is applied.
3. Confirm the workflow run no longer emits a Node runtime-deprecation warning.

### Testing that has already taken place:

- Verified `b8dd2d9be0f68b860e7dae5dae7d772984eacd6d` is the peeled commit of tag `v6.2.0` (GitHub commits API — not a tag object) and that `action.yml` at that ref declares `using: 'node24'`.
- Confirmed the migrated config parses and preserves all 22 labels and their globs 1:1 against the previous version.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
