### PR TITLE
Temporarily skip checkout E2E tests on WordPress 7.1

### DIFF
--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -37,6 +37,16 @@ const blockData: BlockData = {
 	},
 };
 
+const testsFailingOnWordPress71 = new Set( [
+	'renders without crashing and can only be inserted once',
+	'Merchant can see T&S and Privacy Policy links with checkbox',
+	'can enable dark mode inputs',
+	'Company input visibility and optional and required can be toggled',
+	'Apartment input visibility and optional and required can be toggled',
+	'Phone input visibility and optional and required can be toggled',
+	'Return to cart link is visible and can be toggled',
+] );
+
 const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
 	checkoutPageObject: async ( { page }, use ) => {
 		const pageObject = new CheckoutPage( {
@@ -50,7 +60,14 @@ test.describe( 'Merchant → Checkout', () => {
 	// `as string` is safe here because we know the variable is a string, it is defined above.
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.beforeEach( async ( { admin, editor, wpCoreVersion }, testInfo ) => {
+		test.skip(
+			wpCoreVersion === 7.1 &&
+				testsFailingOnWordPress71.has( testInfo.title ),
+			'Currently broken with WordPress 7.1 beta 1 and requires upstream patch. ' +
+				'See: https://github.com/WordPress/gutenberg/pull/80026#issuecomment-5003222851'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -347,7 +347,13 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 	// `as string` is safe here because we know the variable is a string, it is defined above.
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
-	test.beforeEach( async ( { admin, editor, page } ) => {
+	test.beforeEach( async ( { admin, editor, page, wpCoreVersion } ) => {
+		test.skip(
+			wpCoreVersion === 7.1,
+			'Currently broken with WordPress 7.1 beta 1 and requires upstream patch. ' +
+				'See: https://github.com/WordPress/gutenberg/pull/80026#issuecomment-5003222851'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
@@ -653,7 +659,18 @@ test.describe( 'Shopper → Checkout Form Errors (guest user)', () => {
 test.describe( 'Billing Address Form', () => {
 	const blockSelectorInEditor = blockData.selectors.editor.block as string;
 
-	test( 'Enable company field', async ( { page, admin, editor } ) => {
+	test( 'Enable company field', async ( {
+		page,
+		admin,
+		editor,
+		wpCoreVersion,
+	} ) => {
+		test.skip(
+			wpCoreVersion === 7.1,
+			'Currently broken with WordPress 7.1 beta 1 and requires upstream patch. ' +
+				'See: https://github.com/WordPress/gutenberg/pull/80026#issuecomment-5003222851'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',

--- a/plugins/woocommerce/tests/e2e/tests/blocks/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/templates/checkout-template.block_theme.spec.ts
@@ -10,7 +10,14 @@ test.describe( 'Test the checkout template', () => {
 	test( 'Template can be opened in the site editor', async ( {
 		admin,
 		editor,
+		wpCoreVersion,
 	} ) => {
+		test.skip(
+			wpCoreVersion === 7.1,
+			'Currently broken with WordPress 7.1 beta 1 and requires upstream patch. ' +
+				'See: https://github.com/WordPress/gutenberg/pull/80026#issuecomment-5003222851'
+		);
+
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress 7.1 beta 1 contains an upstream Site Editor regression that breaks several Checkout E2E tests. Temporarily skip the ten affected tests on WordPress 7.1 while keeping the remaining Checkout coverage enabled; the tests should be restored once the [upstream Gutenberg patch](https://github.com/WordPress/gutenberg/pull/80026#issuecomment-5003222851) is available.

Context: pca54o-9TC-p2#comment-7884

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Configure the Blocks E2E environment to use a WordPress 7.1 development or pre-release build.
2. Run the affected merchant, shopper, and Checkout template E2E specs.
3. Confirm the ten tests linked to the upstream regression are skipped and other Checkout tests remain enabled.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Confirmed the local E2E environment reports WordPress `7.1-beta2-62798` and the `wpCoreVersion` fixture normalizes it to `7.1`.
- Ran the ten affected Playwright tests and confirmed all ten were skipped.
- Ran the changed-file JavaScript lint check with no errors.
- Ran `git diff --check` successfully.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Temporary development-only change to tests; no production code is shipped.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"
</details>