### PR TITLE
Email Editor: Detect width only for local images in image blocks without width

### DIFF
--- a/packages/php/email-editor/changelog/wooprd-3573-email-editor-image-block-can-make-the-server-fetch-any-url
+++ b/packages/php/email-editor/changelog/wooprd-3573-email-editor-image-block-can-make-the-server-fetch-any-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+For image blocks without a set width, only detect the width for local uploads images and fall back to the max width for external images.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -141,14 +141,9 @@ class Image extends Abstract_Block_Renderer {
 				}
 			}
 
-			// Fallback to wp_getimagesize if we still don't have a size.
+			// Fall back to reading the local image file if we still don't have a size.
 			if ( ! isset( $image_size ) ) {
-				$upload_dir = wp_upload_dir();
-				$image_path = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $image_url );
-				$result     = wp_getimagesize( $image_path );
-				if ( $result ) {
-					$image_size = (int) $result[0];
-				}
+				$image_size = $this->get_local_image_width( $image_url );
 			}
 		}
 
@@ -157,6 +152,28 @@ class Image extends Abstract_Block_Renderer {
 
 		$parsed_block['attrs']['width'] = "{$width}px";
 		return $parsed_block;
+	}
+
+	/**
+	 * Get the width of an image stored locally in the uploads directory.
+	 *
+	 * Only local files are measured. External URLs return null so the caller
+	 * can fall back to the max width.
+	 *
+	 * @param string $image_url Image URL.
+	 * @return int|null Image width in pixels, or null if it can't be determined locally.
+	 */
+	private function get_local_image_width( string $image_url ): ?int {
+		$upload_dir = wp_upload_dir();
+		$image_path = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $image_url );
+
+		if ( $image_path === $image_url || ! file_exists( $image_path ) ) {
+			return null;
+		}
+
+		$result = wp_getimagesize( $image_path );
+
+		return $result ? (int) $result[0] : null;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -165,9 +165,24 @@ class Image extends Abstract_Block_Renderer {
 	 */
 	private function get_local_image_width( string $image_url ): ?int {
 		$upload_dir = wp_upload_dir();
-		$image_path = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $image_url );
+		$base_url   = trailingslashit( $upload_dir['baseurl'] );
 
-		if ( $image_path === $image_url || ! file_exists( $image_path ) ) {
+		// Only measure images served from the uploads directory.
+		if ( ! str_starts_with( $image_url, $base_url ) ) {
+			return null;
+		}
+
+		$base_dir   = realpath( $upload_dir['basedir'] );
+		$image_path = realpath( $upload_dir['basedir'] . '/' . substr( $image_url, strlen( $base_url ) ) );
+
+		if ( false === $base_dir || false === $image_path ) {
+			return null;
+		}
+
+		// Make sure the resolved file stays inside the uploads directory.
+		$base_dir   = trailingslashit( wp_normalize_path( $base_dir ) );
+		$image_path = wp_normalize_path( $image_path );
+		if ( ! str_starts_with( $image_path, $base_dir ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The image block in the email editor detects an image width when the width is not set. To do this it called `wp_getimagesize()` on a path built from the image URL.

The path was only correct for images inside `wp-content/uploads`. For any other URL the value stayed a full URL, so the server could load an external file while rendering the email.

This PR moves the size detection into a small helper that only reads local uploads files. External URLs now fall back to the max width and no file is loaded for them.

Closes [WOO6-77](https://linear.app/a8c/issue/WOO6-77/).

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In the email editor, add an Image block by URL (do not upload) and use `http://localhost:9999/x.png` (preferably a server that you can read the access log). Leave the width unset. Alternatively, you can add some logging in [class-image.php](https://github.com/woocommerce/woocommerce/blob/9379871c4f9b11919a9a718d024b3e51e9a0dda6/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php#L170) and use it to verify that it gets triggered.
2. Preview or send the email.
3. Before the fix, the server made a request to the remote server. After the fix it skips the request and the image uses the max width.
4. Add a normal uploaded image and confirm its width is still detected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
