### PR TITLE
Fix shipping method names on manual orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-manual-order-shipping-method-name
+++ b/plugins/woocommerce/changelog/fix-manual-order-shipping-method-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the selected shipping method name for manually created orders.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1,5 +1,35 @@
 // eslint-disable-next-line max-len
-/*global woocommerce_admin_meta_boxes, woocommerce_admin, accounting, woocommerce_admin_meta_boxes_order, wcSetClipboard, wcClearClipboard, wc_enhanced_select_params */
+/*global woocommerce_admin_meta_boxes, woocommerce_admin, accounting, woocommerce_admin_meta_boxes_order, wcSetClipboard, wcClearClipboard, wc_enhanced_select_params, module */
+
+/**
+ * Get the shipping method title to use after a method selection changes.
+ *
+ * @param {Object} args               Shipping title data.
+ * @param {string} args.currentTitle  Current shipping title.
+ * @param {string} args.defaultTitle  Default shipping title.
+ * @param {string} args.previousTitle Previously selected method title.
+ * @param {string} args.methodValue   Selected shipping method value.
+ * @param {string} args.methodTitle   Selected shipping method title.
+ * @return {string} The shipping title to use.
+ */
+function getShippingMethodTitle( args ) {
+	if (
+		args.currentTitle
+		&& args.currentTitle !== args.defaultTitle
+		&& args.currentTitle !== args.previousTitle
+	) {
+		return args.currentTitle;
+	}
+
+	return args.methodValue && 'other' !== args.methodValue
+		? args.methodTitle
+		: args.defaultTitle;
+}
+
+if ( typeof module !== 'undefined' && module.exports ) {
+	module.exports = { getShippingMethodTitle };
+}
+
 jQuery( function ( $ ) {
 
 	// Stand-in wcTracks.recordEvent in case tracks is not available (for any reason).
@@ -386,15 +416,18 @@ jQuery( function ( $ ) {
 			} ).text();
 			var currentTitle  = $name.val();
 			var defaultTitle  = $name.data( 'default-shipping-title' );
+			var nextTitle     = getShippingMethodTitle( {
+				currentTitle: currentTitle,
+				defaultTitle: defaultTitle,
+				previousTitle: previousTitle,
+				methodValue: $select.val(),
+				methodTitle: title
+			} );
 
 			$select.data( 'selected-title', title );
 
-			if ( currentTitle && currentTitle !== defaultTitle && currentTitle !== previousTitle ) {
-				return;
-			}
-
-			if ( $select.val() && 'other' !== $select.val() ) {
-				$name.val( title ).trigger( 'change' );
+			if ( currentTitle !== nextTitle ) {
+				$name.val( nextTitle ).trigger( 'change' );
 			}
 		},
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -283,6 +283,7 @@ jQuery( function ( $ ) {
 				.on( 'click', 'button.calculate-action', this.recalculate )
 				.on( 'click', 'a.edit-order-item', this.edit_item )
 				.on( 'click', 'a.delete-order-item', this.delete_item )
+				.on( 'change', 'select.shipping_method', this.shipping_method_changed )
 
 				// Refunds
 				.on( 'click', '.delete_refund', this.refunds.delete_refund )
@@ -374,6 +375,27 @@ jQuery( function ( $ ) {
 		reloaded_items: function() {
 			wc_meta_boxes_order.init_tiptip();
 			wc_meta_boxes_order_items.stupidtable.init();
+		},
+
+		shipping_method_changed: function() {
+			var $select       = $( this );
+			var $name         = $select.closest( 'tr.shipping' ).find( 'input.shipping_method_name' );
+			var title         = $select.find( 'option:selected' ).text();
+			var previousTitle = $select.data( 'selected-title' ) || $select.find( 'option' ).filter( function() {
+				return this.defaultSelected;
+			} ).text();
+			var currentTitle  = $name.val();
+			var defaultTitle  = $name.data( 'default-shipping-title' );
+
+			$select.data( 'selected-title', title );
+
+			if ( currentTitle && currentTitle !== defaultTitle && currentTitle !== previousTitle ) {
+				return;
+			}
+
+			if ( $select.val() && 'other' !== $select.val() ) {
+				$name.val( title ).trigger( 'change' );
+			}
 		},
 
 		// When the qty is changed, increase or decrease costs

--- a/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-order.test.js
+++ b/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-order.test.js
@@ -1,0 +1,42 @@
+/**
+ * Tests for the order meta box shipping method name synchronization.
+ */
+
+global.jQuery = jest.fn();
+
+const { getShippingMethodTitle } = require( '../meta-boxes-order' );
+
+describe( 'Order meta box shipping method names', () => {
+	test( 'uses the selected method title for the default shipping name', () => {
+		expect( getShippingMethodTitle( {
+			currentTitle: 'Shipping',
+			defaultTitle: 'Shipping',
+			previousTitle: 'N/A',
+			methodValue: 'free_shipping',
+			methodTitle: 'Free shipping',
+		} ) ).toBe( 'Free shipping' );
+	} );
+
+	test.each( [
+		[ 'N/A', '', 'N/A' ],
+		[ 'Other', 'other', 'Other' ],
+	] )( 'resets an auto-synced name when selecting %s', ( label, methodValue, methodTitle ) => {
+		expect( getShippingMethodTitle( {
+			currentTitle: 'Free shipping',
+			defaultTitle: 'Shipping',
+			previousTitle: 'Free shipping',
+			methodValue,
+			methodTitle,
+		} ) ).toBe( 'Shipping' );
+	} );
+
+	test( 'preserves a custom name when selecting N/A', () => {
+		expect( getShippingMethodTitle( {
+			currentTitle: 'Local courier',
+			defaultTitle: 'Shipping',
+			previousTitle: 'Free shipping',
+			methodValue: '',
+			methodTitle: 'N/A',
+		} ) ).toBe( 'Local courier' );
+	} );
+} );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -23,7 +23,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 		<div class="edit" style="display: none;">
 			<input type="hidden" name="shipping_method_id[]" value="<?php echo esc_attr( $item_id ); ?>" />
-			<input type="text" class="shipping_method_name" placeholder="<?php esc_attr_e( 'Shipping name', 'woocommerce' ); ?>" name="shipping_method_title[<?php echo esc_attr( $item_id ); ?>]" value="<?php echo esc_attr( $item->get_name() ); ?>" />
+			<input
+				type="text"
+				class="shipping_method_name"
+				placeholder="<?php esc_attr_e( 'Shipping name', 'woocommerce' ); ?>"
+				name="shipping_method_title[<?php echo esc_attr( $item_id ); ?>]"
+				value="<?php echo esc_attr( $item->get_name() ); ?>"
+				data-default-shipping-title="<?php esc_attr_e( 'Shipping', 'woocommerce' ); ?>"
+			/>
 			<select class="shipping_method" name="shipping_method[<?php echo esc_attr( $item_id ); ?>]">
 				<optgroup label="<?php esc_attr_e( 'Shipping method', 'woocommerce' ); ?>">
 					<option value=""><?php esc_html_e( 'N/A', 'woocommerce' ); ?></option>

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -404,12 +404,13 @@ function wc_save_order_items( $order_id, $items ) {
 
 	// Shipping Rows.
 	if ( isset( $items['shipping_method_id'] ) ) {
-		$data_keys = array(
+		$data_keys        = array(
 			'shipping_method'       => null,
 			'shipping_method_title' => null,
 			'shipping_cost'         => 0,
 			'shipping_taxes'        => array(),
 		);
+		$shipping_methods = null;
 
 		foreach ( $items['shipping_method_id'] as $item_id ) {
 			$item = WC_Order_Factory::get_order_item( absint( $item_id ) );
@@ -422,6 +423,22 @@ function wc_save_order_items( $order_id, $items ) {
 
 			foreach ( $data_keys as $key => $default ) {
 				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
+			}
+
+			$item_data['shipping_method']       = is_string( $item_data['shipping_method'] ) ? $item_data['shipping_method'] : '';
+			$item_data['shipping_method_title'] = is_string( $item_data['shipping_method_title'] ) ? $item_data['shipping_method_title'] : '';
+
+			if (
+				! empty( $item_data['shipping_method'] ) &&
+				in_array( $item_data['shipping_method_title'], array( '', __( 'Shipping', 'woocommerce' ) ), true )
+			) {
+				if ( null === $shipping_methods ) {
+					$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
+				}
+
+				if ( isset( $shipping_methods[ $item_data['shipping_method'] ] ) ) {
+					$item_data['shipping_method_title'] = $shipping_methods[ $item_data['shipping_method'] ]->get_method_title();
+				}
 			}
 
 			$item->set_props(

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -581,4 +581,34 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( $original_product_id, $saved_item->get_product_id(), 'Reserved internal key should not overwrite core item data' );
 		$this->assertFalse( $saved_item->meta_exists( '_reduced_stock' ), 'Reserved hidden key should not be stored as item meta' );
 	}
+
+	/**
+	 * @testdox wc_save_order_items() should use the shipping method title when the posted shipping title is the default label.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/36049
+	 */
+	public function test_wc_save_order_items_uses_shipping_method_title_when_posted_shipping_title_is_default_label(): void {
+		$order         = WC_Helper_Order::create_order();
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_order_id( $order->get_id() );
+		$item_id = $shipping_item->save();
+
+		$items = array(
+			'shipping_method_id'    => array( $item_id ),
+			'shipping_method'       => array( $item_id => 'free_shipping' ),
+			'shipping_method_title' => array( $item_id => __( 'Shipping', 'woocommerce' ) ),
+			'shipping_cost'         => array( $item_id => 0 ),
+			'shipping_taxes'        => array( $item_id => array() ),
+		);
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		$saved_item = new WC_Order_Item_Shipping( $item_id );
+
+		$this->assertSame(
+			'Free shipping',
+			$saved_item->get_name(),
+			'Known shipping methods should use their title when the posted title is the default label'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Manual orders retain the generic `Shipping` line-item name after an admin selects a shipping method, so customer and merchant emails do not identify the selected method. Synchronize the shipping name with the selected method while preserving custom names, and add a server-side fallback for requests that still submit the default label. No public APIs or hooks are changed.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #36049.

Bug introduced in PR #5867.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before

<img width="1460" height="492" alt="Shipping name remains Shipping before the fix" src="https://github.com/user-attachments/assets/509e73fa-359c-4f15-8c67-6b665e692cd1" />

After

<img width="1540" height="432" alt="Shipping name updates to Free shipping after the fix" src="https://github.com/user-attachments/assets/23312b03-073d-484d-9654-5fbbc89ab1d0" />

<img width="1550" height="328" alt="Saved shipping line named Free shipping" src="https://github.com/user-attachments/assets/f0e1252f-db92-4983-9c5b-c313a2b35721" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Configure and enable at least two shipping methods, including Free shipping.
2. In **WooCommerce > Orders**, create a manual order and add a shipping line item.
3. Edit the shipping line item, select **Free shipping**, and save the order items.
4. Confirm that the shipping line item is named **Free shipping**, then send the customer invoice and confirm the email uses the same name.
5. Edit the shipping name to a custom value, select a different shipping method, and save again.
6. Confirm that the custom shipping name is preserved.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `WC_Admin_Functions_Test`: 13 tests, 44 assertions on PHP 8.1.34.
- PHPStan on the changed production PHP files: no errors.
- PHP and JavaScript branch lint: passed.
- PHP syntax checks and `git diff --check`: passed.
- Manual wp-env test: selecting Free shipping updated the shipping name, which remained Free shipping after saving the order items.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
