### PR TITLE
Update rubik CODEOWNERS to match team-owned areas

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,8 +29,9 @@
 /plugins/woocommerce/includes/wc-cart-functions.php @woocommerce/rubik
 /plugins/woocommerce/includes/class-wc-session-handler.php @woocommerce/rubik
 
-# Store API related files
+# Store API and internal REST routes
 /plugins/woocommerce/src/StoreApi/ @woocommerce/rubik
+/plugins/woocommerce/src/Internal/RestApi/ @woocommerce/rubik
 
 # Cart Checkout Blocks
 /plugins/woocommerce/client/blocks/assets/js/blocks/cart @woocommerce/rubik
@@ -39,6 +40,32 @@
 /plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart @woocommerce/rubik
 /plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation @woocommerce/rubik
 /plugins/woocommerce/client/blocks/packages/checkout @woocommerce/rubik
+
+# Cart and checkout data stores
+/plugins/woocommerce/client/blocks/assets/js/data/cart @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/data/checkout @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/data/payment @woocommerce/rubik
+
+# Order admin page (edit screen, list table, order meta boxes)
+/plugins/woocommerce/src/Internal/Admin/Orders/ @woocommerce/rubik
+/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-*.php @woocommerce/rubik
+/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-*.php @woocommerce/rubik
+
+# Shopper Lists (wishlist, saved for later)
+/plugins/woocommerce/src/Internal/ShopperLists/ @woocommerce/rubik
+/plugins/woocommerce/src/Blocks/BlockTypes/Wishlist.php @woocommerce/rubik
+/plugins/woocommerce/src/Blocks/BlockTypes/AddToWishlistButton.php @woocommerce/rubik
+/plugins/woocommerce/src/Blocks/BlockTypes/SavedForLater.php @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/blocks/wishlist @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-wishlist-button @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/blocks/saved-for-later @woocommerce/rubik
+/plugins/woocommerce/client/blocks/assets/js/blocks/shopper-lists @woocommerce/rubik
+
+# Stock notifications (back-in-stock)
+/plugins/woocommerce/src/Internal/StockNotifications/ @woocommerce/rubik
+
+# Customer email verification
+/plugins/woocommerce/src/Internal/CustomerEmailVerification/ @woocommerce/rubik
 
 # Email Editor packages
 /packages/js/email-editor/ @woocommerce/ballade


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This updates the `CODEOWNERS` rubik section to match what Team Rubik actually owns today. Right now the file only lists cart, checkout, and Store API, so plenty of our work lands with no owner requested and reviews get missed.

I looked at where the team has been spending its time (recent merged PRs from rubik members) and added the areas that were missing:

- Order admin page — `src/Internal/Admin/Orders/` plus the legacy order meta boxes.
- Shopper Lists — wishlist and saved for later (blocks + `src/Internal/ShopperLists/`).
- Stock notifications (back-in-stock) and customer email verification.
- Cart/checkout data stores and the internal REST routes.

I intentionally left out shared infrastructure (`base/components`, `base/context`, `class-wc-admin-post-types.php`); owning those would pull us onto other teams' changes.

Closes # .

### Testing that has already taken place:

Validated every new path exists on `trunk` and that the patterns match the intended files. `shopper-collection` was dropped from the proposal since it no longer exists on trunk; it was reorganized into `shopper-lists`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

`CODEOWNERS` lives at the repo root; it is not part of any package, so no changelog entry applies.

</details>
