### PR TITLE
[Email Editor] Render email galleries at the author's chosen column count (up to 8)

### DIFF
--- a/packages/php/email-editor/changelog/fix-nl-739-gallery-columns-clamp
+++ b/packages/php/email-editor/changelog/fix-nl-739-gallery-columns-clamp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Render email galleries with the same number of columns the block author chose (up to 8) instead of clamping to 5. Clamping wide galleries forced extra partial rows whose trailing images stretched to a size the author never set.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -445,13 +445,16 @@ class Gallery extends Abstract_Block_Renderer {
 	 * Get the columns value from block attributes.
 	 *
 	 * @param array $block_attrs Block attributes.
-	 * @return int Number of columns (1-5).
+	 * @return int Number of columns (1-8).
 	 */
 	private function get_columns_from_attributes( array $block_attrs ): int {
 		$columns = $block_attrs['columns'] ?? 3;
 
-		// Ensure the columns are within reasonable bounds.
-		$columns = max( 1, min( 5, (int) $columns ) );
+		// Clamp to the same 1-8 range the core gallery block allows, so the email doesn't
+		// silently render fewer columns than the author chose. A lower cap forced wide galleries
+		// into extra partial rows whose images then stretched to a size the author never set
+		// (e.g. a 6-column gallery clamped to 5 rendered 5 + 5 + 2, ballooning the trailing pair).
+		$columns = max( 1, min( 8, (int) $columns ) );
 
 		return $columns;
 	}

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -145,7 +145,7 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$rendered_0_col = $this->gallery_renderer->render( '', $parsed_gallery_0_col, $this->rendering_context );
 		$this->assertStringContainsString( 'image1.jpg', $rendered_0_col );
 
-		// Test 10 columns (should be limited to 5).
+		// Test 10 columns (should be limited to 8).
 		$parsed_gallery_10_col                     = $this->parsed_gallery;
 		$parsed_gallery_10_col['attrs']['columns'] = 10;
 
@@ -587,5 +587,100 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertSame( $widths[1], $widths[2], 'Images in the same full row share a width.' );
 		$this->assertGreaterThan( $widths[0], $widths[3], 'A lone trailing image is sized to the full row width.' );
 		$this->assertGreaterThanOrEqual( 2 * $widths[0], $widths[3], 'The full-width cell is substantially wider than a one-third cell.' );
+	}
+
+	/**
+	 * Build a parsed gallery block with a given number of images and a columns attribute.
+	 *
+	 * @param int $image_count Number of core/image inner blocks to generate.
+	 * @param int $columns     Value for the gallery's columns attribute.
+	 * @return array Parsed gallery block.
+	 */
+	private function build_gallery_with_images( int $image_count, int $columns ): array {
+		$inner_blocks = array();
+		for ( $i = 1; $i <= $image_count; $i++ ) {
+			$image_html     = sprintf(
+				'<figure class="wp-block-image size-large"><img src="https://example.com/image%1$d.jpg" alt="Image %1$d" class="wp-image-%1$d"/></figure>',
+				$i
+			);
+			$inner_blocks[] = array(
+				'blockName'    => 'core/image',
+				'attrs'        => array(
+					'id'              => $i,
+					'sizeSlug'        => 'large',
+					'linkDestination' => 'none',
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => $image_html,
+				'innerContent' => array( 0 => $image_html ),
+			);
+		}
+
+		return array(
+			'blockName'   => 'core/gallery',
+			'attrs'       => array(
+				'columns' => $columns,
+				'linkTo'  => 'none',
+			),
+			'innerHTML'   => sprintf( '<figure class="wp-block-gallery has-nested-images columns-%d is-cropped"></figure>', $columns ),
+			'innerBlocks' => $inner_blocks,
+		);
+	}
+
+	/**
+	 * A 6-column gallery must render 6 images per row, not silently clamp to 5.
+	 *
+	 * Regression test: clamping 6 columns down to 5 chunked a 12-image gallery into 5 + 5 + 2 rows,
+	 * and the trailing pair then ballooned to 50% each (100 / images-in-row). Honoring 6 columns
+	 * renders two even rows of six (100 / 6 = 16.67% per cell) with no widened partial row.
+	 */
+	public function testItRendersSixColumnsWithoutClampingToFive(): void {
+		$parsed_gallery = $this->build_gallery_with_images( 12, 6 );
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		$this->assertStringContainsString( 'width: 16.67%', $rendered, 'Six-column cells are one-sixth wide.' );
+		$this->assertStringNotContainsString( 'width: 20.00%', $rendered, 'Columns must not be clamped to five.' );
+		$this->assertStringNotContainsString( 'width: 50.00%', $rendered, 'There is no partial row to balloon.' );
+		$this->assertStringContainsString( 'image12.jpg', $rendered, 'All twelve images are rendered.' );
+	}
+
+	/**
+	 * The renderer supports up to 8 columns, matching the core gallery block's maximum.
+	 */
+	public function testItSupportsUpToEightColumns(): void {
+		$parsed_gallery = $this->build_gallery_with_images( 8, 8 );
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		$this->assertStringContainsString( 'width: 12.50%', $rendered, 'Eight-column cells are one-eighth wide.' );
+		$this->assertStringContainsString( 'image8.jpg', $rendered, 'All eight images are rendered.' );
+	}
+
+	/**
+	 * Columns beyond 8 are clamped to 8 (the block's own maximum), not rendered at a smaller width.
+	 */
+	public function testItClampsColumnsToEight(): void {
+		$parsed_gallery = $this->build_gallery_with_images( 16, 10 );
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		$this->assertStringContainsString( 'width: 12.50%', $rendered, 'Cells are sized for eight columns.' );
+		$this->assertStringNotContainsString( 'width: 10.00%', $rendered, 'Columns must be clamped to eight, not ten.' );
+		$this->assertStringContainsString( 'image16.jpg', $rendered, 'All sixteen images are rendered.' );
+	}
+
+	/**
+	 * A genuine partial last row stretches its images to fill the width, matching the core gallery
+	 * block (whose flex items grow to fill the final row). Ten images in an 8-column gallery render
+	 * as a full row of eight (12.50% each) plus a trailing pair that stretches to 50% each.
+	 */
+	public function testItStretchesPartialLastRowLikeTheBlock(): void {
+		$parsed_gallery = $this->build_gallery_with_images( 10, 8 );
+
+		$rendered = $this->gallery_renderer->render( '', $parsed_gallery, $this->rendering_context );
+
+		$this->assertStringContainsString( 'width: 12.50%', $rendered, 'The full row uses the column width.' );
+		$this->assertStringContainsString( 'width: 50.00%', $rendered, 'The trailing pair stretches to fill the row, as in the block.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes NL-739.

The email gallery renderer decided images-per-row on its own, diverging from the block's `columns` setting. `get_columns_from_attributes()` clamped `columns` to `max( 1, min( 5, … ) )`, so any gallery with more than 5 columns silently rendered fewer columns than the author chose.

Because `build_gallery_table()` chunks images into rows of the (clamped) column count, this cap did more than shrink the grid — it manufactured **extra partial rows**, and `build_gallery_row_table()` sizes a partial row's cells at `100 / images_in_row` (a lone image spans the full width). Net effect on the reported post: a 6-column, ~12-image gallery rendered as **5 + 5 + 2**, and that trailing pair ballooned to ~50% each — a ragged last row at a size the author never selected.

**Fix:** raise the clamp to `min( 8, … )` so it matches the core gallery block's own maximum (the block editor allows 1–8 columns). With the cap aligned, the reported post renders **6 + 6** — identical to the block — and no manufactured partial row.

**What is intentionally *not* changed — the partial-row width redistribution.** The core gallery block is a flex layout (`flex-wrap: wrap`) where each image has both a fixed `width: calc(100% / columns …)` and `flex-grow: 1`. In a genuine partial last row (e.g. 8 columns, 10 images), `flex-grow` grows the remaining images to fill the row, so the block itself renders the last two at ~50% each. The renderer's existing `100 / images_in_row` redistribution reproduces exactly that, so keeping it means the email continues to match the block for every valid column count. A test was added to lock this behavior so it isn't "fixed" into a divergence later.

Before | After
---- | ----
<img width="609" height="401" alt="Screenshot 2026-07-20 at 4 22 21 PM" src="https://github.com/user-attachments/assets/54589775-8f70-4897-b50c-bcad8480d0db" /> | <img width="625" height="535" alt="Screenshot 2026-07-20 at 4 22 15 PM" src="https://github.com/user-attachments/assets/733a0e8a-65d5-4c72-a154-b49dc76179e2" />


#### Backward compatibility

No public signatures, hooks, or filters change. `get_columns_from_attributes()` is a `private` method; only its internal clamp bound is widened (5 → 8). Galleries with ≤5 columns render identically to before.

### Screenshots or screen recordings:

Renderer-only change; verified via integration tests that assert the real rendered HTML (cell widths and row chunking). See testing notes below.

### How to test the changes in this Pull Request:

1. In a WordPress.com post: add a **Gallery** block and set it to **6 columns** with 12 images.
2. Publish the post and check the email.
3. Before this change: the gallery renders 5 + 5 + 2, and the final two images are noticeably larger than the rest.
4. With this change: the gallery renders 6 + 6, every image the same width, matching the block in the editor/front end.
5. Repeat with **8 columns** (max) and confirm 8-up rendering; a genuine partial last row (e.g. 10 images at 8 columns) still stretches its trailing images to fill, exactly as the block does.

Automated:

```sh
cd packages/php/email-editor
pnpm wp-env start
pnpm wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor \
  ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist --filter Gallery_Test
```

### Testing that has already taken place:

- Added 4 integration tests: 6-column (no clamp to 5), 8-column support, clamp-to-8 for `columns > 8`, and the block-matching partial-row stretch. Confirmed each fails against the old `min(5)` clamp and passes with the fix.
- Full `Gallery_Test` suite green (24 tests, 99 assertions) on PHP 8.1 via wp-env.
- `phpcs` (email-editor package's stricter ruleset) and PHPStan both clean on the changed files.
- Not performed: a live email-client visual pass (Mailpit). The change only affects row chunking and cell-width percentages, which the integration tests assert against the real rendered HTML.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request includes a changelog entry (added manually at `packages/php/email-editor/changelog/fix-nl-739-gallery-columns-clamp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
