### PR TITLE
Fix Storybook nightly failing on a composer cache race

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install: true
+                  install: '@woocommerce/storybook...'
 
             - name: Build Storybook
               run: pnpm --filter='@woocommerce/storybook' build


### PR DESCRIPTION
Verification run (Deploy/Slack disabled): https://github.com/woocommerce/woocommerce/actions/runs/29740645644
Example failure: https://github.com/woocommerce/woocommerce/actions/runs/29387013341

### Changes proposed in this Pull Request:

The Storybook nightly fails roughly 40% of the time (Jul 7, 8, 15, 19, 20) in **Setup WooCommerce Monorepo**, never reaching the build:

```
/home/runner/.cache/composer/files/sebastian/lines-of-code does not exist and could not be created
```

The package named differs every run — `sebastian/version`, `nikic/php-parser`, `symfony/polyfill-intl-normalizer` — which is the tell that this is a race, not a missing dependency. The workflow runs an unfiltered `pnpm install`, so all five PHP workspace packages fire their `composer install` postinstall concurrently and race to create the same `~/.cache/composer/files/*` directories. This job passes no `pull-package-deps`, so unlike the CI jobs it never restores a composer cache; every directory is created from cold, every night.

Storybook needs no PHP. Scoping the install to `@woocommerce/storybook...` (27 packages, all JS) means no composer process runs at all, so the race cannot occur — rather than being made less likely by a cache warm-up or a retry. Install also drops from ~60s to ~45s on a cold runner.

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install --filter='@woocommerce/storybook...' --frozen-lockfile`.
2. Confirm no `composer install` postinstall appears in the output. Five did before this change, one per PHP package.
3. Run `pnpm --filter='@woocommerce/storybook' build`.
4. Confirm it exits 0 and `tools/storybook/storybook-static/` is populated, including `assets/woocommerce-blocks/iframe.html`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
