### PR TITLE
Fix shipping recommendation dismissal accessibility and fallbacks

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7093-shipping-recommendations-dismiss
+++ b/plugins/woocommerce/changelog/wooplug-7093-shipping-recommendations-dismiss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve focus and screen reader feedback when hiding shipping recommendations, and restore marketplace links where the recommendations component is unavailable.

--- a/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
@@ -120,9 +120,7 @@ const ShippingRecommendations = () => {
 		! hasRecommendationEligibilityResolved ||
 		( ! hasRecommendationsDismissResolved && hasVisibleExtensions );
 	const shouldShowRecommendationsFallback =
-		( hasRecommendationsDismissResolved && isRecommendationsHidden ) ||
-		! hasVisibleExtensions ||
-		isSellingDigitalProductsOnly;
+		! hasVisibleExtensions || isSellingDigitalProductsOnly;
 	const shouldTrackRecommendationsImpression =
 		hasRecommendationEligibilityResolved &&
 		hasRecommendationsDismissResolved &&
@@ -182,7 +180,11 @@ const ShippingRecommendations = () => {
 			<ShippingTour
 				showShippingRecommendationsStep={ ! isRecommendationsHidden }
 			/>
-			<div style={ { paddingBottom: 60 } }>
+			<div
+				style={ {
+					paddingBottom: isRecommendationsHidden ? 0 : 60,
+				} }
+			>
 				<ShippingRecommendationsList
 					dismissState={ recommendationsDismissState }
 				>
@@ -241,6 +243,7 @@ const ShippingRecommendations = () => {
 					} ) }
 				</ShippingRecommendationsList>
 			</div>
+			{ isRecommendationsHidden && marketplaceFallbackLink }
 		</>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/shipping/test/shipping-recommendations.test.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/test/shipping-recommendations.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { speak } from '@wordpress/a11y';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -23,24 +24,35 @@ jest.mock( '~/components/tracked-link/tracked-link', () => ( {
 		</span>
 	),
 } ) );
-jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
-	DismissableList: ( {
-		children,
-		isDismissed,
-	}: {
-		children: React.ReactNode;
-		isDismissed?: boolean;
-	} ) => (
-		<div
-			data-dismissed={ String( Boolean( isDismissed ) ) }
-			data-testid="dismissable-list"
-		>
-			{ ! isDismissed && children }
-		</div>
-	),
-	DismissableListHeading: ( { children }: { children: React.ReactNode } ) =>
-		children,
-} ) );
+jest.mock( '../../settings-recommendations/dismissable-list', () => {
+	const { DismissableList } = jest.requireActual(
+		'../../settings-recommendations/dismissable-list'
+	);
+
+	return {
+		DismissableList: ( {
+			children,
+			isDismissed,
+		}: {
+			children: React.ReactNode;
+			isDismissed?: boolean;
+		} ) => (
+			<div
+				data-dismissed={ String( Boolean( isDismissed ) ) }
+				data-testid="dismissable-list"
+			>
+				<DismissableList isDismissed={ isDismissed }>
+					{ children }
+				</DismissableList>
+			</div>
+		),
+		DismissableListHeading: ( {
+			children,
+		}: {
+			children: React.ReactNode;
+		} ) => children,
+	};
+} );
 jest.mock( '~/guided-tours/shipping-tour', () => ( {
 	ShippingTour: ( {
 		showShippingRecommendationsStep,
@@ -65,6 +77,9 @@ jest.mock( '../../lib/notices', () => ( {
 } ) );
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
+} ) );
+jest.mock( '@wordpress/a11y', () => ( {
+	speak: jest.fn(),
 } ) );
 
 const defaultSelectReturn = {
@@ -97,6 +112,7 @@ describe( 'ShippingRecommendations', () => {
 			activatePlugins: () => Promise.resolve(),
 		} );
 		( recordEvent as jest.Mock ).mockClear();
+		( speak as jest.Mock ).mockClear();
 	} );
 
 	it( 'renders recommendations and the shipping tour recommendations step', () => {
@@ -190,6 +206,46 @@ describe( 'ShippingRecommendations', () => {
 		);
 	} );
 
+	it( 'keeps the dismissal wrapper mounted to restore focus and announce the change', () => {
+		let dismissOption = 'no';
+		mockSelect( {
+			getOption: ( option: string ) =>
+				option === SHIPPING_RECOMMENDATIONS_DISMISS_OPTION
+					? dismissOption
+					: undefined,
+		} );
+
+		const { rerender } = render( <ShippingRecommendations /> );
+		const dismissalWrapper = document.querySelector(
+			'.woocommerce-dismissable-list__wrapper'
+		);
+
+		expect( dismissalWrapper ).toBeInTheDocument();
+		expect( screen.getByTestId( 'dismissable-list' ) ).toHaveAttribute(
+			'data-dismissed',
+			'false'
+		);
+
+		dismissOption = 'yes';
+		rerender( <ShippingRecommendations /> );
+
+		expect(
+			document.querySelector( '.woocommerce-dismissable-list__wrapper' )
+		).toBe( dismissalWrapper );
+		expect( screen.getByTestId( 'dismissable-list' ) ).toHaveAttribute(
+			'data-dismissed',
+			'true'
+		);
+		expect( speak ).toHaveBeenCalledWith(
+			'Recommendation hidden.',
+			'assertive'
+		);
+		expect( dismissalWrapper ).toHaveFocus();
+		expect(
+			screen.getByText( 'the WooCommerce Marketplace' )
+		).toBeInTheDocument();
+	} );
+
 	it( 'does not render recommendations before the product profile resolves', () => {
 		mockSelect( {
 			hasFinishedResolution: ( selector: string ) =>
@@ -231,9 +287,11 @@ describe( 'ShippingRecommendations', () => {
 		expect(
 			screen.queryByText( 'the WooCommerce Marketplace' )
 		).toBeInTheDocument();
-		expect(
-			screen.queryByTestId( 'dismissable-list' )
-		).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'dismissable-list' ) ).toHaveAttribute(
+			'data-dismissed',
+			'true'
+		);
+		expect( speak ).not.toHaveBeenCalled();
 		expect( screen.getByTestId( 'shipping-tour' ) ).toHaveAttribute(
 			'data-show-recommendations-step',
 			'false'

--- a/plugins/woocommerce/includes/admin/views/html-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-settings.php
@@ -124,7 +124,13 @@ if ( isset( $_GET['zone_id'] ) && is_string( $_GET['zone_id'] ) ) {
 // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 $is_shipping_zone_screen = '' !== $shipping_zone_id;
-if ( 'shipping' === $current_tab && '' === $current_section && ! $is_shipping_zone_screen && current_user_can( 'install_plugins' ) ) {
+if (
+	'shipping' === $current_tab
+	&& (
+		'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' )
+		|| ( '' === $current_section && ! $is_shipping_zone_screen && current_user_can( 'install_plugins' ) )
+	)
+) {
 	unset( $marketplace_links['shipping'] );
 }
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-settings.php
@@ -87,6 +87,12 @@ $marketplace_links = array(
 		/* translators: %1$s: opening link tag, %2$s: closing link tag */
 		'message'     => __( '%1$sExplore solutions%2$s that help with tax calculations, compliance, and regional requirements.', 'woocommerce' ),
 	),
+	'shipping' => array(
+		'url'         => $marketplace_base_url . 'shipping-delivery-and-fulfillment/',
+		'is_external' => true,
+		/* translators: %1$s: opening link tag, %2$s: closing link tag */
+		'message'     => __( '%1$sExplore solutions%2$s that enhance shipping, delivery, and fulfillment workflows.', 'woocommerce' ),
+	),
 	'account'  => array(
 		'url'         => $marketplace_base_url . 'store-content-and-customizations/cart-and-checkout-features/',
 		'is_external' => true,
@@ -106,6 +112,21 @@ $marketplace_links = array(
 		'message'     => __( '%1$sDiscover additional solutions%2$s to boost your business and expand what your store can do.', 'woocommerce' ),
 	),
 );
+
+// The React recommendations component owns the marketplace link on the main
+// Shipping screen, but it does not render on subsections, zone screens, or for
+// users who cannot install plugins.
+$shipping_zone_id = '';
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Used only to select non-mutating view output.
+if ( isset( $_GET['zone_id'] ) && is_string( $_GET['zone_id'] ) ) {
+	$shipping_zone_id = sanitize_text_field( wp_unslash( $_GET['zone_id'] ) );
+}
+// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+$is_shipping_zone_screen = '' !== $shipping_zone_id;
+if ( 'shipping' === $current_tab && '' === $current_section && ! $is_shipping_zone_screen && current_user_can( 'install_plugins' ) ) {
+	unset( $marketplace_links['shipping'] );
+}
 
 ?>
 

--- a/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-settings-view-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-settings-view-test.php
@@ -99,6 +99,24 @@ class WC_Admin_Settings_View_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not render the shipping marketplace link when marketplace suggestions are disabled.
+	 */
+	public function test_shipping_marketplace_link_is_not_rendered_when_marketplace_suggestions_are_disabled(): void {
+		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
+
+		$output = $this->render_settings_view( 'shipping', 'options' );
+
+		$this->assertStringNotContainsString(
+			'data-settings-tab="shipping"',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'shipping-delivery-and-fulfillment',
+			$output
+		);
+	}
+
+	/**
 	 * @testdox Should render the shipping marketplace link on Shipping zone screens.
 	 */
 	public function test_shipping_marketplace_link_is_rendered_on_shipping_zone_screens(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-settings-view-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/views/class-wc-admin-settings-view-test.php
@@ -79,6 +79,64 @@ class WC_Admin_Settings_View_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should render the shipping marketplace link on Shipping settings subsections.
+	 */
+	public function test_shipping_marketplace_link_is_rendered_on_shipping_settings_subsections(): void {
+		$output = $this->render_settings_view( 'shipping', 'options' );
+
+		$this->assertStringContainsString(
+			'data-settings-tab="shipping"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'data-settings-section="options"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'shipping-delivery-and-fulfillment',
+			$output
+		);
+	}
+
+	/**
+	 * @testdox Should render the shipping marketplace link on Shipping zone screens.
+	 */
+	public function test_shipping_marketplace_link_is_rendered_on_shipping_zone_screens(): void {
+		$_GET['zone_id'] = '1';
+
+		$output = $this->render_settings_view( 'shipping' );
+
+		$this->assertStringContainsString(
+			'data-settings-tab="shipping"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'shipping-delivery-and-fulfillment',
+			$output
+		);
+	}
+
+	/**
+	 * @testdox Should render the shipping marketplace link for users who cannot install plugins.
+	 */
+	public function test_shipping_marketplace_link_is_rendered_for_users_without_plugin_install_permissions(): void {
+		$shop_manager_user_id = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $shop_manager_user_id );
+		$this->assertFalse( current_user_can( 'install_plugins' ) );
+
+		$output = $this->render_settings_view( 'shipping' );
+
+		$this->assertStringContainsString(
+			'data-settings-tab="shipping"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'shipping-delivery-and-fulfillment',
+			$output
+		);
+	}
+
+	/**
 	 * @testdox Should keep non-shipping marketplace links when shipping smart defaults are enabled.
 	 */
 	public function test_non_shipping_marketplace_links_are_rendered_when_shipping_smart_defaults_are_enabled(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there are no other open Pull Requests for the same update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- I have reviewed the final diff and relevant regression coverage.

### Changes proposed in this Pull Request:

PR #66110 switched dismissed recommendations to a fallback branch, unmounting `DismissableList` before its focus restoration and screen-reader announcement could run.

This keeps `DismissableList` mounted through dismissal and restores the existing PHP Marketplace fallback on Shipping subsections, zone screens, and for users who cannot install plugins, while avoiding duplicate links on the main Shipping screen.

Closes #66667.

Bug introduced in PR #66110.

### Screenshots or screen recordings:

In browse mode, the hierarchy provides context. In search results, every leaf item shows its parent path because the hierarchy is flattened. Parent results show their child count and remain navigational.

Before dismissal (fixed branch)
<img width="1280" height="1501" alt="Before dismissal" src="https://github.com/user-attachments/assets/30b7270e-d106-4a3b-ab06-6e32f0d7e25b" />

After dismissal (fixed branch)
<img width="1280" height="1194" alt="After dismissal" src="https://github.com/user-attachments/assets/7c53a5c4-576b-45b6-aebd-133a316aa6a2" />

Shipping subsection fallback (fixed branch)
<img width="1280" height="873" alt="Shipping subsection fallback" src="https://github.com/user-attachments/assets/02c5adf8-aaae-4618-ba85-f4b101a9c509" />


### How to test the changes in this Pull Request:

1. Open WooCommerce > Settings > Shipping with recommendations visible.
2. Using the keyboard, open the recommendations ellipsis menu and select "Hide this".
3. Confirm the card is replaced by the Marketplace link, focus remains on a stable element, and "Recommendation hidden." is announced.
4. Open Shipping settings and a Shipping zone screen.
5. Confirm the PHP "Explore solutions" Marketplace fallback is present.
6. Test as a user without `install_plugins` and confirm the fallback remains available.

### Testing that has already taken place:

- Targeted Jest suites: 21 tests passed.
- PHP regression suite: 5 tests and 12 assertions passed.
- ESLint, PHP lint, PHPStan, branch lint, and changelog validation passed.
- Verified the built UI and dismissal transition in a local WordPress/WooCommerce environment.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require an automated changelog entry.

A manual changelog entry is included in this branch.

### Release Communication

- [ ] **Feature Highlight** - For user-facing features
- [ ] **Developer Advisory** - For developer-facing changes
