### PR TITLE
Exclude infinite scrolling preference from customer metadata

### DIFF
--- a/plugins/woocommerce/changelog/fix-customer-infinite-scrolling-meta
+++ b/plugins/woocommerce/changelog/fix-customer-infinite-scrolling-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WordPress personal preferences from being exposed as customer metadata.

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php
@@ -67,6 +67,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'wptests_capabilities',
 		'wptests_user_level',
 		'syntax_highlighting',
+		'infinite_scrolling',
 		'_order_count',
 		'_money_spent',
 		'_last_order',

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
@@ -62,6 +62,22 @@ class WC_Customer_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox WordPress personal preferences are excluded from customer meta data.
+	 */
+	public function test_wordpress_personal_preferences_are_excluded_from_customer_meta_data(): void {
+		$customer = WC_Helper_Customer::create_customer();
+
+		update_user_meta( $customer->get_id(), 'infinite_scrolling', 'true' );
+		update_user_meta( $customer->get_id(), 'custom_preference', 'custom-value' );
+
+		$read_customer = new WC_Customer( $customer->get_id() );
+		$meta_keys     = wp_list_pluck( $read_customer->get_meta_data(), 'key' );
+
+		$this->assertNotContains( 'infinite_scrolling', $meta_keys, 'WordPress personal preferences should not be exposed as customer meta data.' );
+		$this->assertContains( 'custom_preference', $meta_keys, 'Custom user meta should remain available as customer meta data.' );
+	}
+
+	/**
 	 * @testdox A backslash in a customer address field survives a save/read round-trip.
 	 *
 	 * Addresses entered through the Store API (block checkout) are not magic-quoted, so the value


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress 7.1 adds the `infinite_scrolling` personal preference to user metadata when creating a user. WooCommerce currently loads that WordPress-owned preference as arbitrary customer `meta_data`, which changes customer REST responses and breaks the WordPress pre-release compatibility tests.

Classify the preference alongside the existing internal WordPress user settings, and cover the boundary with a version-independent regression test that also verifies custom user metadata remains available. The upstream behavior was introduced in [WordPress/wordpress-develop@97e8e28](https://github.com/WordPress/wordpress-develop/commit/97e8e28e6b7586971a47612ffeba70aa95630a51).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

From `plugins/woocommerce`:

1. Start the PHP test environment if it is not already running: `pnpm env:test:start`.
2. Run `pnpm test:php:env -- --filter 'WC_Customer_Data_Store_CPT_Test|WC_REST_Customers_V2_Controller_Tests|WC_REST_Customers_Controller_Test'`.
3. Confirm all customer data-store and REST controller tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified the regression test fails before the internal-key change and passes afterward.
- Passed the customer data-store and v2/v3 REST controller suites on PHP 8.1: 23 tests, 61 assertions.
- Passed PHP syntax checks, changed-file and branch-wide PHP linting, PHPStan for `class-wc-customer-data-store.php`, and changelog validation.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
