### PR TITLE
Guard legacy Select2 tracking against older analytics packages

### DIFF
--- a/plugins/woocommerce/changelog/fix-legacy-select2-analytics-guard
+++ b/plugins/woocommerce/changelog/fix-legacy-select2-analytics-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when older WooCommerce Analytics packages are loaded.

--- a/plugins/woocommerce/phpstan.neon
+++ b/plugins/woocommerce/phpstan.neon
@@ -27,6 +27,7 @@ parameters:
 	scanDirectories:
 		- vendor/wordpress/abilities-api
 		- packages/action-scheduler
+		- ../../packages/php/woocommerce-analytics/src
 	scanFiles:
 		- php-stubs/wc-admin-feature-config.php
 		- php-stubs/wc-constants.php
@@ -52,4 +53,3 @@ parameters:
 			path: src/StoreApi/Utilities/ProductItemTrait.php
 	parallel:
 		maximumNumberOfProcesses: 4
-

--- a/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
+++ b/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
@@ -204,7 +204,7 @@ class LegacySelect2UsageTracker implements RegisterHooksInterface {
 	 * @since 11.0.0
 	 */
 	protected function record_frontend_event( string $event_name, array $properties ): void {
-		if ( ! class_exists( WC_Analytics_Tracking::class ) ) {
+		if ( ! class_exists( WC_Analytics_Tracking::class ) || ! is_callable( array( WC_Analytics_Tracking::class, 'add_event_to_queue' ) ) ) {
 			return;
 		}
 
@@ -219,7 +219,9 @@ class LegacySelect2UsageTracker implements RegisterHooksInterface {
 	 * @since 11.0.0
 	 */
 	protected function is_frontend_tracking_available(): bool {
-		return did_action( 'woocommerce_analytics_init' ) && class_exists( WC_Analytics_Tracking::class );
+		return did_action( 'woocommerce_analytics_init' )
+			&& class_exists( WC_Analytics_Tracking::class )
+			&& is_callable( array( WC_Analytics_Tracking::class, 'add_event_to_queue' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
+++ b/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
@@ -204,7 +204,7 @@ class LegacySelect2UsageTracker implements RegisterHooksInterface {
 	 * @since 11.0.0
 	 */
 	protected function record_frontend_event( string $event_name, array $properties ): void {
-		if ( ! class_exists( WC_Analytics_Tracking::class ) || ! is_callable( array( WC_Analytics_Tracking::class, 'add_event_to_queue' ) ) ) {
+		if ( $this->is_frontend_tracking_available() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
+++ b/plugins/woocommerce/src/Internal/LegacyAssets/LegacySelect2UsageTracker.php
@@ -204,7 +204,7 @@ class LegacySelect2UsageTracker implements RegisterHooksInterface {
 	 * @since 11.0.0
 	 */
 	protected function record_frontend_event( string $event_name, array $properties ): void {
-		if ( $this->is_frontend_tracking_available() ) {
+		if ( ! $this->is_frontend_tracking_available() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Older Jetpack-family plugins can provide `WC_Analytics_Tracking` without the newer `add_event_to_queue()` method, causing a storefront fatal when legacy Select2 usage tracking runs. Require the queue method to be callable in both the availability check and the final recording boundary so affected stores safely skip this telemetry. This does not change any public API, hook, or storage behavior.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66702.

Bug introduced in PR #66652.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. No needed.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `LegacySelect2UsageTrackerTest`: 10 tests, 13 assertions passing in wp-env with PHP 8.1.34.
- Changed-file PHP lint and full branch-diff lint pass without errors or warnings.
- PHPStan passes for `LegacySelect2UsageTracker.php` with no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
