### PR TITLE
Fix product CSV importer crash when mbstring is unavailable

### DIFF
--- a/plugins/woocommerce/changelog/38541-fix-csv-importer-mbstring-fallback
+++ b/plugins/woocommerce/changelog/38541-fix-csv-importer-mbstring-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product CSV importer form crashing when the mbstring extension is unavailable.

--- a/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
@@ -79,17 +79,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td><input type="checkbox" id="woocommerce-importer-map-preferences" name="map_preferences" value="1" /></td>
 				</tr>
 				<tr class="woocommerce-importer-advanced hidden">
-					<th><label><?php esc_html_e( 'Character encoding of the file', 'woocommerce' ); ?></label><br/></th>
-					<td><select id="woocommerce-importer-character-encoding" name="character_encoding">
-							<option value="" selected><?php esc_html_e( 'Autodetect', 'woocommerce' ); ?></option>
-							<?php
-							$encodings = mb_list_encodings();
-							sort( $encodings, SORT_NATURAL );
-							foreach ( $encodings as $encoding ) {
-								echo '<option>' . esc_html( $encoding ) . '</option>';
-							}
+					<th><label for="woocommerce-importer-character-encoding"><?php esc_html_e( 'Character encoding of the file', 'woocommerce' ); ?></label><br/></th>
+					<td>
+						<?php
+						if ( function_exists( 'mb_list_encodings' ) ) {
 							?>
-						</select>
+							<select id="woocommerce-importer-character-encoding" name="character_encoding">
+								<option value="" selected><?php esc_html_e( 'Autodetect', 'woocommerce' ); ?></option>
+								<?php
+								$encodings = mb_list_encodings();
+								sort( $encodings, SORT_NATURAL );
+								foreach ( $encodings as $encoding ) {
+									echo '<option>' . esc_html( $encoding ) . '</option>';
+								}
+								?>
+							</select>
+							<?php
+						} else {
+							?>
+							<div class="notice notice-warning inline">
+								<p><?php esc_html_e( 'Requires the mbstring PHP extension, which is not available on your server. Files will be treated as UTF-8, so characters in other encodings may be removed.', 'woocommerce' ); ?></p>
+							</div>
+							<?php
+						}
+						?>
 					</td>
 				</tr>
 			</tbody>

--- a/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-product-csv-import-form.php
@@ -98,7 +98,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						} else {
 							?>
 							<div class="notice notice-warning inline">
-								<p><?php esc_html_e( 'Requires the mbstring PHP extension, which is not available on your server. Files will be treated as UTF-8, so characters in other encodings may be removed.', 'woocommerce' ); ?></p>
+								<p><?php esc_html_e( 'Your server does not support the mbstring PHP extension, so the file will be treated as UTF-8. Characters in other encodings may be removed.', 'woocommerce' ); ?></p>
 							</div>
 							<?php
 						}

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -90,7 +90,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 */
 	private function adjust_character_encoding( $value ) {
 		$encoding = $this->params['character_encoding'];
-		return 'UTF-8' === $encoding ? $value : mb_convert_encoding( $value, 'UTF-8', $encoding );
+
+		// Skip conversion when the value is already UTF-8 or when mbstring is unavailable.
+		if ( 'UTF-8' === $encoding || ! function_exists( 'mb_convert_encoding' ) ) {
+			return $value;
+		}
+
+		return mb_convert_encoding( $value, 'UTF-8', $encoding );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -301,4 +301,41 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 
 		$this->assertSame( '', $importer->parse_float_field( '' ), 'Empty values should be returned unchanged.' );
 	}
+
+	/**
+	 * @testdox adjust_character_encoding should convert values from the configured encoding to UTF-8 (issue #38541).
+	 * @dataProvider provider_adjust_character_encoding
+	 *
+	 * @param string $encoding The configured character encoding.
+	 * @param string $value    The raw value expressed in that encoding.
+	 * @param string $expected The expected UTF-8 value.
+	 */
+	public function test_adjust_character_encoding_converts_to_utf8( string $encoding, string $value, string $expected ) {
+		$importer = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv', array( 'character_encoding' => $encoding ) );
+
+		$method = new ReflectionMethod( WC_Product_CSV_Importer::class, 'adjust_character_encoding' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			$expected,
+			$method->invoke( $importer, $value ),
+			"Expected a '{$encoding}' value to be converted to UTF-8."
+		);
+	}
+
+	/**
+	 * Data provider for test_adjust_character_encoding_converts_to_utf8.
+	 *
+	 * The é character is the single byte 0xE9 in both ISO-8859-1 and Windows-1252, and the
+	 * two-byte sequence 0xC3 0xA9 in UTF-8.
+	 *
+	 * @return array
+	 */
+	public function provider_adjust_character_encoding(): array {
+		return array(
+			'UTF-8 is returned unchanged' => array( 'UTF-8', 'Café', 'Café' ),
+			'ISO-8859-1 is converted'     => array( 'ISO-8859-1', "Caf\xE9", 'Café' ),
+			'Windows-1252 is converted'   => array( 'Windows-1252', "Caf\xE9", 'Café' ),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -311,6 +311,10 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @param string $expected The expected UTF-8 value.
 	 */
 	public function test_adjust_character_encoding_converts_to_utf8( string $encoding, string $value, string $expected ) {
+		if ( ! function_exists( 'mb_convert_encoding' ) ) {
+			$this->markTestSkipped( 'The mbstring extension is required for this test.' );
+		}
+
 		$importer = new WC_Product_CSV_Importer( __DIR__ . '/sample.csv', array( 'character_encoding' => $encoding ) );
 
 		$method = new ReflectionMethod( WC_Product_CSV_Importer::class, 'adjust_character_encoding' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The product CSV importer form called `mb_list_encodings()` unconditionally to build the character encoding selector. On servers without the `mbstring` extension that fataled while rendering the form, so no Continue button appeared.

The selector now renders only when `mbstring` is available. Without it, the row shows a notice that files will be treated as UTF-8. `WC_Product_CSV_Importer::adjust_character_encoding()` is also guarded so a submitted encoding can't fatal on a server without `mbstring`.

Closes #38541.

### Screenshots or screen recordings:

<img width="556" height="737" alt="image" src="https://github.com/user-attachments/assets/c9174ed8-b82d-4a20-8000-98d62d350242" />


### How to test the changes in this Pull Request:

1. Go to Products > All Products > Import and click "Show advanced options".
2. With `mbstring` installed: the "Character encoding of the file" selector shows and import works as before.
3. Without `mbstring`: the form no longer errors, the selector is replaced by a notice, and import proceeds with the file treated as UTF-8.
4. Make sure the form works as before.

### Testing that has already taken place:

-   Manual check on a local env.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

The changelog entry was added manually in this branch (`changelog/38541-fix-csv-importer-mbstring-fallback`).

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix product CSV importer form crashing when the mbstring extension is unavailable.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

