### PR TITLE
Implement stabilized isPreviewMode flag (WordPress 6.7) across WooCommerce blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-53125-implement-ispreviewmode-flag
+++ b/plugins/woocommerce/changelog/fix-53125-implement-ispreviewmode-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Implement stabilized WordPress 6.7 isPreviewMode flag across WooCommerce blocks, replacing the custom isPreview attribute.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { usePrevious, useShallowEqual } from '@woocommerce/base-hooks';
+import { usePreviewMode, usePrevious, useShallowEqual } from '@woocommerce/base-hooks';
 import {
 	useCollection,
 	useQueryStateByKey,
@@ -94,8 +94,10 @@ const AttributeFilterBlock = ( {
 	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );
 
+	const isPreviewMode = usePreviewMode();
+
 	const attributeObject =
-		blockAttributes.isPreview && ! blockAttributes.attributeId
+		isPreviewMode && ! blockAttributes.attributeId
 			? previewAttributeObject
 			: getAttributeFromID( blockAttributes.attributeId );
 
@@ -116,7 +118,7 @@ const AttributeFilterBlock = ( {
 	const [ displayedOptions, setDisplayedOptions ] = useState<
 		DisplayOption[]
 	>(
-		blockAttributes.isPreview && ! blockAttributes.attributeId
+		isPreviewMode && ! blockAttributes.attributeId
 			? previewOptions
 			: []
 	);
@@ -492,8 +494,8 @@ const AttributeFilterBlock = ( {
 
 	const TagName =
 		`h${ blockAttributes.headingLevel }` as keyof JSX.IntrinsicElements;
-	const termsLoading = ! blockAttributes.isPreview && attributeTermsLoading;
-	const countsLoading = ! blockAttributes.isPreview && filteredCountsLoading;
+	const termsLoading = ! isPreviewMode && attributeTermsLoading;
+	const countsLoading = ! isPreviewMode && filteredCountsLoading;
 
 	const isLoading =
 		( termsLoading || countsLoading ) && displayedOptions.length === 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/types.ts
@@ -14,6 +14,7 @@ export interface BlockAttributes {
 	displayStyle: string;
 	showFilterButton: boolean;
 	selectType: string;
+	/** @deprecated Use isPreviewMode from blockEditorStore via usePreviewMode hook instead. */
 	isPreview?: boolean;
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/handpicked-products/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/handpicked-products/block.tsx
@@ -3,6 +3,7 @@
  */
 import ServerSideRender from '@wordpress/server-side-render';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -11,8 +12,9 @@ import { Props } from './types';
 
 export const HandpickedProductsBlock = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
+	const isPreviewMode = usePreviewMode();
 
-	if ( attributes.isPreview ) {
+	if ( isPreviewMode ) {
 		return gridBlockPreview;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/handpicked-products/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/handpicked-products/types.ts
@@ -24,7 +24,8 @@ export interface Attributes {
 		| 'menu_order';
 	products: Array< number >;
 	alignButtons: boolean;
-	isPreview: boolean;
+	/** @deprecated Use usePreviewMode hook instead. */
+	isPreview?: boolean;
 }
 /**
  * Component to handle edit mode of "Hand-picked Products".

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-best-sellers/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-best-sellers/block.tsx
@@ -4,6 +4,7 @@
 import { Disabled } from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -13,8 +14,9 @@ import { ProductBestSellersInspectorControls } from './inspector-controls';
 
 export const ProductBestSellersBlock = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
+	const isPreviewMode = usePreviewMode();
 
-	if ( attributes.isPreview ) {
+	if ( isPreviewMode ) {
 		return gridBlockPreview;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-best-sellers/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-best-sellers/types.ts
@@ -11,7 +11,8 @@ interface Attributes {
 	};
 	categories: Array< number >;
 	catOperator: string;
-	isPreview: boolean;
+	/** @deprecated Use usePreviewMode hook instead. */
+	isPreview?: boolean;
 	stockStatus: Array< string >;
 	editMode: boolean;
 	orderby:

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -14,6 +14,7 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 import { isString, type ProductResponseItem } from '@woocommerce/types';
 import { getProduct } from '@woocommerce/editor-components/utils';
 import {
@@ -410,6 +411,7 @@ export const useSetPreviewState = ( {
 } ) => {
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
+	const isPreviewMode = usePreviewMode();
 
 	const setState = ( newPreviewState: PreviewState ) => {
 		__unstableMarkNextChangeAsNotPersistent();
@@ -434,12 +436,13 @@ export const useSetPreviewState = ( {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				__privatePreviewState: {
-					isPreview: usesReferencePreviewMessage.length > 0,
+					isPreview: isPreviewMode,
 					previewMessage: usesReferencePreviewMessage,
 				},
 			} );
 		}
 	}, [
+		isPreviewMode,
 		setAttributes,
 		usesReferencePreviewMessage,
 		isUsingReferencePreviewMode,
@@ -474,21 +477,12 @@ export const useSetPreviewState = ( {
 	 * - Products by Attribute
 	 * - Products by Brand
 	 */
-	const termId =
-		location.type === LocationType.Archive
-			? location.sourceData?.termId
-			: null;
 	useEffect( () => {
 		if ( ! setPreviewState && ! isUsingReferencePreviewMode ) {
-			const isGenericArchiveTemplate =
-				location.type === LocationType.Archive && termId === null;
-
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				__privatePreviewState: {
-					isPreview: isGenericArchiveTemplate
-						? !! attributes?.query?.inherit
-						: false,
+					isPreview: isPreviewMode,
 					previewMessage: __(
 						'Actual products will vary depending on the page being viewed.',
 						'woocommerce'
@@ -497,10 +491,8 @@ export const useSetPreviewState = ( {
 			} );
 		}
 	}, [
-		attributes?.query?.inherit,
+		isPreviewMode,
 		usesReferencePreviewMessage,
-		termId,
-		location.type,
 		setAttributes,
 		setPreviewState,
 		isUsingReferencePreviewMode,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/products-by-attribute/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/products-by-attribute/block.tsx
@@ -3,6 +3,7 @@
  */
 import ServerSideRender from '@wordpress/server-side-render';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
+import { usePreviewMode } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -11,8 +12,9 @@ import { Props } from './types';
 
 export const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
+	const isPreviewMode = usePreviewMode();
 
-	if ( attributes.isPreview ) {
+	if ( isPreviewMode ) {
 		return gridBlockPreview;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/products-by-attribute/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/products-by-attribute/types.ts
@@ -25,7 +25,8 @@ export interface Attributes {
 		| 'menu_order';
 	rows: number;
 	alignButtons: boolean;
-	isPreview: boolean;
+	/** @deprecated Use usePreviewMode hook instead. */
+	isPreview?: boolean;
 	stockStatus: Array< string >;
 }
 


### PR DESCRIPTION
Closes woocommerce/woocommerce#53125

### Changes proposed in this Pull Request:

Replaces the custom `isPreview` attribute with WordPress 6.7's stabilized `isPreviewMode` flag (from `blockEditorStore`) across several WooCommerce blocks, simplifying preview state management.

**Blocks updated:**

* Products by Attribute
* Best Selling Products
* Hand-picked Products
* Attribute Filter
* Product Collection (`useSetPreviewState`)

**Other changes:**

* `isPreview` marked as `@deprecated` in TypeScript types
* Removed unused `termId` computation from `useSetPreviewState`

### How to test:

1. Build: `pnpm --filter=@woocommerce/block-library build`
2. Start: `pnpm --filter=@woocommerce/block-library env:start`
3. Open Site Editor > add Product Collection block > select a collection
4. Verify block renders correctly
5. Verify attribute filter still works

Changelog entry created manually (patch/dev).

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview behavior across WooCommerce product and attribute blocks by using the WordPress editor’s preview state.
  * Ensured preview content, loading indicators, and server-rendered block output display consistently in the editor.
* **Refactor**
  * Deprecated the older preview attribute in favor of the standardized preview mode hook.