### PR TITLE
Remove obsolete OAuth documentation link

### DIFF
--- a/plugins/woocommerce/changelog/fix-53799-dead-oauth-link
+++ b/plugins/woocommerce/changelog/fix-53799-dead-oauth-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove an obsolete OAuth reference from REST API authentication documentation.

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -340,7 +340,7 @@ class WC_REST_Authentication {
 	}
 
 	/**
-	 * Perform OAuth 1.0a "one-legged" (http://oauthbible.com/#oauth-10a-one-legged) authentication for non-SSL requests.
+	 * Perform OAuth 1.0a "one-legged" authentication for non-SSL requests.
 	 *
 	 * This is required so API credentials cannot be sniffed or intercepted when making API requests over plain HTTP.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The authentication method's docblock links to `oauthbible.com`, which no longer provides valid reference material and now resolves to spam. Remove the obsolete link while retaining the existing RFC 5849 context for the OAuth 1.0a implementation.

Closes woocommerce/woocommerce#53799.

(For Bug Fixes) Bug introduced in PR [#10435](<https://github.com/woocommerce/woocommerce/issues/10435>).

### Screenshots or screen recordings:

Not applicable; this change only updates an inline PHP docblock.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Open `plugins/woocommerce/includes/class-wc-rest-authentication.php`.
2. Find the `perform_oauth_authentication()` docblock.
3. Confirm it no longer references `oauthbible.com` and still identifies RFC 5849 as the OAuth 1.0a specification.

### Testing that has already taken place:

* `git diff --check` passed.
* A targeted search confirmed `oauthbible.com` is absent from the updated file and the RFC 5849 context remains.
* The manually created changelog entry matches the repository's `patch` / `tweak` format.
* Runtime tests are not applicable because executable code is unchanged.
* The prescribed PHP lint and PHPStan commands could not run locally because PHP and Composer are unavailable in this environment; dependency bootstrap also stopped on the existing pnpm trust policy for `allure-js-commons@3.7.1` and `allure-playwright@3.7.1`. No lockfile changes were made.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `plugins/woocommerce/changelog/fix-53799-dead-oauth-link`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>