### PR TITLE
Fix CSV importer HTML-encoding attribute names

### DIFF
--- a/plugins/woocommerce/changelog/fix-28172-csv-importer-attribute-name-sanitization
+++ b/plugins/woocommerce/changelog/fix-28172-csv-importer-attribute-name-sanitization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CSV importer HTML-encoding attribute names, which prevented matching existing global attributes and caused duplicate attributes or slug-too-long import errors.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -844,9 +844,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			if ( isset( $data_formatting[ $heading ] ) ) {
 				$callback = $data_formatting[ $heading ];
 			} else {
-				foreach ( $regex_match_data_formatting as $regex => $callback ) {
+				foreach ( $regex_match_data_formatting as $regex => $regex_callback ) {
 					if ( preg_match( $regex, $heading ) ) {
-						$callback = $callback;
+						$callback = $regex_callback;
 						break;
 					}
 				}

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -294,6 +294,53 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Attribute names with special characters should match existing global attributes on import instead of creating duplicates (issue #28172).
+	 */
+	public function test_import_matches_existing_attribute_with_special_characters_in_name_28172() {
+		// Set admin user to allow term creation.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$attribute_id = wc_create_attribute(
+			array(
+				'name' => 'ARC Flash > Gloves > CE Category',
+				'slug' => 'arc-glove-ce',
+			)
+		);
+		$taxonomy     = wc_attribute_taxonomy_name_by_id( $attribute_id );
+		register_taxonomy( $taxonomy, 'product' );
+		wp_insert_term( 'Meeny', $taxonomy );
+
+		$csv_file = __DIR__ . '/import-attribute-special-chars-28172-data.csv';
+		$args     = array(
+			'parse'   => true,
+			'mapping' => array(
+				'Name'                 => 'name',
+				'Type'                 => 'type',
+				'Attribute 1 name'     => 'attributes:name1',
+				'Attribute 1 value(s)' => 'attributes:value1',
+				'Attribute 1 visible'  => 'attributes:visible1',
+				'Attribute 1 global'   => 'attributes:taxonomy1',
+			),
+		);
+		$importer = new WC_Product_CSV_Importer( $csv_file, $args );
+
+		$parsed = $importer->get_parsed_data();
+		$this->assertSame( 'ARC Flash > Gloves > CE Category', $parsed[0]['raw_attributes'][0]['name'], 'The attribute name should not be HTML-encoded during parsing' );
+
+		$data = $importer->import();
+		$this->assertCount( 1, $data['imported'], 'Expected 1 imported product' );
+		$this->assertEmpty( $data['failed'], 'Expected 0 failed products' );
+
+		$this->assertSame( 0, wc_attribute_taxonomy_id_by_name( 'arc-flash-gloves-ce-category' ), 'A duplicate attribute should not be created' );
+
+		$product = wc_get_product( $data['imported'][0] );
+		$this->assertArrayHasKey( 'pa_arc-glove-ce', $product->get_attributes(), 'The product should use the existing attribute' );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+		wc_delete_attribute( $attribute_id );
+	}
+
+	/**
 	 * @testdox parse_float_field should return an empty string unchanged.
 	 */
 	public function test_parse_float_field_returns_empty_string_unchanged() {

--- a/plugins/woocommerce/tests/php/includes/importer/import-attribute-special-chars-28172-data.csv
+++ b/plugins/woocommerce/tests/php/includes/importer/import-attribute-special-chars-28172-data.csv
@@ -1,0 +1,2 @@
+Name,Type,Attribute 1 name,Attribute 1 value(s),Attribute 1 visible,Attribute 1 global
+Special Chars Attribute Product,simple,ARC Flash > Gloves > CE Category,Meeny,1,1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The CSV importer HTML-encodes attribute names read from the file (`>` becomes `&gt;`), so they never match the existing global attribute they refer to, and the importer wrongly creates a new attribute - either a duplicate, or a hard "Slug is too long" failure when the name is long. The cause is a clobbered loop variable in `get_formatting_callback()`: columns without an explicit parser fell through with `wp_kses_post` (the last regex callback in the list) instead of the documented `wc_clean` default.

Note: the exact error from the issue no longer reproduces on trunk because the attribute slug limit has been relaxed since the report: #31795 changed the check from `>= 28` to `> 28` characters, and #64159 later moved it to a 29-byte budget (32-byte taxonomy name limit minus the `pa_` prefix). The reporter's 28-character slug now passes, so their attribute name produces a silent duplicate instead of the error. Also out of scope: names that sanitize to a slug over 29 characters for attributes that genuinely don't exist yet still fail instead of being truncated (see the 2024 comment on the issue) - that's a separate behavior decision.

BC note: CSV columns with no dedicated parser (e.g. attribute names) are now sanitized with `wc_clean` instead of `wp_kses_post`, so HTML no longer survives in them; `meta:` columns keep `wp_kses_post` as before.

Closes #28172.

Bug introduced in PR #15373.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a global attribute named `ARC Flash > Gloves > CE Category` with slug `arc-glove-ce`, give it a term, and assign it to a product.
2. Export that product to CSV (Products > Export), then import the file back (Products > Import, tick "Update existing products").
3. Check Products > Attributes: without this fix, a duplicate attribute with slug `arc-flash-gloves-ce-category` is created; with the fix, no duplicate appears and the product keeps the existing attribute.

<!-- End testing instructions -->

### Testing that has already taken place:

- Reproduced and verified the fix on a local site: existing attributes with `>` or `&` in their names now match on import (no duplicates), and the "Slug is too long" import failure for such names is gone.
- Added a regression test with a CSV fixture; confirmed it fails without the fix and passes with it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
