### PR TITLE
[Email Editor] Fix gallery crop misclassifying ampersand-src images as server-cropped

### DIFF
--- a/packages/php/email-editor/changelog/fix-nl-738-gallery-crop-server-detect-encoding
+++ b/packages/php/email-editor/changelog/fix-nl-738-gallery-crop-server-detect-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email gallery aspect-ratio crop misclassifying images whose src contains a query-string ampersand (e.g. CDN URLs) as server-cropped, which stamped distorting fixed dimensions on uncropped images. The renderer now detects a server crop by comparing the filter result to the original URL before escaping.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -236,18 +236,23 @@ class Gallery extends Abstract_Block_Renderer {
 		 */
 		$filtered_url = apply_filters( 'woocommerce_email_editor_gallery_cropped_image_url', $image_url, $aspect_ratio, $width, $height, $image_attrs );
 
-		// Extensions can return anything (arrays, WP_Error, objects). Only accept a string, and
-		// sanitize it before we compare or use it so an invalid value can't emit a warning, be
-		// misclassified as a server crop, or become an empty src.
-		$cropped_url = is_string( $filtered_url ) ? esc_url( $filtered_url ) : '';
+		// Extensions can return anything (arrays, WP_Error, objects). A crop happened only when an
+		// integration returned a *different*, non-empty string. Compare the raw filter result against
+		// the original src here, BEFORE escaping: get_attribute() returns the entity-decoded src (raw
+		// "&"), while esc_url() re-encodes "&" to "&#038;", so comparing an escaped URL against the
+		// decoded original would misclassify any image whose src has a multi-param query string (e.g.
+		// "?w=600&h=600", common with image CDNs) as server-cropped.
+		$is_server_cropped = is_string( $filtered_url ) && '' !== $image_url && '' !== $filtered_url && $filtered_url !== $image_url;
 
-		$is_server_cropped = '' !== $image_url && '' !== $cropped_url && $cropped_url !== $image_url;
+		// Escape for output only after the decision. If esc_url() reduces a hostile/invalid crop URL
+		// to an empty string, fall through to the CSS branch rather than emit an empty src.
+		$cropped_url = $is_server_cropped ? esc_url( (string) $filtered_url ) : '';
 
 		// These crop styles are appended after Html_Processing_Helper::sanitize_image_html() has run
 		// (its style allowlist would otherwise strip object-fit), so they intentionally bypass that
 		// sanitizer. Only the regex-validated $aspect_ratio may be interpolated here — every other
 		// token is a literal. Do not add dynamic values to $crop_styles without validating them.
-		if ( $is_server_cropped ) {
+		if ( '' !== $cropped_url ) {
 			// The file is already cropped to the requested ratio, so we can give it concrete
 			// dimensions. This renders the crop correctly even in clients without CSS crop support.
 			$html->set_attribute( 'src', $cropped_url );

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -520,6 +520,35 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test an image whose src has a multi-param query string (e.g. a CDN URL with "&") is not
+	 * misclassified as server-cropped when no integration rewrites it.
+	 *
+	 * Regression: get_attribute() returns the entity-decoded src while esc_url() re-encodes "&" to
+	 * "&#038;", so comparing an escaped URL against the decoded original wrongly flagged any "&"-in-src
+	 * image as cropped and stamped it with distorting fixed dimensions.
+	 */
+	public function testItDoesNotMisclassifyAmpersandSrcAsServerCropped(): void {
+		$parsed_gallery                         = $this->parsed_gallery;
+		$parsed_gallery['attrs']['aspectRatio'] = '1';
+		// A CDN-style src with more than one query parameter, so the URL contains an ampersand.
+		$parsed_gallery['innerBlocks'][0]['innerHTML'] = '<figure class="wp-block-image size-large"><img src="https://example.com/image1.jpg?w=600&h=600" alt="Image 1" class="wp-image-1"/></figure>';
+
+		// No filter is attached, so nothing is server-cropped.
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		// The ampersand image keeps CSS-only cropping: no fixed width/height that would distort it.
+		$image_count = 0;
+		$html        = new \WP_HTML_Tag_Processor( $rendered );
+		while ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			++$image_count;
+			$this->assertNull( $html->get_attribute( 'width' ), 'An uncropped ampersand-src image must not get a fixed width.' );
+			$this->assertNull( $html->get_attribute( 'height' ), 'An uncropped ampersand-src image must not get a fixed height.' );
+		}
+		$this->assertSame( 3, $image_count, 'All three images are present.' );
+		$this->assertStringContainsString( 'object-fit: cover', $rendered, 'Images still get CSS cropping.' );
+	}
+
+	/**
 	 * Test the crop is sized to the actual rendered cell width, so an incomplete final row
 	 * (e.g. a lone trailing image spanning the full width) is not served an undersized file.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes #66738.

The email gallery aspect-ratio crop renderer decided whether an integration had server-cropped an image by comparing the filter result against the original `src`:

```php
$cropped_url       = is_string( $filtered_url ) ? esc_url( $filtered_url ) : '';
$is_server_cropped = '' !== $image_url && '' !== $cropped_url && $cropped_url !== $image_url;
```

`$image_url` comes from `WP_HTML_Tag_Processor::get_attribute( 'src' )`, which returns the **entity-decoded** value (raw `&`), while `esc_url()` **re-encodes** `&` to `&#038;`. So for any image whose `src` has a multi-param query string (e.g. a CDN/optimizer URL like `?w=600&h=600`), the escaped `$cropped_url` differed from the decoded `$image_url` **even when no integration was attached** — the image was wrongly classified as server-cropped and given concrete `width`/`height` attributes for an uncropped file. In clients that honor `width`/`height` but ignore `object-fit` CSS (Outlook desktop), those images render **stretched/distorted**. Plain `.jpg` srcs (no `&`) were unaffected, which is why the original tests stayed green.

This PR:

-   Detects a server crop by comparing the **raw filter result to the original `src` before escaping**, eliminating the decode/encode asymmetry.
-   Escapes with `esc_url()` only for output, **after** the decision, and branches on the escaped URL being non-empty — so a hostile/invalid URL that `esc_url()` reduces to an empty string also falls back to CSS cropping instead of emitting an empty `src`.
-   Adds a regression test (`testItDoesNotMisclassifyAmpersandSrcAsServerCropped`) with an ampersand-containing `src`, verified to fail on the pre-fix code (`Failed asserting that '306' is null`) and pass after.

Bug introduced in PR #66570.

### How to test the changes in this Pull Request:

1.  Render an email gallery with `aspectRatio` set (e.g. `"1"`) containing an image whose `src` has a multi-param query string, e.g. `https://example.com/i.jpg?w=600&h=600`, with **no** callback attached to `woocommerce_email_editor_gallery_cropped_image_url`.
2.  Confirm the rendered `<img>` gets **no** `width`/`height` attributes (CSS-only crop, `object-fit: cover`) — before this fix it received `width`/`height` for the uncropped file.
3.  Confirm an actual server-crop integration (a callback returning a rewritten URL) still sets concrete `width`/`height` as intended.

### Testing that has already taken place:

-   New regression test proven to fail without the fix and pass with it.
-   Full Core renderer integration suite passes (251 tests). PHPCS and PHPStan (level 9) clean.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `packages/php/email-editor/changelog/`.

</details>

### Release Communication

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->