### PR TITLE
Fix WooCommerce Analytics detection in custom directories

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/fix-custom-woocommerce-plugin-directory
+++ b/packages/php/woocommerce-analytics/changelog/fix-custom-woocommerce-plugin-directory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Recognize active WooCommerce installations in custom plugin directories.

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -90,7 +90,7 @@ class Woocommerce_Analytics {
 		 *
 		 * This action is documented in https://docs.woocommerce.com/document/create-a-plugin
 		 */
-		if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+		if ( ! defined( 'WC_PLUGIN_FILE' ) || ! is_plugin_active( plugin_basename( WC_PLUGIN_FILE ) ) ) {
 			return false;
 		}
 		// Ensure the WooCommerce class exists and is a valid version.

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -274,6 +274,7 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		class_alias( WooCommerce_Test_Double::class, 'WooCommerce' );
 		define( 'WC_VERSION', '10.0.0' );
 		define( 'WC_PLUGIN_FILE', WP_PLUGIN_DIR . '/custom-woocommerce/woocommerce.php' );
+		define( 'WP_ADMIN', true );
 		update_option( 'active_plugins', array( 'custom-woocommerce/woocommerce.php' ) );
 
 		Woocommerce_Analytics::should_track_store();

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -264,24 +264,4 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 			Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT
 		);
 	}
-
-	/**
-	 * @testdox Should recognize an active WooCommerce plugin installed in a custom directory.
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_should_track_store_recognizes_woocommerce_in_custom_directory(): void {
-		class_alias( WooCommerce_Test_Double::class, 'WooCommerce' );
-		define( 'WC_VERSION', '10.0.0' );
-		define( 'WC_PLUGIN_FILE', WP_PLUGIN_DIR . '/custom-woocommerce/woocommerce.php' );
-		define( 'WP_ADMIN', true );
-		update_option( 'active_plugins', array( 'custom-woocommerce/woocommerce.php' ) );
-
-		Woocommerce_Analytics::should_track_store();
-
-		$this->assertNotFalse(
-			has_action( 'admin_init', array( Woocommerce_Analytics::class, 'maybe_update_proxy_speed_module' ) ),
-			'WooCommerce Analytics should continue initialization for WooCommerce installed in a custom directory.'
-		);
-	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -11,6 +11,11 @@ use Automattic\Woocommerce_Analytics;
 use WorDBless\BaseTestCase;
 
 /**
+ * WooCommerce test double.
+ */
+class WooCommerce_Test_Double {}
+
+/**
  * Tests for the Woocommerce_Analytics class.
  *
  * Focuses on testing the MU-plugin auto-update mechanism.
@@ -257,6 +262,25 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		$this->assertSame(
 			'woocommerce_analytics_proxy_speed_module_version_check',
 			Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT
+		);
+	}
+
+	/**
+	 * @testdox Should recognize an active WooCommerce plugin installed in a custom directory.
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_track_store_recognizes_woocommerce_in_custom_directory(): void {
+		class_alias( WooCommerce_Test_Double::class, 'WooCommerce' );
+		define( 'WC_VERSION', '10.0.0' );
+		define( 'WC_PLUGIN_FILE', WP_PLUGIN_DIR . '/custom-woocommerce/woocommerce.php' );
+		update_option( 'active_plugins', array( 'custom-woocommerce/woocommerce.php' ) );
+
+		Woocommerce_Analytics::should_track_store();
+
+		$this->assertNotFalse(
+			has_action( 'admin_init', array( Woocommerce_Analytics::class, 'maybe_update_proxy_speed_module' ) ),
+			'WooCommerce Analytics should continue initialization for WooCommerce installed in a custom directory.'
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce Analytics assumes the active WooCommerce plugin basename is `woocommerce/woocommerce.php`. PR builds and other installations using a custom plugin directory are therefore treated as inactive, preventing storefront analytics from initializing. Resolve the active basename from WooCommerce's `WC_PLUGIN_FILE` constant and add regression coverage for custom-directory installations.


I discovered this issue while I was testing https://github.com/woocommerce/woocommerce/pull/66652 with JN live branch feature. In that case, the path of WooCommerce is different. 

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a site connected to Jetpack, confirm the **WooCommerce Analytics** Jetpack module is enabled.
2. Install and activate this WooCommerce build from a custom plugin directory, such as `custom-woocommerce/woocommerce.php`.
3. Load a storefront page and run `window.wcAnalytics` in the browser console.
4. Confirm it returns the analytics configuration object instead of `undefined`.
5. Confirm the Network panel includes the WooCommerce Analytics scripts from `stats.wp.com` and `woocommerce-analytics-client`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Package PHPUnit suite: 79 tests and 115 assertions passed.
- PHPCS passed for both modified PHP files.
- PHP syntax checks passed for both modified PHP files.
- Package changelog validation passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
