### PR TITLE
fix(email-editor): stop email galleries from floating and eating the gap below them

### DIFF
--- a/packages/php/email-editor/changelog/fix-nl-742-gallery-float-spacing
+++ b/packages/php/email-editor/changelog/fix-nl-742-gallery-float-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep email galleries in normal document flow so the block after a gallery (e.g. a heading) keeps its vertical spacing. The gallery wrapper table's align="left" rendered as a float in email clients, pulling the gallery out of flow so the following block failed to clear it. Alignment is preserved via the existing text-align CSS.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -426,10 +426,15 @@ class Gallery extends Abstract_Block_Renderer {
 		);
 
 		// Apply class and style attributes to the wrapper table.
+		//
+		// Intentionally omit the `align` attribute. `align="left"` (or "right") on a table renders as
+		// `float: left` in email clients, taking the gallery out of normal flow — the block that follows
+		// (e.g. a heading) then fails to clear it and butts up against the gallery with no vertical gap.
+		// Horizontal alignment is already carried by the `text-align` declaration in $block_styles['css'],
+		// so dropping the attribute preserves alignment while keeping the gallery in normal flow.
 		$table_attrs = array(
 			'class' => 'email-block-gallery ' . Html_Processing_Helper::clean_css_classes( $original_wrapper_classname ),
 			'style' => $block_styles['css'],
-			'align' => $rendering_context->get_default_text_align(),
 			'width' => '100%',
 		);
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -117,19 +117,26 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItDoesNotFloatWrapperTableWithAlignAttribute(): void {
 		$rendered = $this->gallery_renderer->render( '', $this->parsed_gallery, $this->rendering_context );
 
-		// Isolate the gallery wrapper table's opening tag.
-		$this->assertSame(
-			1,
-			preg_match( '/<table[^>]*class="email-block-gallery[^"]*"[^>]*>/', $rendered, $matches ),
+		// Locate the gallery wrapper table by its class. Parsing the tag with WP_HTML_Tag_Processor is
+		// more robust than matching the raw HTML string, and matches the convention used elsewhere here.
+		$processor = new \WP_HTML_Tag_Processor( $rendered );
+		$this->assertTrue(
+			$processor->next_tag(
+				array(
+					'tag_name'   => 'table',
+					'class_name' => 'email-block-gallery',
+				)
+			),
 			'Expected a gallery wrapper table with the email-block-gallery class.'
 		);
-		$wrapper_tag = $matches[0];
 
-		// No float-triggering align attribute on the wrapper table.
-		$this->assertStringNotContainsString( 'align=', $wrapper_tag );
+		// No float-triggering align attribute on the wrapper table ( get_attribute() is null when absent ).
+		$this->assertNull( $processor->get_attribute( 'align' ) );
 
-		// Alignment is preserved via CSS instead, keeping the block in normal flow.
-		$this->assertStringContainsString( 'text-align', $wrapper_tag );
+		// Alignment is preserved via the text-align CSS declaration instead, keeping the block in normal flow.
+		$style = $processor->get_attribute( 'style' );
+		$this->assertIsString( $style );
+		$this->assertStringContainsString( 'text-align', $style );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -109,6 +109,30 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * The gallery wrapper table must not carry an `align="left"`/`align="right"` attribute: those
+	 * render as `float` in email clients, pulling the gallery out of normal flow so the following
+	 * block (e.g. a heading) fails to clear it and loses its vertical gap. Horizontal alignment must
+	 * instead come from the `text-align` CSS declaration, which keeps the gallery in normal flow.
+	 */
+	public function testItDoesNotFloatWrapperTableWithAlignAttribute(): void {
+		$rendered = $this->gallery_renderer->render( '', $this->parsed_gallery, $this->rendering_context );
+
+		// Isolate the gallery wrapper table's opening tag.
+		$this->assertSame(
+			1,
+			preg_match( '/<table[^>]*class="email-block-gallery[^"]*"[^>]*>/', $rendered, $matches ),
+			'Expected a gallery wrapper table with the email-block-gallery class.'
+		);
+		$wrapper_tag = $matches[0];
+
+		// No float-triggering align attribute on the wrapper table.
+		$this->assertStringNotContainsString( 'align=', $wrapper_tag );
+
+		// Alignment is preserved via CSS instead, keeping the block in normal flow.
+		$this->assertStringContainsString( 'text-align', $wrapper_tag );
+	}
+
+	/**
 	 * Test it handles different column counts
 	 */
 	public function testItHandlesDifferentColumnCounts(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

Part of the WordPress.org News post-to-email rendering work (internal issues NL-736 / NL-742).

**Problem:** In the rendered email, the block immediately after a gallery (typically a heading) had little-to-no vertical space above it — noticeably less than the space after a standalone image — breaking the vertical rhythm.

**Root cause:** The gallery renderer set `align="left"` on its wrapper `<table>` (derived from the default text alignment). Per the HTML spec, `align="left"`/`align="right"` on a table renders as `float`, which takes the gallery out of normal document flow. The following block then fails to clear the float, so its top margin collapses and the gap disappears. A standalone image never showed the bug because the image renderer maps full/wide alignment to `align="center"` (which does not float).

**Fix:** Drop the `align` attribute from the gallery wrapper table. Horizontal alignment is already carried by the `text-align` declaration in the wrapper's inline styles, so alignment is preserved while the gallery stays in normal flow. Confirmed via the integration test: with the old `align="left"` present the wrapper style still contained `text-align:left`, so nothing about the visual alignment relies on the attribute.

This is a strict subset of the reported "line spacing looks off" symptom. Investigation also confirmed the sibling `line-height:100%` reported in the issue is the intentional image whitespace reset (`content.css` `img { line-height: 100% }`) and is correctly scoped to `<img>` only — not a text/vertical-rhythm bug.

(For Bug Fixes) Bug introduced in the original gallery email renderer (PR #60775).

### Screenshots or screen recordings:

_UI/email change; before/after in Gmail to be attached._

| Before | After |
| ------ | ----- |
| <img width="713" height="181" alt="Screenshot 2026-07-21 at 4 11 53 PM" src="https://github.com/user-attachments/assets/2c29522e-8b9e-4fd3-95b7-fce517599a6d" /> | <img width="707" height="227" alt="Screenshot 2026-07-21 at 4 11 47 PM" src="https://github.com/user-attachments/assets/1bc3d22d-8e42-4c77-8a93-a43de89ce449" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In the block/email editor, create a post/email containing: a paragraph, a **core Gallery** block (2+ images), then a **Heading** directly after the gallery. Add a standalone **Image** block followed by another Heading for comparison.
2. Send/preview the email (Gmail web client is the clearest repro).
3. **Before this fix:** the heading directly after the gallery sits tight against it with no/very little gap — visibly less space than the heading after the standalone image.
4. **After this fix:** the heading after the gallery has the same standard vertical gap as the heading after the image. Gallery horizontal alignment is unchanged.
5. Confirm the rendered gallery wrapper `<table class="email-block-gallery ...">` no longer carries an `align="left"` attribute and still has `text-align` in its style.

<!-- End testing instructions -->

### Testing that has already taken place:

- New integration test `Gallery_Test::testItDoesNotFloatWrapperTableWithAlignAttribute` asserts the gallery wrapper table has no float-triggering `align` attribute while retaining `text-align`. Verified it fails on the pre-fix code and passes after the fix.
- Full `Gallery_Test` integration suite passes (31 tests) against wp-env / PHP 8.1.
- PHPCS clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the next WooCommerce version
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request includes a changelog entry (added manually at `packages/php/email-editor/changelog/fix-nl-742-gallery-float-spacing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtoLgUASMqdJG9TjJn7a1J
