### PR TITLE
Fix inert lodash orderBy restricted-import in Blocks ESLint config

### DIFF
--- a/plugins/woocommerce/changelog/fix-lodash-orderby-import-restriction
+++ b/plugins/woocommerce/changelog/fix-lodash-orderby-import-restriction
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fix the inert lodash `orderBy` restricted-import entry in the Blocks ESLint config, which was spelled `orderby` and never matched. Tooling only; no runtime change.

--- a/plugins/woocommerce/client/blocks/eslint.config.mjs
+++ b/plugins/woocommerce/client/blocks/eslint.config.mjs
@@ -83,7 +83,7 @@ const restrictedImports = [
 			'omit',
 			'omitBy',
 			'once',
-			'orderby',
+			'orderBy',
 			'overEvery',
 			'partial',
 			'partialRight',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The Blocks ESLint config restricts the lodash import name `orderby`, but lodash's actual export is `orderBy`. `no-restricted-imports` matches `importNames` case-sensitively, so this entry has never applied — the restriction was silently inert.

This corrects the casing so the rule actually enforces. Of the 108 names in that `importNames` list, `orderby` was the only one that is not a real lodash export (verified programmatically against `require( 'lodash' )`).

The typo is pre-existing — trunk's `.eslintrc.js` carried it before the Flat Config migration (`7b4e6ba31c^`, line 73). It was deliberately left out of #66621 to avoid burying a behaviour change in a 280-file diff. Follow-up to #66621; tracked in #66078.

Nothing in the Blocks source imports lodash today, so restoring the restriction surfaces no new violations.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This is a lint-config-only change with no runtime surface. To verify the rule is now live:

1. Create `plugins/woocommerce/client/blocks/assets/js/probe.ts` containing:
   ```ts
   import { orderBy } from 'lodash';
   export const probe = ( x: object[] ) => orderBy( x );
   ```
2. From `plugins/woocommerce/client/blocks`, run `npx eslint --no-cache assets/js/probe.ts`.
3. Confirm it reports `'orderBy' import from 'lodash' is restricted` (`no-restricted-imports`).
4. Check out `trunk`, repeat step 2, and confirm the same import is **not** flagged — demonstrating the entry was inert before this change.
5. Delete the probe file.
6. From `plugins/woocommerce/client/blocks`, run `pnpm lint:js` and confirm no new errors.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

-   **Proved the rule was inert and is now live.** With a planted probe importing `{ orderBy, omit } from 'lodash'`: without the fix ESLint flags only `omit`; with the fix it flags both. Exit code alone was not treated as proof.
-   **Validated the whole list.** Checked all 108 restricted names against the real `lodash` exports; `orderby` was the sole mismatch, and its case-insensitive match is `orderBy`.
-   **Confirmed zero impact.** No file under `client/blocks/assets/` or `packages/` imports lodash at all (grep verified against a 302-file control hit to rule out a false negative). Only `bin/webpack-entries.js` requires lodash, and the config's `**/bin/**.js` scope does not restrict it.
-   **Full lint run.** `wp-scripts lint-js` on `client/blocks`: 0 errors, 1573 warnings — all pre-existing relaxed-rule debt from #66621, unchanged by this PR.
-   **Changelog tooling.** `tools/monorepo/check-changelogger-use.php --debug origin/trunk <sha>` confirms `client/blocks` maps to the `plugins/woocommerce` changelog directory; `changelogger validate` passes on the entry.

**Backward compatibility:** none. This file is a private monorepo config (both `plugins/woocommerce/package.json` and `client/blocks/package.json` are `private`). It is not the public `@woocommerce/eslint-plugin`, whose exports, peer range, and rule severities are untouched — external extension authors are unaffected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an import restriction rule so usage of Lodash’s `orderBy` method is properly detected during development checks.

* **Chores**
  * Updated internal tooling documentation to reflect the corrected restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->