### PR TITLE
ci: replace node20 deploy-nightly action with gh release upload

### DIFF
--- a/.github/workflows/create-trunk-snapshot-build.yml
+++ b/.github/workflows/create-trunk-snapshot-build.yml
@@ -2,11 +2,13 @@ name: 'Create Trunk Snapshot Build'
 on:
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
 env:
-    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
     SOURCE_REF: trunk
     TARGET_REF: trunk-snapshot
-    RELEASE_ID: 256718410
 
 permissions: {}
 
@@ -59,12 +61,12 @@ jobs:
                   echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
             - name: 'Upload trunk snapshot build'
-              uses: 'WebFreak001/deploy-nightly@46ecbabd7fad70d3e7d2c97fe8cd54e7a52e215b' #v3.2.0
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets{?name,label}
-                  release_id: ${{ env.RELEASE_ID }}
-                  asset_path: plugins/woocommerce/woocommerce.zip
-                  asset_name: woocommerce-${{ steps.build_vars.outputs.BUILD_DATE }}-${{ steps.build_vars.outputs.SHORT_SHA }}-trunk-snapshot.zip
-                  asset_content_type: application/zip
-                  max_releases: 1
+              working-directory: plugins/woocommerce
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  BUILD_DATE: ${{ steps.build_vars.outputs.BUILD_DATE }}
+                  SHORT_SHA: ${{ steps.build_vars.outputs.SHORT_SHA }}
+              run: |
+                  asset_name="woocommerce-${BUILD_DATE}-${SHORT_SHA}-trunk-snapshot.zip"
+                  cp woocommerce.zip "$asset_name"
+                  gh release upload "$TARGET_REF" "$asset_name" --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -4,8 +4,11 @@ on:
     - cron: '0 0 * * *' # Run at 12 AM UTC.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
   SOURCE_REF: trunk
   TARGET_REF: nightly
   RELEASE_ID: 25945111
@@ -54,15 +57,13 @@ jobs:
         run: bash bin/build-zip.sh
 
       - name: 'Upload nightly build'
-        uses: 'WebFreak001/deploy-nightly@46ecbabd7fad70d3e7d2c97fe8cd54e7a52e215b' #v3.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets{?name,label}
-          release_id: ${{ env.RELEASE_ID }}
-          asset_path: plugins/woocommerce/woocommerce.zip
-          asset_name: woocommerce-${{ env.SOURCE_REF }}-nightly.zip
-          asset_content_type: application/zip
-          max_releases: 1
+        working-directory: plugins/woocommerce
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          asset_name="woocommerce-${SOURCE_REF}-nightly.zip"
+          cp woocommerce.zip "$asset_name"
+          gh release upload "$TARGET_REF" "$asset_name" --clobber --repo "$GITHUB_REPOSITORY"
 
       - name: 'Update nightly release notes'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
Resolves **[TESTOPS-224](https://linear.app/a8c/issue/TESTOPS-224)** — follow-up to the Node 20 → 24 action sweep (#66571).

### Changes proposed in this Pull Request:

`WebFreak001/deploy-nightly` has no `node24` release to bump to (latest is v3.2.0, from Sept 2024). Instead of waiting on a dormant dependency behind the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` warning suppression, replace it with a `gh release upload --clobber` run step in the nightly and trunk-snapshot workflows.

<details>
<summary>Why the tag/asset handling is equivalent</summary>

- `gh` derives the asset name from the file basename, so the built `woocommerce.zip` is copied to the target name before upload.
- Tags map to the same releases the old hardcoded `release_id` pointed at (verified live: `nightly` → `25945111`, `trunk-snapshot` → `256718410`).
- `RELEASE_ID` is removed only from the trunk-snapshot workflow; it stays in the nightly one, whose "Update nightly release notes" step still uses it.
- Remaining actions are all `node24` (`checkout@v7`, `github-script@v8`, and the `setup-woocommerce-monorepo` composite), so the suppression env is genuinely dead.
</details>

### How to test the changes in this Pull Request:

These workflows publish real release assets and can only be exercised on GitHub.

1. From this branch, run **Create Trunk Snapshot Build** via `workflow_dispatch` (Actions → Run workflow).
2. Confirm the "Upload trunk snapshot build" step succeeds with no deprecated-`node20` warning.
3. Check the [`trunk-snapshot` release](https://github.com/woocommerce/woocommerce/releases/tag/trunk-snapshot) has a fresh `woocommerce-<date>-<sha>-trunk-snapshot.zip`.
4. After merge, confirm the next scheduled **Nightly builds** run uploads `woocommerce-trunk-nightly.zip` to the [`nightly` release](https://github.com/woocommerce/woocommerce/releases/tag/nightly) and still updates the release notes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
