### PR TITLE
Fix CSV importer matching special columns anywhere in the name

### DIFF
--- a/plugins/woocommerce/changelog/33773-fix-csv-importer-special-column-matching
+++ b/plugins/woocommerce/changelog/33773-fix-csv-importer-special-column-matching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CSV product importer: match special columns (attributes, downloads, meta) by prefix instead of with unanchored regexes, so columns that merely contain a special name no longer get the wrong formatting callback.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -825,14 +825,20 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		);
 
 		/**
-		 * Match special column names.
+		 * Match special column names by prefix.
+		 *
+		 * These prefixes must stay in sync with the `starts_with()` checks in `expand_data()`,
+		 * which is what decides how the column is actually consumed. Matching anywhere in the
+		 * column name instead of at the start would apply a formatting callback to columns
+		 * `expand_data()` never treats as special.
 		 */
-		$regex_match_data_formatting = array(
-			'/attributes:value*/'    => array( $this, 'parse_comma_field' ),
-			'/attributes:visible*/'  => array( $this, 'parse_bool_field' ),
-			'/attributes:taxonomy*/' => array( $this, 'parse_bool_field' ),
-			'/downloads:url*/'       => array( $this, 'parse_download_file_field' ),
-			'/meta:*/'               => 'wp_kses_post', // Allow some HTML in meta fields.
+		$prefix_match_data_formatting = array(
+			'attributes:value'    => array( $this, 'parse_comma_field' ),
+			'attributes:visible'  => array( $this, 'parse_bool_field' ),
+			'attributes:taxonomy' => array( $this, 'parse_bool_field' ),
+			'downloads:url'       => array( $this, 'parse_download_file_field' ),
+			// Allow some HTML in meta fields.
+			'meta:'               => 'wp_kses_post',
 		);
 
 		$callbacks = array();
@@ -844,9 +850,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			if ( isset( $data_formatting[ $heading ] ) ) {
 				$callback = $data_formatting[ $heading ];
 			} else {
-				foreach ( $regex_match_data_formatting as $regex => $regex_callback ) {
-					if ( preg_match( $regex, $heading ) ) {
-						$callback = $regex_callback;
+				foreach ( $prefix_match_data_formatting as $prefix => $prefix_callback ) {
+					if ( $this->starts_with( $heading, $prefix ) ) {
+						$callback = $prefix_callback;
 						break;
 					}
 				}

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -396,6 +396,40 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Special column formatting callbacks are only applied to columns whose name starts with the special prefix.
+	 */
+	public function test_get_formatting_callback_matches_special_columns_by_prefix() {
+		$importer = new WC_Product_CSV_Importer( $this->csv_file, array( 'lines' => 1 ) );
+
+		$mapped_keys = array(
+			// Canonical special columns.
+			'attributes:value1'    => array( $importer, 'parse_comma_field' ),
+			'attributes:visible1'  => array( $importer, 'parse_bool_field' ),
+			'attributes:taxonomy1' => array( $importer, 'parse_bool_field' ),
+			'downloads:url1'       => array( $importer, 'parse_download_file_field' ),
+			'meta:_my_field'       => 'wp_kses_post',
+			// Columns that merely contain a special name must fall back to wc_clean.
+			'metamask'             => 'wc_clean',
+			'hellometa:'           => 'wc_clean',
+			'product_metadata'     => 'wc_clean',
+			'my attributes:value'  => 'wc_clean',
+			'a downloads:url1'     => 'wc_clean',
+			// Special columns handled elsewhere still get the default callback.
+			'attributes:name1'     => 'wc_clean',
+			'attributes:default1'  => 'wc_clean',
+			'downloads:name1'      => 'wc_clean',
+		);
+
+		$reflected_keys = new ReflectionProperty( $importer, 'mapped_keys' );
+		$reflected_keys->setAccessible( true );
+		$reflected_keys->setValue( $importer, array_keys( $mapped_keys ) );
+
+		$callbacks = $this->invoke_protected( $importer, 'get_formatting_callback', array() );
+
+		$this->assertEquals( array_values( $mapped_keys ), $callbacks );
+	}
+
+	/**
 	 * Test get_raw_data.
 	 * @since 3.1.0
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The CSV importer picked the wrong sanitization callback for some columns. The five regexes in `get_formatting_callback()` are malformed. In PCRE, `*` applies to the preceding character, and none of the patterns are anchored. So `/meta:*/` matched any column name containing `meta`, and those columns got `wp_kses_post` (HTML allowed) instead of `wc_clean` (HTML stripped).

I replaced the regexes with prefix matching, using the `starts_with()` helper that already exists in the class. `expand_data()` uses the same helper on the same five prefixes, so the two now agree.

Core's own columns already resolved correctly, so a normal export and import round trip does not change. The wrong callback was reachable through extension columns registered via `woocommerce_csv_product_import_mapping_options`.

On backwards compatibility: no signatures changed. An extension column whose key merely contains one of the prefixes now gets `wc_clean`, so HTML that used to survive is stripped. Columns using the documented prefixes are not affected.

Closes #33773.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run `pnpm test:php:env -- --filter WC_Tests_Product_CSV_Importer`. All tests pass.
2. Export a CSV from **Products > All Products > Export** with "Export all columns".
3. Import it back under **Products > All Products > Import**. Attributes, downloads and meta columns import as before.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally on WordPress 7.0.2, PHP 8.4.23, WooCommerce trunk, single site, default theme.

- A column named `metamask` parses to `"bold"` on this branch, and to `"<strong>bold</strong>alert(1)"` on trunk.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

I created the changelog entry manually. It is included in this branch.

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [ ] **Developer Advisory**
