### PR TITLE
Guard visual attribute screen IDs

### DIFF
--- a/plugins/woocommerce/changelog/fix-visual-attribute-screen-id
+++ b/plugins/woocommerce/changelog/fix-visual-attribute-screen-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent visual attribute admin asset enqueueing from throwing a TypeError when an integration provides a malformed admin screen ID.

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -326,6 +326,10 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 			return;
 		}
 
+		if ( ! is_string( $screen->id ) ) {
+			return;
+		}
+
 		$is_attribute_term_screen = 0 === strpos( $screen->id, 'edit-pa_' );
 		$taxonomy                 = $this->get_current_taxonomy();
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
@@ -234,4 +234,22 @@ class VisualAttributeTermAdminTest extends WC_Unit_Test_Case {
 			wc_delete_attribute( $attribute_id );
 		}
 	}
+
+	/**
+	 * @testdox Should ignore malformed admin screen IDs when enqueueing visual attribute assets.
+	 */
+	public function test_enqueue_visual_attribute_script_ignores_non_string_screen_id(): void {
+		global $current_screen;
+
+		$original_screen = $current_screen ?? null;
+		$current_screen  = (object) array( 'id' => 35202 ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		try {
+			( new VisualAttributeTermAdmin() )->enqueue_visual_attribute_script();
+
+			$this->assertTrue( true, 'Malformed screen IDs should be ignored without throwing a TypeError.' );
+		} finally {
+			$current_screen = $original_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
- I have checked to ensure there are not other open Pull Requests for the same update/change.
- I have reviewed the code for security best practices.

### Changes proposed in this Pull Request:

This prevents the visual attribute admin asset loader from throwing a `TypeError` when `get_current_screen()->id` is not a string.

The normal product editor and product attribute term screens keep the same behavior. Malformed screen objects now return early before the `strpos()` check.

Closes #66528.

### Screenshots or screen recordings:

Not applicable; this is a PHP guard for an admin enqueue edge case and does not change UI.

### How to test the changes in this Pull Request:

1. Run the targeted regression test:
   `pnpm --filter='@woocommerce/plugin-woocommerce' run test:php:env -- --filter VisualAttributeTermAdminTest::test_enqueue_visual_attribute_script_ignores_non_string_screen_id`
2. Run the full related test class:
   `pnpm --filter='@woocommerce/plugin-woocommerce' run test:php:env -- --filter VisualAttributeTermAdminTest`
3. Confirm PHP syntax and coding standards for the changed PHP files.

### Testing that has already taken place:

Local environment: WooCommerce wp-env test container, PHP 8.1.34, WordPress test suite, only targeted PHPUnit/PHPCS checks for the changed area.

- `pnpm --filter='@woocommerce/plugin-woocommerce' run test:php:env -- --filter VisualAttributeTermAdminTest::test_enqueue_visual_attribute_script_ignores_non_string_screen_id` passed: 1 test, 1 assertion.
- `pnpm --filter='@woocommerce/plugin-woocommerce' run test:php:env -- --filter VisualAttributeTermAdminTest` passed: 4 tests, 32 assertions.
- `php -l plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php` passed.
- `php -l plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php` passed.
- `./vendor/bin/phpcs -s -p src/Internal/ProductAttributes/VisualAttributeTermAdmin.php tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php` passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A changelog entry is included in `plugins/woocommerce/changelog/fix-visual-attribute-screen-id`.

### Release Communication

No generated release note summary needed.
