### PR TITLE
Fix fatal error saving order with invalid billing email in admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-invalid-billing-email-admin-order-save
+++ b/plugins/woocommerce/changelog/fix-invalid-billing-email-admin-order-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when saving an order with an invalid billing email in wp-admin.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -856,7 +856,8 @@ class WC_Meta_Box_Order_Data {
 				if ( isset( $field['update_callback'] ) ) {
 					call_user_func( $field['update_callback'], $field['id'], $value, $order );
 				} elseif ( is_callable( array( $order, 'set_billing_' . $key ) ) ) {
-					// Validate the billing email to avoid an uncaught WC_Data_Exception on save. Empty is allowed as the field is optional.
+					// An invalid email makes set_billing_email() throw an uncaught WC_Data_Exception, causing a fatal error on save.
+					// Surface an admin notice and skip the value instead. An empty email is allowed as the field is optional.
 					if ( 'email' === $key && '' !== $value && ! is_email( $value ) ) {
 						WC_Admin_Meta_Boxes::add_error( __( 'Invalid billing email address.', 'woocommerce' ) );
 						continue;

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -856,6 +856,11 @@ class WC_Meta_Box_Order_Data {
 				if ( isset( $field['update_callback'] ) ) {
 					call_user_func( $field['update_callback'], $field['id'], $value, $order );
 				} elseif ( is_callable( array( $order, 'set_billing_' . $key ) ) ) {
+					// Validate the billing email to avoid an uncaught WC_Data_Exception on save. Empty is allowed as the field is optional.
+					if ( 'email' === $key && '' !== $value && ! is_email( $value ) ) {
+						WC_Admin_Meta_Boxes::add_error( __( 'Invalid billing email address.', 'woocommerce' ) );
+						continue;
+					}
 					$props[ 'billing_' . $key ] = $value;
 				} else {
 					$order->update_meta_data( $field['id'], $value );

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-order-data-test.php
@@ -8,6 +8,7 @@
 declare( strict_types = 1 );
 
 require_once WC_ABSPATH . 'includes/admin/wc-meta-box-functions.php';
+require_once WC_ABSPATH . 'includes/admin/class-wc-admin-meta-boxes.php';
 require_once WC_ABSPATH . 'includes/admin/meta-boxes/class-wc-meta-box-order-data.php';
 
 /**
@@ -70,6 +71,8 @@ class WC_Meta_Box_Order_Data_Test extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		WC_Admin_Meta_Boxes::$meta_box_errors = array();
+
 		$this->had_shipping_calculation_option      = false !== get_option( 'woocommerce_calc_shipping', false );
 		$this->original_shipping_calculation_option = get_option( 'woocommerce_calc_shipping' );
 		$this->had_global_order                     = array_key_exists( 'theorder', $GLOBALS );
@@ -106,7 +109,83 @@ class WC_Meta_Box_Order_Data_Test extends WC_Unit_Test_Case {
 			unset( $GLOBALS['theorder'] );
 		}
 
+		WC_Admin_Meta_Boxes::$meta_box_errors = array();
+
 		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Saving an order with an invalid billing email registers an admin error instead of throwing a fatal.
+	 */
+	public function test_invalid_billing_email_registers_error_without_throwing(): void {
+		$order = $this->create_order_with_shipping_data( false );
+		$order->set_billing_email( 'valid@example.com' );
+		$order->save();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Simulate the nonce-verified meta-box save request.
+		$previous_post = $_POST;
+		$_POST         = array(
+			'order_status'    => $order->get_status(),
+			'_payment_method' => $order->get_payment_method(),
+			'customer_user'   => 0,
+			'_billing_email'  => 'notanemail',
+		);
+
+		try {
+			WC_Meta_Box_Order_Data::save( $order->get_id() );
+		} finally {
+			$_POST = $previous_post;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->assertContains(
+			'Invalid billing email address.',
+			WC_Admin_Meta_Boxes::$meta_box_errors,
+			'An invalid billing email should register an admin error instead of throwing WC_Data_Exception.'
+		);
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame(
+			'valid@example.com',
+			$order->get_billing_email( 'edit' ),
+			'The invalid billing email should be skipped, leaving the previous value intact.'
+		);
+	}
+
+	/**
+	 * @testdox Saving an order with a valid billing email persists the value without registering an error.
+	 */
+	public function test_valid_billing_email_is_saved_without_error(): void {
+		$order = $this->create_order_with_shipping_data( false );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Simulate the nonce-verified meta-box save request.
+		$previous_post = $_POST;
+		$_POST         = array(
+			'order_status'    => $order->get_status(),
+			'_payment_method' => $order->get_payment_method(),
+			'customer_user'   => 0,
+			'_billing_email'  => 'shopper@example.com',
+		);
+
+		try {
+			WC_Meta_Box_Order_Data::save( $order->get_id() );
+		} finally {
+			$_POST = $previous_post;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->assertNotContains(
+			'Invalid billing email address.',
+			WC_Admin_Meta_Boxes::$meta_box_errors,
+			'A valid billing email should not register an admin error.'
+		);
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame(
+			'shopper@example.com',
+			$order->get_billing_email( 'edit' ),
+			'A valid billing email should be persisted on the order.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Saving a shop order in wp-admin with an invalid billing email produced an uncaught `WC_Data_Exception` and a PHP fatal (white screen). The billing-fields save loop in `WC_Meta_Box_Order_Data::save()` passed the raw value straight to `set_billing_email()`, which throws when the value fails `is_email()`; `wc_clean()` does not validate emails, and only the client-side HTML5 `type=email` guarded the field, which is trivially bypassed.

This validates the billing email before assigning the prop: a non-empty, invalid email now registers an admin notice via `WC_Admin_Meta_Boxes::add_error()` and is skipped, so the merchant sees a clear error instead of a fatal. Empty values are still allowed because the field is optional.

Closes woocommerce/woocommerce#66708.

### Screenshots or screen recordings:

Not applicable — no UI changes. The fix replaces a fatal error with an existing-style admin notice.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. In wp-admin, go to **WooCommerce > Orders > Add order**.
2. Click the edit (pencil) icon next to **Billing** to reveal the address form.
3. In browser DevTools, change the billing email input's `type` attribute from `email` to `text` (bypasses the client-side validation).
4. Enter an invalid value such as `notanemail` and click **Update / Create**.
5. **Expected:** the order page reloads with an "Invalid billing email address." admin notice and no fatal error. The billing email keeps its previous value.
6. Repeat with a valid email (e.g. `shopper@example.com`) and confirm it saves normally with no error notice.

### Testing that has already taken place:

* Added PHPUnit coverage in `WC_Meta_Box_Order_Data_Test` for both the invalid-email (error registered, no throw, previous value preserved) and valid-email (persisted, no error) save paths.
* `pnpm --filter='@woocommerce/plugin-woocommerce' test:php` (filtered to the affected test class): `OK (22 tests, 146 assertions)` on PHP 8.1 via wp-env.
* `phpcs-changed` against `trunk`: no violations on the changed lines.
* Manually reproduced the original fatal and confirmed the fix converts it to an admin notice.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually — see `plugins/woocommerce/changelog/fix-invalid-billing-email-admin-order-save` (Significance: patch, Type: fix).

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>