### PR TITLE
Allow selecting user-created templates in product editor

### DIFF
--- a/plugins/woocommerce/changelog/update-load-custom-templates-in-product-editor
+++ b/plugins/woocommerce/changelog/update-load-custom-templates-in-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow selecting user-created templates in product editor

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -297,8 +297,11 @@ class WC_Admin_Meta_Boxes {
 
 			$block_template = get_block_template( $theme . '//' . $template_key );
 
+			$is_product_template = is_array( $block_template->post_types ) && in_array( 'product', $block_template->post_types );
+			$is_user_template    = (bool) $block_template->is_custom && 'plugin' !== $block_template->origin;
+
 			// If the block template has the product post type specified, include it.
-			if ( $block_template && is_array( $block_template->post_types ) && in_array( 'product', $block_template->post_types ) ) {
+			if ( $block_template && ( $is_product_template || $is_user_template ) ) {
 				$filtered_templates[ $template_key ] = $template_name;
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #42393.

This PR allows selecting user-created templates in the Product Editor.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Add Template > Custom template.
2. Create a template with any content.
3. Edit any product.
4. In the sidebar, verify the newly create template shows up under the _Post Attributes_ metabox.
5. Select it and save.
6. The product in the frontend and verify the template is applied correctly.

<img width="478" alt="" src="https://github.com/user-attachments/assets/1213423c-4461-434c-84ed-527907195aed" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->