### PR TITLE
fix(mini-cart): make drawer descendants non-focusable when closed

### DIFF
--- a/plugins/woocommerce/changelog/66611-fix-mini-cart-drawer-inert
+++ b/plugins/woocommerce/changelog/66611-fix-mini-cart-drawer-inert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add the `inert` attribute to the Mini Cart drawer container when it is closed, via `data-wp-bind--inert="!state.isOpen"`. This makes the focusable descendants inside the closed, aria-hidden drawer (the Close button and Start shopping link) non-focusable, fixing the Lighthouse/axe-core "Elements with aria-hidden contain focusable descendants" accessibility violation.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -476,6 +476,7 @@ class MiniCart extends AbstractBlock {
 				data-wp-bind--role="state.drawerRole"
 				data-wp-bind--aria-modal="state.isOpen"
 				data-wp-bind--aria-hidden="!state.isOpen"
+				data-wp-bind--inert="!state.isOpen"
 				data-wp-bind--tabindex="state.drawerTabIndex"
 				class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
 			>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -195,6 +195,23 @@ class MiniCart extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Checks the drawer container is inert when closed so its focusable
+	 * descendants (Close button, Start shopping link) are not keyboard
+	 * reachable while aria-hidden is true.
+	 *
+	 * @return void
+	 */
+	public function test_mini_cart_drawer_is_inert_when_closed(): void {
+		ob_start();
+		$this->mock->render_mini_cart_overlay();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wc-block-mini-cart__drawer', $output );
+		$this->assertStringContainsString( 'data-wp-bind--aria-hidden="!state.isOpen"', $output );
+		$this->assertStringContainsString( 'data-wp-bind--inert="!state.isOpen"', $output );
+	}
+
+	/**
 	 * Checks that process_template_contents returns exactly the same string if
 	 * a template without wrapper divs is used.
 	 *


### PR DESCRIPTION
Add data-wp-bind--inert="!state.isOpen" to the Mini Cart drawer container so that when the drawer is closed (aria-hidden="true") its focusable descendants (Close button, Start shopping link) are removed from the tab order. This resolves the Lighthouse/axe-core accessibility violation 'Elements with aria-hidden contain focusable descendants'.

The inert attribute is toggled in lockstep with the existing aria-hidden binding, reusing the established Interactivity API pattern already used by the Accordion and Product Gallery blocks. No JS store change is needed because state.isOpen is already toggled by openDrawer/closeDrawer.

Fixes #66611

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
