### PR TITLE
Honour the position argument of wc_admin_register_page() for sub pages

### DIFF
--- a/docs/extensions/settings-and-config/working-with-woocommerce-admin-pages.md
+++ b/docs/extensions/settings-and-config/working-with-woocommerce-admin-pages.md
@@ -60,7 +60,7 @@ To register a React-powered page, use the [`wc_admin_register_page()`](https://w
 -   `path` (**required**) - This is the page's path (relative to `#wc-admin`). It is used for identifying this page and for linking breadcrumb pieces when this page is a parent.
 -   `capability` (_optional_) - User capability needed to access this page. The default value is `manage_options`.
 -   `icon` (_optional_) - Use this to apply a Dashicons helper class or base64-encoded SVG. Include the entire dashicon class name, ie `dashicons-*`. Note that this won't be included in WooCommerce Admin Navigation.
--   `position` (_optional_) - Menu item position for parent pages. See: [`add_menu_page()`](https://developer.wordpress.org/reference/functions/add_menu_page/).
+-   `position` (_optional_) - Menu item position. See: [`add_menu_page()`](https://developer.wordpress.org/reference/functions/add_menu_page/) and [`add_submenu_page()`](https://developer.wordpress.org/reference/functions/add_submenu_page/).
 
 Registering a React-powered page is similar to connecting a PHP page, but with some key differences. Registering pages will automatically create WordPress menu items for them, with the appropriate hierarchy based on the value of `parent`.
 

--- a/plugins/woocommerce/changelog/35216-fix-register-page-submenu-position
+++ b/plugins/woocommerce/changelog/35216-fix-register-page-submenu-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honour the position argument of wc_admin_register_page() for sub pages, so extensions can control where their React-powered pages appear within a parent submenu. Previously position was only passed to add_menu_page() for top level pages and silently ignored for sub pages.

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -504,7 +504,8 @@ class PageController {
 				$options['title'],
 				$options['capability'],
 				$options['path'],
-				array( __CLASS__, 'page_wrapper' )
+				array( __CLASS__, 'page_wrapper' ),
+				$options['position']
 			);
 		}
 

--- a/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
@@ -56,6 +56,20 @@ class PageControllerTest extends WC_Unit_Test_Case {
 	private $redirected_to = '';
 
 	/**
+	 * Backup of $GLOBALS['menu'], set when a menu fixture is registered.
+	 *
+	 * @var array|null
+	 */
+	private $menu_backup = null;
+
+	/**
+	 * Backup of $GLOBALS['submenu'], set when a menu fixture is registered.
+	 *
+	 * @var array|null
+	 */
+	private $submenu_backup = null;
+
+	/**
 	 * Set things up before each test case.
 	 *
 	 * @return void
@@ -102,6 +116,15 @@ class PageControllerTest extends WC_Unit_Test_Case {
 		// Restore screen backup.
 		if ( $this->current_screen_backup ) {
 			$GLOBALS['current_screen'] = $this->current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		// Restore the admin menu globals if a menu fixture was registered.
+		if ( null !== $this->menu_backup ) {
+			$GLOBALS['menu']    = $this->menu_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$GLOBALS['submenu'] = $this->submenu_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			$this->menu_backup    = null;
+			$this->submenu_backup = null;
 		}
 
 		parent::tearDown();
@@ -530,6 +553,137 @@ class PageControllerTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 'wc-settings', $params['page'], 'Redirect should go to wc-settings page.' );
 		$this->assertEquals( 'checkout', $params['tab'], 'Redirect should go to checkout tab.' );
 		$this->assertEquals( 'WCADMIN_PAYMENT_TASK', $params['from'], 'Redirect should include from parameter.' );
+	}
+
+	/**
+	 * @testdox Should append sub pages in registration order when no position is given.
+	 */
+	public function test_register_page_appends_sub_pages_without_position(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$parent_path = $this->register_menu_fixture(
+			array(
+				array( 'id' => 'position-test-first' ),
+				array( 'id' => 'position-test-second' ),
+				array( 'id' => 'position-test-third' ),
+			)
+		);
+
+		$this->assertSame(
+			array( 'position-test-parent', 'position-test-first', 'position-test-second', 'position-test-third' ),
+			$this->get_submenu_titles( $parent_path ),
+			'Sub pages without a position should keep their registration order.'
+		);
+	}
+
+	/**
+	 * @testdox Should place a sub page at the given position within the parent submenu.
+	 */
+	public function test_register_page_honours_position_for_sub_pages(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		// Position 2 accounts for the link back to the parent that WordPress adds as the first submenu item.
+		$parent_path = $this->register_menu_fixture(
+			array(
+				array( 'id' => 'position-test-first' ),
+				array( 'id' => 'position-test-third' ),
+				array(
+					'id'       => 'position-test-second',
+					'position' => 2,
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'position-test-parent', 'position-test-first', 'position-test-second', 'position-test-third' ),
+			$this->get_submenu_titles( $parent_path ),
+			'A sub page registered with position 2 should be inserted as the third item.'
+		);
+	}
+
+	/**
+	 * @testdox Should append a sub page whose position is beyond the end of the parent submenu.
+	 */
+	public function test_register_page_appends_sub_page_with_out_of_range_position(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$parent_path = $this->register_menu_fixture(
+			array(
+				array( 'id' => 'position-test-first' ),
+				array( 'id' => 'position-test-second' ),
+				array(
+					'id'       => 'position-test-third',
+					'position' => 99,
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'position-test-parent', 'position-test-first', 'position-test-second', 'position-test-third' ),
+			$this->get_submenu_titles( $parent_path ),
+			'An out of range position should append the sub page instead of dropping it.'
+		);
+	}
+
+	/**
+	 * Registers a top level page plus the given sub pages, and returns the parent menu slug.
+	 *
+	 * The global admin menu is emptied first so that assertions only see the fixture, and restored
+	 * in tear down.
+	 *
+	 * @param array $sub_pages List of option arrays passed to register_page(), each with at least an `id`.
+	 *
+	 * @return string The parent menu slug to look up in $submenu.
+	 */
+	private function register_menu_fixture( array $sub_pages ): string {
+		global $menu, $submenu;
+
+		$this->menu_backup    = $menu ?? array();
+		$this->submenu_backup = $submenu ?? array();
+
+		$menu    = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->sut->register_page(
+			array(
+				'id'         => 'position-test-parent',
+				'title'      => 'position-test-parent',
+				'parent'     => null,
+				'path'       => '/position-test-parent',
+				'capability' => 'manage_woocommerce',
+			)
+		);
+
+		foreach ( $sub_pages as $sub_page ) {
+			$this->sut->register_page(
+				array_merge(
+					array(
+						'title'      => $sub_page['id'],
+						'parent'     => 'position-test-parent',
+						'path'       => '/' . $sub_page['id'],
+						'capability' => 'manage_woocommerce',
+					),
+					$sub_page
+				)
+			);
+		}
+
+		return $this->sut->get_path_from_id( 'position-test-parent' );
+	}
+
+	/**
+	 * Returns the menu titles of the sub pages registered under the given parent, in menu order.
+	 *
+	 * @param string $parent_path The parent menu slug.
+	 *
+	 * @return array
+	 */
+	private function get_submenu_titles( string $parent_path ): array {
+		global $submenu;
+
+		$items = $submenu[ $parent_path ] ?? array();
+
+		return array_values( wp_list_pluck( $items, 0 ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
@@ -14,6 +14,13 @@ use WC_Unit_Test_Case;
  */
 class PageControllerTest extends WC_Unit_Test_Case {
 	/**
+	 * Admin menu globals mutated by register_page() via add_menu_page()/add_submenu_page().
+	 *
+	 * @var string[]
+	 */
+	private const MENU_FIXTURE_GLOBALS = array( 'menu', 'submenu', 'admin_page_hooks', '_registered_pages', '_parent_pages' );
+
+	/**
 	 * PageController instance.
 	 *
 	 * @var PageController
@@ -56,18 +63,12 @@ class PageControllerTest extends WC_Unit_Test_Case {
 	private $redirected_to = '';
 
 	/**
-	 * Backup of $GLOBALS['menu'], set when a menu fixture is registered.
+	 * Snapshot of the state mutated by the menu fixture, set when one is registered.
+	 * Holds the admin menu globals (MENU_FIXTURE_GLOBALS) and the PageController pages collection.
 	 *
 	 * @var array|null
 	 */
-	private $menu_backup = null;
-
-	/**
-	 * Backup of $GLOBALS['submenu'], set when a menu fixture is registered.
-	 *
-	 * @var array|null
-	 */
-	private $submenu_backup = null;
+	private $menu_fixture_backup = null;
 
 	/**
 	 * Set things up before each test case.
@@ -118,13 +119,22 @@ class PageControllerTest extends WC_Unit_Test_Case {
 			$GLOBALS['current_screen'] = $this->current_screen_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
-		// Restore the admin menu globals if a menu fixture was registered.
-		if ( null !== $this->menu_backup ) {
-			$GLOBALS['menu']    = $this->menu_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$GLOBALS['submenu'] = $this->submenu_backup; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		// Restore the state mutated by the menu fixture, if one was registered.
+		if ( null !== $this->menu_fixture_backup ) {
+			foreach ( self::MENU_FIXTURE_GLOBALS as $global_name ) {
+				if ( array_key_exists( $global_name, $this->menu_fixture_backup['globals'] ) ) {
+					$GLOBALS[ $global_name ] = $this->menu_fixture_backup['globals'][ $global_name ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the pre-fixture values.
+				} else {
+					unset( $GLOBALS[ $global_name ] );
+				}
+			}
 
-			$this->menu_backup    = null;
-			$this->submenu_backup = null;
+			// Restore the private pages collection of the PageController singleton.
+			$pages_property = new \ReflectionProperty( PageController::class, 'pages' );
+			$pages_property->setAccessible( true );
+			$pages_property->setValue( $this->sut, $this->menu_fixture_backup['pages'] );
+
+			$this->menu_fixture_backup = null;
 		}
 
 		parent::tearDown();
@@ -628,8 +638,9 @@ class PageControllerTest extends WC_Unit_Test_Case {
 	/**
 	 * Registers a top level page plus the given sub pages, and returns the parent menu slug.
 	 *
-	 * The global admin menu is emptied first so that assertions only see the fixture, and restored
-	 * in tear down.
+	 * The global admin menu is emptied first so that assertions only see the fixture. All the state
+	 * mutated by the registration (the admin menu globals and the PageController pages collection)
+	 * is snapshotted here and restored in tear down.
 	 *
 	 * @param array $sub_pages List of option arrays passed to register_page(), each with at least an `id`.
 	 *
@@ -638,8 +649,17 @@ class PageControllerTest extends WC_Unit_Test_Case {
 	private function register_menu_fixture( array $sub_pages ): string {
 		global $menu, $submenu;
 
-		$this->menu_backup    = $menu ?? array();
-		$this->submenu_backup = $submenu ?? array();
+		$backup_globals = array();
+		foreach ( self::MENU_FIXTURE_GLOBALS as $global_name ) {
+			if ( isset( $GLOBALS[ $global_name ] ) ) {
+				$backup_globals[ $global_name ] = $GLOBALS[ $global_name ];
+			}
+		}
+
+		$this->menu_fixture_backup = array(
+			'globals' => $backup_globals,
+			'pages'   => $this->sut->get_pages(),
+		);
 
 		$menu    = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`PageController::register_page()` passed `position` to `add_menu_page()` for top level pages but dropped it when calling `add_submenu_page()`, so extensions could not control where their React-powered pages appear within a parent submenu. The docs were later narrowed to say `position` was for parent pages only, but the underlying limitation remained.

This passes `position` through as the seventh argument of `add_submenu_page()`. That argument has been supported since WP 5.3 and WooCommerce requires WP 6.9, so no version guard is needed. The semantics match WordPress exactly.

The docs entry and the `register_page()` docblock are updated to match.

Closes #35216.

#### Backward compatibility

Low risk. The default stays `null`, and no page registered by WooCommerce core passes a `position` for a sub page, so existing menus are unchanged.

### Screenshots or screen recordings:

Test plugin registering two PHP sub pages (Dashboard, Tools) plus a React page (Analytics) with `'position' => 1`:

| Before | After |
| ------ | ----- |
| <img width="200" height="131" alt="issue35216-before-submenu-order" src="https://github.com/user-attachments/assets/5507f258-524e-4d64-a400-b3da0829aaca" /> | <img width="200" height="131" alt="issue35216-after-submenu-order" src="https://github.com/user-attachments/assets/5c81d9f5-78e7-4618-bf10-3366e530b180" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1.  Add the following to a plugin or an mu-plugin:

    ```php
    add_action( 'admin_menu', function () {
        add_menu_page( 'AW Test', 'AW Test', 'manage_woocommerce', 'aw-test', '__return_empty_string', 'dashicons-controls-repeat', 57 );
        add_submenu_page( 'aw-test', 'Dashboard', 'Dashboard', 'manage_woocommerce', 'aw-test', '__return_empty_string' );
        add_submenu_page( 'aw-test', 'Tools', 'Tools', 'manage_woocommerce', 'aw-test-tools', '__return_empty_string' );

        wc_admin_register_page( array(
            'id'         => 'aw-test-analytics',
            'title'      => 'Analytics',
            'parent'     => 'aw-test',
            'path'       => '/aw-test/analytics',
            'capability' => 'manage_woocommerce',
            'position'   => 1,
        ) );
    }, 20 );
    ```

2.  Go to any wp-admin page and hover the **AW Test** menu.
3.  Confirm the submenu order is Dashboard, Analytics, Tools. On `trunk` the order is Dashboard, Tools, Analytics.
4.  Remove `'position' => 1` from the `wc_admin_register_page()` call and reload. Confirm Analytics is appended last, unchanged from `trunk`.
5.  Confirm the WooCommerce, Analytics, Marketing and Products menus are unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

-   Three unit tests added to `PageControllerTest` covering append with no position, insertion at a given position, and append for an out of range position. Verified the insertion test fails on `trunk` and passes with the fix.
-   Manual verification of the scenario above, at the data layer and in the browser.
-   Regression check across the 14 Woo plugins installed locally (core, WooPayments, Subscriptions, Bookings, Product Bundles, Composite Products, Gift Cards, Product Add-ons, Min/Max Quantities, Back in Stock Notifications, Product Recommendations, PayPal Payments).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Release Communication

<!-- release-communication-section -->

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
