### PR TITLE
Add single-line changelog validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,10 +641,10 @@ jobs:
             fail=0
             while IFS= read -r file; do
               if ! awk '
-                NR==1 && $0 !~ /^Significance:/ { exit 0 }
-                /^[[:space:]]*$/ { if (!body) { body=1; next } }
+                !body && /^Significance:/ { sig=1 }
+                !body && /^[[:space:]]*$/ { body=1; next }
                 body { if (NF) c++ }
-                END { exit (c>1) }
+                END { exit (sig && c>1) }
               ' "$file"; then
                 echo "::error file=${file}::Changelog message must be a single line so it can be sorted and rendered correctly during release. Move any extra detail into the 'Comment:' header."
                 fail=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,24 @@ jobs:
 
             pnpm --parallel --workspace-concurrency=10 --stream $filter changelog validate
 
+      - name: 'Validate - single-line messages'
+        run: |
+            # Changelog entry messages must be a single line. Multi-line messages break the
+            # line-based sorting and rendering done by the "Release: Compile changelog" workflow.
+            fail=0
+            while IFS= read -r file; do
+              if ! awk '
+                NR==1 && $0 !~ /^Significance:/ { exit 0 }
+                /^[[:space:]]*$/ { if (!body) { body=1; next } }
+                body { if (NF) c++ }
+                END { exit (c>1) }
+              ' "$file"; then
+                echo "::error file=${file}::Changelog message must be a single line so it can be sorted and rendered correctly during release. Move any extra detail into the 'Comment:' header."
+                fail=1
+              fi
+            done < <(git ls-files -- '*/changelog/*' ':!:*/changelog/*.md' ':!:*/changelog/*.txt' ':!:*/changelog/.*')
+            exit $fail
+
   validate-markdown:
     name: 'Validate markdown'
     if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'trunk' && needs.identify-jobs-to-run.outputs.needs-markdown-validation == 'true' }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #60678

This PR adds a new validation step to the CI workflow that enforces changelog entry messages must be single-line. Multi-line messages break the line-based sorting and rendering performed by the "Release: Compile changelog" workflow.

The validation:
- Checks all changelog files in `*/changelog/*` directories (excluding `.md`, `.txt`, and dotfiles)
- Ensures the message body contains only a single line of content
- Provides a clear error message directing contributors to move extra details into the `Comment:` header field
- Fails the CI check if any changelog entries violate this constraint

### Testing that has already taken place:

The validation script uses standard POSIX `awk` and shell utilities. The logic has been validated to:
- Identify changelogger entry files by a `Significance:` header appearing anywhere in the header block (regardless of header order), so non-entry files — e.g. source files under directories named `changelog` — are skipped
- Properly detect multi-line message bodies while still allowing `Comment:`-only entries
- Generate appropriate error output with file references for GitHub Actions annotation

Verified against all tracked files under `*/changelog/*` with zero false positives, while still flagging a deliberately multi-line entry.

The check runs inside the existing `Validate changelog` CI job, so — consistent with that job's scope — it applies to pull requests that touch package source and require a changelog entry. It does not run on PRs that opt out of a changelog, `woocommercebot`/bot PRs, or changelog-only changes that don't otherwise trigger the job.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [x] This Pull Request does not require a changelog entry.

**Comment:** This is a CI/workflow improvement that enforces existing changelog conventions. No user-facing or developer-facing changes.

https://claude.ai/code/session_013mYJFSbssivXbaZpHWTqqG