### PR TITLE
Fix auto-milestone assignment for fork PRs after actions/checkout v7 bump

### DIFF
--- a/.github/workflows/pr-auto-milestone-on-merge.yml
+++ b/.github/workflows/pr-auto-milestone-on-merge.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Fork PRs need this. Without it, under pull_request_target checkout defaults its commit
+          # to github.sha, which for a merged fork PR is the merge commit that actions/checkout
+          # refuses to check out due to its "pwn request" guard.
+          ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
             .github/workflows/scripts
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Community (fork) pull requests merged into `trunk` stopped receiving their automatic milestone. The `actions/checkout` bump from v4 to v7.0.0 in #66434 introduced a "pwn request" safety guard that refuses to check out fork PR code in a `pull_request_target` workflow, and that breaking change was not accounted for in the `Auto-assign milestone on merge` workflow. Its Checkout step therefore failed before the assignment script could run, and the milestone was silently skipped for every fork PR merged after the bump.

For example:
- #66544
- https://github.com/woocommerce/woocommerce/actions/runs/29325804304/job/87061695004?pr=66544
   <img width="1431" height="480" alt="image" src="https://github.com/user-attachments/assets/1522cf6b-a590-42d4-9996-9924b851cd9f" />

(For Bug Fixes) Bug introduced in PR #66434.

### How to test the changes in this Pull Request:

💡 Because it cannot be tested live before merging, the reproduction and end-to-end validation already performed are described in the "Testing that has already taken place" section below.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. 📌 This fix only takes effect once it has landed on trunk. Live verification is therefore the first community (fork) pull request merged into trunk after this PR lands.
2. When the next community (fork) pull request is merged into trunk, its **Auto-assign milestone on merge** run passes, and the Checkout step succeeds.
3. That fork pull request receives the next-version milestone automatically.
4. Internal (non-fork) pull requests continue to be milestoned as before.

<!-- End testing instructions -->

### Testing that has already taken place:

The fix was reproduced and verified end-to-end in another repository, https://github.com/eason9487/gha-playground:

1. **Created the workflow.** A `pull_request_target: [closed]` workflow that checks out with the same pinned `actions/checkout@v7.0.0` and no `ref`, mirroring the `pr-auto-milestone-on-merge.yml` workflow.
   - https://github.com/eason9487/gha-playground/commit/23443d743f85b045902e24eefe16f4072a7737ae
2. **Reproduced the failure.** A fork pull request opened from a second account was merged into the base branch. The workflow failed at the Checkout step with "Refusing to check out fork pull request code from a 'pull_request_target' workflow".
   - https://github.com/eason9487/gha-playground/pull/5
   - https://github.com/eason9487/gha-playground/actions/runs/29387628486/job/87264077862
      <img width="1431" height="559" alt="image" src="https://github.com/user-attachments/assets/f85b6e1f-8029-4d67-baca-f1d3c4fc5abb" />
3. **Applied the same fix.** Added `ref: ${{ github.event.pull_request.base.ref }}` to the Checkout step, identical to this PR.
   - https://github.com/eason9487/gha-playground/commit/70ffc78b7f85156efcc0a2b7ab3c66138a9817e1
5. **Confirmed the fix.** A second fork pull request was merged into the base branch. The Checkout step now succeeded, and the run passed.
   - https://github.com/eason9487/gha-playground/pull/6
   - https://github.com/eason9487/gha-playground/actions/runs/29387843526/job/87264707625
      <img width="1428" height="782" alt="image" src="https://github.com/user-attachments/assets/e7267205-121f-4b47-976b-5291fb68c9ee" />
6. **Verified internal (non-fork) PRs are unaffected.** With the fix in place, a non-fork pull request merged into the base branch also passed the Checkout step, confirming the `ref` pin does not regress the internal PR path (the guard only ever blocks fork PRs).
   - https://github.com/eason9487/gha-playground/pull/7
   - https://github.com/eason9487/gha-playground/actions/runs/29389932072/job/87270907102
      <img width="1432" height="778" alt="image" src="https://github.com/user-attachments/assets/e9171890-696d-44d5-a0bf-c0e4deab1233" />

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

GitHub Actions workflow change (release automation only). Nothing is shipped to merchants, so no changelog entry is required.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
