### PR TITLE
Show the Save Draft button on the coupon edit screen

### DIFF
--- a/plugins/woocommerce/changelog/31746-fix-coupon-save-draft
+++ b/plugins/woocommerce/changelog/31746-fix-coupon-save-draft
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the Save Draft button when creating or editing a coupon.

--- a/plugins/woocommerce/changelog/31746-fix-coupon-save-draft
+++ b/plugins/woocommerce/changelog/31746-fix-coupon-save-draft
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Show the Save Draft button when creating or editing a coupon.
+Show the Save Draft button when creating a coupon.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -33,7 +33,7 @@ class WC_Meta_Box_Coupon_Data {
 		?>
 
 		<style type="text/css">
-			#edit-slug-box, #preview-action { display:none }
+			#edit-slug-box { display:none }
 		</style>
 		<div id="coupon_options" class="panel-wrap coupon_data">
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -33,7 +33,7 @@ class WC_Meta_Box_Coupon_Data {
 		?>
 
 		<style type="text/css">
-			#edit-slug-box, #minor-publishing-actions { display:none }
+			#edit-slug-box, #preview-action { display:none }
 		</style>
 		<div id="coupon_options" class="panel-wrap coupon_data">
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The coupon edit screen hides the whole `#minor-publishing-actions` container with inline CSS, which removes both the Preview and the Save Draft buttons, so a new coupon can only be published and then manually switched back to draft. This narrows the hide to `#preview-action` only, so Save Draft becomes available while Preview stays hidden (coupons have no front end). No BC impact: on published coupons the container only ever holds the Preview button, so nothing else changes there, and the coupon meta save path has no post status checks.

Closes #31746.

### How to test the changes in this Pull Request:

1. Go to Marketing > Coupons > Add coupon.
2. Confirm the Publish box shows a "Save Draft" button and no "Preview" button.
3. Enter a coupon code and some coupon data, click "Save Draft", and confirm the coupon is saved as a draft with its data intact.

| Before | After |
| - | - |
| <img width="937" height="737" alt="CleanShot 2026-07-15 at 18 15 51" src="https://github.com/user-attachments/assets/5e270cb1-6135-469f-9c23-80700cc34258" /> | <img width="937" height="737" alt="CleanShot 2026-07-15 at 18 15 57" src="https://github.com/user-attachments/assets/7e2f1e0f-6f54-4284-983f-a36ea0fcf8ea" /> |

### Testing that has already taken place:

- Verified via code analysis that the coupon meta save path (`WC_Admin_Meta_Boxes::save_meta_boxes()` and `WC_Meta_Box_Coupon_Data::save()`) has no post status checks, and that draft coupons are already a supported state (the existing publish-then-draft workaround produces them).
- Ran `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified file; all clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually in this PR (`plugins/woocommerce/changelog/31746-fix-coupon-save-draft`).

-   [ ] Automatically create a changelog entry from the details below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
