### PR TITLE
Fix nullable parent names in REST API order items

### DIFF
--- a/plugins/woocommerce/changelog/fix-28861-nullable-parent-name
+++ b/plugins/woocommerce/changelog/fix-28861-nullable-parent-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow null parent names in REST API order line items.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1506,7 +1506,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'parent_name'      => array(
 								'description' => __( 'Parent product name if the product is a variation.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'product_id'       => array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -798,7 +798,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the order line items schema.
+	 * @testdox Should expose the expected order line item schema.
 	 */
 	public function test_order_line_items_schema() {
 		wp_set_current_user( $this->user );
@@ -813,6 +813,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
+		$this->assertSame( array( 'string', 'null' ), $line_item_properties['parent_name']['type'] );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -578,6 +578,33 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should accept a null parent name when updating a non-variation line item.
+	 */
+	public function test_update_order_accepts_null_parent_name(): void {
+		wp_set_current_user( $this->user );
+		$product   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$order     = OrderHelper::create_order( 1, $product );
+		$line_item = current( $order->get_items( 'line_item' ) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'id'          => $line_item->get_id(),
+						'parent_name' => null,
+					),
+				),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $data['line_items'][0]['parent_name'] );
+	}
+
+	/**
 	 * Tests updating an order and removing items.
 	 *
 	 * @since 3.5.0
@@ -1153,7 +1180,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the order line items schema.
+	 * @testdox Should expose the expected order line item schema.
 	 */
 	public function test_order_line_items_schema() {
 		wp_set_current_user( $this->user );
@@ -1168,6 +1195,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
+		$this->assertSame( array( 'string', 'null' ), $line_item_properties['parent_name']['type'] );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Order responses return `parent_name: null` for non-variation line items, while the REST schema only permits strings. This causes clients that send returned line items back through PUT to receive a `400 rest_invalid_param` response.

This widens the inherited v2/v3 schema to accept strings or null and adds schema and endpoint-level regression coverage. The runtime response remains unchanged, so the public REST schema now accurately describes the established API behavior.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #28861.

Bug introduced in PR #28080.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the Orders REST API tests:

   ```sh
   pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter 'WC_Tests_API_Orders(_V2)?'
   ```

2. Confirm all tests pass.
3. Create an order containing a simple product and request it through `GET /wp-json/wc/v3/orders/<order_id>`.
4. Confirm its line item contains `"parent_name": null`.
5. Update the order through `PUT /wp-json/wc/v3/orders/<order_id>` with:

   ```json
   {
     "line_items": [
       {
         "id": "<line_item_id>",
         "parent_name": null
       }
     ]
   }
   ```

6. Confirm the request returns HTTP 200 and the response retains `"parent_name": null`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Reproduced the original HTTP 400 response on WooCommerce 11.1.0-dev, WordPress 7.0.1, and PHP 8.1.34.
- Ran both complete legacy Orders REST API test classes: 77 tests and 307 assertions passed.
- Ran `lint:php:changes` and `lint:changes:branch`.
- Ran PHPStan against the modified production controller with no errors.
- Reviewed the final diff against WooCommerce backend and testing conventions.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-28861-nullable-parent-name`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
