### PR TITLE
[Performance] Address edge-case concerns reported by an AI after merging #66675.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -114,7 +114,7 @@ class WC_Product_Variable extends WC_Product {
 
 		// Performance note: loose != compares key/value pairs regardless of order, so a re-sort is only triggered when prices actually change.
 		$cache_key = $for_display ? 'for_display:1' : 'for_display:0';
-		if ( $this->variation_prices[ $cache_key ] != $prices ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+		if ( $this->variation_prices[ $cache_key ] != $prices && is_array( $prices ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
 			$this->variation_prices[ $cache_key ] = array_map( fn( $variation_prices ) => $this->sort_variation_prices( $variation_prices ), $prices );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -111,10 +111,13 @@ class WC_Product_Variable extends WC_Product {
 	public function get_variation_prices( $for_display = false ) {
 		/** @var array<string,array<int,float>> $prices */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		$prices = $this->data_store->read_price_data( $this, $for_display );
+		if ( ! is_array( $prices ) ) {
+			return $prices;
+		}
 
 		// Performance note: loose != compares key/value pairs regardless of order, so a re-sort is only triggered when prices actually change.
 		$cache_key = $for_display ? 'for_display:1' : 'for_display:0';
-		if ( $this->variation_prices[ $cache_key ] != $prices && is_array( $prices ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+		if ( $this->variation_prices[ $cache_key ] != $prices ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
 			$this->variation_prices[ $cache_key ] = array_map( fn( $variation_prices ) => $this->sort_variation_prices( $variation_prices ), $prices );
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -409,6 +409,44 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_variation_prices returns a valid array structure when the woocommerce_variation_prices filter returns malformed data (null or false), restoring the pre-refactor foreach behaviour that tolerated non-array filter output.
+	 *
+	 * @dataProvider provider_malformed_variation_prices_filter_values
+	 */
+	public function test_get_variation_prices_tolerates_malformed_filter_output( mixed $malformed_value ): void {
+		$product = WC_Helper_Product::create_variation_product();
+
+		// Bust the transient so read_price_data() always reaches the woocommerce_variation_prices filter.
+		$invalidate_cache = static fn( array $hash ) => array( ...$hash, wp_rand() );
+		add_filter( 'woocommerce_get_variation_prices_hash', $invalidate_cache );
+
+		$bad_filter = static fn() => $malformed_value;
+		add_filter( 'woocommerce_variation_prices', $bad_filter );
+
+		try {
+			$prices = $product->get_variation_prices();
+			$this->assertSame( $malformed_value, $prices );
+		} finally {
+			remove_filter( 'woocommerce_variation_prices', $bad_filter );
+			remove_filter( 'woocommerce_get_variation_prices_hash', $invalidate_cache );
+		}
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @return array<string,array>
+	 */
+	public function provider_malformed_variation_prices_filter_values(): array {
+		return array(
+			'null'   => array( null ),
+			'false'  => array( false ),
+			'string' => array( 'bad_return' ),
+			'object' => array( new stdClass() ),
+		);
+	}
+
+	/**
 	 * Create a real image attachment that passes `wp_attachment_is_image()`.
 	 *
 	 * @param string $title         Post title.

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -410,8 +410,9 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 
 	/**
 	 * @testdox get_variation_prices returns a valid array structure when the woocommerce_variation_prices filter returns malformed data (null or false), restoring the pre-refactor foreach behaviour that tolerated non-array filter output.
-	 *
 	 * @dataProvider provider_malformed_variation_prices_filter_values
+	 *
+	 * @param mixed $malformed_value The malformed value for returning via woocommerce_get_variation_prices_hash filter.
 	 */
 	public function test_get_variation_prices_tolerates_malformed_filter_output( mixed $malformed_value ): void {
 		$product = WC_Helper_Product::create_variation_product();

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -414,7 +414,7 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	 *
 	 * @param mixed $malformed_value The malformed value for returning via woocommerce_get_variation_prices_hash filter.
 	 */
-	public function test_get_variation_prices_tolerates_malformed_filter_output( mixed $malformed_value ): void {
+	public function test_get_variation_prices_tolerates_malformed_filter_output( $malformed_value ): void {
 		$product = WC_Helper_Product::create_variation_product();
 
 		// Bust the transient so read_price_data() always reaches the woocommerce_variation_prices filter.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes #66809

Adds an additional `is_array( ... )` check to match the original behavior for handling unexpected data returned by filters. Skipping changelog entry as I've just merged #66675 and this PR has no point for a dedicated changelog entry.

### How to test the changes in this Pull Request:

- CI checks shall pass (the change is covered by existing test coverage)
- No other testing required

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
See PR description.

</details>

