### PR TITLE
Fix TypeError when screen ID is not a string in visual attribute script enqueue

### DIFF
--- a/plugins/woocommerce/changelog/fix-66528-strpos-typeerror-visual-attribute-admin
+++ b/plugins/woocommerce/changelog/fix-66528-strpos-typeerror-visual-attribute-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard against non-string screen ID in visual attribute script enqueue

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -314,7 +314,7 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 	public function enqueue_visual_attribute_script(): void {
 		$screen = get_current_screen();
 
-		if ( ! $screen ) {
+		if ( ! $screen || ! is_string( $screen->id ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\ProductAttributes;
 
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermAdmin;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use WC_Unit_Test_Case;
 
 /**
@@ -232,6 +233,48 @@ class VisualAttributeTermAdminTest extends WC_Unit_Test_Case {
 		} finally {
 			unregister_taxonomy( $taxonomy );
 			wc_delete_attribute( $attribute_id );
+		}
+	}
+
+	/**
+	 * @testdox Should not throw a TypeError when the current screen has a non-string id.
+	 *
+	 * Reproduces issue #66528: Visual Composer calls do_action('admin_enqueue_scripts', NULL),
+	 * which triggers enqueue_visual_attribute_script() in a context where get_current_screen()
+	 * may return a screen object whose id is an integer (post ID) rather than a string,
+	 * causing strpos(): Argument #1 ($haystack) must be of type string.
+	 */
+	public function test_does_not_fatal_on_non_string_screen_id(): void {
+		// We need the wc-visual attribute type available, same setup as other tests.
+		switch_theme( 'twentytwentyfour' );
+		delete_option( 'woocommerce_feature_wc_visual_attribute_enabled' );
+		wc_get_container()
+			->get( \Automattic\WooCommerce\Internal\Features\FeaturesController::class )
+			->change_feature_enable( 'wc-visual-attribute', true );
+
+		$instance = wc_get_container()->get( VisualAttributeTermAdmin::class );
+
+		// Simulate the scenario where get_current_screen() returns a screen with an integer id
+		// (e.g. a post ID), as happens when third-party code triggers admin_enqueue_scripts
+		// from outside the normal admin context.
+		$screen = \WP_Screen::get( 'test-screen' );
+		// Non-string, integer id like in the reported error.
+		$screen->id = 35202; // phpcs:ignore Generic.Formatting.MultipleStatementAlignment.IncorrectWarning
+
+		$original_screen           = isset( $GLOBALS['current_screen'] ) ? $GLOBALS['current_screen'] : null;
+		$GLOBALS['current_screen'] = $screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		try {
+			// This should not throw a TypeError even though $screen->id is an integer.
+			$instance->enqueue_visual_attribute_script();
+			// If we reach here, the method handled the non-string id gracefully.
+			$this->assertTrue( true );
+		} catch ( \TypeError $e ) {
+			$this->fail( 'TypeError thrown: ' . $e->getMessage() );
+		} finally {
+			$GLOBALS['current_screen'] = $original_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			delete_option( 'woocommerce_feature_wc_visual_attribute_enabled' );
+			switch_theme( $this->original_theme );
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When Visual Composer (or any third-party plugin) calls `do_action('admin_enqueue_scripts', NULL)` outside the normal admin context, `get_current_screen()` may return a `WP_Screen` object whose `id` property is an integer (a post ID) rather than a string. The `enqueue_visual_attribute_script()` method then passes this integer to `strpos()`, which throws a `TypeError` on PHP 8+.

This PR adds an `is_string()` guard on `$screen->id` to prevent the fatal error when the screen ID is not a string.

Closes woocommerce/woocommerce#66528.

Bug introduced in PR [#65347](<https://github.com/woocommerce/woocommerce/issues/65347>).

### How to test the changes in this Pull Request:

1. Apply this patch.
2. Run `phpunit --filter VisualAttributeTermAdminTest::test_does_not_fatal_on_non_string_screen_id` to verify the fix.
3. Or manually: trigger `do_action('admin_enqueue_scripts', NULL)` from a plugin and verify no fatal error occurs.

### Testing that has already taken place:

* PHP lint (`pnpm lint:php:changes`) passes with no errors or warnings.
* PHPStan analysis passes with no errors.
* A new PHPUnit test (`test_does_not_fatal_on_non_string_screen_id`) was added that reproduces the exact scenario (screen `id` set to integer `35202`) and confirms the method handles it gracefully.

### Milestone

- [X] Automatically assign milestone for the **next WooCommerce version**.

### Changelog entry

- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>