### PR TITLE
Fix 'Free' label in email order totals applying to non-shipping rows

### DIFF
--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -154,7 +154,7 @@ endif;
 				$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
 				// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
 				if ( $email_improvements_enabled && 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
-					$total['value'] = __( 'Free', 'woocommerce' );
+					$total['value'] = __( 'Free!', 'woocommerce' );
 				}
 				?>
 				<tr class="order-totals order-totals-<?php echo esc_attr( $total['type'] ?? 'unknown' ); ?><?php echo esc_attr( $last_class ); ?>">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -153,7 +153,7 @@ endif;
 				++$i;
 				$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
 				// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
-				if ( $email_improvements_enabled && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
+				if ( $email_improvements_enabled && 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
 					$total['value'] = __( 'Free', 'woocommerce' );
 				}
 				?>

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -66,7 +66,7 @@ if ( $item_totals ) {
 		if ( $email_improvements_enabled ) {
 			// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
 			if ( 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
-				$total['value'] = __( 'Free', 'woocommerce' );
+				$total['value'] = __( 'Free!', 'woocommerce' );
 			}
 			$label = $total['label'];
 			if ( isset( $total['meta'] ) ) {

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -65,7 +65,7 @@ if ( $item_totals ) {
 	foreach ( $item_totals as $total ) {
 		if ( $email_improvements_enabled ) {
 			// The shipping method name is already shown in the row header, so avoid duplicating it in the value cell.
-			if ( isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
+			if ( 'shipping' === ( $total['type'] ?? '' ) && isset( $total['meta'] ) && $total['value'] === $total['meta'] ) {
 				$total['value'] = __( 'Free', 'woocommerce' );
 			}
 			$label = $total['label'];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The "Free" relabel happened on `value === meta` which could also change non-shipping row added by an extension via the `woocommerce_get_order_item_totals`. This PR adds check to also relabel for shipping rows.

Also updates the label from "Free" to "Free!" to match the long-standing core copy in `WC_Abstract_Order::get_shipping_to_display()`.

Closes #66610, closes WOOPLUG-7077

Bug introduced in PR #66034.

### How to test the changes in this Pull Request:

1. Enable email improvements feature.
2. Add a snippet registering a custom totals row where value equals meta:
   ```php
   add_filter( 'woocommerce_get_order_item_totals', function( $rows ) {
       $rows['custom'] = array( 'type' => 'custom', 'label' => 'Pickup point:', 'value' => 'Store A', 'meta' => 'Store A' );
       return $rows;
   } );
   ```
3. Place an order and check the order email: the custom row must show "Store A", not "Free!".
4. Place an order with free shipping (method assigned): the shipping row must show "Free!".

### Testing that has already taken place:



### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Cosmetic display-only fix for an unreleased regression introduced in #66034 (the "Free" relabel shipped in the same release cycle), plus a minor copy alignment. No merchant-facing behavior change worth a standalone changelog entry.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
