### PR TITLE
Restore Core Breadcrumbs callback compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-66821-core-breadcrumbs-callback-compatibility
+++ b/plugins/woocommerce/changelog/fix-66821-core-breadcrumbs-callback-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve Core Breadcrumbs callback compatibility for extensions.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -63,6 +63,8 @@ final class BlockTypesController {
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_filter( 'register_block_type_args', array( $this, 'enqueue_block_style_for_classic_themes' ), 10, 2 );
+		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 3 );
+		add_filter( 'block_core_breadcrumbs_items', array( $this, 'apply_woocommerce_breadcrumb_filters' ), 10, 1 );
 	}
 
 	/**
@@ -580,5 +582,31 @@ final class BlockTypesController {
 		$args['style']         = array();
 
 		return $args;
+	}
+
+	/**
+	 * Set the preferred taxonomy and term for product breadcrumbs.
+	 *
+	 * @internal
+	 *
+	 * @param array  $settings The settings for the breadcrumbs block.
+	 * @param string $post_type The post type.
+	 * @param int    $post_id The current post ID.
+	 * @return array The settings for the breadcrumbs block.
+	 */
+	public function set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type, $post_id = 0 ) {
+		return Package::container()->get( CoreBreadcrumbsCompatibility::class )->set_product_breadcrumbs_preferred_taxonomy( $settings, $post_type, $post_id );
+	}
+
+	/**
+	 * Apply WooCommerce compatibility behavior to Core breadcrumb items.
+	 *
+	 * @internal
+	 *
+	 * @param array $items Array of breadcrumb items from Core.
+	 * @return array Modified breadcrumb items.
+	 */
+	public function apply_woocommerce_breadcrumb_filters( $items ) {
+		return Package::container()->get( CoreBreadcrumbsCompatibility::class )->apply_woocommerce_breadcrumb_filters( $items );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -150,7 +150,6 @@ class Bootstrap {
 			if ( ( new BlockRegistrationContext() )->should_register() ) {
 				$this->container->get( BlockPatterns::class );
 				$this->container->get( BlockTypesController::class );
-				$this->container->get( CoreBreadcrumbsCompatibility::class )->init();
 			}
 			$this->container->get( ClassicTemplatesCompatibility::class );
 			$this->container->get( Notices::class )->init();

--- a/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks;
 
+use Automattic\WooCommerce\Blocks\BlockTypesController;
 use Automattic\WooCommerce\Blocks\CoreBreadcrumbsCompatibility;
 use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
 use Automattic\WooCommerce\Blocks\Domain\Package as BlocksPackage;
@@ -171,7 +172,7 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should register Core Breadcrumbs compatibility filters through the Blocks bootstrap.
+	 * @testdox Should preserve Core Breadcrumbs callback identity through the Blocks bootstrap.
 	 */
 	public function test_blocks_bootstrap_registers_core_breadcrumbs_filters(): void {
 		$container = new Container();
@@ -183,14 +184,17 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 		);
 
 		new Bootstrap( $container );
-		$compatibility = $container->get( CoreBreadcrumbsCompatibility::class );
+		$controller = $container->get( BlockTypesController::class );
 
 		try {
-			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_post_type_settings', array( $compatibility, 'set_product_breadcrumbs_preferred_taxonomy' ) ), 'Bootstrap should register the product breadcrumb settings filter.' );
-			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_items', array( $compatibility, 'apply_woocommerce_breadcrumb_filters' ) ), 'Bootstrap should register the breadcrumb items filter.' );
+			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_post_type_settings', array( $controller, 'set_product_breadcrumbs_preferred_taxonomy' ) ), 'Bootstrap should retain the product breadcrumb settings callback identity.' );
+			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ) ), 'Bootstrap should retain the breadcrumb items callback identity.' );
+			$this->assertSame( array( 'taxonomy' => 'product_cat' ), $controller->set_product_breadcrumbs_preferred_taxonomy( array(), 'product' ), 'The released product breadcrumb settings method should remain callable.' );
+			$this->assertSame( array(), $controller->apply_woocommerce_breadcrumb_filters( array() ), 'The released breadcrumb items method should remain callable.' );
+			$this->assertTrue( remove_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ), 10 ), 'Existing code should be able to remove the released callback.' );
 		} finally {
-			remove_filter( 'block_core_breadcrumbs_post_type_settings', array( $compatibility, 'set_product_breadcrumbs_preferred_taxonomy' ), 10 );
-			remove_filter( 'block_core_breadcrumbs_items', array( $compatibility, 'apply_woocommerce_breadcrumb_filters' ), 10 );
+			remove_filter( 'block_core_breadcrumbs_post_type_settings', array( $controller, 'set_product_breadcrumbs_preferred_taxonomy' ), 10 );
+			remove_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ), 10 );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
@@ -172,7 +172,7 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should preserve Core Breadcrumbs callback identity through the Blocks bootstrap.
+	 * @testdox Should register Core Breadcrumbs compatibility filters through the Blocks bootstrap.
 	 */
 	public function test_blocks_bootstrap_registers_core_breadcrumbs_filters(): void {
 		$container = new Container();
@@ -187,11 +187,11 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 		$controller = $container->get( BlockTypesController::class );
 
 		try {
-			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_post_type_settings', array( $controller, 'set_product_breadcrumbs_preferred_taxonomy' ) ), 'Bootstrap should retain the product breadcrumb settings callback identity.' );
-			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ) ), 'Bootstrap should retain the breadcrumb items callback identity.' );
-			$this->assertSame( array( 'taxonomy' => 'product_cat' ), $controller->set_product_breadcrumbs_preferred_taxonomy( array(), 'product' ), 'The released product breadcrumb settings method should remain callable.' );
-			$this->assertSame( array(), $controller->apply_woocommerce_breadcrumb_filters( array() ), 'The released breadcrumb items method should remain callable.' );
-			$this->assertTrue( remove_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ), 10 ), 'Existing code should be able to remove the released callback.' );
+			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_post_type_settings', array( $controller, 'set_product_breadcrumbs_preferred_taxonomy' ) ), 'Bootstrap should register the product breadcrumb settings filter.' );
+			$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ) ), 'Bootstrap should register the breadcrumb items filter.' );
+			$this->assertSame( array( 'taxonomy' => 'product_cat' ), $controller->set_product_breadcrumbs_preferred_taxonomy( array(), 'product' ), 'BlockTypesController should set the product breadcrumb settings.' );
+			$this->assertSame( array(), $controller->apply_woocommerce_breadcrumb_filters( array() ), 'BlockTypesController should filter the breadcrumb items.' );
+			$this->assertTrue( remove_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ), 10 ), 'The breadcrumb items filter should be removable.' );
 		} finally {
 			remove_filter( 'block_core_breadcrumbs_post_type_settings', array( $controller, 'set_product_breadcrumbs_preferred_taxonomy' ), 10 );
 			remove_filter( 'block_core_breadcrumbs_items', array( $controller, 'apply_woocommerce_breadcrumb_filters' ), 10 );


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In [https://github.com/woocommerce/woocommerce/pull/66382](<https://github.com/woocommerce/woocommerce/pull/66382>) I moved two methods to dedicated class. But that breaks the public contract.

This PR restores the removed `BlockTypesController` breadcrumb methods while delegating implementation to `CoreBreadcrumbsCompatibility`. This keeps direct calls and existing `remove_filter()` integrations working.

Closes woocommerce/woocommerce#66821.

Bug introduced in PR woocommerce/woocommerce#66382.

### How to test the changes in this Pull Request:

1. In the local env, run:

```bash
wp eval '
$controller = \Automattic\WooCommerce\Blocks\Package::container()->get(
        \Automattic\WooCommerce\Blocks\BlockTypesController::class
);

var_export(
        $controller->set_product_breadcrumbs_preferred_taxonomy(
                array(),
                "product"
        )
);

var_export(
        $controller->apply_woocommerce_breadcrumb_filters(
                array()
        )
);
'
```

2. Confirm that neither call causes a fatal error (it does on `trunk`). The first should return `array ( 'taxonomy' => 'product_cat' )`; the second should return an empty array.

### Testing that has already taken place:

* PHPUnit: 23 tests, 30 assertions.
* PHPCS and PHPStan passed.
* `git diff --check` passed.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

Follow-up fix; no changelog entry needed.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants will notice.

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

</details>