### PR TITLE
Fix leading zeros not trimmed from coupon amount on save

### DIFF
--- a/plugins/woocommerce/changelog/fix-52333-coupon-leading-zero-trim
+++ b/plugins/woocommerce/changelog/fix-52333-coupon-leading-zero-trim
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Leading zeros are now trimmed from the coupon amount on save for cleaner display.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -617,6 +617,15 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function set_amount( $amount ) {
 		$amount = wc_format_decimal( $amount );
 
+		// Remove leading zeros from numeric strings (e.g., "050" becomes "50")
+		// to ensure clean display of the coupon amount.
+		if ( '' !== $amount && is_string( $amount ) ) {
+			$amount = ltrim( $amount, '0' );
+			if ( '' === $amount || '.' === $amount[0] ) {
+				$amount = '0' . $amount;
+			}
+		}
+
 		if ( ! is_numeric( $amount ) ) {
 			$amount = 0;
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -262,7 +262,7 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 			'multiple leading zeros'      => array( '00.50', '0.50' ),
 			'normal number without zeros' => array( '20', '20' ),
 			'over 100 for non-percent'    => array( 150, '150' ),
-			'empty string becomes zero'   => array( '', 0 ),
+			'empty string becomes zero'   => array( '', '0' ),
 			'string 0.0'                  => array( '0.0', '0.0' ),
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -246,7 +246,7 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 		$coupon = new WC_Coupon();
 		$coupon->set_amount( $input );
 
-		$this->assertEquals( $expected, $coupon->get_amount() );
+		$this->assertSame( $expected, $coupon->get_amount() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -256,14 +256,14 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 	 */
 	public function data_provider_for_amount_leading_zeros() {
 		return array(
-			'leading zeros like 050'      => array( '050', 50.0 ),
-			'just zero'                   => array( '0', 0.0 ),
-			'decimal with leading zero'   => array( '0.50', 0.5 ),
-			'multiple leading zeros'      => array( '00.50', 0.5 ),
-			'normal number without zeros' => array( '20', 20.0 ),
-			'over 100 for non-percent'    => array( 150, 150.0 ),
-			'empty string becomes zero'   => array( '', 0.0 ),
-			'string 0.0'                  => array( '0.0', 0.0 ),
+			'leading zeros like 050'      => array( '050', '50' ),
+			'just zero'                   => array( '0', '0' ),
+			'decimal with leading zero'   => array( '0.50', '0.50' ),
+			'multiple leading zeros'      => array( '00.50', '0.50' ),
+			'normal number without zeros' => array( '20', '20' ),
+			'over 100 for non-percent'    => array( 150, '150' ),
+			'empty string becomes zero'   => array( '', 0 ),
+			'string 0.0'                  => array( '0.0', '0.0' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -236,6 +236,8 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 	 * @testdox set_amount removes leading zeros from numeric strings for clean display.
 	 *
 	 * @dataProvider data_provider_for_amount_leading_zeros
+	 * @param mixed $input    The input amount.
+	 * @param mixed $expected The expected stored amount.
 	 */
 	public function test_set_amount_removes_leading_zeros_from_coupon_amount(
 		$input,
@@ -244,7 +246,7 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 		$coupon = new WC_Coupon();
 		$coupon->set_amount( $input );
 
-		$this->assertSame( $expected, $coupon->get_amount() );
+		$this->assertEquals( $expected, $coupon->get_amount() );
 	}
 
 	/**
@@ -255,14 +257,24 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 	public function data_provider_for_amount_leading_zeros() {
 		return array(
 			'leading zeros like 050'      => array( '050', 50.0 ),
-			'just zero'                    => array( '0', 0.0 ),
-			'decimal with leading zero'    => array( '0.50', 0.5 ),
-			'multiple leading zeros'       => array( '00.50', 0.5 ),
-			'normal number without zeros'  => array( '20', 20.0 ),
-			'negative amount allowed'      => array( -10, -10.0 ),
-			'over 100 for non-percent'     => array( 150, 150.0 ),
-			'empty string becomes zero'    => array( '', 0.0 ),
-			'string 0.0'                   => array( '0.0', 0.0 ),
+			'just zero'                   => array( '0', 0.0 ),
+			'decimal with leading zero'   => array( '0.50', 0.5 ),
+			'multiple leading zeros'      => array( '00.50', 0.5 ),
+			'normal number without zeros' => array( '20', 20.0 ),
+			'over 100 for non-percent'    => array( 150, 150.0 ),
+			'empty string becomes zero'   => array( '', 0.0 ),
+			'string 0.0'                  => array( '0.0', 0.0 ),
 		);
+	}
+
+	/**
+	 * @testdox set_amount throws exception for negative amounts.
+	 */
+	public function test_set_amount_throws_exception_for_negative_amounts(): void {
+		$coupon = new WC_Coupon();
+
+		$this->expectException( \WC_Data_Exception::class );
+
+		$coupon->set_amount( -10.0 );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-coupon-test.php
@@ -231,4 +231,38 @@ class WC_Coupon_Tests extends WC_Unit_Test_Case {
 			'Line items associated with deleted products are not included in the discount calculation.'
 		);
 	}
+
+	/**
+	 * @testdox set_amount removes leading zeros from numeric strings for clean display.
+	 *
+	 * @dataProvider data_provider_for_amount_leading_zeros
+	 */
+	public function test_set_amount_removes_leading_zeros_from_coupon_amount(
+		$input,
+		$expected
+	): void {
+		$coupon = new WC_Coupon();
+		$coupon->set_amount( $input );
+
+		$this->assertSame( $expected, $coupon->get_amount() );
+	}
+
+	/**
+	 * Data provider for leading zero trimming tests.
+	 *
+	 * @return array
+	 */
+	public function data_provider_for_amount_leading_zeros() {
+		return array(
+			'leading zeros like 050'      => array( '050', 50.0 ),
+			'just zero'                    => array( '0', 0.0 ),
+			'decimal with leading zero'    => array( '0.50', 0.5 ),
+			'multiple leading zeros'       => array( '00.50', 0.5 ),
+			'normal number without zeros'  => array( '20', 20.0 ),
+			'negative amount allowed'      => array( -10, -10.0 ),
+			'over 100 for non-percent'     => array( 150, 150.0 ),
+			'empty string becomes zero'    => array( '', 0.0 ),
+			'string 0.0'                   => array( '0.0', 0.0 ),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there are not other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

When a user enters a percentage coupon amount with leading zeros (e.g., "050" instead of "50"), the leading zeros are now trimmed on save for clean display. The coupon logic was already working correctly — this is a visual/display fix only.

The fix normalizes the amount in \`WC_Coupon::set_amount()\` by stripping leading zeros after formatting, with proper handling of edge cases like "0" and "0.50".

Closes woocommerce/woocommerce#52333 .

### How to test the changes in this Pull Request:

1. Go to Marketing > Coupons > Add new coupon
2. Enter coupon code
3. For "Discount type" choose "Percentage discount"
4. For "Coupon amount" enter "050"
5. Click "Publish"
6. Verify the coupon amount shows as "50" instead of "050"
7. Also test with "0", "0.50", and normal values like "20" to ensure they work correctly

### Testing that has already taken place:

* PHP lint: passed (no errors)
* PHPStan: passed (no errors)

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

<details><summary>Changelog Entry Details</summary>

#### Significance

- [X] Patch

#### Type

- [X] Fix - Fixes an existing bug

#### Message

Leading zeros are now trimmed from the coupon amount on save for cleaner display.

</details>