### PR TITLE
Fix Featured Product and Featured Category ignoring selected image

### DIFF
--- a/plugins/woocommerce/changelog/fix-66765-featured-item-ignoring-selected-image
+++ b/plugins/woocommerce/changelog/fix-66765-featured-item-ignoring-selected-image
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Featured Product and Featured Category ignoring selected image
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FeaturedItem.php
@@ -418,7 +418,7 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 			}
 		}
 
-		$image_url = $this->get_item_image( $item, $image_size );
+		$image_url = $this->get_image_url( $attributes, $item );
 
 		if ( ! empty( $image_url ) ) {
 			return sprintf(

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/FeaturedProductTest.php
@@ -1,0 +1,109 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Featured Product block type.
+ */
+class FeaturedProductTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Product created for tests.
+	 *
+	 * @var \WC_Product|null
+	 */
+	private $product;
+
+	/**
+	 * Attachment IDs created during tests.
+	 *
+	 * @var int[]
+	 */
+	private $attachment_ids = array();
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		if ( $this->product ) {
+			$this->product->delete( true );
+			$this->product = null;
+		}
+
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+		$this->attachment_ids = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should render the merchant-selected custom image when Image Fit is none.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/66765.
+	 */
+	public function test_renders_custom_media_image_when_image_fit_is_none(): void {
+		$product_image_id = $this->create_attachment();
+		$custom_image_id  = $this->create_attachment();
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->set_image_id( $product_image_id );
+		$this->product->save();
+
+		$custom_image_url  = wp_get_attachment_image_url( $custom_image_id, 'large' );
+		$product_image_url = wp_get_attachment_image_url( $product_image_id, 'large' );
+
+		$output = $this->render_featured_product(
+			array(
+				'productId'   => $this->product->get_id(),
+				'mediaId'     => $custom_image_id,
+				'imageFit'    => 'none',
+				'isRepeated'  => false,
+				'hasParallax' => false,
+			)
+		);
+
+		$this->assertStringContainsString(
+			esc_url( $custom_image_url ),
+			$output,
+			'Custom mediaId image should be used when imageFit is none.'
+		);
+		$this->assertStringNotContainsString(
+			esc_url( $product_image_url ),
+			$output,
+			'Product image should not be used when a custom mediaId is set.'
+		);
+	}
+
+	/**
+	 * Render a Featured Product block with the given attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	private function render_featured_product( array $attributes ): string {
+		return do_blocks(
+			sprintf(
+				'<!-- wp:woocommerce/featured-product %s /-->',
+				wp_json_encode( $attributes )
+			)
+		);
+	}
+
+	/**
+	 * Create and track a test attachment.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment(): int {
+		$attachment_id          = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$this->attachment_ids[] = $attachment_id;
+
+		return $attachment_id;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/66765.
Closes WOOPLUG-7118.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/66466.

In my last commit in #66466 I used the wrong function for the "fall back" logic when _Image fit_ was _None_. Instead of using `get_image_url()` which is what [was used in the previous implementation](https://github.com/woocommerce/woocommerce/pull/66466/changes#diff-70a3cdfa6aeafdb69c4d2c5821685b4e9cf08735e3c318d5e086d17f1b80627eL234) and checks the `mediaId` attribute before falling back to the item image, [I used `get_item_image()`](https://github.com/woocommerce/woocommerce/pull/66466/changes/0db7e15e3804026aa8ec5bba3b17f27b01687df3#diff-70a3cdfa6aeafdb69c4d2c5821685b4e9cf08735e3c318d5e086d17f1b80627eR421), which gets the item featured image directly.

That meant that for Featured Product/Featured Category blocks with _Image fit_ set to _None_ and a specific image selected, we were still displaying the item image instead of the image selected on the block.

### How to test the changes in this Pull Request:

1. Add the Featured Product and Featured Category blocks.
2. Select different images than the default for each one of them, by using the _Replace_ button in the toolbar.
3. Verify the image is changed correctly in the editor.
4. Go to the frontend.
5. Verify the custom image is applied to the frontend as well.

Editor | Frontend before | Frontend after
--- | --- | ---
<img width="1005" height="866" alt="imatge" src="https://github.com/user-attachments/assets/8b039681-b863-4df2-95b4-b8606cf880a4" /> | <img width="991" height="774" alt="imatge" src="https://github.com/user-attachments/assets/773973e1-8e43-4fa5-ab3a-61146df18fca" /> | <img width="991" height="774" alt="imatge" src="https://github.com/user-attachments/assets/ff45ae37-7d81-487b-bf83-78ac50b23825" />