### PR TITLE
Fix HPOS meta guard flagging extension virtual meta as corrupt

### DIFF
--- a/plugins/woocommerce/changelog/66551-fix-hpos-virtual-meta-corruption-guard
+++ b/plugins/woocommerce/changelog/66551-fix-hpos-virtual-meta-corruption-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop the HPOS order meta corruption guard from treating extension-injected virtual meta rows (a meta_key and meta_value but no meta_id) as corrupt, which purged the meta cache and logged a warning on every read.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -740,7 +740,8 @@ abstract class WC_Data {
 		foreach ( $filtered_meta_data as $meta ) {
 			$this->meta_data[] = new WC_Meta_Data(
 				array(
-					'id'    => (int) $meta->meta_id,
+					// Virtual meta injected by data-store read filters can omit meta_id; default it to 0 rather than emitting an undefined-property warning.
+					'id'    => (int) ( $meta->meta_id ?? 0 ),
 					'key'   => $meta->meta_key,
 					'value' => maybe_unserialize( $meta->meta_value ),
 				)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1498,10 +1498,11 @@ WHERE
 		 * boundary (those always have a meta_id), this guard also runs against the post-filter output
 		 * that WC_Data::read_meta_data() caches and re-validates on a cache hit. That output can
 		 * legitimately include virtual rows injected by extensions via the
-		 * woocommerce_data_store_wp_order_read_meta filter, which carry meta_key and meta_value but
-		 * no meta_id (init_meta_data() reads such a row's id as 0). Requiring meta_id would
-		 * reclassify those legitimate rows as corrupt and churn the cache - purging it and re-logging
-		 * on every read - so we only treat a missing meta_key or meta_value as corruption. Drop
+		 * woocommerce_data_store_wp_post_read_meta filter (orders use the 'post' meta type), which
+		 * carry meta_key and meta_value but no meta_id (init_meta_data() reads such a row's id as 0).
+		 * Requiring meta_id would reclassify those legitimate rows as corrupt and churn the cache -
+		 * purging it and re-logging on every read - so we only treat a missing meta_key or meta_value
+		 * as corruption. Drop
 		 * anything that is not a usable meta row so the order still loads, and when corruption is
 		 * detected invalidate the cached entries so the next read self-heals from the database.
 		 */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1485,14 +1485,23 @@ WHERE
 	public function filter_raw_meta_data( &$object, $raw_meta_data ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
 
 		/*
-		 * Defensive last-resort guard. The meta data should always arrive as an array of complete
-		 * meta-row objects, but a corrupt persistent object cache entry can surface as a scalar, an
-		 * object, a well-formed array whose elements are not meta rows, or an array of objects that
-		 * are missing required columns. Any of these would otherwise fatal or silently load wrong
-		 * values downstream (array_filter()/array_diff() on a non-array, $meta->meta_key on a
-		 * non-object element, or a real key hydrated with a null value from a partial row). A row is
-		 * only usable when it carries meta_id, meta_key and meta_value - the same completeness check
-		 * OrdersTableDataStoreMeta::is_valid_cached_meta() applies at the HPOS cache boundary. Drop
+		 * Defensive last-resort guard. The meta data should always arrive as an array of meta-row
+		 * objects, but a corrupt persistent object cache entry can surface as a scalar, an object, a
+		 * well-formed array whose elements are not meta rows, or an array of objects that are missing
+		 * required columns. Any of these would otherwise fatal or silently load wrong values
+		 * downstream (array_filter()/array_diff() on a non-array, $meta->meta_key on a non-object
+		 * element, or a real key hydrated with a null value from a partial row).
+		 *
+		 * A row is usable when it carries meta_key and meta_value - the fields init_meta_data() reads
+		 * as data. meta_id is intentionally NOT required here: unlike OrdersTableDataStoreMeta::
+		 * is_valid_cached_meta(), which validates raw database rows at the HPOS 'orders_meta'
+		 * boundary (those always have a meta_id), this guard also runs against the post-filter output
+		 * that WC_Data::read_meta_data() caches and re-validates on a cache hit. That output can
+		 * legitimately include virtual rows injected by extensions via the
+		 * woocommerce_data_store_wp_order_read_meta filter, which carry meta_key and meta_value but
+		 * no meta_id (init_meta_data() reads such a row's id as 0). Requiring meta_id would
+		 * reclassify those legitimate rows as corrupt and churn the cache - purging it and re-logging
+		 * on every read - so we only treat a missing meta_key or meta_value as corruption. Drop
 		 * anything that is not a usable meta row so the order still loads, and when corruption is
 		 * detected invalidate the cached entries so the next read self-heals from the database.
 		 */
@@ -1501,7 +1510,6 @@ WHERE
 			$valid_meta_data = array_filter(
 				$raw_meta_data,
 				static fn( $meta ) => is_object( $meta )
-					&& property_exists( $meta, 'meta_id' )
 					&& property_exists( $meta, 'meta_key' )
 					&& property_exists( $meta, 'meta_value' )
 			);

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
@@ -790,7 +790,7 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 			$meta_data[]         = $virtual;
 			return $meta_data;
 		};
-		add_filter( 'woocommerce_data_store_wp_order_read_meta', $read_meta_filter );
+		add_filter( 'woocommerce_data_store_wp_post_read_meta', $read_meta_filter );
 
 		// Make sure the legacy meta cache starts empty so the first read is a cache miss.
 		$cache_key = $order->get_meta_cache_key();
@@ -818,7 +818,7 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 		$this->assertSame( 'virtual_value', $order->get_meta( '_virtual_meta' ), 'The injected virtual meta should still resolve after a cache hit.' );
 		$this->assertSame( 'custom_value', $order->get_meta( 'custom_meta_key' ), 'The real database meta should be unaffected.' );
 
-		remove_filter( 'woocommerce_data_store_wp_order_read_meta', $read_meta_filter );
+		remove_filter( 'woocommerce_data_store_wp_post_read_meta', $read_meta_filter );
 		remove_all_filters( 'woocommerce_logging_class' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreCacheCrossBleedTest.php
@@ -728,9 +728,9 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 
 		/*
 		 * Poison the legacy 'orders' meta cache with an object row that has meta_key but is missing
-		 * meta_id and meta_value. This is a valid array of objects with meta_key, so a meta_key-only
-		 * shape check would accept it and hydrate the real key with a null value. The completeness
-		 * check (meta_id + meta_key + meta_value) must treat it as corrupt and self-heal instead.
+		 * meta_value. This is a valid array of objects with meta_key, so a meta_key-only shape check
+		 * would accept it and hydrate the real key with a null value. The completeness check
+		 * (meta_key + meta_value) must treat the missing value as corrupt and self-heal instead.
 		 */
 		$cache_key = $order->get_meta_cache_key();
 		wp_cache_set( $cache_key, array( (object) array( 'meta_key' => 'custom_meta_key' ) ), 'orders' ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
@@ -750,6 +750,75 @@ class OrdersTableDataStoreCacheCrossBleedTest extends \HposTestCase {
 			'The incomplete row should be discarded and the real value re-read from the database, not loaded as null.'
 		);
 
+		remove_all_filters( 'woocommerce_logging_class' );
+	}
+
+	/**
+	 * @testdox A virtual meta row injected via the read-meta filter (meta_key/meta_value, no meta_id) is not treated as corrupt and does not churn the legacy meta cache.
+	 */
+	public function test_filter_injected_virtual_meta_is_not_treated_as_corrupt(): void {
+		$fake_logger = $this->create_fake_logger();
+		add_filter(
+			'woocommerce_logging_class',
+			function () use ( $fake_logger ) {
+				return $fake_logger;
+			}
+		);
+
+		// Rebuild the data store so its injected logger (captured in init() via wc_get_logger())
+		// is the fake logger added above, and orders created below use this instance.
+		$container = wc_get_container();
+		$container->reset_all_resolved();
+		$container->get( OrdersTableDataStore::class );
+
+		$order = new WC_Order();
+		$order->add_meta_data( 'custom_meta_key', 'custom_value', true );
+		$order->save();
+		$order_id = $order->get_id();
+
+		// Reload a fresh order object so its meta cache key reflects current cache prefixes.
+		$order = wc_get_order( $order_id );
+
+		/*
+		 * Simulate an extension that appends a virtual meta row on read. The row carries meta_key and
+		 * meta_value but no meta_id - a shape the guard must accept, not flag as corrupt.
+		 */
+		$read_meta_filter = function ( $meta_data ) {
+			$virtual             = new \stdClass();
+			$virtual->meta_key   = '_virtual_meta';
+			$virtual->meta_value = 'virtual_value';
+			$meta_data[]         = $virtual;
+			return $meta_data;
+		};
+		add_filter( 'woocommerce_data_store_wp_order_read_meta', $read_meta_filter );
+
+		// Make sure the legacy meta cache starts empty so the first read is a cache miss.
+		$cache_key = $order->get_meta_cache_key();
+		wp_cache_delete( $cache_key, 'orders' );
+
+		// First read: cache miss. Caches the post-filter output (including the injected virtual row)
+		// in the legacy 'orders' group and hydrates the object's meta data.
+		$order->read_meta_data();
+		$this->assertSame( 'virtual_value', $order->get_meta( '_virtual_meta' ), 'The injected virtual meta should load without a meta_id.' );
+		$this->assertIsArray( wp_cache_get( $cache_key, 'orders' ), 'The legacy meta cache should be primed after the first read.' );
+
+		// Second read: cache hit. The guard re-validates the cached post-filter data, which now
+		// includes the injected virtual row. It must not be reclassified as corrupt.
+		$order->read_meta_data();
+
+		$this->assertSame(
+			0,
+			$this->count_hpos_cache_warnings( $fake_logger, 'Discarded malformed meta data' ),
+			'A filter-injected virtual meta row must not trigger the corruption guard.'
+		);
+		$this->assertIsArray(
+			wp_cache_get( $cache_key, 'orders' ),
+			'The legacy meta cache must stay warm - the guard should not purge it for a filter-injected virtual row.'
+		);
+		$this->assertSame( 'virtual_value', $order->get_meta( '_virtual_meta' ), 'The injected virtual meta should still resolve after a cache hit.' );
+		$this->assertSame( 'custom_value', $order->get_meta( 'custom_meta_key' ), 'The real database meta should be unaffected.' );
+
+		remove_filter( 'woocommerce_data_store_wp_order_read_meta', $read_meta_filter );
 		remove_all_filters( 'woocommerce_logging_class' );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On stores where an extension appends virtual order meta via the `woocommerce_data_store_wp_post_read_meta` filter, the corruption guard in `OrdersTableDataStore::filter_raw_meta_data()` reclassified those virtual rows as corrupt. `WC_Data::read_meta_data()` caches its post-filter output and re-validates it on a cache hit, and the guard PR #66510 tightened it to require `meta_id` + `meta_key` + `meta_value`. A filter-injected row carries `meta_key` and `meta_value` but no `meta_id`, so on every cache-hit read the guard logged `Discarded malformed meta data` and purged the meta cache. The order still loaded correctly (the filter re-injects the row), but the cache never stayed warm and the log filled up.

This relaxes the guard to require only `meta_key` and `meta_value` — the fields `init_meta_data()` actually consumes as data. `meta_id` is intentionally no longer required there: unlike `OrdersTableDataStoreMeta::is_valid_cached_meta()`, which validates raw database rows at the HPOS `orders_meta` boundary (those always have a `meta_id`), this guard also runs against post-filter output that can legitimately include virtual rows. The original corruption case the guard protects against — a partial row that hydrates a real key with a `null` value — is still caught, because that case is missing `meta_value`. `WC_Data::init_meta_data()` is also hardened to read a missing `meta_id` as `0` instead of emitting a PHP undefined-property warning.

Closes #66551 .

(For Bug Fixes) Bug introduced in PR #66510 .

**Backward compatibility:** Both changes are additive/relaxing and change no signatures. The guard now accepts a superset of what it accepted before (it stops rejecting `meta_id`-less rows), so no previously-valid data is newly rejected. `WC_Data::init_meta_data()` keeps its signature; the only behavioral change is that a row missing `meta_id` now loads as id `0` rather than warning — identical output for well-formed rows.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable HPOS and HPOS data-store caching on a store with a persistent object cache.
2. Create an order with a normal meta value (for example `custom_meta_key` = `custom_value`).
3. Add a snippet that injects a virtual meta row with no `meta_id`:
   ```php
   add_filter( 'woocommerce_data_store_wp_post_read_meta', function ( $meta_data ) {
       $virtual             = new stdClass();
       $virtual->meta_key   = '_virtual_meta';
       $virtual->meta_value = 'virtual_value';
       $meta_data[]         = $virtual;
       return $meta_data;
   } );
   ```
4. Load the order, then call `$order->read_meta_data()` twice (first read caches, second read is a cache hit).
5. **Before this fix:** the second read logs `Discarded malformed meta data...` (source `hpos-data-cache`) and purges the meta cache; it re-logs on every subsequent read.
6. **After this fix:** no warning is logged, the legacy meta cache stays warm, and both `$order->get_meta( '_virtual_meta' )` and `$order->get_meta( 'custom_meta_key' )` resolve correctly.

The added test `OrdersTableDataStoreCacheCrossBleedTest::test_filter_injected_virtual_meta_is_not_treated_as_corrupt` automates this; it fails against the old guard and passes with the fix.

<!-- End testing instructions -->

### Testing that has already taken place:

-   Static analysis: `php -l` on all three changed files and PHPStan clean on both source files.
-   Root-cause tracing of both meta read paths (`init_order_record()` feeds pre-filter DB rows; `WC_Data::read_meta_data()` caches and re-validates post-filter output on a cache hit) and confirmation that the `orders_meta` boundary (`is_valid_cached_meta()`) correctly still requires `meta_id`.
-   Note: local PHPUnit could not be run in this workspace — `wp-env` start fails with a `wp-config.php is not writable` error unrelated to this change. CI will run the added regression test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

Milestone set manually to 11.0.0 to match the bug-introducing PR #66510 (cherry-picked to `release/11.0`).

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `plugins/woocommerce/changelog/66551-fix-hpos-virtual-meta-corruption-guard`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)