### PR TITLE
Fix User-Facing Documentation Check failing after claude-code-action v1.0.171 bump

### DIFF
--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -26,6 +26,7 @@ jobs:
           # defaults its commit to github.sha, which for a merged fork PR is the merge commit
           # that actions/checkout refuses to check out due to its "pwn request" guard.
           ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
 
       - name: 'Analyze Pull Request'
         id: analyze

--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -168,12 +168,16 @@ jobs:
 
       - name: 'Setup Linear'
         if: ${{ steps.analyze.outputs.structured_output && fromJSON(steps.analyze.outputs.structured_output).needs_docs }}
-        run: npm install @linear/sdk@71.0.0
+        # Install outside the workspace: the checkout put the monorepo root package.json there,
+        # whose workspace:* deps make a bare `npm install` abort (npm has no workspace: support).
+        run: npm install --prefix "${{ runner.temp }}/linear" @linear/sdk@71.0.0
 
       - name: 'Create Linear Issue'
         if: ${{ steps.analyze.outputs.structured_output && fromJSON(steps.analyze.outputs.structured_output).needs_docs }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
+          # Resolve @linear/sdk from the isolated dir it was installed into in 'Setup Linear'.
+          NODE_PATH: ${{ runner.temp }}/linear/node_modules
           STRUCTURED_OUTPUT: ${{ steps.analyze.outputs.structured_output }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_OAUTH_TOKEN }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_DOCS_TEAM_ID }}

--- a/.github/workflows/docs-needed-detection.yml
+++ b/.github/workflows/docs-needed-detection.yml
@@ -19,6 +19,14 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: 'Checkout'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Fork PRs need the explicit ref. Without it, under pull_request_target checkout
+          # defaults its commit to github.sha, which for a merged fork PR is the merge commit
+          # that actions/checkout refuses to check out due to its "pwn request" guard.
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: 'Analyze Pull Request'
         id: analyze
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `User-Facing Documentation Check` workflow runs `claude-code-action` on every merged PR. The action assumes a checkout: it configures git and, since [v1.0.74](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.74), restores trusted config files from the PR base branch with `git fetch origin <base>`.
- The pinned v1.0.66 predated that restore step and only logged a non-fatal warning when the git config failed, so the missing checkout stayed harmless.
   <img width="1072" height="637" alt="image" src="https://github.com/user-attachments/assets/77321194-b1e2-44ea-a692-d25ab4103c91" />
- After the action was bumped to v1.0.171, whose restore step hard-fails without a git repository, the job began failing on every merged PR.
   <img width="1076" height="592" alt="image" src="https://github.com/user-attachments/assets/a5a40486-8da7-4884-a9ee-bffe1cf0875c" />
   <img width="1092" height="1226" alt="image" src="https://github.com/user-attachments/assets/6f73da8f-ebf8-4811-9ca6-4af786f0b863" />

This PR adds an `actions/checkout` step before the action. It is pinned to the PR's base branch (`ref: ${{ github.event.pull_request.base.ref }}`) so it checks out the base branch's trusted files and clears `actions/checkout@v7`'s "pwn request" guard for fork PRs, without opting into `allow-unsafe-pr-checkout`.

This is a latent defect: the workflow has had no checkout step since it was added, so the assumption that a repository is present was never satisfied. The `claude-code-action` version bump only turned that assumption from harmless into a hard failure.

For traceability:

-   The `claude-code-action` bump that surfaced the failure: #66571
-   Last passing run before the bump: https://github.com/woocommerce/woocommerce/actions/runs/29325804238/job/87061694973
-   First failing run after the bump: https://github.com/woocommerce/woocommerce/actions/runs/29326614268/job/87064337822

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

- This fix takes effect on this PR's own merge: this PR's `User-Facing Documentation Check` run (and every merged PR after) should be the first to complete its `Checkout` and `Analyze Pull Request` steps instead of failing at the config-restore `git fetch origin <base>`.

<!-- End testing instructions -->

### Testing that has already taken place:

The root cause was established from the CI runs rather than a live pre-merge reproduction, because the workflow only triggers when a PR is merged.

1. Identified the last passing run before the bump and the first failing run after it (links above). Both hit the same non-fatal `fatal: not in a git directory` while `claude-code-action` configured its git user, confirming the workflow never had a repository checked out in either version.
2. Confirmed only the post-bump run hard-fails, at `restoreConfigFromBase`'s `git fetch origin trunk --depth=1 --no-recurse-submodules` with `fatal: not a git repository`, which the older version did not run.
3. Traced the hard failure to `claude-code-action` v1.0.74, the first release that wires `restoreConfigFromBase` into `run.ts` (via `anthropics/claude-code-action` PR 1066).
4. Live verification is this PR's own merge run: it should be the first successful `User-Facing Documentation Check` run since the bump, since the `closed` event uses the post-merge workflow.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

GitHub Actions workflow change (release automation only). Nothing is shipped to merchants, so no changelog entry is required.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>