### PR TITLE
Fix ESLint errors in the default scaffolded extension

### DIFF
--- a/packages/js/create-woo-extension/changelog/66078-fix-scaffold-lint-clean
+++ b/packages/js/create-woo-extension/changelog/66078-fix-scaffold-lint-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ESLint errors in the default scaffolded extension: allow the extension's own text domain, skip `no-require-imports` on CommonJS config files, declare `@wordpress/components`/`@wordpress/element`, and fix the example page's undefined `setInlineSelect` handler.

--- a/packages/js/create-woo-extension/index.js
+++ b/packages/js/create-woo-extension/index.js
@@ -1,6 +1,8 @@
 const { join } = require( 'path' );
 
 const defaultDependencies = [
+	'@wordpress/components',
+	'@wordpress/element',
 	'@wordpress/hooks',
 	'@wordpress/i18n',
 	'@woocommerce/components',

--- a/packages/js/create-woo-extension/variants/add-report/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/add-report/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/packages/js/create-woo-extension/variants/add-task/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/add-task/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/packages/js/create-woo-extension/variants/dashboard-section/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/dashboard-section/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/packages/js/create-woo-extension/variants/default/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/default/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/packages/js/create-woo-extension/variants/default/src/index.js.mustache
+++ b/packages/js/create-woo-extension/variants/default/src/index.js.mustache
@@ -5,62 +5,76 @@ import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { Dropdown } from '@wordpress/components';
 import * as Woo from '@woocommerce/components';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './index.scss';
 
-const MyExamplePage = () => (
-	<Fragment>
-		<Woo.Section component="article">
-			<Woo.SectionHeader title={ __( 'Search', '{{textdomain}}' ) } />
-			<Woo.Search
-				type="products"
-				placeholder="Search for something"
-				selected={ [] }
-				onChange={ ( items ) => setInlineSelect( items ) }
-				inlineTags
-			/>
-		</Woo.Section>
+const MyExamplePage = () => {
+	const [ inlineSelect, setInlineSelect ] = useState( [] );
 
-		<Woo.Section component="article">
-			<Woo.SectionHeader title={ __( 'Dropdown', '{{textdomain}}' ) } />
-			<Dropdown
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Woo.DropdownButton
-						onClick={ onToggle }
-						isOpen={ isOpen }
-						labels={ [ 'Dropdown' ] }
-					/>
-				) }
-				renderContent={ () => <p>Dropdown content here</p> }
-			/>
-		</Woo.Section>
+	return (
+		<Fragment>
+			<Woo.Section component="article">
+				<Woo.SectionHeader
+					title={ __( 'Search', '{{textdomain}}' ) }
+				/>
+				<Woo.Search
+					type="products"
+					placeholder="Search for something"
+					selected={ inlineSelect }
+					onChange={ ( items ) => setInlineSelect( items ) }
+					inlineTags
+				/>
+			</Woo.Section>
 
-		<Woo.Section component="article">
-			<Woo.SectionHeader title={ __( 'Pill shaped container', '{{textdomain}}' ) } />
-			<Woo.Pill className={ 'pill' }>
-				{ __( 'Pill Shape Container', '{{textdomain}}' ) }
-			</Woo.Pill>
-		</Woo.Section>
+			<Woo.Section component="article">
+				<Woo.SectionHeader
+					title={ __( 'Dropdown', '{{textdomain}}' ) }
+				/>
+				<Dropdown
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Woo.DropdownButton
+							onClick={ onToggle }
+							isOpen={ isOpen }
+							labels={ [ 'Dropdown' ] }
+						/>
+					) }
+					renderContent={ () => <p>Dropdown content here</p> }
+				/>
+			</Woo.Section>
 
-		<Woo.Section component="article">
-			<Woo.SectionHeader title={ __( 'Spinner', '{{textdomain}}' ) } />
-			<Woo.H>I am a spinner!</Woo.H>
-			<Woo.Spinner />
-		</Woo.Section>
+			<Woo.Section component="article">
+				<Woo.SectionHeader
+					title={ __( 'Pill shaped container', '{{textdomain}}' ) }
+				/>
+				<Woo.Pill className={ 'pill' }>
+					{ __( 'Pill Shape Container', '{{textdomain}}' ) }
+				</Woo.Pill>
+			</Woo.Section>
 
-		<Woo.Section component="article">
-			<Woo.SectionHeader title={ __( 'Datepicker', '{{textdomain}}' ) } />
-			<Woo.DatePicker
-				text={ __( 'I am a datepicker!', '{{textdomain}}' ) }
-				dateFormat={ 'MM/DD/YYYY' }
-			/>
-		</Woo.Section>
-	</Fragment>
-);
+			<Woo.Section component="article">
+				<Woo.SectionHeader
+					title={ __( 'Spinner', '{{textdomain}}' ) }
+				/>
+				<Woo.H>I am a spinner!</Woo.H>
+				<Woo.Spinner />
+			</Woo.Section>
+
+			<Woo.Section component="article">
+				<Woo.SectionHeader
+					title={ __( 'Datepicker', '{{textdomain}}' ) }
+				/>
+				<Woo.DatePicker
+					text={ __( 'I am a datepicker!', '{{textdomain}}' ) }
+					dateFormat={ 'MM/DD/YYYY' }
+				/>
+			</Woo.Section>
+		</Fragment>
+	);
+};
 
 addFilter( 'woocommerce_admin_pages_list', '{{slug}}', ( pages ) => {
 	pages.push( {

--- a/packages/js/create-woo-extension/variants/sql-modification/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/sql-modification/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/packages/js/create-woo-extension/variants/table-column/eslint.config.mjs.mustache
+++ b/packages/js/create-woo-extension/variants/table-column/eslint.config.mjs.mustache
@@ -5,6 +5,18 @@ export default [
 	{
 		rules: {
 			'react/react-in-jsx-scope': 'off',
+			/* The scaffolded extension ships its own text domain, not WooCommerce's. */
+			'@wordpress/i18n-text-domain': [
+				'error',
+				{ allowedTextDomain: '{{textdomain}}' },
+			],
+		},
+	},
+	{
+		/* Node config files (e.g. webpack.config.js) use CommonJS require(). */
+		files: [ '**/*.config.js' ],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #66078 (Flat Config migration). A fresh `create-woo-extension` scaffold (default variant) emits 12 ESLint errors on its first `npm run lint:js`. This fixes each cause:

- **8× `@wordpress/i18n-text-domain`** — the public `@woocommerce/eslint-plugin` recommended config hardcodes `allowedTextDomain: 'woocommerce'`, so an extension using its own text domain always fails. The scaffolded `eslint.config.mjs` now overrides the rule with the extension's own text domain. *(applies to all variants)*
- **2× `@typescript-eslint/no-require-imports`** — the CommonJS `webpack.config.js`. Added a flat-config override turning the rule off for `**/*.config.js`. *(applies to all variants)*
- **1× `no-undef`** — the example page called an undefined `setInlineSelect`; now tracked with `useState`.
- **2× `import/no-extraneous-dependencies` warnings** — declared `@wordpress/components` and `@wordpress/element`, which the example page imports.

**Note on formatting:** the example source is pre-formatted for the README's example slug (`my-extension-name`). A mustache template can't be prettier-stable for every slug length, so unusually short/long slugs may need a one-off `npm run format`.

**Scope:** default variant only, matching what the follow-up item measured. The shared ESLint config fixes above benefit all variants, but the 5 non-default variants have their own separate formatting debt (tracked as a follow-up).

Part of #66078.

### How to test the changes in this Pull Request:

1. From this branch: `npx @wordpress/create-block -t ./packages/js/create-woo-extension my-extension-name`.
2. `cd my-extension-name && npm run lint:js`.
3. Expect **0 errors** (previously 12).

### Testing that has already taken place:

Rendered the default variant templates with the README slug `my-extension-name` and ran the workspace ESLint (v10.7) and wp-prettier (3.0.3) against them: 12 errors → 0, prettier clean. Verified the fix is live by reverting each override (errors return) and with planted violations.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually: `packages/js/create-woo-extension/changelog/66078-fix-scaffold-lint-clean` (Patch / Fix).
