### PR TITLE
Fix Quick Edit keeping expired sale dates when prices change

### DIFF
--- a/plugins/woocommerce/changelog/fix-66718-quick-edit-expired-sale-dates
+++ b/plugins/woocommerce/changelog/fix-66718-quick-edit-expired-sale-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear expired scheduled sale dates during Quick Edit so a new sale price takes effect immediately.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -465,11 +465,13 @@ class WC_Admin_Post_Types {
 				$product->set_sale_price( $new_sale_price );
 			}
 
-			$regular_price = $product->get_regular_price( 'edit' );
-			$sale_price    = $product->get_sale_price( 'edit' );
-			$price_changed = $regular_price !== $old_regular_price || $sale_price !== $old_sale_price;
+			$regular_price  = $product->get_regular_price( 'edit' );
+			$sale_price     = $product->get_sale_price( 'edit' );
+			$price_changed  = $regular_price !== $old_regular_price || $sale_price !== $old_sale_price;
+			$sale_date_to   = $product->get_date_on_sale_to( 'edit' );
+			$sale_has_ended = $sale_date_to && $sale_date_to->getTimestamp() < time();
 
-			if ( $price_changed && ( '' === $sale_price || $sale_price >= $regular_price ) ) {
+			if ( $price_changed && ( '' === $sale_price || $sale_price >= $regular_price || $sale_has_ended ) ) {
 				$product->set_date_on_sale_to( '' );
 				$product->set_date_on_sale_from( '' );
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -452,8 +452,8 @@ class WC_Admin_Post_Types {
 		if ( $product->is_type( ProductType::SIMPLE ) || $product->is_type( ProductType::EXTERNAL ) ) {
 			// The Quick Edit form is prefilled with view-context (filtered) prices, so detecting
 			// an actual edit requires comparing the submission against those same values.
-			$old_regular_price = wc_format_decimal( $product->get_regular_price() );
-			$old_sale_price    = wc_format_decimal( $product->get_sale_price() );
+			$old_regular_price = $this->normalize_price_for_comparison( $product->get_regular_price() );
+			$old_sale_price    = $this->normalize_price_for_comparison( $product->get_sale_price() );
 
 			if ( isset( $request_data['_regular_price'] ) ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
@@ -471,8 +471,8 @@ class WC_Admin_Post_Types {
 			$sale_price    = $product->get_sale_price( 'edit' );
 
 			// Only a submitted field can be a changed field.
-			$regular_price_changed = isset( $request_data['_regular_price'] ) && wc_format_decimal( $regular_price ) !== $old_regular_price;
-			$sale_price_changed    = isset( $request_data['_sale_price'] ) && wc_format_decimal( $sale_price ) !== $old_sale_price;
+			$regular_price_changed = isset( $request_data['_regular_price'] ) && $this->normalize_price_for_comparison( $regular_price ) !== $old_regular_price;
+			$sale_price_changed    = isset( $request_data['_sale_price'] ) && $this->normalize_price_for_comparison( $sale_price ) !== $old_sale_price;
 
 			$price_changed  = $regular_price_changed || $sale_price_changed;
 			$sale_date_to   = $product->get_date_on_sale_to( 'edit' );
@@ -517,6 +517,20 @@ class WC_Admin_Post_Types {
 		$product->save();
 
 		do_action( 'woocommerce_product_quick_edit_save', $product );
+	}
+
+	/**
+	 * Normalize a price value for change detection during Quick Edit.
+	 *
+	 * View-context prices pass through the woocommerce_product_get_regular_price and
+	 * woocommerce_product_get_sale_price filters, which may return non-scalar values
+	 * or differently formatted numbers.
+	 *
+	 * @param mixed $price Raw price value.
+	 * @return string Normalized price string.
+	 */
+	private function normalize_price_for_comparison( $price ): string {
+		return wc_format_decimal( is_scalar( $price ) ? (string) $price : '', false, true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -467,9 +467,14 @@ class WC_Admin_Post_Types {
 				$product->set_sale_price( $new_sale_price );
 			}
 
-			$regular_price  = $product->get_regular_price( 'edit' );
-			$sale_price     = $product->get_sale_price( 'edit' );
-			$price_changed  = wc_format_decimal( $regular_price ) !== $old_regular_price || wc_format_decimal( $sale_price ) !== $old_sale_price;
+			$regular_price = $product->get_regular_price( 'edit' );
+			$sale_price    = $product->get_sale_price( 'edit' );
+
+			// Only a submitted field can be a changed field.
+			$regular_price_changed = isset( $request_data['_regular_price'] ) && wc_format_decimal( $regular_price ) !== $old_regular_price;
+			$sale_price_changed    = isset( $request_data['_sale_price'] ) && wc_format_decimal( $sale_price ) !== $old_sale_price;
+
+			$price_changed  = $regular_price_changed || $sale_price_changed;
 			$sale_date_to   = $product->get_date_on_sale_to( 'edit' );
 			$sale_has_ended = $sale_date_to && $sale_date_to->getTimestamp() < time();
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -450,8 +450,10 @@ class WC_Admin_Post_Types {
 		$product->set_featured( isset( $request_data['_featured'] ) );
 
 		if ( $product->is_type( ProductType::SIMPLE ) || $product->is_type( ProductType::EXTERNAL ) ) {
-			$old_regular_price = $product->get_regular_price( 'edit' );
-			$old_sale_price    = $product->get_sale_price( 'edit' );
+			// The Quick Edit form is prefilled with view-context (filtered) prices, so detecting
+			// an actual edit requires comparing the submission against those same values.
+			$old_regular_price = wc_format_decimal( $product->get_regular_price() );
+			$old_sale_price    = wc_format_decimal( $product->get_sale_price() );
 
 			if ( isset( $request_data['_regular_price'] ) ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
@@ -467,7 +469,7 @@ class WC_Admin_Post_Types {
 
 			$regular_price  = $product->get_regular_price( 'edit' );
 			$sale_price     = $product->get_sale_price( 'edit' );
-			$price_changed  = $regular_price !== $old_regular_price || $sale_price !== $old_sale_price;
+			$price_changed  = wc_format_decimal( $regular_price ) !== $old_regular_price || wc_format_decimal( $sale_price ) !== $old_sale_price;
 			$sale_date_to   = $product->get_date_on_sale_to( 'edit' );
 			$sale_has_ended = $sale_date_to && $sale_date_to->getTimestamp() < time();
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -138,6 +138,42 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Quick Edit clears expired sale dates when prices change so the new sale takes effect.
+	 * @dataProvider expired_schedule_price_changes_provider
+	 *
+	 * @param string $new_regular_price New regular price.
+	 * @param string $new_sale_price New sale price.
+	 */
+	public function test_quick_edit_clears_expired_sale_dates_when_prices_change( string $new_regular_price, string $new_sale_price ): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$product->set_regular_price( '100' );
+		$product->set_sale_price( '80' );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->save();
+
+		$_REQUEST = array(
+			'woocommerce_quick_edit'       => '1',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'_regular_price'               => $new_regular_price,
+			'_sale_price'                  => $new_sale_price,
+			'_stock_status'                => 'instock',
+		);
+
+		$this->sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( $new_regular_price, $updated_product->get_regular_price( 'edit' ), 'Quick Edit should persist the regular price.' );
+		$this->assertSame( $new_sale_price, $updated_product->get_sale_price( 'edit' ), 'Quick Edit should persist the sale price.' );
+		$this->assertNull( $updated_product->get_date_on_sale_from( 'edit' ), 'Quick Edit should clear the expired sale start date.' );
+		$this->assertNull( $updated_product->get_date_on_sale_to( 'edit' ), 'Quick Edit should clear the expired sale end date.' );
+		$this->assertTrue( $updated_product->is_on_sale( 'edit' ), 'The product should be on sale once the expired schedule is cleared.' );
+		$this->assertSame( $new_sale_price, $updated_product->get_price( 'edit' ), 'The active price should be the new sale price.' );
+	}
+
+	/**
 	 * Provides valid price changes for active and future sale schedules.
 	 *
 	 * @return array<string, array{int, int, string, string}>
@@ -147,6 +183,18 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 			'active schedule with sale price change'    => array( -DAY_IN_SECONDS, DAY_IN_SECONDS, '100', '70' ),
 			'future schedule with sale price change'    => array( DAY_IN_SECONDS, 2 * DAY_IN_SECONDS, '100', '70' ),
 			'active schedule with regular price change' => array( -DAY_IN_SECONDS, DAY_IN_SECONDS, '90', '80' ),
+		);
+	}
+
+	/**
+	 * Provides price changes for a product whose scheduled sale has already ended.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public static function expired_schedule_price_changes_provider(): array {
+		return array(
+			'expired schedule with new sale price'       => array( '100', '70' ),
+			'expired schedule with regular price change' => array( '90', '80' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -174,6 +174,47 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Quick Edit preserves expired sale dates when prices are not edited, even if display filters reformat prices.
+	 */
+	public function test_quick_edit_preserves_expired_sale_dates_when_prices_not_edited(): void {
+		// Simulates extensions (currency switchers, wholesale, dynamic pricing) that filter
+		// prices in view context, reshaping the values the Quick Edit form is prefilled with.
+		$format_price = function ( $value ) {
+			return '' === $value || null === $value ? $value : number_format( (float) $value, 2, '.', '' );
+		};
+		add_filter( 'woocommerce_product_get_regular_price', $format_price );
+		add_filter( 'woocommerce_product_get_sale_price', $format_price );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$product->set_regular_price( '100' );
+		$product->set_sale_price( '80' );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->save();
+
+		// A stock-only Quick Edit: the price inputs hold the filtered display values, submitted back unchanged.
+		$_REQUEST = array(
+			'woocommerce_quick_edit'       => '1',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'_regular_price'               => '100.00',
+			'_sale_price'                  => '80.00',
+			'_stock_status'                => 'outofstock',
+		);
+
+		$this->sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		remove_filter( 'woocommerce_product_get_regular_price', $format_price );
+		remove_filter( 'woocommerce_product_get_sale_price', $format_price );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_from( 'edit' ), 'Quick Edit should preserve the expired sale start date when no price was edited.' );
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_to( 'edit' ), 'Quick Edit should preserve the expired sale end date when no price was edited.' );
+		$this->assertFalse( $updated_product->is_on_sale( 'edit' ), 'The expired sale should not be reactivated by an edit that did not touch prices.' );
+	}
+
+	/**
 	 * Provides valid price changes for active and future sale schedules.
 	 *
 	 * @return array<string, array{int, int, string, string}>

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -215,6 +215,44 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Quick Edit preserves expired sale dates when price fields are absent from the request.
+	 */
+	public function test_quick_edit_preserves_expired_sale_dates_when_price_fields_not_submitted(): void {
+		$format_price = function ( $value ) {
+			return '' === $value || null === $value ? $value : number_format( (float) $value, 2, '.', '' );
+		};
+		add_filter( 'woocommerce_product_get_regular_price', $format_price );
+		add_filter( 'woocommerce_product_get_sale_price', $format_price );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$product->set_regular_price( '100' );
+		$product->set_sale_price( '80' );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->save();
+
+		$_REQUEST = array(
+			'woocommerce_quick_edit'       => '1',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'_stock_status'                => 'instock',
+		);
+
+		$this->sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		remove_filter( 'woocommerce_product_get_regular_price', $format_price );
+		remove_filter( 'woocommerce_product_get_sale_price', $format_price );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( '100', $updated_product->get_regular_price( 'edit' ), 'An absent regular price field should leave the stored regular price untouched.' );
+		$this->assertSame( '80', $updated_product->get_sale_price( 'edit' ), 'An absent sale price field should leave the stored sale price untouched.' );
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_from( 'edit' ), 'Quick Edit should preserve the expired sale start date when no price fields were submitted.' );
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_to( 'edit' ), 'Quick Edit should preserve the expired sale end date when no price fields were submitted.' );
+		$this->assertFalse( $updated_product->is_on_sale( 'edit' ), 'The expired sale should not be reactivated by a request without price fields.' );
+	}
+
+	/**
 	 * Provides valid price changes for active and future sale schedules.
 	 *
 	 * @return array<string, array{int, int, string, string}>

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-post-types-test.php
@@ -209,9 +209,87 @@ class WC_Admin_Post_Types_Test extends WC_Unit_Test_Case {
 
 		$updated_product = wc_get_product( $product->get_id() );
 
+		$this->assertSame( '100.00', $updated_product->get_regular_price( 'edit' ), 'The submitted display-formatted regular price is what gets persisted.' );
+		$this->assertSame( '80.00', $updated_product->get_sale_price( 'edit' ), 'The submitted display-formatted sale price is what gets persisted.' );
 		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_from( 'edit' ), 'Quick Edit should preserve the expired sale start date when no price was edited.' );
 		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_to( 'edit' ), 'Quick Edit should preserve the expired sale end date when no price was edited.' );
 		$this->assertFalse( $updated_product->is_on_sale( 'edit' ), 'The expired sale should not be reactivated by an edit that did not touch prices.' );
+	}
+
+	/**
+	 * @testdox Quick Edit preserves expired sale dates when a converting display filter round-trips unedited prices.
+	 */
+	public function test_quick_edit_preserves_expired_sale_dates_with_converting_filter(): void {
+		// Simulates a value-converting filter (currency switcher, dynamic pricing) that is
+		// active during both the form render and the save request.
+		$convert_price = function ( $value ) {
+			return '' === $value || null === $value ? $value : (string) ( 2 * (float) $value );
+		};
+		add_filter( 'woocommerce_product_get_regular_price', $convert_price );
+		add_filter( 'woocommerce_product_get_sale_price', $convert_price );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$product->set_regular_price( '100' );
+		$product->set_sale_price( '80' );
+		$product->set_date_on_sale_from( gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ) );
+		$product->set_date_on_sale_to( gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$product->save();
+
+		// A stock-only Quick Edit: the form displayed the converted values and submits them back unchanged.
+		$_REQUEST = array(
+			'woocommerce_quick_edit'       => '1',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'_regular_price'               => '200',
+			'_sale_price'                  => '160',
+			'_stock_status'                => 'outofstock',
+		);
+
+		$this->sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		remove_filter( 'woocommerce_product_get_regular_price', $convert_price );
+		remove_filter( 'woocommerce_product_get_sale_price', $convert_price );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_from( 'edit' ), 'Quick Edit should preserve the expired sale start date under a converting display filter.' );
+		$this->assertInstanceOf( WC_DateTime::class, $updated_product->get_date_on_sale_to( 'edit' ), 'Quick Edit should preserve the expired sale end date under a converting display filter.' );
+		$this->assertFalse( $updated_product->is_on_sale( 'edit' ), 'The expired sale should not be reactivated by a round-trip of converted display prices.' );
+	}
+
+	/**
+	 * @testdox Quick Edit survives a display filter returning a non-scalar value.
+	 */
+	public function test_quick_edit_survives_non_scalar_price_filter(): void {
+		$break_price = function () {
+			return new stdClass();
+		};
+		add_filter( 'woocommerce_product_get_regular_price', $break_price );
+		add_filter( 'woocommerce_product_get_sale_price', $break_price );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$product->set_regular_price( '100' );
+		$product->set_sale_price( '80' );
+		$product->save();
+
+		$_REQUEST = array(
+			'woocommerce_quick_edit'       => '1',
+			'woocommerce_quick_edit_nonce' => wp_create_nonce( 'woocommerce_quick_edit_nonce' ),
+			'_regular_price'               => '90',
+			'_sale_price'                  => '70',
+			'_stock_status'                => 'instock',
+		);
+
+		$this->sut->bulk_and_quick_edit_save_post( $product->get_id(), get_post( $product->get_id() ) );
+
+		remove_filter( 'woocommerce_product_get_regular_price', $break_price );
+		remove_filter( 'woocommerce_product_get_sale_price', $break_price );
+
+		$updated_product = wc_get_product( $product->get_id() );
+
+		$this->assertSame( '90', $updated_product->get_regular_price( 'edit' ), 'Submitted prices should persist even when a display filter returns a non-scalar value.' );
+		$this->assertSame( '70', $updated_product->get_sale_price( 'edit' ), 'Submitted prices should persist even when a display filter returns a non-scalar value.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a scheduled sale ends, WooCommerce keeps `_sale_price` and both date metas and only resets `_price`, so an expired schedule is the durable state of any product that ran a timed sale. Since #66648, entering a new sale price via Quick Edit on such a product saved successfully but never went on sale: the preserved past end date kept `is_on_sale()` false, and Quick Edit exposes no date fields to fix it.

Two changes to `quick_edit_save()`:

- Treat an ended schedule as stale: the date-clearing predicate gains a `$sale_has_ended` clause, so a price change clears the expired dates and the sale takes effect immediately (pre-#66648 behavior; active and future schedules stay protected). A regular-price-only change therefore resurrects the previous sale price, also matching pre-#66648 behavior, pinned by a test.
- Make the `$price_changed` gate reliable: the form is prefilled from view-context (filtered) price getters, but the old values were compared raw, so display-reshaping extensions made every save register a price change, and with the new clause a stock-only edit would clear an expired schedule. The comparison now uses the view-context values, normalized with `wc_format_decimal()`, and only fields present in the request can register as changed.

The open #66715 proposes the same `$sale_has_ended` predicate for Bulk Edit; whichever lands second needs a careful rebase since both touch this method.

**Backward compatibility:** no public signatures, hooks, or templates change. Behavior changes are limited to the admin Quick Edit save path and restore pre-11.1.0 semantics for the expired-schedule case.

Closes #66718.

(For Bug Fixes) Bug introduced in PR #66648.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a product whose scheduled sale has already ended, e.g. with WP-CLI:
   `wp eval '$p = new WC_Product_Simple(); $p->set_name("Expired sale"); $p->set_regular_price("100"); $p->set_sale_price("80"); $p->set_date_on_sale_from(gmdate("Y-m-d H:i:s", time() - 3 * DAY_IN_SECONDS)); $p->set_date_on_sale_to(gmdate("Y-m-d H:i:s", time() - DAY_IN_SECONDS)); $p->set_status("publish"); echo $p->save();'`
2. In **Products**, open **Quick Edit** for it, set the Sale price to `70`, and Update.
- [ ] Verify the Price column shows ~~$100.00~~ $70.00 and the product page shows the sale price with the Sale badge.
3. Repeat steps 1-2 with a product whose sale is still active (end date in the future).
- [ ] Verify the sale schedule dates are preserved (product Edit screen → sale price schedule) and the price updates.
4. In Quick Edit, set the sale price to be empty or ≥ the regular price.
- [ ] Verify the sale is removed and the schedule cleared.
5. Display-filter regression check: add a snippet that reformats displayed prices, e.g. `add_filter( 'woocommerce_product_get_regular_price', fn( $v ) => '' === $v ? $v : number_format( (float) $v, 2, '.', '' ) );` (and the same for `woocommerce_product_get_sale_price`). Recreate the expired-sale product from step 1, then in Quick Edit change **only** the stock status and Update.
- [ ] Verify the product does **not** go on sale and the sale schedule dates are still present.

<!-- End testing instructions -->

### Testing that has already taken place:

- TDD, all red-first in wp-env (PHP 8.1): expired-schedule clearing (2 data sets), display-filter round-trip preservation, and absent-price-fields preservation (mutation-verified: removing the per-field gates fails it). Suite green: 9 tests, 44 assertions.
- Browser-verified in wp-env: sale visible in admin and storefront after Quick Edit; post meta confirmed (`_price=70`, date metas cleared).
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified file: clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/fix-66718-quick-edit-expired-sale-dates`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
