### PR TITLE
Add regression test for flat-rate shipping cost entered with a thousand separator

### DIFF
--- a/plugins/woocommerce/changelog/add-flat-rate-thousand-separator-test
+++ b/plugins/woocommerce/changelog/add-flat-rate-thousand-separator-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add regression test for flat-rate shipping cost entered with a thousand separator.

--- a/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
+++ b/plugins/woocommerce/tests/php/includes/shipping/flat-rate/class-wc-shipping-flat-rate-test.php
@@ -248,4 +248,54 @@ class WC_Shipping_Flat_Rate_Test extends WC_Unit_Test_Case {
 			'alphanumeric'                  => array( '10abc', '.', ',' ),
 		);
 	}
+
+	/**
+	 * @testDox sanitize_cost() delocalises a plain thousand-separated cost so it is never evaluated as free shipping.
+	 *
+	 * Regression guard for #47864: a flat rate entered with a thousand separator (for
+	 * example "1,234.56") must be delocalised to a clean numeric value, not silently
+	 * collapsed to a wrong or zero amount. The delocalisation runs through
+	 * NumberUtil::sanitize_cost_in_current_locale(); this asserts the flat-rate wiring
+	 * to it, and that the sanitized value then evaluates to the expected cost.
+	 *
+	 * @dataProvider provider_thousand_separated_costs
+	 *
+	 * @param string $value        Raw cost as a merchant would enter it.
+	 * @param string $decimal_sep  Decimal separator for the locale.
+	 * @param string $thousand_sep Thousand separator for the locale.
+	 * @param string $expected     Delocalised cost sanitize_cost() should return.
+	 * @param float  $evaluated    Amount evaluate_cost() should yield for the sanitized cost.
+	 */
+	public function test_sanitize_cost_delocalises_thousand_separated_value( string $value, string $decimal_sep, string $thousand_sep, string $expected, float $evaluated ): void {
+		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );
+		update_option( 'woocommerce_price_thousand_sep', $thousand_sep );
+
+		$sanitized = $this->call_sanitize_cost->call( $this->sut, $value );
+		$this->assertEquals( $expected, trim( $sanitized ) );
+
+		$result = $this->call_evaluate_cost->call(
+			$this->sut,
+			$sanitized,
+			array(
+				'qty'  => 1,
+				'cost' => 1,
+			)
+		);
+		$this->assertEquals( $evaluated, $result );
+	}
+
+	/**
+	 * Plain (non-expression) thousand-separated costs across locales.
+	 *
+	 * Format: [ value, decimal_separator, thousand_separator, expected_sanitized, expected_evaluated ]
+	 */
+	public function provider_thousand_separated_costs(): array {
+		return array(
+			// period decimal, comma thousand (US).
+			'US thousand separator' => array( '1,234.56', '.', ',', '1234.56', 1234.56 ),
+
+			// comma decimal, period thousand (EU).
+			'EU thousand separator' => array( '1.234,56', ',', '.', '1234.56', 1234.56 ),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

Adds a regression test for a flat-rate shipping cost entered with a thousand separator (for example `1,234.56` in a US locale, or `1.234,56` in an EU locale).

`WC_Shipping_Flat_Rate::sanitize_cost()` delocalises a plain cost through `NumberUtil::sanitize_cost_in_current_locale()` before it is evaluated, so a thousand-separated amount resolves to the correct value rather than a wrong, near-zero one. `NumberUtil` itself is well covered, but the flat-rate `sanitize_cost()` wiring to it had no test for a plain thousand-separated value: the existing cases cover math expressions and sub-thousand plain numbers only. This test closes that gap and guards the delegation.

Closes #47864.

### How to test the changes in this Pull Request:

1. Run `pnpm test:php:env -- --filter WC_Shipping_Flat_Rate_Test` and confirm the suite passes, including `test_sanitize_cost_delocalises_thousand_separated_value` (2 cases, US and EU locales).
2. To see the behaviour it guards, temporarily remove the `NumberUtil::sanitize_cost_in_current_locale()` call in `WC_Shipping_Flat_Rate::sanitize_cost()` and re-run: the new test fails, because `sanitize_cost( '1,234.56' )` then returns `1,234.56` unchanged instead of `1234.56`. Restore the line and it passes.

### Testing that has already taken place:

- phpcs passes on the test file against the WooCommerce ruleset.
- Verified the asserted behaviour by executing the exact code path against a WooCommerce 10.9.4 runtime: `sanitize_cost( '1,234.56' )` returns `1234.56` and evaluates to `1234.56` (US locale), and `sanitize_cost( '1.234,56' )` returns `1234.56` (EU locale). With the `NumberUtil` delegation bypassed, the same inputs evaluate to a wrong, near-zero amount (`0.69` instead of `1234.56`), which is the merchant-facing bug this coverage protects against.

### Milestone

- [x] Automatically assign milestone for the next WooCommerce version

### Changelog entry

Changelog entry added manually (`Type: dev`).

🤖 Pinned the thousand-separated flat rate against reading as free by Claude (on behalf of Daniel)
