### PR TITLE
Docs: Fix dynamic settings hook documentation

### DIFF
--- a/docs/extensions/settings-and-config/README.md
+++ b/docs/extensions/settings-and-config/README.md
@@ -33,7 +33,7 @@ There are three core responsibilities of this class:
 - Render them through `admin_options()`.
 - Hook `process_admin_options()` to the update hook that matches your context.
 
-For `process_admin_options()`, those contexts could be `woocommerce_update_options_payment_gateways` for a payment gateway, or `woocommerce_update_options_shipping_methods` for a shipping method.
+For `process_admin_options()`, use the dynamic update hook for the context and append the gateway or shipping method ID. Payment gateways use `woocommerce_update_options_payment_gateways_{$gateway_id}`, while shipping methods use `woocommerce_update_options_shipping_{$shipping_method_id}`.
 
 The API lets you control field placements without presupposing a location. However, this means it doesn't create a settings page for you, so you'll need to register that separately if needed. For extensions that fit within payment or shipping contexts, you are extending the same class that WooCommerce's own gateways use.
 
@@ -44,7 +44,7 @@ class My_Extension_Settings extends WC_Settings_API {
 		$this->init_form_fields();
 		$this->init_settings();
 		add_action(
-			'woocommerce_update_options_' . $this->id,
+			'woocommerce_update_options_payment_gateways_' . $this->id,
 			array( $this, 'process_admin_options' )
 		);
 	}
@@ -113,7 +113,7 @@ Rather than creating a whole new page, you can add a section beneath an existing
 - `woocommerce_get_sections_{tab}` registers the section.
 - `woocommerce_get_settings_{tab}` supplies its fields.
 
-The `{tab}` portion of each filter corresponds to the tab you want to extend. For instance, `products` targets the **Products** tab, while `accounts` targets **Account and Privacy**.
+The `{tab}` portion of each filter corresponds to the settings page ID for the tab you want to extend. For instance, `products` targets the **Products** tab, while `account` targets **Accounts & Privacy**.
 
 Placing settings under an existing tab keeps the admin area organized and means merchants find your extension's options in an understandable context. The limit is that linking to your section from documentation or onboarding flows requires a URL with both a tab and a section parameter rather than a page URL you control.
 

--- a/docs/extensions/settings-and-config/settings-api.md
+++ b/docs/extensions/settings-and-config/settings-api.md
@@ -86,16 +86,16 @@ This will output your settings in the correct format.
 
 ## Saving your settings
 
-To have your settings save, add your class's `process_admin_options` method to the appropriate `_update_options_` hook. For example, payment gateways should use the payment gateway hook:
+To have your settings save, add your class's `process_admin_options` method to the appropriate `_update_options_` hook. The hook includes the gateway or shipping method ID. For example, payment gateways should use:
 
 ```php
-add_action( 'woocommerce_update_options_payment_gateways', array( $this, 'process_admin_options' ) );
+add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 ```
 
-Other types of plugins have similar hooks:
+Shipping methods use:
 
 ```php
-add_action( 'woocommerce_update_options_shipping_methods', array( $this, 'process_admin_options' ) );
+add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
 ```
 
 ## Loading your settings


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The settings overview named unsuffixed payment and shipping save actions and used the wrong Account & Privacy settings page ID, which could cause extension callbacks never to run. This corrects the dynamic ID-suffixed hooks, uses the `account` page ID, and updates the older Settings API examples from which the incorrect snippets originated.

Closes #66831.

Bug introduced in PR #66567.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable; this is a documentation-only change.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Review `docs/extensions/settings-and-config/README.md` and confirm the payment and shipping save hooks include their dynamic IDs.
2. Confirm the Account & Privacy example uses the `account` settings page ID.
3. Review `docs/extensions/settings-and-config/settings-api.md` and confirm its payment and shipping code examples use the same ID-suffixed hooks.
4. Run `markdownlint docs/extensions/settings-and-config/README.md docs/extensions/settings-and-config/settings-api.md`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, conducting performance profiling, or using LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Ran Markdown auto-fixing and linting on both changed files.
- Ran `git diff --check`.
- Verified on a local WordPress 7.1-beta2 and WooCommerce 11.0.0-beta.2 site that the singular `account` section and settings filters fire while the plural variants do not.
- Traced the payment gateway and shipping method save actions in WooCommerce core to confirm their ID-suffixed names.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation-only change; no shipped package is modified.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants or store owners will notice.

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes, plugins, or extensions.

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
