### PR TITLE
Performance: Limit WooPayments test orders query in LaunchYourStore API

### DIFF
--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -8,7 +8,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 // @ts-ignore No types for this exist yet.
 import SidebarNavigationItem from '@wordpress/edit-site/build-module/components/sidebar-navigation-item';
 import {
@@ -37,7 +37,7 @@ export const LaunchYourStoreHubSidebar = ( props: SidebarComponentProps ) => {
 		context: {
 			tasklist,
 			removeTestOrders: removeTestOrdersContext,
-			testOrderCount,
+			hasTestOrders,
 			launchStoreError,
 		},
 	} = props;
@@ -146,7 +146,7 @@ export const LaunchYourStoreHubSidebar = ( props: SidebarComponentProps ) => {
 						</SidebarNavigationItem>
 					) }
 				</ItemGroup>
-				{ testOrderCount > 0 && (
+				{ hasTestOrders && (
 					<>
 						<div className="woocommerce-edit-site-sidebar-navigation-screen-test-data__group-header">
 							<Heading level={ 2 }>
@@ -156,13 +156,9 @@ export const LaunchYourStoreHubSidebar = ( props: SidebarComponentProps ) => {
 						<ItemGroup className="woocommerce-edit-site-sidebar-navigation-screen-remove-test-data__group">
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ sprintf(
-									// translators: %d is the number of test orders
-									__(
-										'Remove %d test orders',
-										'woocommerce'
-									),
-									testOrderCount
+								label={ __(
+									'Remove test orders',
+									'woocommerce'
 								) }
 								checked={ removeTestOrders }
 								onChange={ setRemoveTestOrder }

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/test/payments-sidebar.test.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/test/payments-sidebar.test.tsx
@@ -217,7 +217,7 @@ const mockProps = {
 	context: {
 		externalUrl: null,
 		mainContentMachineRef: {} as never, // Mock ref
-		testOrderCount: 0,
+		hasTestOrders: false,
 		tasklist: {
 			tasks: [],
 		},

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -56,7 +56,7 @@ export type SidebarMachineContext = {
 	mainContentMachineRef: ActorRefFrom< typeof mainContentMachine >;
 	tasklist?: LYSAugmentedTaskListType;
 	hasWooPayments?: boolean;
-	testOrderCount: number;
+	hasTestOrders?: boolean;
 	removeTestOrders?: boolean;
 	launchStoreAttemptTimestamp?: number;
 	launchStoreError?: {
@@ -96,13 +96,13 @@ const launchStoreAction = async () => {
 	throw new Error( JSON.stringify( results ) );
 };
 
-const getTestOrderCount = async () => {
+const hasTestOrders = async () => {
 	const result = ( await apiFetch( {
-		path: '/wc-admin/launch-your-store/woopayments/test-orders/count',
+		path: '/wc-admin/launch-your-store/woopayments/test-orders/has',
 		method: 'GET',
-	} ) ) as { count: number };
+	} ) ) as { has_orders: boolean };
 
-	return result.count;
+	return result.has_orders;
 };
 
 export const pageHasComingSoonMetaTag = async ( {
@@ -350,6 +350,9 @@ export const sidebarMachine = setup( {
 		hasWooPayments: ( { context } ) => {
 			return !! context.hasWooPayments;
 		},
+		hasTestOrders: ( { context } ) => {
+			return !! context.hasTestOrders;
+		},
 		siteIsShowingCachedContent: ( { context } ) => {
 			return !! context.siteIsShowingCachedContent;
 		},
@@ -357,7 +360,7 @@ export const sidebarMachine = setup( {
 	actors: {
 		sidebarQueryParamListener,
 		getTasklist: fromPromise( getLysTasklist ),
-		getTestOrderCount: fromPromise( getTestOrderCount ),
+		hasTestOrders: fromPromise( hasTestOrders ),
 		getSiteCachedStatus: fromPromise( getSiteCachedStatus ),
 		updateLaunchStoreOptions: fromPromise( launchStoreAction ),
 		deleteTestOrders: fromPromise( deleteTestOrders ),
@@ -369,7 +372,6 @@ export const sidebarMachine = setup( {
 	initial: 'navigate',
 	context: ( { input } ) => ( {
 		externalUrl: null,
-		testOrderCount: 0,
 		mainContentMachineRef: input.mainContentMachineRef,
 	} ),
 	invoke: {
@@ -432,34 +434,40 @@ export const sidebarMachine = setup( {
 							actions: assign( {
 								hasWooPayments: ( { event } ) => event.output,
 							} ),
-							target: 'maybeCountTestOrders',
+							target: 'maybeCheckTestOrders',
 						},
 						onError: {
-							target: 'maybeCountTestOrders',
+							target: 'maybeCheckTestOrders',
 						},
 					},
 				},
-				maybeCountTestOrders: {
+				maybeCheckTestOrders: {
 					always: [
 						{
 							guard: 'hasWooPayments',
-							target: 'countTestOrders',
+							target: 'hasTestOrders',
 						},
 						{
+							actions: assign( {
+								hasTestOrders: false,
+							} ),
 							target: 'launchYourStoreHub',
 						},
 					],
 				},
-				countTestOrders: {
+				hasTestOrders: {
 					invoke: {
-						src: 'getTestOrderCount',
+						src: 'hasTestOrders',
 						onDone: {
 							actions: assign( {
-								testOrderCount: ( { event } ) => event.output,
+								hasTestOrders: ( { event } ) => event.output,
 							} ),
 							target: 'launchYourStoreHub',
 						},
 						onError: {
+							actions: assign( {
+								hasTestOrders: false,
+							} ),
 							target: 'launchYourStoreHub',
 						},
 					},
@@ -527,10 +535,10 @@ export const sidebarMachine = setup( {
 							actions: assign( {
 								hasWooPayments: ( { event } ) => event.output,
 							} ),
-							target: 'backgroundMaybeCountTestOrders',
+							target: 'backgroundMaybeCheckTestOrders',
 						},
 						onError: {
-							target: 'backgroundMaybeCountTestOrders',
+							target: 'backgroundMaybeCheckTestOrders',
 						},
 					},
 					on: {
@@ -542,7 +550,7 @@ export const sidebarMachine = setup( {
 						},
 					},
 				},
-				backgroundMaybeCountTestOrders: {
+				backgroundMaybeCheckTestOrders: {
 					tags: 'sidebar-visible',
 					meta: {
 						component: LaunchYourStoreHubSidebar,
@@ -551,28 +559,34 @@ export const sidebarMachine = setup( {
 					always: [
 						{
 							guard: 'hasWooPayments',
-							target: 'backgroundCountTestOrders',
+							target: 'backgroundHasTestOrders',
 						},
 						{
+							actions: assign( {
+								hasTestOrders: false,
+							} ),
 							target: 'launchYourStoreHub',
 						},
 					],
 				},
-				backgroundCountTestOrders: {
+				backgroundHasTestOrders: {
 					tags: 'sidebar-visible',
 					meta: {
 						component: LaunchYourStoreHubSidebar,
 						mobileHeader: LaunchStoreHubMobileHeader,
 					},
 					invoke: {
-						src: 'getTestOrderCount',
+						src: 'hasTestOrders',
 						onDone: {
 							actions: assign( {
-								testOrderCount: ( { event } ) => event.output,
+								hasTestOrders: ( { event } ) => event.output,
 							} ),
 							target: 'launchYourStoreHub',
 						},
 						onError: {
+							actions: assign( {
+								hasTestOrders: false,
+							} ),
 							target: 'launchYourStoreHub',
 						},
 					},

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -167,6 +167,7 @@ class LaunchYourStore {
 				// phpcs:ignore
 				'meta_value' => 'test',
 				'return'     => 'ids',
+				'limit'      => 1,
 			)
 		);
 

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -80,6 +80,18 @@ class LaunchYourStore {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/woopayments/test-orders/has',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'has_woopay_test_orders' ),
+					'permission_callback' => array( $this, 'must_be_shop_manager_or_admin' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/woopayments/test-orders/count',
 			array(
 				array(
@@ -151,27 +163,66 @@ class LaunchYourStore {
 	}
 
 	/**
-	 * Count the test orders created during Woo Payments test mode.
+	 * Get the query arguments for WooPayments test orders.
 	 *
-	 * @return \WP_REST_Response
+	 * @param array $args Additional query arguments.
+	 *
+	 * @return array
 	 */
-	public function get_woopay_test_orders_count() {
-		$return = function ( $count ) {
-			return new \WP_REST_Response( array( 'count' => $count ) );
-		};
-
-		$orders = wc_get_orders(
+	private function get_woopay_test_orders_query_args( array $args = array() ) {
+		return array_merge(
 			array(
 				// phpcs:ignore
 				'meta_key'   => '_wcpay_mode',
 				// phpcs:ignore
 				'meta_value' => 'test',
 				'return'     => 'ids',
-				'limit'      => 1,
+			),
+			$args
+		);
+	}
+
+	/**
+	 * Check whether WooPayments test orders exist.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function has_woopay_test_orders() {
+		$orders = wc_get_orders(
+			$this->get_woopay_test_orders_query_args(
+				array(
+					'limit' => 1,
+				)
 			)
 		);
 
-		return $return( count( $orders ) );
+		return new \WP_REST_Response(
+			array(
+				'has_orders' => ! empty( $orders ),
+			)
+		);
+	}
+
+	/**
+	 * Count the test orders created during Woo Payments test mode.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function get_woopay_test_orders_count() {
+		$query = wc_get_orders(
+			$this->get_woopay_test_orders_query_args(
+				array(
+					'paginate' => true,
+					'limit'    => 1,
+				)
+			)
+		);
+
+		return new \WP_REST_Response(
+			array(
+				'count' => is_object( $query ) && isset( $query->total ) ? (int) $query->total : 0,
+			)
+		);
 	}
 
 	/**
@@ -184,17 +235,28 @@ class LaunchYourStore {
 			return new \WP_REST_Response( null, $status );
 		};
 
-		$orders = wc_get_orders(
+		$query_args = $this->get_woopay_test_orders_query_args(
 			array(
-				// phpcs:ignore
-				'meta_key'   => '_wcpay_mode',
-				// phpcs:ignore
-				'meta_value' => 'test',
+				'limit'   => 100,
+				'orderby' => 'ID',
+				'order'   => 'ASC',
 			)
 		);
 
-		foreach ( $orders as $order ) {
-			$order->delete();
+		$processed_ids = array();
+		$order_ids     = wc_get_orders( $query_args );
+
+		while ( ! empty( $order_ids ) ) {
+			foreach ( $order_ids as $order_id ) {
+				$order = wc_get_order( $order_id );
+				if ( $order ) {
+					$order->delete( true );
+				}
+				$processed_ids[] = $order_id;
+			}
+
+			$query_args['exclude'] = $processed_ids;
+			$order_ids             = wc_get_orders( $query_args );
 		}
 
 		return $return();

--- a/plugins/woocommerce/tests/php/src/Admin/API/LaunchYourStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/LaunchYourStoreTest.php
@@ -45,6 +45,16 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Check whether any WooPayments test orders exist.
+	 *
+	 * @return bool
+	 */
+	protected function has_test_orders() {
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/woopayments/test-orders/has' );
+		return $this->server->dispatch( $request )->get_data()['has_orders'];
+	}
+
+	/**
 	 * Add a new test order
 	 *
 	 * @return void
@@ -53,6 +63,19 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 		$order = OrderHelper::create_order( $this->user );
 		$order->update_meta_data( '_wcpay_mode', 'test' );
 		$order->save();
+	}
+
+	/**
+	 * Add multiple WooPayments test orders.
+	 *
+	 * @param int $count Number of orders to create.
+	 *
+	 * @return void
+	 */
+	protected function add_test_orders( int $count ) {
+		for ( $i = 0; $i < $count; $i++ ) {
+			$this->add_test_order();
+		}
 	}
 
 	/**
@@ -65,9 +88,23 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 0, $count );
 
 		$this->add_test_order();
+		$this->add_test_order();
 
 		$count = $this->get_order_count();
-		$this->assertEquals( 1, $count );
+		$this->assertEquals( 2, $count );
+	}
+
+	/**
+	 * Test order presence endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_it_returns_whether_test_orders_exist() {
+		$this->assertFalse( $this->has_test_orders() );
+
+		$this->add_test_order();
+
+		$this->assertTrue( $this->has_test_orders() );
 	}
 
 	/**
@@ -88,8 +125,25 @@ class LaunchYourStoreTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_endpoint_deletes_test_order() {
 		$this->add_test_order();
+		$this->add_test_order();
 		$request = new WP_REST_Request( 'DELETE', self::ENDPOINT . '/woopayments/test-orders' );
 		$this->server->dispatch( $request );
 		$this->assertEquals( 0, $this->get_order_count() );
+		$this->assertFalse( $this->has_test_orders() );
+	}
+
+	/**
+	 * Test delete endpoint deletes test orders across multiple batches.
+	 *
+	 * @return void
+	 */
+	public function test_delete_endpoint_deletes_test_orders_across_multiple_batches() {
+		$this->add_test_orders( 101 );
+
+		$request = new WP_REST_Request( 'DELETE', self::ENDPOINT . '/woopayments/test-orders' );
+		$this->server->dispatch( $request );
+
+		$this->assertEquals( 0, $this->get_order_count() );
+		$this->assertFalse( $this->has_test_orders() );
 	}
 }


### PR DESCRIPTION
This PR adds a `'limit' => 1` parameter to the order query in `get_woopay_test_orders_count`. Since the method only needs to detect whether any test orders exist (to show or hide the task), fetching all orders from the database is unnecessary and can cause out-of-memory errors on large sites.

Closes woocommerce/woocommerce#66224.

### Changes proposed in this Pull Request:

Previously, `LaunchYourStore::get_woopay_test_orders_count` performed an unbounded `wc_get_orders()` query to count WooCommerce Payments test orders. If a high-volume merchant switched to WooCommerce Payments with a large number of existing test orders in their database, this could trigger out-of-memory (OOM) errors.

Since the application only needs to know whether at least one test order exists, this PR adds a `'limit' => 1` parameter to the query.

### How to test the changes in this Pull Request:

1. Create a test order:

   ```
   wp wc shop_order create --status=completed --porcelain --user=YOUR_ADMIN_USER
   ```
2. Set the `_wcpay_mode` metadata on the created order (replace `42` with the order ID from step 1):

   ```
   wp eval "$order = wc_get_order(42); if ($order) { $order->update_meta_data('_wcpay_mode', 'test'); $order->save(); echo 'Meta saved!'; }"
   ```
3. Verify the limited query returns exactly one result:

   ```
   wp eval "print_r(wc_get_orders(array('meta_key' => '_wcpay_mode', 'meta_value' => 'test', 'return' => 'ids', 'limit' => 1)));"
   ```

   Expected output:

   ```
   Array
   (
       [0] => 42
   )
   ```

### Changelog entry

- [X] Automatically create a changelog entry from the details below.

Significance: Patch

Type: Performance

Message: Performance — Limit the WooCommerce Payments test orders query to 1 in the Launch Your Store task to prevent out-of-memory errors on large stores.