### PR TITLE
Fix saved payment methods being limited by the posts_per_page option

### DIFF
--- a/plugins/woocommerce/changelog/25025-payment-tokens-posts-per-page-limit
+++ b/plugins/woocommerce/changelog/25025-payment-tokens-posts-per-page-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Saved payment methods are no longer capped by the posts_per_page option: customer token queries now default to a dedicated limit of 100 (filterable via woocommerce_get_customer_payment_tokens_limit), and the payment token data store no longer applies a LIMIT unless one is explicitly requested, so the personal data eraser and user deletion clean up all tokens.

--- a/plugins/woocommerce/changelog/25025-payment-tokens-posts-per-page-limit
+++ b/plugins/woocommerce/changelog/25025-payment-tokens-posts-per-page-limit
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Saved payment methods are no longer capped by the posts_per_page option: customer token queries now default to a dedicated limit of 100 (filterable via woocommerce_get_customer_payment_tokens_limit), and the payment token data store no longer applies a LIMIT unless one is explicitly requested, so the personal data eraser and user deletion clean up all tokens.
+Saved payment methods are no longer capped by the posts_per_page option: customer token queries now default to a dedicated limit of 100 (filterable via woocommerce_get_customer_payment_tokens_limit), and the payment token data store no longer applies a LIMIT to queries scoped to a user_id or token_id unless one is explicitly requested, so the personal data eraser and user deletion clean up all tokens. Unscoped data store queries (no user_id, token_id or limit) match on unindexed columns and read the whole table, so they fall back to a ceiling of 500 rows, filterable via woocommerce_get_payment_tokens_unscoped_limit; pass an explicit limit to opt out.

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -37,6 +37,8 @@ class WC_Payment_Tokens {
 	 *     @type string $user_id    User ID.
 	 *     @type string $gateway_id Gateway ID.
 	 *     @type string $type       Token type.
+	 *     @type int    $limit      Maximum number of tokens to return. Unlimited when omitted or not positive.
+	 *     @type int    $page       Page of results to return when `limit` is set. Default 1.
 	 * }
 	 * @return WC_Payment_Token[]
 	 */

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -37,7 +37,10 @@ class WC_Payment_Tokens {
 	 *     @type string $user_id    User ID.
 	 *     @type string $gateway_id Gateway ID.
 	 *     @type string $type       Token type.
-	 *     @type int    $limit      Maximum number of tokens to return. Unlimited when omitted or not positive.
+	 *     @type int    $limit      Maximum number of tokens to return. When omitted or not positive, queries
+	 *                              scoped to a `token_id` or `user_id` are unlimited, while unscoped queries
+	 *                              fall back to a ceiling filterable via
+	 *                              `woocommerce_get_payment_tokens_unscoped_limit`.
 	 *     @type int    $page       Page of results to return when `limit` is set. Default 1.
 	 * }
 	 * @return WC_Payment_Token[]

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -28,6 +28,8 @@ class WC_Payment_Tokens {
 	 * Gets valid tokens from the database based on user defined criteria.
 	 *
 	 * @since  2.6.0
+	 * @since  11.1.0 Results are no longer implicitly limited by the `posts_per_page` option;
+	 *                pass a positive `limit` arg to bound the query.
 	 * @param  array $args Query arguments {
 	 *     Array of query parameters.
 	 *

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -17,6 +17,14 @@ defined( 'ABSPATH' ) || exit;
 class WC_Payment_Tokens {
 
 	/**
+	 * Default maximum number of tokens returned by `get_customer_tokens`.
+	 *
+	 * @since 11.1.0
+	 * @var int
+	 */
+	const DEFAULT_CUSTOMER_TOKENS_LIMIT = 100;
+
+	/**
 	 * Gets valid tokens from the database based on user defined criteria.
 	 *
 	 * @since  2.6.0
@@ -78,10 +86,11 @@ class WC_Payment_Tokens {
 				 * Controls the maximum number of Payment Methods that will be listed via the My Account page.
 				 *
 				 * @since 7.2.0
+				 * @since 11.1.0 The default changed from the value of the `posts_per_page` option to 100.
 				 *
-				 * @param int $limit Defaults to the value of the `posts_per_page` option.
+				 * @param int $limit Maximum number of tokens to return. Defaults to 100.
 				 */
-				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', get_option( 'posts_per_page' ) ),
+				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', self::DEFAULT_CUSTOMER_TOKENS_LIMIT ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -263,11 +263,15 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 			$gateway_ids = $gateways->get_payment_gateway_ids();
 		}
 
-		$page           = isset( $args['page'] ) ? absint( $args['page'] ) : 1;
-		$posts_per_page = absint( isset( $args['limit'] ) ? $args['limit'] : get_option( 'posts_per_page' ) );
+		$page  = isset( $args['page'] ) ? absint( $args['page'] ) : 1;
+		$limit = isset( $args['limit'] ) ? absint( $args['limit'] ) : 0;
 
-		$pgstrt = absint( ( $page - 1 ) * $posts_per_page ) . ', ';
-		$limits = 'LIMIT ' . $pgstrt . $posts_per_page;
+		// Only limit the results when explicitly requested: consumers like the personal data
+		// eraser and user deletion cleanup rely on retrieving every matching token.
+		$limits = '';
+		if ( $limit > 0 ) {
+			$limits = 'LIMIT ' . absint( ( $page - 1 ) * $limit ) . ', ' . $limit;
+		}
 
 		$gateway_ids[] = '';
 		$where[]       = "gateway_id IN ('" . implode( "','", array_map( 'esc_sql', $gateway_ids ) ) . "')";

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -269,7 +269,8 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		$limit = isset( $args['limit'] ) ? absint( $args['limit'] ) : 0;
 
 		// Only limit the results when explicitly requested: consumers like the personal data
-		// eraser and user deletion cleanup rely on retrieving every matching token.
+		// eraser and user deletion cleanup rely on retrieving every matching token, reaching
+		// this method via WC_Payment_Tokens::get_tokens() without a limit.
 		$limits = '';
 		if ( $limit > 0 ) {
 			$limits = 'LIMIT ' . absint( ( $page - 1 ) * $limit ) . ', ' . $limit;

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -24,6 +24,19 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	protected $meta_type = 'payment_token';
 
 	/**
+	 * Fallback maximum number of rows returned by `get_tokens()` for queries that are neither
+	 * scoped to a `user_id`/`token_id` nor given an explicit `limit`.
+	 *
+	 * Such a query matches on `gateway_id`/`type` only, and neither column is indexed, so it is a
+	 * full table scan across every user's tokens. This ceiling keeps an accidental store-wide
+	 * query bounded; scoped queries ride the primary key or the `user_id` index and stay unlimited.
+	 *
+	 * @since 11.1.0
+	 * @var int
+	 */
+	const DEFAULT_UNSCOPED_TOKENS_LIMIT = 500;
+
+	/**
 	 * If we have already saved our extra data, don't do automatic / default handling.
 	 *
 	 * @var bool
@@ -228,9 +241,15 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	 * Accepts token_id, user_id, gateway_id, and type.
 	 * Each object should contain the fields token_id, gateway_id, token, user_id, type, is_default.
 	 *
+	 * Queries scoped to a `token_id` or `user_id` are unlimited unless a positive `limit` arg is
+	 * passed. An unscoped query (neither of those, nor a `limit`) reads every token in the store, so
+	 * it falls back to DEFAULT_UNSCOPED_TOKENS_LIMIT rows, filterable via
+	 * `woocommerce_get_payment_tokens_unscoped_limit`.
+	 *
 	 * @since 3.0.0
-	 * @since 11.1.0 Results are no longer implicitly limited by the `posts_per_page` option;
-	 *               a `LIMIT` clause is applied only when a positive `limit` arg is passed.
+	 * @since 11.1.0 Results are no longer implicitly limited by the `posts_per_page` option; a `LIMIT`
+	 *               clause is applied when a positive `limit` arg is passed, or as a fallback ceiling
+	 *               on unscoped queries.
 	 * @param array $args List of accepted args: token_id, gateway_id, user_id, type, limit, page.
 	 * @return array
 	 */
@@ -268,9 +287,27 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 		$page  = isset( $args['page'] ) ? max( 1, absint( $args['page'] ) ) : 1;
 		$limit = isset( $args['limit'] ) ? absint( $args['limit'] ) : 0;
 
-		// Only limit the results when explicitly requested: consumers like the personal data
-		// eraser and user deletion cleanup rely on retrieving every matching token, reaching
-		// this method via WC_Payment_Tokens::get_tokens() without a limit.
+		// Without an explicit limit, a query scoped to a token_id or user_id stays unlimited:
+		// consumers like the personal data eraser and user deletion cleanup rely on retrieving
+		// every matching token, reaching this method via WC_Payment_Tokens::get_tokens(). An
+		// unscoped query has no such natural bound, so it falls back to a ceiling instead.
+		if ( $limit < 1 && ! $args['token_id'] && ! $args['user_id'] ) {
+			/**
+			 * Controls the fallback maximum number of tokens returned by an unscoped query, i.e. one
+			 * passing neither `user_id`/`token_id` nor an explicit `limit`. Such a query matches on
+			 * the unindexed `gateway_id`/`type` columns and would otherwise read every token in the
+			 * store. Pass an explicit `limit` (and `page`) to opt out of this ceiling.
+			 *
+			 * Queries scoped to a `user_id` or `token_id` are unaffected and remain unlimited.
+			 *
+			 * @since 11.1.0
+			 *
+			 * @param int   $limit Maximum number of tokens to return. Defaults to 500.
+			 * @param array $args  The arguments passed to `get_tokens()`.
+			 */
+			$limit = absint( apply_filters( 'woocommerce_get_payment_tokens_unscoped_limit', self::DEFAULT_UNSCOPED_TOKENS_LIMIT, $args ) );
+		}
+
 		$limits = '';
 		if ( $limit > 0 ) {
 			$limits = 'LIMIT ' . absint( ( $page - 1 ) * $limit ) . ', ' . $limit;

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -265,7 +265,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 			$gateway_ids = $gateways->get_payment_gateway_ids();
 		}
 
-		$page  = isset( $args['page'] ) ? absint( $args['page'] ) : 1;
+		$page  = isset( $args['page'] ) ? max( 1, absint( $args['page'] ) ) : 1;
 		$limit = isset( $args['limit'] ) ? absint( $args['limit'] ) : 0;
 
 		// Only limit the results when explicitly requested: consumers like the personal data

--- a/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php
@@ -229,7 +229,9 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Object_
 	 * Each object should contain the fields token_id, gateway_id, token, user_id, type, is_default.
 	 *
 	 * @since 3.0.0
-	 * @param array $args List of accepted args: token_id, gateway_id, user_id, type.
+	 * @since 11.1.0 Results are no longer implicitly limited by the `posts_per_page` option;
+	 *               a `LIMIT` clause is applied only when a positive `limit` arg is passed.
+	 * @param array $args List of accepted args: token_id, gateway_id, user_id, type, limit, page.
 	 * @return array
 	 */
 	public function get_tokens( $args ) {

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -1061,8 +1061,10 @@ function wc_delete_user_data( $user_id ) {
 		)
 	);
 
-	// Clean up payment tokens. Query without a limit so every token is removed,
-	// not just the customer-facing subset capped by `get_customer_tokens()`.
+	// Clean up payment tokens. Query without a limit so every token is removed, not just the
+	// customer-facing subset capped by `get_customer_tokens()`. Deliberately bypasses the
+	// `woocommerce_get_customer_payment_tokens` filter too: cleanup must not be narrowed by a
+	// display-oriented filter, and this matches the personal data eraser, which also omits it.
 	$payment_tokens = WC_Payment_Tokens::get_tokens( array( 'user_id' => $user_id ) );
 
 	foreach ( $payment_tokens as $payment_token ) {

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -1061,8 +1061,9 @@ function wc_delete_user_data( $user_id ) {
 		)
 	);
 
-	// Clean up payment tokens.
-	$payment_tokens = WC_Payment_Tokens::get_customer_tokens( $user_id );
+	// Clean up payment tokens. Query without a limit so every token is removed,
+	// not just the customer-facing subset capped by `get_customer_tokens()`.
+	$payment_tokens = WC_Payment_Tokens::get_tokens( array( 'user_id' => $user_id ) );
 
 	foreach ( $payment_tokens as $payment_token ) {
 		$payment_token->delete();

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -1,0 +1,147 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * @package WooCommerce\Tests\PaymentTokens
+ */
+
+/**
+ * Class WC_Payment_Tokens_Test.
+ */
+class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * ID of the customer used in the tests.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->user_id = self::factory()->user->create( array( 'role' => 'customer' ) );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_get_customer_payment_tokens_limit' );
+		remove_all_filters( 'pre_option_posts_per_page' );
+		update_option( 'posts_per_page', 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a number of credit card tokens for the test customer.
+	 *
+	 * @param int $count Number of tokens to create.
+	 */
+	private function create_tokens_for_user( int $count ): void {
+		for ( $i = 0; $i < $count; $i++ ) {
+			WC_Helper_Payment_Token::create_cc_token( $this->user_id );
+		}
+	}
+
+	/**
+	 * @testdox get_customer_tokens should not be limited by the posts_per_page option (issue 25025).
+	 */
+	public function test_get_customer_tokens_is_not_limited_by_posts_per_page(): void {
+		update_option( 'posts_per_page', 1 );
+		$this->create_tokens_for_user( 3 );
+
+		$this->assertCount(
+			3,
+			WC_Payment_Tokens::get_customer_tokens( $this->user_id ),
+			'All customer tokens should be returned regardless of the posts_per_page option'
+		);
+	}
+
+	/**
+	 * @testdox get_customer_tokens should return all tokens when the posts_per_page option is an empty string.
+	 */
+	public function test_get_customer_tokens_returns_all_tokens_when_posts_per_page_is_empty(): void {
+		add_filter(
+			'pre_option_posts_per_page',
+			function () {
+				return '';
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		$this->assertCount(
+			3,
+			WC_Payment_Tokens::get_customer_tokens( $this->user_id ),
+			'An empty posts_per_page option must not result in zero tokens (LIMIT 0)'
+		);
+	}
+
+	/**
+	 * @testdox get_customer_tokens should respect the woocommerce_get_customer_payment_tokens_limit filter.
+	 */
+	public function test_get_customer_tokens_limit_filter_is_respected(): void {
+		add_filter(
+			'woocommerce_get_customer_payment_tokens_limit',
+			function () {
+				return 2;
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		$this->assertCount(
+			2,
+			WC_Payment_Tokens::get_customer_tokens( $this->user_id ),
+			'The filter should still cap the number of returned tokens'
+		);
+	}
+
+	/**
+	 * @testdox Data store get_tokens should return all tokens when no limit argument is passed.
+	 */
+	public function test_data_store_get_tokens_returns_all_tokens_without_limit(): void {
+		update_option( 'posts_per_page', 1 );
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		$this->assertCount(
+			3,
+			$data_store->get_tokens( array( 'user_id' => $this->user_id ) ),
+			'Without an explicit limit, the data store should return all matching tokens (GDPR eraser and user-deletion cleanup rely on this)'
+		);
+	}
+
+	/**
+	 * @testdox Data store get_tokens should respect an explicit limit and page.
+	 */
+	public function test_data_store_get_tokens_respects_explicit_limit_and_page(): void {
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		$this->assertCount(
+			2,
+			$data_store->get_tokens(
+				array(
+					'user_id' => $this->user_id,
+					'limit'   => 2,
+				)
+			),
+			'An explicit limit should cap the results'
+		);
+		$this->assertCount(
+			1,
+			$data_store->get_tokens(
+				array(
+					'user_id' => $this->user_id,
+					'limit'   => 2,
+					'page'    => 2,
+				)
+			),
+			'Pagination should return the remaining tokens on the second page'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -61,21 +61,19 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_customer_tokens should return all tokens when the posts_per_page option is an empty string.
+	 * @testdox Data store get_tokens should not consult the posts_per_page option even when it is empty.
 	 */
-	public function test_get_customer_tokens_returns_all_tokens_when_posts_per_page_is_empty(): void {
-		add_filter(
-			'pre_option_posts_per_page',
-			function () {
-				return '';
-			}
-		);
+	public function test_data_store_get_tokens_ignores_empty_posts_per_page(): void {
+		add_filter( 'pre_option_posts_per_page', '__return_empty_string' );
 		$this->create_tokens_for_user( 3 );
 
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		// Regression guard: the data store used to fall back to posts_per_page, and an empty value produced LIMIT 0 (zero rows).
 		$this->assertCount(
 			3,
-			WC_Payment_Tokens::get_customer_tokens( $this->user_id ),
-			'An empty posts_per_page option must not result in zero tokens (LIMIT 0)'
+			$data_store->get_tokens( array( 'user_id' => $this->user_id ) ),
+			'Token queries must not be affected by the posts_per_page option'
 		);
 	}
 
@@ -111,6 +109,26 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 			3,
 			$data_store->get_tokens( array( 'user_id' => $this->user_id ) ),
 			'Without an explicit limit, the data store should return all matching tokens (GDPR eraser and user-deletion cleanup rely on this)'
+		);
+	}
+
+	/**
+	 * @testdox Data store get_tokens should return all tokens when page is passed without a limit.
+	 */
+	public function test_data_store_get_tokens_ignores_page_without_limit(): void {
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		$this->assertCount(
+			3,
+			$data_store->get_tokens(
+				array(
+					'user_id' => $this->user_id,
+					'page'    => 2,
+				)
+			),
+			'A page argument without an explicit limit should not paginate the results'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -154,6 +154,27 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Data store get_tokens should treat page zero as the first page.
+	 */
+	public function test_data_store_get_tokens_treats_page_zero_as_first_page(): void {
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		$this->assertCount(
+			2,
+			$data_store->get_tokens(
+				array(
+					'user_id' => $this->user_id,
+					'limit'   => 2,
+					'page'    => 0,
+				)
+			),
+			'Page 0 must return the first page of results, not skip past it'
+		);
+	}
+
+	/**
 	 * @testdox Data store get_tokens should respect an explicit limit and page.
 	 */
 	public function test_data_store_get_tokens_respects_explicit_limit_and_page(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -133,6 +133,27 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox wc_delete_user_data should delete all payment tokens, not just the customer-facing limited subset.
+	 */
+	public function test_wc_delete_user_data_deletes_all_tokens(): void {
+		add_filter(
+			'woocommerce_get_customer_payment_tokens_limit',
+			function () {
+				return 1;
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		wc_delete_user_data( $this->user_id );
+
+		global $wpdb;
+		$remaining = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_payment_tokens WHERE user_id = %d", $this->user_id )
+		);
+		$this->assertSame( 0, $remaining, 'Deleting a user must remove every saved payment token' );
+	}
+
+	/**
 	 * @testdox Data store get_tokens should respect an explicit limit and page.
 	 */
 	public function test_data_store_get_tokens_respects_explicit_limit_and_page(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -30,6 +30,7 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		remove_all_filters( 'woocommerce_get_customer_payment_tokens_limit' );
+		remove_all_filters( 'woocommerce_get_payment_tokens_unscoped_limit' );
 		remove_all_filters( 'pre_option_posts_per_page' );
 		update_option( 'posts_per_page', 10 );
 		parent::tearDown();
@@ -171,6 +172,88 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 				)
 			),
 			'Page 0 must return the first page of results, not skip past it'
+		);
+	}
+
+	/**
+	 * @testdox Data store get_tokens should cap an unscoped query with the fallback ceiling.
+	 */
+	public function test_data_store_get_tokens_caps_unscoped_queries(): void {
+		$received = null;
+		add_filter(
+			'woocommerce_get_payment_tokens_unscoped_limit',
+			function ( $limit ) use ( &$received ) {
+				$received = $limit;
+				return 2;
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		// An unscoped query matches on the unindexed gateway_id/type columns, so it must not read the
+		// whole table.
+		$this->assertCount(
+			2,
+			$data_store->get_tokens( array() ),
+			'An unscoped query should be capped by the fallback ceiling'
+		);
+
+		// Pins the ceiling's default without creating 500 tokens.
+		$this->assertSame(
+			WC_Payment_Token_Data_Store::DEFAULT_UNSCOPED_TOKENS_LIMIT,
+			$received,
+			'The unscoped limit filter should receive DEFAULT_UNSCOPED_TOKENS_LIMIT as its default'
+		);
+		$this->assertSame( 500, WC_Payment_Token_Data_Store::DEFAULT_UNSCOPED_TOKENS_LIMIT );
+	}
+
+	/**
+	 * @testdox Data store get_tokens should not apply the unscoped ceiling to scoped queries.
+	 */
+	public function test_data_store_get_tokens_ceiling_does_not_apply_to_scoped_queries(): void {
+		add_filter(
+			'woocommerce_get_payment_tokens_unscoped_limit',
+			function () {
+				return 1;
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+		$token_ids  = wp_list_pluck( $data_store->get_tokens( array( 'user_id' => $this->user_id ) ), 'token_id' );
+
+		// The eraser and user-deletion cleanup scope by user_id and must stay unlimited.
+		$this->assertCount(
+			3,
+			$data_store->get_tokens( array( 'user_id' => $this->user_id ) ),
+			'A user_id-scoped query must not be capped by the unscoped ceiling'
+		);
+		$this->assertCount(
+			3,
+			$data_store->get_tokens( array( 'token_id' => $token_ids ) ),
+			'A token_id-scoped query must not be capped by the unscoped ceiling'
+		);
+	}
+
+	/**
+	 * @testdox An explicit limit should override the unscoped ceiling.
+	 */
+	public function test_data_store_get_tokens_explicit_limit_overrides_unscoped_ceiling(): void {
+		add_filter(
+			'woocommerce_get_payment_tokens_unscoped_limit',
+			function () {
+				return 1;
+			}
+		);
+		$this->create_tokens_for_user( 3 );
+
+		$data_store = WC_Data_Store::load( 'payment-token' );
+
+		$this->assertCount(
+			3,
+			$data_store->get_tokens( array( 'limit' => 10 ) ),
+			'An explicit limit should take precedence over the unscoped fallback ceiling'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-tokens-test.php
@@ -176,6 +176,30 @@ class WC_Payment_Tokens_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_customer_tokens should default the limit filter to DEFAULT_CUSTOMER_TOKENS_LIMIT.
+	 */
+	public function test_get_customer_tokens_defaults_to_the_documented_limit(): void {
+		$received = null;
+		add_filter(
+			'woocommerce_get_customer_payment_tokens_limit',
+			function ( $limit ) use ( &$received ) {
+				$received = $limit;
+				return $limit;
+			}
+		);
+
+		WC_Payment_Tokens::get_customer_tokens( $this->user_id );
+
+		// Pins the default without creating 100 tokens: a silent change to the constant fails here.
+		$this->assertSame(
+			WC_Payment_Tokens::DEFAULT_CUSTOMER_TOKENS_LIMIT,
+			$received,
+			'The customer token limit filter should receive DEFAULT_CUSTOMER_TOKENS_LIMIT as its default'
+		);
+		$this->assertSame( 100, WC_Payment_Tokens::DEFAULT_CUSTOMER_TOKENS_LIMIT );
+	}
+
+	/**
 	 * @testdox Data store get_tokens should cap an unscoped query with the fallback ceiling.
 	 */
 	public function test_data_store_get_tokens_caps_unscoped_queries(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Saved payment methods (`WC_Payment_Tokens::get_customer_tokens()`) were capped by the `posts_per_page` Reading setting — a blog pagination option with no relationship to payment tokens. Stores with a low `posts_per_page` silently hid saved cards on **My Account → Payment methods** and at checkout; a raw empty option value produced `LIMIT 0` and hid all of them. The same data-store default also silently capped the **personal data eraser** and **user deletion cleanup**, which pass no limit and need every token.

Four changes:

1. `WC_Payment_Token_Data_Store::get_tokens()` no longer applies a SQL `LIMIT` to queries scoped to a `user_id` or `token_id` unless a positive `limit` argument is explicitly passed — consumers that need all tokens (privacy eraser, `get_order_tokens()`) are no longer truncated. These queries are bounded by design: they ride the `user_id` index or the primary key.
2. `WC_Payment_Tokens::get_customer_tokens()` now defaults the `woocommerce_get_customer_payment_tokens_limit` filter to a dedicated constant (`DEFAULT_CUSTOMER_TOKENS_LIMIT = 100`) instead of `get_option( 'posts_per_page' )`, keeping customer-facing lists bounded while decoupling them from the pagination setting.
3. `wc_delete_user_data()` now cleans up payment tokens via the unbounded `WC_Payment_Tokens::get_tokens()` path (matching the GDPR eraser), so deleting a user removes every saved token — previously the cleanup went through the customer-facing limited list and could orphan tokens beyond the limit.
4. **Unscoped** data-store queries — no `user_id`, no `token_id` and no `limit` — fall back to a ceiling of 500 rows, filterable via the new `woocommerce_get_payment_tokens_unscoped_limit`. Such a query has no natural bound: the only predicate left is `gateway_id`/`type`, and the `woocommerce_payment_tokens` table indexes neither (it carries only `PRIMARY KEY (token_id)` and `KEY user_id`), so it is a full table scan that materializes every token in the store across all users, each hydrated into an object with its meta. The old implicit `posts_per_page` cap silently defused this; no core caller queries unscoped, but the public API made it easy for an extension to trigger accidentally. Unscoped callers previously received at most `posts_per_page` rows (default 10), so 500 is ~50× more permissive and cannot regress an existing consumer. Pass an explicit `limit` to opt out.

**Backward compatibility:** No class, method, or hook signatures change. The `woocommerce_get_customer_payment_tokens_limit` filter is retained — sites already using it are unaffected. `woocommerce_get_payment_tokens_unscoped_limit` is new and purely additive. Behavior changes intentionally, in every case returning **more** rows than before, never fewer:

| Data-store `get_tokens()` call | Before | After |
| --- | --- | --- |
| Scoped (`user_id`/`token_id`), no `limit` | `posts_per_page` rows (default 10) | All matching rows |
| Unscoped, no `limit` | `posts_per_page` rows (default 10) | Up to 500 rows (filterable) |
| Explicit `limit` | `limit` rows | Unchanged |

Customer token lists (`get_customer_tokens()`) now default to up to 100 tokens instead of `posts_per_page`. Extension authors relying on a store-wide `get_tokens()` read should pass an explicit `limit` and paginate: the unscoped path is a full table scan and is now ceilinged rather than unbounded.

Closes #25025.

(For Bug Fixes) Bug introduced in PR #29850 (kept the `posts_per_page` default when adding the filter; the underlying data-store default dates back to the original WC 3.0 token data store).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start the environment: `pnpm wc:env`.
2. Create three saved cards for the admin user (no gateway account needed):

    ```bash
    pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli -- wp eval 'for ( $i = 1; $i <= 3; $i++ ) { $t = new WC_Payment_Token_CC(); $t->set_token( "tok_test_$i" ); $t->set_gateway_id( "cod" ); $t->set_user_id( 1 ); $t->set_card_type( "visa" ); $t->set_last4( "000$i" ); $t->set_expiry_month( "12" ); $t->set_expiry_year( "2030" ); $t->save(); } echo count( WC_Payment_Tokens::get_customer_tokens( 1 ) );'
    ```

3. Go to **Settings → Reading** and set "Blog pages show at most" to `1`.
4. Visit **My Account → Payment methods** as the admin user.
5. - [ ] Verify all three cards (`visa ending in 0001/0002/0003`) are listed, not just one.
6. Run the unit tests: `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Payment_Tokens_Test`.
7. - [ ] Verify all 12 tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

-   TDD: 12 unit tests in `tests/php/includes/class-wc-payment-tokens-test.php`; the 3 bug-demonstrating tests were verified failing before the fix and passing after.
-   Regression suites green: `--filter Payment_Token` (52 tests, 1 pre-existing skip), `--filter Privacy` (17 tests).
-   Mutation-tested the new guards to confirm they are not vacuous: changing `DEFAULT_CUSTOMER_TOKENS_LIMIT` to 99, changing `DEFAULT_UNSCOPED_TOKENS_LIMIT` to 499, and disabling the unscoped-ceiling condition each fail the corresponding test. All reverted; suite green.
-   End-to-end in wp-env (WC 11.1.0-dev): with `posts_per_page=1` all 3 tokens are returned on both the customer path and the eraser path; with a raw empty `posts_per_page` DB value (previously `LIMIT 0` → zero tokens) all 3 are returned.
-   Manual browser verification in wp-env (Storefront-equivalent block theme, logged in as admin): with `posts_per_page=1`, **My Account → Payment methods** renders all three cards (`Visa ending in 0001/0002/0003`) — previously only one was listed.
-   `lint:php:changes` + `lint:changes:branch` clean; PHPStan clean on both modified production files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

*(Changelog entry `25025-payment-tokens-posts-per-page-limit` is already committed in this PR — created manually via `pnpm changelog add`.)*

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (the default value of the `woocommerce_get_customer_payment_tokens_limit` filter changed from `posts_per_page` to 100; data-store `get_tokens()` calls scoped to a `user_id`/`token_id` without an explicit `limit` are no longer capped; unscoped calls are a full table scan and now fall back to a 500-row ceiling filterable via the new `woocommerce_get_payment_tokens_unscoped_limit`)

---
🤖 Generated with [Claude Code](https://claude.ai/code)



