### PR TITLE
Fix singular product brand label in block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-51569-dynamic-brand-label
+++ b/plugins/woocommerce/changelog/fix-51569-dynamic-brand-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use a singular Brand label for products with one brand in block themes.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1);
+declare( strict_types = 1 );
 
 use Automattic\Jetpack\Constants;
 
@@ -12,6 +12,11 @@ use Automattic\Jetpack\Constants;
  * @version 9.5.0
  */
 class WC_Brands {
+
+	/**
+	 * Class name used to identify the managed product brand terms block.
+	 */
+	private const PRODUCT_BRAND_BLOCK_CLASS_NAME = 'wc-block-product-brand-terms';
 
 	/**
 	 * Template URL -- filterable.
@@ -64,10 +69,14 @@ class WC_Brands {
 		// REST API.
 		add_action( 'rest_api_init', array( $this, 'rest_api_register_routes' ) );
 		add_action( 'woocommerce_rest_insert_product', array( $this, 'rest_api_maybe_set_brands' ), 10, 2 );
-		add_filter( 'woocommerce_rest_prepare_product', array( $this, 'rest_api_prepare_brands_to_product' ), 10, 2 ); // WC 2.6.x.
-		add_filter( 'woocommerce_rest_prepare_product_object', array( $this, 'rest_api_prepare_brands_to_product' ), 10, 2 ); // WC 3.x.
-		add_action( 'woocommerce_rest_insert_product', array( $this, 'rest_api_add_brands_to_product' ), 10, 3 ); // WC 2.6.x.
-		add_action( 'woocommerce_rest_insert_product_object', array( $this, 'rest_api_add_brands_to_product' ), 10, 3 ); // WC 3.x.
+		// WC 2.6.x.
+		add_filter( 'woocommerce_rest_prepare_product', array( $this, 'rest_api_prepare_brands_to_product' ), 10, 2 );
+		// WC 3.x.
+		add_filter( 'woocommerce_rest_prepare_product_object', array( $this, 'rest_api_prepare_brands_to_product' ), 10, 2 );
+		// WC 2.6.x.
+		add_action( 'woocommerce_rest_insert_product', array( $this, 'rest_api_add_brands_to_product' ), 10, 3 );
+		// WC 3.x.
+		add_action( 'woocommerce_rest_insert_product_object', array( $this, 'rest_api_add_brands_to_product' ), 10, 3 );
 		add_filter( 'woocommerce_rest_product_object_query', array( $this, 'rest_api_filter_products_by_brand' ), 10, 2 );
 		add_filter( 'rest_product_collection_params', array( $this, 'rest_api_product_collection_params' ), 10, 2 );
 
@@ -81,6 +90,7 @@ class WC_Brands {
 		// Block theme integration.
 		add_filter( 'hooked_block_types', array( $this, 'hook_product_brand_block' ), 10, 4 );
 		add_filter( 'hooked_block_core/post-terms', array( $this, 'configure_product_brand_block' ), 10, 5 );
+		add_filter( 'render_block_data', array( $this, 'handle_render_block_data' ), 10, 3 );
 	}
 
 	/**
@@ -1100,7 +1110,7 @@ class WC_Brands {
 	 * Hooks the product brand terms block into single product templates.
 	 *
 	 * @param array $hooked_block_types The array of hooked block types.
-	 * @param int $relative_position The relative position of the hooked block.
+	 * @param string $relative_position The relative position of the hooked block.
 	 * @param string $anchor_block_type The type of anchor block.
 	 * @param WP_Block_Template $context The context of the block.
 	 *
@@ -1114,13 +1124,13 @@ class WC_Brands {
 			 $context instanceof WP_Block_Template &&
 			 'single-product' === $context->slug ) {
 
-				remove_action( 'woocommerce_product_meta_end', array( $this, 'show_brand' ) );
+			remove_action( 'woocommerce_product_meta_end', array( $this, 'show_brand' ) );
 
-				// Check if the template already has a product brand block
-				if ( ! $this->template_already_has_brand_block( $context ) ) {
-					// Simply add the core/post-terms block type
-					$hooked_block_types[] = 'core/post-terms';
-				}
+			// Check if the template already has a product brand block
+			if ( ! $this->template_already_has_brand_block( $context ) ) {
+				// Simply add the core/post-terms block type
+				$hooked_block_types[] = 'core/post-terms';
+			}
 		}
 
 		return $hooked_block_types;
@@ -1146,7 +1156,7 @@ class WC_Brands {
 	 *
 	 * @param array $parsed_hooked_block The parsed hooked block.
 	 * @param string $hooked_block_type The type of hooked block.
-	 * @param int $relative_position The relative position of the hooked block.
+	 * @param string $relative_position The relative position of the hooked block.
 	 * @param array $parsed_anchor_block The parsed anchor block.
 	 * @param WP_Block_Template $context The context of the block.
 	 *
@@ -1163,12 +1173,51 @@ class WC_Brands {
 			 empty( $parsed_anchor_block['attrs'] ) ) {
 
 			$parsed_hooked_block['attrs'] = array(
-				'term'	 => 'product_brand',
-				'prefix' => __( 'Brands: ', 'woocommerce' ),
+				'term'      => 'product_brand',
+				'prefix'    => __( 'Brands: ', 'woocommerce' ),
+				'className' => self::PRODUCT_BRAND_BLOCK_CLASS_NAME,
 			);
 		}
 
 		return $parsed_hooked_block;
+	}
+
+	/**
+	 * Set the managed product brand block prefix from its product context.
+	 *
+	 * @internal
+	 *
+	 * @param array         $parsed_block The block being rendered.
+	 * @param array         $source_block The unmodified source block.
+	 * @param WP_Block|null $parent_block The parent block, if available.
+	 * @return array The block to render.
+	 */
+	public function handle_render_block_data( $parsed_block, $source_block, $parent_block ) {
+		unset( $source_block );
+
+		if ( 'core/post-terms' !== ( $parsed_block['blockName'] ?? null ) ||
+			'product_brand' !== ( $parsed_block['attrs']['term'] ?? null ) ) {
+			return $parsed_block;
+		}
+
+		$class_names = (array) preg_split( '/\s+/', trim( (string) ( $parsed_block['attrs']['className'] ?? '' ) ) );
+		if ( ! in_array( self::PRODUCT_BRAND_BLOCK_CLASS_NAME, $class_names, true ) || ! ( $parent_block instanceof WP_Block ) ) {
+			return $parsed_block;
+		}
+
+		$post_id = absint( $parent_block->context['postId'] ?? 0 );
+		if ( ! $post_id ) {
+			return $parsed_block;
+		}
+
+		$brand_terms = get_the_terms( $post_id, 'product_brand' );
+		if ( ! is_array( $brand_terms ) ) {
+			return $parsed_block;
+		}
+
+		$parsed_block['attrs']['prefix'] = _n( 'Brand: ', 'Brands: ', count( $brand_terms ), 'woocommerce' );
+
+		return $parsed_block;
 	}
 }
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-brands-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-brands-test.php
@@ -5,12 +5,29 @@
  * @package woocommerce-brands
  */
 
-declare( strict_types = 1);
+declare( strict_types = 1 );
 
 /**
  * WC Brands test
  */
 class WC_Brands_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Brands
+	 */
+	private $sut;
+
+	/**
+	 * Set up test data.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WC_Brands::init_taxonomy();
+		$this->sut = $GLOBALS['WC_Brands'];
+	}
 
 	/**
 	 * Tear down test data.
@@ -21,6 +38,36 @@ class WC_Brands_Test extends WC_Unit_Test_Case {
 		// Clear term cache to prevent interference between tests.
 		clean_term_cache( array(), 'product_brand' );
 	}
+
+	/**
+	 * @testdox Should render a singular label for one brand in the managed product brand block.
+	 */
+	public function test_managed_product_brand_block_renders_singular_label(): void {
+		$output = $this->render_product_brand_block( array( 'First brand' ) );
+
+		$this->assertStringContainsString( 'Brand: ', $output );
+		$this->assertStringNotContainsString( 'Brands: ', $output );
+	}
+
+	/**
+	 * @testdox Should render a plural label for multiple brands in the managed product brand block.
+	 */
+	public function test_managed_product_brand_block_renders_plural_label(): void {
+		$output = $this->render_product_brand_block( array( 'First brand', 'Second brand' ) );
+
+		$this->assertStringContainsString( 'Brands: ', $output );
+	}
+
+	/**
+	 * @testdox Should preserve the prefix on a merchant-authored product brand block.
+	 */
+	public function test_custom_product_brand_block_preserves_prefix(): void {
+		$output = $this->render_product_brand_block( array( 'First brand' ), 'Maker: ', false );
+
+		$this->assertStringContainsString( 'Maker: ', $output );
+		$this->assertStringNotContainsString( 'Brand: ', $output );
+	}
+
 	/**
 	 * Test that `product_brand_thumbnails` shortcode's `show_empty` argument works as expected.
 	 * This test prevents regression of the issue where double filtering caused no brands to be displayed.
@@ -219,6 +266,70 @@ class WC_Brands_Test extends WC_Unit_Test_Case {
 
 		// Reset the setting.
 		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );
+	}
+
+	/**
+	 * Render a product brand terms block for a product with the supplied brands.
+	 *
+	 * @param string[] $brand_names Brand names to assign to the product.
+	 * @param string   $prefix      Prefix for a merchant-authored block.
+	 * @param bool     $is_managed  Whether to configure the WooCommerce-managed block.
+	 * @return string Rendered block output.
+	 */
+	private function render_product_brand_block( array $brand_names, string $prefix = 'Brands: ', bool $is_managed = true ): string {
+		$product   = WC_Helper_Product::create_simple_product();
+		$brand_ids = array();
+
+		foreach ( $brand_names as $brand_name ) {
+			$brand_ids[] = self::factory()->term->create(
+				array(
+					'name'     => $brand_name,
+					'taxonomy' => 'product_brand',
+				)
+			);
+		}
+
+		wp_set_object_terms( $product->get_id(), $brand_ids, 'product_brand' );
+
+		$brand_block = array(
+			'blockName'    => 'core/post-terms',
+			'attrs'        => array(
+				'term'   => 'product_brand',
+				'prefix' => $prefix,
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
+
+		if ( $is_managed ) {
+			$brand_block = $this->sut->configure_product_brand_block(
+				$brand_block,
+				'core/post-terms',
+				'last_child',
+				array(
+					'blockName' => 'woocommerce/product-meta',
+					'attrs'     => array(),
+				),
+				null
+			);
+		}
+
+		$product_meta_block = new WP_Block(
+			array(
+				'blockName'    => 'woocommerce/product-meta',
+				'attrs'        => array(),
+				'innerBlocks'  => array( $brand_block ),
+				'innerHTML'    => '',
+				'innerContent' => array( null ),
+			),
+			array(
+				'postId'   => $product->get_id(),
+				'postType' => 'product',
+			)
+		);
+
+		return $product_meta_block->render();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

WooCommerce-managed Product Brand blocks in block-theme single-product templates always used the plural `Brands:` prefix. This marks managed blocks and selects `Brand:` or `Brands:` at render time from the assigned-term count while preserving merchant-authored prefixes. The callback uses block product context instead of front-end globals, and no public signatures or hooks change; multisite was not tested separately.

Closes #51569.

Bug introduced in PR #55936.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use a block theme and create a product with one assigned brand.
2. View the product on the front end and confirm its Product Brand block starts with `Brand:`.
3. Assign a second brand, refresh the product, and confirm the prefix changes to `Brands:`.
4. Add a separate Post Terms block for Product Brand with a custom prefix such as `Maker:` and confirm that custom prefix remains unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `WC_Brands_Test`: 12 tests, 29 assertions passed on PHP 8.3.28 with WordPress 7.0.1.
- PHPCS passed for the changed PHP files.
- PHPStan passed for `includes/class-wc-brands.php`.
- Both changed-file PHP lint and branch-wide lint passed.
- WooCommerce code review found no correctness, security, performance, compatibility, or coding-standard issues.
- Multisite was not tested. The change only reads taxonomy terms for the contextual product and does not alter site or network storage.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
