### PR TITLE
Fix 0% tax rates not added to refund orders

### DIFF
--- a/plugins/woocommerce/changelog/27118-fix-zero-rate-tax-refund
+++ b/plugins/woocommerce/changelog/27118-fix-zero-rate-tax-refund
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve 0% tax lines when refunding order line items, so zero-rated tax entries are recorded on the refund order instead of being dropped.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2458,7 +2458,8 @@ class WC_AJAX {
 				$line_items[ $item_id ]['refund_total'] = wc_format_decimal( $total );
 			}
 			foreach ( $line_item_tax_totals as $item_id => $tax_totals ) {
-				$line_items[ $item_id ]['refund_tax'] = array_filter( array_map( 'wc_format_decimal', $tax_totals ) );
+				// Use is_numeric so a 0% tax amount ('0') is preserved. A callback-less array_filter would drop it as falsy, losing the 0-rate tax line (0% is a valid rate, not "no tax"). See #27118.
+				$line_items[ $item_id ]['refund_tax'] = array_filter( array_map( 'wc_format_decimal', $tax_totals ), 'is_numeric' );
 			}
 
 			// Create the refund object.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -617,7 +617,12 @@ function wc_create_refund( $args = array() ) {
 					}
 				}
 
-				if ( empty( $qty ) && empty( $refund_total ) && empty( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
+				// The admin refund form posts a 0 total and 0 tax amounts for every untouched row, so an
+				// all-zero refund_tax alone must not create a refund line item (a genuine 0% tax line
+				// still survives, because its item is refunded via qty or refund_total).
+				$refund_tax_sum = array_sum( array_map( 'abs', $refund_tax ) );
+
+				if ( empty( $qty ) && empty( $refund_total ) && empty( $refund_tax_sum ) ) {
 					continue;
 				}
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -606,7 +606,16 @@ function wc_create_refund( $args = array() ) {
 
 				$qty          = isset( $args['line_items'][ $item_id ]['qty'] ) ? $args['line_items'][ $item_id ]['qty'] : 0;
 				$refund_total = $args['line_items'][ $item_id ]['refund_total'];
-				$refund_tax   = isset( $args['line_items'][ $item_id ]['refund_tax'] ) ? array_filter( (array) $args['line_items'][ $item_id ]['refund_tax'] ) : array();
+
+				// Keep every numeric tax entry, including a 0% amount that a callback-less array_filter would drop as falsy. 0% is a valid rate, not "no tax". See #27118.
+				$refund_tax = array();
+				if ( isset( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
+					foreach ( (array) $args['line_items'][ $item_id ]['refund_tax'] as $tax_rate_id => $tax_amount ) {
+						if ( is_numeric( $tax_amount ) ) {
+							$refund_tax[ $tax_rate_id ] = (float) $tax_amount;
+						}
+					}
+				}
 
 				if ( empty( $qty ) && empty( $refund_total ) && empty( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
 					continue;

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -608,14 +608,7 @@ function wc_create_refund( $args = array() ) {
 				$refund_total = $args['line_items'][ $item_id ]['refund_total'];
 
 				// Keep every numeric tax entry, including a 0% amount that a callback-less array_filter would drop as falsy. 0% is a valid rate, not "no tax". See #27118.
-				$refund_tax = array();
-				if ( isset( $args['line_items'][ $item_id ]['refund_tax'] ) ) {
-					foreach ( (array) $args['line_items'][ $item_id ]['refund_tax'] as $tax_rate_id => $tax_amount ) {
-						if ( is_numeric( $tax_amount ) ) {
-							$refund_tax[ $tax_rate_id ] = (float) $tax_amount;
-						}
-					}
-				}
+				$refund_tax = isset( $args['line_items'][ $item_id ]['refund_tax'] ) ? array_map( 'floatval', array_filter( (array) $args['line_items'][ $item_id ]['refund_tax'], 'is_numeric' ) ) : array();
 
 				// The admin refund form posts a 0 total and 0 tax amounts for every untouched row, so an
 				// all-zero refund_tax alone must not create a refund line item (a genuine 0% tax line

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1502,6 +1502,77 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Refunding a 0% taxed line item preserves the 0-rate tax line on the refund order.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/27118
+	 */
+	public function test_wc_create_refund_preserves_zero_rate_tax_27118() {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '0.0000',
+				'tax_rate_name'     => 'Zero Rate',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tax_status( ProductTaxStatus::TAXABLE );
+		$product->set_tax_class( '' );
+		$product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals( true );
+		$order->save();
+
+		$line_items = $order->get_items( 'line_item' );
+		$item_id    = array_keys( $line_items )[0];
+
+		// The admin refund UI posts the tax total as a numeric 0 (accounting.unformat),
+		// which wc_create_refund() must not silently drop as it would a "no tax" value.
+		$refund = wc_create_refund(
+			array(
+				'amount'     => $order->get_total(),
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 1,
+						'refund_total' => $order->get_total(),
+						'refund_tax'   => array( $rate_id => 0 ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+
+		$refund_tax_items = $refund->get_items( 'tax' );
+		$this->assertCount( 1, $refund_tax_items, 'The 0% tax line must be carried over to the refund order.' );
+
+		$refund_tax_item = array_values( $refund_tax_items )[0];
+		$this->assertEquals( $rate_id, $refund_tax_item->get_rate_id(), 'The preserved tax line must reference the 0% rate.' );
+		$this->assertEquals( 0, $refund_tax_item->get_tax_total(), 'The preserved 0% tax line total must be 0.' );
+
+		$refunded_line_item = array_values( $refund->get_items( 'line_item' ) )[0];
+		$this->assertArrayHasKey(
+			$rate_id,
+			$refunded_line_item->get_taxes()['total'],
+			'The refunded line item must retain the 0% rate in its tax map.'
+		);
+
+		WC_Tax::_delete_tax_rate( $rate_id );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+	}
+
+	/**
 	 * Test wc_sanitize_order_id().
 	 */
 	public function test_wc_sanitize_order_id() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1573,6 +1573,172 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox An amount-only refund whose line items carry only zero qty, zero total and zero tax creates no refund line items.
+	 */
+	public function test_wc_create_refund_skips_untouched_items_with_zero_tax() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$product_2 = WC_Helper_Product::create_simple_product();
+
+		$order = new WC_Order();
+		$order->add_product( $product_1, 1 );
+		$order->add_product( $product_2, 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$item_ids = array_keys( $order->get_items( 'line_item' ) );
+
+		// The admin refund form posts a 0 total and a 0 tax amount for every
+		// untouched row (only qty fields are omitted when empty), so an
+		// amount-only refund arrives with all-zero line item entries.
+		$line_items = array();
+		foreach ( $item_ids as $item_id ) {
+			$line_items[ $item_id ] = array(
+				'refund_total' => 0,
+				'refund_tax'   => array( 1 => 0 ),
+			);
+		}
+
+		$refund = wc_create_refund(
+			array(
+				'amount'     => 5,
+				'order_id'   => $order->get_id(),
+				'line_items' => $line_items,
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+		$this->assertCount( 0, $refund->get_items( 'line_item' ), 'Untouched items must not become refund line items.' );
+		$this->assertCount( 0, $refund->get_items( 'tax' ), 'Untouched items must not produce refund tax items.' );
+	}
+
+	/**
+	 * @testdox Partially refunding one item creates no refund line items for its untouched siblings.
+	 */
+	public function test_wc_create_refund_partial_refund_ignores_untouched_siblings() {
+		$refunded_product  = WC_Helper_Product::create_simple_product();
+		$untouched_product = WC_Helper_Product::create_simple_product();
+
+		$order = new WC_Order();
+		$order->add_product( $refunded_product, 1 );
+		$order->add_product( $untouched_product, 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$refunded_item_id  = null;
+		$untouched_item_id = null;
+		foreach ( $order->get_items( 'line_item' ) as $item_id => $item ) {
+			if ( $item->get_product_id() === $refunded_product->get_id() ) {
+				$refunded_item_id = $item_id;
+			} else {
+				$untouched_item_id = $item_id;
+			}
+		}
+
+		$refunded_item_total = $order->get_items( 'line_item' )[ $refunded_item_id ]->get_total();
+
+		$refund = wc_create_refund(
+			array(
+				'amount'     => $refunded_item_total,
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$refunded_item_id  => array(
+						'qty'          => 1,
+						'refund_total' => $refunded_item_total,
+						'refund_tax'   => array( 1 => 0 ),
+					),
+					$untouched_item_id => array(
+						'refund_total' => 0,
+						'refund_tax'   => array( 1 => 0 ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+
+		$refund_items = $refund->get_items( 'line_item' );
+		$this->assertCount( 1, $refund_items, 'Only the explicitly refunded item must appear on the refund.' );
+
+		$refunded_item = array_values( $refund_items )[0];
+		$this->assertEquals(
+			$refunded_item_id,
+			$refunded_item->get_meta( '_refunded_item_id' ),
+			'The refund line item must reference the refunded order item, not an untouched sibling.'
+		);
+	}
+
+	/**
+	 * @testdox Partially refunding one item keeps download permissions for products that were not refunded.
+	 */
+	public function test_wc_create_refund_keeps_downloads_of_unrefunded_products() {
+		$refunded_product = WC_Helper_Product::create_simple_product();
+
+		$downloadable_product = WC_Helper_Product::create_simple_product();
+		$downloadable_product->set_downloadable( true );
+		$downloadable_product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $refunded_product, 1 );
+		$order->add_product( $downloadable_product, 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( 1 );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $downloadable_product->get_id() );
+		$download->set_download_id( wp_generate_uuid4() );
+		$download->save();
+
+		$refunded_item_id     = null;
+		$downloadable_item_id = null;
+		foreach ( $order->get_items( 'line_item' ) as $item_id => $item ) {
+			if ( $item->get_product_id() === $refunded_product->get_id() ) {
+				$refunded_item_id = $item_id;
+			} else {
+				$downloadable_item_id = $item_id;
+			}
+		}
+
+		$refunded_item_total = $order->get_items( 'line_item' )[ $refunded_item_id ]->get_total();
+
+		// The untouched downloadable item still appears in the payload with
+		// zero total and zero tax, exactly as the admin refund form posts it.
+		$refund = wc_create_refund(
+			array(
+				'amount'     => $refunded_item_total,
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$refunded_item_id     => array(
+						'qty'          => 1,
+						'refund_total' => $refunded_item_total,
+						'refund_tax'   => array( 1 => 0 ),
+					),
+					$downloadable_item_id => array(
+						'refund_total' => 0,
+						'refund_tax'   => array( 1 => 0 ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund, 'The refund should be created successfully.' );
+
+		$download_data_store = WC_Data_Store::load( 'customer-download' );
+		$remaining_downloads = $download_data_store->get_downloads(
+			array(
+				'order_id'   => $order->get_id(),
+				'product_id' => $downloadable_product->get_id(),
+			)
+		);
+		$this->assertCount(
+			1,
+			$remaining_downloads,
+			'Download permissions for a product that was not refunded must be kept.'
+		);
+	}
+
+	/**
 	 * Test wc_sanitize_order_id().
 	 */
 	public function test_wc_sanitize_order_id() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -693,6 +693,136 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Refunding a 0% taxed line item via the AJAX handler preserves the 0-rate tax line on the refund order.
+	 */
+	public function test_refund_line_items_preserves_zero_rate_tax(): void {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '0.0000',
+				'tax_rate_name'     => 'Zero Rate',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$order = new WC_Order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals( true );
+		$order->save();
+
+		$item_id = array_keys( $order->get_items( 'line_item' ) )[0];
+
+		$this->_setRole( 'administrator' );
+
+		// The exact payload shape the admin refund form serializes: the tax
+		// amount arrives as a numeric 0 (accounting.unformat of an empty field).
+		$_POST['security']             = wp_create_nonce( 'order-item' );
+		$_POST['order_id']             = $order->get_id();
+		$_POST['refund_amount']        = $order->get_total();
+		$_POST['refunded_amount']      = '0';
+		$_POST['refund_reason']        = '';
+		$_POST['line_item_qtys']       = wp_json_encode( array( $item_id => 1 ) );
+		$_POST['line_item_totals']     = wp_json_encode( array( $item_id => $order->get_total() ) );
+		$_POST['line_item_tax_totals'] = wp_json_encode( array( $item_id => array( $rate_id => 0 ) ) );
+		$_POST['api_refund']           = 'false';
+
+		$response = $this->do_ajax( 'woocommerce_refund_line_items' );
+
+		$this->assertTrue( $response['success'] ?? false, 'The AJAX refund request should succeed.' );
+
+		$refunds = wc_get_order( $order->get_id() )->get_refunds();
+		$this->assertCount( 1, $refunds, 'One refund should be created for the order.' );
+
+		$refund_tax_items = $refunds[0]->get_items( 'tax' );
+		$this->assertCount( 1, $refund_tax_items, 'The 0% tax line must be carried over to the refund order.' );
+		$this->assertEquals(
+			$rate_id,
+			array_values( $refund_tax_items )[0]->get_rate_id(),
+			'The preserved tax line must reference the 0% rate.'
+		);
+
+		unset( $_POST['security'], $_POST['order_id'], $_POST['refund_amount'], $_POST['refunded_amount'], $_POST['refund_reason'], $_POST['line_item_qtys'], $_POST['line_item_totals'], $_POST['line_item_tax_totals'], $_POST['api_refund'] );
+		WC_Tax::_delete_tax_rate( $rate_id );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+	}
+
+	/**
+	 * @testdox An amount-only AJAX refund on a multi-item order creates no line items and keeps downloads of unrefunded products.
+	 */
+	public function test_refund_line_items_amount_only_skips_untouched_items(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$downloadable_product = WC_Helper_Product::create_simple_product();
+		$downloadable_product->set_downloadable( true );
+		$downloadable_product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product, 1 );
+		$order->add_product( $downloadable_product, 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( 1 );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $downloadable_product->get_id() );
+		$download->set_download_id( wp_generate_uuid4() );
+		$download->save();
+
+		$item_ids = array_keys( $order->get_items( 'line_item' ) );
+
+		$this->_setRole( 'administrator' );
+
+		// An amount-only refund: the form posts no qtys, but a 0 total and a 0
+		// tax amount for every row in the order (those inputs are not gated).
+		$totals     = array();
+		$tax_totals = array();
+		foreach ( $item_ids as $item_id ) {
+			$totals[ $item_id ]     = 0;
+			$tax_totals[ $item_id ] = array( 1 => 0 );
+		}
+
+		$_POST['security']             = wp_create_nonce( 'order-item' );
+		$_POST['order_id']             = $order->get_id();
+		$_POST['refund_amount']        = '5';
+		$_POST['refunded_amount']      = '0';
+		$_POST['refund_reason']        = '';
+		$_POST['line_item_qtys']       = wp_json_encode( array() );
+		$_POST['line_item_totals']     = wp_json_encode( $totals );
+		$_POST['line_item_tax_totals'] = wp_json_encode( $tax_totals );
+		$_POST['api_refund']           = 'false';
+
+		$response = $this->do_ajax( 'woocommerce_refund_line_items' );
+
+		$this->assertTrue( $response['success'] ?? false, 'The AJAX refund request should succeed.' );
+
+		$refunds = wc_get_order( $order->get_id() )->get_refunds();
+		$this->assertCount( 1, $refunds, 'One refund should be created for the order.' );
+		$this->assertCount( 0, $refunds[0]->get_items( 'line_item' ), 'Untouched items must not become refund line items.' );
+		$this->assertCount( 0, $refunds[0]->get_items( 'tax' ), 'Untouched items must not produce refund tax items.' );
+
+		$download_data_store = WC_Data_Store::load( 'customer-download' );
+		$remaining_downloads = $download_data_store->get_downloads(
+			array(
+				'order_id'   => $order->get_id(),
+				'product_id' => $downloadable_product->get_id(),
+			)
+		);
+		$this->assertCount( 1, $remaining_downloads, 'Download permissions for a product that was not refunded must be kept.' );
+
+		unset( $_POST['security'], $_POST['order_id'], $_POST['refund_amount'], $_POST['refunded_amount'], $_POST['refund_reason'], $_POST['line_item_qtys'], $_POST['line_item_totals'], $_POST['line_item_tax_totals'], $_POST['api_refund'] );
+	}
+
+	/**
 	 * Does the 'hard work' of triggering an ajax endpoint and capturing the response.
 	 *
 	 * @param string $ajax_action The action to be triggered.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

A 0% tax rate is a valid rate (zero-rated VAT, tax-exempt classes), not "no tax", and must be recorded on refunds for accurate tax reporting. When refunding a line item taxed at 0%, the 0% tax line was silently dropped: `$refund->get_items( 'tax' )` held no entry for that rate.

The admin refund UI posts each tax total via `accounting.unformat()` as the numeric `0`, and `wc_format_decimal( 0 )` returns the falsy string `'0'`. Two cooperating callback-less `array_filter()` calls then stripped it — `WC_AJAX::refund_line_items()` before handing off, and `wc_create_refund()` again on its own input — so `update_taxes()` created no `WC_Order_Item_Tax` for the rate.

This keeps every numeric refund-tax entry (including `0`) at both sites. In `wc_create_refund()` the retained values are cast to `float` so the existing `array_map( 'wc_format_refund_total', ... )` calls (whose callback is typed `float`) keep a stable parameter type.

Closes #27118

### How to test the changes in this Pull Request:

1. Enable taxes: **WooCommerce → Settings → General → Enable tax rates and calculations**.
2. Under **WooCommerce → Settings → Tax → Standard rates**, add a rate with **Rate %** `0.0000` and a name like `Zero Rate`.
3. Create a taxable product (e.g. `$20`) in the standard tax class.
4. Place an order containing that product — the order shows a `$0.00` tax line.
5. On the order edit screen, click **Refund**, refund the single line item in full, then **Refund manually**.
6. Inspect the refund's tax items (WP-CLI / snippet):
   ```php
   $refund = current( wc_get_orders( [ 'parent' => <ORDER_ID>, 'type' => 'shop_order_refund' ] ) );
   var_dump( $refund->get_items( 'tax' ) );
   ```
   - **Before:** `array(0) {}` — the 0% tax line is missing.
   - **After:** one `WC_Order_Item_Tax` for `Zero Rate` with `tax_total` `0`.
7. Repeat with a non-zero rate to confirm normal tax refunds are unaffected.

### Testing that has already taken place:

- Reproduced on current `trunk` in wp-env through the faithful admin AJAX refund transform + real `wc_create_refund()`: the refund had **0** tax items. With the fix it has **1** (the 0% rate preserved, `tax_total` `0`).
- Added PHPUnit regression test `WC_Tests_Order_Functions::test_wc_create_refund_preserves_zero_rate_tax_27118`. It **fails on trunk** (0 vs 1 tax item) and **passes with the fix**. The full `WC_Tests_Order_Functions` class is green (46 tests, 1 pre-existing unrelated skip).
- `phpcs` clean on all changed lines; full-project PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — see `plugins/woocommerce/changelog/27118-fix-zero-rate-tax-refund` (patch / fix).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

