### PR TITLE
Fix coupon codes with ampersand being double-encoded on save

### DIFF
--- a/plugins/woocommerce/changelog/fix-44795-coupon-ampersand-encoding
+++ b/plugins/woocommerce/changelog/fix-44795-coupon-ampersand-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon codes with ampersand characters being double-encoded on save.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -374,7 +374,7 @@ class WC_Post_Data {
 			$data['post_title'] = 'AUTO-DRAFT';
 		} elseif ( 'shop_coupon' === $data['post_type'] ) {
 			// Coupons should never allow unfiltered HTML.
-			$data['post_title'] = wp_filter_kses( $data['post_title'] );
+			$data['post_title'] = wc_sanitize_coupon_code( $data['post_title'] );
 		}
 
 		return $data;

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -388,11 +388,21 @@ function wc_format_coupon_code( $value ) {
  *
  * @since  3.6.0
  * @since  10.0.0 Decode HTML entities here instead of via woocommerce_coupon_code filter.
+ * @since  X.X.X Recursively decode HTML entities and use wp_strip_all_tags instead of wp_kses to avoid encoding ampersands.
  * @param  string $value Coupon code to format.
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT, get_bloginfo( 'charset' ) ), 0, 'db' ), 'entities' );
+	$value = $value ?? '';
+
+	// Recursively decode HTML entities to handle double-encoded values (e.g., &amp;amp;).
+	$prev = '';
+	while ( $value !== $prev ) {
+		$prev  = $value;
+		$value = html_entity_decode( $value, ENT_COMPAT, get_bloginfo( 'charset' ) );
+	}
+
+	$value = wp_strip_all_tags( sanitize_post_field( 'post_title', $value, 0, 'db' ) );
 	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 

--- a/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-coupon-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/meta-boxes/class-wc-meta-box-coupon-data-test.php
@@ -145,6 +145,27 @@ class WC_Meta_Box_Coupon_Data_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox save() preserves the coupon code when it contains an ampersand.
+	 */
+	public function test_save_preserves_ampersand_in_coupon_code(): void {
+		$coupon_code = 'Coupon&Test';
+		$post_id     = $this->create_coupon_post( $coupon_code );
+		$post        = $this->get_coupon_post( $post_id );
+
+		// Verify the post title was saved with the raw ampersand.
+		$this->assertStringContainsString( '&', $post->post_title, 'Expected the post title to contain a raw ampersand.' );
+		$this->assertStringNotContainsString( '&amp;', $post->post_title, 'Expected the post title not to contain HTML-encoded ampersand.' );
+
+		$this->set_coupon_post_data();
+
+		WC_Meta_Box_Coupon_Data::save( $post_id, $post );
+
+		$coupon = new WC_Coupon( $post_id );
+
+		$this->assertSame( $coupon_code, $coupon->get_code(), 'Expected the coupon code to preserve the raw ampersand.' );
+	}
+
+	/**
 	 * Create a coupon post for metabox save tests.
 	 *
 	 * @param string $coupon_code Coupon code.

--- a/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
@@ -18,7 +18,9 @@ class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
 	public function data_provider_test_wc_sanitize_coupon_code(): array {
 		return array(
 			array( 'DUMMYCOUPON', 'DUMMYCOUPON' ),
-			array( 'a&amp;a', 'a&a' ),
+			array( 'a&a', 'a&a' ),
+			array( 'a&a', 'a&amp;a' ),
+			array( 'a&a', 'a&amp;amp;a' ),
 			array( "test's", "test's" ),
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When a coupon code contains an ampersand (`&`), `WC_Post_Data::wp_insert_post_data` was running `wp_filter_kses()` on the post title, which converted `&` to `&amp;`. On subsequent edits, WordPress's `esc_html()` double-encoded it to `&amp;amp;`, causing the coupon code to display incorrectly (e.g., `Coupon&amp;Test` instead of `Coupon&Test`).

Two changes fix this:

1. `WC_Post_Data::wp_insert_post_data` now uses `wc_sanitize_coupon_code()` instead of `wp_filter_kses()` for coupon post titles, matching how coupon codes are sanitized everywhere else in WooCommerce.
2. `wc_sanitize_coupon_code()` now recursively decodes HTML entities (handling double-encoded values) and uses `wp_strip_all_tags()` instead of `wp_kses(..., 'entities')`, which was also encoding bare ampersands.

Closes woocommerce/woocommerce#44795.

### Screenshots or screen recordings:

<img src="https://github.com/user-attachments/assets/e8b5361c-fa94-477c-a6b9-8c0af14f93ce " alt="CleanShot 2026-07-17 at 11  11 36@2x" width="3446" data-linear-height="1700" />

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Go to Marketing > Coupons > Add new coupon.
2. Enter a coupon code containing an ampersand, e.g., `Coupon&Test`.
3. Configure discount type and amount as desired.
4. Click "Publish".
5. Go to Marketing > Coupons and verify the coupon code displays as `Coupon&Test` (not `Coupon&amp;Test`).
6. Click into the coupon to edit it and verify the code field still shows `Coupon&Test` correctly.
7. Apply the coupon at checkout and verify it works correctly.

### Testing that has already taken place:

* Code review and PHP linting (PHPCS, PHPStan) passed.
* Unit tests updated and verified through static analysis.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)