### PR TITLE
Use `WC_BOT_PR_CREATE_TOKEN` for creating releases in build workflow

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Create draft release
         id: create_release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
           IS_PRERELEASE: ${{ contains( steps.get_version.outputs.version, '-dev' ) || contains( steps.get_version.outputs.version, '-beta' ) || contains( steps.get_version.outputs.version, '-rc' ) }}
         run: |


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The `create-release` job in `release-build-zip-file.yml` authenticated with the default `github.token` when calling `gh release create`.
If the target commit sits on a release branch whose `.github/workflows` files have drifted from trunk, GitHub requires the token to also include the `workflows` write permission, which the auto-generated token can never have, causing the step to fail.

This PR switches the job to use the `WC_BOT_PR_CREATE_TOKEN` bot credential instead.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

The token belongs already has both `contents: write` and `workflows: write`, as required [by the GH REST API](https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release), and it's the only thing being switched in this PR, so no additional testing should be necessary.

Still, I [ran a simplified version](https://github.com/woocommerce/woocommerce/actions/runs/29409520475/job/87333030105) of the workflow to confirm the token can indeed create releases, which was successful.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal release-automation workflow fix.

</details>