### PR TITLE
Add quantity input type to field action hooks

### DIFF
--- a/plugins/woocommerce/changelog/add-40923-quantity-input-hook-type
+++ b/plugins/woocommerce/changelog/add-40923-quantity-input-hook-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pass the quantity input type to the before and after quantity input field actions.

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.1.0
+ * @version 11.1.0
  *
  * @var bool   $readonly If the input should be set to readonly mode.
  * @var string $type     The input type attribute.
@@ -29,9 +29,12 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 	/**
 	 * Hook to output something before the quantity input field.
 	 *
+	 * @param string $type The quantity input type.
+	 *
 	 * @since 7.2.0
+	 * @since 11.1.0 Added the `$type` parameter.
 	 */
-	do_action( 'woocommerce_before_quantity_input_field' );
+	do_action( 'woocommerce_before_quantity_input_field', $type );
 	?>
 	<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
 	<input
@@ -58,10 +61,13 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 	/>
 	<?php
 	/**
-	 * Hook to output something after quantity input field
+	 * Hook to output something after the quantity input field.
+	 *
+	 * @param string $type The quantity input type.
 	 *
 	 * @since 3.6.0
+	 * @since 11.1.0 Added the `$type` parameter.
 	 */
-	do_action( 'woocommerce_after_quantity_input_field' );
+	do_action( 'woocommerce_after_quantity_input_field', $type );
 	?>
 </div>

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -145,4 +145,58 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertNotFalse( $cached );
 		$this->assertCount( 3, $cached );
 	}
+
+	/**
+	 * @testdox Quantity input hooks receive the final input type.
+	 * @dataProvider quantity_input_type_provider
+	 *
+	 * @param array  $args          Quantity input arguments.
+	 * @param string $expected_type Expected input type.
+	 */
+	public function test_quantity_input_hooks_receive_input_type( array $args, string $expected_type ): void {
+		$before_types = array();
+		$after_types  = array();
+
+		$before_callback = static function ( string $type ) use ( &$before_types ): void {
+			$before_types[] = $type;
+		};
+		$after_callback  = static function ( string $type ) use ( &$after_types ): void {
+			$after_types[] = $type;
+		};
+
+		add_action( 'woocommerce_before_quantity_input_field', $before_callback );
+		add_action( 'woocommerce_after_quantity_input_field', $after_callback );
+
+		woocommerce_quantity_input( $args, new WC_Product_Simple(), false );
+
+		remove_action( 'woocommerce_before_quantity_input_field', $before_callback );
+		remove_action( 'woocommerce_after_quantity_input_field', $after_callback );
+
+		$this->assertSame( array( $expected_type ), $before_types, 'The before hook should receive the final input type.' );
+		$this->assertSame( array( $expected_type ), $after_types, 'The after hook should receive the final input type.' );
+	}
+
+	/**
+	 * Data provider for quantity input types.
+	 *
+	 * @return array<string, array{array<string, int|string>, string}>
+	 */
+	public static function quantity_input_type_provider(): array {
+		return array(
+			'changeable quantity' => array(
+				array(
+					'min_value' => 1,
+					'max_value' => '',
+				),
+				'number',
+			),
+			'fixed quantity'      => array(
+				array(
+					'min_value' => 1,
+					'max_value' => 1,
+				),
+				'hidden',
+			),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Extensions and themes using the quantity input actions cannot determine whether the rendered input is visible or hidden. This passes the final filtered input type to both actions, documents the new parameter, updates the template version, and covers `number` and `hidden` inputs. The trailing hook argument is additive for existing callbacks; older template overrides continue firing the hooks without it until updated.

Closes #40923.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; the rendered quantity controls are unchanged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Template_Functions_Tests`.
2. Confirm the suite passes the `changeable quantity` and `fixed quantity` data sets.
3. Confirm both quantity input actions receive `number` for a changeable quantity and `hidden` for a fixed quantity.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHPUnit suite: 6 tests and 14 assertions passed on PHP 8.1.
- Changed-PHP lint, branch lint, explicit PHPCS, PHP syntax checks, and `git diff --check` passed.
- Browser validation on WooCommerce 11.1.0-dev confirmed `number` and `hidden` states on single-product and classic-cart surfaces.
- WooCommerce code review completed with no findings.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
