### PR TITLE
Fix CSV import ending sales a day early for date-only end dates

### DIFF
--- a/plugins/woocommerce/changelog/fix-35321-csv-import-sale-end-date
+++ b/plugins/woocommerce/changelog/fix-35321-csv-import-sale-end-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product CSV import: store date-only "date sale price ends" values as end-of-day (23:59:59) to match the product edit screen, so sales no longer end ~24 hours earlier when set via import.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -637,6 +637,57 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Parse the "date on sale to" field from a CSV.
+	 *
+	 * When a date-only value (with no time component) is supplied, it is treated as the
+	 * end of that day (23:59:59) to match the behaviour of the product edit screen, where
+	 * the "On sale to" date input is stored with an end-of-day time.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param string $value Field value.
+	 *
+	 * @return string|null
+	 */
+	public function parse_date_on_sale_to_field( $value ) {
+		$parsed = $this->parse_datetime_field( $value );
+
+		if ( null === $parsed ) {
+			return null;
+		}
+
+		// If the value is numeric (Unix timestamp) it was already normalised to an ISO8601
+		// UTC string with an explicit time component by parse_datetime_field(); leave it alone.
+		if ( is_numeric( $value ) ) {
+			return $parsed;
+		}
+
+		// Detect any time component in the original string (e.g. "2023-01-26 10:00",
+		// "2023-01-26T10:00:00Z"). If one is present, preserve the caller's intent.
+		if ( preg_match( '/\d{1,2}:\d{2}/', (string) $value ) ) {
+			return $parsed;
+		}
+
+		// Canonical date-only value (Y-m-d): append end-of-day as a pure string operation.
+		// No timestamp round-trip means no timezone can shift the calendar day. The
+		// timezone-less result is interpreted as site-local by WC_Data::set_date_prop(),
+		// exactly like the value the admin product screen produces.
+		if ( preg_match( '/^\s*(\d{4}-\d{2}-\d{2})\s*$/', (string) $parsed, $matches ) ) {
+			return $matches[1] . ' 23:59:59';
+		}
+
+		// Other date-only formats accepted by strtotime() (e.g. "26-01-2099"). WordPress
+		// pins PHP's default timezone to UTC, so strtotime() and gmdate() operate in the
+		// same zone and the reformat cannot shift the calendar day.
+		$timestamp = strtotime( (string) $parsed );
+		if ( false === $timestamp ) {
+			return $parsed;
+		}
+
+		return gmdate( 'Y-m-d', $timestamp ) . ' 23:59:59';
+	}
+
+	/**
 	 * Parse backorders from a CSV.
 	 *
 	 * @param string $value Field value.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -840,7 +840,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'published'         => array( $this, 'parse_published_field' ),
 			'featured'          => array( $this, 'parse_bool_field' ),
 			'date_on_sale_from' => array( $this, 'parse_datetime_field' ),
-			'date_on_sale_to'   => array( $this, 'parse_datetime_field' ),
+			'date_on_sale_to'   => array( $this, 'parse_date_on_sale_to_field' ),
 			'name'              => array( $this, 'parse_skip_field' ),
 			'short_description' => array( $this, 'parse_description_field' ),
 			'description'       => array( $this, 'parse_description_field' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -582,7 +582,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 				'short_description'  => 'Lorem ipsum dolor sit amet, at exerci civibus appetere sit, iuvaret hendrerit mea no. Eam integre feugait liberavisse an.',
 				'description'        => 'Lorem ipsum dolor sit amet, at exerci civibus appetere sit, iuvaret hendrerit mea no. Eam integre feugait liberavisse an.',
 				'date_on_sale_from'  => '2023-07-08 05:10:15',
-				'date_on_sale_to'    => '2023/07/13',
+				'date_on_sale_to'    => '2023-07-13 23:59:59',
 				'tax_status'         => ProductTaxStatus::TAXABLE,
 				'tax_class'          => 'standard',
 				'stock_status'       => ProductStockStatus::IN_STOCK,

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -301,4 +301,79 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		$this->assertSame( '', $importer->parse_float_field( '' ), 'Empty values should be returned unchanged.' );
 	}
+
+	/**
+	 * @testdox Date-only "date on sale to" values are stored as end-of-day to match admin behaviour (#35321).
+	 */
+	public function test_parse_date_on_sale_to_field_date_only_is_end_of_day() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( '2099-01-26' ) );
+		$this->assertSame( '2022-10-25 23:59:59', $importer->parse_date_on_sale_to_field( '2022-10-25' ) );
+	}
+
+	/**
+	 * @testdox "date on sale to" values that already include a time component are preserved.
+	 */
+	public function test_parse_date_on_sale_to_field_preserves_time_component() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 10:30:00', $importer->parse_date_on_sale_to_field( '2099-01-26 10:30:00' ) );
+		$this->assertSame( '2099-01-26 10:30', $importer->parse_date_on_sale_to_field( '2099-01-26 10:30' ) );
+		// ISO8601 UTC form — both a plausible CSV value and the exact format this importer
+		// emits for Unix timestamps; must pass through with its UTC marker intact.
+		$this->assertSame( '2099-01-26T10:30:00Z', $importer->parse_date_on_sale_to_field( '2099-01-26T10:30:00Z' ) );
+	}
+
+	/**
+	 * @testdox Date-only "date on sale to" values in non-Y-m-d formats are normalised to Y-m-d end-of-day.
+	 */
+	public function test_parse_date_on_sale_to_field_alternate_date_formats() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( '26-01-2099' ) );
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( 'January 26, 2099' ) );
+	}
+
+	/**
+	 * @testdox "date on sale to" Unix timestamps are normalised to ISO8601 without being shifted to end-of-day.
+	 */
+	public function test_parse_date_on_sale_to_field_unix_timestamp_preserved() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		// The Unix timestamp 4073068800 corresponds to 2099-01-26 00:00:00 UTC.
+		$this->assertSame( '2099-01-26T00:00:00Z', $importer->parse_date_on_sale_to_field( '4073068800' ) );
+	}
+
+	/**
+	 * @testdox The site timezone setting cannot shift the calendar day of a date-only "date on sale to" value.
+	 */
+	public function test_parse_date_on_sale_to_field_site_timezone_does_not_drift() {
+		// Pacific/Kiritimati (UTC+14) is the maximum-drift-risk zone. WP keeps PHP's
+		// default timezone at UTC regardless, and the parser must be a pure string
+		// transformation, so the output may not depend on this option at all.
+		// WP_UnitTestCase rolls back option changes after each test.
+		update_option( 'timezone_string', 'Pacific/Kiritimati' );
+
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( '2099-01-26' ) );
+		$this->assertSame( '2099-01-26 23:59:59', $importer->parse_date_on_sale_to_field( '26-01-2099' ) );
+	}
+
+	/**
+	 * @testdox Empty / invalid "date on sale to" values are returned as null.
+	 */
+	public function test_parse_date_on_sale_to_field_empty_and_invalid() {
+		$csv_file = __DIR__ . '/sample.csv';
+		$importer = new WC_Product_CSV_Importer( $csv_file );
+
+		$this->assertNull( $importer->parse_date_on_sale_to_field( '' ) );
+		$this->assertNull( $importer->parse_date_on_sale_to_field( 'not-a-date' ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -400,8 +400,13 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		// file_put_contents/wp_delete_file (not fopen/fputcsv/@unlink) keep this clean
 		// against WooCommerce's phpcs ruleset, which treats warnings as failures.
-		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
-		$lines    = array(
+		// wp_tempnam() always appends a .tmp extension; the importer requires a
+		// .csv/.txt extension, so rename in place (no leftover stub file).
+		$tmp_path = wp_tempnam( 'wc-csv' );
+		$csv_path = $tmp_path . '.csv';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Tests rename a tmp file we control.
+		rename( $tmp_path, $csv_path );
+		$lines = array(
 			'"ID","date sale price starts","date sale price ends","Sale price"',
 			sprintf( '%d,"2022-10-25","2099-01-26","2.00"', $product->get_id() ),
 			sprintf( '%d,"2022-10-25 09:00:00","2099-01-26 10:30:00","2.00"', $timed_product->get_id() ),
@@ -427,8 +432,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$updated   = wc_get_product( $product->get_id() );
 		$date_to   = $updated->get_date_on_sale_to();
 		$date_from = $updated->get_date_on_sale_from();
-		// tempnam() also created this extensionless file.
-		$tmp_stub = preg_replace( '/\.csv$/', '', $csv_path );
 
 		$this->assertNotNull( $date_to, 'date_on_sale_to should be set' );
 		$this->assertNotNull( $date_from, 'date_on_sale_from should be set' );
@@ -453,7 +456,6 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 		WC_Helper_Product::delete_product( $timed_product->get_id() );
 		wp_delete_file( $csv_path );
-		wp_delete_file( $tmp_stub );
 	}
 
 	/**
@@ -465,8 +467,13 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$product->set_regular_price( '10.00' );
 		$product->save();
 
-		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
-		$lines    = array(
+		// wp_tempnam() always appends a .tmp extension; the importer requires a
+		// .csv/.txt extension, so rename in place (no leftover stub file).
+		$tmp_path = wp_tempnam( 'wc-csv' );
+		$csv_path = $tmp_path . '.csv';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Tests rename a tmp file we control.
+		rename( $tmp_path, $csv_path );
+		$lines = array(
 			'"ID","date sale price starts","date sale price ends","Sale price"',
 			sprintf( '%d,"2022-10-25","2099-01-26","2.00"', $product->get_id() ),
 		);
@@ -524,7 +531,5 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		WC_Helper_Product::delete_product( $product->get_id() );
 		wp_delete_file( $csv_path );
-		// tempnam() also created this extensionless file.
-		wp_delete_file( preg_replace( '/\.csv$/', '', $csv_path ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -376,4 +376,155 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->assertNull( $importer->parse_date_on_sale_to_field( '' ) );
 		$this->assertNull( $importer->parse_date_on_sale_to_field( 'not-a-date' ) );
 	}
+
+	/**
+	 * @testdox Importing a CSV with a date-only "date sale price ends" stores end-of-day, matching admin (#35321).
+	 */
+	public function test_import_date_on_sale_to_date_only_is_end_of_day() {
+		// Run under a non-UTC site timezone (UTC+12/+13) so any timezone drift in the
+		// parse → set_date_prop → meta round trip would surface as a wrong calendar day
+		// or time below. WP_UnitTestCase rolls back option changes after each test.
+		update_option( 'timezone_string', 'Pacific/Auckland' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'issue-35321-sku' );
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		// Second product with explicit times: the preserved (timed) path must reach the
+		// stored props at the exact site-local times, untouched by the end-of-day bump.
+		$timed_product = WC_Helper_Product::create_simple_product();
+		$timed_product->set_sku( 'issue-35321-timed-sku' );
+		$timed_product->set_regular_price( '10.00' );
+		$timed_product->save();
+
+		// file_put_contents/wp_delete_file (not fopen/fputcsv/@unlink) keep this clean
+		// against WooCommerce's phpcs ruleset, which treats warnings as failures.
+		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
+		$lines    = array(
+			'"ID","date sale price starts","date sale price ends","Sale price"',
+			sprintf( '%d,"2022-10-25","2099-01-26","2.00"', $product->get_id() ),
+			sprintf( '%d,"2022-10-25 09:00:00","2099-01-26 10:30:00","2.00"', $timed_product->get_id() ),
+		);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tests write to a tmp file we control.
+		file_put_contents( $csv_path, implode( "\n", $lines ) . "\n" );
+
+		$importer = new WC_Product_CSV_Importer(
+			$csv_path,
+			array(
+				'update_existing' => true,
+				'parse'           => true,
+				'mapping'         => array(
+					'ID'                     => 'id',
+					'date sale price starts' => 'date_on_sale_from',
+					'date sale price ends'   => 'date_on_sale_to',
+					'Sale price'             => 'sale_price',
+				),
+			)
+		);
+		$importer->import();
+
+		$updated   = wc_get_product( $product->get_id() );
+		$date_to   = $updated->get_date_on_sale_to();
+		$date_from = $updated->get_date_on_sale_from();
+		// tempnam() also created this extensionless file.
+		$tmp_stub = preg_replace( '/\.csv$/', '', $csv_path );
+
+		$this->assertNotNull( $date_to, 'date_on_sale_to should be set' );
+		$this->assertNotNull( $date_from, 'date_on_sale_from should be set' );
+		// WC_DateTime::date() renders in the site timezone, so these assert the
+		// site-local (admin-parity) values, not UTC.
+		$this->assertSame( '23:59:59', $date_to->date( 'H:i:s' ), 'date_on_sale_to should be end-of-day (site-local) to match admin' );
+		$this->assertSame( '2099-01-26', $date_to->date( 'Y-m-d' ), 'date_on_sale_to calendar day must not drift in a non-UTC site timezone' );
+		$this->assertSame( '00:00:00', $date_from->date( 'H:i:s' ), 'date_on_sale_from should remain start-of-day' );
+		$this->assertSame( '2022-10-25', $date_from->date( 'Y-m-d' ) );
+
+		// Timed values are preserved exactly, interpreted as site-local (like the admin),
+		// enabling sub-day sales (here: a 09:00–10:30 window on specific days).
+		$updated_timed   = wc_get_product( $timed_product->get_id() );
+		$timed_date_to   = $updated_timed->get_date_on_sale_to();
+		$timed_date_from = $updated_timed->get_date_on_sale_from();
+
+		$this->assertNotNull( $timed_date_to, 'timed date_on_sale_to should be set' );
+		$this->assertNotNull( $timed_date_from, 'timed date_on_sale_from should be set' );
+		$this->assertSame( '2099-01-26 10:30:00', $timed_date_to->date( 'Y-m-d H:i:s' ), 'explicit end time must be preserved site-local, not bumped to end-of-day' );
+		$this->assertSame( '2022-10-25 09:00:00', $timed_date_from->date( 'Y-m-d H:i:s' ), 'explicit start time must be preserved site-local' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		WC_Helper_Product::delete_product( $timed_product->get_id() );
+		wp_delete_file( $csv_path );
+		wp_delete_file( $tmp_stub );
+	}
+
+	/**
+	 * @testdox Re-importing the same CSV is idempotent: the sale-end timestamp is unchanged, the end-of-day bump does not compound, and no duplicate scheduled actions pile up.
+	 */
+	public function test_import_date_on_sale_to_reimport_is_idempotent() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'issue-35321-idempotent-sku' );
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		$csv_path = tempnam( sys_get_temp_dir(), 'wc-csv-' ) . '.csv';
+		$lines    = array(
+			'"ID","date sale price starts","date sale price ends","Sale price"',
+			sprintf( '%d,"2022-10-25","2099-01-26","2.00"', $product->get_id() ),
+		);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tests write to a tmp file we control.
+		file_put_contents( $csv_path, implode( "\n", $lines ) . "\n" );
+
+		$make_importer = function () use ( $csv_path ) {
+			return new WC_Product_CSV_Importer(
+				$csv_path,
+				array(
+					'update_existing' => true,
+					'parse'           => true,
+					'mapping'         => array(
+						'ID'                     => 'id',
+						'date sale price starts' => 'date_on_sale_from',
+						'date sale price ends'   => 'date_on_sale_to',
+						'Sale price'             => 'sale_price',
+					),
+				)
+			);
+		};
+
+		// wc_schedule_product_sale_events() schedules the exact-time end-of-sale action
+		// with these args/group; args shape per wc-product-functions.php.
+		$pending_end_actions = function () use ( $product ) {
+			return as_get_scheduled_actions(
+				array(
+					'hook'     => 'wc_product_end_scheduled_sale',
+					'args'     => array( 'product_id' => $product->get_id() ),
+					'group'    => 'woocommerce-sales',
+					'status'   => ActionScheduler_Store::STATUS_PENDING,
+					'per_page' => 10,
+				),
+				'ids'
+			);
+		};
+
+		$make_importer()->import();
+		$first = wc_get_product( $product->get_id() )->get_date_on_sale_to();
+
+		$this->assertNotNull( $first, 'date_on_sale_to should be set after the first import' );
+		$this->assertSame( '23:59:59', $first->date( 'H:i:s' ) );
+		$first_timestamp = $first->getTimestamp();
+		$this->assertCount( 1, $pending_end_actions(), 'exactly one pending end-sale action after the first import' );
+
+		// Second, identical import. The parser reads the raw CSV value again (never the
+		// stored value), so the result is byte-identical; unchanged props mean the data
+		// store writes no meta, no meta hook fires, and nothing is rescheduled.
+		$make_importer()->import();
+		$second = wc_get_product( $product->get_id() )->get_date_on_sale_to();
+
+		$this->assertSame( $first_timestamp, $second->getTimestamp(), 're-import must not change the stored sale-end timestamp' );
+		$this->assertSame( '23:59:59', $second->date( 'H:i:s' ), 'the end-of-day bump must not compound on re-import' );
+		$this->assertCount( 1, $pending_end_actions(), 'still exactly one pending end-sale action after re-import' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wp_delete_file( $csv_path );
+		// tempnam() also created this extensionless file.
+		wp_delete_file( preg_replace( '/\.csv$/', '', $csv_path ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

**Why?** A date-only "date sale price ends" value in a product CSV (e.g. `2023-01-26`) imports as midnight, so the sale ends ~24 hours earlier than the same sale configured on the product edit screen — the admin stores the end date as `Y-m-d 23:59:59`, while the importer passed the raw value through and `WC_Data::set_date_prop()` read it as start-of-day. Since WooCommerce 10.5.0, `wc_product_end_scheduled_sale` fires at the *exact* stored timestamp, so the day-early flip is precise. This PR makes imported sales end at the same moment as admin-configured ones.

**How?** Adds `WC_Product_CSV_Importer::parse_date_on_sale_to_field()` — a wrapper around the existing `parse_datetime_field()` that bumps date-only values to `23:59:59`, and switches only the `date_on_sale_to` column mapping to it. Whether a value names a time is decided by `date_parse()`, which reports an hour for every format `strtotime()` understands (`2099-01-26T10`, `20990126T103000`, `January 26, 2099 10am`) and flags relative expressions (`now`, `+1 week`, `@4073068800`) separately — so anything that already says when the sale ends is passed through untouched, Unix timestamps included. A bare calendar day is rebuilt from the parsed year/month/day as a string _(no timestamp round-trip — no timezone can shift the calendar day)_. `date_on_sale_from` keeps its start-of-day semantics, which already match the admin.

Worth noting:

- **BC impact:** one new public method (additive, non-breaking). Date-only `date_on_sale_to` values now import as `23:59:59` instead of `00:00:00` — an intentional behavior change matching the admin UI. The Woo→Woo export/import round trip is unaffected (the exporter writes full datetimes).
- **First re-import after upgrading is not a no-op.** Re-running an otherwise unchanged CSV rewrites stored date-only end dates from midnight to `23:59:59` and reschedules the corresponding `wc_product_end_scheduled_sale` actions. That is the fix landing, not a side effect, and it is called out in the changelog entry. Stores that want the old behavior can restore it per column through the existing `woocommerce_product_importer_formatting_callbacks` filter.
- **Action Scheduler:** no scheduling code is touched — since 10.8.0 (#64140) the post-meta hooks reschedule `wc_product_end_scheduled_sale` automatically when the importer writes `_sale_price_dates_to`.
- Not a recent regression — the behavior dates back to the original importer (the parser was last touched in #38757), so no "bug introduced in PR" link applies.

Closes #35321.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a simple product with a regular price and note its ID.
2. Create a CSV with columns `ID`, `Sale price`, `date sale price starts`, `date sale price ends`, using date-only values — e.g. `"2022-10-25"` and `"2099-01-26"` — and a sale price.
3. Go to **Products → All Products → Import**, enable **Update existing products**, map the columns, and run the import.
4. Check `_sale_price_dates_to` post meta (e.g. `wp post meta get <ID> _sale_price_dates_to`) — it should correspond to `2099-01-26 23:59:59` site-local (before this fix: `00:00:00`), while `_sale_price_dates_from` stays at `2022-10-25 00:00:00`.
5. Re-run the same import — stored dates must be unchanged, with exactly one pending `wc_product_end_scheduled_sale` action under **WooCommerce → Status → Scheduled Actions**.
6. Optionally, import a row with an explicit time (e.g. `"2099-01-26 10:30:00"`) and confirm it is preserved exactly.

<!-- End testing instructions -->

### Testing that has already taken place:

- New unit tests covering the parser: date-only → end-of-day, alternate date-only formats (`26-01-2099`, `2099/01/26`, `January 26, 2099`), explicit-time passthrough including colonless forms (`20990126T103000`, `2099-01-26T10`, `January 26, 2099 10am`), relative expressions (`now`, `+1 week`, `tomorrow`, `@4073068800`) left alone, Unix timestamps normalised to ISO8601 without an end-of-day bump, and empty/invalid → null.
- New end-to-end import tests: admin parity under a non-UTC site timezone (Pacific/Auckland), `date_on_sale_from` staying start-of-day, exact preservation of explicit times, re-import idempotency (stable timestamp, no compounding bump, exactly one pending `wc_product_end_scheduled_sale` action), and the first post-upgrade re-import moving a pre-existing midnight value to `23:59:59` and rescheduling its sale-end action.
- The `date_on_sale_to` tests pass in wp-env (10 tests, 41 assertions), as does the full `WC_Product_CSV_Importer_Test` class (62 tests, 236 assertions); `lint:php:changes`, `lint:changes:branch`, and PHPStan on the touched importer file are all clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
