### PR TITLE
Consolidate the shared ESLint import/core-modules list

### DIFF
--- a/packages/js/admin-layout/changelog/consolidate-eslint-core-modules
+++ b/packages/js/admin-layout/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/admin-layout/eslint.config.mjs
+++ b/packages/js/admin-layout/eslint.config.mjs
@@ -2,12 +2,13 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
-			'import/core-modules': [ '@woocommerce/components' ],
+			'import/core-modules': [ ...coreModules ],
 			'import/resolver': {
 				node: {},
 				webpack: {},

--- a/packages/js/components/changelog/consolidate-eslint-core-modules
+++ b/packages/js/components/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/components/eslint.config.mjs
+++ b/packages/js/components/eslint.config.mjs
@@ -7,6 +7,7 @@ import { globalIgnores } from 'eslint/config';
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
@@ -14,17 +15,9 @@ export default [
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/components',
-				'@woocommerce/currency',
-				'@woocommerce/data',
-				'@woocommerce/date',
-				'@woocommerce/navigation',
+				...coreModules,
 				'@storybook/react',
 				'@automattic/tour-kit',
-				'@wordpress/blocks',
-				'@wordpress/components',
-				'@wordpress/element',
-				'@wordpress/media-utils',
 				'dompurify',
 				'downshift',
 				'moment',

--- a/packages/js/currency/changelog/consolidate-eslint-core-modules
+++ b/packages/js/currency/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/currency/eslint.config.mjs
+++ b/packages/js/currency/eslint.config.mjs
@@ -2,15 +2,13 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
-			'import/core-modules': [
-				'@woocommerce/number',
-				'@woocommerce/settings',
-			],
+			'import/core-modules': [ ...coreModules ],
 			'import/resolver': {
 				node: {},
 				typescript: {},

--- a/packages/js/customer-effort-score/changelog/consolidate-eslint-core-modules
+++ b/packages/js/customer-effort-score/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/customer-effort-score/eslint.config.mjs
+++ b/packages/js/customer-effort-score/eslint.config.mjs
@@ -2,16 +2,14 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/data',
-				'@woocommerce/experimental',
-				'@woocommerce/navigation',
-				'@woocommerce/tracks',
+				...coreModules,
 				'@testing-library/react',
 			],
 			'import/resolver': {

--- a/packages/js/data/changelog/consolidate-eslint-core-modules
+++ b/packages/js/data/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/data/eslint.config.mjs
+++ b/packages/js/data/eslint.config.mjs
@@ -2,18 +2,15 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/date',
-				'@woocommerce/navigation',
-				'@woocommerce/tracks',
+				...coreModules,
 				'@wordpress/api-fetch',
-				'@wordpress/core-data',
-				'@wordpress/data',
 				'redux',
 			],
 			'import/resolver': {

--- a/packages/js/email-editor/changelog/consolidate-eslint-core-modules
+++ b/packages/js/email-editor/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/email-editor/eslint.config.mjs
+++ b/packages/js/email-editor/eslint.config.mjs
@@ -2,24 +2,17 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
 			'import/core-modules': [
-				'@wordpress/blocks',
-				'@wordpress/block-editor',
-				'@wordpress/components',
-				'@wordpress/core-data',
+				...coreModules,
 				'@wordpress/date',
-				'@wordpress/data',
 				'@wordpress/data-controls',
-				'@wordpress/editor',
-				'@wordpress/element',
 				'@wordpress/keycodes',
-				'@wordpress/media-utils',
-				'@wordpress/notices',
 				'@wordpress/hooks',
 				'@wordpress/preferences',
 			],

--- a/packages/js/experimental-products-app/changelog/consolidate-eslint-core-modules
+++ b/packages/js/experimental-products-app/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/experimental-products-app/eslint.config.mjs
+++ b/packages/js/experimental-products-app/eslint.config.mjs
@@ -2,21 +2,16 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/data',
-				'@woocommerce/settings',
-				'@wordpress/components',
+				...coreModules,
 				'@wordpress/compose',
-				'@wordpress/core-data',
-				'@wordpress/data',
 				'@wordpress/dataviews',
-				'@wordpress/editor',
-				'@wordpress/element',
 				'@wordpress/html-entities',
 				'@wordpress/i18n',
 				'@wordpress/icons',

--- a/packages/js/experimental/changelog/consolidate-eslint-core-modules
+++ b/packages/js/experimental/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/experimental/eslint.config.mjs
+++ b/packages/js/experimental/eslint.config.mjs
@@ -2,14 +2,14 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/components',
-				'@wordpress/components',
+				...coreModules,
 				'@storybook/react',
 				'react-transition-group/CSSTransition',
 				'dompurify',

--- a/packages/js/onboarding/changelog/consolidate-eslint-core-modules
+++ b/packages/js/onboarding/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/onboarding/eslint.config.mjs
+++ b/packages/js/onboarding/eslint.config.mjs
@@ -2,16 +2,13 @@
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	{
 		settings: {
-			'import/core-modules': [
-				'@woocommerce/experimental',
-				'@woocommerce/components',
-				'@woocommerce/tracks',
-			],
+			'import/core-modules': [ ...coreModules ],
 			'import/resolver': {
 				node: {},
 				webpack: {},

--- a/packages/js/remote-logging/changelog/consolidate-eslint-core-modules
+++ b/packages/js/remote-logging/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/packages/js/remote-logging/eslint.config.mjs
+++ b/packages/js/remote-logging/eslint.config.mjs
@@ -7,13 +7,14 @@ import { globalIgnores } from 'eslint/config';
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	...woocommerce,
 	globalIgnores( [ '**/test/*.ts', '**/test/*.tsx' ] ),
 	{
 		settings: {
-			'import/core-modules': [ '@woocommerce/settings' ],
+			'import/core-modules': [ ...coreModules ],
 			'import/resolver': {
 				node: {},
 				typescript: {},

--- a/plugins/woocommerce/changelog/consolidate-eslint-core-modules
+++ b/plugins/woocommerce/changelog/consolidate-eslint-core-modules
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Consolidate the shared `import/core-modules` list into `@woocommerce/eslint-config`. Tooling only; no runtime change.

--- a/plugins/woocommerce/client/admin/eslint.config.mjs
+++ b/plugins/woocommerce/client/admin/eslint.config.mjs
@@ -7,6 +7,7 @@ import { globalIgnores } from 'eslint/config';
  * Internal dependencies
  */
 import woocommerce from '@woocommerce/eslint-config';
+import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
 
 export default [
 	// node_modules is ignored by default. `api` has its own config and command.
@@ -34,29 +35,8 @@ export default [
 	{
 		settings: {
 			'import/core-modules': [
-				'@woocommerce/admin-layout',
-				'@woocommerce/components',
-				'@woocommerce/customer-effort-score',
-				'@woocommerce/currency',
-				'@woocommerce/csv-export',
-				'@woocommerce/data',
-				'@woocommerce/date',
-				'@woocommerce/explat',
-				'@woocommerce/internal-js-tests',
-				'@woocommerce/navigation',
-				'@woocommerce/number',
-				'@woocommerce/onboarding',
-				'@woocommerce/product-editor',
-				'@woocommerce/settings',
-				'@woocommerce/tracks',
-				'@woocommerce/experimental',
-				'@wordpress/components',
-				'@wordpress/core-data',
-				'@wordpress/element',
-				'@wordpress/blocks',
-				'@wordpress/block-editor',
+				...coreModules,
 				'@wordpress/block-library',
-				'@wordpress/notices',
 				'dompurify',
 				'@react-spring/web',
 				'react-router-dom',

--- a/tools/eslint-config/core-modules.js
+++ b/tools/eslint-config/core-modules.js
@@ -1,0 +1,46 @@
+/*
+ * Shared `import/core-modules` list for the monorepo's package ESLint configs.
+ *
+ * These specifiers are webpack externals or WordPress-provided globals resolved
+ * at runtime (`window.wc.*` / `window.wp.*`), so they never resolve on disk.
+ * Listing them here stops `import/no-unresolved` and
+ * `import/no-extraneous-dependencies` firing on every such import, and gives the
+ * package configs one source of truth instead of drifting per-package copies.
+ *
+ * It holds the monorepo `@woocommerce/*` siblings plus the `@wordpress/*`
+ * packages that recur across multiple configs. Package-specific specifiers
+ * (one-off `@wordpress/*` and third-party externals) stay in the consuming
+ * config, spread after this list.
+ */
+const coreModules = [
+	// Monorepo @woocommerce/* siblings (webpack externals / aliases).
+	'@woocommerce/admin-layout',
+	'@woocommerce/components',
+	'@woocommerce/csv-export',
+	'@woocommerce/currency',
+	'@woocommerce/customer-effort-score',
+	'@woocommerce/data',
+	'@woocommerce/date',
+	'@woocommerce/experimental',
+	'@woocommerce/explat',
+	'@woocommerce/internal-js-tests',
+	'@woocommerce/navigation',
+	'@woocommerce/number',
+	'@woocommerce/onboarding',
+	'@woocommerce/product-editor',
+	'@woocommerce/settings',
+	'@woocommerce/tracks',
+
+	// @wordpress/* packages used across multiple package configs.
+	'@wordpress/block-editor',
+	'@wordpress/blocks',
+	'@wordpress/components',
+	'@wordpress/core-data',
+	'@wordpress/data',
+	'@wordpress/editor',
+	'@wordpress/element',
+	'@wordpress/media-utils',
+	'@wordpress/notices',
+];
+
+module.exports = { coreModules };

--- a/tools/eslint-config/core-modules.js
+++ b/tools/eslint-config/core-modules.js
@@ -27,7 +27,6 @@ const coreModules = [
 	'@woocommerce/navigation',
 	'@woocommerce/number',
 	'@woocommerce/onboarding',
-	'@woocommerce/product-editor',
 	'@woocommerce/settings',
 	'@woocommerce/tracks',
 

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -10,13 +10,14 @@
 	},
 	"main": "index.js",
 	"files": [
-		"index.js"
+		"index.js",
+		"core-modules.js"
 	],
 	"scripts": {
 		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
 		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",
-		"lint:lang:js": "eslint ./index.js",
-		"lint:fix:lang:js": "eslint ./index.js --fix"
+		"lint:lang:js": "eslint ./index.js ./core-modules.js",
+		"lint:fix:lang:js": "eslint ./index.js ./core-modules.js --fix"
 	},
 	"dependencies": {
 		"@woocommerce/eslint-plugin": "workspace:*"
@@ -29,7 +30,8 @@
 			"lint": {
 				"command": "lint",
 				"changes": [
-					"index.js"
+					"index.js",
+					"core-modules.js"
 				]
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- [X] I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
- [X] I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
- [X] I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Follow-up to the ESLint Flat Config migration (woocommerce/woocommerce#66621); tracked in woocommerce/woocommerce#66078.

The `import/core-modules` lists — the specifiers `eslint-plugin-import` treats as runtime-provided webpack/WordPress externals so `import/no-unresolved` and `import/no-extraneous-dependencies` don't fire on them — were hand-maintained and had drifted across \~11 package configs.

This hoists the shared set into `@woocommerce/eslint-config` (`core-modules.js`, exporting `coreModules`): the monorepo `@woocommerce/*` siblings plus the `@wordpress/*` packages that recurred across multiple configs. Each consumer now spreads it and keeps only its package-specific extras:

```js
import { coreModules } from '@woocommerce/eslint-config/core-modules.js';
// ...
'import/core-modules': [ ...coreModules, '@wordpress/api-fetch', 'redux' ],
```

Per-package extras were computed as `oldList − sharedList`, so every config's list stays a superset of what it had — no specifier is dropped. `import/resolver` blocks are untouched. `client/blocks` is intentionally left out: it already de-dups internally via a single const and its list is blocks-specific.

Tooling only; no runtime change. `@woocommerce/eslint-config` is private, so no external backward-compatibility surface is affected.

### How to test the changes in this Pull Request:

1. `pnpm install`, then lint an affected package, e.g. `pnpm --filter=@woocommerce/currency lint:lang:js` — it loads the shared config and reports 0 errors.
2. Confirm the shared list applies: add a file importing `@wordpress/components` (in the shared list) and a nonexistent package to any affected package's `src/`, lint it — only the nonexistent import trips `import/no-unresolved`, proving the whitelist is live and the linter still fires.
3. `pnpm --filter=@woocommerce/eslint-config lint` passes (the new `core-modules.js` is linted).

### Testing that has already taken place:

* Verified the CJS→ESM named import resolves under Node 24 and that all 11 changed flat configs load without error.
* Linted every affected package (`client/admin` + the `packages/js/*` set): 0 errors, only the pre-existing relaxed-rule warnings from the migration.
* Planted-probe verification per package confirmed the shared list applies and `import/no-unresolved` still fires on genuinely unresolvable imports.
* Diffed all 11 configs against `trunk` to confirm the superset property (no dropped specifiers). Reviewed by Codex.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

### Changelog entry

- [X] This Pull Request does not require an auto-generated changelog entry.

Changelog entries were added manually (`dev`/`patch`) for each affected package: the 10 `packages/js/*` packages and `plugins/woocommerce` (for `client/admin`). `tools/eslint-config` has no changelogger, so it needs none.