### PR TITLE
Settings UI: converge the renderer and extension contract on DataForm

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -490,6 +490,16 @@
 			"isIgnored": true
 		},
 		{
+			"label": "settings-ui pins dataviews ahead of the WordPress bundle for the non-collapsible DataForm card layout; the pin is bundled into the settings-ui asset only",
+			"dependencies": [
+				"@wordpress/dataviews"
+			],
+			"packages": [
+				"@woocommerce/settings-ui"
+			],
+			"isIgnored": true
+		},
+		{
 			"label": "@wordpress/* dependencies that WooCommerce bundles instead of externalizing to WordPress",
 			"dependencyTypes": [
 				"prod",

--- a/docs/extensions/settings-and-config/registering-settings-ui-components.md
+++ b/docs/extensions/settings-and-config/registering-settings-ui-components.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 # Registering settings UI components
 
-> **Experimental.** The Settings UI is behind the default-off `settings-ui` feature flag and its APIs are subject to change. The component contract described here changed in the DataForm migration and may change again before the feature is stable.
+> **Experimental.** The Settings UI is behind the default-off `settings-ui` feature flag and its APIs, including the component contract described here, are subject to change while the feature matures.
 
 Use custom components when a WooCommerce settings field needs plugin-specific React UI that cannot be represented by a supported field type.
 
@@ -77,6 +77,8 @@ type SettingsEditControlProps = {
 Page-level state is available through the `useSettingsUIContext()` hook:
 
 ```ts
+import { useSettingsUIContext } from '@woocommerce/settings-ui';
+
 const { schema, context, initialValues } = useSettingsUIContext();
 ```
 

--- a/docs/extensions/settings-and-config/registering-settings-ui-components.md
+++ b/docs/extensions/settings-and-config/registering-settings-ui-components.md
@@ -6,9 +6,13 @@ sidebar_position: 6
 
 # Registering settings UI components
 
-Use custom components when a WooCommerce settings field needs plugin-specific React UI that cannot be represented by a native field type.
+> **Experimental.** The Settings UI is behind the default-off `settings-ui` feature flag and its APIs are subject to change. The component contract described here changed in the DataForm migration and may change again before the feature is stable.
 
-For most fields, prefer the native renderer. Custom components are best for specialized selectors, previews, or validation flows.
+Use custom components when a WooCommerce settings field needs plugin-specific React UI that cannot be represented by a supported field type.
+
+For most fields, prefer the built-in renderer. Custom components are best for specialized selectors, previews, or validation flows.
+
+Registered components are [DataForm](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/) edit controls: the same component contract used by WordPress DataForm everywhere else in the admin. A component written for the Settings UI works as a DataForm control and the other way round.
 
 ## PHP field metadata
 
@@ -52,49 +56,49 @@ Registrations are scoped by settings page and, optionally, by section. This prev
 
 ## Component props
 
-Custom components receive stable field props:
+Custom components receive the DataForm control props, re-exported as `SettingsEditControlProps`:
 
 ```ts
-type SettingsFieldComponentProps = {
-	field: {
-		id: string;
-		label: string;
-		type: string;
-		description?: string;
-		value?: string | number | boolean | string[] | null;
-		options?: Array< { label: string; value: string } >;
-		component?: string;
-		placeholder?: string;
-		disabled?: boolean;
-		customAttributes?: Record< string, string | number | boolean >;
-	};
-	value: string | number | boolean | string[] | null;
-	onChange: ( value: string | number | boolean | string[] | null ) => void;
-	context: {
-		page: string;
-		section?: string;
-	};
+type SettingsEditControlProps = {
+	// The current settings values, keyed by field id.
+	data: Record< string, string | number | boolean | string[] | null >;
+	// The normalized DataForm field. Use field.getValue( { item: data } )
+	// to read the current value and field.setValue( { item, value } ) to
+	// build a change record that preserves the saved value format.
+	field: NormalizedField;
+	// Takes a partial record of field ids to new values. Multi-field
+	// writes are a single call.
+	onChange: ( edits: Record< string, unknown > ) => void;
+	hideLabelFromVision?: boolean;
+	validity?: SettingsFieldValidity;
 };
 ```
 
-Call `onChange()` with the next field value. The settings UI handles hidden input serialization for the field's save adapter.
+Page-level state is available through the `useSettingsUIContext()` hook:
+
+```ts
+const { schema, context, initialValues } = useSettingsUIContext();
+```
+
+Call `onChange()` with a record of field ids to next values. The settings UI handles hidden input serialization for the field's save adapter.
 
 ## Example component
 
 ```tsx
-import type { SettingsFieldComponentProps } from '@woocommerce/settings-ui';
+import type { SettingsEditControlProps } from '@woocommerce/settings-ui';
 
 export const PaymentMethodPicker = ( {
+	data,
 	field,
-	value,
 	onChange,
-}: SettingsFieldComponentProps ) => {
+}: SettingsEditControlProps ) => {
+	const value = field.getValue( { item: data } );
 	const selectedValues = Array.isArray( value ) ? value : [];
 
 	return (
 		<fieldset>
 			<legend>{ field.label }</legend>
-			{ field.options?.map( ( option ) => {
+			{ field.elements?.map( ( option ) => {
 				const checked = selectedValues.includes( option.value );
 
 				return (
@@ -104,12 +108,18 @@ export const PaymentMethodPicker = ( {
 							checked={ checked }
 							onChange={ () => {
 								onChange(
-									checked
-										? selectedValues.filter(
-												( item ) =>
-													item !== option.value
-										  )
-										: [ ...selectedValues, option.value ]
+									field.setValue( {
+										item: data,
+										value: checked
+											? selectedValues.filter(
+													( item ) =>
+														item !== option.value
+											  )
+											: [
+													...selectedValues,
+													option.value,
+											  ],
+									} )
 								);
 							} }
 						/>
@@ -159,7 +169,7 @@ Resolution order is:
 1. `field.component`
 2. `fieldOverrides[ field.id ]`
 3. `typeRenderers[ field.type ]`
-4. Native field renderer
+4. The DataForm control for the field type
 
 ## Enqueue the component script
 

--- a/docs/extensions/settings-and-config/settings-ui.md
+++ b/docs/extensions/settings-and-config/settings-ui.md
@@ -6,9 +6,11 @@ sidebar_position: 5
 
 # Settings UI
 
-The settings UI is an opt-in path for rendering WooCommerce settings pages with React while keeping the existing `WC_Settings_Page` registration and save flow.
+> **Experimental.** The Settings UI is behind the default-off `settings-ui` feature flag and its APIs, both PHP and JavaScript, are subject to change while the feature matures. Build against it to give feedback, not for production releases.
 
-It is designed for extension authors who want to migrate incrementally. PHP still owns page registration, settings schema, permissions, script dependencies, and persistence. React owns field rendering and client-side interaction.
+The settings UI is an opt-in path for rendering WooCommerce settings pages with React while keeping the existing `WC_Settings_Page` registration and save flow. Fields render through [DataForm](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/) from `@wordpress/dataviews`, the WordPress primitive for generated forms.
+
+It is designed for extension authors who want to migrate incrementally. PHP still owns page registration, settings schema, permissions, script dependencies, and persistence. DataForm owns field rendering, visibility, and validity, and React components handle client-side interaction.
 
 ## Status
 
@@ -16,7 +18,7 @@ It is designed for extension authors who want to migrate incrementally. PHP stil
 -   With the flag disabled, settings pages keep the legacy PHP renderer.
 -   With the flag enabled, a settings page still has to opt in explicitly.
 -   Saves use the existing WooCommerce settings form POST flow by default.
--   The public PHP API is available under `Automattic\WooCommerce\Admin\Settings`.
+-   The PHP API is available under `Automattic\WooCommerce\Admin\Settings` and is experimental.
 
 ## Build a settings UI integration
 

--- a/packages/js/settings-ui/changelog/fix-value-representation
+++ b/packages/js/settings-ui/changelog/fix-value-representation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix value handling for extension-supplied schemas: numeric option values match in the native select, the badge intent lookup ignores Object.prototype keys, and controls preserve the schema's value representation.

--- a/packages/js/settings-ui/changelog/update-dataform-renderer
+++ b/packages/js/settings-ui/changelog/update-dataform-renderer
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Render Settings UI fields through DataForm and align the experimental component contract with DataForm edit controls.

--- a/packages/js/settings-ui/package.json
+++ b/packages/js/settings-ui/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/admin-ui": "catalog:wp-bundled",
 		"@wordpress/a11y": "catalog:wp-min",
 		"@wordpress/components": "catalog:wp-min",
+		"@wordpress/dataviews": "10.3.0",
 		"@wordpress/element": "catalog:wp-min",
 		"@wordpress/i18n": "catalog:wp-min",
 		"@wordpress/ui": "catalog:wp-bundled"

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -11,12 +11,13 @@ import type {
 	FormValidity,
 	Rules,
 } from '@wordpress/dataviews';
+import type { ComponentType } from 'react';
 
 /**
  * Internal dependencies
  */
 import { warn } from './diagnostics';
-import { sanitizeSettingsHtml } from './html';
+import { toSanitizedHtmlNode } from './html';
 import { NativeSettingsField } from './native-fields';
 import {
 	resolveFieldComponent,
@@ -31,7 +32,9 @@ import type {
 	SettingsUISchema,
 	SettingsValue,
 	SettingsValues,
+	SettingsVisibilityPredicate,
 } from './types';
+import { isCheckedValue, toStringValue } from './values';
 
 export type DataFormAdapterOptions = {
 	schema: SettingsUISchema;
@@ -50,7 +53,7 @@ export type DataFormAdapterOptions = {
  * shape), or a single group that falls back to the shell-owned card
  * because the package card header has no slot for header actions.
  */
-export type DataFormRenderSection =
+type DataFormRenderSection =
 	| {
 			type: 'dataform';
 			key: string;
@@ -63,15 +66,8 @@ export type DataFormRenderSection =
 			group: SettingsUIGroup;
 	  };
 
-const toStringValue = ( value: SettingsValue | undefined ) =>
-	value === null || typeof value === 'undefined' ? '' : String( value );
-
-const isCheckedValue = ( value: SettingsValue | undefined ): boolean =>
-	value === true || value === 1 || value === 'yes' || value === '1';
-
-// Legacy PHP settings express checkbox state as yes/no, 1/0, or booleans
-// depending on the source. Echo the initial representation back so the
-// save flow round-trips values unchanged.
+// Echo the initial checkbox representation back so the save flow
+// round-trips values unchanged.
 const toCheckboxValue = (
 	checked: boolean,
 	initialValue: SettingsValue | undefined
@@ -181,8 +177,8 @@ const restoreOptionValue = (
 	return typeof option === 'undefined' ? next : option.value;
 };
 
-const toElements = ( options?: SettingsUIOption[] ) =>
-	( options || [] ).map( ( option ) => ( {
+const toElements = ( options: SettingsUIOption[] ) =>
+	options.map( ( option ) => ( {
 		value: toStringValue( option.value ),
 		label: option.label,
 	} ) );
@@ -200,11 +196,7 @@ const toDescriptionNode = ( description?: string ) => {
 		return description;
 	}
 
-	return createElement( 'span', {
-		dangerouslySetInnerHTML: {
-			__html: sanitizeSettingsHtml( description ),
-		},
-	} ) as unknown as string;
+	return toSanitizedHtmlNode( description ) as unknown as string;
 };
 
 type TypeAndEdit = {
@@ -212,10 +204,14 @@ type TypeAndEdit = {
 	Edit?: Field< SettingsValues >[ 'Edit' ];
 };
 
+// Types without an explicit Edit use the package's default control for
+// the DataForm type. Radio and select need one because fields with
+// elements default to the select control, and textarea is a control
+// config on the text type.
 const getPackageTypeAndEdit = ( field: SettingsUIField ): TypeAndEdit => {
 	switch ( field.type ) {
 		case 'checkbox':
-			return { type: 'boolean', Edit: 'checkbox' };
+			return { type: 'boolean' };
 		case 'radio':
 			return { type: 'text', Edit: 'radio' };
 		case 'select':
@@ -223,9 +219,9 @@ const getPackageTypeAndEdit = ( field: SettingsUIField ): TypeAndEdit => {
 		case 'textarea':
 			return { type: 'text', Edit: { control: 'textarea' } };
 		case 'number':
-			return { type: 'number', Edit: 'number' };
+			return { type: 'number' };
 		case 'tel':
-			return { type: 'telephone', Edit: 'telephone' };
+			return { type: 'telephone' };
 		case 'array':
 			return { type: 'array' };
 		case 'date':
@@ -233,7 +229,7 @@ const getPackageTypeAndEdit = ( field: SettingsUIField ): TypeAndEdit => {
 		case 'password':
 		case 'text':
 		case 'url':
-			return { type: field.type, Edit: field.type };
+			return { type: field.type };
 		default:
 			return {};
 	}
@@ -276,15 +272,9 @@ const createInfoRender = ( settingsField: SettingsUIField ) => {
 		return (
 			<div className="wc-settings-ui__info" id={ settingsField.id }>
 				<strong>{ settingsField.label }</strong>
-				{ settingsField.description ? (
-					<span
-						dangerouslySetInnerHTML={ {
-							__html: sanitizeSettingsHtml(
-								settingsField.description
-							),
-						} }
-					/>
-				) : null }
+				{ settingsField.description
+					? toSanitizedHtmlNode( settingsField.description )
+					: null }
 			</div>
 		);
 	};
@@ -295,7 +285,7 @@ const createInfoRender = ( settingsField: SettingsUIField ) => {
 const createRegisteredEdit = (
 	settingsField: SettingsUIField,
 	context: SettingsFieldContext,
-	fallback: Field< SettingsValues >[ 'Edit' ]
+	Fallback?: ComponentType< DataFormControlProps< SettingsValues > >
 ) => {
 	return function RegisteredFieldEdit(
 		props: DataFormControlProps< SettingsValues >
@@ -306,12 +296,7 @@ const createRegisteredEdit = (
 			return <Registered { ...props } />;
 		}
 
-		if ( typeof fallback === 'function' ) {
-			const Fallback = fallback;
-			return <Fallback { ...props } />;
-		}
-
-		return null;
+		return Fallback ? <Fallback { ...props } /> : null;
 	};
 };
 
@@ -344,57 +329,67 @@ const createGetValue = ( settingsField: SettingsUIField ) => {
 	};
 };
 
+type SetValueArgs = {
+	item: SettingsValues;
+	value: SettingsValue;
+};
+
 const createSetValue = (
 	settingsField: SettingsUIField,
 	initialValues: SettingsValues
 ) => {
-	return ( {
-		value,
-	}: {
-		item: SettingsValues;
-		value: SettingsValue;
-	} ): Partial< SettingsValues > => {
-		if (
-			settingsField.type === 'select' ||
-			settingsField.type === 'radio'
-		) {
-			return {
-				[ settingsField.id ]: restoreOptionValue(
-					value,
-					settingsField.options
-				),
-			};
-		}
+	const { id } = settingsField;
 
-		if ( settingsField.type === 'array' ) {
-			return {
-				[ settingsField.id ]: ( Array.isArray( value )
-					? value
-					: []
-				).map( String ),
-			};
-		}
+	if ( settingsField.type === 'select' || settingsField.type === 'radio' ) {
+		return ( { value }: SetValueArgs ) => ( {
+			[ id ]: restoreOptionValue( value, settingsField.options ),
+		} );
+	}
 
-		if ( settingsField.type === 'checkbox' ) {
-			return {
-				[ settingsField.id ]: toCheckboxValue(
-					Boolean( value ),
-					initialValues[ settingsField.id ]
-				),
-			};
-		}
+	if ( settingsField.type === 'array' ) {
+		return ( { value }: SetValueArgs ) => ( {
+			[ id ]: ( Array.isArray( value ) ? value : [] ).map( String ),
+		} );
+	}
 
-		if ( settingsField.type === 'number' ) {
-			return {
-				[ settingsField.id ]: toNumberFieldValue(
-					value,
-					initialValues[ settingsField.id ]
-				),
-			};
-		}
+	if ( settingsField.type === 'checkbox' ) {
+		return ( { value }: SetValueArgs ) => ( {
+			[ id ]: toCheckboxValue( Boolean( value ), initialValues[ id ] ),
+		} );
+	}
 
-		return { [ settingsField.id ]: value };
-	};
+	if ( settingsField.type === 'number' ) {
+		return ( { value }: SetValueArgs ) => ( {
+			[ id ]: toNumberFieldValue( value, initialValues[ id ] ),
+		} );
+	}
+
+	return ( { value }: SetValueArgs ) => ( { [ id ]: value } );
+};
+
+// Predicates fail open: a broken visibility callback renders the field
+// or group rather than hiding it.
+const runVisibilityPredicate = (
+	predicate: SettingsVisibilityPredicate,
+	kind: 'field' | 'group',
+	id: string,
+	values: SettingsValues,
+	options: DataFormAdapterOptions
+) => {
+	try {
+		return predicate( {
+			values,
+			initialValues: options.initialValues,
+			context: options.context,
+			schema: options.schema,
+		} );
+	} catch ( predicateError ) {
+		warn(
+			`Visibility predicate for ${ kind } "${ id }" failed. Rendering it visible.`,
+			{ error: predicateError, context: options.context }
+		);
+		return true;
+	}
 };
 
 const createIsVisible = (
@@ -408,20 +403,13 @@ const createIsVisible = (
 		);
 
 		if ( predicate ) {
-			try {
-				return predicate( {
-					values: item,
-					initialValues: options.initialValues,
-					context: options.context,
-					schema: options.schema,
-				} );
-			} catch ( predicateError ) {
-				warn(
-					`Visibility predicate for field "${ settingsField.id }" failed. Rendering it visible.`,
-					{ error: predicateError, context: options.context }
-				);
-				return true;
-			}
+			return runVisibilityPredicate(
+				predicate,
+				'field',
+				settingsField.id,
+				item,
+				options
+			);
 		}
 
 		if ( settingsField.visibility ) {
@@ -478,10 +466,7 @@ export const buildDataFormField = (
 		defaultEdit = createNativeEdit( settingsField );
 	} else if ( needsNativeEdit( settingsField ) ) {
 		defaultEdit = createNativeEdit( settingsField );
-	} else if (
-		typeof packageControl.type === 'undefined' &&
-		typeof packageControl.Edit === 'undefined'
-	) {
+	} else if ( typeof packageControl.type === 'undefined' ) {
 		warn( `Field type "${ settingsField.type }" is not supported.`, {
 			field: settingsField,
 		} );
@@ -502,8 +487,8 @@ export const buildDataFormField = (
 			typeof defaultEdit === 'function' ? defaultEdit : undefined
 		);
 	} else if ( typeof defaultEdit !== 'undefined' ) {
-		// String and config controls resolve inside DataForm; leaving
-		// array fields without an Edit keeps the package's type default.
+		// String and config controls resolve inside DataForm; fields left
+		// without an Edit use the package default for their type.
 		field.Edit = defaultEdit;
 	}
 
@@ -514,10 +499,8 @@ export const buildDataFormField = (
 // the card body, so group descriptions go through the package.
 const getCardFormField = ( group: SettingsUIGroup ): FormField => ( {
 	id: group.id,
-	...( group.title ? { label: group.title } : {} ),
-	...( group.description
-		? { description: toDescriptionNode( group.description ) }
-		: {} ),
+	label: group.title,
+	description: toDescriptionNode( group.description ),
 	layout: {
 		type: 'card',
 		withHeader: Boolean( group.title ),
@@ -552,38 +535,56 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 			options.context
 		);
 
-		if ( predicate ) {
-			try {
-				return predicate( {
+		return predicate
+			? runVisibilityPredicate(
+					predicate,
+					'group',
+					group.id,
 					values,
-					initialValues: options.initialValues,
-					context: options.context,
-					schema,
-				} );
-			} catch ( predicateError ) {
-				warn(
-					`Visibility predicate for group "${ group.id }" failed. Rendering it visible.`,
-					{ error: predicateError, context: options.context }
-				);
-				return true;
-			}
-		}
-
-		return true;
+					options
+			  )
+			: true;
 	};
 
-	const getVisibleGroups = ( values: SettingsValues ) =>
-		Object.values( schema.groups )
-			.filter( ( group ) => isGroupVisible( group, values ) )
-			.filter( ( group ) =>
-				group.fields.some( ( field ) =>
-					isFieldVisible( field.id, values )
-				)
-			);
+	// The page derives the render sections and the validation form from
+	// the same values object in one render pass, so a one-entry cache
+	// halves the visibility evaluation per change.
+	let lastVisibleGroupsValues: SettingsValues | undefined;
+	let lastVisibleGroups: SettingsUIGroup[] = [];
+
+	const getVisibleGroups = ( values: SettingsValues ) => {
+		if ( values !== lastVisibleGroupsValues ) {
+			lastVisibleGroupsValues = values;
+			lastVisibleGroups = Object.values( schema.groups )
+				.filter( ( group ) => isGroupVisible( group, values ) )
+				.filter( ( group ) =>
+					group.fields.some( ( field ) =>
+						isFieldVisible( field.id, values )
+					)
+				);
+		}
+
+		return lastVisibleGroups;
+	};
+
+	let lastSectionsKey: string | undefined;
+	let lastSections: DataFormRenderSection[] = [];
 
 	const getRenderSections = (
 		values: SettingsValues
 	): DataFormRenderSection[] => {
+		// Sections depend only on which groups are visible, so keep their
+		// identity stable across value changes. Stable form objects let
+		// DataForm's own normalization memos survive keystrokes.
+		const visibleGroups = getVisibleGroups( values );
+		const sectionsKey = visibleGroups
+			.map( ( group ) => group.id )
+			.join( '\n' );
+
+		if ( sectionsKey === lastSectionsKey ) {
+			return lastSections;
+		}
+
 		const sections: DataFormRenderSection[] = [];
 		let pendingCardFields: FormField[] = [];
 		let segmentIndex = 0;
@@ -605,7 +606,7 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 			segmentIndex += 1;
 		};
 
-		getVisibleGroups( values ).forEach( ( group ) => {
+		visibleGroups.forEach( ( group ) => {
 			if ( ! group.actions?.length ) {
 				pendingCardFields.push( getCardFormField( group ) );
 				return;
@@ -623,6 +624,9 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 			} );
 		} );
 		flushDataForm();
+
+		lastSectionsKey = sectionsKey;
+		lastSections = sections;
 
 		return sections;
 	};

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -199,42 +199,6 @@ const toDescriptionNode = ( description?: string ) => {
 	return toSanitizedHtmlNode( description ) as unknown as string;
 };
 
-type TypeAndEdit = {
-	type?: FieldType;
-	Edit?: Field< SettingsValues >[ 'Edit' ];
-};
-
-// Types without an explicit Edit use the package's default control for
-// the DataForm type. Radio and select need one because fields with
-// elements default to the select control, and textarea is a control
-// config on the text type.
-const getPackageTypeAndEdit = ( field: SettingsUIField ): TypeAndEdit => {
-	switch ( field.type ) {
-		case 'checkbox':
-			return { type: 'boolean' };
-		case 'radio':
-			return { type: 'text', Edit: 'radio' };
-		case 'select':
-			return { type: 'text', Edit: 'select' };
-		case 'textarea':
-			return { type: 'text', Edit: { control: 'textarea' } };
-		case 'number':
-			return { type: 'number' };
-		case 'tel':
-			return { type: 'telephone' };
-		case 'array':
-			return { type: 'array' };
-		case 'date':
-		case 'email':
-		case 'password':
-		case 'text':
-		case 'url':
-			return { type: field.type };
-		default:
-			return {};
-	}
-};
-
 // The package controls cannot express a disabled state or arbitrary
 // input attributes (including min/max/step on number fields), so fields
 // carrying them render through the native renderer until upstream
@@ -300,72 +264,125 @@ const createRegisteredEdit = (
 	};
 };
 
-const createGetValue = ( settingsField: SettingsUIField ) => {
-	if ( settingsField.type === 'checkbox' ) {
-		return ( { item }: { item: SettingsValues } ) =>
-			isCheckedValue( item[ settingsField.id ] );
-	}
+type ValueGetter = NonNullable< Field< SettingsValues >[ 'getValue' ] >;
+type ValueSetter = NonNullable< Field< SettingsValues >[ 'setValue' ] >;
 
-	if ( settingsField.type === 'array' ) {
-		return ( { item }: { item: SettingsValues } ) => {
-			const value = item[ settingsField.id ];
-			return Array.isArray( value ) ? value : [];
-		};
-	}
+/**
+ * How one settings field type maps onto DataForm: the field type, an
+ * explicit control where the package default is not the right one, and
+ * value accessors that preserve the saved vocabulary. Types without an
+ * entry warn and render through the native renderer as text.
+ */
+type SettingsTypeDescriptor = {
+	type: FieldType;
+	Edit?: Field< SettingsValues >[ 'Edit' ];
+	// The package has no control for this type; render natively.
+	nativeEdit?: boolean;
+	// Renders a read-only block instead of an edit control.
+	render?: (
+		settingsField: SettingsUIField
+	) => Field< SettingsValues >[ 'render' ];
+	getValue?: ( settingsField: SettingsUIField ) => ValueGetter;
+	setValue?: (
+		settingsField: SettingsUIField,
+		initialValues: SettingsValues
+	) => ValueSetter;
+};
 
-	if ( settingsField.type === 'select' || settingsField.type === 'radio' ) {
-		return ( { item }: { item: SettingsValues } ) =>
-			toStringValue( item[ settingsField.id ] );
-	}
+const optionValue: Pick< SettingsTypeDescriptor, 'getValue' | 'setValue' > = {
+	getValue:
+		( settingsField ) =>
+		( { item } ) =>
+			toStringValue( item[ settingsField.id ] ),
+	setValue:
+		( settingsField ) =>
+		( { value } ) => ( {
+			[ settingsField.id ]: restoreOptionValue(
+				value,
+				settingsField.options
+			),
+		} ),
+};
 
-	if ( settingsField.type === 'number' ) {
-		return ( { item }: { item: SettingsValues } ) =>
-			toNumberControlValue( item[ settingsField.id ] );
-	}
+const settingsTypeDescriptors: Record< string, SettingsTypeDescriptor > = {
+	checkbox: {
+		type: 'boolean',
+		getValue:
+			( settingsField ) =>
+			( { item } ) =>
+				isCheckedValue( item[ settingsField.id ] ),
+		setValue:
+			( settingsField, initialValues ) =>
+			( { value } ) => ( {
+				[ settingsField.id ]: toCheckboxValue(
+					Boolean( value ),
+					initialValues[ settingsField.id ]
+				),
+			} ),
+	},
+	// Radio and select need explicit controls: fields with elements
+	// default to the select control, so radio would lose its buttons and
+	// an options-less select would fall back to a text input.
+	radio: { type: 'text', Edit: 'radio', ...optionValue },
+	select: { type: 'text', Edit: 'select', ...optionValue },
+	textarea: { type: 'text', Edit: { control: 'textarea' } },
+	number: {
+		type: 'number',
+		getValue:
+			( settingsField ) =>
+			( { item } ) =>
+				toNumberControlValue( item[ settingsField.id ] ),
+		setValue:
+			( settingsField, initialValues ) =>
+			( { value } ) => ( {
+				[ settingsField.id ]: toNumberFieldValue(
+					value,
+					initialValues[ settingsField.id ]
+				),
+			} ),
+	},
+	tel: { type: 'telephone' },
+	array: {
+		type: 'array',
+		getValue:
+			( settingsField ) =>
+			( { item } ) => {
+				const value = item[ settingsField.id ];
+				return Array.isArray( value ) ? value : [];
+			},
+		setValue:
+			( settingsField ) =>
+			( { value } ) => ( {
+				[ settingsField.id ]: ( Array.isArray( value )
+					? value
+					: []
+				).map( String ),
+			} ),
+	},
+	date: { type: 'date' },
+	email: { type: 'email' },
+	password: { type: 'password' },
+	text: { type: 'text' },
+	url: { type: 'url' },
+	// The package has no control for precise time inputs.
+	time: { type: 'text', nativeEdit: true },
+	'datetime-local': { type: 'text', nativeEdit: true },
+	// The regular layout skips fields whose normalized Edit control is
+	// null even when read-only, so info carries a control type the
+	// read-only path never mounts.
+	info: { type: 'text', render: createInfoRender },
+};
 
-	return ( { item }: { item: SettingsValues } ) => {
+const defaultGetValue =
+	( settingsField: SettingsUIField ): ValueGetter =>
+	( { item } ) => {
 		const value = item[ settingsField.id ];
 		return typeof value === 'undefined' ? '' : value;
 	};
-};
 
-type SetValueArgs = {
-	item: SettingsValues;
-	value: SettingsValue;
-};
-
-const createSetValue = (
-	settingsField: SettingsUIField,
-	initialValues: SettingsValues
-) => {
-	const { id } = settingsField;
-
-	if ( settingsField.type === 'select' || settingsField.type === 'radio' ) {
-		return ( { value }: SetValueArgs ) => ( {
-			[ id ]: restoreOptionValue( value, settingsField.options ),
-		} );
-	}
-
-	if ( settingsField.type === 'array' ) {
-		return ( { value }: SetValueArgs ) => ( {
-			[ id ]: ( Array.isArray( value ) ? value : [] ).map( String ),
-		} );
-	}
-
-	if ( settingsField.type === 'checkbox' ) {
-		return ( { value }: SetValueArgs ) => ( {
-			[ id ]: toCheckboxValue( Boolean( value ), initialValues[ id ] ),
-		} );
-	}
-
-	if ( settingsField.type === 'number' ) {
-		return ( { value }: SetValueArgs ) => ( {
-			[ id ]: toNumberFieldValue( value, initialValues[ id ] ),
-		} );
-	}
-
-	return ( { value }: SetValueArgs ) => ( { [ id ]: value } );
-};
+const defaultSetValue =
+	( settingsField: SettingsUIField ): ValueSetter =>
+	( { value } ) => ( { [ settingsField.id ]: value } );
 
 // Predicates fail open: a broken visibility callback renders the field
 // or group rather than hiding it.
@@ -427,13 +444,19 @@ export const buildDataFormField = (
 	settingsField: SettingsUIField,
 	options: DataFormAdapterOptions
 ): Field< SettingsValues > => {
+	const descriptor = settingsTypeDescriptors[ settingsField.type ];
+
 	const field: Field< SettingsValues > = {
 		id: settingsField.id,
 		label: settingsField.label,
 		description: toDescriptionNode( settingsField.description ),
 		placeholder: settingsField.placeholder,
-		getValue: createGetValue( settingsField ),
-		setValue: createSetValue( settingsField, options.initialValues ),
+		type: descriptor?.type,
+		getValue: ( descriptor?.getValue ?? defaultGetValue )( settingsField ),
+		setValue: ( descriptor?.setValue ?? defaultSetValue )(
+			settingsField,
+			options.initialValues
+		),
 		isVisible: createIsVisible( settingsField, options ),
 		isValid: options.fieldRules?.[ settingsField.id ],
 	};
@@ -442,38 +465,24 @@ export const buildDataFormField = (
 		field.elements = toElements( settingsField.options );
 	}
 
-	if ( settingsField.type === 'info' ) {
-		// The regular layout skips fields whose normalized Edit control
-		// is null, including read-only render fields, so info needs a
-		// control type even though the read-only path never mounts it.
-		field.type = 'text';
+	if ( descriptor?.render ) {
 		field.readOnly = true;
-		field.render = createInfoRender( settingsField );
+		field.render = descriptor.render( settingsField );
 		return field;
 	}
 
-	const packageControl = getPackageTypeAndEdit( settingsField );
-	field.type = packageControl.type;
-
 	let defaultEdit: Field< SettingsValues >[ 'Edit' ] | undefined;
 
-	if (
-		settingsField.type === 'time' ||
-		settingsField.type === 'datetime-local'
-	) {
-		// No package control exists for precise time inputs.
-		field.type = 'text';
+	if ( descriptor?.nativeEdit || needsNativeEdit( settingsField ) ) {
 		defaultEdit = createNativeEdit( settingsField );
-	} else if ( needsNativeEdit( settingsField ) ) {
-		defaultEdit = createNativeEdit( settingsField );
-	} else if ( typeof packageControl.type === 'undefined' ) {
+	} else if ( ! descriptor ) {
 		warn( `Field type "${ settingsField.type }" is not supported.`, {
 			field: settingsField,
 		} );
 		field.type = 'text';
 		defaultEdit = createNativeEdit( settingsField );
 	} else {
-		defaultEdit = packageControl.Edit;
+		defaultEdit = descriptor.Edit;
 	}
 
 	const registeredAtBuild = Boolean(

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -38,9 +38,8 @@ export type DataFormAdapterOptions = {
 	context: SettingsFieldContext;
 	initialValues: SettingsValues;
 	/**
-	 * Validation rules per field id. Internal for now: the public
-	 * validation surface is still a design proposal, but the DataForm
-	 * validity pipeline is fully wired and tested through this option.
+	 * Validation rules per field id. Internal until the public
+	 * validation surface is agreed.
 	 */
 	fieldRules?: Record< string, Rules< SettingsValues > >;
 };
@@ -62,7 +61,6 @@ export type DataFormRenderSection =
 			key: string;
 			form: Form;
 			group: SettingsUIGroup;
-			reasons: 'actions'[];
 	  };
 
 const toStringValue = ( value: SettingsValue | undefined ) =>
@@ -190,9 +188,9 @@ const toElements = ( options?: SettingsUIOption[] ) =>
 	} ) );
 
 // DataForm types descriptions as plain strings while the schema carries
-// sanitized HTML. The controls render the description as a node, so a
-// sanitized element keeps links and formatting working. This bypasses
-// the declared type and is flagged upstream.
+// sanitized HTML. The layouts render the description as a node, so a
+// sanitized element keeps links and formatting working despite the
+// declared string type.
 const toDescriptionNode = ( description?: string ) => {
 	if ( ! description ) {
 		return undefined;
@@ -512,10 +510,6 @@ export const buildDataFormField = (
 	return field;
 };
 
-const getFallbackReasons = ( group: SettingsUIGroup ) => [
-	...( group.actions?.length ? ( [ 'actions' ] as const ) : [] ),
-];
-
 // The card layout renders the combined field's description at the top of
 // the card body, so group descriptions go through the package.
 const getCardFormField = ( group: SettingsUIGroup ): FormField => ( {
@@ -525,10 +519,8 @@ const getCardFormField = ( group: SettingsUIGroup ): FormField => ( {
 		? { description: toDescriptionNode( group.description ) }
 		: {} ),
 	layout: {
-		type: 'card' as const,
-		...( group.title
-			? { withHeader: true as const }
-			: { withHeader: false as const } ),
+		type: 'card',
+		withHeader: Boolean( group.title ),
 		isCollapsible: false,
 	},
 	children: group.fields.map( ( field ) => field.id ),
@@ -547,6 +539,9 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 	const fieldsById = new Map(
 		fields.map( ( field ) => [ field.id, field ] )
 	);
+
+	const isFieldVisible = ( fieldId: string, values: SettingsValues ) =>
+		fieldsById.get( fieldId )?.isVisible?.( values ) !== false;
 
 	const isGroupVisible = (
 		group: SettingsUIGroup,
@@ -581,10 +576,8 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 		Object.values( schema.groups )
 			.filter( ( group ) => isGroupVisible( group, values ) )
 			.filter( ( group ) =>
-				group.fields.some(
-					( field ) =>
-						fieldsById.get( field.id )?.isVisible?.( values ) !==
-						false
+				group.fields.some( ( field ) =>
+					isFieldVisible( field.id, values )
 				)
 			);
 
@@ -613,9 +606,7 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 		};
 
 		getVisibleGroups( values ).forEach( ( group ) => {
-			const reasons = getFallbackReasons( group );
-
-			if ( reasons.length === 0 ) {
+			if ( ! group.actions?.length ) {
 				pendingCardFields.push( getCardFormField( group ) );
 				return;
 			}
@@ -625,7 +616,6 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 				type: 'fallback',
 				key: `fallback-${ group.id }`,
 				group,
-				reasons,
 				form: {
 					layout: { type: 'regular' },
 					fields: group.fields.map( ( field ) => field.id ),
@@ -644,11 +634,7 @@ export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
 		fields: getVisibleGroups( values ).map( ( group ) => ( {
 			id: group.id,
 			children: group.fields
-				.filter(
-					( field ) =>
-						fieldsById.get( field.id )?.isVisible?.( values ) !==
-						false
-				)
+				.filter( ( field ) => isFieldVisible( field.id, values ) )
 				.map( ( field ) => field.id ),
 		} ) ),
 	} );

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -100,6 +100,42 @@ const toCheckboxValue = (
 	return checked ? 'yes' : 'no';
 };
 
+// Legacy PHP settings deliver numeric values as strings, which the
+// package number control and the number type validation reject. Present
+// finite numbers to the package and let toNumberFieldValue restore the
+// saved representation on the way back.
+const toNumberControlValue = ( value: SettingsValue | undefined ) => {
+	if ( value === '' || value === null || typeof value === 'undefined' ) {
+		return undefined;
+	}
+
+	if ( typeof value === 'string' && value.trim() !== '' ) {
+		const parsed = Number( value );
+
+		if ( Number.isFinite( parsed ) ) {
+			return parsed;
+		}
+	}
+
+	return value;
+};
+
+const toNumberFieldValue = (
+	next: SettingsValue,
+	initialValue: SettingsValue | undefined
+): SettingsValue => {
+	// The native renderer already emits the legacy string vocabulary.
+	if ( typeof next === 'string' ) {
+		return next;
+	}
+
+	if ( typeof next === 'undefined' || next === null ) {
+		return '';
+	}
+
+	return typeof initialValue === 'number' ? next : String( next );
+};
+
 export const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	if ( Array.isArray( a ) || Array.isArray( b ) ) {
 		return (
@@ -299,6 +335,11 @@ const createGetValue = ( settingsField: SettingsUIField ) => {
 			toStringValue( item[ settingsField.id ] );
 	}
 
+	if ( settingsField.type === 'number' ) {
+		return ( { item }: { item: SettingsValues } ) =>
+			toNumberControlValue( item[ settingsField.id ] );
+	}
+
 	return ( { item }: { item: SettingsValues } ) => {
 		const value = item[ settingsField.id ];
 		return typeof value === 'undefined' ? '' : value;
@@ -340,6 +381,15 @@ const createSetValue = (
 			return {
 				[ settingsField.id ]: toCheckboxValue(
 					Boolean( value ),
+					initialValues[ settingsField.id ]
+				),
+			};
+		}
+
+		if ( settingsField.type === 'number' ) {
+			return {
+				[ settingsField.id ]: toNumberFieldValue(
+					value,
 					initialValues[ settingsField.id ]
 				),
 			};

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -101,7 +101,7 @@ const toCheckboxValue = (
 	return checked ? 'yes' : 'no';
 };
 
-const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
+export const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
 	if ( Array.isArray( a ) || Array.isArray( b ) ) {
 		return (
 			Array.isArray( a ) &&
@@ -237,9 +237,6 @@ const createNativeEdit = ( settingsField: SettingsUIField ) => {
 		);
 	};
 };
-
-const createDateTimeEdit = ( settingsField: SettingsUIField ) =>
-	createNativeEdit( settingsField );
 
 const createInfoRender = ( settingsField: SettingsUIField ) => {
 	return function InfoField() {
@@ -431,7 +428,7 @@ export const buildDataFormField = (
 	) {
 		// No package control exists for precise time inputs.
 		field.type = 'text';
-		defaultEdit = createDateTimeEdit( settingsField );
+		defaultEdit = createNativeEdit( settingsField );
 	} else if ( needsNativeEdit( settingsField ) ) {
 		defaultEdit = createNativeEdit( settingsField );
 	} else if (

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -1,0 +1,611 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import type {
+	DataFormControlProps,
+	Field,
+	FieldType,
+	Form,
+	FormField,
+	FormValidity,
+	Rules,
+} from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { warn } from './diagnostics';
+import { sanitizeSettingsHtml } from './html';
+import { NativeSettingsField } from './native-fields';
+import {
+	resolveFieldComponent,
+	resolveFieldVisibilityPredicate,
+	resolveGroupVisibilityPredicate,
+} from './registry';
+import type {
+	SettingsFieldContext,
+	SettingsUIField,
+	SettingsUIGroup,
+	SettingsUIOption,
+	SettingsUISchema,
+	SettingsValue,
+	SettingsValues,
+} from './types';
+
+export type DataFormAdapterOptions = {
+	schema: SettingsUISchema;
+	context: SettingsFieldContext;
+	initialValues: SettingsValues;
+	/**
+	 * Validation rules per field id. Internal for now: the public
+	 * validation surface is still a design proposal, but the DataForm
+	 * validity pipeline is fully wired and tested through this option.
+	 */
+	fieldRules?: Record< string, Rules< SettingsValues > >;
+};
+
+/**
+ * A render section is either a run of consecutive groups rendered as one
+ * DataForm with card-layout combined fields (the package-recommended
+ * shape), or a single group that falls back to the shell-owned card
+ * because the package card header has no slot for HTML descriptions or
+ * header actions.
+ */
+export type DataFormRenderSection =
+	| {
+			type: 'dataform';
+			key: string;
+			form: Form;
+	  }
+	| {
+			type: 'fallback';
+			key: string;
+			form: Form;
+			group: SettingsUIGroup;
+			reasons: ( 'actions' | 'description' )[];
+	  };
+
+const toStringValue = ( value: SettingsValue | undefined ) =>
+	value === null || typeof value === 'undefined' ? '' : String( value );
+
+const isCheckedValue = ( value: SettingsValue | undefined ): boolean =>
+	value === true || value === 1 || value === 'yes' || value === '1';
+
+// Legacy PHP settings express checkbox state as yes/no, 1/0, or booleans
+// depending on the source. Echo the initial representation back so the
+// save flow round-trips values unchanged.
+const toCheckboxValue = (
+	checked: boolean,
+	initialValue: SettingsValue | undefined
+): SettingsValue => {
+	if (
+		typeof initialValue !== 'undefined' &&
+		checked === isCheckedValue( initialValue )
+	) {
+		return initialValue;
+	}
+
+	if ( typeof initialValue === 'boolean' ) {
+		return checked;
+	}
+
+	if ( initialValue === 1 || initialValue === 0 ) {
+		return checked ? 1 : 0;
+	}
+
+	if ( initialValue === '1' || initialValue === '0' ) {
+		return checked ? '1' : '0';
+	}
+
+	return checked ? 'yes' : 'no';
+};
+
+const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
+	if ( Array.isArray( a ) || Array.isArray( b ) ) {
+		return (
+			Array.isArray( a ) &&
+			Array.isArray( b ) &&
+			a.length === b.length &&
+			a.every( ( value, index ) => value === b[ index ] )
+		);
+	}
+
+	return a === b;
+};
+
+const valueMatchesVisibilityRule = (
+	value: SettingsValue,
+	expected: SettingsValue | SettingsValue[] | undefined
+) => {
+	const expectedValues = Array.isArray( expected )
+		? expected
+		: [ expected ?? true ];
+
+	return expectedValues.some( ( expectedValue ) => {
+		// Boolean expectations match any checkbox vocabulary, so rules
+		// written against `true` work for `yes` and `1` values too.
+		if ( typeof expectedValue === 'boolean' ) {
+			return isCheckedValue( value ) === expectedValue;
+		}
+
+		return areValuesEqual( value, expectedValue );
+	} );
+};
+
+// PHP-supplied schemas can carry non-string option values at runtime, so
+// selections are matched by string representation and mapped back to the
+// original option value to preserve its type.
+const restoreOptionValue = (
+	next: SettingsValue,
+	options?: SettingsUIOption[]
+): SettingsValue => {
+	const nextString = toStringValue( next );
+	const option = ( options || [] ).find(
+		( candidate ) => toStringValue( candidate.value ) === nextString
+	);
+
+	return typeof option === 'undefined' ? next : option.value;
+};
+
+const toElements = ( options?: SettingsUIOption[] ) =>
+	( options || [] ).map( ( option ) => ( {
+		value: toStringValue( option.value ),
+		label: option.label,
+	} ) );
+
+// DataForm types descriptions as plain strings while the schema carries
+// sanitized HTML. The controls render the description as a node, so a
+// sanitized element keeps links and formatting working. This bypasses
+// the declared type and is flagged upstream.
+const toDescriptionNode = ( description?: string ) => {
+	if ( ! description ) {
+		return undefined;
+	}
+
+	if ( ! /<[^>]+>/.test( description ) ) {
+		return description;
+	}
+
+	return createElement( 'span', {
+		dangerouslySetInnerHTML: {
+			__html: sanitizeSettingsHtml( description ),
+		},
+	} ) as unknown as string;
+};
+
+type TypeAndEdit = {
+	type?: FieldType;
+	Edit?: Field< SettingsValues >[ 'Edit' ];
+};
+
+const getPackageTypeAndEdit = ( field: SettingsUIField ): TypeAndEdit => {
+	switch ( field.type ) {
+		case 'checkbox':
+			return { type: 'boolean', Edit: 'checkbox' };
+		case 'radio':
+			return { type: 'text', Edit: 'radio' };
+		case 'select':
+			return { type: 'text', Edit: 'select' };
+		case 'textarea':
+			return { type: 'text', Edit: { control: 'textarea' } };
+		case 'number':
+			return { type: 'number', Edit: 'number' };
+		case 'tel':
+			return { type: 'telephone', Edit: 'telephone' };
+		case 'array':
+			return { type: 'array' };
+		case 'date':
+		case 'email':
+		case 'password':
+		case 'text':
+		case 'url':
+			return { type: field.type, Edit: field.type };
+		default:
+			return {};
+	}
+};
+
+// The package controls cannot express a disabled state or arbitrary
+// input attributes (including min/max/step on number fields), so fields
+// carrying them render through the native renderer until upstream
+// supports them.
+const needsNativeEdit = ( field: SettingsUIField ) =>
+	Boolean( field.disabled ) ||
+	Object.keys( field.customAttributes || {} ).length > 0;
+
+const createNativeEdit = ( settingsField: SettingsUIField ) => {
+	return function NativeFieldEdit( {
+		data,
+		field,
+		onChange,
+	}: DataFormControlProps< SettingsValues > ) {
+		const value = data[ settingsField.id ];
+
+		return (
+			<div className="wc-settings-ui__field">
+				<NativeSettingsField
+					field={ settingsField }
+					value={ typeof value === 'undefined' ? '' : value }
+					onChange={ ( nextValue ) =>
+						onChange(
+							field.setValue( { item: data, value: nextValue } )
+						)
+					}
+				/>
+			</div>
+		);
+	};
+};
+
+const createDateTimeEdit = ( settingsField: SettingsUIField ) =>
+	createNativeEdit( settingsField );
+
+const createInfoRender = ( settingsField: SettingsUIField ) => {
+	return function InfoField() {
+		return (
+			<div className="wc-settings-ui__info" id={ settingsField.id }>
+				<strong>{ settingsField.label }</strong>
+				{ settingsField.description ? (
+					<span
+						dangerouslySetInnerHTML={ {
+							__html: sanitizeSettingsHtml(
+								settingsField.description
+							),
+						} }
+					/>
+				) : null }
+			</div>
+		);
+	};
+};
+
+// Registered components are DataForm Edit controls. Resolution happens
+// on every render so late registrations behave the same as before.
+const createRegisteredEdit = (
+	settingsField: SettingsUIField,
+	context: SettingsFieldContext,
+	fallback: Field< SettingsValues >[ 'Edit' ]
+) => {
+	return function RegisteredFieldEdit(
+		props: DataFormControlProps< SettingsValues >
+	) {
+		const Registered = resolveFieldComponent( settingsField, context );
+
+		if ( Registered ) {
+			return <Registered { ...props } />;
+		}
+
+		if ( typeof fallback === 'function' ) {
+			const Fallback = fallback;
+			return <Fallback { ...props } />;
+		}
+
+		return null;
+	};
+};
+
+const createGetValue = ( settingsField: SettingsUIField ) => {
+	if ( settingsField.type === 'checkbox' ) {
+		return ( { item }: { item: SettingsValues } ) =>
+			isCheckedValue( item[ settingsField.id ] );
+	}
+
+	if ( settingsField.type === 'array' ) {
+		return ( { item }: { item: SettingsValues } ) => {
+			const value = item[ settingsField.id ];
+			return Array.isArray( value ) ? value : [];
+		};
+	}
+
+	if ( settingsField.type === 'select' || settingsField.type === 'radio' ) {
+		return ( { item }: { item: SettingsValues } ) =>
+			toStringValue( item[ settingsField.id ] );
+	}
+
+	return ( { item }: { item: SettingsValues } ) => {
+		const value = item[ settingsField.id ];
+		return typeof value === 'undefined' ? '' : value;
+	};
+};
+
+const createSetValue = (
+	settingsField: SettingsUIField,
+	initialValues: SettingsValues
+) => {
+	return ( {
+		value,
+	}: {
+		item: SettingsValues;
+		value: SettingsValue;
+	} ): Partial< SettingsValues > => {
+		if (
+			settingsField.type === 'select' ||
+			settingsField.type === 'radio'
+		) {
+			return {
+				[ settingsField.id ]: restoreOptionValue(
+					value,
+					settingsField.options
+				),
+			};
+		}
+
+		if ( settingsField.type === 'array' ) {
+			return {
+				[ settingsField.id ]: ( Array.isArray( value )
+					? value
+					: []
+				).map( String ),
+			};
+		}
+
+		if ( settingsField.type === 'checkbox' ) {
+			return {
+				[ settingsField.id ]: toCheckboxValue(
+					Boolean( value ),
+					initialValues[ settingsField.id ]
+				),
+			};
+		}
+
+		return { [ settingsField.id ]: value };
+	};
+};
+
+const createIsVisible = (
+	settingsField: SettingsUIField,
+	options: DataFormAdapterOptions
+) => {
+	return ( item: SettingsValues ) => {
+		const predicate = resolveFieldVisibilityPredicate(
+			settingsField.id,
+			options.context
+		);
+
+		if ( predicate ) {
+			try {
+				return predicate( {
+					values: item,
+					initialValues: options.initialValues,
+					context: options.context,
+					schema: options.schema,
+				} );
+			} catch ( predicateError ) {
+				warn(
+					`Visibility predicate for field "${ settingsField.id }" failed. Rendering it visible.`,
+					{ error: predicateError, context: options.context }
+				);
+				return true;
+			}
+		}
+
+		if ( settingsField.visibility ) {
+			return valueMatchesVisibilityRule(
+				item[ settingsField.visibility.controller ],
+				settingsField.visibility.value
+			);
+		}
+
+		return true;
+	};
+};
+
+export const buildDataFormField = (
+	settingsField: SettingsUIField,
+	options: DataFormAdapterOptions
+): Field< SettingsValues > => {
+	const field: Field< SettingsValues > = {
+		id: settingsField.id,
+		label: settingsField.label,
+		description: toDescriptionNode( settingsField.description ),
+		placeholder: settingsField.placeholder,
+		getValue: createGetValue( settingsField ),
+		setValue: createSetValue( settingsField, options.initialValues ),
+		isVisible: createIsVisible( settingsField, options ),
+		isValid: options.fieldRules?.[ settingsField.id ],
+	};
+
+	if ( settingsField.options && settingsField.options.length > 0 ) {
+		field.elements = toElements( settingsField.options );
+	}
+
+	if ( settingsField.type === 'info' ) {
+		// The regular layout skips fields whose normalized Edit control
+		// is null, including read-only render fields, so info needs a
+		// control type even though the read-only path never mounts it.
+		field.type = 'text';
+		field.readOnly = true;
+		field.render = createInfoRender( settingsField );
+		return field;
+	}
+
+	const packageControl = getPackageTypeAndEdit( settingsField );
+	field.type = packageControl.type;
+
+	let defaultEdit: Field< SettingsValues >[ 'Edit' ] | undefined;
+
+	if (
+		settingsField.type === 'time' ||
+		settingsField.type === 'datetime-local'
+	) {
+		// No package control exists for precise time inputs.
+		field.type = 'text';
+		defaultEdit = createDateTimeEdit( settingsField );
+	} else if ( needsNativeEdit( settingsField ) ) {
+		defaultEdit = createNativeEdit( settingsField );
+	} else if (
+		typeof packageControl.type === 'undefined' &&
+		typeof packageControl.Edit === 'undefined'
+	) {
+		warn( `Field type "${ settingsField.type }" is not supported.`, {
+			field: settingsField,
+		} );
+		field.type = 'text';
+		defaultEdit = createNativeEdit( settingsField );
+	} else {
+		defaultEdit = packageControl.Edit;
+	}
+
+	const registeredAtBuild = Boolean(
+		resolveFieldComponent( settingsField, options.context )
+	);
+
+	if ( registeredAtBuild || typeof defaultEdit === 'function' ) {
+		field.Edit = createRegisteredEdit(
+			settingsField,
+			options.context,
+			typeof defaultEdit === 'function' ? defaultEdit : undefined
+		);
+	} else if ( typeof defaultEdit !== 'undefined' ) {
+		// String and config controls resolve inside DataForm; leaving
+		// array fields without an Edit keeps the package's type default.
+		field.Edit = defaultEdit;
+	}
+
+	return field;
+};
+
+const getFallbackReasons = ( group: SettingsUIGroup ) => [
+	...( group.description ? ( [ 'description' ] as const ) : [] ),
+	...( group.actions?.length ? ( [ 'actions' ] as const ) : [] ),
+];
+
+const getCardFormField = ( group: SettingsUIGroup ): FormField => ( {
+	id: group.id,
+	...( group.title ? { label: group.title } : {} ),
+	layout: {
+		type: 'card' as const,
+		...( group.title
+			? { withHeader: true as const }
+			: { withHeader: false as const } ),
+		isCollapsible: false,
+	},
+	children: group.fields.map( ( field ) => field.id ),
+} );
+
+export const getGroupValidity = (
+	validity: FormValidity,
+	groupId: string
+): FormValidity => validity?.[ groupId ]?.children;
+
+export const createDataFormAdapter = ( options: DataFormAdapterOptions ) => {
+	const { schema } = options;
+	const fields = Object.values( schema.groups ).flatMap( ( group ) =>
+		group.fields.map( ( field ) => buildDataFormField( field, options ) )
+	);
+	const fieldsById = new Map(
+		fields.map( ( field ) => [ field.id, field ] )
+	);
+
+	const isGroupVisible = (
+		group: SettingsUIGroup,
+		values: SettingsValues
+	) => {
+		const predicate = resolveGroupVisibilityPredicate(
+			group.id,
+			options.context
+		);
+
+		if ( predicate ) {
+			try {
+				return predicate( {
+					values,
+					initialValues: options.initialValues,
+					context: options.context,
+					schema,
+				} );
+			} catch ( predicateError ) {
+				warn(
+					`Visibility predicate for group "${ group.id }" failed. Rendering it visible.`,
+					{ error: predicateError, context: options.context }
+				);
+				return true;
+			}
+		}
+
+		return true;
+	};
+
+	const getVisibleGroups = ( values: SettingsValues ) =>
+		Object.values( schema.groups )
+			.filter( ( group ) => isGroupVisible( group, values ) )
+			.filter( ( group ) =>
+				group.fields.some(
+					( field ) =>
+						fieldsById.get( field.id )?.isVisible?.( values ) !==
+						false
+				)
+			);
+
+	const getRenderSections = (
+		values: SettingsValues
+	): DataFormRenderSection[] => {
+		const sections: DataFormRenderSection[] = [];
+		let pendingCardFields: FormField[] = [];
+		let segmentIndex = 0;
+
+		const flushDataForm = () => {
+			if ( pendingCardFields.length === 0 ) {
+				return;
+			}
+
+			sections.push( {
+				type: 'dataform',
+				key: `dataform-${ segmentIndex }`,
+				form: {
+					layout: { type: 'card' },
+					fields: pendingCardFields,
+				},
+			} );
+			pendingCardFields = [];
+			segmentIndex += 1;
+		};
+
+		getVisibleGroups( values ).forEach( ( group ) => {
+			const reasons = getFallbackReasons( group );
+
+			if ( reasons.length === 0 ) {
+				pendingCardFields.push( getCardFormField( group ) );
+				return;
+			}
+
+			flushDataForm();
+			sections.push( {
+				type: 'fallback',
+				key: `fallback-${ group.id }`,
+				group,
+				reasons,
+				form: {
+					layout: { type: 'regular' },
+					fields: group.fields.map( ( field ) => field.id ),
+				},
+			} );
+		} );
+		flushDataForm();
+
+		return sections;
+	};
+
+	// Only visible fields validate, so a hidden required field can never
+	// block saving.
+	const getValidationForm = ( values: SettingsValues ): Form => ( {
+		layout: { type: 'regular' },
+		fields: getVisibleGroups( values ).map( ( group ) => ( {
+			id: group.id,
+			children: group.fields
+				.filter(
+					( field ) =>
+						fieldsById.get( field.id )?.isVisible?.( values ) !==
+						false
+				)
+				.map( ( field ) => field.id ),
+		} ) ),
+	} );
+
+	return {
+		fields,
+		getRenderSections,
+		getValidationForm,
+	};
+};

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -49,8 +49,7 @@ export type DataFormAdapterOptions = {
  * A render section is either a run of consecutive groups rendered as one
  * DataForm with card-layout combined fields (the package-recommended
  * shape), or a single group that falls back to the shell-owned card
- * because the package card header has no slot for HTML descriptions or
- * header actions.
+ * because the package card header has no slot for header actions.
  */
 export type DataFormRenderSection =
 	| {
@@ -63,7 +62,7 @@ export type DataFormRenderSection =
 			key: string;
 			form: Form;
 			group: SettingsUIGroup;
-			reasons: ( 'actions' | 'description' )[];
+			reasons: 'actions'[];
 	  };
 
 const toStringValue = ( value: SettingsValue | undefined ) =>
@@ -464,13 +463,17 @@ export const buildDataFormField = (
 };
 
 const getFallbackReasons = ( group: SettingsUIGroup ) => [
-	...( group.description ? ( [ 'description' ] as const ) : [] ),
 	...( group.actions?.length ? ( [ 'actions' ] as const ) : [] ),
 ];
 
+// The card layout renders the combined field's description at the top of
+// the card body, so group descriptions go through the package.
 const getCardFormField = ( group: SettingsUIGroup ): FormField => ( {
 	id: group.id,
 	...( group.title ? { label: group.title } : {} ),
+	...( group.description
+		? { description: toDescriptionNode( group.description ) }
+		: {} ),
 	layout: {
 		type: 'card' as const,
 		...( group.title

--- a/packages/js/settings-ui/src/hidden-inputs.tsx
+++ b/packages/js/settings-ui/src/hidden-inputs.tsx
@@ -8,6 +8,7 @@ import { createElement, Fragment } from '@wordpress/element';
  */
 import { error } from './diagnostics';
 import type { SettingsUIField, SettingsValue } from './types';
+import { isCheckedValue, toStringValue } from './values';
 
 type HiddenInput = {
 	name: string;
@@ -40,10 +41,7 @@ export const getHiddenInputs = (
 		return [
 			{
 				name,
-				value:
-					value === true || value === 'yes' || value === '1'
-						? 'yes'
-						: 'no',
+				value: isCheckedValue( value ) ? 'yes' : 'no',
 			},
 		];
 	}
@@ -58,10 +56,7 @@ export const getHiddenInputs = (
 	return [
 		{
 			name,
-			value:
-				value === null || typeof value === 'undefined'
-					? ''
-					: String( value ),
+			value: toStringValue( value ),
 		},
 	];
 };

--- a/packages/js/settings-ui/src/html.ts
+++ b/packages/js/settings-ui/src/html.ts
@@ -2,5 +2,11 @@
  * External dependencies
  */
 import { sanitizeHTML } from '@woocommerce/sanitize';
+import { createElement } from '@wordpress/element';
 
 export const sanitizeSettingsHtml = ( html?: string ) => sanitizeHTML( html );
+
+export const toSanitizedHtmlNode = ( html: string ) =>
+	createElement( 'span', {
+		dangerouslySetInnerHTML: { __html: sanitizeSettingsHtml( html ) },
+	} );

--- a/packages/js/settings-ui/src/index.ts
+++ b/packages/js/settings-ui/src/index.ts
@@ -1,5 +1,4 @@
 export { SettingsUIErrorBoundary, SettingsUIPage } from './settings-ui-page';
-export { NativeSettingsField } from './native-fields';
 export { HiddenInputs, getHiddenInputs } from './hidden-inputs';
 export {
 	registerSettingsExtension,
@@ -9,11 +8,15 @@ export {
 	resolveRegionComponent,
 	resolveSaveHandler,
 } from './registry';
+export { useSettingsUIContext } from './settings-ui-context';
 export type {
+	SettingsEditControlProps,
+	SettingsFieldValidity,
 	SettingsUIField,
 	SettingsUIGroup,
 	SettingsUIGroupAction,
 	SettingsUIOption,
+	SettingsUIPageContextValue,
 	SettingsUIRegistry,
 	SettingsUISaveSchema,
 	SettingsUISaveStrategy,
@@ -25,7 +28,6 @@ export type {
 	SettingsExtensionRegistration,
 	SettingsExtensionScope,
 	SettingsFieldComponent,
-	SettingsFieldComponentProps,
 	SettingsFieldContext,
 	SettingsRegionComponent,
 	SettingsRegionComponentProps,

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -12,7 +12,7 @@ import { warn } from './diagnostics';
 import { toSanitizedHtmlNode } from './html';
 import { NumberSpinControl } from './number-spin-control';
 import type { SettingsUIField, SettingsValue } from './types';
-import { toStringValue } from './values';
+import { isCheckedValue, toStringValue } from './values';
 
 // Internal renderer for fields the DataForm controls cannot express yet
 // (disabled state, custom input attributes). The DataForm adapter wraps
@@ -97,7 +97,7 @@ export const NativeSettingsField = ( {
 				className="wc-settings-ui__control"
 				label={ field.label }
 				help={ getHelp( field.description ) }
-				checked={ value === true || value === 'yes' || value === '1' }
+				checked={ isCheckedValue( value ) }
 				disabled={ field.disabled }
 				onChange={ onChange }
 				__nextHasNoMarginBottom

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -9,9 +9,10 @@ import { Field, InputControl, SelectControl, Textarea } from '@wordpress/ui';
  * Internal dependencies
  */
 import { warn } from './diagnostics';
-import { sanitizeSettingsHtml } from './html';
+import { toSanitizedHtmlNode } from './html';
 import { NumberSpinControl } from './number-spin-control';
 import type { SettingsUIField, SettingsValue } from './types';
+import { toStringValue } from './values';
 
 // Internal renderer for fields the DataForm controls cannot express yet
 // (disabled state, custom input attributes). The DataForm adapter wraps
@@ -42,9 +43,6 @@ const textInputTypes: TextInputType[] = [
 	'url',
 	'tel',
 ];
-
-const toStringValue = ( value: SettingsValue ) =>
-	value === null || typeof value === 'undefined' ? '' : String( value );
 
 const isTextInputType = ( type: string ): type is TextInputType =>
 	textInputTypes.includes( type as TextInputType );
@@ -86,13 +84,7 @@ const getNumberInputAttributes = (
 };
 
 const getHelp = ( description?: string ) =>
-	description ? (
-		<span
-			dangerouslySetInnerHTML={ {
-				__html: sanitizeSettingsHtml( description ),
-			} }
-		/>
-	) : undefined;
+	description ? toSanitizedHtmlNode( description ) : undefined;
 
 export const NativeSettingsField = ( {
 	field,

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -11,7 +11,16 @@ import { Field, InputControl, SelectControl, Textarea } from '@wordpress/ui';
 import { warn } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
 import { NumberSpinControl } from './number-spin-control';
-import type { SettingsFieldComponentProps, SettingsValue } from './types';
+import type { SettingsUIField, SettingsValue } from './types';
+
+// Internal renderer for fields the DataForm controls cannot express yet
+// (disabled state, custom input attributes). The DataForm adapter wraps
+// it in an Edit control; it is not part of the public API.
+export type NativeSettingsFieldProps = {
+	field: SettingsUIField;
+	value: SettingsValue;
+	onChange: ( value: SettingsValue ) => void;
+};
 
 type TextInputType =
 	| 'text'
@@ -89,7 +98,7 @@ export const NativeSettingsField = ( {
 	field,
 	value,
 	onChange,
-}: SettingsFieldComponentProps ) => {
+}: NativeSettingsFieldProps ) => {
 	if ( field.type === 'info' ) {
 		return (
 			<div className="wc-settings-ui__info" id={ field.id }>

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BaseControl, CheckboxControl } from '@wordpress/components';
-import { createElement, RawHTML } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import { Field, InputControl, SelectControl, Textarea } from '@wordpress/ui';
 
 /**
@@ -99,19 +99,6 @@ export const NativeSettingsField = ( {
 	value,
 	onChange,
 }: NativeSettingsFieldProps ) => {
-	if ( field.type === 'info' ) {
-		return (
-			<div className="wc-settings-ui__info" id={ field.id }>
-				<strong>{ field.label }</strong>
-				{ field.description ? (
-					<RawHTML>
-						{ sanitizeSettingsHtml( field.description ) }
-					</RawHTML>
-				) : null }
-			</div>
-		);
-	}
-
 	if ( field.type === 'checkbox' ) {
 		return (
 			<CheckboxControl

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -125,8 +125,11 @@ export const NativeSettingsField = ( {
 	}
 
 	if ( field.type === 'select' || field.type === 'radio' ) {
+		// PHP-supplied schemas can carry numeric option values at runtime;
+		// items are stringified so saved values match, and the adapter's
+		// setValue restores the original option value type on change.
 		const items = ( field.options || [] ).map( ( option ) => ( {
-			value: option.value,
+			value: toStringValue( option.value ),
 			label: option.label,
 		} ) );
 		const selectedItem =

--- a/packages/js/settings-ui/src/settings-ui-context.ts
+++ b/packages/js/settings-ui/src/settings-ui-context.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { SettingsUIPageContextValue } from './types';
+
+export const SettingsUIPageContext =
+	createContext< SettingsUIPageContextValue | null >( null );
+
+/**
+ * Page-level state for registered settings field components: the schema,
+ * the page/section context, and the initial values. Field-level state
+ * travels through the component props instead.
+ */
+export const useSettingsUIContext = (): SettingsUIPageContextValue => {
+	const value = useContext( SettingsUIPageContext );
+
+	if ( ! value ) {
+		throw new Error(
+			'useSettingsUIContext must be used within a settings UI page.'
+		);
+	}
+
+	return value;
+};

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -29,7 +29,11 @@ import type { ComponentProps, ErrorInfo, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
-import { createDataFormAdapter, getGroupValidity } from './dataform-adapter';
+import {
+	areValuesEqual,
+	createDataFormAdapter,
+	getGroupValidity,
+} from './dataform-adapter';
 import { HiddenInputs } from './hidden-inputs';
 import { error } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
@@ -42,7 +46,6 @@ import type {
 	SettingsUISchema,
 	SettingsUIShellBadgeIntent,
 	SettingsFieldContext,
-	SettingsValue,
 	SettingsValues,
 } from './types';
 
@@ -71,19 +74,6 @@ const getInitialValues = ( schema: SettingsUISchema ): SettingsValues => {
 	} );
 
 	return values;
-};
-
-const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
-	if ( Array.isArray( a ) || Array.isArray( b ) ) {
-		return (
-			Array.isArray( a ) &&
-			Array.isArray( b ) &&
-			a.length === b.length &&
-			a.every( ( value, index ) => value === b[ index ] )
-		);
-	}
-
-	return a === b;
 };
 
 const getChangedValues = (

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -108,11 +108,12 @@ const BADGE_INTENTS: Record<
 };
 
 // TS unions erase at runtime, so guard against unexpected strings from
-// PHP-supplied schemas.
+// PHP-supplied schemas. Own-property check: `in` would accept
+// Object.prototype keys such as "constructor".
 const getBadgeIntent = (
 	intent?: string
 ): ComponentProps< typeof Badge >[ 'intent' ] =>
-	intent && intent in BADGE_INTENTS
+	intent && Object.prototype.hasOwnProperty.call( BADGE_INTENTS, intent )
 		? BADGE_INTENTS[ intent as SettingsUIShellBadgeIntent ]
 		: BADGE_INTENTS.default;
 

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -38,6 +38,7 @@ import { HiddenInputs } from './hidden-inputs';
 import { error } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
 import { resolveRegionComponent, resolveSaveHandler } from './registry';
+import { preserveInitialRepresentation } from './values';
 import { SettingsUIPageContext } from './settings-ui-context';
 import type {
 	SettingsUIField,
@@ -631,7 +632,11 @@ export const SettingsUIPage = ( {
 				Object.entries( nextValues ).forEach(
 					( [ fieldId, value ] ) => {
 						if ( typeof value !== 'undefined' ) {
-							mergedValues[ fieldId ] = value;
+							mergedValues[ fieldId ] =
+								preserveInitialRepresentation(
+									value,
+									initialValues[ fieldId ]
+								);
 						}
 					}
 				);
@@ -639,7 +644,7 @@ export const SettingsUIPage = ( {
 				return mergedValues;
 			} );
 		},
-		[]
+		[ initialValues ]
 	);
 
 	const handleCustomSave = useCallback( async () => {

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -14,6 +14,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import {
 	Badge,
 	Button as UIButton,
@@ -28,17 +29,12 @@ import type { ComponentProps, ErrorInfo, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
+import { createDataFormAdapter, getGroupValidity } from './dataform-adapter';
 import { HiddenInputs } from './hidden-inputs';
-import { error, warn } from './diagnostics';
+import { error } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
-import { NativeSettingsField } from './native-fields';
-import {
-	resolveFieldComponent,
-	resolveFieldVisibilityPredicate,
-	resolveGroupVisibilityPredicate,
-	resolveRegionComponent,
-	resolveSaveHandler,
-} from './registry';
+import { resolveRegionComponent, resolveSaveHandler } from './registry';
+import { SettingsUIPageContext } from './settings-ui-context';
 import type {
 	SettingsUIField,
 	SettingsUIGroup,
@@ -104,9 +100,6 @@ const getChangedValues = (
 
 	return changedValues;
 };
-
-const getFieldTypeClassName = ( type: string ) =>
-	`wc-settings-ui__field--${ type.replace( /[^a-z0-9_-]/gi, '-' ) }`;
 
 const getActionVariant = ( variant?: string ) =>
 	( [ 'primary', 'secondary', 'tertiary', 'link' ].includes( variant || '' )
@@ -200,11 +193,13 @@ const getNavigationHref = ( event: MouseEvent ) => {
 
 const UnsavedChangesModal = ( {
 	isSaving,
+	isValid,
 	onClose,
 	onDiscard,
 	onSave,
 }: {
 	isSaving: boolean;
+	isValid: boolean;
 	onClose: () => void;
 	onDiscard: () => void;
 	onSave: () => void;
@@ -245,7 +240,7 @@ const UnsavedChangesModal = ( {
 					</UIButton>
 					<UIButton
 						loading={ isSaving }
-						disabled={ isSaving }
+						disabled={ isSaving || ! isValid }
 						onClick={ onSave }
 					>
 						{ __( 'Save', 'woocommerce' ) }
@@ -320,63 +315,6 @@ const GroupHeader = ( { group }: { group: SettingsUIGroup } ) => {
 			) : null }
 		</Card.Header>
 	);
-};
-
-const valueMatchesVisibilityRule = (
-	value: SettingsValue,
-	expected: SettingsValue | SettingsValue[] | undefined
-) => {
-	const expectedValues = Array.isArray( expected )
-		? expected
-		: [ expected ?? true ];
-
-	return expectedValues.some( ( expectedValue ) =>
-		areValuesEqual( value, expectedValue )
-	);
-};
-
-const getVisible = ( {
-	id,
-	kind,
-	field,
-	values,
-	initialValues,
-	context,
-	schema,
-}: {
-	id: string;
-	kind: 'field' | 'group';
-	field?: SettingsUIField;
-	values: SettingsValues;
-	initialValues: SettingsValues;
-	context: SettingsFieldContext;
-	schema: SettingsUISchema;
-} ) => {
-	const predicate =
-		kind === 'field'
-			? resolveFieldVisibilityPredicate( id, context )
-			: resolveGroupVisibilityPredicate( id, context );
-
-	if ( predicate ) {
-		try {
-			return predicate( { values, initialValues, context, schema } );
-		} catch ( predicateError ) {
-			warn(
-				`Visibility predicate for ${ kind } "${ id }" failed. Rendering it visible.`,
-				{ error: predicateError, context }
-			);
-			return true;
-		}
-	}
-
-	if ( field?.visibility ) {
-		return valueMatchesVisibilityRule(
-			values[ field.visibility.controller ],
-			field.visibility.value
-		);
-	}
-
-	return true;
 };
 
 const getAllFields = ( schema: SettingsUISchema ): SettingsUIField[] =>
@@ -629,6 +567,28 @@ export const SettingsUIPage = ( {
 	);
 	const isDirty = dirtyFields.length > 0;
 
+	const dataFormAdapter = useMemo(
+		() => createDataFormAdapter( { schema, context, initialValues } ),
+		[ context, initialValues, schema ]
+	);
+	const dataFormSections = useMemo(
+		() => dataFormAdapter.getRenderSections( values ),
+		[ dataFormAdapter, values ]
+	);
+	const validationForm = useMemo(
+		() => dataFormAdapter.getValidationForm( values ),
+		[ dataFormAdapter, values ]
+	);
+	const { validity, isValid } = useFormValidity(
+		values,
+		dataFormAdapter.fields,
+		validationForm
+	);
+	const pageContextValue = useMemo(
+		() => ( { schema, context, initialValues } ),
+		[ schema, context, initialValues ]
+	);
+
 	useEffect( () => {
 		const nextValues = getInitialValues( schema );
 		setInitialValues( nextValues );
@@ -637,16 +597,6 @@ export const SettingsUIPage = ( {
 		setPendingNavigation( null );
 	}, [ schema ] );
 
-	const setValue = useCallback(
-		( fieldId: string, nextValue: SettingsValue ) => {
-			setValuesState( ( currentValues ) => ( {
-				...currentValues,
-				[ fieldId ]: nextValue,
-			} ) );
-		},
-		[]
-	);
-
 	const allowNavigation = useCallback( () => {
 		allowNavigationRef.current = true;
 		clearLegacyFormPrompt();
@@ -654,6 +604,10 @@ export const SettingsUIPage = ( {
 
 	const submitSettingsForm = useCallback(
 		( redirectTo?: string ) => {
+			if ( ! isValid ) {
+				return;
+			}
+
 			const form = document.getElementById( 'mainform' );
 
 			if ( ! ( form instanceof HTMLFormElement ) ) {
@@ -675,7 +629,7 @@ export const SettingsUIPage = ( {
 
 			form.requestSubmit();
 		},
-		[ allowNavigation ]
+		[ allowNavigation, isValid ]
 	);
 
 	const setValues = useCallback(
@@ -698,7 +652,7 @@ export const SettingsUIPage = ( {
 	);
 
 	const handleCustomSave = useCallback( async () => {
-		if ( saveStrategy.adapter !== 'custom' ) {
+		if ( saveStrategy.adapter !== 'custom' || ! isValid ) {
 			return false;
 		}
 
@@ -752,6 +706,7 @@ export const SettingsUIPage = ( {
 		context,
 		dirtyFields,
 		initialValues,
+		isValid,
 		saveStrategy,
 		schema,
 		values,
@@ -853,37 +808,6 @@ export const SettingsUIPage = ( {
 		submitSettingsForm,
 	] );
 
-	const visibleGroups = useMemo(
-		() =>
-			Object.values( schema.groups )
-				.filter( ( group ) =>
-					getVisible( {
-						id: group.id,
-						kind: 'group',
-						values,
-						initialValues,
-						context,
-						schema,
-					} )
-				)
-				.map( ( group ) => ( {
-					...group,
-					fields: group.fields.filter( ( field ) =>
-						getVisible( {
-							id: field.id,
-							kind: 'field',
-							field,
-							values,
-							initialValues,
-							context,
-							schema,
-						} )
-					),
-				} ) )
-				.filter( ( group ) => group.fields.length > 0 ),
-		[ context, initialValues, schema, values ]
-	);
-
 	const formPostFields =
 		saveStrategy.adapter === 'form_post' ? getAllFields( schema ) : [];
 
@@ -899,7 +823,7 @@ export const SettingsUIPage = ( {
 				}
 				name="save"
 				value={ saveButtonLabel }
-				disabled={ ! isDirty || isSaving }
+				disabled={ ! isDirty || isSaving || ! isValid }
 				isBusy={ isSaving }
 				onClick={ () =>
 					saveStrategy.adapter === 'form_post'
@@ -912,101 +836,94 @@ export const SettingsUIPage = ( {
 		) : undefined;
 
 	return (
-		<ShellHeader
-			schema={ schema }
-			context={ context }
-			values={ values }
-			initialValues={ initialValues }
-			actions={ saveButton }
-		>
-			{ pendingNavigation ? (
-				<UnsavedChangesModal
-					isSaving={ isSaving }
-					onClose={ () => setPendingNavigation( null ) }
-					onDiscard={ handleDiscardNavigation }
-					onSave={ handleSavePendingNavigation }
-				/>
-			) : null }
-			{ saveNotice ? (
-				<Notice.Root
-					className="wc-settings-ui-shell__notice"
-					intent={ saveNotice.status }
-				>
-					<Notice.Description>
-						{ saveNotice.message }
-					</Notice.Description>
-					<Notice.CloseIcon onClick={ () => setSaveNotice( null ) } />
-				</Notice.Root>
-			) : null }
-			<Stack className="wc-settings-ui" direction="column" gap="xl">
-				{ visibleGroups.map( ( group ) => (
-					<section
-						className="wc-settings-ui__section"
-						key={ group.id }
+		<SettingsUIPageContext.Provider value={ pageContextValue }>
+			<ShellHeader
+				schema={ schema }
+				context={ context }
+				values={ values }
+				initialValues={ initialValues }
+				actions={ saveButton }
+			>
+				{ pendingNavigation ? (
+					<UnsavedChangesModal
+						isSaving={ isSaving }
+						isValid={ isValid }
+						onClose={ () => setPendingNavigation( null ) }
+						onDiscard={ handleDiscardNavigation }
+						onSave={ handleSavePendingNavigation }
+					/>
+				) : null }
+				{ saveNotice ? (
+					<Notice.Root
+						className="wc-settings-ui-shell__notice"
+						intent={ saveNotice.status }
 					>
-						<Card.Root className="wc-settings-ui__section-card">
-							<GroupHeader group={ group } />
-							<Card.Content
-								className="wc-settings-ui__section-fields"
-								render={ <Stack direction="column" gap="lg" /> }
-							>
-								{ group.fields.map( ( field ) => {
-									const FieldComponent =
-										resolveFieldComponent(
-											field,
-											context
-										) || NativeSettingsField;
-									const value = values[ field.id ];
+						<Notice.Description>
+							{ saveNotice.message }
+						</Notice.Description>
+						<Notice.CloseIcon
+							onClick={ () => setSaveNotice( null ) }
+						/>
+					</Notice.Root>
+				) : null }
+				<Stack className="wc-settings-ui" direction="column" gap="xl">
+					{ dataFormSections.map( ( renderSection ) => {
+						if ( renderSection.type === 'dataform' ) {
+							return (
+								<DataForm
+									data={ values }
+									fields={ dataFormAdapter.fields }
+									form={ renderSection.form }
+									key={ renderSection.key }
+									onChange={ setValues }
+									validity={ validity }
+								/>
+							);
+						}
 
-									return (
-										<div
-											className={ [
-												'wc-settings-ui__field',
-												getFieldTypeClassName(
-													field.type
-												),
-											].join( ' ' ) }
-											key={ field.id }
-										>
-											<FieldComponent
-												field={ field }
-												value={ value }
-												context={ context }
-												values={ values }
-												initialValues={ initialValues }
-												setValue={ setValue }
-												setValues={ setValues }
-												onChange={ ( nextValue ) =>
-													setValue(
-														field.id,
-														nextValue
-													)
-												}
-											/>
-										</div>
-									);
-								} ) }
-							</Card.Content>
-						</Card.Root>
-					</section>
-				) ) }
-				{ ! showHeader && saveButton ? (
-					<div className="wc-settings-ui__footer-actions">
-						{ saveButton }
+						return (
+							<section
+								className="wc-settings-ui__section"
+								key={ renderSection.key }
+							>
+								<Card.Root className="wc-settings-ui__section-card">
+									<GroupHeader
+										group={ renderSection.group }
+									/>
+									<Card.Content className="wc-settings-ui__section-fields">
+										<DataForm
+											data={ values }
+											fields={ dataFormAdapter.fields }
+											form={ renderSection.form }
+											onChange={ setValues }
+											validity={ getGroupValidity(
+												validity,
+												renderSection.group.id
+											) }
+										/>
+									</Card.Content>
+								</Card.Root>
+							</section>
+						);
+					} ) }
+					{ ! showHeader && saveButton ? (
+						<div className="wc-settings-ui__footer-actions">
+							{ saveButton }
+						</div>
+					) : null }
+				</Stack>
+				{ formPostFields.length > 0 ? (
+					<div className="wc-settings-ui__hidden-inputs">
+						{ formPostFields.map( ( field ) => (
+							<HiddenInputs
+								field={ field }
+								value={ values[ field.id ] }
+								key={ field.id }
+							/>
+						) ) }
 					</div>
 				) : null }
-			</Stack>
-			{ formPostFields.length > 0 ? (
-				<div className="wc-settings-ui__hidden-inputs">
-					{ formPostFields.map( ( field ) => (
-						<HiddenInputs
-							field={ field }
-							value={ values[ field.id ] }
-							key={ field.id }
-						/>
-					) ) }
-				</div>
-			) : null }
-		</ShellHeader>
+			</ShellHeader>
+		</SettingsUIPageContext.Provider>
 	);
 };

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -557,9 +557,13 @@ export const SettingsUIPage = ( {
 	);
 	const isDirty = dirtyFields.length > 0;
 
-	const dataFormAdapter = useMemo(
-		() => createDataFormAdapter( { schema, context, initialValues } ),
+	const pageContextValue = useMemo(
+		() => ( { schema, context, initialValues } ),
 		[ context, initialValues, schema ]
+	);
+	const dataFormAdapter = useMemo(
+		() => createDataFormAdapter( pageContextValue ),
+		[ pageContextValue ]
 	);
 	const dataFormSections = useMemo(
 		() => dataFormAdapter.getRenderSections( values ),
@@ -573,10 +577,6 @@ export const SettingsUIPage = ( {
 		values,
 		dataFormAdapter.fields,
 		validationForm
-	);
-	const pageContextValue = useMemo(
-		() => ( { schema, context, initialValues } ),
-		[ schema, context, initialValues ]
 	);
 
 	useEffect( () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -317,6 +317,60 @@ describe( 'dataform-adapter', () => {
 				field.setValue?.( { item: {}, value: [ 'GB', 5 ] } )
 			).toEqual( { countries: [ 'GB', '5' ] } );
 		} );
+
+		it( 'presents numeric strings as numbers to the package', () => {
+			const settingsField: SettingsUIField = {
+				id: 'window',
+				label: 'Window',
+				type: 'number',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.getValue?.( { item: { window: '30' } } ) ).toBe( 30 );
+			expect( field.getValue?.( { item: { window: 30 } } ) ).toBe( 30 );
+			expect(
+				field.getValue?.( { item: { window: '' } } )
+			).toBeUndefined();
+			expect( field.getValue?.( { item: {} } ) ).toBeUndefined();
+			expect( field.getValue?.( { item: { window: 'abc' } } ) ).toBe(
+				'abc'
+			);
+		} );
+
+		it( 'preserves the initial number value representation on write', () => {
+			const settingsField: SettingsUIField = {
+				id: 'window',
+				label: 'Window',
+				type: 'number',
+			};
+
+			const stringInitial = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField, { window: '30' } )
+			);
+			expect(
+				stringInitial.setValue?.( { item: {}, value: 35 } )
+			).toEqual( { window: '35' } );
+			expect(
+				stringInitial.setValue?.( { item: {}, value: undefined } )
+			).toEqual( { window: '' } );
+
+			const numberInitial = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField, { window: 30 } )
+			);
+			expect(
+				numberInitial.setValue?.( { item: {}, value: 35 } )
+			).toEqual( { window: 35 } );
+
+			// The native renderer emits strings; they pass through unchanged.
+			expect(
+				stringInitial.setValue?.( { item: {}, value: '42' } )
+			).toEqual( { window: '42' } );
+		} );
 	} );
 
 	describe( 'visibility', () => {
@@ -620,6 +674,40 @@ describe( 'dataform-adapter', () => {
 			await act( async () => Promise.resolve() );
 
 			expect( results[ results.length - 1 ] ).toBe( false );
+
+			cleanup();
+		} );
+
+		it( 'accepts numeric string values on number fields', async () => {
+			const numberField: SettingsUIField = {
+				id: 'window',
+				label: 'Window',
+				type: 'number',
+			};
+			const options = makeOptions(
+				[ { id: 'general', fields: [ numberField ] } ],
+				{ window: '30' }
+			);
+			const adapter = createDataFormAdapter( options );
+
+			const results: boolean[] = [];
+			const Harness = () => {
+				const [ values ] = useState< SettingsValues >( {
+					window: '30',
+				} );
+				const { isValid } = useFormValidity(
+					values,
+					adapter.fields,
+					adapter.getValidationForm( values )
+				);
+				results.push( isValid );
+				return null;
+			};
+
+			const { cleanup } = render( <Harness /> );
+			await act( async () => Promise.resolve() );
+
+			expect( results[ results.length - 1 ] ).toBe( true );
 
 			cleanup();
 		} );

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -4,7 +4,6 @@
 import { createElement, useState } from '@wordpress/element';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { act } from 'react';
-import { createRoot } from 'react-dom/client';
 
 /**
  * Internal dependencies
@@ -19,6 +18,7 @@ import type {
 	SettingsUISchema,
 	SettingsValues,
 } from '../types';
+import { renderElement as render } from './helpers/render-element';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -225,6 +225,11 @@ describe( 'dataform-adapter', () => {
 				true
 			);
 			expect( field.getValue?.( { item: { flag: '1' } } ) ).toBe( true );
+			// The checked vocabulary mirrors wc_string_to_bool().
+			expect( field.getValue?.( { item: { flag: 1 } } ) ).toBe( true );
+			expect( field.getValue?.( { item: { flag: 'true' } } ) ).toBe(
+				true
+			);
 			expect( field.getValue?.( { item: { flag: 'no' } } ) ).toBe(
 				false
 			);

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -48,38 +48,21 @@ const fieldOptions = (
 	initialValues: SettingsValues = {}
 ) => makeOptions( [ { id: 'general', fields: [ field ] } ], initialValues );
 
-const render = ( element: JSX.Element ) => {
-	const container = document.createElement( 'div' );
-	document.body.appendChild( container );
-	const root = createRoot( container );
-
-	act( () => {
-		root.render( element );
-	} );
-
-	return {
-		container,
-		cleanup: () => {
-			act( () => root.unmount() );
-			container.remove();
-		},
-	};
-};
-
 describe( 'dataform-adapter', () => {
 	afterEach( () => {
 		__resetRegistry();
 	} );
 
 	describe( 'package control mapping', () => {
+		// An undefined control means the package default for the type.
 		it.each( [
-			[ 'checkbox', 'boolean', 'checkbox' ],
+			[ 'checkbox', 'boolean', undefined ],
 			[ 'radio', 'text', 'radio' ],
 			[ 'select', 'text', 'select' ],
-			[ 'number', 'number', 'number' ],
-			[ 'tel', 'telephone', 'telephone' ],
-			[ 'text', 'text', 'text' ],
-			[ 'email', 'email', 'email' ],
+			[ 'number', 'number', undefined ],
+			[ 'tel', 'telephone', undefined ],
+			[ 'text', 'text', undefined ],
+			[ 'email', 'email', undefined ],
 		] )(
 			'maps %s to package type %s and control %s',
 			( settingsType, dataFormType, control ) => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -573,8 +573,8 @@ describe( 'dataform-adapter', () => {
 				'dataform',
 			] );
 			expect(
-				sections[ 1 ].type === 'fallback' && sections[ 1 ].reasons
-			).toEqual( [ 'actions' ] );
+				sections[ 1 ].type === 'fallback' && sections[ 1 ].group.id
+			).toBe( 'with-actions' );
 		} );
 
 		it( 'drops groups whose fields are all hidden', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -467,9 +467,49 @@ describe( 'dataform-adapter', () => {
 			expect( sections[ 0 ].form.fields ).toHaveLength( 2 );
 		} );
 
-		it( 'falls back to the shell card for groups with descriptions, preserving order', () => {
+		it( 'renders group descriptions through the package card, batching with plain groups', () => {
 			const adapter = createDataFormAdapter(
 				makeOptions( [ plainGroup, describedGroup, plainGroupB ] )
+			);
+			const sections = adapter.getRenderSections( {} );
+
+			expect( sections ).toHaveLength( 1 );
+			expect( sections[ 0 ].type ).toBe( 'dataform' );
+			expect( sections[ 0 ].form.fields ).toHaveLength( 3 );
+
+			const { container, cleanup } = render(
+				<DataForm
+					data={ {} }
+					fields={ adapter.fields }
+					form={ sections[ 0 ].form }
+					onChange={ () => {} }
+				/>
+			);
+
+			const description = container.querySelector(
+				'.dataforms-layouts-card__field-description'
+			);
+			expect( description?.textContent ).toBe( 'Rich text' );
+			expect( description?.querySelector( 'strong' ) ).not.toBeNull();
+
+			cleanup();
+		} );
+
+		it( 'falls back to the shell card for groups with header actions, preserving order', () => {
+			const actionsGroup: SettingsUIGroup = {
+				id: 'with-actions',
+				title: 'With actions',
+				actions: [
+					{
+						id: 'manage',
+						label: 'Manage',
+						href: 'https://example.com',
+					},
+				],
+				fields: [ { id: 'd', label: 'D', type: 'text' } ],
+			};
+			const adapter = createDataFormAdapter(
+				makeOptions( [ plainGroup, actionsGroup, plainGroupB ] )
 			);
 			const sections = adapter.getRenderSections( {} );
 
@@ -480,7 +520,7 @@ describe( 'dataform-adapter', () => {
 			] );
 			expect(
 				sections[ 1 ].type === 'fallback' && sections[ 1 ].reasons
-			).toEqual( [ 'description' ] );
+			).toEqual( [ 'actions' ] );
 		} );
 
 		it( 'drops groups whose fields are all hidden', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -1,0 +1,587 @@
+/**
+ * External dependencies
+ */
+import { createElement, useState } from '@wordpress/element';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { buildDataFormField, createDataFormAdapter } from '../dataform-adapter';
+import type { DataFormAdapterOptions } from '../dataform-adapter';
+import { __resetRegistry, registerSettingsExtension } from '../registry';
+import type {
+	SettingsEditControlProps,
+	SettingsUIField,
+	SettingsUIGroup,
+	SettingsUISchema,
+	SettingsValues,
+} from '../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const makeSchema = ( groups: SettingsUIGroup[] ): SettingsUISchema => ( {
+	id: 'test-page',
+	title: 'Test page',
+	section: 'default',
+	save: { adapter: 'none' },
+	groups: Object.fromEntries(
+		groups.map( ( group ) => [ group.id, group ] )
+	),
+} );
+
+const makeOptions = (
+	groups: SettingsUIGroup[],
+	initialValues: SettingsValues = {},
+	extra: Partial< DataFormAdapterOptions > = {}
+): DataFormAdapterOptions => ( {
+	schema: makeSchema( groups ),
+	context: { page: 'test-page', section: '' },
+	initialValues,
+	...extra,
+} );
+
+const fieldOptions = (
+	field: SettingsUIField,
+	initialValues: SettingsValues = {}
+) => makeOptions( [ { id: 'general', fields: [ field ] } ], initialValues );
+
+const render = ( element: JSX.Element ) => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	act( () => {
+		root.render( element );
+	} );
+
+	return {
+		container,
+		cleanup: () => {
+			act( () => root.unmount() );
+			container.remove();
+		},
+	};
+};
+
+describe( 'dataform-adapter', () => {
+	afterEach( () => {
+		__resetRegistry();
+	} );
+
+	describe( 'package control mapping', () => {
+		it.each( [
+			[ 'checkbox', 'boolean', 'checkbox' ],
+			[ 'radio', 'text', 'radio' ],
+			[ 'select', 'text', 'select' ],
+			[ 'number', 'number', 'number' ],
+			[ 'tel', 'telephone', 'telephone' ],
+			[ 'text', 'text', 'text' ],
+			[ 'email', 'email', 'email' ],
+		] )(
+			'maps %s to package type %s and control %s',
+			( settingsType, dataFormType, control ) => {
+				const settingsField: SettingsUIField = {
+					id: 'field',
+					label: 'Field',
+					type: settingsType,
+				};
+				const field = buildDataFormField(
+					settingsField,
+					fieldOptions( settingsField )
+				);
+
+				expect( field.type ).toBe( dataFormType );
+				expect( field.Edit ).toBe( control );
+			}
+		);
+
+		it( 'maps textarea to the textarea edit config', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'textarea',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.Edit ).toEqual( { control: 'textarea' } );
+		} );
+
+		it( 'leaves array fields on the package array control', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'array',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.type ).toBe( 'array' );
+			expect( field.Edit ).toBeUndefined();
+		} );
+
+		it( 'renders fields with a disabled state through the native renderer', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'text',
+				disabled: true,
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( typeof field.Edit ).toBe( 'function' );
+		} );
+
+		it( 'renders fields with custom attributes through the native renderer', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'number',
+				customAttributes: { min: 0, max: 10, step: 1 },
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( typeof field.Edit ).toBe( 'function' );
+		} );
+
+		it( 'renders unknown field types through the native renderer with a warning', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'image_width',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.type ).toBe( 'text' );
+			expect( typeof field.Edit ).toBe( 'function' );
+		} );
+
+		it( 'renders info fields as read-only blocks with sanitized HTML', () => {
+			const settingsField: SettingsUIField = {
+				id: 'notice',
+				label: 'Heads up',
+				type: 'info',
+				description: '<em>Allowed</em><script>alert("x")</script>',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.readOnly ).toBe( true );
+
+			const Render = field.render as React.ComponentType<
+				Record< string, unknown >
+			>;
+			const { container, cleanup } = render( <Render /> );
+
+			expect(
+				container.querySelector( '.wc-settings-ui__info' )
+			).not.toBeNull();
+			expect( container.querySelector( 'em' )?.textContent ).toBe(
+				'Allowed'
+			);
+			expect( container.querySelector( 'script' ) ).toBeNull();
+
+			cleanup();
+		} );
+
+		it( 'builds elements from options with stringified values', () => {
+			const settingsField: SettingsUIField = {
+				id: 'field',
+				label: 'Field',
+				type: 'select',
+				options: [
+					// PHP-supplied schemas can carry non-string values at
+					// runtime despite the declared types.
+					{ value: 1 as unknown as string, label: 'One' },
+					{ value: 'two', label: 'Two' },
+				],
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.elements ).toEqual( [
+				{ value: '1', label: 'One' },
+				{ value: 'two', label: 'Two' },
+			] );
+		} );
+	} );
+
+	describe( 'value round-trips', () => {
+		it( 'normalizes checkbox vocabulary to booleans on read', () => {
+			const settingsField: SettingsUIField = {
+				id: 'flag',
+				label: 'Flag',
+				type: 'checkbox',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.getValue?.( { item: { flag: 'yes' } } ) ).toBe(
+				true
+			);
+			expect( field.getValue?.( { item: { flag: '1' } } ) ).toBe( true );
+			expect( field.getValue?.( { item: { flag: 'no' } } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'preserves the initial checkbox value representation on write', () => {
+			const settingsField: SettingsUIField = {
+				id: 'flag',
+				label: 'Flag',
+				type: 'checkbox',
+			};
+
+			const yesNo = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField, { flag: 'no' } )
+			);
+			expect( yesNo.setValue?.( { item: {}, value: true } ) ).toEqual( {
+				flag: 'yes',
+			} );
+
+			const boolean = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField, { flag: false } )
+			);
+			expect( boolean.setValue?.( { item: {}, value: true } ) ).toEqual( {
+				flag: true,
+			} );
+
+			const numericString = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField, { flag: '0' } )
+			);
+			expect(
+				numericString.setValue?.( { item: {}, value: true } )
+			).toEqual( { flag: '1' } );
+		} );
+
+		it( 'restores original option value types for selects', () => {
+			const settingsField: SettingsUIField = {
+				id: 'unit',
+				label: 'Unit',
+				type: 'select',
+				options: [
+					{ value: 5 as unknown as string, label: 'Five' },
+					{ value: 'ten', label: 'Ten' },
+				],
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.setValue?.( { item: {}, value: '5' } ) ).toEqual( {
+				unit: 5,
+			} );
+			expect( field.setValue?.( { item: {}, value: 'ten' } ) ).toEqual( {
+				unit: 'ten',
+			} );
+		} );
+
+		it( 'casts array values to string arrays', () => {
+			const settingsField: SettingsUIField = {
+				id: 'countries',
+				label: 'Countries',
+				type: 'array',
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect(
+				field.setValue?.( { item: {}, value: [ 'GB', 5 ] } )
+			).toEqual( { countries: [ 'GB', '5' ] } );
+		} );
+	} );
+
+	describe( 'visibility', () => {
+		it( 'evaluates declarative visibility rules against the item', () => {
+			const settingsField: SettingsUIField = {
+				id: 'dependent',
+				label: 'Dependent',
+				type: 'text',
+				visibility: { controller: 'mode', value: 'advanced' },
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.isVisible?.( { mode: 'advanced' } ) ).toBe( true );
+			expect( field.isVisible?.( { mode: 'simple' } ) ).toBe( false );
+		} );
+
+		it( 'matches boolean rule expectations against checkbox vocabulary', () => {
+			const settingsField: SettingsUIField = {
+				id: 'dependent',
+				label: 'Dependent',
+				type: 'text',
+				visibility: { controller: 'flag', value: true },
+			};
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.isVisible?.( { flag: 'yes' } ) ).toBe( true );
+			expect( field.isVisible?.( { flag: '1' } ) ).toBe( true );
+			expect( field.isVisible?.( { flag: true } ) ).toBe( true );
+			expect( field.isVisible?.( { flag: 'no' } ) ).toBe( false );
+		} );
+
+		it( 'prefers registered visibility predicates and survives predicate errors', () => {
+			const settingsField: SettingsUIField = {
+				id: 'dependent',
+				label: 'Dependent',
+				type: 'text',
+				visibility: { controller: 'mode', value: 'advanced' },
+			};
+			registerSettingsExtension( {
+				scope: { page: 'test-page', section: '' },
+				fieldVisibility: {
+					dependent: ( { values } ) => values.mode === 'simple',
+				},
+			} );
+			const field = buildDataFormField(
+				settingsField,
+				fieldOptions( settingsField )
+			);
+
+			expect( field.isVisible?.( { mode: 'simple' } ) ).toBe( true );
+			expect( field.isVisible?.( { mode: 'advanced' } ) ).toBe( false );
+
+			__resetRegistry();
+			registerSettingsExtension( {
+				scope: { page: 'test-page', section: '' },
+				fieldVisibility: {
+					dependent: () => {
+						throw new Error( 'boom' );
+					},
+				},
+			} );
+
+			expect( field.isVisible?.( {} ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'registered components', () => {
+		it( 'renders registered components with the DataForm control contract', () => {
+			const received: Array< SettingsEditControlProps > = [];
+			const CustomField = ( props: SettingsEditControlProps ) => {
+				received.push( props );
+				return <div>Custom field</div>;
+			};
+			registerSettingsExtension( {
+				scope: { page: 'test-page', section: '' },
+				fieldOverrides: { store_name: CustomField },
+			} );
+			const settingsField: SettingsUIField = {
+				id: 'store_name',
+				label: 'Store name',
+				type: 'text',
+			};
+			const options = fieldOptions( settingsField, {
+				store_name: 'Initial',
+			} );
+			const adapter = createDataFormAdapter( options );
+			const onChange = jest.fn();
+
+			const { container, cleanup } = render(
+				<DataForm
+					data={ { store_name: 'Current' } }
+					fields={ adapter.fields }
+					form={ { fields: [ 'store_name' ] } }
+					onChange={ onChange }
+				/>
+			);
+
+			expect( container.textContent ).toContain( 'Custom field' );
+			expect(
+				received[ 0 ].field.getValue( {
+					item: { store_name: 'Current' },
+				} )
+			).toBe( 'Current' );
+
+			act( () => {
+				received[ 0 ].onChange( { store_name: 'Changed' } );
+			} );
+			expect( onChange ).toHaveBeenCalledWith( {
+				store_name: 'Changed',
+			} );
+
+			cleanup();
+		} );
+	} );
+
+	describe( 'render sections', () => {
+		const plainGroup: SettingsUIGroup = {
+			id: 'plain-a',
+			title: 'Plain A',
+			fields: [ { id: 'a', label: 'A', type: 'text' } ],
+		};
+		const plainGroupB: SettingsUIGroup = {
+			id: 'plain-b',
+			title: 'Plain B',
+			fields: [ { id: 'b', label: 'B', type: 'text' } ],
+		};
+		const describedGroup: SettingsUIGroup = {
+			id: 'described',
+			title: 'Described',
+			description: 'Rich <strong>text</strong>',
+			fields: [ { id: 'c', label: 'C', type: 'text' } ],
+		};
+
+		it( 'batches consecutive plain groups into one DataForm section', () => {
+			const adapter = createDataFormAdapter(
+				makeOptions( [ plainGroup, plainGroupB ] )
+			);
+			const sections = adapter.getRenderSections( {} );
+
+			expect( sections ).toHaveLength( 1 );
+			expect( sections[ 0 ].type ).toBe( 'dataform' );
+			expect( sections[ 0 ].form.fields ).toHaveLength( 2 );
+		} );
+
+		it( 'falls back to the shell card for groups with descriptions, preserving order', () => {
+			const adapter = createDataFormAdapter(
+				makeOptions( [ plainGroup, describedGroup, plainGroupB ] )
+			);
+			const sections = adapter.getRenderSections( {} );
+
+			expect( sections.map( ( section ) => section.type ) ).toEqual( [
+				'dataform',
+				'fallback',
+				'dataform',
+			] );
+			expect(
+				sections[ 1 ].type === 'fallback' && sections[ 1 ].reasons
+			).toEqual( [ 'description' ] );
+		} );
+
+		it( 'drops groups whose fields are all hidden', () => {
+			const hiddenGroup: SettingsUIGroup = {
+				id: 'hidden',
+				title: 'Hidden',
+				fields: [
+					{
+						id: 'h',
+						label: 'H',
+						type: 'text',
+						visibility: { controller: 'mode', value: 'never' },
+					},
+				],
+			};
+			const adapter = createDataFormAdapter(
+				makeOptions( [ plainGroup, hiddenGroup ] )
+			);
+			const sections = adapter.getRenderSections( { mode: 'other' } );
+
+			expect( sections ).toHaveLength( 1 );
+			expect( sections[ 0 ].form.fields ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'validation', () => {
+		const requiredField: SettingsUIField = {
+			id: 'name',
+			label: 'Name',
+			type: 'text',
+		};
+
+		it( 'excludes hidden fields from the validation form', () => {
+			const groups: SettingsUIGroup[] = [
+				{
+					id: 'general',
+					fields: [
+						{ id: 'mode', label: 'Mode', type: 'text' },
+						{
+							id: 'dependent',
+							label: 'Dependent',
+							type: 'text',
+							visibility: {
+								controller: 'mode',
+								value: 'advanced',
+							},
+						},
+					],
+				},
+			];
+			const adapter = createDataFormAdapter(
+				makeOptions(
+					groups,
+					{},
+					{
+						fieldRules: { dependent: { required: true } },
+					}
+				)
+			);
+
+			const hiddenForm = adapter.getValidationForm( {
+				mode: 'simple',
+			} );
+			expect( hiddenForm.fields ).toEqual( [
+				{ id: 'general', children: [ 'mode' ] },
+			] );
+
+			const visibleForm = adapter.getValidationForm( {
+				mode: 'advanced',
+			} );
+			expect( visibleForm.fields ).toEqual( [
+				{ id: 'general', children: [ 'mode', 'dependent' ] },
+			] );
+		} );
+
+		it( 'flows field rules into DataForm validity', async () => {
+			const options = makeOptions(
+				[ { id: 'general', fields: [ requiredField ] } ],
+				{ name: '' },
+				{ fieldRules: { name: { required: true } } }
+			);
+			const adapter = createDataFormAdapter( options );
+
+			const results: boolean[] = [];
+			const Harness = () => {
+				const [ values ] = useState< SettingsValues >( { name: '' } );
+				const { isValid } = useFormValidity(
+					values,
+					adapter.fields,
+					adapter.getValidationForm( values )
+				);
+				results.push( isValid );
+				return null;
+			};
+
+			const { cleanup } = render( <Harness /> );
+			await act( async () => Promise.resolve() );
+
+			expect( results[ results.length - 1 ] ).toBe( false );
+
+			cleanup();
+		} );
+	} );
+} );

--- a/packages/js/settings-ui/src/test/header-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/header-fields.test.tsx
@@ -167,6 +167,33 @@ describe( 'settings UI shell header fields', () => {
 		container.remove();
 	} );
 
+	it( 'falls back to the default intent for Object.prototype key intent values', () => {
+		const { container, root } = renderElement(
+			<SettingsUIPage
+				schema={ baseSchema( {
+					header: 'visible',
+					title: 'Test page',
+					// 'constructor' exists on Object.prototype, so an `in`
+					// check would wrongly resolve it to a function.
+					badges: [
+						{
+							label: 'Mystery',
+							intent: 'constructor' as never,
+						},
+					],
+				} ) }
+				page="test_page"
+			/>
+		);
+
+		const badge = container.querySelector( '[data-testid="shell-badge"]' );
+		expect( badge ).not.toBeNull();
+		expect( badge?.getAttribute( 'data-intent' ) ).toBe( 'draft' );
+
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
 	it( 'omits subtitle and badges when not provided', () => {
 		const { container, root } = renderElement(
 			<SettingsUIPage

--- a/packages/js/settings-ui/src/test/helpers/render-element.tsx
+++ b/packages/js/settings-ui/src/test/helpers/render-element.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+// Mount harness shared by the suites that render without a testing
+// library. Callers unmount via cleanup, or through root for suites that
+// manage unmounting themselves.
+export const renderElement = ( element: JSX.Element ) => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	act( () => {
+		root.render( element );
+	} );
+
+	return {
+		container,
+		root,
+		cleanup: () => {
+			act( () => root.unmount() );
+			container.remove();
+		},
+	};
+};

--- a/packages/js/settings-ui/src/test/hidden-inputs.test.ts
+++ b/packages/js/settings-ui/src/test/hidden-inputs.test.ts
@@ -5,17 +5,27 @@ import { getHiddenInputs } from '../hidden-inputs';
 
 describe( 'getHiddenInputs', () => {
 	it( 'serializes checkbox values for legacy form posts', () => {
-		expect(
-			getHiddenInputs(
-				{
-					id: 'enabled',
-					label: 'Enabled',
-					type: 'checkbox',
-					save: { adapter: 'form_post', name: 'enabled' },
-				},
-				true
-			)
-		).toEqual( [ { name: 'enabled', value: 'yes' } ] );
+		const checkboxField = {
+			id: 'enabled',
+			label: 'Enabled',
+			type: 'checkbox',
+			save: { adapter: 'form_post' as const, name: 'enabled' },
+		};
+
+		expect( getHiddenInputs( checkboxField, true ) ).toEqual( [
+			{ name: 'enabled', value: 'yes' },
+		] );
+		// Every value wc_string_to_bool() treats as true serializes back
+		// as yes, so an untouched save cannot flip the setting off.
+		expect( getHiddenInputs( checkboxField, 1 ) ).toEqual( [
+			{ name: 'enabled', value: 'yes' },
+		] );
+		expect( getHiddenInputs( checkboxField, 'true' ) ).toEqual( [
+			{ name: 'enabled', value: 'yes' },
+		] );
+		expect( getHiddenInputs( checkboxField, 'no' ) ).toEqual( [
+			{ name: 'enabled', value: 'no' },
+		] );
 	} );
 
 	it( 'serializes array values with bracketed field names', () => {

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -21,7 +21,8 @@ jest.mock( '@wordpress/admin-ui', () => ( {
  */
 import { SettingsUIPage } from '../settings-ui-page';
 import { __resetRegistry, registerSettingsExtension } from '../registry';
-import type { SettingsUISchema } from '../types';
+import { useSettingsUIContext } from '../settings-ui-context';
+import type { SettingsFieldContext, SettingsUISchema } from '../types';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -157,9 +158,11 @@ describe( 'settings HTML rendering', () => {
 	} );
 
 	it( 'normalizes the default schema section to default-section scope', () => {
-		const DefaultSectionField = jest.fn( () => (
-			<div>Default section field</div>
-		) );
+		const seenContexts: SettingsFieldContext[] = [];
+		const DefaultSectionField = jest.fn( () => {
+			seenContexts.push( useSettingsUIContext().context );
+			return <div>Default section field</div>;
+		} );
 		registerSettingsExtension( {
 			scope: { page: 'test-page', section: '' },
 			fieldOverrides: {
@@ -191,9 +194,7 @@ describe( 'settings HTML rendering', () => {
 		);
 
 		expect( container.textContent ).toContain( 'Default section field' );
-		expect( DefaultSectionField.mock.calls[ 0 ][ 0 ].context.section ).toBe(
-			''
-		);
+		expect( seenContexts[ 0 ].section ).toBe( '' );
 
 		act( () => root.unmount() );
 		container.remove();
@@ -305,7 +306,9 @@ describe( 'settings HTML rendering', () => {
 			<SettingsUIPage schema={ schema } />
 		);
 
-		const input = container.querySelector( 'input[type="text"]' );
+		const input = container.querySelector(
+			'input.components-input-control__input'
+		);
 		const link = container.querySelector(
 			'a[href="https://example.com/next"]'
 		);
@@ -383,7 +386,9 @@ describe( 'settings HTML rendering', () => {
 		form.insertBefore( sectionLinks, container );
 
 		try {
-			const input = container.querySelector( 'input[type="text"]' );
+			const input = container.querySelector(
+				'input.components-input-control__input'
+			);
 			const link = sectionLinks.querySelector( 'a' );
 
 			expect( input ).toBeInstanceOf( HTMLInputElement );
@@ -451,7 +456,9 @@ describe( 'settings HTML rendering', () => {
 		);
 
 		try {
-			const input = container.querySelector( 'input[type="text"]' );
+			const input = container.querySelector(
+				'input.components-input-control__input'
+			);
 			const link = container.querySelector(
 				'a[href="https://example.com/next"]'
 			);
@@ -549,7 +556,9 @@ describe( 'settings HTML rendering', () => {
 			<SettingsUIPage schema={ schema } />
 		);
 
-		const input = container.querySelector( 'input[type="text"]' );
+		const input = container.querySelector(
+			'input.components-input-control__input'
+		);
 		const link = container.querySelector(
 			'a[href="https://example.com/next"]'
 		);

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -132,14 +132,16 @@ describe( 'settings HTML rendering', () => {
 		);
 
 		expect(
-			container.querySelector( '.wc-settings-ui__section' )
+			container.querySelector( '.dataforms-layouts-card__field' )
 		).not.toBeNull();
+		expect(
+			container.querySelector(
+				'.dataforms-layouts-card__field-description'
+			)?.textContent
+		).toBe( 'Configure the basics.' );
 		expect(
 			container.querySelector( '.wc-settings-ui__section-card' )
-		).not.toBeNull();
-		expect(
-			container.querySelector( '.wc-settings-ui__section-fields' )
-		).not.toBeNull();
+		).toBeNull();
 		expect( container.querySelector( '.wc-settings-ui__row' ) ).toBeNull();
 		expect(
 			container.querySelector( '.wc-settings-ui__group-panel' )

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -23,23 +23,12 @@ import { SettingsUIPage } from '../settings-ui-page';
 import { __resetRegistry, registerSettingsExtension } from '../registry';
 import { useSettingsUIContext } from '../settings-ui-context';
 import type { SettingsFieldContext, SettingsUISchema } from '../types';
+import { renderElement } from './helpers/render-element';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const unsafeDescription =
 	'<strong>Safe</strong><script>alert("x")</script><img src=x onerror=alert(1)><a href="javascript:alert(1)" onclick="alert(1)">Link</a><iframe src="https://example.com"></iframe>';
-
-const renderElement = ( element: JSX.Element ) => {
-	const container = document.createElement( 'div' );
-	document.body.appendChild( container );
-	const root = createRoot( container );
-
-	act( () => {
-		root.render( element );
-	} );
-
-	return { container, root };
-};
 
 const renderElementInMainForm = ( element: JSX.Element ) => {
 	const form = document.createElement( 'form' );

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -417,4 +417,87 @@ describe( 'NativeSettingsField', () => {
 			).toBeNull();
 		} );
 	} );
+
+	describe( 'select and radio fields', () => {
+		// TS unions erase at runtime: extension-supplied PHP schemas can
+		// carry numeric option values, which must still match the saved
+		// value.
+		const numericOptions = [
+			{ label: 'One', value: 1 as unknown as string },
+			{ label: 'Two', value: 2 as unknown as string },
+		];
+
+		it( 'selects a numeric option value matching a numeric saved value', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_select',
+							label: 'Amount',
+							type: 'select',
+							options: numericOptions,
+						},
+						1
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'button[role="combobox"]' )
+					?.textContent
+			).toBe( 'One' );
+		} );
+
+		it( 'selects a numeric option value matching a string saved value', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							id: 'wc_test_radio',
+							label: 'Amount',
+							type: 'radio',
+							options: numericOptions,
+						},
+						'2'
+					) }
+				/>
+			);
+
+			expect(
+				container.querySelector( 'button[role="combobox"]' )
+					?.textContent
+			).toBe( 'Two' );
+		} );
+	} );
+
+	describe( 'checkbox fields', () => {
+		const checkboxField: SettingsUIField = {
+			id: 'wc_test_checkbox',
+			label: 'Enable feature',
+			type: 'checkbox',
+		};
+
+		it.each( [
+			[ true, true ],
+			[ 'yes', true ],
+			[ '1', true ],
+			[ 1, true ],
+			[ 'true', true ],
+			[ false, false ],
+			[ 0, false ],
+			[ '0', false ],
+			[ 'no', false ],
+			[ '', false ],
+		] )( 'renders saved value %p as checked=%p', ( value, checked ) => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps( checkboxField, value as SettingsValue ) }
+				/>
+			);
+
+			const input = container.querySelector( 'input[type="checkbox"]' );
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			expect( ( input as HTMLInputElement ).checked ).toBe( checked );
+		} );
+	} );
 } );

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -4,17 +4,14 @@
 import { speak } from '@wordpress/a11y';
 import { createElement } from '@wordpress/element';
 import { act } from 'react';
-import { createRoot } from 'react-dom/client';
 
 /**
  * Internal dependencies
  */
 import { NativeSettingsField } from '../native-fields';
-import type {
-	SettingsFieldComponentProps,
-	SettingsUIField,
-	SettingsValue,
-} from '../types';
+import type { NativeSettingsFieldProps } from '../native-fields';
+import type { SettingsUIField, SettingsValue } from '../types';
+import { renderElement } from './helpers/render-element';
 
 jest.mock( '@wordpress/a11y', () => ( {
 	speak: jest.fn(),
@@ -27,31 +24,14 @@ afterAll( () => {
 	globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
 } );
 
-const renderElement = ( element: JSX.Element ) => {
-	const container = document.createElement( 'div' );
-	document.body.appendChild( container );
-	const root = createRoot( container );
-
-	act( () => {
-		root.render( element );
-	} );
-
-	return { container, root };
-};
-
 const makeProps = (
 	field: SettingsUIField,
 	value: SettingsValue,
 	onChange: ( next: SettingsValue ) => void = () => {}
-): SettingsFieldComponentProps => ( {
+): NativeSettingsFieldProps => ( {
 	field,
 	value,
 	onChange,
-	values: { [ field.id ]: value },
-	initialValues: { [ field.id ]: value },
-	setValue: () => {},
-	setValues: () => {},
-	context: { page: 'test-page' },
 } );
 
 describe( 'NativeSettingsField', () => {
@@ -63,14 +43,9 @@ describe( 'NativeSettingsField', () => {
 	} );
 
 	const render = ( element: JSX.Element ) => {
-		const { container, root } = renderElement( element );
-		cleanup = () => {
-			act( () => {
-				root.unmount();
-			} );
-			container.remove();
-		};
-		return container;
+		const rendered = renderElement( element );
+		cleanup = rendered.cleanup;
+		return rendered.container;
 	};
 
 	const clickButton = ( button: HTMLElement ) => {

--- a/packages/js/settings-ui/src/test/values.test.ts
+++ b/packages/js/settings-ui/src/test/values.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import {
+	isCheckedValue,
+	preserveInitialRepresentation,
+	toStringValue,
+} from '../values';
+
+describe( 'values', () => {
+	describe( 'toStringValue', () => {
+		it( 'stringifies values and maps empty to the empty string', () => {
+			expect( toStringValue( 'abc' ) ).toBe( 'abc' );
+			expect( toStringValue( 10 ) ).toBe( '10' );
+			expect( toStringValue( null ) ).toBe( '' );
+			expect( toStringValue( undefined ) ).toBe( '' );
+		} );
+	} );
+
+	describe( 'isCheckedValue', () => {
+		it.each( [
+			[ true, true ],
+			[ 1, true ],
+			[ '1', true ],
+			[ 'yes', true ],
+			[ 'YES', true ],
+			[ 'true', true ],
+			[ false, false ],
+			[ 0, false ],
+			[ '0', false ],
+			[ 'no', false ],
+			[ '', false ],
+			[ undefined, false ],
+		] )( 'mirrors wc_string_to_bool for %p', ( value, expected ) => {
+			expect( isCheckedValue( value ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'preserveInitialRepresentation', () => {
+		it( 'restores non-string initials when a control emits their string form', () => {
+			expect( preserveInitialRepresentation( '10', 10 ) ).toBe( 10 );
+			expect( preserveInitialRepresentation( 'true', true ) ).toBe(
+				true
+			);
+			expect( preserveInitialRepresentation( '', null ) ).toBe( null );
+		} );
+
+		it( 'restores empty initials when a control emits an empty array', () => {
+			expect( preserveInitialRepresentation( [], '' ) ).toBe( '' );
+			expect( preserveInitialRepresentation( [], null ) ).toBe( null );
+		} );
+
+		it( 'keeps genuinely changed values as emitted', () => {
+			expect( preserveInitialRepresentation( '11', 10 ) ).toBe( '11' );
+			expect(
+				preserveInitialRepresentation( 'changed', 'initial' )
+			).toBe( 'changed' );
+			expect( preserveInitialRepresentation( [ 'GB' ], '' ) ).toEqual( [
+				'GB',
+			] );
+			expect( preserveInitialRepresentation( 'kept', undefined ) ).toBe(
+				'kept'
+			);
+		} );
+	} );
+} );

--- a/packages/js/settings-ui/src/types.ts
+++ b/packages/js/settings-ui/src/types.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import type { DataFormControlProps, FieldValidity } from '@wordpress/dataviews';
+
 export type SettingsValue = string | number | boolean | string[] | null;
 
 export type SettingsValues = Record< string, SettingsValue >;
@@ -119,20 +124,35 @@ export type SettingsFieldContext = {
 	section?: string;
 };
 
-export type SettingsFieldComponentProps = {
-	field: SettingsUIField;
-	value: SettingsValue;
-	onChange: ( value: SettingsValue ) => void;
-	values: SettingsValues;
-	initialValues: SettingsValues;
-	setValue: ( fieldId: string, value: SettingsValue ) => void;
-	setValues: ( values: Partial< SettingsValues > ) => void;
-	context: SettingsFieldContext;
-};
+/**
+ * The props a registered settings field component receives. This is the
+ * DataForm control contract from @wordpress/dataviews, re-exported under
+ * a Woo name so extensions do not import dataviews types directly and
+ * upgrades are absorbed at this alias.
+ *
+ * `data` holds the current values, `field` is the normalized DataForm
+ * field (use `field.getValue( { item: data } )` for the current value),
+ * and `onChange` takes a partial record of field ids to new values, so
+ * multi-field writes are a single call. Page-level context is available
+ * through the `useSettingsUIContext` hook.
+ */
+export type SettingsEditControlProps = DataFormControlProps< SettingsValues >;
+
+export type SettingsFieldValidity = FieldValidity;
 
 export type SettingsFieldComponent = (
-	props: SettingsFieldComponentProps
+	props: SettingsEditControlProps
 ) => JSX.Element | null;
+
+/**
+ * Page-level state exposed to registered components through the
+ * `useSettingsUIContext` hook.
+ */
+export type SettingsUIPageContextValue = {
+	schema: SettingsUISchema;
+	context: SettingsFieldContext;
+	initialValues: SettingsValues;
+};
 
 export type SettingsVisibilityPredicateArgs = {
 	values: SettingsValues;

--- a/packages/js/settings-ui/src/values.ts
+++ b/packages/js/settings-ui/src/values.ts
@@ -6,7 +6,19 @@ import type { SettingsValue } from './types';
 export const toStringValue = ( value: SettingsValue | undefined ) =>
 	value === null || typeof value === 'undefined' ? '' : String( value );
 
-// Legacy PHP settings express checkbox state as yes/no, 1/0, or booleans
-// depending on the source.
-export const isCheckedValue = ( value: SettingsValue | undefined ): boolean =>
-	value === true || value === 1 || value === 'yes' || value === '1';
+// Mirrors wc_string_to_bool(): every value PHP treats as true must
+// render checked, or an untouched save would flip the setting off.
+export const isCheckedValue = ( value: SettingsValue | undefined ): boolean => {
+	if ( typeof value === 'boolean' ) {
+		return value;
+	}
+
+	if ( value === 1 ) {
+		return true;
+	}
+
+	return (
+		typeof value === 'string' &&
+		[ 'yes', 'true', '1' ].includes( value.toLowerCase() )
+	);
+};

--- a/packages/js/settings-ui/src/values.ts
+++ b/packages/js/settings-ui/src/values.ts
@@ -6,6 +6,37 @@ import type { SettingsValue } from './types';
 export const toStringValue = ( value: SettingsValue | undefined ) =>
 	value === null || typeof value === 'undefined' ? '' : String( value );
 
+// Restores the schema representation when a control emits an equivalent
+// value, so numeric and empty values do not flip type and mark the form
+// dirty.
+export const preserveInitialRepresentation = (
+	value: SettingsValue,
+	initialValue: SettingsValue | undefined
+): SettingsValue => {
+	if ( typeof initialValue === 'undefined' || value === initialValue ) {
+		return value;
+	}
+
+	if (
+		typeof value === 'string' &&
+		typeof initialValue !== 'string' &&
+		! Array.isArray( initialValue ) &&
+		toStringValue( initialValue ) === value
+	) {
+		return initialValue;
+	}
+
+	if (
+		Array.isArray( value ) &&
+		value.length === 0 &&
+		( initialValue === '' || initialValue === null )
+	) {
+		return initialValue;
+	}
+
+	return value;
+};
+
 // Mirrors wc_string_to_bool(): every value PHP treats as true must
 // render checked, or an untouched save would flip the setting off.
 export const isCheckedValue = ( value: SettingsValue | undefined ): boolean => {

--- a/packages/js/settings-ui/src/values.ts
+++ b/packages/js/settings-ui/src/values.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import type { SettingsValue } from './types';
+
+export const toStringValue = ( value: SettingsValue | undefined ) =>
+	value === null || typeof value === 'undefined' ? '' : String( value );
+
+// Legacy PHP settings express checkbox state as yes/no, 1/0, or booleans
+// depending on the source.
+export const isCheckedValue = ( value: SettingsValue | undefined ): boolean =>
+	value === true || value === 1 || value === 'yes' || value === '1';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2445,6 +2445,9 @@ importers:
       '@wordpress/components':
         specifier: catalog:wp-min
         version: 30.6.5(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews':
+        specifier: 10.3.0
+        version: 10.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: catalog:wp-min
         version: 6.33.1
@@ -23639,12 +23642,12 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/base-styles': 5.23.0
       '@wordpress/components': 29.12.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.20.0(react@18.3.1)
+      '@wordpress/compose': 7.20.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.44.0(react@18.3.1)
       '@wordpress/date': 5.20.0
       '@wordpress/html-entities': 4.20.0
       '@wordpress/i18n': 5.26.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/icons': 10.32.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/react-i18n': 4.44.0
       '@wordpress/url': 4.48.1
@@ -23683,12 +23686,12 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/base-styles': 5.23.0
       '@wordpress/components': 29.12.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.20.0(react@18.3.1)
+      '@wordpress/compose': 7.20.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/date': 5.20.0
       '@wordpress/html-entities': 4.20.0
       '@wordpress/i18n': 5.26.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/icons': 10.32.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/react-i18n': 4.44.0
       '@wordpress/url': 4.48.1
@@ -31705,8 +31708,8 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/route': 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/style-runtime': 0.4.1
@@ -31725,8 +31728,8 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/route': 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/style-runtime': 0.4.1
@@ -32458,10 +32461,10 @@ snapshots:
       '@wordpress/keycodes': 4.48.1
       '@wordpress/latex-to-mathml': 1.16.0
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/server-side-render': 6.20.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.48.1
@@ -32515,10 +32518,10 @@ snapshots:
       '@wordpress/keycodes': 4.48.1
       '@wordpress/latex-to-mathml': 1.16.0
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/server-side-render': 6.20.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.48.1
@@ -32929,7 +32932,7 @@ snapshots:
 
   '@wordpress/components@28.13.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.25.7
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -32942,22 +32945,22 @@ snapshots:
       '@types/highlight-words-core': 1.2.1
       '@use-gesture/react': 10.3.1(react@18.3.1)
       '@wordpress/a11y': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/element': 8.2.0
       '@wordpress/escape-html': 3.48.1
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 10.6.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -32983,7 +32986,7 @@ snapshots:
 
   '@wordpress/components@29.12.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.25.7
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -32997,7 +33000,7 @@ snapshots:
       '@use-gesture/react': 10.3.1(react@18.3.1)
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/date': 5.48.1
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.48.1
       '@wordpress/dom': 4.48.1
       '@wordpress/element': 6.45.0
@@ -33005,13 +33008,13 @@ snapshots:
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 5.26.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/icons': 10.32.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -33059,7 +33062,7 @@ snapshots:
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 5.26.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/icons': 10.32.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.48.1
       '@wordpress/keycodes': 4.48.1
       '@wordpress/primitives': 4.48.1(react@18.3.1)
@@ -33202,7 +33205,7 @@ snapshots:
 
   '@wordpress/components@32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/utc': 2.1.1
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -33218,21 +33221,21 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 6.20.0
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
       '@wordpress/element': 6.45.0
       '@wordpress/escape-html': 3.48.1
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -33259,7 +33262,7 @@ snapshots:
 
   '@wordpress/components@33.0.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/utc': 2.1.1
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -33275,21 +33278,21 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 7.0.0
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
       '@wordpress/element': 6.45.0
       '@wordpress/escape-html': 3.48.1
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -33316,7 +33319,7 @@ snapshots:
 
   '@wordpress/components@35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/utc': 2.1.1
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -33330,25 +33333,25 @@ snapshots:
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
       '@wordpress/a11y': 4.48.1
-      '@wordpress/base-styles': 10.0.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/base-styles': 10.2.0
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/element': 8.2.0
       '@wordpress/escape-html': 3.48.1
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/ui': 0.15.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -33377,7 +33380,7 @@ snapshots:
 
   '@wordpress/components@35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/utc': 2.1.1
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -33391,25 +33394,25 @@ snapshots:
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
       '@wordpress/a11y': 4.48.1
-      '@wordpress/base-styles': 10.0.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/base-styles': 10.2.0
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/element': 8.2.0
       '@wordpress/escape-html': 3.48.1
       '@wordpress/hooks': 4.48.1
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/ui': 0.15.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -33667,7 +33670,7 @@ snapshots:
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
 
-  '@wordpress/compose@7.20.0(react@18.3.1)':
+  '@wordpress/compose@7.20.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@types/mousetrap': 1.6.15
@@ -33675,7 +33678,7 @@ snapshots:
       '@wordpress/dom': 4.48.1
       '@wordpress/element': 6.45.0
       '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
       '@wordpress/priority-queue': 3.48.1
       '@wordpress/undo-manager': 1.48.1
       change-case: 4.1.2
@@ -33683,6 +33686,8 @@ snapshots:
       mousetrap: 1.6.5
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/compose@7.33.1(react@18.3.1)':
     dependencies:
@@ -33719,12 +33724,12 @@ snapshots:
     dependencies:
       '@types/mousetrap': 1.6.15
       '@types/react': 18.3.28
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/dom': 4.48.1
-      '@wordpress/element': 8.0.1
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/priority-queue': 3.48.1
+      '@wordpress/element': 8.2.0
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/priority-queue': 3.50.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/undo-manager': 1.48.1
       change-case: 4.1.2
@@ -33946,19 +33951,19 @@ snapshots:
       '@wordpress/api-fetch': 7.48.1
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/blocks': 15.21.1(react@18.3.1)
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/is-shallow-equal': 5.48.1
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/is-shallow-equal': 5.50.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/sync': 1.48.1
       '@wordpress/undo-manager': 1.48.1
       '@wordpress/url': 4.48.1
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -33980,19 +33985,19 @@ snapshots:
       '@wordpress/api-fetch': 7.48.1
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/blocks': 15.21.1(react@18.3.1)
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/is-shallow-equal': 5.48.1
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/is-shallow-equal': 5.50.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/sync': 1.48.1
       '@wordpress/undo-manager': 1.48.1
       '@wordpress/url': 4.48.1
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -34014,19 +34019,19 @@ snapshots:
       '@wordpress/api-fetch': 7.48.1
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/blocks': 15.21.1(react@18.3.1)
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/is-shallow-equal': 5.48.1
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/is-shallow-equal': 5.50.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/sync': 1.48.1
       '@wordpress/undo-manager': 1.48.1
       '@wordpress/url': 4.48.1
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -34048,19 +34053,19 @@ snapshots:
       '@wordpress/api-fetch': 7.48.1
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/blocks': 15.21.1(react@18.3.1)
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
       '@wordpress/html-entities': 4.48.1
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/is-shallow-equal': 5.48.1
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/is-shallow-equal': 5.50.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/sync': 1.48.1
       '@wordpress/undo-manager': 1.48.1
       '@wordpress/url': 4.48.1
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -34122,12 +34127,12 @@ snapshots:
   '@wordpress/data@10.45.0(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/is-shallow-equal': 5.48.1
-      '@wordpress/priority-queue': 3.48.1
+      '@wordpress/is-shallow-equal': 5.50.0
+      '@wordpress/priority-queue': 3.50.0
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/redux-routine': 5.48.1(redux@5.0.1)
+      '@wordpress/redux-routine': 5.50.0(redux@5.0.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
       is-plain-object: 5.0.0
@@ -34245,20 +34250,20 @@ snapshots:
 
   '@wordpress/dataviews@10.3.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles': 6.20.0
       '@wordpress/components': 30.9.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 11.8.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.1.0
@@ -34274,21 +34279,21 @@ snapshots:
 
   '@wordpress/dataviews@14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles': 7.0.0
       '@wordpress/components': 33.0.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/ui': 0.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.1.0
@@ -34306,21 +34311,21 @@ snapshots:
 
   '@wordpress/dataviews@14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles': 7.0.0
       '@wordpress/components': 33.0.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.45.0(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/ui': 0.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.1.0
@@ -34338,22 +34343,22 @@ snapshots:
 
   '@wordpress/dataviews@16.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
-      '@wordpress/base-styles': 10.0.1
+      '@wordpress/base-styles': 10.2.0
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/ui': 0.15.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.1.0
@@ -34370,22 +34375,22 @@ snapshots:
 
   '@wordpress/dataviews@16.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
-      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
-      '@wordpress/base-styles': 10.0.1
+      '@wordpress/base-styles': 10.2.0
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/date': 5.48.1
-      '@wordpress/deprecated': 4.48.1
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
+      '@wordpress/deprecated': 4.50.0
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/ui': 0.15.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/warning': 3.48.1
+      '@wordpress/warning': 3.51.0
       clsx: 2.1.1
       colord: 2.9.3
       date-fns: 4.1.0
@@ -34410,7 +34415,7 @@ snapshots:
       '@wordpress/deprecated': 4.45.0
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.18.0
-      '@wordpress/icons': 13.0.0(react@18.3.1)
+      '@wordpress/icons': 13.0.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/keycodes': 4.45.0
       '@wordpress/primitives': 4.45.0(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
@@ -34453,7 +34458,7 @@ snapshots:
 
   '@wordpress/date@5.45.0':
     dependencies:
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/deprecated': 4.50.0
       moment: 2.30.1
       moment-timezone: 0.5.48
 
@@ -34758,11 +34763,11 @@ snapshots:
       '@wordpress/keycodes': 4.48.1
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/plugins': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/server-side-render': 6.20.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.48.1
@@ -34818,11 +34823,11 @@ snapshots:
       '@wordpress/keycodes': 4.48.1
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/plugins': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/server-side-render': 6.20.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.48.1
@@ -34878,11 +34883,11 @@ snapshots:
       '@wordpress/keycodes': 4.48.1
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/plugins': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
-      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/reusable-blocks': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/rich-text': 7.48.1(react@18.3.1)
       '@wordpress/server-side-render': 6.20.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.48.1
@@ -34954,7 +34959,7 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
-      '@wordpress/deprecated': 4.48.1
+      '@wordpress/deprecated': 4.50.0
       '@wordpress/escape-html': 3.48.1
       change-case: 4.1.2
       is-plain-object: 5.0.0
@@ -35201,7 +35206,7 @@ snapshots:
       '@wordpress/icons': 11.8.0(react@18.3.1)
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/router': 1.44.0(react@18.3.1)
@@ -35242,7 +35247,7 @@ snapshots:
       '@wordpress/icons': 11.8.0(react@18.3.1)
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/router': 1.44.0(react@18.3.1)
@@ -35283,7 +35288,7 @@ snapshots:
       '@wordpress/icons': 11.8.0(react@18.3.1)
       '@wordpress/media-utils': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.33.1(react@18.3.1)
-      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
+      '@wordpress/patterns': 2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/primitives': 4.48.1(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/router': 1.44.0(react@18.3.1)
@@ -35458,12 +35463,13 @@ snapshots:
       memize: 2.1.1
       tannin: 1.2.0
 
-  '@wordpress/icons@10.32.0(react@18.3.1)':
+  '@wordpress/icons@10.32.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/element': 6.45.0
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
     transitivePeerDependencies:
+      - '@types/react'
       - react
 
   '@wordpress/icons@10.6.0(react@18.3.1)':
@@ -35488,32 +35494,38 @@ snapshots:
       change-case: 4.1.2
       react: 18.3.1
 
-  '@wordpress/icons@12.2.0(react@18.3.1)':
+  '@wordpress/icons@12.2.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@wordpress/element': 6.45.0
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
-  '@wordpress/icons@13.0.0(react@18.3.1)':
+  '@wordpress/icons@13.0.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@wordpress/element': 6.45.0
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
-  '@wordpress/icons@13.3.0(react@18.3.1)':
+  '@wordpress/icons@13.3.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
-      '@wordpress/element': 8.0.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/icons@14.0.1(react@18.3.1)':
     dependencies:
       '@types/react': 18.3.28
-      '@wordpress/element': 8.0.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
 
@@ -35542,8 +35554,8 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       clsx: 2.1.1
       dequal: 2.0.3
       react: 18.3.1
@@ -35559,8 +35571,8 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       clsx: 2.1.1
       dequal: 2.0.3
       react: 18.3.1
@@ -35828,7 +35840,7 @@ snapshots:
 
   '@wordpress/keycodes@4.45.0':
     dependencies:
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
 
   '@wordpress/keycodes@4.48.1':
     dependencies:
@@ -35851,13 +35863,13 @@ snapshots:
       '@wordpress/components': 32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/core-data': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/date': 5.48.1
+      '@wordpress/date': 5.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/url': 4.48.1
       clsx: 2.1.1
       react: 18.3.1
@@ -35877,13 +35889,13 @@ snapshots:
       '@wordpress/components': 32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/core-data': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/date': 5.48.1
+      '@wordpress/date': 5.50.0
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/url': 4.48.1
       clsx: 2.1.1
       react: 18.3.1
@@ -35924,7 +35936,7 @@ snapshots:
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/media-fields': 0.9.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
@@ -35953,7 +35965,7 @@ snapshots:
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/media-fields': 0.9.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
@@ -35982,7 +35994,7 @@ snapshots:
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/media-fields': 0.9.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
@@ -36018,7 +36030,7 @@ snapshots:
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
     transitivePeerDependencies:
@@ -36033,7 +36045,7 @@ snapshots:
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
       '@wordpress/components': 35.0.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
     transitivePeerDependencies:
@@ -36109,7 +36121,7 @@ snapshots:
       - stylelint
       - supports-color
 
-  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
+  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 6.20.0
@@ -36122,7 +36134,7 @@ snapshots:
       '@wordpress/element': 6.45.0
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36131,12 +36143,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
+  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 6.20.0
@@ -36149,7 +36162,7 @@ snapshots:
       '@wordpress/element': 6.45.0
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36158,12 +36171,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
+  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 6.20.0
@@ -36176,7 +36190,7 @@ snapshots:
       '@wordpress/element': 6.45.0
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36185,12 +36199,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
+  '@wordpress/patterns@2.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@wordpress/a11y': 4.48.1
       '@wordpress/base-styles': 6.20.0
@@ -36203,7 +36218,7 @@ snapshots:
       '@wordpress/element': 6.45.0
       '@wordpress/html-entities': 4.48.1
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36212,6 +36227,7 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
@@ -36500,7 +36516,7 @@ snapshots:
   '@wordpress/react-i18n@4.44.0':
     dependencies:
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/i18n': 6.23.0
       utility-types: 3.10.0
 
   '@wordpress/redux-routine@4.58.0(redux@4.2.1)':
@@ -36548,7 +36564,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
+  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
@@ -36558,7 +36574,7 @@ snapshots:
       '@wordpress/data': 10.48.1(react@18.3.1)
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36567,12 +36583,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
+  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -36582,7 +36599,7 @@ snapshots:
       '@wordpress/data': 10.48.1(react@18.3.1)
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36591,12 +36608,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
+  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
@@ -36606,7 +36624,7 @@ snapshots:
       '@wordpress/data': 10.48.1(react@18.3.1)
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36615,12 +36633,13 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
       - supports-color
 
-  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
+  '@wordpress/reusable-blocks@5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/block-editor': 15.21.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -36630,7 +36649,7 @@ snapshots:
       '@wordpress/data': 10.48.1(react@18.3.1)
       '@wordpress/element': 6.45.0
       '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/notices': 5.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -36639,6 +36658,7 @@ snapshots:
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
+      - '@types/react'
       - '@types/react-dom'
       - date-fns
       - stylelint
@@ -37500,7 +37520,7 @@ snapshots:
   '@wordpress/theme@0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@types/react': 18.3.28
-      '@wordpress/element': 8.0.1
+      '@wordpress/element': 8.2.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       colorjs.io: 0.6.1
@@ -37513,7 +37533,7 @@ snapshots:
   '@wordpress/theme@0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@types/react': 18.3.28
-      '@wordpress/element': 8.0.1
+      '@wordpress/element': 8.2.0
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       colorjs.io: 0.6.1
@@ -37584,10 +37604,10 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       clsx: 2.1.1
@@ -37606,10 +37626,10 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       clsx: 2.1.1
@@ -37628,10 +37648,10 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       clsx: 2.1.1
@@ -37650,10 +37670,10 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/theme': 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       clsx: 2.1.1
@@ -37672,10 +37692,10 @@ snapshots:
       '@wordpress/a11y': 4.48.1
       '@wordpress/compose': 7.45.0(react@18.3.1)
       '@wordpress/element': 6.45.0
-      '@wordpress/i18n': 6.21.1
-      '@wordpress/icons': 13.3.0(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/i18n': 6.23.0
+      '@wordpress/icons': 13.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/theme': 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       clsx: 2.1.1
@@ -37693,12 +37713,12 @@ snapshots:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/theme': 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
@@ -37716,12 +37736,12 @@ snapshots:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/theme': 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -37739,12 +37759,12 @@ snapshots:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/theme': 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
@@ -37762,12 +37782,12 @@ snapshots:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@wordpress/a11y': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/icons': 14.0.1(react@18.3.1)
-      '@wordpress/keycodes': 4.48.1
-      '@wordpress/primitives': 4.48.1(react@18.3.1)
+      '@wordpress/keycodes': 4.50.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/style-runtime': 0.4.1
       '@wordpress/theme': 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
@@ -37999,10 +38019,10 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/blob': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -38020,10 +38040,10 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
       '@wordpress/blob': 4.48.1
-      '@wordpress/compose': 8.1.1(react@18.3.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
-      '@wordpress/element': 8.0.1
-      '@wordpress/i18n': 6.21.1
+      '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 8.2.0
+      '@wordpress/i18n': 6.23.0
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/private-apis': 1.48.1
       '@wordpress/url': 4.48.1
@@ -38076,7 +38096,7 @@ snapshots:
   '@wordpress/views@1.11.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)':
     dependencies:
       '@wordpress/core-data': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
       '@wordpress/element': 6.45.0
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
@@ -38096,7 +38116,7 @@ snapshots:
   '@wordpress/views@1.11.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))':
     dependencies:
       '@wordpress/core-data': 7.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(date-fns@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
-      '@wordpress/data': 10.48.1(react@18.3.1)
+      '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/dataviews': 14.2.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))
       '@wordpress/element': 6.45.0
       '@wordpress/preferences': 4.48.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.7.3))


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Converges the Settings UI renderer on DataForm from `@wordpress/dataviews` (WOOPRD-3571). Supersedes the two spike drafts #66686 and #66693, combining what each proved.

The Settings UI rendered each field itself and gave extensions a bespoke component contract, so the extension settings renderer was a parallel implementation of a WordPress primitive with a Woo-only API. This PR makes DataForm the renderer and the DataForm control contract the extension contract.

- Add a `dataform-adapter` that builds one DataForm field per settings field from a per-type descriptor table: explicit `getValue`/`setValue`, visibility rules and registry predicates compiled into `isVisible`, and value vocabulary preserved at the boundary (checkbox values round-trip in their saved representation, select values map back to the original option value type, number values present as numbers to the package and save back in their original representation, boolean visibility rules match any checkbox vocabulary).
- Align the checkbox "checked" vocabulary with `wc_string_to_bool()` and share it between the adapter, the native renderer, and the hidden-input serializer. The three sites disagreed, so a value PHP considers true (numeric `1`) could render checked but serialize as `no` on an untouched save.
- Fold in the value-handling fixes from #66561, which this PR supersedes: numeric option values match in the native select, the badge intent lookup ignores `Object.prototype` keys, and the values state preserves the schema's value representation when controls emit equivalent values (a numeric initial no longer turns into a string, and an emptied token field no longer leaves the form dirty forever over an empty-string initial).
- Render groups through the package's non-collapsible card layout, batched in schema order as the package recommends. Group descriptions render through the card body's description slot. Groups with header actions keep the shell-owned card, because the package card header has no slot for them.
- Use the package controls for supported field types: text family, textarea, select, checkbox, radio, number, and the token field for multiselects. Radio fields rendered as selects before and multiselects were raw `<select multiple>` elements; both now use the proper controls.
- Keep the existing renderer as the internal path for what the package controls cannot express: `disabled` state, custom input attributes (including number `min`/`max`/`step`), `time` inputs, and unknown field types.
- Rework the extension component contract to DataForm's: registered components receive `DataFormControlProps`, re-exported as `SettingsEditControlProps` so dataviews type churn is absorbed at the alias, with page-level state on the new `useSettingsUIContext()` hook. This is a hard switch with no dual-shape compatibility.
- Wire `useFormValidity` to gate the Save button and save-before-navigation. Only visible fields validate, so a hidden required field can never block saving. Rules flow through an internal adapter option until the public validation schema is agreed; no public validation surface ships here.
- Pin `@wordpress/dataviews` to exactly 10.3.0 inside `@woocommerce/settings-ui` (the first version with non-collapsible cards) instead of raising the shared wp-bundled catalog. The newer copy bundles into the settings-ui asset only; the email listing and offline payments surfaces keep the catalog version. Same exact-pin rationale as `@wordpress/ui`.
- Mark the Settings UI docs experimental and document the new component contract.

**Backward compatibility:** this intentionally breaks the experimental extension contract. `SettingsFieldComponentProps` and the `NativeSettingsField` export are removed, and registered components now receive the DataForm control props. The feature is behind the default-off `settings-ui` feature flag, shipped only in that state, and the docs now carry an experimental banner. Known integrations built against the old contract (Square, Subscriptions) need a mechanical update; that heads-up is being handled separately. The PHP API, schema shape, save flow, hooks, and everything outside the flag are unchanged.

**Visual changes** (all behind the flag): supported fields move from the `@wordpress/ui` skins to the DataForm controls. Selects become native dropdowns instead of popup listboxes, text inputs and cards pick up the `@wordpress/components` skin, number fields without custom attributes lose the spin buttons, and radio/multiselect fields gain proper controls. Group descriptions move from the card header block to the top of the card body, which is where the package renders them. The deliberate call is convergence first; pixel fidelity returns when `@wordpress/ui` ships DataForm controls. Shell header behaviors and the page structure are unchanged.

**Needs sign-off:** the full install re-resolve moves transitive `@wordpress/i18n` from 6.21.1 to 6.23.0 across shared lockfile snapshot groups. Flagged rather than shipped silently.

**Supersedes:** #66561 (closed in favor of this PR). Its three fixes are folded in as separate commits, adapted to the adapter boundary where that is now the right place, with its tests ported. The earlier #66232 checkbox vocabulary work is also covered by the shared `isCheckedValue`.

**Bundle:** the settings-ui asset grows from 424 KB to 511 KB minified with the bundled DataForm slice.

**Known notes:**

- The package radio and token field controls emit a dev-only React key warning from their internals.
- The package card title and the shell card title render slightly differently; the shell card remains for groups with header actions, so both appear until the upstream card header gains an actions slot.

### Screenshots or screen recordings:

(To be added: trunk vs branch Products comparison, the radio/token/info section, both card styles.)

### How to test the changes in this Pull Request:

**Happy path**

1. Enable the `settings-ui` feature flag (WooCommerce Beta Tester's Features screen, or the `woocommerce_admin_features` filter).
2. Build the admin client: `pnpm --filter=@woocommerce/admin-library build:project:bundle`.
3. Go to **WooCommerce > Settings > Products**. Groups render as non-collapsible cards with the DataForm controls: native selects, checkboxes, and a text input, with descriptions and links intact.
4. Change the weight unit and check the Save button enables. Save, and check the value persists and the button disables again.
5. With unsaved changes, click another section link and check the save/discard prompt appears, and that Discard and Save both work.

**Radio, multiselect, and info fields**

6. Register a settings section containing `radio`, `multiselect`, and `info` fields (snippet below).
7. Check the radio field renders as radio buttons, the multiselect renders as a token field with saved values as chips, and the info field renders its HTML including links.
8. Change the radio selection, remove a token, and change the payment window number, save, and check all three persist.

<details>
<summary>Test section snippet (mu-plugin)</summary>

```php
<?php
add_action( 'init', function () {
	if ( ! class_exists( \Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry::class ) ) {
		return;
	}
	$section = new class() extends \Automattic\WooCommerce\Admin\Settings\SettingsSection {
		public function get_parent_page_id(): string { return 'checkout'; }
		public function get_id(): string { return 'dataform_smoke'; }
		public function get_label(): string { return 'DataForm Smoke'; }
		public function get_settings( \WC_Settings_Page $parent_page ): array {
			return array(
				array( 'type' => 'title', 'id' => 'df_smoke_section', 'title' => 'Field type coverage' ),
				array( 'type' => 'info', 'id' => 'df_smoke_info', 'title' => 'Heads up', 'text' => '<p>This is an <strong>info</strong> field with <a href="https://woocommerce.com">a link</a>.</p>' ),
				array( 'id' => 'df_smoke_capture', 'type' => 'radio', 'title' => 'Capture behavior', 'options' => array( 'immediate' => 'Capture immediately', 'manual' => 'Authorize only' ), 'default' => 'immediate' ),
				array( 'id' => 'df_smoke_methods', 'type' => 'multiselect', 'title' => 'Enabled card networks', 'options' => array( 'visa' => 'Visa', 'mc' => 'Mastercard', 'amex' => 'American Express' ), 'default' => array( 'visa', 'mc' ) ),
				array( 'id' => 'df_smoke_window', 'type' => 'number', 'title' => 'Payment window (minutes)', 'default' => '30' ),
				array( 'type' => 'sectionend', 'id' => 'df_smoke_section' ),
			);
		}
	};
	\Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry::get_instance()->register( $section );
} );
```

</details>

**Regression: flag off**

9. Disable the feature flag and reload the settings pages. The classic PHP-rendered screens should be unchanged.

### Testing that has already taken place:

- The package Jest suite passes: 102 tests across 9 suites, including adapter tests for control mapping, value round-trips, visibility, render-section batching, the fallback rules, validation form visibility filtering, the DataForm control contract for registered components, and the value tests ported from #66561.
- Typecheck and ESLint pass.
- Smoke tested on a local store with the flag enabled: Products renders as batched package cards with no collapse chevrons, the weight unit save round-trip persists through the classic form POST, a test section with radio/multiselect/info fields renders through the package controls and persists radio and token changes, the unsaved-changes dialog blocks navigation with working Discard, and an extension settings tab renders unchanged.
- Smoke tested a drill-down section with group descriptions and a number field: all groups batch into one DataForm with descriptions rendered by the package card, the number input carries no validity error at rest, and a save round-trip persists a checkbox toggle and keeps the number's saved string representation.
- With the flag disabled, the classic settings screens are unchanged.
- No new console errors; the only warning on the Products page is a pre-existing `useSelect` notice unrelated to this change.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

A changelog entry is included in the PR (`packages/js/settings-ui/changelog/update-dataform-renderer`).

Refs WOOPRD-3571.
