### PR TITLE
Fix shipping tax for manual orders without products

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-only-order-tax
+++ b/plugins/woocommerce/changelog/fix-shipping-only-order-tax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply shipping tax to manual orders that contain shipping but no products.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1999,7 +1999,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$found_classes      = array_intersect( array_merge( array( '' ), WC_Tax::get_tax_class_slugs() ), $this->get_items_tax_classes() );
 			$shipping_tax_class = count( $found_classes ) ? current( $found_classes ) : false;
 
-			// Shipping-only orders have no product tax class to inherit, so use the standard class.
+			// Orders without product line items have no tax class to inherit, so use the standard class.
 			if ( false === $shipping_tax_class && 0 === count( $this->get_items() ) ) {
 				$shipping_tax_class = '';
 			}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1998,6 +1998,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 'inherit' === $shipping_tax_class ) {
 			$found_classes      = array_intersect( array_merge( array( '' ), WC_Tax::get_tax_class_slugs() ), $this->get_items_tax_classes() );
 			$shipping_tax_class = count( $found_classes ) ? current( $found_classes ) : false;
+
+			// Shipping-only orders have no product tax class to inherit, so use the standard class.
+			if ( false === $shipping_tax_class && 0 === count( $this->get_items() ) ) {
+				$shipping_tax_class = '';
+			}
 		}
 
 		$is_vat_exempt = apply_filters( 'woocommerce_order_is_vat_exempt', 'yes' === $this->get_meta( 'is_vat_exempt' ), $this );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
@@ -712,6 +713,75 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$tax_item_after = reset( $tax_items_after );
 		$this->assertSame( 2.00, (float) $tax_item_after->get_tax_total() );
 		$this->assertSame( 0.50, (float) $tax_item_after->get_shipping_tax_total() );
+	}
+
+	/**
+	 * @testdox calculate_taxes handles inherited shipping tax when no taxable product class is available.
+	 * @dataProvider inherited_shipping_tax_without_taxable_products_provider
+	 *
+	 * @param bool  $add_non_taxable_product Whether to add a non-taxable product to the order.
+	 * @param float $expected_shipping_tax   Expected shipping tax total.
+	 */
+	public function test_calculate_taxes_handles_inherited_shipping_tax_without_taxable_products( bool $add_non_taxable_product, float $expected_shipping_tax ): void {
+		$original_calc_taxes         = get_option( 'woocommerce_calc_taxes', 'no' );
+		$original_shipping_tax_class = get_option( 'woocommerce_shipping_tax_class', 'inherit' );
+		$order                       = new WC_Order();
+		$product                     = null;
+
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		$tax_rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'Standard tax',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		try {
+			if ( $add_non_taxable_product ) {
+				$product = WC_Helper_Product::create_simple_product();
+				$product->set_tax_status( ProductTaxStatus::NONE );
+				$product->save();
+				$order->add_product( $product );
+			}
+
+			$shipping_item = new WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( 'Manual shipping' );
+			$shipping_item->set_total( 10 );
+			$order->add_item( $shipping_item );
+
+			$order->calculate_totals();
+
+			$this->assertSame( $expected_shipping_tax, (float) $order->get_shipping_tax() );
+		} finally {
+			WC_Tax::_delete_tax_rate( $tax_rate_id );
+			update_option( 'woocommerce_calc_taxes', $original_calc_taxes );
+			update_option( 'woocommerce_shipping_tax_class', $original_shipping_tax_class );
+			$order->delete( true );
+			if ( $product ) {
+				$product->delete( true );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for inherited shipping tax calculations without taxable products.
+	 *
+	 * @return array<string, array{bool, float}>
+	 */
+	public function inherited_shipping_tax_without_taxable_products_provider(): array {
+		return array(
+			'shipping-only order' => array( false, 1.0 ),
+			'non-taxable product' => array( true, 0.0 ),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -720,9 +720,10 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 * @dataProvider inherited_shipping_tax_without_taxable_products_provider
 	 *
 	 * @param bool  $add_non_taxable_product Whether to add a non-taxable product to the order.
+	 * @param bool  $add_non_taxable_fee     Whether to add a non-taxable fee to the order.
 	 * @param float $expected_shipping_tax   Expected shipping tax total.
 	 */
-	public function test_calculate_taxes_handles_inherited_shipping_tax_without_taxable_products( bool $add_non_taxable_product, float $expected_shipping_tax ): void {
+	public function test_calculate_taxes_handles_inherited_shipping_tax_without_taxable_products( bool $add_non_taxable_product, bool $add_non_taxable_fee, float $expected_shipping_tax ): void {
 		$original_calc_taxes         = get_option( 'woocommerce_calc_taxes', 'no' );
 		$original_shipping_tax_class = get_option( 'woocommerce_shipping_tax_class', 'inherit' );
 		$order                       = new WC_Order();
@@ -753,9 +754,18 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 				$order->add_product( $product );
 			}
 
+			if ( $add_non_taxable_fee ) {
+				$fee_item = new WC_Order_Item_Fee();
+				$fee_item->set_name( 'Manual fee' );
+				$fee_item->set_amount( '5' );
+				$fee_item->set_total( '5' );
+				$fee_item->set_tax_status( ProductTaxStatus::NONE );
+				$order->add_item( $fee_item );
+			}
+
 			$shipping_item = new WC_Order_Item_Shipping();
 			$shipping_item->set_method_title( 'Manual shipping' );
-			$shipping_item->set_total( 10 );
+			$shipping_item->set_total( '10' );
 			$order->add_item( $shipping_item );
 
 			$order->calculate_totals();
@@ -775,12 +785,13 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	/**
 	 * Data provider for inherited shipping tax calculations without taxable products.
 	 *
-	 * @return array<string, array{bool, float}>
+	 * @return array<string, array{bool, bool, float}>
 	 */
 	public function inherited_shipping_tax_without_taxable_products_provider(): array {
 		return array(
-			'shipping-only order' => array( false, 1.0 ),
-			'non-taxable product' => array( true, 0.0 ),
+			'shipping-only order'           => array( false, false, 1.0 ),
+			'non-taxable product'           => array( true, false, 0.0 ),
+			'non-taxable fee with shipping' => array( false, true, 1.0 ),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Manual orders without product line items cannot inherit a product tax class, causing recalculation to clear otherwise applicable shipping tax. Fall back to the Standard tax class when the order has no product line items, including orders containing fees and shipping, while preserving the existing behavior for orders containing non-taxable products.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #27225.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable taxes and create a 10% Standard tax rate with shipping enabled.
2. Set **WooCommerce > Settings > Tax > Tax options > Shipping tax class** to **Standard** initially to create the rate, then select **Based on cart items**.
3. Create a manual order with a matching taxable address, no products, and a $10 shipping line.
4. Click **Recalculate** and confirm the shipping line has $1 tax and the order total is $11.
5. Add a non-taxable product to a separate order with shipping, recalculate, and confirm shipping remains untaxed.
6. Create an order with a non-taxable fee and shipping but no products, recalculate, and confirm the shipping uses the Standard tax class.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Confirmed the regression test fails before the fix and passes afterward.
- Verified three focused cases: shipping-only, non-taxable product, and non-taxable fee with shipping (`3 tests, 3 assertions`).
- Ran `WC_Abstract_Order_Test`: 34 tests, 108 assertions.
- Ran changed-file PHPCS and the full branch-diff lint.
- Ran PHPStan against `includes/abstracts/abstract-wc-order.php`.
- Reproduced and verified the fix in wp-env using WordPress latest, WooCommerce 11.1.0-dev, and PHP 8.1. The legacy admin order page rendered $1 shipping tax and an $11 total for the $10 shipping-only order.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>