### PR TITLE
Pin wp-prettier in scaffolded extensions

### DIFF
--- a/packages/js/create-woo-extension/changelog/66078-fix-scaffold-prettier-resolution
+++ b/packages/js/create-woo-extension/changelog/66078-fix-scaffold-prettier-resolution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pin wp-prettier in scaffolded extensions so `prettier/prettier` stops reporting WordPress code style as errors.

--- a/packages/js/create-woo-extension/index.js
+++ b/packages/js/create-woo-extension/index.js
@@ -17,13 +17,9 @@ const defaultDevDependencies = {
 	'@woocommerce/eslint-plugin': '^4.0.0',
 	'@wordpress/prettier-config': 'latest',
 	'@wordpress/scripts': 'latest',
-	/**
-	 * `@wordpress/prettier-config` peers `prettier: >=3`, which npm satisfies with
-	 * plain prettier and then dedupes over the wp-prettier alias that
-	 * `@wordpress/scripts` asks for. `eslint-plugin-prettier` resolves that hoisted
-	 * copy, so `prettier/prettier` reports WordPress style as errors. Declaring the
-	 * alias directly keeps wp-prettier at the top of the tree. Pinned exactly to
-	 * match `@woocommerce/eslint-plugin`, so both resolve to a single copy.
+	/*
+	 * Without this, `@wordpress/prettier-config`'s `prettier: >=3` peer hoists plain
+	 * prettier over wp-prettier. Pinned to match `@woocommerce/eslint-plugin`.
 	 */
 	prettier: 'npm:wp-prettier@3.0.3',
 };

--- a/packages/js/create-woo-extension/index.js
+++ b/packages/js/create-woo-extension/index.js
@@ -17,6 +17,15 @@ const defaultDevDependencies = {
 	'@woocommerce/eslint-plugin': '^4.0.0',
 	'@wordpress/prettier-config': 'latest',
 	'@wordpress/scripts': 'latest',
+	/**
+	 * `@wordpress/prettier-config` peers `prettier: >=3`, which npm satisfies with
+	 * plain prettier and then dedupes over the wp-prettier alias that
+	 * `@wordpress/scripts` asks for. `eslint-plugin-prettier` resolves that hoisted
+	 * copy, so `prettier/prettier` reports WordPress style as errors. Declaring the
+	 * alias directly keeps wp-prettier at the top of the tree. Pinned exactly to
+	 * match `@woocommerce/eslint-plugin`, so both resolve to a single copy.
+	 */
+	prettier: 'npm:wp-prettier@3.0.3',
 };
 
 module.exports = {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

A freshly scaffolded extension emits 36 lint errors on first `npm run lint:js`, 25 of them `prettier/prettier` demanding plain style (`__('x')`) instead of WordPress style (`__( 'x' )`).

`@wordpress/prettier-config` peers `prettier: >=3`. npm satisfies that peer with plain prettier, hoists it, and dedupes everything onto it — including the `npm:wp-prettier` alias `@wordpress/scripts` asks for. `eslint-plugin-prettier` then resolves plain prettier.

Declaring the alias in the scaffolded `devDependencies` keeps wp-prettier on top. Pinned exactly to match `@woocommerce/eslint-plugin` so both resolve to one copy. Also fixes `npm run format`, which errors unless the resolved prettier is `wp-prettier`.

Pre-existing, not caused by #66621 — trunk produces the same errors. No BC impact: only affects what newly scaffolded projects get; the public `@woocommerce/eslint-plugin` is untouched.

This does **not** make the scaffold lint clean — 12 errors remain from unrelated causes (invalid text domain, `require()` in `webpack.config.js`, an undefined `setInlineSelect` in the template). Tracked separately.

Part of #66078.

### How to test the changes in this Pull Request:

1. Scaffold against this branch: `npx @wordpress/create-block --template /path/to/packages/js/create-woo-extension my-ext`
2. Confirm the alias won: `node -p "require('./node_modules/prettier/package.json').name"` → `wp-prettier`
3. `npm run lint:js` — no `prettier/prettier` errors rewriting `__( 'x' )` to `__('x')`.

> Two unrelated blockers get in the way today: `@woocommerce/eslint-plugin@^4.0.0` isn't published yet (point it at a local `npm pack` tarball), and `i18n-calypso@7.4.1` ships a Yarn-only `patch:` spec npm can't parse, breaking install for any scaffold (work around with `"overrides": { "i18n-calypso": "7.4.0" }`). Both reported separately.

### Testing that has already taken place:

Scaffolded a real extension and ran real installs. Controlled before/after reverting only the changed line:

| | top-level `prettier` | `lint:js` | `prettier/prettier` |
| --- | --- | --- | --- |
| Before | `prettier@3.9.5` | 36 errors, 2 warnings | 25 |
| After | `wp-prettier@3.0.3` | 12 errors, 2 warnings | 1 |

Cause isolated by bisecting installs: `@wordpress/scripts` alone resolves to wp-prettier; adding `@wordpress/prettier-config` flips it to plain prettier. macOS, Node 24.18.0, npm 11.18.0 (also reproduced on npm 10).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] Changelog entry added manually (`packages/js/create-woo-extension/changelog/66078-fix-scaffold-prettier-resolution`).
