### PR TITLE
[e2e] Reduce Site Editor navigation timeout in tests

### DIFF
--- a/bin/patches/@wordpress__e2e-test-utils-playwright@1.33.2.patch
+++ b/bin/patches/@wordpress__e2e-test-utils-playwright@1.33.2.patch
@@ -1,0 +1,17 @@
+diff --git a/build/admin/visit-site-editor.js b/build/admin/visit-site-editor.js
+index 8396b16ffcac2b39384ec878aa38a3eb18b6fc1f..6f851e640195973840b8919d9279d48802fd017c 100644
+--- a/build/admin/visit-site-editor.js
++++ b/build/admin/visit-site-editor.js
+@@ -52,7 +52,11 @@ async function visitSiteEditor(options = {}) {
+       ".edit-site-canvas-loader, .edit-site-canvas-spinner"
+     );
+     try {
+-      await canvasLoader.waitFor({ state: "visible", timeout: 6e4 });
++      // The loader either renders within a tick or is skipped entirely, so a
++      // long visible-state timeout is wasted when it never appears.
++      // Backported from Gutenberg #77725. Remove this package patch when the
++      // minimum package catalog reaches version 1.45.0 or later.
++      await canvasLoader.waitFor({ state: "visible", timeout: 3e3 });
+       await canvasLoader.waitFor({
+         state: "hidden",
+         // Bigger timeout is needed for larger entities, like the Large Post

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
 			"sass": "1.69.5"
 		},
 		"patchedDependencies": {
-			"@wordpress/edit-site@5.15.0": "bin/patches/@wordpress__edit-site@5.15.0.patch"
+			"@wordpress/edit-site@5.15.0": "bin/patches/@wordpress__edit-site@5.15.0.patch",
+			"@wordpress/e2e-test-utils-playwright@1.33.2": "bin/patches/@wordpress__e2e-test-utils-playwright@1.33.2.patch"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ overrides:
 pnpmfileChecksum: sha256-7lEtYKkj9MKUQ1wDfOySWQ01OX5tYIUQTnfpMq5epMI=
 
 patchedDependencies:
+  '@wordpress/e2e-test-utils-playwright@1.33.2':
+    hash: 0a3df7448f0a035981fcb1ecddf9c699450bcfe7c1f6c334d6cdfea5db1e0d52
+    path: bin/patches/@wordpress__e2e-test-utils-playwright@1.33.2.patch
   '@wordpress/edit-site@5.15.0':
     hash: 63381743e38412fb89154386a5d169639ca10f8315407527829db669201fce9b
     path: bin/patches/@wordpress__edit-site@5.15.0.patch
@@ -2631,7 +2634,7 @@ importers:
         version: 6.43.1-next.v.202604091042.0
       '@wordpress/e2e-test-utils-playwright':
         specifier: catalog:wp-min
-        version: 1.33.2(@playwright/test@1.61.1)
+        version: 1.33.2(patch_hash=0a3df7448f0a035981fcb1ecddf9c699450bcfe7c1f6c334d6cdfea5db1e0d52)(@playwright/test@1.61.1)
       '@wordpress/env':
         specifier: 11.9.0
         version: 11.9.0(@types/node@24.12.2)
@@ -3660,7 +3663,7 @@ importers:
         version: 4.33.1
       '@wordpress/e2e-test-utils-playwright':
         specifier: catalog:wp-min
-        version: 1.33.2(@playwright/test@1.61.1)
+        version: 1.33.2(patch_hash=0a3df7448f0a035981fcb1ecddf9c699450bcfe7c1f6c334d6cdfea5db1e0d52)(@playwright/test@1.61.1)
       '@wordpress/editor':
         specifier: catalog:wp-min
         version: 14.33.11(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -35618,7 +35621,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@wordpress/e2e-test-utils-playwright@1.33.2(@playwright/test@1.61.1)':
+  '@wordpress/e2e-test-utils-playwright@1.33.2(patch_hash=0a3df7448f0a035981fcb1ecddf9c699450bcfe7c1f6c334d6cdfea5db1e0d52)(@playwright/test@1.61.1)':
     dependencies:
       '@playwright/test': 1.61.1
       change-case: 4.1.2


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`visitSiteEditor` can wait for up to 60 seconds for a canvas loader that is legitimately skipped, delaying otherwise successful E2E tests before the existing fallback runs.

Backport WordPress/gutenberg#77725 as a pnpm patch against the pinned `@wordpress/e2e-test-utils-playwright` 1.33.2 dependency. This reduces only the loader-visible wait to three seconds while preserving the 60-second hidden wait and fallback behavior. The patch can be removed when the minimum package catalog reaches 1.45.0 or later.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm install --frozen-lockfile`.
2. Run `rg -n 'timeout: (3e3|6e4)' plugins/woocommerce/node_modules/@wordpress/e2e-test-utils-playwright/build/admin/visit-site-editor.js`.
3. Confirm the visible wait uses `3e3` and the subsequent hidden wait still uses `6e4`.
4. Run `pnpm wc:build:blocks`.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
6. From `plugins/woocommerce`, run `pnpm test:e2e:blocks tests/e2e/tests/blocks/templates/cart-template.block_theme.spec.ts`.
7. Confirm the setup project and the cart-template Site Editor test pass.
8. Run `pnpm env:e2e:stop`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- A focused behavioral harness verified the three-second loader-absent branch and unchanged 60-second loader-visible branch: 2 tests passed.
- `pnpm install --frozen-lockfile`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm wc:build:blocks`
- Cart-template Blocks E2E test using the local Docker/wp-env environment: setup and test passed.
- `pnpm exec prettier --check package.json`
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

E2E test tooling only; no merchant-facing package behavior is shipped.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
