### PR TITLE
Add tax_lines meta schema assertion to orders REST controller test

### DIFF
--- a/plugins/woocommerce/changelog/dev-66517-orders-meta-schema-union-coverage
+++ b/plugins/woocommerce/changelog/dev-66517-orders-meta-schema-union-coverage
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Add REST orders schema test coverage for tax line item meta, and document the orders meta schema correction shipped in 11.1.0. Meta value fields now advertise a standard type union (null, object, string, number, boolean, integer, array) instead of the non-standard 'mixed', line item display_value advertises the same union instead of 'string', and line item display_key and display_value are now marked readonly. Order writes persist only meta key, value, and id, so no previously valid request is rejected and no response data changes.
+Add test coverage for the orders REST tax line item meta schema type union.

--- a/plugins/woocommerce/changelog/dev-66517-orders-meta-schema-union-coverage
+++ b/plugins/woocommerce/changelog/dev-66517-orders-meta-schema-union-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add REST orders schema test coverage for tax line item meta, and document the orders meta schema correction shipped in 11.1.0. Meta value fields now advertise a standard type union (null, object, string, number, boolean, integer, array) instead of the non-standard 'mixed', line item display_value advertises the same union instead of 'string', and line item display_key and display_value are now marked readonly. Order writes persist only meta key, value, and id, so no previously valid request is rejected and no response data changes.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1119,6 +1119,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$meta_containers = array(
 			$properties['meta_data']['items']['properties'],
 			$properties['line_items']['items']['properties']['meta_data']['items']['properties'],
+			$properties['tax_lines']['items']['properties']['meta_data']['items']['properties'],
 			$properties['shipping_lines']['items']['properties']['meta_data']['items']['properties'],
 			$properties['fee_lines']['items']['properties']['meta_data']['items']['properties'],
 			$properties['coupon_lines']['items']['properties']['meta_data']['items']['properties'],


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

PR #65513 widened the orders REST `meta_data` schema so complex line item meta display values round-trip on write. That change touched every meta `value` field (`'mixed'` to a standard 7-member type union) and the line item `display_value` field (`'string'` to the same union, and both `display_key`/`display_value` gained `readonly`). Its schema-assertion test (`test_meta_data_schema_advertises_type_union`) covered `meta_data`, `line_items`, `shipping_lines`, `fee_lines`, and `coupon_lines`, but omitted `tax_lines`, whose `value` field was widened in the same PR.

This PR:

- Adds the missing `tax_lines` assertion to `test_meta_data_schema_advertises_type_union`, closing the coverage gap flagged by the AI regression review.
- Adds a `dev` changelog entry documenting the schema-type change for external consumers (strict codegen/SDK). Write behavior is unchanged: order writes persist only meta `key`, `value`, and `id`, so no previously valid request is rejected and no response data changes.

No production code changes; the schema itself shipped in 11.1.0 via PR #65513.

Closes #66517.

Coverage gap introduced in PR #65513.

### Screenshots or screen recordings:

Not applicable (test + changelog only).

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run the affected test:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_meta_data_schema_advertises_type_union
   ```
3. Confirm it passes. The new assertion checks that `tax_lines[].meta_data[].value` in `WC_REST_Orders_Controller::get_item_schema()` advertises the type union `array( 'null', 'object', 'string', 'number', 'boolean', 'integer', 'array' )`, matching the other line types.

### Testing that has already taken place:

- `phpcs-changed` against `trunk` on the modified test file: clean on the changed lines.
- Branch lint (`lint:changes:branch`): clean.
- Static verification of the schema path: `tax_lines.items.properties.meta_data.items.properties.value.type` resolves to the expected union in `class-wc-rest-orders-v2-controller.php`, so the new assertion is non-vacuous.
- Changelog wording fact-checked against the PR #65513 diff and the WordPress `readonly`/write-schema behavior (LLM-assisted review).
- Full PHPUnit run deferred to CI.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> Milestone set manually to **11.1.0** to match PR #65513 (the PR the schema change and coverage gap originate from).

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry added manually in `plugins/woocommerce/changelog/dev-66517-orders-meta-schema-union-coverage` (Significance: patch, Type: dev).
