### PR TITLE
Add editor asset size performance metrics

### DIFF
--- a/plugins/woocommerce/changelog/performance-editor-asset-metrics
+++ b/plugins/woocommerce/changelog/performance-editor-asset-metrics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add editor asset count and network transfer size performance metrics.

--- a/plugins/woocommerce/tests/metrics/config/performance-reporter.ts
+++ b/plugins/woocommerce/tests/metrics/config/performance-reporter.ts
@@ -12,6 +12,11 @@ import type {
 } from '@playwright/test/reporter';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
+/**
+ * Internal dependencies
+ */
+import { formatMetricValue } from '../utils.js';
+
 export type WPPerformanceResults = Record< string, number >;
 
 class PerformanceReporter implements Reporter {
@@ -66,7 +71,9 @@ class PerformanceReporter implements Reporter {
 			const printableResults: Record< string, { value: string } > = {};
 
 			for ( const [ key, value ] of Object.entries( results ) ) {
-				printableResults[ key ] = { value: `${ value } ms` };
+				printableResults[ key ] = {
+					value: formatMetricValue( key, value ),
+				};
 			}
 
 			// eslint-disable-next-line no-console

--- a/plugins/woocommerce/tests/metrics/specs/editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/editor.spec.js
@@ -11,9 +11,8 @@ import { test, Metrics } from '@wordpress/e2e-test-utils-playwright';
 import { PerfUtils } from '../fixtures';
 import {
 	getTotalBlockingTime,
-	getWooEditorAssetMetrics,
 	median,
-	startWooEditorNetworkTransferMetrics,
+	startWooEditorAssetMetrics,
 } from '../utils';
 
 // See https://github.com/WordPress/gutenberg/issues/51383#issuecomment-1613460429
@@ -61,8 +60,8 @@ test.describe( 'Editor Performance', () => {
 				perfUtils,
 				metrics,
 			} ) => {
-				const stopWooEditorNetworkTransferMetrics =
-					await startWooEditorNetworkTransferMetrics( page );
+				const stopWooEditorAssetMetrics =
+					await startWooEditorAssetMetrics( page );
 
 				try {
 					// Open the test draft.
@@ -90,11 +89,9 @@ test.describe( 'Editor Performance', () => {
 						BROWSER_IDLE_WAIT
 					);
 
-					// Measure WooCommerce editor asset sizes.
+					// Measure WooCommerce editor assets.
 					const wooEditorAssetMetrics =
-						await getWooEditorAssetMetrics( page );
-					const wooEditorNetworkTransferMetrics =
-						await stopWooEditorNetworkTransferMetrics();
+						await stopWooEditorAssetMetrics();
 
 					// Save the results.
 					if ( i > throwaway ) {
@@ -131,17 +128,9 @@ test.describe( 'Editor Performance', () => {
 								results[ metric ].push( value );
 							}
 						);
-						Object.entries(
-							wooEditorNetworkTransferMetrics
-						).forEach( ( [ metric, value ] ) => {
-							if ( ! results[ metric ] ) {
-								results[ metric ] = [];
-							}
-							results[ metric ].push( value );
-						} );
 					}
 				} finally {
-					await stopWooEditorNetworkTransferMetrics();
+					await stopWooEditorAssetMetrics();
 				}
 			} );
 		}

--- a/plugins/woocommerce/tests/metrics/specs/editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/editor.spec.js
@@ -9,7 +9,12 @@ import { test, Metrics } from '@wordpress/e2e-test-utils-playwright';
  * Internal dependencies
  */
 import { PerfUtils } from '../fixtures';
-import { getTotalBlockingTime, median } from '../utils';
+import {
+	getTotalBlockingTime,
+	getWooEditorAssetMetrics,
+	median,
+	startWooEditorNetworkTransferMetrics,
+} from '../utils';
 
 // See https://github.com/WordPress/gutenberg/issues/51383#issuecomment-1613460429
 const BROWSER_IDLE_WAIT = 1000;
@@ -56,54 +61,87 @@ test.describe( 'Editor Performance', () => {
 				perfUtils,
 				metrics,
 			} ) => {
-				// Open the test draft.
-				await admin.editPost( draftId );
-				const canvas = await perfUtils.getCanvas();
+				const stopWooEditorNetworkTransferMetrics =
+					await startWooEditorNetworkTransferMetrics( page );
 
-				// Wait for the first block.
-				await canvas.locator( '.wp-block' ).first().waitFor();
+				try {
+					// Open the test draft.
+					await admin.editPost( draftId );
+					const canvas = await perfUtils.getCanvas();
 
-				// Get the durations.
-				const loadingDurations = await metrics.getLoadingDurations();
+					// Wait for the first block.
+					await canvas.locator( '.wp-block' ).first().waitFor();
 
-				// Measure CLS
-				const cumulativeLayoutShift =
-					await metrics.getCumulativeLayoutShift();
+					// Get the durations.
+					const loadingDurations =
+						await metrics.getLoadingDurations();
 
-				// Measure LCP
-				const largestContentfulPaint =
-					await metrics.getLargestContentfulPaint();
+					// Measure CLS
+					const cumulativeLayoutShift =
+						await metrics.getCumulativeLayoutShift();
 
-				// Measure TBT
-				const totalBlockingTime = await getTotalBlockingTime(
-					page,
-					BROWSER_IDLE_WAIT
-				);
+					// Measure LCP
+					const largestContentfulPaint =
+						await metrics.getLargestContentfulPaint();
 
-				// Save the results.
-				if ( i > throwaway ) {
-					results.totalBlockingTime = results.tbt || [];
-					results.totalBlockingTime.push( totalBlockingTime );
-					results.cumulativeLayoutShift =
-						results.cumulativeLayoutShift || [];
-					results.cumulativeLayoutShift.push( cumulativeLayoutShift );
-					results.largestContentfulPaint =
-						results.largestContentfulPaint || [];
-					results.largestContentfulPaint.push(
-						largestContentfulPaint
+					// Measure TBT
+					const totalBlockingTime = await getTotalBlockingTime(
+						page,
+						BROWSER_IDLE_WAIT
 					);
-					Object.entries( loadingDurations ).forEach(
-						( [ metric, duration ] ) => {
-							const metricKey =
-								metric === 'timeSinceResponseEnd'
-									? 'firstBlock'
-									: metric;
-							if ( ! results[ metricKey ] ) {
-								results[ metricKey ] = [];
+
+					// Measure WooCommerce editor asset sizes.
+					const wooEditorAssetMetrics =
+						await getWooEditorAssetMetrics( page );
+					const wooEditorNetworkTransferMetrics =
+						await stopWooEditorNetworkTransferMetrics();
+
+					// Save the results.
+					if ( i > throwaway ) {
+						results.totalBlockingTime =
+							results.totalBlockingTime || [];
+						results.totalBlockingTime.push( totalBlockingTime );
+						results.cumulativeLayoutShift =
+							results.cumulativeLayoutShift || [];
+						results.cumulativeLayoutShift.push(
+							cumulativeLayoutShift
+						);
+						results.largestContentfulPaint =
+							results.largestContentfulPaint || [];
+						results.largestContentfulPaint.push(
+							largestContentfulPaint
+						);
+						Object.entries( loadingDurations ).forEach(
+							( [ metric, duration ] ) => {
+								const metricKey =
+									metric === 'timeSinceResponseEnd'
+										? 'firstBlock'
+										: metric;
+								if ( ! results[ metricKey ] ) {
+									results[ metricKey ] = [];
+								}
+								results[ metricKey ].push( duration );
 							}
-							results[ metricKey ].push( duration );
-						}
-					);
+						);
+						Object.entries( wooEditorAssetMetrics ).forEach(
+							( [ metric, value ] ) => {
+								if ( ! results[ metric ] ) {
+									results[ metric ] = [];
+								}
+								results[ metric ].push( value );
+							}
+						);
+						Object.entries(
+							wooEditorNetworkTransferMetrics
+						).forEach( ( [ metric, value ] ) => {
+							if ( ! results[ metric ] ) {
+								results[ metric ] = [];
+							}
+							results[ metric ].push( value );
+						} );
+					}
+				} finally {
+					await stopWooEditorNetworkTransferMetrics();
 				}
 			} );
 		}

--- a/plugins/woocommerce/tests/metrics/utils.js
+++ b/plugins/woocommerce/tests/metrics/utils.js
@@ -23,6 +23,154 @@ export function readFile( filePath ) {
 	return readFileSync( filePath, 'utf8' ).trim();
 }
 
+export function getMetricUnit( metric ) {
+	if ( metric.endsWith( 'Size' ) ) {
+		return 'KB';
+	}
+
+	if ( metric.endsWith( 'Count' ) ) {
+		return 'count';
+	}
+
+	return 'ms';
+}
+
+export function formatMetricValue( metric, value ) {
+	return `${ value } ${ getMetricUnit( metric ) }`;
+}
+
+const WOO_BLOCKS_ASSETS_PATH =
+	'/wp-content/plugins/woocommerce/assets/client/blocks/';
+const KB = 1024;
+
+function roundSize( value ) {
+	return Math.round( value * 100 ) / 100;
+}
+
+function getWooEditorAssetUrl( rawUrl, baseUrl ) {
+	const url = new URL( rawUrl, baseUrl );
+
+	if (
+		! url.pathname.includes( WOO_BLOCKS_ASSETS_PATH ) ||
+		! /\.(js|css)$/.test( url.pathname )
+	) {
+		return null;
+	}
+
+	return {
+		normalizedUrl: url.origin + url.pathname,
+		isScript: url.pathname.endsWith( '.js' ),
+		isStyle: url.pathname.endsWith( '.css' ),
+	};
+}
+
+function getEmptyWooEditorNetworkTransferMetrics() {
+	return {
+		wooEditorNetworkTransferAssetSize: 0,
+		wooEditorNetworkTransferScriptSize: 0,
+		wooEditorNetworkTransferStyleSize: 0,
+	};
+}
+
+function formatWooEditorNetworkTransferMetrics( metrics ) {
+	return {
+		wooEditorNetworkTransferAssetSize: roundSize(
+			metrics.wooEditorNetworkTransferAssetSize / KB
+		),
+		wooEditorNetworkTransferScriptSize: roundSize(
+			metrics.wooEditorNetworkTransferScriptSize / KB
+		),
+		wooEditorNetworkTransferStyleSize: roundSize(
+			metrics.wooEditorNetworkTransferStyleSize / KB
+		),
+	};
+}
+
+export async function startWooEditorNetworkTransferMetrics( page ) {
+	const client = await page.context().newCDPSession( page );
+	const requests = new Map();
+	const assetUrls = new Set();
+	const metrics = getEmptyWooEditorNetworkTransferMetrics();
+	let isCollecting = true;
+
+	const onRequestWillBeSent = ( event ) => {
+		const assetUrl = getWooEditorAssetUrl( event.request.url, page.url() );
+
+		if ( assetUrl ) {
+			requests.set( event.requestId, assetUrl );
+		}
+	};
+
+	const onLoadingFinished = ( event ) => {
+		const assetUrl = requests.get( event.requestId );
+
+		if ( ! assetUrl || assetUrls.has( assetUrl.normalizedUrl ) ) {
+			return;
+		}
+
+		assetUrls.add( assetUrl.normalizedUrl );
+
+		const size = event.encodedDataLength || 0;
+		metrics.wooEditorNetworkTransferAssetSize += size;
+
+		if ( assetUrl.isScript ) {
+			metrics.wooEditorNetworkTransferScriptSize += size;
+		}
+
+		if ( assetUrl.isStyle ) {
+			metrics.wooEditorNetworkTransferStyleSize += size;
+		}
+	};
+
+	client.on( 'Network.requestWillBeSent', onRequestWillBeSent );
+	client.on( 'Network.loadingFinished', onLoadingFinished );
+	await client.send( 'Network.enable' );
+
+	return async () => {
+		if ( ! isCollecting ) {
+			return formatWooEditorNetworkTransferMetrics( metrics );
+		}
+
+		isCollecting = false;
+		client.off( 'Network.requestWillBeSent', onRequestWillBeSent );
+		client.off( 'Network.loadingFinished', onLoadingFinished );
+		await client.detach();
+
+		return formatWooEditorNetworkTransferMetrics( metrics );
+	};
+}
+
+export async function getWooEditorAssetMetrics( page ) {
+	return await page.evaluate( () => {
+		const wooBlocksAssetsPath =
+			'/wp-content/plugins/woocommerce/assets/client/blocks/';
+		const assetUrls = new Set();
+		const metrics = {
+			wooEditorAssetCount: 0,
+		};
+
+		performance.getEntriesByType( 'resource' ).forEach( ( entry ) => {
+			const url = new URL( entry.name, window.location.href );
+			const normalizedUrl = url.origin + url.pathname;
+
+			if (
+				! url.pathname.includes( wooBlocksAssetsPath ) ||
+				! /\.(js|css)$/.test( url.pathname ) ||
+				assetUrls.has( normalizedUrl )
+			) {
+				return;
+			}
+
+			assetUrls.add( normalizedUrl );
+			metrics.wooEditorAssetCount += 1;
+		} );
+
+		return {
+			wooEditorAssetCount: metrics.wooEditorAssetCount,
+		};
+	} );
+}
+
 export async function getTotalBlockingTime( page, idleWait ) {
 	const totalBlockingTime = await page.evaluate( async ( waitTime ) => {
 		return new Promise( ( resolve ) => {

--- a/plugins/woocommerce/tests/metrics/utils.js
+++ b/plugins/woocommerce/tests/metrics/utils.js
@@ -45,16 +45,18 @@ function getWooEditorAssetUrl( rawUrl, baseUrl ) {
 	};
 }
 
-function getEmptyWooEditorNetworkTransferMetrics() {
+function getEmptyWooEditorAssetMetrics() {
 	return {
+		wooEditorAssetCount: 0,
 		wooEditorNetworkTransferAssetSize: 0,
 		wooEditorNetworkTransferScriptSize: 0,
 		wooEditorNetworkTransferStyleSize: 0,
 	};
 }
 
-function formatWooEditorNetworkTransferMetrics( metrics ) {
+function formatWooEditorAssetMetrics( metrics ) {
 	return {
+		wooEditorAssetCount: metrics.wooEditorAssetCount,
 		wooEditorNetworkTransferAssetSize: roundSize(
 			metrics.wooEditorNetworkTransferAssetSize / KB
 		),
@@ -67,14 +69,21 @@ function formatWooEditorNetworkTransferMetrics( metrics ) {
 	};
 }
 
-export async function startWooEditorNetworkTransferMetrics( page ) {
+export async function startWooEditorAssetMetrics( page ) {
 	const client = await page.context().newCDPSession( page );
+	const { frameTree } = await client.send( 'Page.getFrameTree' );
+	const mainFrameId = frameTree.frame.id;
 	const requests = new Map();
 	const assetUrls = new Set();
-	const metrics = getEmptyWooEditorNetworkTransferMetrics();
+	const metrics = getEmptyWooEditorAssetMetrics();
 	let isCollecting = true;
 
 	const onRequestWillBeSent = ( event ) => {
+		// Exclude assets loaded within editor iframes.
+		if ( event.frameId !== mainFrameId ) {
+			return;
+		}
+
 		const assetUrl = getWooEditorAssetUrl( event.request.url, page.url() );
 
 		if ( assetUrl ) {
@@ -90,6 +99,7 @@ export async function startWooEditorNetworkTransferMetrics( page ) {
 		}
 
 		assetUrls.add( assetUrl.normalizedUrl );
+		metrics.wooEditorAssetCount += 1;
 
 		const size = event.encodedDataLength || 0;
 		metrics.wooEditorNetworkTransferAssetSize += size;
@@ -109,7 +119,7 @@ export async function startWooEditorNetworkTransferMetrics( page ) {
 
 	return async () => {
 		if ( ! isCollecting ) {
-			return formatWooEditorNetworkTransferMetrics( metrics );
+			return formatWooEditorAssetMetrics( metrics );
 		}
 
 		isCollecting = false;
@@ -117,41 +127,8 @@ export async function startWooEditorNetworkTransferMetrics( page ) {
 		client.off( 'Network.loadingFinished', onLoadingFinished );
 		await client.detach();
 
-		return formatWooEditorNetworkTransferMetrics( metrics );
+		return formatWooEditorAssetMetrics( metrics );
 	};
-}
-
-export async function getWooEditorAssetMetrics( page ) {
-	return await page.evaluate( () => {
-		const wooBlocksAssetsPath =
-			'/wp-content/plugins/woocommerce/assets/client/blocks/';
-		const assetUrls = new Set();
-		const metrics = {
-			wooEditorAssetCount: 0,
-		};
-
-		// This intentionally excludes assets loaded only within editor iframes,
-		// which have their own resource performance timelines.
-		performance.getEntriesByType( 'resource' ).forEach( ( entry ) => {
-			const url = new URL( entry.name, window.location.href );
-			const normalizedUrl = url.origin + url.pathname;
-
-			if (
-				! url.pathname.includes( wooBlocksAssetsPath ) ||
-				! /\.(js|css)$/.test( url.pathname ) ||
-				assetUrls.has( normalizedUrl )
-			) {
-				return;
-			}
-
-			assetUrls.add( normalizedUrl );
-			metrics.wooEditorAssetCount += 1;
-		} );
-
-		return {
-			wooEditorAssetCount: metrics.wooEditorAssetCount,
-		};
-	} );
 }
 
 export async function getTotalBlockingTime( page, idleWait ) {

--- a/plugins/woocommerce/tests/metrics/utils.js
+++ b/plugins/woocommerce/tests/metrics/utils.js
@@ -3,17 +3,14 @@
  */
 import { existsSync, readFileSync } from 'fs';
 
-export function median( array ) {
-	if ( ! array || ! array.length ) return undefined;
-
-	const numbers = [ ...array ].sort( ( a, b ) => a - b );
-	const middleIndex = Math.floor( numbers.length / 2 );
-
-	if ( numbers.length % 2 === 0 ) {
-		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
-	}
-	return numbers[ middleIndex ];
-}
+/**
+ * Internal dependencies
+ */
+export {
+	median,
+	getMetricUnit,
+	formatMetricValue,
+} from '../../../../tools/compare-perf/metric-utils.js';
 
 export function readFile( filePath ) {
 	if ( ! existsSync( filePath ) ) {
@@ -21,22 +18,6 @@ export function readFile( filePath ) {
 	}
 
 	return readFileSync( filePath, 'utf8' ).trim();
-}
-
-export function getMetricUnit( metric ) {
-	if ( metric.endsWith( 'Size' ) ) {
-		return 'KB';
-	}
-
-	if ( metric.endsWith( 'Count' ) ) {
-		return 'count';
-	}
-
-	return 'ms';
-}
-
-export function formatMetricValue( metric, value ) {
-	return `${ value } ${ getMetricUnit( metric ) }`;
 }
 
 const WOO_BLOCKS_ASSETS_PATH =

--- a/plugins/woocommerce/tests/metrics/utils.js
+++ b/plugins/woocommerce/tests/metrics/utils.js
@@ -149,6 +149,8 @@ export async function getWooEditorAssetMetrics( page ) {
 			wooEditorAssetCount: 0,
 		};
 
+		// This intentionally excludes assets loaded only within editor iframes,
+		// which have their own resource performance timelines.
 		performance.getEntriesByType( 'resource' ).forEach( ( entry ) => {
 			const url = new URL( entry.name, window.location.href );
 			const normalizedUrl = url.origin + url.pathname;

--- a/tools/compare-perf/metric-utils.js
+++ b/tools/compare-perf/metric-utils.js
@@ -1,0 +1,40 @@
+/**
+ * Computes the median number from an array of numbers.
+ *
+ * @param {number[]} array
+ *
+ * @return {number|undefined} Median value or undefined if array empty.
+ */
+function median( array ) {
+	if ( ! array || ! array.length ) return undefined;
+
+	const numbers = [ ...array ].sort( ( a, b ) => a - b );
+	const middleIndex = Math.floor( numbers.length / 2 );
+
+	if ( numbers.length % 2 === 0 ) {
+		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
+	}
+	return numbers[ middleIndex ];
+}
+
+function getMetricUnit( metric ) {
+	if ( metric.endsWith( 'Size' ) ) {
+		return 'KB';
+	}
+
+	if ( metric.endsWith( 'Count' ) ) {
+		return 'count';
+	}
+
+	return 'ms';
+}
+
+function formatMetricValue( metric, value ) {
+	return `${ value } ${ getMetricUnit( metric ) }`;
+}
+
+module.exports = {
+	median,
+	getMetricUnit,
+	formatMetricValue,
+};

--- a/tools/compare-perf/process-reports.ts
+++ b/tools/compare-perf/process-reports.ts
@@ -13,8 +13,9 @@ const {
 	readJSONFile,
 	logAtIndent,
 	sanitizeBranchName,
-	median
-} = require( './utils' ) ;
+	median,
+	formatMetricValue,
+} = require( './utils' );
 
 const formats = {
 	success: bold.green,
@@ -104,7 +105,10 @@ async function processPerformanceReports(
 		) ) {
 			for ( const [ metric, value ] of Object.entries( metrics ) ) {
 				invertedResult[ metric ] = invertedResult[ metric ] || {};
-				invertedResult[ metric ][ branch ] = `${ value } ms`;
+				invertedResult[ metric ][ branch ] = formatMetricValue(
+					metric,
+					value
+				);
 			}
 		}
 

--- a/tools/compare-perf/process-reports.ts
+++ b/tools/compare-perf/process-reports.ts
@@ -13,9 +13,8 @@ const {
 	readJSONFile,
 	logAtIndent,
 	sanitizeBranchName,
-	median,
-	formatMetricValue,
 } = require( './utils' );
+const { median, formatMetricValue } = require( './metric-utils' );
 
 const formats = {
 	success: bold.green,

--- a/tools/compare-perf/utils.js
+++ b/tools/compare-perf/utils.js
@@ -124,41 +124,6 @@ function sanitizeBranchName( branch ) {
 	return branch.replace( /[^a-zA-Z0-9-]/g, '-' );
 }
 
-/**
- * Computes the median number from an array numbers.
- *
- * @param {number[]} array
- *
- * @return {number|undefined} Median value or undefined if array empty.
- */
-function median( array ) {
-	if ( ! array || ! array.length ) return undefined;
-
-	const numbers = [ ...array ].sort( ( a, b ) => a - b );
-	const middleIndex = Math.floor( numbers.length / 2 );
-
-	if ( numbers.length % 2 === 0 ) {
-		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
-	}
-	return numbers[ middleIndex ];
-}
-
-function getMetricUnit( metric ) {
-	if ( metric.endsWith( 'Size' ) ) {
-		return 'KB';
-	}
-
-	if ( metric.endsWith( 'Count' ) ) {
-		return 'count';
-	}
-
-	return 'ms';
-}
-
-function formatMetricValue( metric, value ) {
-	return `${ value } ${ getMetricUnit( metric ) }`;
-}
-
 module.exports = {
 	askForConfirmation,
 	readJSONFile,
@@ -166,6 +131,4 @@ module.exports = {
 	getFilesFromDir,
 	logAtIndent,
 	sanitizeBranchName,
-	median,
-	formatMetricValue,
 };

--- a/tools/compare-perf/utils.js
+++ b/tools/compare-perf/utils.js
@@ -143,6 +143,22 @@ function median( array ) {
 	return numbers[ middleIndex ];
 }
 
+function getMetricUnit( metric ) {
+	if ( metric.endsWith( 'Size' ) ) {
+		return 'KB';
+	}
+
+	if ( metric.endsWith( 'Count' ) ) {
+		return 'count';
+	}
+
+	return 'ms';
+}
+
+function formatMetricValue( metric, value ) {
+	return `${ value } ${ getMetricUnit( metric ) }`;
+}
+
 module.exports = {
 	askForConfirmation,
 	readJSONFile,
@@ -150,5 +166,6 @@ module.exports = {
 	getFilesFromDir,
 	logAtIndent,
 	sanitizeBranchName,
-	median
+	median,
+	formatMetricValue,
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves the performance metrics by collecting the number of network requests and the bundle size that the clients need to download on the editor side. 

This PR is needed to measure the improvements introduced by https://github.com/woocommerce/woocommerce/pull/66200.


<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check the metric CI job
2. Confirm all six editor performance tests pass and the output table includes `wooEditorAssetCount`, `wooEditorNetworkTransferAssetSize`, `wooEditorNetworkTransferScriptSize`, and `wooEditorNetworkTransferStyleSize` with count or KB units.

<!-- End testing instructions -->



<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/performance-editor-asset-metrics`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
