### PR TITLE
Fix Blocks E2E tests with WordPress 7.1 beta 1

### DIFF
--- a/plugins/woocommerce/changelog/dev-wp-7-1-e2e-content-locators
+++ b/plugins/woocommerce/changelog/dev-wp-7-1-e2e-content-locators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update Blocks E2E Site Editor content locators for WordPress 7.1.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -170,7 +170,6 @@ test.describe( `${ blockData.name } Block`, () => {
 		editor,
 		requestUtils,
 		blockUtils,
-		wpCoreVersion,
 	} ) => {
 		// Add to Cart with Options in the Site Editor is only available as
 		// inner block of the Single Product Block except for the Single Product
@@ -187,16 +186,9 @@ test.describe( `${ blockData.name } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
 		await editor.insertBlock( { name: 'woocommerce/single-product' } );
 
@@ -218,7 +210,6 @@ test.describe( `${ blockData.name } Block`, () => {
 		admin,
 		editor,
 		requestUtils,
-		wpCoreVersion,
 	} ) => {
 		const template = await requestUtils.createTemplate( 'wp_template', {
 			slug: 'single-product',
@@ -232,16 +223,9 @@ test.describe( `${ blockData.name } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
 		await editor.insertBlock( { name: blockData.slug } );
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/breadcrumbs/breadcrumbs.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/breadcrumbs/breadcrumbs.block_theme.spec.ts
@@ -30,7 +30,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 		requestUtils,
 		editor,
-		wpCoreVersion,
 	} ) => {
 		const template = await requestUtils.createTemplate( 'wp_template', {
 			slug: 'sorter',
@@ -44,16 +43,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/catalog-sorting/catalog-sorting.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/catalog-sorting/catalog-sorting.block_theme.spec.ts
@@ -31,7 +31,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 		requestUtils,
 		editor,
-		wpCoreVersion,
 	} ) => {
 		const template = await requestUtils.createTemplate( 'wp_template', {
 			slug: 'sorter',
@@ -45,15 +44,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/extensibility-events.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/extensibility-events.block_theme.spec.ts
@@ -88,16 +88,22 @@ test.describe( 'Product Collection: Extensibility Events', () => {
 		test.beforeEach( async ( { page, pageObject } ) => {
 			await pageObject.createNewPostAndInsertBlock( 'featured' );
 
+			let resolvePayload!: ( payload: {
+				productId?: number;
+				collection?: string;
+			} ) => void;
 			promise = new Promise( ( resolve ) => {
-				void page.exposeFunction( 'resolvePayload', resolve );
-				void page.addInitScript( () => {
-					window.document.addEventListener(
-						'wc-blocks_viewed_product',
-						( e ) => {
-							window.resolvePayload( e.detail );
-						}
-					);
-				} );
+				resolvePayload = resolve;
+			} );
+
+			await page.exposeFunction( 'resolvePayload', resolvePayload );
+			await page.addInitScript( () => {
+				window.document.addEventListener(
+					'wc-blocks_viewed_product',
+					( e ) => {
+						window.resolvePayload( e.detail );
+					}
+				);
 			} );
 
 			await pageObject.publishAndGoToFrontend();
@@ -117,7 +123,11 @@ test.describe( 'Product Collection: Extensibility Events', () => {
 		} );
 
 		test( 'when Product Title is clicked', async ( { page } ) => {
-			await page.locator( '.wp-block-post-title' ).nth( 0 ).click();
+			await page
+				.locator( '.wp-block-post-title' )
+				.first()
+				.getByRole( 'link' )
+				.click();
 
 			const { collection, productId } = await promise;
 			expect( collection ).toEqual(

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/inspector-controls.block_theme.spec.ts
@@ -578,13 +578,14 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 
 			// Disable the option in the first Product Catalog
 			await editor.selectBlocks( productCollection.first() );
+			await expect( defaultQueryType ).toBeChecked();
 			await customQueryType.click();
+			await expect( customQueryType ).toBeChecked();
 
 			// Third Product Catalog
 			// Option should be visible & ENABLED by default
 			await pageObject.insertProductCollection();
 			await pageObject.chooseCollectionInTemplate( 'productCatalog' );
-			await editor.selectBlocks( productCollection.last() );
 
 			await expect( defaultQueryType ).toBeChecked();
 			await expect( customQueryType ).not.toBeChecked();

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.block_theme.spec.ts
@@ -788,7 +788,6 @@ test.describe( 'Product Collection', () => {
 					admin,
 					editor,
 					page,
-					wpCoreVersion,
 				} ) => {
 					await pageObject.refreshLocators( 'frontend' );
 
@@ -812,15 +811,9 @@ test.describe( 'Product Collection', () => {
 						canvas: 'edit',
 					} );
 
-					// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-					// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-					const placeholderLocator =
-						wpCoreVersion >= 7
-							? editor.canvas
-									.frameLocator( 'iframe' )
-									.getByText( 'placeholder' )
-							: editor.canvas.getByText( 'placeholder' );
-					await expect( placeholderLocator ).toBeVisible();
+					await expect(
+						editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+					).toBeVisible();
 
 					await editor.insertBlock( { name: legacyBlockName } );
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
@@ -210,19 +210,14 @@ class ProductCollectionPage {
 				.getByRole( 'button', { name: 'Choose collection' } )
 				.click();
 
-			return this.editor.wpCoreVersion >= 7.1
-				? this.admin.page.getByRole( 'button', {
-						name: buttonName,
-						exact: true,
-				  } )
-				: this.editor.canvas
-						.locator(
-							'.wc-blocks-product-collection__collections-dropdown-content'
-						)
-						.getByRole( 'button', {
-							name: buttonName,
-							exact: true,
-						} );
+			return this.admin.page
+				.locator(
+					'.wc-blocks-product-collection__collections-dropdown-content'
+				)
+				.getByRole( 'button', {
+					name: buttonName,
+					exact: true,
+				} );
 		}
 
 		return placeholderSelector.getByRole( 'button', {

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
@@ -185,15 +185,17 @@ class ProductCollectionPage {
 		] );
 	}
 
-	async chooseCollectionInTemplate( collection?: Collections ) {
+	async locateCollectionButtonInEditor( collection?: Collections ) {
 		await this.editor.closeGlobalBlockInserter();
 
 		const buttonName = collection
 			? collectionToButtonNameMap[ collection ]
 			: collectionToButtonNameMap.productCatalog;
 
-		const inserterClass = await this.editor.canvas
-			.locator( SELECTORS.collectionPlaceholder )
+		const placeholderSelector = this.editor.canvas.locator(
+			SELECTORS.collectionPlaceholder
+		);
+		const inserterClass = await placeholderSelector
 			.locator(
 				'.wc-blocks-product-collection__collections-grid, .wc-blocks-product-collection__collections-dropdown'
 			)
@@ -204,22 +206,37 @@ class ProductCollectionPage {
 		);
 
 		if ( isDropdown ) {
-			await this.editor.canvas
+			await placeholderSelector
 				.getByRole( 'button', { name: 'Choose collection' } )
 				.click();
 
-			await this.editor.canvas
-				.locator(
-					'.wc-blocks-product-collection__collections-dropdown-content'
-				)
-				.getByRole( 'button', { name: buttonName, exact: true } )
-				.click();
-		} else {
-			await this.editor.canvas
-				.locator( SELECTORS.collectionPlaceholder )
-				.getByRole( 'button', { name: buttonName, exact: true } )
-				.click();
+			return this.editor.wpCoreVersion >= 7.1
+				? this.admin.page.getByRole( 'button', {
+						name: buttonName,
+						exact: true,
+				  } )
+				: this.editor.canvas
+						.locator(
+							'.wc-blocks-product-collection__collections-dropdown-content'
+						)
+						.getByRole( 'button', {
+							name: buttonName,
+							exact: true,
+						} );
 		}
+
+		return placeholderSelector.getByRole( 'button', {
+			name: buttonName,
+			exact: true,
+		} );
+	}
+
+	async chooseCollectionInTemplate( collection?: Collections ) {
+		const collectionButton = await this.locateCollectionButtonInEditor(
+			collection
+		);
+
+		await collectionButton.click();
 	}
 
 	async chooseProductInEditorProductPickerIfAvailable(

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/product-collection.page.ts
@@ -374,7 +374,7 @@ class ProductCollectionPage {
 	}
 
 	async insertProductCollection() {
-		await this.editor.insertBlock( { name: this.BLOCK_SLUG } );
+		await this.editor.insertBlockUsingGlobalInserter( this.BLOCK_NAME );
 	}
 
 	async goToTemplateAndInsertCollection(

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-collection/register-product-collection.block_theme.spec.ts
@@ -642,40 +642,30 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 	test.describe( 'with "scope" argument', () => {
 		test( 'Collection with only `inserter` scope should not be displayed in Collection Chooser', async ( {
 			pageObject,
-			editor,
 			admin,
 		} ) => {
 			await admin.createNewPost();
 			await pageObject.insertProductCollection();
 
-			const placeholderSelector = editor.canvas.locator(
-				SELECTORS.collectionPlaceholder
-			);
-
-			const collectionButton = placeholderSelector.getByRole( 'button', {
-				name: 'My Custom Collection - With Inserter Scope',
-				exact: true,
-			} );
+			const collectionButton =
+				await pageObject.locateCollectionButtonInEditor(
+					'myCustomCollectionWithInserterScope'
+				);
 
 			await expect( collectionButton ).toBeHidden();
 		} );
 
 		test( 'Collection with only `block` scope should be displayed in Collection Chooser', async ( {
 			pageObject,
-			editor,
 			admin,
 		} ) => {
 			await admin.createNewPost();
 			await pageObject.insertProductCollection();
 
-			const placeholderSelector = editor.canvas.locator(
-				SELECTORS.collectionPlaceholder
-			);
-
-			const collectionButton = placeholderSelector.getByRole( 'button', {
-				name: 'My Custom Collection - With Block Scope',
-				exact: true,
-			} );
+			const collectionButton =
+				await pageObject.locateCollectionButtonInEditor(
+					'myCustomCollectionWithBlockScope'
+				);
 
 			await expect( collectionButton ).toBeVisible();
 		} );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-filters/attribute-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-filters/attribute-filter-editor.block_theme.spec.ts
@@ -19,6 +19,11 @@ const blockData = {
 	slug: 'archive-product',
 };
 
+const getExpectedStyleControls = ( wpCoreVersion: number ) =>
+	wpCoreVersion >= 7.1
+		? [ 'Typography', 'Dimensions', 'Border' ]
+		: [ 'Color', 'Typography', 'Dimensions' ];
+
 const test = base.extend< { pageObject: ProductFiltersPage } >( {
 	pageObject: async ( { page, editor, frontendUtils }, use ) => {
 		const pageObject = new ProductFiltersPage( {
@@ -42,6 +47,7 @@ test.describe( `${ blockData.name }`, () => {
 	test( 'should display the correct inspector style controls', async ( {
 		editor,
 		pageObject,
+		wpCoreVersion,
 	} ) => {
 		await pageObject.addProductFiltersBlock( { cleanContent: true } );
 
@@ -53,18 +59,13 @@ test.describe( `${ blockData.name }`, () => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.page.getByRole( 'tab', { name: 'Styles' } ).click();
 
-		await expect(
-			editor.page.getByText( 'ColorAll options are currently hidden' )
-		).toBeVisible();
-		await expect(
-			editor.page.getByText(
-				'TypographyAll options are currently hidden'
-			)
-		).toBeVisible();
-		await expect(
-			editor.page.getByText(
-				'DimensionsAll options are currently hidden'
-			)
-		).toBeVisible();
+		for ( const control of getExpectedStyleControls( wpCoreVersion ) ) {
+			await expect(
+				editor.page.getByRole( 'heading', {
+					name: control,
+					exact: true,
+				} )
+			).toBeVisible();
+		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/product-gallery-thumbnails.block_theme.spec.ts
@@ -4,40 +4,31 @@
 import { test, expect } from '@woocommerce/e2e-utils';
 
 test.describe( 'Product Gallery Thumbnails block', () => {
-	test.beforeEach(
-		async ( { admin, editor, requestUtils, wpCoreVersion } ) => {
-			const template = await requestUtils.createTemplate( 'wp_template', {
-				slug: 'single-product',
-				title: 'Custom Single Product',
-				content: 'placeholder',
-			} );
+	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+		const template = await requestUtils.createTemplate( 'wp_template', {
+			slug: 'single-product',
+			title: 'Custom Single Product',
+			content: 'placeholder',
+		} );
 
-			await admin.visitSiteEditor( {
-				postId: template.id,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+		await admin.visitSiteEditor( {
+			postId: template.id,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
 
-			// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-			// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-			const placeholderLocator =
-				wpCoreVersion >= 7
-					? editor.canvas
-							.frameLocator( 'iframe' )
-							.getByText( 'placeholder' )
-					: editor.canvas.getByText( 'placeholder' );
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
-			await expect( placeholderLocator ).toBeVisible();
+		await editor.insertBlock( {
+			name: 'woocommerce/product-gallery',
+		} );
 
-			await editor.insertBlock( {
-				name: 'woocommerce/product-gallery',
-			} );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-		}
-	);
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+	} );
 
 	test( 'renders as expected', async ( { page, editor } ) => {
 		await test.step( 'in editor', async () => {

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.block_theme.spec.ts
@@ -67,32 +67,23 @@ const getThumbnailImageIdByNth = async (
 };
 
 test.describe( `${ blockData.name }`, () => {
-	test.beforeEach(
-		async ( { admin, editor, requestUtils, wpCoreVersion } ) => {
-			const template = await requestUtils.createTemplate( 'wp_template', {
-				slug: blockData.slug,
-				title: 'Custom Single Product',
-				content: 'placeholder',
-			} );
+	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+		const template = await requestUtils.createTemplate( 'wp_template', {
+			slug: blockData.slug,
+			title: 'Custom Single Product',
+			content: 'placeholder',
+		} );
 
-			await admin.visitSiteEditor( {
-				postId: template.id,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+		await admin.visitSiteEditor( {
+			postId: template.id,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
 
-			// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-			// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-			const placeholderLocator =
-				wpCoreVersion >= 7
-					? editor.canvas
-							.frameLocator( 'iframe' )
-							.getByText( 'placeholder' )
-					: editor.canvas.getByText( 'placeholder' );
-
-			await expect( placeholderLocator ).toBeVisible();
-		}
-	);
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
+	} );
 
 	test.describe( 'with thumbnails', () => {
 		test( 'should have as first thumbnail, the same image that it is visible in the product block', async ( {

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-results-count/product-results-count.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-results-count/product-results-count.block_theme.spec.ts
@@ -31,7 +31,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 		requestUtils,
 		editor,
-		wpCoreVersion,
 	} ) => {
 		const template = await requestUtils.createTemplate( 'wp_template', {
 			slug: 'sorter',
@@ -45,15 +44,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 		await editor.insertBlock( {
 			name: blockData.slug,
 		} );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/products/products.block_theme.spec.ts
@@ -131,6 +131,9 @@ test.describe( `${ blockData.name } Block `, () => {
 		page,
 	} ) => {
 		await admin.createNewPost();
+		await expect(
+			editor.canvas.getByLabel( /Add default block|Empty block/ )
+		).toBeVisible();
 		await insertProductsQuery( editor, { inherit: false } );
 		await editor.publishAndVisitPost();
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/products/utils.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/products/utils.ts
@@ -50,6 +50,7 @@ export const insertProductsQuery = async (
 			namespace: 'woocommerce/product-query',
 			query: {
 				inherit: options.inherit ?? true,
+				postType: 'product',
 			},
 		},
 		innerBlocks: productQueryInnerBlocksTemplate,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
@@ -34,7 +34,6 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 		requestUtils,
 		editor,
-		wpCoreVersion,
 	} ) => {
 		const template = await requestUtils.createTemplate( 'wp_template', {
 			// Single Product Details block is addable only in Single Product Templates
@@ -49,15 +48,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 			canvas: 'edit',
 		} );
 
-		// TODO: WP 7.0 compat - Custom HTML block content is inside an iframe
-		// since WP 7.0. Simplify when WP 7.0 is the minimum supported version.
-		const placeholderLocator =
-			wpCoreVersion >= 7
-				? editor.canvas
-						.frameLocator( 'iframe' )
-						.getByText( 'placeholder' )
-				: editor.canvas.getByText( 'placeholder' );
-		await expect( placeholderLocator ).toBeVisible();
+		await expect(
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
+		).toBeVisible();
 
 		await editor.insertBlock( {
 			name: blockData.slug,

--- a/plugins/woocommerce/tests/e2e/utils/blocks/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/editor/editor-utils.page.ts
@@ -20,6 +20,17 @@ export class Editor extends CoreEditor {
 		this.wpCoreVersion = wpCoreVersion;
 	}
 
+	/**
+	 * Returns a locator for Custom HTML block content in the Site Editor canvas.
+	 * WordPress 7.0 renders the content inside an additional iframe.
+	 * WordPress 6.9 and 7.1+ render it directly in the editor canvas.
+	 */
+	getCustomHtmlBlockContentLocator( content: string ) {
+		return this.wpCoreVersion === 7
+			? this.canvas.frameLocator( 'iframe' ).getByText( content )
+			: this.canvas.getByText( content );
+	}
+
 	async getBlockByName( name: string ) {
 		const blockSelector = `[data-type="${ name }"]`;
 		const canvasLocator = this.page


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Adjusting Blocks E2E tests to WordPress 7.1 beta 1.

Skipped for now:
- Cart and Checkout tests
- Core tests regarding Email Editor

These are being handled separately so they're expected to fail in this PR!

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run the Blocks E2E CI matrices for WordPress 6.9 (`blocks-e2e-wp-latest-1`), WordPress 7.0 (`blocks-e2e`), and WordPress 7.1 beta (`blocks-e2e-wp-pre-release`).
2. Verify all affected Site Editor specs pass, including Breadcrumbs, Catalog Sorting, Product Results Count, Single Product Details, Add to Cart Form, Product Gallery, and Product Collection.
3. Confirm the tests locate the template placeholder directly in the editor canvas on WordPress 6.9 and 7.1, and inside the additional iframe on WordPress 7.0.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Local wp-env with WordPress 7.1-beta1: the targeted Breadcrumbs Site Editor test passed.
- A focused cross-spec run passed 10 affected scenarios before an unrelated local REST/auth environment failure prevented the remaining scenarios from reaching their locator assertions.
- Prettier and ESLint passed for all changed TypeScript files.
- The shared editor utility passed isolated TypeScript compilation.
- Playwright successfully discovered 69 tests across the nine affected files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/dev-wp-7-1-e2e-content-locators`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
