### PR TITLE
Correct Zambian kwacha currency symbol

### DIFF
--- a/docs/apis/rest-api/v2/setting-options.mdx
+++ b/docs/apis/rest-api/v2/setting-options.mdx
@@ -1278,7 +1278,7 @@ woocommerce.get("settings/general").parsed_response
       "XPF": "CFP franc (Fr)",
       "YER": "Yemeni rial (&#xfdfc;)",
       "ZAR": "South African rand (&#82;)",
-      "ZMW": "Zambian kwacha (ZK)"
+      "ZMW": "Zambian kwacha (K)"
     },
     "tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
     "value": "USD",
@@ -1916,7 +1916,7 @@ woocommerce.post("products/22/settings/general/batch", data).parsed_response
         "XPF": "CFP franc (Fr)",
         "YER": "Yemeni rial (&#xfdfc;)",
         "ZAR": "South African rand (&#82;)",
-        "ZMW": "Zambian kwacha (ZK)"
+        "ZMW": "Zambian kwacha (K)"
       },
       "tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
       "value": "GBP",

--- a/docs/apis/rest-api/v3/setting-options.mdx
+++ b/docs/apis/rest-api/v3/setting-options.mdx
@@ -1284,7 +1284,7 @@ woocommerce.get("settings/general").parsed_response
 			"XPF": "CFP franc (Fr)",
 			"YER": "Yemeni rial (&#xfdfc;)",
 			"ZAR": "South African rand (&#82;)",
-			"ZMW": "Zambian kwacha (ZK)"
+			"ZMW": "Zambian kwacha (K)"
 		},
 		"tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
 		"value": "USD",
@@ -1923,7 +1923,7 @@ woocommerce.post("products/22/settings/general/batch", data).parsed_response
 				"XPF": "CFP franc (Fr)",
 				"YER": "Yemeni rial (&#xfdfc;)",
 				"ZAR": "South African rand (&#82;)",
-				"ZMW": "Zambian kwacha (ZK)"
+				"ZMW": "Zambian kwacha (K)"
 			},
 			"tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
 			"value": "GBP",

--- a/plugins/woocommerce/changelog/fix-40931-zambian-kwacha-symbol
+++ b/plugins/woocommerce/changelog/fix-40931-zambian-kwacha-symbol
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct the Zambian kwacha currency symbol from ZK to K. This changes the public symbol returned by currency APIs and the symbol recognized when saving flat-rate shipping costs.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -696,7 +696,8 @@ function get_woocommerce_currency_symbols() {
 			'XPF' => 'XPF',
 			'YER' => '&#xfdfc;',
 			'ZAR' => '&#82;',
-			'ZMW' => 'ZK',
+			// CLDR uses K for en-ZM and ZK for its narrow representation.
+			'ZMW' => 'K',
 		)
 	);
 

--- a/plugins/woocommerce/tests/e2e/data/settings.ts
+++ b/plugins/woocommerce/tests/e2e/data/settings.ts
@@ -169,7 +169,7 @@ export const currencies = {
 	XPF: 'CFP franc (XPF) — XPF',
 	YER: 'Yemeni rial (&#xfdfc;) — YER',
 	ZAR: 'South African rand (&#82;) — ZAR',
-	ZMW: 'Zambian kwacha (ZK) — ZMW',
+	ZMW: 'Zambian kwacha (K) — ZMW',
 };
 
 export const externalCurrencies = {
@@ -334,7 +334,7 @@ export const externalCurrencies = {
 	XPF: 'CFP franc (Fr)',
 	YER: 'Yemeni rial (&#xfdfc;)',
 	ZAR: 'South African rand (&#82;)',
-	ZMW: 'Zambian kwacha (ZK)',
+	ZMW: 'Zambian kwacha (K)',
 };
 
 export const stateOptions = {

--- a/plugins/woocommerce/tests/e2e/tests/api-tests/data/data-crud.test.ts
+++ b/plugins/woocommerce/tests/e2e/tests/api-tests/data/data-crud.test.ts
@@ -8263,7 +8263,7 @@ test.describe( 'Data API tests', () => {
 				expect.objectContaining( {
 					code: 'ZMW',
 					name: 'Zambian kwacha',
-					symbol: 'ZK',
+					symbol: 'K',
 					_links: {
 						self: [
 							{

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -229,6 +229,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		// Given specific currency.
 		$this->assertEquals( '&pound;', get_woocommerce_currency_symbol( 'GBP' ) );
 		$this->assertEquals( 'MOP&#36;', get_woocommerce_currency_symbol( 'MOP' ) );
+		$this->assertSame( 'K', get_woocommerce_currency_symbol( 'ZMW' ), 'The Zambian kwacha should use its local display symbol.' );
 
 		// Each case.
 		foreach ( array_keys( get_woocommerce_currencies() ) as $currency_code ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Use `K` as the Zambian kwacha display symbol instead of the narrow `ZK` form. `ZMW` remains the currency code.

CLDR's Zambia locale uses `K` as the standard symbol and `ZK` as the narrow form. This updates settings labels, currency APIs, docs, and tests.

Backward compatibility: public symbol outputs now return `K` instead of `ZK`. Newly saved flat-rate shipping costs recognize `K` instead of `ZK`. The existing currency-symbol filters remain available for overrides.

The incorrect mapping was introduced in commit [`71aa29d`](https://github.com/woocommerce/woocommerce/commit/71aa29d).

Closes #40931.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| `Zambian kwacha (ZK) — ZMW` | `Zambian kwacha (K) — ZMW` |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to **WooCommerce > Settings > General** and open the **Currency** selector.
2. Confirm the option reads `Zambian kwacha (K) — ZMW`.
3. Request `/wp-json/wc/v3/data/currencies/ZMW` and confirm `symbol` is `K`.
4. With `ZMW` selected, save `K 10` as a flat-rate shipping cost and confirm it saves without an error.

<!-- End testing instructions -->

### Testing that has already taken place:

- PHP syntax checks for the modified PHP files.
- `git diff --check`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Correct the Zambian kwacha currency symbol from ZK to K.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

A changelog entry was created manually at `plugins/woocommerce/changelog/fix-40931-zambian-kwacha-symbol`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
