### PR TITLE
Sanitize single dismissible store notice before rendering

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-notices-single-notice-xss
+++ b/plugins/woocommerce/changelog/fix-store-notices-single-notice-xss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sanitize the single dismissible store notice before rendering so entity-encoded HTML in Store API error messages (e.g. a product name) cannot execute script on the Cart and Checkout blocks.

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -144,7 +144,7 @@ const StoreNotices = ( {
 							key={ 'store-notice-' + status }
 							{ ...noticeProps }
 						>
-							<RawHTML>{ noticeGroup[ 0 ].content }</RawHTML>
+							<RawHTML>{ uniqueNotices[ 0 ].content }</RawHTML>
 						</StoreNotice>
 					) : (
 						<StoreNotice

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/test/index.tsx
@@ -180,6 +180,40 @@ describe( 'StoreNoticesContainer', () => {
 		);
 	} );
 
+	it( 'Sanitizes HTML in a single dismissible notice before rendering', async () => {
+		// The notice-creation pipeline (e.g. notify-errors.ts) decodes entities
+		// before storing the message, so live HTML can reach the notice content.
+		// The single-notice render branch must sanitize it via RawHTML rather than
+		// injecting it as-is. See XSS regression.
+		dispatch( noticesStore ).createErrorNotice(
+			'PWNXSS <img src=x onerror="window.__xss=1">',
+			{
+				id: 'custom-xss-test-error',
+				context: 'test-context',
+			}
+		);
+		const { container } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+		// The disallowed <img> must be stripped, so no image element is injected.
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.innerHTML ).not.toContain( 'onerror' );
+		// The harmless text is still shown (visible + spoken message).
+		expect( screen.getAllByText( /PWNXSS/i ).length ).toBeGreaterThan( 0 );
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'custom-xss-test-error',
+				'test-context'
+			)
+		);
+		await waitFor( () => {
+			return (
+				select( noticesStore ).getNotices( 'test-context' ).length === 0
+			);
+		} );
+	} );
+
 	it( 'Combine same notices from several contexts', async () => {
 		dispatch( noticesStore ).createErrorNotice( 'Custom generic error', {
 			id: 'custom-subcontext-test-error',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes an issue in which one If/Else case of notices would render a notice before being sanitized.

### How to test the changes in this Pull Request:

1. Create a product whose **name** is `PWNXSS &lt;img src=x onerror=alert(document.domain)&gt;` (type the entities literally). Enable stock management, set stock quantity to 1, disallow backorders, publish.
2. Click **Add to cart** on that product, then click it again — the second add exceeds stock and returns a "not enough stock" notice containing the product name.
4. Before this change the payload executes; after it, the notice text renders inert (no `<img>`/script injected).


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>
