### PR TITLE
Limit front end email preview to published emails or users who can read the post

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-3572-any-user-can-read-unpublished-emails-via-post-on-the-front
+++ b/packages/php/email-editor/changelog/wooprd-3572-any-user-can-read-unpublished-emails-via-post-on-the-front
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Limit the front end email preview to published emails or users who can read the post, so unpublished emails are no longer shown to logged out visitors.

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -372,6 +372,11 @@ class Email_Editor {
 			return $template;
 		}
 
+		// Anyone can see a published email. For other statuses the user must be able to read the post.
+		if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post->ID ) ) {
+			return $template;
+		}
+
 		add_filter(
 			'woocommerce_email_editor_preview_post_template_html',
 			function () use ( $post ) {

--- a/packages/php/email-editor/tests/integration/Engine/Email_Editor_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Email_Editor_Test.php
@@ -59,9 +59,69 @@ class Email_Editor_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * A logged out visitor should not see a draft email passed via ?post=.
+	 */
+	public function testItDoesNotRenderUnpublishedEmailForAnonymousVisitor(): void {
+		wp_set_current_user( 0 );
+		$post_id      = $this->create_email_post( 'draft' );
+		$_GET['post'] = (string) $post_id;
+		$fallback     = 'fallback-template.php';
+
+		$template = $this->email_editor->load_email_preview_template( $fallback );
+
+		$this->assertSame( $fallback, $template );
+	}
+
+	/**
+	 * Published emails stay public so preview in a new tab keeps working.
+	 */
+	public function testItRendersPublishedEmailForAnonymousVisitor(): void {
+		wp_set_current_user( 0 );
+		$post_id      = $this->create_email_post( 'publish' );
+		$_GET['post'] = (string) $post_id;
+
+		$template = $this->email_editor->load_email_preview_template( 'fallback-template.php' );
+
+		$this->assertStringEndsWith( 'single-email-post-template.php', $template );
+	}
+
+	/**
+	 * A user who can read the email can still preview it while it is a draft.
+	 */
+	public function testItRendersUnpublishedEmailForUserWithReadAccess(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->assertIsInt( $user_id );
+		wp_set_current_user( $user_id );
+		$post_id      = $this->create_email_post( 'draft' );
+		$_GET['post'] = (string) $post_id;
+
+		$template = $this->email_editor->load_email_preview_template( 'fallback-template.php' );
+
+		$this->assertStringEndsWith( 'single-email-post-template.php', $template );
+	}
+
+	/**
+	 * Create an email post of the registered custom type.
+	 *
+	 * @param string $status The post status.
+	 * @return int The created post ID.
+	 */
+	private function create_email_post( string $status ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'custom_email_type',
+				'post_status' => $status,
+			)
+		);
+		$this->assertIsInt( $post_id );
+		return $post_id;
+	}
+
+	/**
 	 * Clean up after each test
 	 */
 	public function tearDown(): void {
+		unset( $_GET['post'] );
 		parent::tearDown();
 		remove_filter( 'woocommerce_email_editor_post_types', $this->post_register_callback );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The front end email preview template reads the post from the `post` query arg and rendered it with `get_post()`, without looking at the post status or the current user. Because the email post type is publicly queryable, a logged out visitor could open the preview of an unpublished email just by passing its ID in the URL.

This PR adds a check in `Email_Editor::load_email_preview_template()`:

- Published (publicly viewable) emails keep working for everyone, so the "preview in a new tab" feature is not affected.
- For any other status the current user must be able to read that post (`read_post`), so drafts are only visible to users who already have access.

Closes [WOO6-76: Any user can read unpublished emails via ?post= on the front end](https://linear.app/a8c/issue/WOO6-76/any-user-can-read-unpublished-emails-via-post-on-the-front-end).

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)
2. Create a `woo_email` post as a draft `pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp post create --post_type=woo_email --post_status=draft --post_title="My Draft Email" --post_content="Draft Content"`. Note its post ID.
3. In a logged out browser session, open any published single post URL and add `?post=<draft_email_id>`, i.e. `http://localhost/hello-world/?post=123`.
4. Before this change the draft email HTML was rendered. After this change the normal template is shown instead.
5. Edit any existing transactional email and confirm the preview in a new tab still works.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
