### PR TITLE
Keep shipping country visible for single-country stores

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-calculator-single-country
+++ b/plugins/woocommerce/changelog/fix-shipping-calculator-single-country
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep the shipping calculator country visible and submit its value when only one shipping country is available.

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,10 +12,21 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.7.0
+ * @version 11.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
+
+$shipping_countries          = WC()->countries->get_shipping_countries();
+$has_single_shipping_country = 1 === count( $shipping_countries );
+
+/**
+ * Filters whether the country field is enabled in the shipping calculator.
+ *
+ * @since 3.4.0
+ * @param bool $enabled Whether the country field is enabled.
+ */
+$show_country_field = apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) || $has_single_shipping_country;
 
 do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
@@ -25,17 +36,22 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 	<section class="shipping-calculator-form" id="shipping-calculator-form" style="display:none;">
 
-		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) ) : ?>
+		<?php if ( $show_country_field ) : ?>
 			<p class="form-row form-row-wide" id="calc_shipping_country_field">
 				<label for="calc_shipping_country"><?php esc_html_e( 'Country / region', 'woocommerce' ); ?></label>
-				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state">
-					<option value="default"><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
+				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state" <?php disabled( $has_single_shipping_country ); ?>>
+					<?php if ( ! $has_single_shipping_country ) : ?>
+						<option value="default"><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
+					<?php endif; ?>
 					<?php
-					foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
+					foreach ( $shipping_countries as $key => $value ) {
 						echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
 					}
 					?>
 				</select>
+				<?php if ( $has_single_shipping_country ) : ?>
+					<input type="hidden" name="calc_shipping_country" value="<?php echo esc_attr( array_key_first( $shipping_countries ) ); ?>" />
+				<?php endif; ?>
 			</p>
 		<?php endif; ?>
 

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.1.0
+ * @version 11.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +45,7 @@ $show_country_field = apply_filters( 'woocommerce_shipping_calculator_enable_cou
 		<?php if ( $show_country_field ) : ?>
 			<p class="form-row form-row-wide" id="calc_shipping_country_field">
 				<label for="calc_shipping_country"><?php esc_html_e( 'Country / region', 'woocommerce' ); ?></label>
-				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select<?php echo $has_single_shipping_country ? ' country_to_state--single' : ''; ?>" rel="calc_shipping_state">
+				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state <?php echo $has_single_shipping_country ? 'country_to_state--single' : 'country_select'; ?>" rel="calc_shipping_state">
 					<?php if ( ! $has_single_shipping_country ) : ?>
 						<option value="default"><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
 					<?php endif; ?>

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -17,6 +17,13 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Fires before the shipping calculator is rendered.
+ *
+ * @since 1.4.0
+ */
+do_action( 'woocommerce_before_shipping_calculator' );
+
 $shipping_countries          = WC()->countries->get_shipping_countries();
 $has_single_shipping_country = 1 === count( $shipping_countries );
 
@@ -26,9 +33,8 @@ $has_single_shipping_country = 1 === count( $shipping_countries );
  * @since 3.4.0
  * @param bool $enabled Whether the country field is enabled.
  */
-$show_country_field = apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) || $has_single_shipping_country;
-
-do_action( 'woocommerce_before_shipping_calculator' ); ?>
+$show_country_field = apply_filters( 'woocommerce_shipping_calculator_enable_country', true );
+?>
 
 <form class="woocommerce-shipping-calculator" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
 
@@ -39,7 +45,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 		<?php if ( $show_country_field ) : ?>
 			<p class="form-row form-row-wide" id="calc_shipping_country_field">
 				<label for="calc_shipping_country"><?php esc_html_e( 'Country / region', 'woocommerce' ); ?></label>
-				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state" <?php disabled( $has_single_shipping_country ); ?>>
+				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select<?php echo $has_single_shipping_country ? ' country_to_state--single' : ''; ?>" rel="calc_shipping_state">
 					<?php if ( ! $has_single_shipping_country ) : ?>
 						<option value="default"><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
 					<?php endif; ?>
@@ -49,10 +55,9 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 					}
 					?>
 				</select>
-				<?php if ( $has_single_shipping_country ) : ?>
-					<input type="hidden" name="calc_shipping_country" value="<?php echo esc_attr( array_key_first( $shipping_countries ) ); ?>" />
-				<?php endif; ?>
 			</p>
+		<?php elseif ( $has_single_shipping_country ) : ?>
+			<input type="hidden" name="calc_shipping_country" value="<?php echo esc_attr( array_key_first( $shipping_countries ) ); ?>" />
 		<?php endif; ?>
 
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) ) : ?>

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
@@ -1,0 +1,124 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the shipping calculator template.
+ *
+ * @package WooCommerce\Tests\Templates
+ */
+
+/**
+ * Class WC_Shipping_Calculator_Template_Test.
+ */
+class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Options changed by the tests.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_options = array();
+
+	/**
+	 * Customer shipping country before each test.
+	 *
+	 * @var string
+	 */
+	private $original_shipping_country = '';
+
+	/**
+	 * Set up the test fixture.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		foreach ( array( 'woocommerce_allowed_countries', 'woocommerce_specific_allowed_countries', 'woocommerce_ship_to_countries' ) as $option_name ) {
+			$this->original_options[ $option_name ] = get_option( $option_name, null );
+		}
+
+		$this->original_shipping_country = WC()->customer->get_shipping_country();
+	}
+
+	/**
+	 * Restore the test fixture.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
+
+		foreach ( $this->original_options as $option_name => $option_value ) {
+			if ( null === $option_value ) {
+				delete_option( $option_name );
+			} else {
+				update_option( $option_name, $option_value );
+			}
+		}
+
+		WC()->customer->set_shipping_country( $this->original_shipping_country );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A single available country should remain visible and be submitted by the calculator.
+	 */
+	public function test_single_shipping_country_is_read_only_and_submitted() {
+		$this->set_shipping_countries( array( 'GR' ) );
+		WC()->customer->set_shipping_country( 'GR' );
+
+		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
+
+		$this->assertMatchesRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=[\'\"]disabled[\'\"]/', $output );
+		$this->assertStringContainsString( '<option value="GR" selected=\'selected\'>Greece</option>', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="calc_shipping_country" value="GR" />', $output );
+		$this->assertStringNotContainsString( 'Select a country / region', $output );
+	}
+
+	/**
+	 * Hiding the country filter should not remove the required value for a single-country store.
+	 */
+	public function test_single_shipping_country_remains_visible_when_filter_is_disabled() {
+		$this->set_shipping_countries( array( 'GR' ) );
+		add_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
+
+		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
+
+		$this->assertStringContainsString( 'id="calc_shipping_country_field"', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="calc_shipping_country" value="GR" />', $output );
+	}
+
+	/**
+	 * Multiple available countries should keep the existing selectable control.
+	 */
+	public function test_multiple_shipping_countries_remain_selectable() {
+		$this->set_shipping_countries( array( 'GR', 'CY' ) );
+
+		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
+
+		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=/', $output );
+		$this->assertStringContainsString( 'Select a country / region', $output );
+		$this->assertStringNotContainsString( '<input type="hidden" name="calc_shipping_country"', $output );
+	}
+
+	/**
+	 * Multiple countries should retain the existing country-filter behavior.
+	 */
+	public function test_multiple_shipping_countries_can_still_hide_country_field() {
+		$this->set_shipping_countries( array( 'GR', 'CY' ) );
+		add_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
+
+		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
+
+		$this->assertStringNotContainsString( 'id="calc_shipping_country_field"', $output );
+	}
+
+	/**
+	 * Configure the countries available to the shipping calculator.
+	 *
+	 * @param string[] $countries Country codes.
+	 */
+	private function set_shipping_countries( array $countries ) {
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', $countries );
+		update_option( 'woocommerce_ship_to_countries', '' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
@@ -68,8 +68,12 @@ class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
 
 		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
 
-		$this->assertMatchesRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+class="[^"]*country_to_state--single[^"]*"/', $output );
-		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=/', $output );
+		$select = new WP_HTML_Tag_Processor( $output );
+		$this->assertTrue( $select->next_tag( array( 'tag_name' => 'select' ) ) );
+		$this->assertSame( 'calc_shipping_country', $select->get_attribute( 'name' ) );
+		$this->assertTrue( $select->has_class( 'country_to_state--single' ) );
+		$this->assertFalse( $select->has_class( 'country_select' ) );
+		$this->assertNull( $select->get_attribute( 'disabled' ) );
 		$this->assertStringContainsString( '<option value="GR" selected=\'selected\'>Greece</option>', $output );
 		$this->assertStringNotContainsString( '<input type="hidden" name="calc_shipping_country"', $output );
 		$this->assertStringNotContainsString( 'Select a country / region', $output );
@@ -109,7 +113,12 @@ class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
 
 		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
 
-		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=/', $output );
+		$select = new WP_HTML_Tag_Processor( $output );
+		$this->assertTrue( $select->next_tag( array( 'tag_name' => 'select' ) ) );
+		$this->assertSame( 'calc_shipping_country', $select->get_attribute( 'name' ) );
+		$this->assertTrue( $select->has_class( 'country_select' ) );
+		$this->assertFalse( $select->has_class( 'country_to_state--single' ) );
+		$this->assertNull( $select->get_attribute( 'disabled' ) );
 		$this->assertStringContainsString( 'Select a country / region', $output );
 		$this->assertStringNotContainsString( '<input type="hidden" name="calc_shipping_country"', $output );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-calculator-template-test.php
@@ -44,6 +44,7 @@ class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
+		remove_action( 'woocommerce_before_shipping_calculator', array( $this, 'disable_country_field_before_calculator' ) );
 
 		foreach ( $this->original_options as $option_name => $option_value ) {
 			if ( null === $option_value ) {
@@ -59,30 +60,44 @@ class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A single available country should remain visible and be submitted by the calculator.
+	 * A single available country should remain visible and be submitted by the calculator's select.
 	 */
-	public function test_single_shipping_country_is_read_only_and_submitted() {
+	public function test_single_shipping_country_uses_single_country_select() {
 		$this->set_shipping_countries( array( 'GR' ) );
 		WC()->customer->set_shipping_country( 'GR' );
 
 		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
 
-		$this->assertMatchesRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=[\'\"]disabled[\'\"]/', $output );
+		$this->assertMatchesRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+class="[^"]*country_to_state--single[^"]*"/', $output );
+		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+name="calc_shipping_country"[^>]+disabled=/', $output );
 		$this->assertStringContainsString( '<option value="GR" selected=\'selected\'>Greece</option>', $output );
-		$this->assertStringContainsString( '<input type="hidden" name="calc_shipping_country" value="GR" />', $output );
+		$this->assertStringNotContainsString( '<input type="hidden" name="calc_shipping_country"', $output );
 		$this->assertStringNotContainsString( 'Select a country / region', $output );
 	}
 
 	/**
-	 * Hiding the country filter should not remove the required value for a single-country store.
+	 * Hiding the country filter should hide the field without removing the required submitted value.
 	 */
-	public function test_single_shipping_country_remains_visible_when_filter_is_disabled() {
+	public function test_single_shipping_country_is_submitted_when_filter_hides_field() {
 		$this->set_shipping_countries( array( 'GR' ) );
 		add_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
 
 		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
 
-		$this->assertStringContainsString( 'id="calc_shipping_country_field"', $output );
+		$this->assertStringNotContainsString( 'id="calc_shipping_country_field"', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="calc_shipping_country" value="GR" />', $output );
+	}
+
+	/**
+	 * Extensions should still be able to register the country filter from the before-calculator hook.
+	 */
+	public function test_country_filter_runs_after_before_calculator_hook() {
+		$this->set_shipping_countries( array( 'GR' ) );
+		add_action( 'woocommerce_before_shipping_calculator', array( $this, 'disable_country_field_before_calculator' ) );
+
+		$output = wc_get_template_html( 'cart/shipping-calculator.php' );
+
+		$this->assertStringNotContainsString( 'id="calc_shipping_country_field"', $output );
 		$this->assertStringContainsString( '<input type="hidden" name="calc_shipping_country" value="GR" />', $output );
 	}
 
@@ -116,9 +131,16 @@ class WC_Shipping_Calculator_Template_Test extends WC_Unit_Test_Case {
 	 *
 	 * @param string[] $countries Country codes.
 	 */
-	private function set_shipping_countries( array $countries ) {
+	private function set_shipping_countries( array $countries ): void {
 		update_option( 'woocommerce_allowed_countries', 'specific' );
 		update_option( 'woocommerce_specific_allowed_countries', $countries );
 		update_option( 'woocommerce_ship_to_countries', '' );
+	}
+
+	/**
+	 * Disable the country field from the before-calculator hook.
+	 */
+	public function disable_country_field_before_calculator(): void {
+		add_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the WooCommerce Contributing Guidelines and WordPress Coding Standards.
- I checked for existing open pull requests covering this issue.
- I reviewed the change for secure output and backwards compatibility.

### Changes proposed in this Pull Request:

For a store that ships to only one country, the classic cart shipping calculator currently offers a country dropdown that cannot provide another meaningful choice. Hiding it with `woocommerce_shipping_calculator_enable_country` also removes the value the shipping handler needs.

This keeps the single country visible in a disabled select and submits its code through a hidden input. Stores with multiple shipping countries keep the existing selectable dropdown and filter behavior.

Closes #27491.

### Screenshots or screen recordings:

No new visual design is introduced; the existing classic-cart country control is reused in its disabled state. The manual visual validation is documented below.

### How to test the changes in this Pull Request:

1. In **WooCommerce > Settings > General**, limit selling/shipping to one country, for example Greece.
2. Enable the shipping calculator on the cart page and configure a shipping method.
3. Add a shippable product to the classic cart and expand **Calculate shipping**.
4. Confirm that **Country / Region** displays Greece and cannot be changed, while state, city, and postcode remain editable.
5. Submit the calculator and confirm that shipping updates without losing the country.
6. Allow a second shipping country and confirm that the normal selectable country dropdown returns.
7. Optionally return `false` from `woocommerce_shipping_calculator_enable_country`: a single-country store should still retain the read-only country value, while a multi-country store should retain the previous hidden-field behavior.

### Testing that has already taken place:

- PHPUnit: `WC_Shipping_Calculator_Template_Test` — 4 tests, 10 assertions.
- PHPCS passed for the new test file and all changed template lines; `git diff --check` passed.
- The classic frontend assets build completed successfully.
- Manual Storefront test: local WordPress 7.0.2, WooCommerce 11.1.0-dev, Storefront 4.6.2, PHP 8.1.34, one shipping country (`GR`), one shippable product, and flat rate shipping. The expanded calculator showed a visible disabled Greece control and submitted hidden value `GR`.
- I traced the classic cart template and shipping handler paths to check the filter and form-submission impact. The change adds no queries, external calls, or customer-data handling.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

A manual changelog file is included in this branch.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Keep the shipping calculator country visible and submit its value when only one shipping country is available.

</details>

### Release Communication

- [ ] Feature Highlight
- [ ] Developer Advisory
