### PR TITLE
Make admin notices dismissable without reloading the page

### DIFF
--- a/plugins/woocommerce/changelog/38629-async-admin-notice-dismiss
+++ b/plugins/woocommerce/changelog/38629-async-admin-notice-dismiss
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Dismiss WooCommerce admin notices asynchronously instead of reloading the page. The query-string based dismissal is kept as a no-JS fallback.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-admin-notices.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-admin-notices.js
@@ -1,0 +1,69 @@
+( function () {
+	'use strict';
+
+	/**
+	 * Dismiss WooCommerce admin notices asynchronously.
+	 *
+	 * Notice dismiss links point at the current page with a `wc-hide-notice`
+	 * query arg, which persists the dismissal via a full page reload. Here we
+	 * intercept the click, persist the dismissal over admin-ajax instead, and
+	 * remove the notice in place. The link href is kept intact as a no-JS
+	 * fallback, and on any request failure we fall back to following it.
+	 */
+	document.addEventListener( 'click', function ( event ) {
+		var link = event.target.closest(
+			'a.woocommerce-message-close[href*="wc-hide-notice"]'
+		);
+
+		if ( ! link || typeof window.ajaxurl === 'undefined' ) {
+			return;
+		}
+
+		var url;
+		try {
+			url = new URL( link.href );
+		} catch ( e ) {
+			return;
+		}
+
+		var noticeName = url.searchParams.get( 'wc-hide-notice' );
+		var nonce = url.searchParams.get( '_wc_notice_nonce' );
+
+		if ( ! noticeName || ! nonce ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		var notice = link.closest( '.notice, .woocommerce-message, #message' );
+
+		window
+			.fetch( window.ajaxurl, {
+				method: 'POST',
+				credentials: 'same-origin',
+				body: new URLSearchParams( {
+					action: 'woocommerce_hide_notice',
+					'wc-hide-notice': noticeName,
+					_wc_notice_nonce: nonce,
+				} ),
+			} )
+			.then( function ( response ) {
+				if ( ! response.ok ) {
+					throw new Error( 'Failed to dismiss notice' );
+				}
+
+				if ( notice ) {
+					notice.remove();
+				}
+
+				document.dispatchEvent(
+					new CustomEvent( 'wc-admin-notice-dismissed', {
+						detail: { notice: noticeName },
+					} )
+				);
+			} )
+			.catch( function () {
+				window.location.href = link.href;
+			} );
+	} );
+} )();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -68,6 +68,7 @@ class WC_Admin_Notices {
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
+		add_action( 'wp_ajax_woocommerce_hide_notice', array( __CLASS__, 'ajax_hide_notice' ) );
 
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
@@ -266,6 +267,43 @@ class WC_Admin_Notices {
 	}
 
 	/**
+	 * AJAX handler to hide a notice without a page reload.
+	 *
+	 * Accepts the same nonce as the query-string based dismissal in hide_notices(),
+	 * which is kept as a no-JS fallback.
+	 *
+	 * @since 11.1.0
+	 * @return void
+	 */
+	public static function ajax_hide_notice() {
+		check_ajax_referer( 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' );
+
+		$notice_name = isset( $_POST['wc-hide-notice'] ) ? sanitize_text_field( wp_unslash( $_POST['wc-hide-notice'] ) ) : '';
+
+		if ( '' === $notice_name ) {
+			wp_send_json_error( null, 400 );
+		}
+
+		/**
+		 * This filter is documented above, in hide_notices().
+		 *
+		 * @since 6.7.0
+		 */
+		$required_capability = apply_filters( 'woocommerce_dismiss_admin_notice_capability', 'manage_woocommerce', $notice_name );
+
+		if ( ! current_user_can( $required_capability ) ) {
+			wp_send_json_error( null, 403 );
+		}
+
+		self::hide_notice( $notice_name );
+
+		// Notices are normally stored to the DB on 'shutdown'; save explicitly so the dismissal is persisted even if that hook was not registered for this request.
+		self::store_notices();
+
+		wp_send_json_success();
+	}
+
+	/**
 	 * Hide a single notice.
 	 *
 	 * @param string $name Notice name.
@@ -322,6 +360,9 @@ class WC_Admin_Notices {
 
 		// Add RTL support.
 		wp_style_add_data( 'woocommerce-activation', 'rtl', 'replace' );
+
+		$suffix = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
+		wp_enqueue_script( 'wc-admin-notices', plugins_url( '/assets/js/admin/wc-admin-notices' . $suffix . '.js', WC_PLUGIN_FILE ), array(), Constants::get_constant( 'WC_VERSION' ), true );
 
 		foreach ( $notices as $notice ) {
 			if ( ! empty( self::$core_notices[ $notice ] ) && apply_filters( 'woocommerce_show_admin_notice', true, $notice ) ) {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-notices-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-notices-test.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Admin_Notices class.
+ */
+class WC_Admin_Notices_Test extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Sets up the test fixture.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		include_once WC_ABSPATH . 'includes/admin/class-wc-admin-notices.php';
+
+		if ( ! has_action( 'wp_ajax_woocommerce_hide_notice', array( 'WC_Admin_Notices', 'ajax_hide_notice' ) ) ) {
+			WC_Admin_Notices::init();
+		}
+
+		WC_Admin_Notices::remove_all_notices();
+	}
+
+	/**
+	 * Tears down the test fixture.
+	 */
+	public function tear_down() {
+		WC_Admin_Notices::remove_all_notices();
+		unset( $_POST['wc-hide-notice'], $_POST['_wc_notice_nonce'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox Should hide the notice and persist the dismissal when dismissed over AJAX.
+	 */
+	public function test_ajax_hide_notice_dismisses_notice(): void {
+		$this->_setRole( 'administrator' );
+		WC_Admin_Notices::add_notice( 'test_notice' );
+
+		$hide_action_fired = false;
+		$callback          = function () use ( &$hide_action_fired ) {
+			$hide_action_fired = true;
+		};
+		add_action( 'woocommerce_hide_test_notice_notice', $callback );
+
+		$_POST['wc-hide-notice']   = 'test_notice';
+		$_POST['_wc_notice_nonce'] = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
+		$response = $this->do_ajax( 'woocommerce_hide_notice' );
+
+		remove_action( 'woocommerce_hide_test_notice_notice', $callback );
+
+		$this->assertTrue( $response['success'], 'The AJAX response should indicate success' );
+		$this->assertFalse( WC_Admin_Notices::has_notice( 'test_notice' ), 'The notice should no longer be present' );
+		$this->assertTrue( WC_Admin_Notices::user_has_dismissed_notice( 'test_notice' ), 'The dismissal should be recorded in user meta' );
+		$this->assertTrue( $hide_action_fired, 'The woocommerce_hide_{name}_notice action should have fired' );
+	}
+
+	/**
+	 * @testdox Should reject the AJAX dismissal when the nonce is invalid.
+	 */
+	public function test_ajax_hide_notice_rejects_invalid_nonce(): void {
+		$this->_setRole( 'administrator' );
+		WC_Admin_Notices::add_notice( 'test_notice' );
+
+		$_POST['wc-hide-notice']   = 'test_notice';
+		$_POST['_wc_notice_nonce'] = 'invalid-nonce';
+
+		$this->expectException( 'WPAjaxDieStopException' );
+
+		try {
+			$this->_handleAjax( 'woocommerce_hide_notice' );
+		} finally {
+			$this->assertTrue( WC_Admin_Notices::has_notice( 'test_notice' ), 'The notice should still be present' );
+		}
+	}
+
+	/**
+	 * @testdox Should reject the AJAX dismissal when the user lacks the required capability.
+	 */
+	public function test_ajax_hide_notice_rejects_unauthorized_user(): void {
+		$this->_setRole( 'subscriber' );
+		WC_Admin_Notices::add_notice( 'test_notice' );
+
+		$_POST['wc-hide-notice']   = 'test_notice';
+		$_POST['_wc_notice_nonce'] = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
+		$response = $this->do_ajax( 'woocommerce_hide_notice' );
+
+		$this->assertFalse( $response['success'], 'The AJAX response should indicate failure' );
+		$this->assertTrue( WC_Admin_Notices::has_notice( 'test_notice' ), 'The notice should still be present' );
+		$this->assertFalse( WC_Admin_Notices::user_has_dismissed_notice( 'test_notice' ), 'No dismissal should be recorded in user meta' );
+	}
+
+	/**
+	 * @testdox Should return an error when no notice name is provided.
+	 */
+	public function test_ajax_hide_notice_requires_notice_name(): void {
+		$this->_setRole( 'administrator' );
+
+		$_POST['_wc_notice_nonce'] = wp_create_nonce( 'woocommerce_hide_notices_nonce' );
+
+		$response = $this->do_ajax( 'woocommerce_hide_notice' );
+
+		$this->assertFalse( $response['success'], 'The AJAX response should indicate failure' );
+	}
+
+	/**
+	 * Triggers an ajax endpoint and captures the JSON response.
+	 *
+	 * @param string $ajax_action The action to be triggered.
+	 *
+	 * @return array|null
+	 */
+	private function do_ajax( string $ajax_action ) {
+		$output_buffering_level = ob_get_level();
+
+		try {
+			// Note that _handleAjax makes use of output buffering, which the die
+			// handler usually cleans up; the finally block below closes only any
+			// buffer it leaves dangling so the buffer level stays balanced.
+			$this->_handleAjax( $ajax_action );
+		} catch ( Exception $e ) {
+			unset( $e );
+		} finally {
+			while ( ob_get_level() > $output_buffering_level ) {
+				ob_end_clean();
+			}
+		}
+
+		$result               = json_decode( $this->_last_response, true );
+		$this->_last_response = false;
+
+		return $result;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Dismissing an admin notice navigates to a `wc-hide-notice` URL, reloading the page. This adds a `woocommerce_hide_notice` admin-ajax endpoint and a small script that intercepts the existing dismiss links, so notices are dismissed in place. The links themselves are unchanged: without JS the reload flow still works, and extension notices rendered through `WC_Admin_Notices` get the new behavior for free.

BC: nonce, capability filter, user meta and the `woocommerce_hide_{name}_notice` action are unchanged; the action now fires during admin-ajax instead of a page load.

Closes #38629.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Build the legacy admin assets first: `pnpm --filter=@woocommerce/plugin-woocommerce build` (the new script lives in the gitignored `assets/js/admin/` folder - without a build, dismissal silently falls back to the reload behavior).
2. Disable silent DB auto-updates, e.g. in an mu-plugin: `add_filter( 'woocommerce_enable_auto_update_db', '__return_false' );`
3. Run `wp option update woocommerce_version 10.9.2 && wp option update woocommerce_db_version 10.9.2`
4. On the WP Dashboard, run the database update from the notice (`wp action-scheduler run` if it stays in progress).
5. Revisit the Dashboard and dismiss the "database update complete" notice: it should disappear without a page reload and stay gone after a refresh.
6. Repeat on WooCommerce > Settings. To re-create a notice: `wp eval 'include_once WC_ABSPATH . "includes/admin/class-wc-admin-notices.php"; WC_Admin_Notices::add_custom_notice( "test_notice", "<p>Test</p>" ); WC_Admin_Notices::store_notices();'`

<!-- End testing instructions -->

### Testing that has already taken place:

- PHPUnit tests for the new endpoint (dismissal + user meta + dismiss action, invalid nonce, missing capability, missing notice name).
- Manual: the DB-update flow above, plus verifying dismissal sends a single admin-ajax request, removes only the targeted notice, and persists across reloads.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**When to use each?**

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
