### PR TITLE
Make it possible to use the Add to Cart + Options block in scheduled products for users with permissions

### DIFF
--- a/docs/apis/store-api/resources-endpoints/products.md
+++ b/docs/apis/store-api/resources-endpoints/products.md
@@ -6,9 +6,14 @@ The store products API provides public product data so it can be rendered on the
 
 ### Draft and non-published products
 
-Draft and non-published products are only available to users who have permission to edit them, like shop managers or administrators.
+Non-published products like drafts, private or scheduled products are excluded from the collection endpoint for all users.
 
-Product variations are only available when the current user has the `edit_products` and `edit_others_products` capabilities.
+When accessing a product directly by its ID or slug, non-published products are available to users who have permission to edit them, like shop managers or administrators. Product variations are available when the user has the `edit_products` and `edit_others_products` capabilities.
+
+In other words:
+
+* `/wc/store/v1/products/` never returns unpublished products.
+* `/wc/store/v1/products/<id_of_an_unpublished_product>` returns the product if the user has permission to edit it, otherwise it returns 404.
 
 ### Password-protected products
 

--- a/docs/apis/store-api/resources-endpoints/products.md
+++ b/docs/apis/store-api/resources-endpoints/products.md
@@ -6,7 +6,9 @@ The store products API provides public product data so it can be rendered on the
 
 ### Draft and non-published products
 
-Only published products are accessible via the Store API. Requesting a draft, pending, or other non-published product by ID or slug returns a `404` error. Non-published products are also excluded from the collection endpoint.
+Draft and non-published products are only available to users who have permission to edit them, like shop managers or administrators.
+
+Product variations are only available when the current user has the `edit_products` and `edit_others_products` capabilities.
 
 ### Password-protected products
 

--- a/plugins/woocommerce/changelog/fix-66239-scheduled-products-iapi-store
+++ b/plugins/woocommerce/changelog/fix-66239-scheduled-products-iapi-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make it possible to use the Add to Cart + Options block in scheduled products for users with permissions

--- a/plugins/woocommerce/changelog/fix-66239-scheduled-products-iapi-store
+++ b/plugins/woocommerce/changelog/fix-66239-scheduled-products-iapi-store
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Make it possible to use the Add to Cart + Options block in scheduled products for users with permissions
+Make it possible for users with the necessary permissions to access unpublished products through the Store API and in the Add to Cart + Options block

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -82,7 +82,7 @@ class ProductsById extends AbstractRoute {
 	protected function get_route_response( \WP_REST_Request $request ) {
 		$object = wc_get_product( (int) $request['id'] );
 
-		if ( ! $object || 0 === $object->get_id() || ! $object->is_publicly_viewable() ) {
+		if ( ! $object || 0 === $object->get_id() || ! $object->is_viewable() ) {
 			throw new RouteException( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), 404 );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -87,7 +87,7 @@ class ProductsBySlug extends AbstractRoute {
 			$object = $this->get_product_variation_by_slug( $slug );
 		}
 
-		if ( ! $object || 0 === $object->get_id() || ! $object->is_publicly_viewable() ) {
+		if ( ! $object || 0 === $object->get_id() || ! $object->is_viewable() ) {
 			throw new RouteException( 'woocommerce_rest_product_invalid_slug', __( 'Invalid product slug.', 'woocommerce' ), 404 );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -365,17 +365,19 @@ class ProductQuery implements QueryClausesGenerator {
 		// Explicit parent lookups (e.g. variation hydration) skip the catalog discovery guard in
 		// add_query_clauses(), so enforce per-product visibility here instead.
 		if ( ! empty( $request['parent'] ) ) {
-			$objects  = array_values(
+			$previous_count = count( $objects );
+			$objects        = array_values(
 				array_filter(
 					$objects,
 					static function ( $product ) {
-						return $product instanceof \WC_Product && $product->is_viewable();
+						return ( $product instanceof \WC_Product || $product instanceof \WC_Product_Variation ) && $product->is_viewable();
 					}
 				)
 			);
-			$total    = count( $objects );
-			$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
-			$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+			$filtered_out   = $previous_count - count( $objects );
+			$total          = (int) $results['total'] - $filtered_out;
+			$per_page       = $request['per_page'] ? (int) $request['per_page'] : -1;
+			$pages          = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
 		}
 
 		// Batch-prime image attachment caches for the whole collection, rather than once per

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -359,25 +359,24 @@ class ProductQuery implements QueryClausesGenerator {
 		}
 
 		$objects = array_map( 'wc_get_product', $results['results'] );
+		$total   = $results['total'];
+		$pages   = $results['pages'];
 
-		// Usually, variations are marked as 'published' even if their
-		// parent is not. So here we make sure any variations included
-		// in the response are visible by the current user.
-		$objects  = array_values(
-			array_filter(
-				$objects,
-				static function ( $product ) {
-					if ( ! $product instanceof \WC_Product_Variation ) {
-						return true;
+		// Explicit parent lookups (e.g. variation hydration) skip the catalog discovery guard in
+		// add_query_clauses(), so enforce per-product visibility here instead.
+		if ( ! empty( $request['parent'] ) ) {
+			$objects  = array_values(
+				array_filter(
+					$objects,
+					static function ( $product ) {
+						return $product instanceof \WC_Product && $product->is_viewable();
 					}
-
-					return $product->is_viewable();
-				}
-			)
-		);
-		$total    = count( $objects );
-		$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
-		$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+				)
+			);
+			$total    = count( $objects );
+			$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
+			$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+		}
 
 		// Batch-prime image attachment caches for the whole collection, rather than once per
 		// product when ProductSchema::get_images() runs during serialization.
@@ -437,6 +436,23 @@ class ProductQuery implements QueryClausesGenerator {
 	 */
 	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
+
+		// Catalog discovery queries (SKU, slug, search) can return variations, so exclude any whose
+		// parent product is not published. Explicit parent[] lookups rely on is_viewable() instead.
+		$is_explicit_parent_query = ! empty( $wp_query->get( 'post_parent__in' ) );
+
+		if (
+			in_array( 'product_variation', (array) $wp_query->get( 'post_type' ), true )
+			&& ! $is_explicit_parent_query
+		) {
+			$args['where'] .= $wpdb->prepare(
+				" AND ( {$wpdb->posts}.post_type != 'product_variation' OR EXISTS (
+					SELECT 1 FROM {$wpdb->posts} AS parent
+					WHERE parent.ID = {$wpdb->posts}.post_parent AND parent.post_status = %s
+				) ) ",
+				ProductStatus::PUBLISH
+			);
+		}
 
 		if ( $wp_query->get( 'search' ) ) {
 			$search         = '%' . $wpdb->esc_like( $wp_query->get( 'search' ) ) . '%';

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -359,24 +359,25 @@ class ProductQuery implements QueryClausesGenerator {
 		}
 
 		$objects = array_map( 'wc_get_product', $results['results'] );
-		$total   = $results['total'];
-		$pages   = $results['pages'];
 
-		// Explicit parent lookups (e.g. variation hydration) skip the catalog discovery guard in
-		// add_query_clauses(), so enforce per-product visibility here instead.
-		if ( ! empty( $request['parent'] ) ) {
-			$objects  = array_values(
-				array_filter(
-					$objects,
-					static function ( $product ) {
-						return $product instanceof \WC_Product && $product->is_viewable();
+		// Usually, variations are marked as 'published' even if their
+		// parent is not. So here we make sure any variations included
+		// in the response are visible by the current user.
+		$objects  = array_values(
+			array_filter(
+				$objects,
+				static function ( $product ) {
+					if ( ! $product instanceof \WC_Product_Variation ) {
+						return true;
 					}
-				)
-			);
-			$total    = count( $objects );
-			$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
-			$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
-		}
+
+					return $product->is_viewable();
+				}
+			)
+		);
+		$total    = count( $objects );
+		$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
+		$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
 
 		// Batch-prime image attachment caches for the whole collection, rather than once per
 		// product when ProductSchema::get_images() runs during serialization.
@@ -436,23 +437,6 @@ class ProductQuery implements QueryClausesGenerator {
 	 */
 	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
-
-		// Catalog discovery queries (SKU, slug, search) can return variations, so exclude any whose
-		// parent product is not published. Explicit parent[] lookups rely on is_viewable() instead.
-		$is_explicit_parent_query = ! empty( $wp_query->get( 'post_parent__in' ) );
-
-		if (
-			in_array( 'product_variation', (array) $wp_query->get( 'post_type' ), true )
-			&& ! $is_explicit_parent_query
-		) {
-			$args['where'] .= $wpdb->prepare(
-				" AND ( {$wpdb->posts}.post_type != 'product_variation' OR EXISTS (
-					SELECT 1 FROM {$wpdb->posts} AS parent
-					WHERE parent.ID = {$wpdb->posts}.post_parent AND parent.post_status = %s
-				) ) ",
-				ProductStatus::PUBLISH
-			);
-		}
 
 		if ( $wp_query->get( 'search' ) ) {
 			$search         = '%' . $wpdb->esc_like( $wp_query->get( 'search' ) ) . '%';

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -359,6 +359,24 @@ class ProductQuery implements QueryClausesGenerator {
 		}
 
 		$objects = array_map( 'wc_get_product', $results['results'] );
+		$total   = $results['total'];
+		$pages   = $results['pages'];
+
+		// Explicit parent lookups (e.g. variation hydration) skip the catalog discovery guard in
+		// add_query_clauses(), so enforce per-product visibility here instead.
+		if ( ! empty( $request['parent'] ) ) {
+			$objects  = array_values(
+				array_filter(
+					$objects,
+					static function ( $product ) {
+						return $product instanceof \WC_Product && $product->is_viewable();
+					}
+				)
+			);
+			$total    = count( $objects );
+			$per_page = $request['per_page'] ? (int) $request['per_page'] : -1;
+			$pages    = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+		}
 
 		// Batch-prime image attachment caches for the whole collection, rather than once per
 		// product when ProductSchema::get_images() runs during serialization.
@@ -366,8 +384,8 @@ class ProductQuery implements QueryClausesGenerator {
 
 		return array(
 			'objects' => $objects,
-			'total'   => $results['total'],
-			'pages'   => $results['pages'],
+			'total'   => $total,
+			'pages'   => $pages,
 		);
 	}
 
@@ -419,8 +437,14 @@ class ProductQuery implements QueryClausesGenerator {
 	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
 
-		// SKU and slug lookups can return variations, so exclude any whose parent product is not published.
-		if ( in_array( 'product_variation', (array) $wp_query->get( 'post_type' ), true ) ) {
+		// Catalog discovery queries (SKU, slug, search) can return variations, so exclude any whose
+		// parent product is not published. Explicit parent[] lookups rely on is_viewable() instead.
+		$is_explicit_parent_query = ! empty( $wp_query->get( 'post_parent__in' ) );
+
+		if (
+			in_array( 'product_variation', (array) $wp_query->get( 'post_type' ), true )
+			&& ! $is_explicit_parent_query
+		) {
 			$args['where'] .= $wpdb->prepare(
 				" AND ( {$wpdb->posts}.post_type != 'product_variation' OR EXISTS (
 					SELECT 1 FROM {$wpdb->posts} AS parent

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -359,26 +359,6 @@ class ProductQuery implements QueryClausesGenerator {
 		}
 
 		$objects = array_map( 'wc_get_product', $results['results'] );
-		$total   = $results['total'];
-		$pages   = $results['pages'];
-
-		// Explicit parent lookups (e.g. variation hydration) skip the catalog discovery guard in
-		// add_query_clauses(), so enforce per-product visibility here instead.
-		if ( ! empty( $request['parent'] ) ) {
-			$previous_count = count( $objects );
-			$objects        = array_values(
-				array_filter(
-					$objects,
-					static function ( $product ) {
-						return ( $product instanceof \WC_Product || $product instanceof \WC_Product_Variation ) && $product->is_viewable();
-					}
-				)
-			);
-			$filtered_out   = $previous_count - count( $objects );
-			$total          = (int) $results['total'] - $filtered_out;
-			$per_page       = $request['per_page'] ? (int) $request['per_page'] : -1;
-			$pages          = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
-		}
 
 		// Batch-prime image attachment caches for the whole collection, rather than once per
 		// product when ProductSchema::get_images() runs during serialization.
@@ -386,8 +366,8 @@ class ProductQuery implements QueryClausesGenerator {
 
 		return array(
 			'objects' => $objects,
-			'total'   => $total,
-			'pages'   => $pages,
+			'total'   => $results['total'],
+			'pages'   => $results['pages'],
 		);
 	}
 
@@ -439,13 +419,9 @@ class ProductQuery implements QueryClausesGenerator {
 	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
 
-		// Catalog discovery queries (SKU, slug, search) can return variations, so exclude any whose
-		// parent product is not published. Explicit parent[] lookups rely on is_viewable() instead.
-		$is_explicit_parent_query = ! empty( $wp_query->get( 'post_parent__in' ) );
-
 		if (
 			in_array( 'product_variation', (array) $wp_query->get( 'post_type' ), true )
-			&& ! $is_explicit_parent_query
+			&& ( ! current_user_can( 'edit_products' ) || ! current_user_can( 'edit_others_products' ) )
 		) {
 			$args['where'] .= $wpdb->prepare(
 				" AND ( {$wpdb->posts}.post_type != 'product_variation' OR EXISTS (

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -132,6 +132,48 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox load_variations() hydrates scheduled variable products into the woocommerce/products store for users who can edit them.
+	 */
+	public function test_load_scheduled_variable_product_variations_hydrates_interactivity_store_for_admin(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$product       = WC_Helper_Product::create_variation_product();
+		$variation_ids = $product->get_children();
+
+		wp_update_post(
+			array(
+				'ID'            => $product->get_id(),
+				'post_status'   => ProductStatus::FUTURE,
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			)
+		);
+		$product = wc_get_product( $product->get_id() );
+
+		$result = TestedProductsStore::load_variations( $this->consent, $product->get_id() );
+		$state  = wp_interactivity_state( $this->store_namespace );
+
+		$this->assertNotEmpty( $result, 'Scheduled product variations should not be empty for admins.' );
+		foreach ( $variation_ids as $variation_id ) {
+			$this->assertArrayHasKey( $variation_id, $result );
+			$this->assertArrayHasKey( $variation_id, $state['productVariations'] );
+		}
+
+		wp_set_current_user( 0 );
+		$this->reset_products_store_static_state();
+		$this->reset_interactivity_state();
+
+		$logged_out_result = TestedProductsStore::load_variations( $this->consent, $product->get_id() );
+
+		$this->assertEmpty(
+			$logged_out_result,
+			'Scheduled product variations should not hydrate into the store for logged-out users.'
+		);
+
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox load_product() fetches each product ID from REST only once.
 	 */
 	public function test_load_product_is_memoized_per_id(): void {

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\Tests\Blocks\SharedStores;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\SharedStores\ProductsStore as TestedProductsStore;
-use Automattic\WooCommerce\Enums\ProductStatus;
 use WC_Helper_Product;
 use WC_Product_Grouped;
 
@@ -88,87 +87,6 @@ class ProductsStore extends \WC_Unit_Test_Case {
 		$this->assertArrayHasKey( $product->get_id(), $state['products'] );
 		$this->assertSame( $product->get_name(), $state['products'][ $product->get_id() ]['name'] );
 		$this->assertSame( $product->get_name(), $result['name'], 'Return value should contain the product data.' );
-
-		$product->delete( true );
-	}
-
-	/**
-	 * @testdox load_product() hydrates scheduled products into the woocommerce/products store for users who can edit them.
-	 */
-	public function test_load_scheduled_product_hydrates_interactivity_store_for_admin(): void {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-
-		$product = WC_Helper_Product::create_simple_product();
-		wp_update_post(
-			array(
-				'ID'            => $product->get_id(),
-				'post_status'   => ProductStatus::FUTURE,
-				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-			)
-		);
-		$product = wc_get_product( $product->get_id() );
-		$result  = TestedProductsStore::load_product( $this->consent, $product->get_id() );
-		$state   = wp_interactivity_state( $this->store_namespace );
-
-		$this->assertNotEmpty( $result, 'Scheduled product REST payload should not be empty for admins.' );
-		$this->assertSame( $product->get_id(), $result['id'] );
-		$this->assertArrayHasKey( $product->get_id(), $state['products'] );
-		$this->assertSame( $product->get_name(), $state['products'][ $product->get_id() ]['name'] );
-
-		wp_set_current_user( 0 );
-		$this->reset_products_store_static_state();
-		$this->reset_interactivity_state();
-
-		$logged_out_result = TestedProductsStore::load_product( $this->consent, $product->get_id() );
-
-		$this->assertArrayNotHasKey(
-			'id',
-			$logged_out_result,
-			'Scheduled products should not hydrate into the store for logged-out users.'
-		);
-
-		$product->delete( true );
-	}
-
-	/**
-	 * @testdox load_variations() hydrates scheduled variable products into the woocommerce/products store for users who can edit them.
-	 */
-	public function test_load_scheduled_variable_product_variations_hydrates_interactivity_store_for_admin(): void {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-
-		$product       = WC_Helper_Product::create_variation_product();
-		$variation_ids = $product->get_children();
-
-		wp_update_post(
-			array(
-				'ID'            => $product->get_id(),
-				'post_status'   => ProductStatus::FUTURE,
-				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-			)
-		);
-		$product = wc_get_product( $product->get_id() );
-
-		$result = TestedProductsStore::load_variations( $this->consent, $product->get_id() );
-		$state  = wp_interactivity_state( $this->store_namespace );
-
-		$this->assertNotEmpty( $result, 'Scheduled product variations should not be empty for admins.' );
-		foreach ( $variation_ids as $variation_id ) {
-			$this->assertArrayHasKey( $variation_id, $result );
-			$this->assertArrayHasKey( $variation_id, $state['productVariations'] );
-		}
-
-		wp_set_current_user( 0 );
-		$this->reset_products_store_static_state();
-		$this->reset_interactivity_state();
-
-		$logged_out_result = TestedProductsStore::load_variations( $this->consent, $product->get_id() );
-
-		$this->assertEmpty(
-			$logged_out_result,
-			'Scheduled product variations should not hydrate into the store for logged-out users.'
-		);
 
 		$product->delete( true );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\SharedStores;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\SharedStores\ProductsStore as TestedProductsStore;
+use Automattic\WooCommerce\Enums\ProductStatus;
 use WC_Helper_Product;
 use WC_Product_Grouped;
 
@@ -87,6 +88,45 @@ class ProductsStore extends \WC_Unit_Test_Case {
 		$this->assertArrayHasKey( $product->get_id(), $state['products'] );
 		$this->assertSame( $product->get_name(), $state['products'][ $product->get_id() ]['name'] );
 		$this->assertSame( $product->get_name(), $result['name'], 'Return value should contain the product data.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox load_product() hydrates scheduled products into the woocommerce/products store for users who can edit them.
+	 */
+	public function test_load_scheduled_product_hydrates_interactivity_store_for_admin(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$product = WC_Helper_Product::create_simple_product();
+		wp_update_post(
+			array(
+				'ID'            => $product->get_id(),
+				'post_status'   => ProductStatus::FUTURE,
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			)
+		);
+		$product = wc_get_product( $product->get_id() );
+		$result  = TestedProductsStore::load_product( $this->consent, $product->get_id() );
+		$state   = wp_interactivity_state( $this->store_namespace );
+
+		$this->assertNotEmpty( $result, 'Scheduled product REST payload should not be empty for admins.' );
+		$this->assertSame( $product->get_id(), $result['id'] );
+		$this->assertArrayHasKey( $product->get_id(), $state['products'] );
+		$this->assertSame( $product->get_name(), $state['products'][ $product->get_id() ]['name'] );
+
+		wp_set_current_user( 0 );
+		$this->reset_products_store_static_state();
+		$this->reset_interactivity_state();
+
+		$logged_out_result = TestedProductsStore::load_product( $this->consent, $product->get_id() );
+
+		$this->assertArrayNotHasKey(
+			'id',
+			$logged_out_result,
+			'Scheduled products should not hydrate into the store for logged-out users.'
+		);
 
 		$product->delete( true );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -585,48 +585,17 @@ class Products extends ControllerTestCase {
 		$public_sku_request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
 		$public_sku_request->set_param( 'sku', 'public-parent-variation' );
 		$this->assertCount( 1, rest_get_server()->dispatch( $public_sku_request )->get_data() );
-	}
 
-	/**
-	 * @testdox Variations of a scheduled parent are returned via parent[] lookups for users who can view the parent.
-	 */
-	public function test_scheduled_parent_variations_via_parent_query() {
-		$fixtures  = new FixtureData();
-		$attribute = FixtureData::get_product_attribute( 'color', array( 'red', 'blue' ) );
-		$parent    = $fixtures->get_variable_product( array( 'name' => 'Scheduled Parent' ), array( $attribute ) );
-		$variation = $fixtures->get_variation_product(
-			$parent->get_id(),
-			array( 'pa_color' => 'red' ),
-			array(
-				'regular_price' => 10,
-			)
-		);
-
-		wp_update_post(
-			array(
-				'ID'            => $parent->get_id(),
-				'post_status'   => ProductStatus::FUTURE,
-				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
-			)
-		);
-
-		$parent_request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
-		$parent_request->set_param( 'parent', array( $parent->get_id() ) );
-		$parent_request->set_param( 'type', ProductType::VARIATION );
-
-		// Logged-out users should not see variations of a scheduled parent.
-		wp_set_current_user( 0 );
-		$logged_out_response = rest_get_server()->dispatch( $parent_request );
-		$this->assertEquals( 200, $logged_out_response->get_status() );
-		$this->assertCount( 0, $logged_out_response->get_data() );
-
-		// Admins who can view the scheduled parent should receive its variations.
+		// Users with permission to edit the parent product should see the variation.
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		$admin_response = rest_get_server()->dispatch( $parent_request );
-		$this->assertEquals( 200, $admin_response->get_status() );
-		$this->assertCount( 1, $admin_response->get_data() );
-		$this->assertSame( $variation->get_id(), $admin_response->get_data()[0]['id'] );
+
+		$admin_by_id = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $hidden_variation->get_id() ) );
+		$this->assertEquals( 200, $admin_by_id->get_status() );
+		$this->assertSame( $hidden_variation->get_id(), $admin_by_id->get_data()['id'] );
+
+		$admin_by_slug = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $hidden_slug ) );
+		$this->assertEquals( 200, $admin_by_slug->get_status() );
+		$this->assertSame( $hidden_variation->get_id(), $admin_by_slug->get_data()['id'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -716,7 +716,6 @@ class Products extends ControllerTestCase {
 		);
 
 		if ( ProductStatus::FUTURE === $status ) {
-			// Keep date_created in sync so product->save() does not overwrite the scheduled date.
 			$product->set_date_created( strtotime( '+1 year' ) );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Products Controller Tests.
@@ -584,6 +585,48 @@ class Products extends ControllerTestCase {
 		$public_sku_request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
 		$public_sku_request->set_param( 'sku', 'public-parent-variation' );
 		$this->assertCount( 1, rest_get_server()->dispatch( $public_sku_request )->get_data() );
+	}
+
+	/**
+	 * @testdox Variations of a scheduled parent are returned via parent[] lookups for users who can view the parent.
+	 */
+	public function test_scheduled_parent_variations_via_parent_query() {
+		$fixtures  = new FixtureData();
+		$attribute = FixtureData::get_product_attribute( 'color', array( 'red', 'blue' ) );
+		$parent    = $fixtures->get_variable_product( array( 'name' => 'Scheduled Parent' ), array( $attribute ) );
+		$variation = $fixtures->get_variation_product(
+			$parent->get_id(),
+			array( 'pa_color' => 'red' ),
+			array(
+				'regular_price' => 10,
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'            => $parent->get_id(),
+				'post_status'   => ProductStatus::FUTURE,
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			)
+		);
+
+		$parent_request = new \WP_REST_Request( 'GET', '/wc/store/v1/products' );
+		$parent_request->set_param( 'parent', array( $parent->get_id() ) );
+		$parent_request->set_param( 'type', ProductType::VARIATION );
+
+		// Logged-out users should not see variations of a scheduled parent.
+		wp_set_current_user( 0 );
+		$logged_out_response = rest_get_server()->dispatch( $parent_request );
+		$this->assertEquals( 200, $logged_out_response->get_status() );
+		$this->assertCount( 0, $logged_out_response->get_data() );
+
+		// Admins who can view the scheduled parent should receive its variations.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$admin_response = rest_get_server()->dispatch( $parent_request );
+		$this->assertEquals( 200, $admin_response->get_status() );
+		$this->assertCount( 1, $admin_response->get_data() );
+		$this->assertSame( $variation->get_id(), $admin_response->get_data()[0]['id'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -680,6 +680,23 @@ class Products extends ControllerTestCase {
 	}
 
 	/**
+	 * Statuses that keep a usable post_name after save (for slug-route coverage).
+	 *
+	 * Pending is omitted: WordPress does not persist post_name for pending posts,
+	 * so the slug route cannot resolve them.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function provider_non_published_statuses_with_slugs() {
+		return array(
+			'draft'      => array( ProductStatus::DRAFT ),
+			'private'    => array( ProductStatus::PRIVATE ),
+			'trash'      => array( ProductStatus::TRASH ),
+			'auto-draft' => array( ProductStatus::AUTO_DRAFT ),
+		);
+	}
+
+	/**
 	 * @testdox Non-published products should not be returned when queried by ID ($status).
 	 * @dataProvider provider_non_published_statuses
 	 *
@@ -699,6 +716,30 @@ class Products extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_id() ) );
 
 		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * @testdox Non-published products should be returned by ID to users who can edit them ($status).
+	 * @dataProvider provider_non_published_statuses
+	 *
+	 * @param string $status The product status to test.
+	 */
+	public function test_non_published_product_by_id_visible_to_admin( $status ) {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Non Published Product For Admin',
+				'regular_price' => 10,
+			)
+		);
+		$product->set_status( $status );
+		$product->save();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_id() ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $product->get_id(), $response->get_data()['id'] );
 	}
 
 	/**
@@ -732,8 +773,39 @@ class Products extends ControllerTestCase {
 	}
 
 	/**
-	 * @testdox Non-published products should not be returned when queried by slug ($status).
+	 * @testdox Non-published products should not be included in the collection for admins ($status).
 	 * @dataProvider provider_non_published_statuses
+	 *
+	 * @param string $status The product status to test.
+	 */
+	public function test_non_published_products_excluded_from_collection_for_admin( $status ) {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Non Published Product In Admin Collection',
+				'regular_price' => 10,
+			)
+		);
+		$product->set_status( $status );
+		$product->save();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products' ) );
+		$data        = $response->get_data();
+		$product_ids = array_map(
+			function ( $product ) {
+				return $product['id'];
+			},
+			$data
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotContains( $product->get_id(), $product_ids );
+	}
+
+	/**
+	 * @testdox Non-published products should not be returned when queried by slug ($status).
+	 * @dataProvider provider_non_published_statuses_with_slugs
 	 *
 	 * @param string $status The product status to test.
 	 */
@@ -751,6 +823,33 @@ class Products extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_slug() ) );
 
 		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * @testdox Non-published products should be returned by slug to users who can edit them ($status).
+	 * @dataProvider provider_non_published_statuses_with_slugs
+	 *
+	 * @param string $status The product status to test.
+	 */
+	public function test_non_published_product_by_slug_visible_to_admin( $status ) {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Non Published Product By Slug For Admin',
+				'regular_price' => 10,
+			)
+		);
+		$product->set_status( $status );
+		$product->save();
+
+		$slug = get_post_field( 'post_name', $product->get_id() );
+		$this->assertNotEmpty( $slug, "Expected a post_name for $status products so the slug route is exercised." );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $slug ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $product->get_id(), $response->get_data()['id'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
-use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * Products Controller Tests.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -675,6 +675,7 @@ class Products extends ControllerTestCase {
 			'private'    => array( ProductStatus::PRIVATE ),
 			'trash'      => array( ProductStatus::TRASH ),
 			'auto-draft' => array( ProductStatus::AUTO_DRAFT ),
+			'future'     => array( ProductStatus::FUTURE ),
 		);
 	}
 
@@ -692,7 +693,37 @@ class Products extends ControllerTestCase {
 			'private'    => array( ProductStatus::PRIVATE ),
 			'trash'      => array( ProductStatus::TRASH ),
 			'auto-draft' => array( ProductStatus::AUTO_DRAFT ),
+			'future'     => array( ProductStatus::FUTURE ),
 		);
+	}
+
+	/**
+	 * Create a simple product with a non-published status.
+	 *
+	 * WordPress rewrites `future` back to `publish` when post_date is in the past,
+	 * so a future date is required to actually schedule the product.
+	 *
+	 * @param string $status Target status.
+	 * @return \WC_Product
+	 */
+	private function get_non_published_simple_product( $status ) {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Non Published Product',
+				'regular_price' => 10,
+			)
+		);
+
+		if ( ProductStatus::FUTURE === $status ) {
+			// Keep date_created in sync so product->save() does not overwrite the scheduled date.
+			$product->set_date_created( strtotime( '+1 year' ) );
+		}
+
+		$product->set_status( $status );
+		$product->save();
+
+		return $product;
 	}
 
 	/**
@@ -702,15 +733,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_product_by_id_returns_404( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_id() ) );
 
@@ -724,15 +747,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_product_by_id_visible_to_admin( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product For Admin',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_id() ) );
@@ -748,15 +763,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_products_excluded_from_collection( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product In Collection',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products' ) );
 		$data        = $response->get_data();
@@ -778,15 +785,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_products_excluded_from_collection_for_admin( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product In Admin Collection',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$response    = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products' ) );
@@ -809,15 +808,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_product_by_slug_returns_404( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product By Slug',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $product->get_slug() ) );
 
@@ -831,15 +822,7 @@ class Products extends ControllerTestCase {
 	 * @param string $status The product status to test.
 	 */
 	public function test_non_published_product_by_slug_visible_to_admin( $status ) {
-		$fixtures = new FixtureData();
-		$product  = $fixtures->get_simple_product(
-			array(
-				'name'          => 'Non Published Product By Slug For Admin',
-				'regular_price' => 10,
-			)
-		);
-		$product->set_status( $status );
-		$product->save();
+		$product = $this->get_non_published_simple_product( $status );
 
 		$slug = get_post_field( 'post_name', $product->get_id() );
 		$this->assertNotEmpty( $slug, "Expected a post_name for $status products so the slug route is exercised." );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #66239.
Closes WOOPLUG-6970.

The way WooCommerce works in the frontend is that non-published products like drafts, scheduled, etc. are not shown in the `/shop` page, but they are visible when accessing the product page directly (assuming the user has permissions, of course).

The Store API, however, was filtering out products that were not publicly viewable in all cases. This PR changes the Store API behavior to check for products being viewable by the current user instead of being publicly viewable by everybody. It doesn't change the requests to get a collection of products, though, to keep things aligned with how the frontend of WC works.

In other words:

* `/wc/store/v1/products/<id_of_an_unpublished_product>`: before, it returned 404 → now, it returns the product (if the user can edit that product)
* `/wc/store/v1/products/`: it keeps not returning unpublished products

I believe this approach is the most consistent one with the current WC behavior, but I'm a bit on the fence if the Store API should really behave this way. An alternative would be adding a param to the request to explicitly include or exclude non-published products.

### How to test the changes in this Pull Request:

0. Read the [documentation changes](https://github.com/woocommerce/woocommerce/pull/66629/changes#diff-a5b6bac611c2301572e55c441c49ffe3fb50866712c01e448685459d0a62f605) (or the explanation above) and evaluate if the changes in the Store API make sense or should be refactored.
1. Update a simple and variable product and set their publish date somewhere in the future, so they become _Scheduled_ instead of _Published_.
2. Go to the frontend of the Single Product template, making sure you are using the Add to Cart + Options block.
3. Verify you can add the product/variation to cart as an admin.
4. Verify the page still redirects to 404 if you are not logged in.
5. Make a rest request to `/wp-json/wc/store/v1/products/<scheduled_product_id>`.
6. Verify the product is returned when you are logged in as an admin and you get 404 when not logged in.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->