### PR TITLE
Restore FlexSlider touch event ordering and keep the fix for in-app browser gestures minimal

### DIFF
--- a/plugins/woocommerce/changelog/codex-66752-restore-flexslider-bubble-phase
+++ b/plugins/woocommerce/changelog/codex-66752-restore-flexslider-bubble-phase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve touch handling for interactive content nested inside FlexSlider galleries.

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -455,7 +455,6 @@
           onTouchStart,
           onTouchMove,
           onTouchEnd,
-          touchListenerOptions = { capture: false, passive: false },
           scrolling = false,
           localX = 0,
           localY = 0,
@@ -482,8 +481,8 @@
                          (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
                 startX = (vertical) ? localY : localX;
                 startY = (vertical) ? localX : localY;
-                el.addEventListener('touchmove', onTouchMove, touchListenerOptions);
-                el.addEventListener('touchend', onTouchEnd, touchListenerOptions);
+                el.addEventListener('touchmove', onTouchMove, false);
+                el.addEventListener('touchend', onTouchEnd, false);
               }
             };
 
@@ -510,7 +509,7 @@
 
             onTouchEnd = function(e) {
               // finish the touch by undoing the touch session
-              el.removeEventListener('touchmove', onTouchMove, touchListenerOptions);
+              el.removeEventListener('touchmove', onTouchMove, false);
 
               if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
                 var updateDx = (reverse) ? -dx : dx,
@@ -522,7 +521,7 @@
                   if (!fade) { slider.flexAnimate(slider.currentSlide, slider.vars.pauseOnAction, true); }
                 }
               }
-              el.removeEventListener('touchend', onTouchEnd, touchListenerOptions);
+              el.removeEventListener('touchend', onTouchEnd, false);
 
               startX = null;
               startY = null;
@@ -533,8 +532,8 @@
             // Register before a gesture starts so embedded WebViews keep touchmove events cancelable.
             el.addEventListener('touchmove', function() {
               // Intentionally empty.
-            }, touchListenerOptions);
-            el.addEventListener('touchstart', onTouchStart, touchListenerOptions);
+            }, { passive: false });
+            el.addEventListener('touchstart', onTouchStart, false);
       },
       resize: function() {
         if (!slider.animating && slider.is(':visible')) {

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -455,7 +455,7 @@
           onTouchStart,
           onTouchMove,
           onTouchEnd,
-          touchListenerOptions = { capture: true, passive: false },
+          touchListenerOptions = { capture: false, passive: false },
           scrolling = false,
           localX = 0,
           localY = 0,

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -532,7 +532,7 @@
             // Register before a gesture starts so embedded WebViews keep touchmove events cancelable.
             el.addEventListener('touchmove', function() {
               // Intentionally empty.
-            }, { passive: false });
+            }, false);
             el.addEventListener('touchstart', onTouchStart, false);
       },
       resize: function() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially revert the listener-option changes from #66602 by restoring FlexSlider's original options for its touch listeners. Keep only the early registration of an empty `touchmove` listener, along with the gallery's `touch-action` CSS; testing confirmed this is sufficient to preserve the Facebook in-app browser fix while allowing interactive descendants to stop touch propagation.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66752.

Bug introduced in PR #66602.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable; there are no visual changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open a product with the classic gallery in the Facebook in-app browser.
2. Swipe the gallery in both directions, including rightward from a later image, and confirm the gallery changes images without closing the browser.
3. Confirm vertical scrolling and pinch-to-zoom still work over the gallery.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter=@woocommerce/classic-assets test:js --runInBand` — 127 passed, 1 skipped.
- `pnpm --filter=@woocommerce/classic-assets build:project:js`.
- Manually verified the classic gallery in the Facebook in-app browser on a Jurassic Ninja test site.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g., for point releases), manually set to the first available milestone that is not in the past (unless otherwise specified).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
