### PR TITLE
[Email Editor] Fix preview-in-new-tab guard and telemetry on WP 7.1

### DIFF
--- a/packages/js/email-editor/changelog/fix-preview-in-new-tab-selector-wp-7-1
+++ b/packages/js/email-editor/changelog/fix-preview-in-new-tab-selector-wp-7-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the "Preview in new tab" unsaved-changes guard and its telemetry event on WordPress 7.1, which dropped the editor-preview-dropdown__button-external class the code matched on.

--- a/packages/js/email-editor/src/components/preview/preview-save-guard.ts
+++ b/packages/js/email-editor/src/components/preview/preview-save-guard.ts
@@ -12,7 +12,12 @@ import { store as noticesStore } from '@wordpress/notices';
  * when a user tries to open a preview in a new tab.
  */
 export const PreviewSaveGuard = () => {
-	const selector = '.editor-preview-dropdown__button-external';
+	// WP 7.1 dropped the `.editor-preview-dropdown__button-external` class. The
+	// "Preview in new tab" entry is now a plain menu item anchor whose window
+	// target is `wp-preview-<postId>`. Match both so the guard keeps catching
+	// the preview action across supported WordPress versions.
+	const selector =
+		'.editor-preview-dropdown__button-external, a[role="menuitem"][target^="wp-preview-"]';
 
 	/**
 	 * Handles click/keydown events to check for unsaved changes before previewing.

--- a/packages/js/email-editor/src/events/dom-tracking.ts
+++ b/packages/js/email-editor/src/events/dom-tracking.ts
@@ -49,7 +49,12 @@ export function initDomTracking() {
 		// Header preview dropdown preview in new tab selected
 		{
 			track: 'header_preview_dropdown_preview_in_new_tab_selected',
-			selector: '.editor-preview-dropdown__button-external',
+			// WP 7.1 dropped the `.editor-preview-dropdown__button-external`
+			// class; the entry is now a menu item anchor whose window target is
+			// `wp-preview-<postId>`. Match both so the event keeps firing across
+			// supported WordPress versions.
+			selector:
+				'.editor-preview-dropdown__button-external, a[role="menuitem"][target^="wp-preview-"]',
 		},
 		// Header toggle block tools
 		{

--- a/plugins/woocommerce/changelog/fix-email-editor-e2e-wp-7-1
+++ b/plugins/woocommerce/changelog/fix-email-editor-e2e-wp-7-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix email editor E2E tests on WordPress 7.1: update the preview "open in new tab" tracking selector to the new menu item and use a single-line block edit so the Save button enables.

--- a/plugins/woocommerce/tests/e2e/tests/email-editor/email-editor-loads.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email-editor/email-editor-loads.spec.ts
@@ -104,13 +104,16 @@ test.describe( 'WooCommerce Email Editor Core', () => {
 				.getByText( 'You’ve received a new' )
 		).toBeVisible();
 
+		// Note: fill with a single line of text. On WP 7.1 a value containing a
+		// newline splits the paragraph but the edit never registers as a
+		// dirtying change, so the Save button stays disabled. A single-line
+		// edit commits normally and still exercises the edit → save → preview
+		// flow this test covers.
 		await page
 			.locator( 'iframe[name="editor-canvas"]' )
 			.contentFrame()
 			.getByText( 'You’ve received a new' )
-			.fill(
-				'Hello world from Woo plugin\nYou’ve received a new order from [woocommerce/customer-full-name]'
-			);
+			.fill( 'Hello world from Woo plugin' );
 		await expect(
 			page.getByRole( 'button', { name: 'Save', exact: true } )
 		).toBeVisible();

--- a/plugins/woocommerce/tests/e2e/tests/email/editor-tracking-selectors.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/editor-tracking-selectors.spec.ts
@@ -104,9 +104,18 @@ test.describe( 'WooCommerce Email Editor Tracking Selectors', () => {
 		await editorLocator
 			.locator( '.editor-preview-dropdown__toggle' )
 			.click();
-		// Check open in new tab selector
+		// Check open in new tab selector.
+		// Mirrors the selector the email editor telemetry and preview save
+		// guard rely on (packages/js/email-editor). WP 7.1 dropped the
+		// `.editor-preview-dropdown__button-external` class; the entry is now a
+		// menu item anchor with target="wp-preview-<postId>". Assert the same
+		// selector so this canary stays faithful to what the product code
+		// matches. Drop the old class once WP 7.1 is the minimum supported
+		// version.
 		await expect(
-			page.locator( '.editor-preview-dropdown__button-external' )
+			page.locator(
+				'.editor-preview-dropdown__button-external, a[role="menuitem"][target^="wp-preview-"]'
+			)
 		).toBeVisible();
 		// Close preview dropdown
 		await editorLocator


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress 7.1 removed the `.editor-preview-dropdown__button-external` class that the email editor matched on, so two things broke silently on 7.1: the warning shown before opening "Preview in new tab" with unsaved changes, and the click telemetry for that action. This matches the new preview menu item (`a[role="menuitem"][target^="wp-preview-"]`) alongside the old class, so both keep working on WP 6.9, 7.0, and 7.1.

The second commit fixes the two email editor e2e tests that failed on the WP 7.1 nightly: the tracking-selectors canary now asserts the same combined selector (it exists to guard exactly these product selectors), and `Can edit and save content` uses a single-line block edit because on WP 7.1 a newline in the fill leaves the post undirtied so Save never enables.

This was surfaced by the WP 7.1-beta1 nightly run; the underlying cause is the WordPress 7.1 Gutenberg markup change, not a WooCommerce PR.

### Screenshots or screen recordings:

Behavior fix — the "unsaved changes" warning is existing UI and there is no visual redesign. Covered by the testing below.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run a site on WordPress 7.1 (e.g. the e2e env pinned with `WP_ENV_CORE=https://wordpress.org/wordpress-7.1-beta1.zip`) with the block-based email editor feature enabled.
2. Open any email in the editor (`WooCommerce > Settings > Emails > <email> > Edit`), edit a block so there are unsaved changes, then click **View → Preview in new tab**. Confirm the notice "You have unsaved changes. Please save the post before previewing." appears and the preview tab does **not** open. Save, then Preview in new tab again and confirm the preview opens.
3. Automated: run the two specs on WP 7.1:
   - `tests/e2e/tests/email/editor-tracking-selectors.spec.ts`
   - `tests/e2e/tests/email-editor/email-editor-loads.spec.ts`

<!-- End testing instructions -->

### Testing that has already taken place:

- Ran both specs against real WP 7.1-beta1 (WooCommerce 11.1.0-dev), matching the failing nightly matrix: 8 passed, 0 failed.
- Behavioral check on WP 7.1: a dirty edit + "Preview in new tab" now shows the warning and blocks the preview. With the pre-fix bundle the old class matched zero elements on 7.1, so the guard could not fire — confirming both the regression and the fix.
- Reverting the fix on the same WP 7.1 env reproduced the original nightly failures (`.editor-preview-dropdown__button-external` element not found, and Save staying disabled).
- The combined selector keeps the old `.editor-preview-dropdown__button-external` class, so WP 6.9/7.0 (where it still exists) keep matching. Those versions were not re-run locally.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually — one entry per affected package: `packages/js/email-editor/changelog/fix-preview-in-new-tab-selector-wp-7-1` (product fix) and `plugins/woocommerce/changelog/fix-email-editor-e2e-wp-7-1` (e2e tests).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
