### PR TITLE
[Email Editor] Fix global typography rendering

### DIFF
--- a/packages/php/email-editor/changelog/fix-global-email-typography-rendering
+++ b/packages/php/email-editor/changelog/fix-global-email-typography-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure emails render global font weight, style, and letter spacing.

--- a/packages/php/email-editor/changelog/issue-60168
+++ b/packages/php/email-editor/changelog/issue-60168
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure emails render the selected global font weight.

--- a/packages/php/email-editor/changelog/issue-60168
+++ b/packages/php/email-editor/changelog/issue-60168
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Ensure emails render the selected global font weight.

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -139,6 +139,7 @@ class Renderer {
 					'padding-top'      => $email_styles['spacing']['padding']['top'] ?? '0px',
 					'padding-bottom'   => $email_styles['spacing']['padding']['bottom'] ?? '0px',
 					'font-family'      => $email_styles['typography']['fontFamily'] ?? 'inherit',
+					'font-weight'      => $email_styles['typography']['fontWeight'] ?? 'inherit',
 					'line-height'      => $email_styles['typography']['lineHeight'] ?? '1.5',
 					'font-size'        => $email_styles['typography']['fontSize'] ?? 'inherit',
 					'direction'        => $rendering_context->get_text_direction(),

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -140,6 +140,8 @@ class Renderer {
 					'padding-bottom'   => $email_styles['spacing']['padding']['bottom'] ?? '0px',
 					'font-family'      => $email_styles['typography']['fontFamily'] ?? 'inherit',
 					'font-weight'      => $email_styles['typography']['fontWeight'] ?? 'inherit',
+					'font-style'       => $email_styles['typography']['fontStyle'] ?? 'inherit',
+					'letter-spacing'   => $email_styles['typography']['letterSpacing'] ?? 'normal',
 					'line-height'      => $email_styles['typography']['lineHeight'] ?? '1.5',
 					'font-size'        => $email_styles['typography']['fontSize'] ?? 'inherit',
 					'direction'        => $rendering_context->get_text_direction(),

--- a/packages/php/email-editor/src/Engine/theme.md
+++ b/packages/php/email-editor/src/Engine/theme.md
@@ -11,7 +11,7 @@ In this file we want to document settings and styles that are specific to the em
 - **layout**: We set content width to 660px, because it's the most common width for emails. This is meant as a default value.
 - **spacing**: We allow only px units, because they are the most reliable in email clients. We may add the support for other units later with some sort of conversion to px. We also disable margins because they are not supported in our renderer (margin collapsing might be tricky).
 - **border**: We want to allow all types of borders and border styles.
-- **typography**: We enable fontWeight because it is supported by our renderer. We disable the dropCap appearance setting because it is not supported. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
+- **typography**: We enable fontWeight, fontStyle, and letterSpacing because they are supported by our renderer. We disable the dropCap appearance setting because it is not supported. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
 
 ## Styles
 

--- a/packages/php/email-editor/src/Engine/theme.md
+++ b/packages/php/email-editor/src/Engine/theme.md
@@ -11,7 +11,7 @@ In this file we want to document settings and styles that are specific to the em
 - **layout**: We set content width to 660px, because it's the most common width for emails. This is meant as a default value.
 - **spacing**: We allow only px units, because they are the most reliable in email clients. We may add the support for other units later with some sort of conversion to px. We also disable margins because they are not supported in our renderer (margin collapsing might be tricky).
 - **border**: We want to allow all types of borders and border styles.
-- **typography**: We enable fontWeight, fontStyle, and letterSpacing because they are supported by our renderer. We disable the dropCap appearance setting because it is not supported. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
+- **typography**: We enable fontWeight, fontStyle, and letterSpacing because they are supported by our renderer. We disable the dropCap appearance setting because it is not supported. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle-tested legacy editor.
 
 ## Styles
 

--- a/packages/php/email-editor/src/Engine/theme.md
+++ b/packages/php/email-editor/src/Engine/theme.md
@@ -11,7 +11,7 @@ In this file we want to document settings and styles that are specific to the em
 - **layout**: We set content width to 660px, because it's the most common width for emails. This is meant as a default value.
 - **spacing**: We allow only px units, because they are the most reliable in email clients. We may add the support for other units later with some sort of conversion to px. We also disable margins because they are not supported in our renderer (margin collapsing might be tricky).
 - **border**: We want to allow all types of borders and border styles.
-- **typography**: We disabled fontWeight and dropCap appearance settings, because they are not supported in our renderer. We may add the support later. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
+- **typography**: We enable fontWeight because it is supported by our renderer. We disable the dropCap appearance setting because it is not supported. We also define a set of basic font families that are safe to use with emails. The list was copied from the battle tested legacy editor.
 
 ## Styles
 

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -47,6 +47,7 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			),
 			'typography' => array(
 				'fontFamily' => 'Test Font Family',
+				'fontWeight' => '400',
 			),
 			'color'      => array(
 				'background' => '#123456',
@@ -281,6 +282,7 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$style = $wrapper->getAttribute( 'style' );
 		$this->assertStringContainsString( 'background-color: #123456', $style );
 		$this->assertStringContainsString( 'font-family: Test Font Family;', $style );
+		$this->assertStringContainsString( 'font-weight: 400;', $style );
 		$this->assertStringContainsString( 'padding-top: 3px;', $style );
 		$this->assertStringContainsString( 'padding-bottom: 4px;', $style );
 		// Horizontal padding is now distributed to individual block wrappers via Spacing_Preprocessor.

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -46,8 +46,10 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 				),
 			),
 			'typography' => array(
-				'fontFamily' => 'Test Font Family',
-				'fontWeight' => '400',
+				'fontFamily'    => 'Test Font Family',
+				'fontWeight'    => '300',
+				'fontStyle'     => 'italic',
+				'letterSpacing' => '-0.1px',
 			),
 			'color'      => array(
 				'background' => '#123456',
@@ -268,6 +270,9 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$style = $this->getStylesValueForTag( $rendered['html'], array( 'tag_name' => 'body' ) );
 		$this->assertIsString( $style );
 		$this->assertStringContainsString( 'background-color: #123456', $style );
+		$this->assertStringContainsString( 'font-weight: 300;', $style );
+		$this->assertStringContainsString( 'font-style: italic;', $style );
+		$this->assertStringContainsString( 'letter-spacing: -.1px;', $style );
 
 		// Verify layout element styles.
 		$doc = new \DOMDocument();
@@ -282,7 +287,9 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$style = $wrapper->getAttribute( 'style' );
 		$this->assertStringContainsString( 'background-color: #123456', $style );
 		$this->assertStringContainsString( 'font-family: Test Font Family;', $style );
-		$this->assertStringContainsString( 'font-weight: 400;', $style );
+		$this->assertStringContainsString( 'font-weight: 300;', $style );
+		$this->assertStringContainsString( 'font-style: italic;', $style );
+		$this->assertStringContainsString( 'letter-spacing: -.1px;', $style );
 		$this->assertStringContainsString( 'padding-top: 3px;', $style );
 		$this->assertStringContainsString( 'padding-bottom: 4px;', $style );
 		// Horizontal padding is now distributed to individual block wrappers via Spacing_Preprocessor.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Email Editor syncs compatible site typography into the email theme, but the PHP renderer omitted the global `fontWeight`, `fontStyle`, and `letterSpacing` values from the rendered email. This caused the editor canvas and delivered email to use different typography. For example, Twenty Twenty-Five supplies a root font weight of `300` and letter spacing of `-0.1px`; the editor applied both, while the rendered email did not.

Apply these global typography values to the rendered email body and layout wrapper, and cover the generated inline styles with integration assertions.

Bug introduced in PR #55598.

### Screenshots or screen recordings:

| Editor canvas | Rendered New order email |
| --- | --- |
| ![WooCommerce Email Editor using the typography synced from Twenty Twenty-Five, including the Light appearance](https://gist.githubusercontent.com/annchichi/ca482b6d303adf06a8b52f7d4c0bf5d1/raw/tt5-email-editor-global-typography.png) | ![WooCommerce New order email rendering the synced global typography](https://gist.githubusercontent.com/annchichi/ca482b6d303adf06a8b52f7d4c0bf5d1/raw/tt5-rendered-email-global-typography.png) |

Both screenshots use an unmodified Twenty Twenty-Five site with site-style sync enabled. WebDriver inspection confirmed that regular text in both the editor and rendered preview uses `font-weight: 300` and `letter-spacing: -0.1px`, while element-specific heading weights remain intact.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the Email Editor test environment from `packages/php/email-editor` with `pnpm env:test`.
2. Run `pnpm test:integration -- --filter Renderer_Test::testItInlinesWrappersStyles`.
3. Confirm the test verifies `font-weight`, `font-style`, and `letter-spacing` on both the rendered `body` and `.email_layout_wrapper`.
4. In a WooCommerce test site, activate Twenty Twenty-Five and enable the block email editor.
5. Go to **WooCommerce > Settings > Emails**, select **Edit template**, then open **Styles > Typography > Text**.
6. Confirm the site styles synced from Twenty Twenty-Five show the Light appearance. The editor canvas should use a computed font weight of `300` and letter spacing of `-0.1px`.
7. Return to the Emails settings and preview the New order email.
8. Confirm regular text in the rendered preview also uses a computed font weight of `300` and letter spacing of `-0.1px`. Element-specific heading weights should remain unchanged.
9. In the editor, select an italic appearance, save, and confirm the rendered preview uses `font-style: italic`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Email Editor `Renderer_Test` integration suite on PHP 8.1: 64 tests, 415 assertions.
- PHPCS on both changed PHP files.
- PHPStan with the package's PHP 8 and PHP 7.4 configurations.
- WooCommerce branch PHP lint commands.
- BrowserStack Automate on Windows 10 and Firefox 152 with Twenty Twenty-Five: regular text in the editor and rendered New order preview used a computed `font-weight` of `300` and `letter-spacing` of `-0.1px`; element-specific heading weights remained unchanged.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
