### PR TITLE
Update 'Direct bank transfer' payment method description to mention SEPA and SWIFT, remove reference to taking payments 'in person'.

### DIFF
--- a/plugins/woocommerce/changelog/update-bacs-description-sepa-swift
+++ b/plugins/woocommerce/changelog/update-bacs-description-sepa-swift
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the Direct Bank Transfer (BACS) payment method description to mention SEPA and SWIFT.

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -61,7 +61,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 		$this->icon               = apply_filters( 'woocommerce_bacs_icon', '' );
 		$this->has_fields         = false;
 		$this->method_title       = __( 'Direct bank transfer', 'woocommerce' );
-		$this->method_description = __( 'Take payments in person via BACS. More commonly known as direct bank/wire transfer.', 'woocommerce' );
+		$this->method_description = __( 'Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT.', 'woocommerce' );
 
 		// Load the settings.
 		$this->init_form_fields();

--- a/plugins/woocommerce/tests/e2e/tests/api-tests/payment-gateways/payment-gateways-crud.test.ts
+++ b/plugins/woocommerce/tests/e2e/tests/api-tests/payment-gateways/payment-gateways-crud.test.ts
@@ -31,7 +31,7 @@ test.describe( 'Payment Gateways API tests', () => {
 					enabled: true,
 					method_title: 'Direct bank transfer',
 					method_description:
-						'Take payments in person via BACS. More commonly known as direct bank/wire transfer.',
+						'Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT.',
 					method_supports: [ 'products' ],
 					settings: {
 						title: {
@@ -210,7 +210,7 @@ test.describe( 'Payment Gateways API tests', () => {
 				enabled: true,
 				method_title: 'Direct bank transfer',
 				method_description:
-					'Take payments in person via BACS. More commonly known as direct bank/wire transfer.',
+					'Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT.',
 				method_supports: [ 'products' ],
 				settings: {
 					title: {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
@@ -979,7 +979,7 @@ class PaymentsRestControllerTest extends WC_Unit_Test_Case {
 				'_order'      => $order++,
 				'_type'       => PaymentsProviders::TYPE_OFFLINE_PM,
 				'title'       => 'Direct bank transfer',
-				'description' => 'Take payments in person via BACS. More commonly known as direct bank/wire transfer.',
+				'description' => 'Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT.',
 				'supports'    => array(
 					'products',
 				),


### PR DESCRIPTION
The 'Direct bank transfer' offline payment method described itself as "Take payments in person via BACS. More commonly known as direct bank/wire transfer." That copy was BACS-centric and inaccurately implied an in-person flow (i.e. bank/wire transfers are not in person).

This PR makes the description scheme-agnostic and mentions SEPA and SWIFT, per the recommendation in the issue thread. Also update the two tests that assert this string.

Closes [issue #41057](https://github.com/woocommerce/woocommerce/issues/41057)

### Changes proposed in this Pull Request:

Updates the **Direct bank transfer** offline payment method description shown to merchants in the admin.

Previously the method described itself as:

> Take payments in person via BACS. More commonly known as direct bank/wire transfer.

This copy was BACS-centric (BACS is a UK-specific scheme) and inaccurately implied an in-person flow. Bank-to-bank and wire transfers are not taken in person. It now reads:

> Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT.

The wording follows the recommendation from the Woo product team in the issue thread. This is a copy-only change to the admin-facing `method_description`; the separate, merchant-editable customer-facing checkout description is unchanged.

Two tests that assert the old string are updated accordingly (`PaymentsRestControllerTest` and the `payment-gateways-crud` e2e API test).

Closes #41057

### Screenshots or screen recordings:

The change is admin copy only (WooCommerce → Settings → Payments → offline payment methods). No layout changes.

### How to test the changes in this Pull Request:

1. Check out this branch on a WooCommerce site.
2. Go to **WooCommerce → Settings → Payments**.
3. In the offline payment methods section, confirm the **Direct bank transfer** entry's description reads: *"Accept offline bank-to-bank and wire transfer payments such as BACS, SEPA, and SWIFT."*
4. Confirm the customer-facing description on the BACS settings page (and at checkout when BACS is enabled) is unchanged.

### Testing that has already taken place:

- Traced the render path: the description is sourced once from `WC_Gateway_BACS::$method_description` and surfaced by the Payments REST layer (`get_method_description()`), so both the legacy and redesigned offline-payments settings UIs display it.
- Confirmed no other production occurrences of the old string; two remaining matches are unrelated mock fixtures.
- `php -l` passes on the changed PHP files. Full PHPCS / PHPUnit / Playwright run in CI (WooCommerce-core dev env was not set up locally).

### Note / possible follow-up (out of scope)

A comment in the issue raised a deeper functional concern that SEPA availability appears to vary by customer country (e.g. not offered for some SEPA-member countries). Given this is a generic offline payment method designed to support various bank transfer type payments, and is not inherently conditional based on shopper location etc, I'm choosing not to address this specific concern here.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->