### PR TITLE
Fix attach product gallery images to their product in the Media Library

### DIFF
--- a/plugins/woocommerce/changelog/55774-fix-attach-product-gallery-images
+++ b/plugins/woocommerce/changelog/55774-fix-attach-product-gallery-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Attach product gallery images to their product so they show as "Uploaded to" the product in the Media Library, matching the featured image behavior. Shared images keep their existing parent.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -169,6 +169,7 @@ class WC_Meta_Box_Product_Images {
 		if ( ! $videos_enabled ) {
 			$product->set_gallery_image_ids( $attachment_ids );
 			$product->save();
+			self::attach_gallery_images( $attachment_ids, $product );
 			return;
 		}
 
@@ -184,11 +185,25 @@ class WC_Meta_Box_Product_Images {
 
 		$product->set_gallery_image_ids( $attachment_ids );
 		$product->save();
+		self::attach_gallery_images( $attachment_ids, $product );
 
 		ProductMediaGallery::set_stored_video_gallery_items(
 			$product,
 			ProductMediaGallery::get_positioned_video_gallery_items_from_media_gallery( $media_gallery )
 		);
+	}
+
+	/**
+	 * Attach gallery images to the first product they are uploaded to.
+	 *
+	 * @param array<int|string> $attachment_ids Gallery attachment IDs.
+	 * @param WC_Product        $product        Product instance.
+	 * @return void
+	 */
+	private static function attach_gallery_images( $attachment_ids, $product ) {
+		foreach ( $attachment_ids as $attachment_id ) {
+			wc_product_attach_image( (int) $attachment_id, $product );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -321,7 +321,9 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$gallery_image_ids = array();
 
 			foreach ( $data['raw_gallery_image_ids'] as $image_id ) {
-				$gallery_image_ids[] = $this->get_attachment_id_from_url( $image_id, $product->get_id() );
+				$gallery_image_id    = $this->get_attachment_id_from_url( $image_id, $product->get_id() );
+				$gallery_image_ids[] = $gallery_image_id;
+				wc_product_attach_image( $gallery_image_id, $product );
 			}
 			$product->set_gallery_image_ids( $gallery_image_ids );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -705,6 +705,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					wc_product_attach_featured_image( $attachment_id, $product, false );
 				} else {
 					$gallery[] = $attachment_id;
+					wc_product_attach_image( $attachment_id, $product );
 				}
 
 				// Set the image alt if present.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -2250,13 +2250,39 @@ function wc_product_attach_featured_image( $attachment_id, $product = null, $sav
 	if ( $save_product ) {
 		$product->save();
 	}
-	if ( 0 === $attachment_post->post_parent ) {
-		wp_update_post(
-			array(
-				'ID'          => $attachment_id,
-				'post_parent' => $product->get_id(),
-			)
-		);
-	}
+
+	wc_product_attach_image( $attachment_id, $product );
 }
 add_action( 'add_attachment', 'wc_product_attach_featured_image' );
+
+/**
+ * Attach an image to a product as its parent, only if the image is not already attached to another post.
+ *
+ * @since 11.1.0
+ * @param int        $attachment_id Media attachment ID.
+ * @param WC_Product $product       Product instance.
+ * @return void
+ */
+function wc_product_attach_image( $attachment_id, $product ) {
+	$attachment_id = absint( $attachment_id );
+	if ( ! $attachment_id || ! $product instanceof WC_Product ) {
+		return;
+	}
+
+	$attachment_post = get_post( $attachment_id );
+	if ( ! $attachment_post || 'attachment' !== $attachment_post->post_type ) {
+		return;
+	}
+
+	// Don't reassign an image already attached to another post.
+	if ( 0 !== (int) $attachment_post->post_parent ) {
+		return;
+	}
+
+	wp_update_post(
+		array(
+			'ID'          => $attachment_id,
+			'post_parent' => $product->get_id(),
+		)
+	);
+}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php
@@ -977,6 +977,8 @@ class Controller extends WC_REST_Products_V2_Controller {
 					wc_product_attach_featured_image( $attachment_id, $product, false );
 				} else {
 					$gallery[] = $attachment_id;
+					// @phpstan-ignore-next-line argument.type -- $product resolves to a phantom namespace-local WC_Product without a use import.
+					wc_product_attach_image( $attachment_id, $product );
 				}
 
 				// Set the image alt if present.

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -1196,4 +1196,84 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 
 		return implode( "\n", (array) $before_data );
 	}
+
+	/**
+	 * Create an image attachment with no parent.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function create_unattached_image(): int {
+		return wp_insert_attachment(
+			array(
+				'post_title'     => 'Unattached product image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+	}
+
+	/**
+	 * @testdox wc_product_attach_image parents an unattached image to the given product.
+	 */
+	public function test_wc_product_attach_image_parents_unattached_image(): void {
+		$product       = WC_Helper_Product::create_simple_product();
+		$attachment_id = $this->create_unattached_image();
+
+		wc_product_attach_image( $attachment_id, $product );
+
+		$this->assertSame(
+			$product->get_id(),
+			(int) get_post( $attachment_id )->post_parent,
+			'An unattached image should be parented to the product.'
+		);
+	}
+
+	/**
+	 * @testdox wc_product_attach_image never overwrites an image already attached to another product.
+	 */
+	public function test_wc_product_attach_image_preserves_existing_parent(): void {
+		$first_product  = WC_Helper_Product::create_simple_product();
+		$second_product = WC_Helper_Product::create_simple_product();
+		$attachment_id  = $this->create_unattached_image();
+
+		wc_product_attach_image( $attachment_id, $first_product );
+		wc_product_attach_image( $attachment_id, $second_product );
+
+		$this->assertSame(
+			$first_product->get_id(),
+			(int) get_post( $attachment_id )->post_parent,
+			'A shared image must stay parented to the first product it was attached to.'
+		);
+	}
+
+	/**
+	 * @testdox wc_product_attach_image ignores non-attachment posts.
+	 */
+	public function test_wc_product_attach_image_ignores_non_attachments(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$post_id = self::factory()->post->create();
+
+		wc_product_attach_image( $post_id, $product );
+
+		$this->assertSame(
+			0,
+			(int) get_post( $post_id )->post_parent,
+			'A regular post should not be parented to the product.'
+		);
+	}
+
+	/**
+	 * @testdox wc_product_attach_image does nothing when not given a product object.
+	 */
+	public function test_wc_product_attach_image_requires_a_product(): void {
+		$attachment_id = $this->create_unattached_image();
+
+		wc_product_attach_image( $attachment_id, null );
+
+		$this->assertSame(
+			0,
+			(int) get_post( $attachment_id )->post_parent,
+			'Without a product object the image should remain unattached.'
+		);
+	}
 }


### PR DESCRIPTION
Gallery images only updated the product's gallery meta and never set the attachment's post_parent, so they showed as "(Unattached)" in the Media Library list view even though the featured image showed as attached.

Add a neutral wc_product_attach_image() helper that parents an attachment to a product only when it is currently unattached, and call it for gallery images from the CSV importer, the REST v3/v4 product image loops, and the classic product gallery metabox. Refactor wc_product_attach_featured_image() to reuse the helper. Images already attached to another product keep their existing parent, preserving WordPress's single-owner "Uploaded to" semantics and keeping shared images safe when a product is deleted.

Closes woocommerce/woocommerce#55774.

### Changes proposed in this Pull Request:

Product gallery images only updated the product's gallery meta and never set the attachment's `post_parent`, so they showed as "(Unattached)" in the Media Library list view even though the featured image showed as attached. This adds a neutral `wc_product_attach_image()` helper that parents an attachment to a product **only when it is currently unattached**, and calls it for gallery images from the CSV importer, the REST v3/v4 product image loops, and the classic product gallery metabox. `wc_product_attach_featured_image()` is refactored to reuse the helper. Images already attached to another product keep their existing parent, preserving WordPress's single-owner "Uploaded to" semantics and keeping shared images safe when a product is deleted.

Closes [#55774](<https://github.com/woocommerce/woocommerce/issues/55774>). This was originally reported in [#36811](<https://github.com/woocommerce/woocommerce/issues/36811>), which PR [#40076](<https://github.com/woocommerce/woocommerce/pull/40076>) closed by fixing only the featured image. The gallery images remained unattached, so the issue was reopened as [#55774](<https://github.com/woocommerce/woocommerce/issues/55774>).

### How to test the changes in this Pull Request:

1. Create a few draft simple products.
2. Edit a product, set a featured image and add 2–3 gallery images from the Media Library, then Update.
3. Go to Media → Library, switch to list view, and confirm the featured and all gallery images show the product name<br>in the "Uploaded to" column (not "(Unattached)").
4. Repeat via CSV import: import a CSV that updates existing products with an `Images` column listing filenames — confirm both the main and gallery images show as "Uploaded to" the product.
5. Repeat via REST API (v3 and v4) product create/update with `images` — confirm gallery images (index > 0) become parented.
6. Shared-image safety: add the same image to a second product; confirm its "Uploaded to" stays the first product. Delete the second product and confirm the image is not removed.

### Testing that has already taken place:

* Unit tests in `wc-product-functions-test.php` cover `wc_product_attach_image()`: parenting an unattached image, preserving an existing parent (shared-image safety), ignoring non-attachment posts, and doing nothing without a product object.
* `phpcs-changed` and PHPStan run clean on the changed files.
* Manually verified on a local site via CSV import: gallery images now show "Uploaded to → \[product\]" in the Media Library list view (previously "(Unattached)"), matching the featured image. A shared image reused by a second product correctly stayed attached to the first product, confirming the shared-image guardrail.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

* \[\] Automatically create a changelog entry from the details below.

- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `plugins/woocommerce/changelog/55774-fix-attach-product-gallery-images`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>