### PR TITLE
Fix stale variation ID when changing an order line item's product

### DIFF
--- a/plugins/woocommerce/changelog/52292-set-product-reset-variation-id
+++ b/plugins/woocommerce/changelog/52292-set-product-reset-variation-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WC_Order_Item_Product::set_product() now resets variation_id to 0 when passed a non-variation product, so reassigning a line item's product no longer leaves a stale variation ID that made get_product() return the previous variation.

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -259,6 +259,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			$this->set_variation( is_callable( array( $product, 'get_variation_attributes' ) ) ? $product->get_variation_attributes() : array() );
 		} else {
 			$this->set_product_id( $product->get_id() );
+			$this->set_variation_id( 0 );
 		}
 		$this->set_name( $product->get_name() );
 		$this->set_tax_class( $product->get_tax_class() );

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -260,6 +260,10 @@ class WC_Order_Item_Product extends WC_Order_Item {
 		} else {
 			$this->set_product_id( $product->get_id() );
 			$this->set_variation_id( 0 );
+			// Any variation attribute meta written by a previous set_variation() call is left in
+			// place on purpose: it is stored with the `attribute_` prefix stripped, so a key like
+			// `color` is indistinguishable from a merchant's own custom meta and clearing it here
+			// risks deleting real data. Removing that stale display meta is tracked in #66733.
 		}
 		$this->set_name( $product->get_name() );
 		$this->set_tax_class( $product->get_tax_class() );

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -678,4 +678,55 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		$this->assertSame( $variation_b->get_id(), $item->get_variation_id(), 'variation_id should track the most recently set variation.' );
 		$this->assertSame( $parent->get_id(), $item->get_product_id(), 'product_id should remain the shared parent.' );
 	}
+
+	/**
+	 * @testdox Should clear variation_id when set_product() is given the variable parent of the item's own current variation.
+	 */
+	public function test_set_product_clears_variation_id_when_switched_to_own_variable_parent(): void {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'T-Shirt' );
+		$parent->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION SKU ' . wp_generate_uuid4(),
+			10,
+			array()
+		);
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $variation );
+
+		$this->assertSame( $variation->get_id(), $item->get_variation_id(), 'Precondition: the item should carry the variation ID before switching to the parent.' );
+
+		$this->assertFalse( $parent->is_type( 'variation' ), 'Precondition: a WC_Product_Variable is not itself a variation.' );
+
+		$item->set_product( $parent );
+
+		$this->assertSame( 0, $item->get_variation_id(), 'A variable parent is not itself a sellable line item, so setting it deliberately clears variation_id rather than preserving the previously selected variation.' );
+		$this->assertSame( $parent->get_id(), $item->get_product_id(), 'product_id should point at the variable parent.' );
+	}
+
+	/**
+	 * @testdox Should set product_id and variation_id when set_product() switches the item from a simple product to a variation.
+	 */
+	public function test_set_product_sets_variation_id_when_switching_from_simple_product_to_variation(): void {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Dummy Variable Product' );
+		$parent->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION SKU ' . wp_generate_uuid4(),
+			10,
+			array()
+		);
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_product( $variation );
+
+		$this->assertSame( $parent->get_id(), $item->get_product_id(), 'product_id should point at the variation\'s parent when switching from a simple product.' );
+		$this->assertSame( $variation->get_id(), $item->get_variation_id(), 'variation_id should be set to the variation ID when switching from a simple product.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -729,4 +729,30 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		$this->assertSame( $parent->get_id(), $item->get_product_id(), 'product_id should point at the variation\'s parent when switching from a simple product.' );
 		$this->assertSame( $variation->get_id(), $item->get_variation_id(), 'variation_id should be set to the variation ID when switching from a simple product.' );
 	}
+
+	/**
+	 * @testdox Should leave stale variation attribute meta in place when set_product() switches to a simple product (documents the tradeoff tracked in #66733).
+	 */
+	public function test_set_product_leaves_stale_variation_attribute_meta_when_switching_to_simple_product(): void {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Dummy Variable Product' );
+		$parent->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION SKU ' . wp_generate_uuid4(),
+			10,
+			array( 'color' => 'blue' )
+		);
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $variation );
+
+		$this->assertSame( 'blue', $item->get_meta( 'color' ), 'Precondition: set_variation() writes the variation attribute as display meta with the attribute_ prefix stripped.' );
+
+		$item->set_product( $this->product );
+
+		$this->assertSame( $this->product->get_id(), $item->get_product()->get_id(), 'get_product() should resolve to the simple product once variation_id is cleared.' );
+		$this->assertSame( 'blue', $item->get_meta( 'color' ), 'Accepted behavior: the stale "color" attribute meta survives the switch because clearing it blindly could delete a merchant\'s own custom meta. Removing it is tracked in #66733.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-item-product-test.php
@@ -622,4 +622,60 @@ class WC_Order_Item_Product_Test extends WC_Unit_Test_Case {
 		// Clean up order.
 		$order->delete( true );
 	}
+
+	/**
+	 * @testdox Should reset variation_id to 0 when set_product() switches the item to a non-variation product.
+	 */
+	public function test_set_product_resets_variation_id_when_switching_to_simple_product(): void {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Dummy Variable Product' );
+		$parent->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION SKU ' . wp_generate_uuid4(),
+			10,
+			array()
+		);
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $variation );
+
+		$this->assertSame( $variation->get_id(), $item->get_variation_id(), 'Precondition: the item should carry the variation ID before switching.' );
+
+		$item->set_product( $this->product );
+
+		$this->assertSame( 0, $item->get_variation_id(), 'variation_id should be reset to 0 when switching to a non-variation product.' );
+		$this->assertSame( $this->product->get_id(), $item->get_product_id(), 'product_id should point at the newly set product.' );
+		$this->assertSame( $this->product->get_id(), $item->get_product()->get_id(), 'get_product() should return the newly set product, not the stale variation.' );
+	}
+
+	/**
+	 * @testdox Should update variation_id when set_product() switches the item between two variations.
+	 */
+	public function test_set_product_updates_variation_id_when_switching_between_variations(): void {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Dummy Variable Product' );
+		$parent->save();
+
+		$variation_a = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION A SKU ' . wp_generate_uuid4(),
+			10,
+			array()
+		);
+		$variation_b = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'VARIATION B SKU ' . wp_generate_uuid4(),
+			15,
+			array()
+		);
+
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $variation_a );
+		$item->set_product( $variation_b );
+
+		$this->assertSame( $variation_b->get_id(), $item->get_variation_id(), 'variation_id should track the most recently set variation.' );
+		$this->assertSame( $parent->get_id(), $item->get_product_id(), 'product_id should remain the shared parent.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1134,4 +1134,113 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertTrue( $line_item_meta['display_value']['readonly'] );
 		$this->assertTrue( $line_item_meta['display_key']['readonly'] );
 	}
+
+	/**
+	 * Builds a variable product with a single variation carrying a real "color" attribute.
+	 *
+	 * @return array Two-element array: the WC_Product_Variable parent and its WC_Product_Variation.
+	 */
+	private function create_variable_product_with_color_variation(): array {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'REST Switch Parent' );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_name( 'color' );
+		$attribute->set_options( array( 'blue', 'green' ) );
+		$attribute->set_variation( true );
+		$parent->set_attributes( array( $attribute ) );
+		$parent->save();
+
+		$variation = WC_Helper_Product::create_product_variation_object(
+			$parent->get_id(),
+			'REST-VAR-' . wp_generate_uuid4(),
+			10,
+			array( 'color' => 'blue' )
+		);
+
+		return array( $parent, $variation );
+	}
+
+	/**
+	 * Creates an order carrying the given variation as its single line item.
+	 *
+	 * @param WC_Product_Variation $variation Variation to add as a line item.
+	 * @return array Two-element array: the saved WC_Order and the line item ID.
+	 */
+	private function create_order_with_variation_line_item( $variation ): array {
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_product( $variation );
+		$item->set_quantity( 1 );
+		$item->set_total( 10 );
+		$order->add_item( $item );
+		$order->save();
+
+		return array( $order, $item->get_id() );
+	}
+
+	/**
+	 * @testdox PUT /orders that switches a variation line item to a simple product clears variation_id over the REST round trip.
+	 */
+	public function test_update_line_item_to_simple_product_clears_variation_id(): void {
+		$fixture                 = $this->create_variable_product_with_color_variation();
+		$variation               = $fixture[1];
+		list( $order, $item_id ) = $this->create_order_with_variation_line_item( $variation );
+		$simple                  = WC_Helper_Product::create_simple_product();
+
+		$this->assertSame( $variation->get_id(), (int) wc_get_order_item_meta( $item_id, '_variation_id' ), 'Precondition: the line item stored the variation ID.' );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'line_items' => array(
+						array(
+							'id'         => $item_id,
+							'product_id' => $simple->get_id(),
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'The update should succeed.' );
+
+		$reloaded = new WC_Order_Item_Product( $item_id );
+		$this->assertSame( 0, $reloaded->get_variation_id(), 'variation_id should be reset to 0 after switching to a simple product over REST.' );
+		$this->assertSame( 0, (int) wc_get_order_item_meta( $item_id, '_variation_id' ), 'The persisted _variation_id meta should be 0.' );
+		$this->assertSame( $simple->get_id(), $reloaded->get_product()->get_id(), 'get_product() should resolve to the simple product, not the old variation.' );
+	}
+
+	/**
+	 * @testdox PUT /orders with a product_id-only payload targeting the variable parent demotes the item and clears variation_id.
+	 */
+	public function test_update_line_item_to_variable_parent_clears_variation_id(): void {
+		list( $parent, $variation ) = $this->create_variable_product_with_color_variation();
+		list( $order, $item_id )    = $this->create_order_with_variation_line_item( $variation );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'line_items' => array(
+						array(
+							'id'         => $item_id,
+							'product_id' => $parent->get_id(),
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'A product_id-only payload targeting the variable parent succeeds with no error.' );
+
+		$reloaded = new WC_Order_Item_Product( $item_id );
+		$this->assertSame( 0, $reloaded->get_variation_id(), 'Omitting variation_id demotes the item to its parent and clears variation_id.' );
+		$this->assertSame( $parent->get_id(), $reloaded->get_product()->get_id(), 'get_product() should resolve to the variable parent.' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Quoting the issue, because it says it best:

> If you want to change the product used on a `WC_Order_Item_Product` once it's created with a variation, you can use the `set_product` method. However, it does not reset the item's `variation_id` so it does not get set as expected.

The item ends up with a new `product_id` but the old `variation_id`, and since `get_product()` reads `variation_id` first it keeps handing back the old variation. So the setter looks like it did nothing. `WC_Abstract_Order::add_product()` and `WC_Checkout` already reset it for non-variation products, so `set_product()` was the odd one out.

It isn't only the filter case from the issue: the REST orders endpoint hits the same path when you change a line item's product, and the stale ID gets written to `_variation_id`, where stock reduction and `wc_order_product_lookup` read it. So this was quietly moving stock and revenue onto the wrong product.

One line, in the else branch: reset `variation_id` to `0`.

Closes woocommerce/woocommerce#52292.

Been there since 3.0.0 (`b20b3590c8`, "First pass at order items"), which predates the PR-per-change convention, so there's no single PR to point at.

#### Backward compatibility

`set_product()` is public; the signature is unchanged and no hooks fire from it that didn't before. One behaviour change to flag: `variation_id` **clears when you pass the item its own variable parent** — reachable over REST by omitting `variation_id` from a partial update. Harmless in practice, since the normal round trip sends both IDs and takes the variation branch. Pinned by a test.

#### Deliberately not fixed here

The item keeps the previous variation's attribute meta, so a reassigned line item can still render "Color: Blue" on a simple product. Clearing it is not safe from here: `set_variation()` stores attributes with the `attribute_` prefix stripped, so a stored `color` row is indistinguishable from a merchant's own. Telling them apart needs provenance recorded at write time — woocommerce/woocommerce#66733, where the prototype and the constraints that sank a delete-time rule are written up. A comment on the else branch says the same in the code, and a test pins the current behaviour so #66733 has to flip it deliberately.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Run `cd plugins/woocommerce && pnpm test:php:env -- --filter WC_Order_Item_Product_Test` (27 tests, five new) and `--filter WC_REST_Orders_Controller_Tests` (35 tests, two new).
2. Create a variable product with a variation, plus a simple product. Then:

   ```php
   $item = new WC_Order_Item_Product();
   $item->set_product( $some_variation );
   $item->set_product( $some_simple_product );

   var_dump( $item->get_variation_id() );      // expect 0, on trunk you get the variation ID
   var_dump( $item->get_product()->get_id() ); // expect the simple product, on trunk the old variation
   ```
3. For the REST path: create an order with a variable product line item, `PUT /wp-json/wc/v3/orders/<order_id>` with `{"line_items":[{"id":<item_id>,"product_id":<a simple product id>}]}`, then `GET` it back. `variation_id` should be `0` and the item should resolve to the simple product. On trunk it keeps the old `variation_id`. If you want to be sure it stuck, check `wp_woocommerce_order_itemmeta._variation_id` is `0`.

<!-- End testing instructions -->

### Testing that has already taken place:

Tests written first and watched failing on trunk.

* **Regressions:** `--filter '/(Order|Checkout|Cart)/'` — 2008 tests, green apart from three pre-existing skips. Lint and PHPStan clean.
* **Live store** (WordPress latest, PHP 8.1, several gateways active), run with and without the fix, reading values back from the database: `PUT` with only `product_id` left the item at `variation_id` 29; with the fix it is `0` and the item resolves to the simple product.

I used AI assistance investigating this; the REST measurements I checked by hand against the source and a running store.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually: `plugins/woocommerce/changelog/52292-set-product-reset-variation-id` (Significance: patch, Type: fix).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>
