### PR TITLE
[Performance] Reduce the number of SQL queries on the cart page for multi-product carts

### DIFF
--- a/plugins/woocommerce/changelog/perfromance-reduce-sqls-cart-page
+++ b/plugins/woocommerce/changelog/perfromance-reduce-sqls-cart-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Reduced the number of SQL queries on the cart page for multi-product carts.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -133,7 +133,9 @@ final class WC_Cart_Session {
 
 		if ( ! empty( $cart ) ) {
 			// Prime caches to reduce future queries.
-			_prime_post_caches( wp_list_pluck( $cart, 'product_id' ) );
+			$product_ids    = array_filter( array_column( $cart, 'product_id' ) );
+			$variations_ids = array_filter( array_column( $cart, 'variation_id' ) );
+			_prime_post_caches( array_merge( $product_ids, $variations_ids ) );
 		}
 
 		$cart_contents = array();

--- a/plugins/woocommerce/src/Internal/Tax/TaxRateDataStore.php
+++ b/plugins/woocommerce/src/Internal/Tax/TaxRateDataStore.php
@@ -8,6 +8,12 @@ namespace Automattic\WooCommerce\Internal\Tax;
  * Data store for tax rates.
  */
 class TaxRateDataStore {
+	/**
+	 * Request-level cache of fetched tax rate rows, keyed by tax_rate_id.
+	 *
+	 * @var array<int,object>
+	 */
+	private array $rate_objects_cache = array();
 
 	/**
 	 * Fetch multiple tax rate rows in a single query, keyed by tax_rate_id.
@@ -18,20 +24,26 @@ class TaxRateDataStore {
 	 * @return array<int,object>
 	 */
 	public function get_rate_objects_for_ids( array $ids ): array {
-		$tax_rate_objects = array();
-		$ids              = array_values( array_filter( array_map( 'absint', array_unique( $ids ) ) ) );
+		global $wpdb;
 
-		if ( ! empty( $ids ) ) {
-			global $wpdb;
-
-			$list = implode( ', ', $ids );
+		$ids          = array_filter( array_map( 'absint', array_unique( $ids ) ) );
+		$uncached_ids = array_diff( $ids, array_keys( $this->rate_objects_cache ) );
+		if ( ! empty( $uncached_ids ) ) {
+			$list = implode( ', ', $uncached_ids );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$rows = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id IN ( $list )" );
 			foreach ( $rows as $row ) {
-				$tax_rate_objects[ (int) $row->tax_rate_id ] = $row;
+				$this->rate_objects_cache[ (int) $row->tax_rate_id ] = $row;
 			}
 		}
 
-		return $tax_rate_objects;
+		$result = array();
+		foreach ( $ids as $id ) {
+			if ( isset( $this->rate_objects_cache[ $id ] ) ) {
+				$result[ $id ] = $this->rate_objects_cache[ $id ];
+			}
+		}
+
+		return $result;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Tax/TaxRateDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Tax/TaxRateDataStoreTest.php
@@ -25,29 +25,46 @@ class TaxRateDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_rate_objects_for_ids() deduplicates mixed int/string IDs and returns a map keyed by int tax_rate_id.
+	 * @testdox get_rate_objects_for_ids() deduplicates mixed int/string IDs, returns a map keyed by int tax_rate_id, and serves subsequent calls from the request-level cache.
 	 */
 	public function test_get_rate_objects_for_ids(): void {
-		// Arrange.
-		$tax_rate    = array(
-			'tax_rate_country'  => 'DE',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '19.0000',
-			'tax_rate_name'     => 'VAT',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '1',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
+		// Arrange: two GB rates as seen on a cart with standard + reduced VAT.
+		$standard_id = \WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'GB',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '20.0000',
+				'tax_rate_name'     => 'Standard Rate',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
 		);
-		$tax_rate_id = \WC_Tax::_insert_tax_rate( $tax_rate );
+		$reduced_id  = \WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'GB',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '5.0000',
+				'tax_rate_name'     => 'Reduced Rate',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '0',
+				'tax_rate_order'    => '2',
+				'tax_rate_class'    => 'reduced-rate',
+			)
+		);
 
-		// Act.
-		$result = $this->sut->get_rate_objects_for_ids( array( $tax_rate_id, (string) $tax_rate_id, PHP_INT_MAX ) );
+		// Act: deduplication — pass standard_id as both int and string, plus a non-existent ID.
+		$ids    = array( $reduced_id, $standard_id, (string) $standard_id, PHP_INT_MAX );
+		$result = $this->sut->get_rate_objects_for_ids( $ids );
 
-		// Assert.
-		$this->assertCount( 1, $result );
-		$this->assertSame( array( $tax_rate_id ), array_keys( $result ) );
-		$this->assertSame( 'VAT', $result[ $tax_rate_id ]->tax_rate_name );
+		// Assert: both rates present, each keyed by its own ID with correct values.
+		$this->assertSame( array( $reduced_id, $standard_id ), array_keys( $result ) );
+		$this->assertSame( array( '5.0000', '20.0000' ), array_column( $result, 'tax_rate' ) );
+
+		// Verify a third call (full cache hit) returns identical result.
+		$this->assertSame( $result, $this->sut->get_rate_objects_for_ids( $ids ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow-up of #66084 and #66675 (exploration testing for variable products surfaced an elevated number of SQL queries on the cart page).

This PR introduces:
- cache priming for variations when populating cart from session
- request-level cache for fetching tax rates in order to reduce the number of SQL queries on the cart page

Number of SQL queries on cart page (variable products, taxes being applied):
- 5 variable products: 98 -> 82 SQLs
- 4 variable products: 94 -> 81 SQLs
- 3 variable products: 90 -> 80 SQLs
- 2 variable products: 87 -> 80 SQLs
- 1 variable product: 84 -> 80 SQLs

### How to test the changes in this Pull Request:

Marking taxes as optional, as the changes enhance the datastore I introduced in #65558 back in June, so the context is still fresh on my end.

- Ensure the testing site has Query Monitor (or similar) plugin installed
- (Optionally) enable and configure taxes so they are applied on cart/checkout pages
- Add multiple variable products to cart
- Verify a reduction in the number of SQLs on this branch compared to trunk
- Using this branch, verify checkout completions
