### PR TITLE
Fix coupon line items not respecting the dp parameter in orders API

### DIFF
--- a/plugins/woocommerce/changelog/fix-35821
+++ b/plugins/woocommerce/changelog/fix-35821
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon line items not respecting the dp parameter in orders API and add tests.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -215,7 +215,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	protected function get_order_item_data( $item ) {
 		$data           = $item->get_data();
-		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total' );
+		$format_decimal = array( 'subtotal', 'subtotal_tax', 'total', 'total_tax', 'tax_total', 'shipping_tax_total', 'discount', 'discount_tax' );
 
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -164,6 +164,73 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests key monetary fields respect the dp request parameter when getting a single order.
+	 */
+	public function test_get_item_monetary_fields_respect_dp() {
+		wp_set_current_user( $this->user );
+
+		$order  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'dp-coupon' );
+		$coupon->set_amount( 2 );
+		$coupon->save();
+
+		$shipping = new WC_Order_Item_Shipping();
+		$shipping->set_method_title( 'Flat rate' );
+		$shipping->set_method_id( 'flat_rate' );
+		$shipping->set_total( 5 );
+		$order->add_item( $shipping );
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_name( 'Handling fee' );
+		$fee->set_tax_status( ProductTaxStatus::NONE );
+		$fee->set_total( 3 );
+		$order->add_item( $fee );
+
+		$order->apply_coupon( $coupon );
+		$order->calculate_totals( true );
+		$order->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() );
+		$request->set_param( 'dp', 5 );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$top_level_decimal_fields = array(
+			'discount_total',
+			'discount_tax',
+			'shipping_total',
+			'shipping_tax',
+			'cart_tax',
+			'total',
+			'total_tax',
+		);
+
+		foreach ( $top_level_decimal_fields as $field ) {
+			$this->assertMatchesRegularExpression( '/^-?\\d+\.\\d{5}$/', $data[ $field ], "Expected $field to use 5 decimal places" );
+		}
+
+		$line_item_decimal_fields = array(
+			'line_items'     => array( 'subtotal', 'subtotal_tax', 'total', 'total_tax' ),
+			'shipping_lines' => array( 'total', 'total_tax' ),
+			'fee_lines'      => array( 'total', 'total_tax' ),
+			'coupon_lines'   => array( 'discount', 'discount_tax' ),
+		);
+
+		foreach ( $line_item_decimal_fields as $line_type => $fields ) {
+			$this->assertNotEmpty( $data[ $line_type ], "Expected $line_type to contain at least one item" );
+
+			foreach ( $data[ $line_type ] as $item ) {
+				foreach ( $fields as $field ) {
+					$this->assertMatchesRegularExpression( '/^-?\\d+\.\\d{5}$/', $item[ $field ], "Expected $line_type.$field to use 5 decimal places" );
+				}
+			}
+		}
+	}
+
+	/**
 	 * Tests getting a single order without the correct permissions.
 	 * @since 3.0.0
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Add `discount` and `discount_tax` to the decimal formatting list in WC_REST_Orders_V2_Controller::get_order_item_data() so coupon line items respect the `dp` query parameter alongside other monetary fields. This ensures consistency between order-level totals and coupon-level discounts when precision is requested.

Also add a regression test in `WC_Tests_API_Orders_V2` that validates `dp` precision behavior across key monetary response fields, including top-level order totals and line-item monetary fields (line items, shipping lines, fee lines, and coupon lines), so similar precision regressions are surfaced in future changes (please let me know if this is out of scope of this issue/PR).

Closes #35821

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create or use an order with an applied coupon (e.g., $2 fixed discount)
2. Send an authenticated GET request to `/wp-json/wc/v3/orders/{id}?dp=5` using OAuth 1.0
3. Confirm `coupon_lines[0].discount` returns `"2.00000"` and `coupon_lines[0].discount_tax` returns `"0.00000"` (5 decimal places)
4. Verify without the `dp` parameter that values default to the shop's configured decimal precision
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=WC_Tests_API_Orders_V2` to confirm all order endpoint tests pass

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
