### PR TITLE
Fix download filename for external URLs without a filename in path

### DIFF
--- a/plugins/woocommerce/changelog/fix-26879-external-download-filename
+++ b/plugins/woocommerce/changelog/fix-26879-external-download-filename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the filename announced by the remote server (Content-Disposition/Content-Type) when force-downloading an external file whose URL has no filename in its path, such as Google Drive links.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -474,6 +474,9 @@ class WC_Download_Handler {
 	 * @param string $filename  File name.
 	 */
 	public static function download_file_force( $file_path, $filename ) {
+		// Raise the time limit and release the session before any potentially slow remote I/O below.
+		self::check_server_config();
+
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -721,6 +721,12 @@ class WC_Download_Handler {
 	 * @return bool Success or fail
 	 */
 	public static function readfile_chunked( $file, $start = 0, $length = 0 ) {
+		// Define before attempting to open the file: the constant has always been defined even
+		// when the open fails, and external code may rely on that side effect.
+		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
+			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
+		}
+
 		$handle = @fopen( $file, 'r' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
 
 		if ( false === $handle ) {

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -477,11 +477,29 @@ class WC_Download_Handler {
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
 
-		self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
-
 		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
 		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
-		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
+
+		if ( $parsed_file_path['remote_file'] ) {
+			// Open the remote file before sending our own headers, so the filename announced by
+			// the remote server in its response headers can be used when the URL contains none.
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streaming a remote file needs fopen (WP_Filesystem cannot stream); a false return is handled below.
+			$handle = @fopen( $parsed_file_path['file_path'], 'r' );
+
+			$served = false;
+			if ( false !== $handle ) {
+				$response_headers = stream_get_meta_data( $handle )['wrapper_data'] ?? array();
+				$filename         = self::resolve_filename_from_response_headers( is_array( $response_headers ) ? $response_headers : array(), $filename );
+
+				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
+				$served = self::readfile_from_handle( $handle, $start, $length );
+			}
+		} else {
+			self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
+			$served = self::readfile_chunked( $parsed_file_path['file_path'], $start, $length );
+		}
+
+		if ( ! $served ) {
 			if ( $parsed_file_path['remote_file'] && 'yes' === get_option( 'woocommerce_downloads_redirect_fallback_allowed' ) ) {
 				wc_get_logger()->warning(
 					sprintf(
@@ -497,6 +515,80 @@ class WC_Download_Handler {
 		}
 
 		exit;
+	}
+
+	/**
+	 * Given the raw HTTP response header lines collected while opening a remote file (possibly
+	 * spanning a redirect chain) and the filename derived from the URL, determine the most
+	 * appropriate filename for serving the download.
+	 *
+	 * The filename derived from the URL wins when it already has an extension. Otherwise the
+	 * filename announced by the remote server in the `Content-Disposition` header of the final
+	 * response is used, falling back to appending an extension derived from its `Content-Type`
+	 * header. This makes downloads hosted on URLs without a filename in their path (for example
+	 * Google Drive links) save under a usable name instead of a bare URL segment like `uc`.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
+	 * @param array  $response_headers Raw HTTP response header lines, e.g. from `stream_get_meta_data()['wrapper_data']`.
+	 * @param string $filename         Filename derived from the URL.
+	 * @return string
+	 */
+	public static function resolve_filename_from_response_headers( array $response_headers, string $filename ): string {
+		if ( '' !== pathinfo( $filename, PATHINFO_EXTENSION ) ) {
+			return $filename;
+		}
+
+		// Only the headers of the final response in a redirect chain describe the actual file.
+		$headers = array();
+		foreach ( $response_headers as $header ) {
+			if ( ! is_string( $header ) ) {
+				continue;
+			}
+
+			if ( 0 === stripos( $header, 'HTTP/' ) ) {
+				$headers = array();
+				continue;
+			}
+
+			$parts = explode( ':', $header, 2 );
+			if ( 2 === count( $parts ) ) {
+				$headers[ strtolower( trim( $parts[0] ) ) ] = trim( $parts[1] );
+			}
+		}
+
+		$remote_filename = '';
+		if ( isset( $headers['content-disposition'] ) ) {
+			// The RFC 5987 encoded `filename*` parameter takes precedence over the plain `filename` one.
+			if ( preg_match( '/filename\*\s*=\s*[^\']*\'[^\']*\'([^;]+)/i', $headers['content-disposition'], $matches ) ) {
+				$remote_filename = rawurldecode( trim( $matches[1], " \t\"" ) );
+			} elseif ( preg_match( '/filename\s*=\s*("([^"]*)"|[^;]+)/i', $headers['content-disposition'], $matches ) ) {
+				$remote_filename = isset( $matches[2] ) ? $matches[2] : trim( $matches[1] );
+			}
+
+			$remote_filename = sanitize_file_name( $remote_filename );
+		}
+
+		if ( '' !== $remote_filename ) {
+			$filename = $remote_filename;
+		}
+
+		if ( '' === pathinfo( $filename, PATHINFO_EXTENSION ) && isset( $headers['content-type'] ) ) {
+			$mime_type = strtolower( trim( (string) strtok( $headers['content-type'], ';' ) ) );
+
+			// application/octet-stream is generic and would map to an arbitrary extension.
+			if ( '' !== $mime_type && 'application/octet-stream' !== $mime_type ) {
+				$extension = wp_get_default_extension_for_mime_type( $mime_type );
+
+				if ( $extension ) {
+					$filename .= '.' . $extension;
+				}
+			}
+		}
+
+		return $filename;
 	}
 
 	/**
@@ -532,8 +624,14 @@ class WC_Download_Handler {
 		self::clean_buffers();
 		wc_nocache_headers();
 
+		$content_type = self::get_download_content_type( $file_path );
+		if ( 'application/force-download' === $content_type && $filename ) {
+			// The URL path may not contain a usable extension; fall back to the resolved filename.
+			$content_type = self::get_download_content_type( $filename );
+		}
+
 		header( 'X-Robots-Tag: noindex, nofollow', true );
-		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
+		header( 'Content-Type: ' . $content_type );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Disposition: ' . self::get_content_disposition() . '; filename="' . $filename . '";' );
 		header( 'Content-Transfer-Encoding: binary' );
@@ -618,9 +716,6 @@ class WC_Download_Handler {
 	 * @return bool Success or fail
 	 */
 	public static function readfile_chunked( $file, $start = 0, $length = 0 ) {
-		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
-			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
-		}
 		$handle = @fopen( $file, 'r' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
 
 		if ( false === $handle ) {
@@ -628,7 +723,25 @@ class WC_Download_Handler {
 		}
 
 		if ( ! $length ) {
-			$length = @filesize( $file ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+			$length = (int) @filesize( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Remote paths make filesize error; false is handled by the cast (0 means read until EOF).
+		}
+
+		return self::readfile_from_handle( $handle, $start, $length );
+	}
+
+	/**
+	 * Read an already-open file handle in chunks and echo its content.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param resource $handle Open file handle, e.g. from `fopen()`.
+	 * @param int      $start  Byte offset/position of the beginning from which to read from the file.
+	 * @param int      $length Length of the chunk to be read from the file in bytes, 0 means until the end of file.
+	 * @return bool Success or fail
+	 */
+	private static function readfile_from_handle( $handle, $start = 0, $length = 0 ) {
+		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
+			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
 		}
 
 		$read_length = (int) WC_CHUNK_SIZE;

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -517,7 +517,7 @@ class WC_Download_Handler {
 					self::derive_filename_from_file_path( $file_path ) !== $filename
 				);
 
-				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
+				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range, true );
 				$served = self::readfile_from_handle( $handle, $start, $length );
 			}
 		} else {
@@ -653,22 +653,55 @@ class WC_Download_Handler {
 	}
 
 	/**
+	 * Determine the Content-Type a download will be served with.
+	 *
+	 * The type is derived from the extension in the file path. The URL path of a remote file may
+	 * not contain a usable extension; in that case the filename resolved from the remote response
+	 * headers is used as a fallback — unless it maps to a type browsers may render or execute
+	 * inline, since for remote files the extension can originate from data controlled by the
+	 * remote server.
+	 *
+	 * @param string $file_path   File path.
+	 * @param string $filename    Filename of the download.
+	 * @param bool   $remote_file Whether the download is a remote file.
+	 * @return string
+	 */
+	private static function get_content_type_for_served_download( $file_path, $filename, $remote_file ) {
+		$content_type = self::get_download_content_type( $file_path );
+
+		if ( $remote_file && 'application/force-download' === $content_type && $filename ) {
+			$filename_content_type = self::get_download_content_type( $filename );
+
+			$renderable_content_types = array(
+				'text/html',
+				'application/xhtml+xml',
+				'image/svg+xml',
+				'text/xml',
+				'application/xml',
+			);
+
+			if ( ! in_array( $filename_content_type, $renderable_content_types, true ) ) {
+				$content_type = $filename_content_type;
+			}
+		}
+
+		return $content_type;
+	}
+
+	/**
 	 * Set headers for the download.
 	 *
 	 * @param string $file_path      File path.
 	 * @param string $filename       File name.
 	 * @param array  $download_range Array containing info about range download request (see {@see get_download_range} for structure).
+	 * @param bool   $remote_file    Whether the download is a remote file.
 	 */
-	private static function download_headers( $file_path, $filename, $download_range = array() ) {
+	private static function download_headers( $file_path, $filename, $download_range = array(), $remote_file = false ) {
 		self::check_server_config();
 		self::clean_buffers();
 		wc_nocache_headers();
 
-		$content_type = self::get_download_content_type( $file_path );
-		if ( 'application/force-download' === $content_type && $filename ) {
-			// The URL path may not contain a usable extension; fall back to the resolved filename.
-			$content_type = self::get_download_content_type( $filename );
-		}
+		$content_type = self::get_content_type_for_served_download( $file_path, $filename, $remote_file );
 
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Type: ' . $content_type );

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -562,10 +562,12 @@ class WC_Download_Handler {
 		$remote_filename = '';
 		if ( isset( $headers['content-disposition'] ) ) {
 			// The RFC 5987 encoded `filename*` parameter takes precedence over the plain `filename` one.
-			if ( preg_match( '/filename\*\s*=\s*[^\']*\'[^\']*\'([^;]+)/i', $headers['content-disposition'], $matches ) ) {
-				$remote_filename = rawurldecode( trim( $matches[1], " \t\"" ) );
-			} elseif ( preg_match( '/filename\s*=\s*("([^"]*)"|[^;]+)/i', $headers['content-disposition'], $matches ) ) {
-				$remote_filename = isset( $matches[2] ) ? $matches[2] : trim( $matches[1] );
+			// Matches e.g. `filename*=UTF-8''My%20Report.pdf`: a charset, a language tag between the quotes, then the percent-encoded value.
+			if ( preg_match( '/filename\*\s*=\s*[^\']*\'[^\']*\'(?<encoded_value>[^;]+)/i', $headers['content-disposition'], $matches ) ) {
+				$remote_filename = rawurldecode( trim( $matches['encoded_value'], " \t\"" ) );
+			} elseif ( preg_match( '/filename\s*=\s*(?:"(?<quoted_value>[^"]*)"|(?<bare_value>[^;]+))/i', $headers['content-disposition'], $matches ) ) {
+				// Matches `filename="My Report.pdf"` (quoted) or `filename=report.pdf` (bare token, terminated by `;`).
+				$remote_filename = isset( $matches['bare_value'] ) ? trim( $matches['bare_value'] ) : $matches['quoted_value'];
 			}
 
 			$remote_filename = sanitize_file_name( $remote_filename );
@@ -731,8 +733,6 @@ class WC_Download_Handler {
 
 	/**
 	 * Read an already-open file handle in chunks and echo its content.
-	 *
-	 * @since 11.1.0
 	 *
 	 * @param resource $handle Open file handle, e.g. from `fopen()`.
 	 * @param int      $start  Byte offset/position of the beginning from which to read from the file.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -231,13 +231,14 @@ class WC_Download_Handler {
 			self::download_error( __( 'No file defined', 'woocommerce' ) );
 		}
 
-		$filename = basename( $file_path );
-
-		if ( strstr( $filename, '?' ) ) {
-			$filename = current( explode( '?', $filename ) );
-		}
-
-		$filename = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
+		/**
+		 * Filter the filename of a downloadable product file before it is served.
+		 *
+		 * @since 2.2.0
+		 * @param string  $filename   Filename derived from the file URL.
+		 * @param integer $product_id Product ID of the product being downloaded.
+		 */
+		$filename = apply_filters( 'woocommerce_file_download_filename', self::derive_filename_from_file_path( $file_path ), $product_id );
 
 		/**
 		 * Filter download method.
@@ -254,6 +255,22 @@ class WC_Download_Handler {
 
 		// Trigger download via one of the methods.
 		do_action( 'woocommerce_download_file_' . $file_download_method, $file_path, $filename );
+	}
+
+	/**
+	 * Derive a download filename from the file path or URL it will be served from.
+	 *
+	 * @param string $file_path File path or URL.
+	 * @return string
+	 */
+	private static function derive_filename_from_file_path( $file_path ) {
+		$filename = basename( $file_path );
+
+		if ( strstr( $filename, '?' ) ) {
+			$filename = current( explode( '?', $filename ) );
+		}
+
+		return $filename;
 	}
 
 	/**
@@ -492,7 +509,13 @@ class WC_Download_Handler {
 			$served = false;
 			if ( false !== $handle ) {
 				$response_headers = stream_get_meta_data( $handle )['wrapper_data'] ?? array();
-				$filename         = self::resolve_filename_from_response_headers( is_array( $response_headers ) ? $response_headers : array(), $filename );
+				$filename         = self::resolve_filename_from_response_headers(
+					is_array( $response_headers ) ? $response_headers : array(),
+					$filename,
+					// A filename customized via the `woocommerce_file_download_filename` filter (or by a
+					// custom caller of this method) is preserved and only completed with an extension.
+					self::derive_filename_from_file_path( $file_path ) !== $filename
+				);
 
 				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
 				$served = self::readfile_from_handle( $handle, $start, $length );
@@ -535,11 +558,15 @@ class WC_Download_Handler {
 	 *
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
-	 * @param array  $response_headers Raw HTTP response header lines, e.g. from `stream_get_meta_data()['wrapper_data']`.
-	 * @param string $filename         Filename derived from the URL.
+	 * @param array  $response_headers  Raw HTTP response header lines, e.g. from `stream_get_meta_data()['wrapper_data']`.
+	 * @param string $filename          Filename derived from the URL.
+	 * @param bool   $preserve_filename When true, `$filename` is kept (it was customized deliberately, e.g. via the
+	 *                                  `woocommerce_file_download_filename` filter) and only completed with an
+	 *                                  extension derived from the response headers, instead of being replaced by
+	 *                                  the remote-announced filename.
 	 * @return string
 	 */
-	public static function resolve_filename_from_response_headers( array $response_headers, string $filename ): string {
+	public static function resolve_filename_from_response_headers( array $response_headers, string $filename, bool $preserve_filename = false ): string {
 		if ( '' !== pathinfo( $filename, PATHINFO_EXTENSION ) ) {
 			return $filename;
 		}
@@ -577,7 +604,15 @@ class WC_Download_Handler {
 		}
 
 		if ( '' !== $remote_filename ) {
-			$filename = $remote_filename;
+			if ( $preserve_filename ) {
+				$remote_extension = pathinfo( $remote_filename, PATHINFO_EXTENSION );
+
+				if ( '' !== $remote_extension ) {
+					$filename .= '.' . $remote_extension;
+				}
+			} else {
+				$filename = $remote_filename;
+			}
 		}
 
 		if ( '' === pathinfo( $filename, PATHINFO_EXTENSION ) && isset( $headers['content-type'] ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -366,6 +366,48 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox resolve_filename_from_response_headers() should only append the remote extension to a filename marked as preserved.
+	 */
+	public function test_resolve_filename_preserves_customized_filename(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename="My Report.pdf"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'Seasons-Catalog', true );
+
+		$this->assertSame( 'Seasons-Catalog.pdf', $resolved, 'A preserved filename should keep its name and only gain the remote extension.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should complete a preserved filename from the Content-Type header when the Content-Disposition filename is absent.
+	 */
+	public function test_resolve_filename_preserves_customized_filename_with_content_type_fallback(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Type: application/zip',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'Seasons-Catalog', true );
+
+		$this->assertSame( 'Seasons-Catalog.zip', $resolved, 'A preserved filename should gain the extension derived from the Content-Type header.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should leave a preserved filename untouched when the remote filename has no extension either.
+	 */
+	public function test_resolve_filename_preserved_filename_untouched_without_remote_extension(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename="report"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'Seasons-Catalog', true );
+
+		$this->assertSame( 'Seasons-Catalog', $resolved, 'An extensionless remote filename provides nothing to complete a preserved filename with.' );
+	}
+
+	/**
 	 * Creates a downloadable product, and then places (and completes) an order for that
 	 * object.
 	 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -222,6 +222,122 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox resolve_filename_from_response_headers() should keep the URL-derived filename when it already has an extension.
+	 */
+	public function test_resolve_filename_keeps_filename_with_extension(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename="remote-name.pdf"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'local-name.zip' );
+
+		$this->assertSame( 'local-name.zip', $resolved, 'A filename that already has an extension should not be overridden.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should use the Content-Disposition filename when the URL-derived filename has no extension.
+	 */
+	public function test_resolve_filename_uses_content_disposition_filename(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Type: application/pdf',
+			'Content-Disposition: attachment; filename="My Report.pdf"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'My-Report.pdf', $resolved, 'The sanitized Content-Disposition filename should be used.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should prefer the RFC 5987 filename* parameter and percent-decode it.
+	 */
+	public function test_resolve_filename_prefers_rfc5987_filename(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename="fallback.pdf"; filename*=UTF-8\'\'My%20Report.pdf',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'My-Report.pdf', $resolved, 'The RFC 5987 filename* parameter should win over the plain filename parameter.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should use the headers of the last response in a redirect chain.
+	 */
+	public function test_resolve_filename_uses_last_response_of_redirect_chain(): void {
+		$headers = array(
+			'HTTP/1.1 302 Found',
+			'Location: https://cdn.example.com/get',
+			'Content-Disposition: attachment; filename="wrong.pdf"',
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename="right.pdf"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'right.pdf', $resolved, 'Only the final response of the redirect chain should be considered.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should match header names and disposition parameters case-insensitively.
+	 */
+	public function test_resolve_filename_is_case_insensitive(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'CONTENT-DISPOSITION: Attachment; FILENAME="Report.PDF"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'Report.PDF', $resolved, 'Header and parameter matching should be case-insensitive.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should fall back to an extension derived from the Content-Type header when no Content-Disposition filename is available.
+	 */
+	public function test_resolve_filename_falls_back_to_content_type_extension(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Type: application/pdf; charset=binary',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'uc.pdf', $resolved, 'The extension should be derived from the Content-Type header.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should return the original filename when the response headers contain nothing usable.
+	 */
+	public function test_resolve_filename_returns_original_when_headers_unusable(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Type: application/octet-stream',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'uc', $resolved, 'The original filename should be kept when the headers provide no better information.' );
+	}
+
+	/**
+	 * @testdox resolve_filename_from_response_headers() should sanitize characters that are unsafe in a filename or header value.
+	 */
+	public function test_resolve_filename_sanitizes_unsafe_characters(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename*=UTF-8\'\'..%2F..%2Fevil%22name.pdf',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'evilname.pdf', $resolved, 'Path traversal sequences and quotes should be stripped from the filename.' );
+	}
+
+	/**
 	 * Creates a downloadable product, and then places (and completes) an order for that
 	 * object.
 	 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -265,6 +265,20 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox resolve_filename_from_response_headers() should handle the non-standard quoted form of the filename* parameter.
+	 */
+	public function test_resolve_filename_handles_quoted_rfc5987_filename(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename*="UTF-8\'\'My%20Report.pdf"',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'uc' );
+
+		$this->assertSame( 'My-Report.pdf', $resolved, 'The quoted filename* form emitted by some non-conforming servers should be parsed too.' );
+	}
+
+	/**
 	 * @testdox resolve_filename_from_response_headers() should use the headers of the last response in a redirect chain.
 	 */
 	public function test_resolve_filename_uses_last_response_of_redirect_chain(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -408,6 +408,19 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox download_file_force() should render an error page, not a download, when the remote file cannot be opened.
+	 */
+	public function test_download_file_force_shows_error_when_remote_file_cannot_be_opened(): void {
+		update_option( 'woocommerce_downloads_redirect_fallback_allowed', 'no' );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessageMatches( '/File not found/' );
+
+		// Port 1 is never listening, so the remote open fails immediately.
+		WC_Download_Handler::download_file_force( 'http://127.0.0.1:1/missing-file', 'missing-file' );
+	}
+
+	/**
 	 * @testdox The Content-Type fallback to the resolved filename should apply to remote files only.
 	 */
 	public function test_content_type_fallback_applies_only_to_remote_files(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -251,6 +251,20 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox resolve_filename_from_response_headers() should parse the unquoted token form of the filename parameter.
+	 */
+	public function test_resolve_filename_parses_bare_token_filename(): void {
+		$headers = array(
+			'HTTP/1.1 200 OK',
+			'Content-Disposition: attachment; filename=Hello-World-master.zip',
+		);
+
+		$resolved = WC_Download_Handler::resolve_filename_from_response_headers( $headers, 'master' );
+
+		$this->assertSame( 'Hello-World-master.zip', $resolved, 'The unquoted filename token form should be parsed.' );
+	}
+
+	/**
 	 * @testdox resolve_filename_from_response_headers() should prefer the RFC 5987 filename* parameter and percent-decode it.
 	 */
 	public function test_resolve_filename_prefers_rfc5987_filename(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -408,6 +408,42 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The Content-Type fallback to the resolved filename should apply to remote files only.
+	 */
+	public function test_content_type_fallback_applies_only_to_remote_files(): void {
+		$method = new ReflectionMethod( WC_Download_Handler::class, 'get_content_type_for_served_download' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			'application/pdf',
+			$method->invoke( null, 'https://drive.google.com/uc', 'My-Report.pdf', true ),
+			'For remote files the Content-Type should fall back to the resolved filename.'
+		);
+		$this->assertSame(
+			'application/force-download',
+			$method->invoke( null, '/some/local/file', 'My-Report.pdf', false ),
+			'For local files the Content-Type should be derived from the file path only.'
+		);
+	}
+
+	/**
+	 * @testdox The Content-Type fallback should not serve types browsers may render inline, since the extension can come from the remote server.
+	 */
+	public function test_content_type_fallback_rejects_renderable_types(): void {
+		// Only users with unfiltered_html have text/html in their allowed mime types at all.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$method = new ReflectionMethod( WC_Download_Handler::class, 'get_content_type_for_served_download' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			'application/force-download',
+			$method->invoke( null, 'https://evil.example.com/uc', 'payload.html', true ),
+			'A remote-derived .html filename should not switch the response to text/html.'
+		);
+	}
+
+	/**
 	 * Creates a downloadable product, and then places (and completes) an order for that
 	 * object.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When a downloadable product file points at an external URL whose path contains no real filename — for example Google Drive links like `https://drive.google.com/uc?export=download&id=…` — the Force Downloads method served the file under a broken name: the filename was derived exclusively from `basename()` of the URL (yielding `uc` with no extension) and served as `application/force-download`, even though the remote server announces the real filename in its `Content-Disposition` response header. Customers received the correct bytes under an unusable name.

`WC_Download_Handler::download_file_force()` now opens the remote stream *before* sending our own headers and, only when the URL-derived filename has no extension, resolves the real filename from the response headers already collected by PHP's HTTP stream wrapper: the `Content-Disposition` filename (RFC 5987 `filename*` preferred) of the final response in the redirect chain, falling back to an extension derived from its `Content-Type` (skipping the generic `application/octet-stream`). The already-open handle is reused for streaming, so no extra HTTP request is made. As a side effect, when a remote file cannot be opened the customer now gets a proper error page instead of downloading the HTML error output under the broken filename (headers used to be sent before the failure was detected).

**Review follow-ups** (from [this review](https://github.com/woocommerce/woocommerce/pull/66604#pullrequestreview-4697773380)): a name customized via the `woocommerce_file_download_filename` filter is now preserved and only completed with the remote-derived extension, instead of being replaced by the remote-announced name; the served `Content-Type` fallback to the resolved filename is scoped to remote downloads only and never yields a type browsers may render inline (HTML/XHTML/SVG/XML), since for remote files the extension can originate from the remote server's own headers; `check_server_config()` runs before the remote connect again; and `WC_CHUNK_SIZE` is defined even when `readfile_chunked()` fails to open the file, as before.

**Backward compatibility:** no existing signatures change. `readfile_chunked()` keeps its signature and behavior (it now delegates to a private handle-based helper); a new public static method `resolve_filename_from_response_headers()` is added, marked `@internal` (no BC guarantee). Behavior changes only for remote files whose URL-derived filename has no extension — the case that is broken today. Files whose URL already contains a filename, and local files, are unaffected. The `woocommerce_file_download_filename` filter still runs first and is always respected: a filtered name carrying an extension is used unchanged, and an extensionless one is kept and only completed with the extension derived from the remote response.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #26879.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Upload any PDF to Google Drive, share it as "Anyone with the link", copy the file ID and build a direct-download URL: `https://drive.google.com/uc?export=download&id=<file-id>`.
2. In **WooCommerce → Settings → Products → Downloadable products**, ensure **File download method** is set to **Force downloads**.
3. Create a simple, virtual, downloadable product and add a downloadable file with the URL from step 1. If Approved Download Directories is enabled, approve `https://drive.google.com/`.
4. Purchase the product and mark the order as completed.
5. On the order confirmation page or **My account → Downloads**, click the download link.
6. - [ ] Verify the file is saved under its real name with the `.pdf` extension and opens correctly. Without this PR it saves as a file literally named `uc` with no extension.
7. Regression check: add a downloadable file whose URL contains a real filename (any directly hosted `…/manual.pdf`), and download it the same way.
8. - [ ] Verify it still downloads under the filename from the URL, as before.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->

- 16 new unit tests: filename resolution (Content-Disposition parsing, RFC 5987 `filename*` precedence, redirect-chain handling, case-insensitivity, content-type extension fallback, filename sanitization, filter-customized name preservation), the remote/renderable-type gating of the served `Content-Type`, and the error path when a remote file cannot be opened; the full `WC_Download_Handler_Tests` suite passes (23 tests, 32 assertions) in wp-env (PHP 8.1, latest WordPress).
- End-to-end against a local HTTP server mimicking Google Drive (302 redirect with an HTML interstitial → PDF with `Content-Disposition: attachment; filename="Sample Report.pdf"`): the download is served as `Sample-Report.pdf` / `application/pdf` with byte-identical content (md5 match); an upstream response with only a `Content-Type` header produces the content-type extension fallback; URLs with real filenames in their path behave exactly as before; a 404ing remote file renders a proper error page instead of a broken download.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan are all clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/fix-26879-external-download-filename` is already committed in this branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

