### PR TITLE
Fix widget block filtering in the Customizer

### DIFF
--- a/plugins/woocommerce/changelog/fix-customizer-widget-block-filtering
+++ b/plugins/woocommerce/changelog/fix-customizer-widget-block-filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure unsupported WooCommerce blocks are hidden from the Customizer's widget inserter.

--- a/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/index.ts
@@ -15,13 +15,21 @@ import {
 type BlockEditorContext = 'post' | 'widgets' | 'other';
 
 const getBlockEditorContext = (): BlockEditorContext => {
-	const adminPage = ( window as Window & { adminpage?: string } ).adminpage;
+	const wordpressWindow = window as Window & {
+		adminpage?: string;
+		pagenow?: string;
+	};
+	const adminPage = wordpressWindow.adminpage;
 
 	if ( [ 'post-php', 'post-new-php' ].includes( adminPage ?? '' ) ) {
 		return 'post';
 	}
 
-	if ( [ 'widgets-php', 'customize-php' ].includes( adminPage ?? '' ) ) {
+	// Customizer controls do not load the admin header, so adminpage is absent.
+	if (
+		[ 'widgets-php', 'customize-php' ].includes( adminPage ?? '' ) ||
+		wordpressWindow.pagenow === 'customize'
+	) {
 		return 'widgets';
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/test/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/filters/unregister-block-types/test/index.ts
@@ -13,8 +13,17 @@ jest.mock( '@wordpress/dom-ready', () => ( {
 	default: jest.fn( ( callback ) => callback() ),
 } ) );
 
-const loadFilter = ( adminPage: string | undefined, blockTypes: string[] ) => {
-	( window as Window & { adminpage?: string } ).adminpage = adminPage;
+const loadFilter = (
+	adminPage: string | undefined,
+	blockTypes: string[],
+	pageNow?: string
+) => {
+	const wordpressWindow = window as Window & {
+		adminpage?: string;
+		pagenow?: string;
+	};
+	wordpressWindow.adminpage = adminPage;
+	wordpressWindow.pagenow = pageNow;
 	( getBlockTypes as jest.Mock ).mockReturnValue(
 		blockTypes.map( ( name ) => ( { name } ) )
 	);
@@ -55,17 +64,24 @@ describe( 'unregister block types', () => {
 		}
 	);
 
-	it.each( [ 'widgets-php', 'customize-php' ] )(
+	it.each( [
+		[ 'widgets.php', 'widgets-php', undefined ],
+		[ 'the Customizer', undefined, 'customize' ],
+	] )(
 		'unregisters WooCommerce blocks outside the widget-editor allow list in %s',
-		( context ) => {
-			loadFilter( context, [
-				'woocommerce/product-search',
-				'woocommerce/product-filters',
-				'woocommerce/checkout',
-				'woocommerce/order-confirmation-status',
-				'woocommerce/new-widget-compatible-block',
-				'myplugin/client-only',
-			] );
+		( _context, adminPage, pageNow ) => {
+			loadFilter(
+				adminPage,
+				[
+					'woocommerce/product-search',
+					'woocommerce/product-filters',
+					'woocommerce/checkout',
+					'woocommerce/order-confirmation-status',
+					'woocommerce/new-widget-compatible-block',
+					'myplugin/client-only',
+				],
+				pageNow
+			);
 
 			expect( unregisterBlockType ).toHaveBeenCalledTimes( 3 );
 			expect( unregisterBlockType ).toHaveBeenCalledWith(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Customizer controls page does not define `window.adminpage`, so WooCommerce's widget filtering treated it as an unrestricted editor and exposed blocks that are incompatible with widget areas. Detect the Customizer through WordPress's `window.pagenow` global and add regression coverage for the globals available on `customize.php`.

Closes #66644.

Bug introduced in PR #66628.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Activate a classic theme that supports widget areas.
2. Go to **Appearance > Customize > Widgets** and open a widget area.
3. Open the block inserter and verify incompatible WooCommerce blocks, including Checkout, Cart, and Order Confirmation, are not listed.
4. Verify supported blocks, including Product Search, Product Filters, and Mini-Cart, remain available.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
