### PR TITLE
fix(email-editor): stamp explicit width on gallery images so Gmail stops widening newsletters

### DIFF
--- a/packages/php/email-editor/changelog/fix-nl-737-gallery-image-width-gmail
+++ b/packages/php/email-editor/changelog/fix-nl-737-gallery-image-width-gmail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Give email gallery images an explicit width attribute sized to their cell. Without it, Gmail desktop and Outlook fell back to each image's intrinsic size and stretched the whole newsletter past its content width. Standalone images were already constrained this way; galleries now match.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-gallery.php
@@ -20,6 +20,17 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Html_Processing_Helper
  */
 class Gallery extends Abstract_Block_Renderer {
 	/**
+	 * Padding (in px) applied to each side of a gallery cell.
+	 *
+	 * Shared between the cell markup (see {@see build_gallery_row_table()}) and the image width
+	 * stamped in {@see normalize_image_for_email()} so an image's fixed width plus its cell padding
+	 * exactly fills the cell instead of overflowing it.
+	 *
+	 * @var int
+	 */
+	private const CELL_PADDING = 8;
+
+	/**
 	 * Renders the gallery block content using a table-based layout.
 	 *
 	 * @param string            $block_content Block content.
@@ -189,17 +200,29 @@ class Gallery extends Abstract_Block_Renderer {
 	}
 
 	/**
-	 * Normalize a gallery <img> for email: drop the web-only class and rein in an oversized raw width.
+	 * Normalize a gallery <img> for email: drop the web-only class and give it a fixed width sized to
+	 * its cell.
 	 *
 	 * The block editor stores the intrinsic `width`/`height` of the original file (e.g. `width="2560"`).
-	 * Outlook honors that raw width literally — blowing a thumbnail-sized cell wide open. The
-	 * core/image renderer avoids this with add_image_dimensions(); the gallery path (which sizes to a
-	 * per-cell width rather than the block width) needs the equivalent tailored to its cell model. We
-	 * clamp the width down to the cell it renders in, but only when the stored width exceeds it,
-	 * scaling any height to keep the aspect ratio. An image with no explicit width is left responsive
-	 * (no attribute added), and a width already at or below the cell width is untouched — so the
-	 * concrete dimensions the aspect-ratio crop sets for a server-cropped file, and the deliberately
-	 * dimensionless CSS-crop fallback, are both preserved.
+	 * Outlook honors that raw width literally — blowing a thumbnail-sized cell wide open. Gmail desktop
+	 * has the opposite failure mode: an <img> with *no* width attribute falls back to the image's
+	 * intrinsic size (it ignores `table-layout: fixed` / percentage cell widths), stretching the whole
+	 * email past its content width (NL-737). The core/image renderer sidesteps both by stamping a
+	 * concrete `width` via add_image_dimensions(); the gallery path (which sizes to a per-cell width
+	 * rather than the block width) needs the equivalent tailored to its cell model:
+	 *
+	 * - An oversized explicit width is clamped down to the cell, scaling any height to keep the aspect
+	 *   ratio.
+	 * - A missing width is stamped with the cell's content width so Gmail/Outlook constrain the image
+	 *   instead of using its intrinsic size. The image keeps its `max-width: 100%` so it still shrinks
+	 *   on mobile.
+	 * - A width already at or below the cell width is left untouched.
+	 *
+	 * CSS-cropped images (an aspect-ratio crop with no server-side rewrite) are the one exception to the
+	 * stamp: they intentionally stay dimensionless so `object-fit`/`aspect-ratio` can crop them without
+	 * distortion in clients that ignore those properties. They're detected by the `object-fit` the crop
+	 * adds, so the concrete dimensions a server-cropped file receives are still preserved (that path
+	 * sets an explicit width, which the missing-width branch never touches).
 	 *
 	 * The other web-only attributes core emits (`srcset`, `sizes`, `loading`, `decoding`) are already
 	 * stripped upstream by {@see Html_Processing_Helper::sanitize_image_html()}, whose allowlist keeps
@@ -224,27 +247,48 @@ class Gallery extends Abstract_Block_Renderer {
 		// renderer strips it too). remove_attribute() is a no-op when the attribute is absent.
 		$html->remove_attribute( 'class' );
 
-		// Rein in a raw width wider than the cell it renders in (e.g. a 2560px original in a 20%-wide
-		// cell). We only shrink an explicit, oversized width — never add one to an otherwise responsive
-		// image, and never touch a width already sized to (or below) the cell — so the aspect-ratio
-		// crop's concrete server-crop dimensions are left intact.
 		if ( $cell_width > 0 ) {
 			$raw_width = $html->get_attribute( 'width' );
 			$width     = is_string( $raw_width ) && is_numeric( $raw_width ) ? (int) $raw_width : 0;
 
 			if ( $width > $cell_width ) {
+				// Rein in a raw width wider than the cell it renders in (e.g. a 2560px original in a
+				// 20%-wide cell) so Outlook — which honors the width attribute literally — doesn't blow
+				// the cell open. Scale any height by the same factor to keep the aspect ratio.
 				$raw_height = $html->get_attribute( 'height' );
 				$height     = is_string( $raw_height ) && is_numeric( $raw_height ) ? (int) $raw_height : 0;
 				if ( $height > 0 ) {
-					// Scale the height by the same factor so the image keeps its aspect ratio.
 					$scaled_height = max( 1, (int) round( $height * ( $cell_width / $width ) ) );
 					$html->set_attribute( 'height', esc_attr( (string) $scaled_height ) );
 				}
 				$html->set_attribute( 'width', esc_attr( (string) $cell_width ) );
+			} elseif ( 0 === $width && ! $this->image_uses_css_crop( $html ) ) {
+				// No explicit width: Gmail desktop and Outlook would fall back to the image's intrinsic
+				// size and stretch the email past its content width (NL-737). Stamp the cell's content
+				// width (cell minus its padding on both sides) so those clients constrain it, while the
+				// image's max-width:100% keeps it responsive on mobile. CSS-cropped images are skipped —
+				// they need to stay dimensionless so object-fit can crop without distortion.
+				$display_width = max( 1, $cell_width - ( 2 * self::CELL_PADDING ) );
+				$html->set_attribute( 'width', esc_attr( (string) $display_width ) );
 			}
 		}
 
 		return $html->get_updated_html();
+	}
+
+	/**
+	 * Whether the image is relying on CSS cropping (an aspect-ratio crop with no server-side rewrite).
+	 *
+	 * {@see apply_aspect_ratio_crop()} adds `object-fit: cover` to every cropped image, and only to
+	 * cropped images, so its presence marks the CSS-crop fallback that must stay dimensionless to avoid
+	 * distortion. The processor is passed by reference and left positioned on the same <img> tag.
+	 *
+	 * @param \WP_HTML_Tag_Processor $html Processor positioned on the <img> tag.
+	 * @return bool True when the image uses CSS cropping and must not receive a stamped width.
+	 */
+	private function image_uses_css_crop( \WP_HTML_Tag_Processor $html ): bool {
+		$style = $html->get_attribute( 'style' );
+		return is_string( $style ) && false !== stripos( $style, 'object-fit' );
 	}
 
 	/**
@@ -467,7 +511,7 @@ class Gallery extends Abstract_Block_Renderer {
 	private function build_gallery_table( array $gallery_images, int $columns ): string {
 		$content_parts = array();
 		$image_count   = count( $gallery_images );
-		$cell_padding  = 8; // 0.5em equivalent (approximately 8px)
+		$cell_padding  = self::CELL_PADDING; // 0.5em equivalent (approximately 8px)
 
 		// Process images in chunks based on columns to create rows.
 		for ( $i = 0; $i < $image_count; $i += $columns ) {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Gallery_Test.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\EmailEditor\Engine\Email_Editor;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Gallery;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 
 /**
  * Integration test for Gallery class
@@ -340,8 +341,9 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $rendered_with_links );
 		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=2">', $rendered_with_links );
 
-		// Verify that images without links don't get wrapped in anchor tags.
-		$this->assertStringContainsString( '<img src="https://example.com/image3.jpg"', $rendered_with_links );
+		// Verify that images without links don't get wrapped in anchor tags. The <img> now carries a
+		// stamped width attribute, so match on the src rather than the exact tag opening.
+		$this->assertStringContainsString( 'src="https://example.com/image3.jpg"', $rendered_with_links );
 		$this->assertStringNotContainsString( '<a href="https://example.com/image3.jpg">', $rendered_with_links );
 	}
 
@@ -776,6 +778,47 @@ class Gallery_Test extends \Email_Editor_Integration_Test_Case {
 
 		$this->assertStringContainsString( 'width="100"', $rendered, 'A small width is preserved.' );
 		$this->assertStringContainsString( 'height="50"', $rendered, 'Its height is preserved too.' );
+	}
+
+	/**
+	 * A gallery image with no explicit width (the common case for editor markup that sizes images with
+	 * CSS) is stamped with its cell's content width. Without the attribute, Gmail desktop and Outlook
+	 * fall back to the image's intrinsic size and stretch the whole email past its content width
+	 * (NL-737); the stamped width constrains it, exactly as the core/image renderer does for standalone
+	 * images.
+	 */
+	public function testItStampsCellWidthOnImagesWithoutAnExplicitWidth(): void {
+		// The default fixture is a 2-column gallery of three width-less images: images 1 and 2 share the
+		// first row, image 3 is alone in the (full-width) second row.
+		$rendered = $this->gallery_renderer->render( '', $this->parsed_gallery, $this->rendering_context );
+
+		$layout_width = (int) Styles_Helper::parse_value( $this->rendering_context->get_layout_width_without_padding() );
+		$cell_padding = 8; // Must match Gallery::CELL_PADDING.
+
+		$widths = array();
+		$html   = new \WP_HTML_Tag_Processor( $rendered );
+		while ( $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			$width = $html->get_attribute( 'width' );
+			$this->assertIsString( $width, 'Every gallery image gets an explicit width so Gmail/Outlook constrain it.' );
+			$widths[] = (int) $width;
+		}
+
+		$this->assertCount( 3, $widths, 'All three images are present.' );
+
+		// First-row images each take half the layout, minus the cell padding on both sides.
+		$expected_half = (int) floor( $layout_width / 2 ) - ( 2 * $cell_padding );
+		$this->assertSame( $expected_half, $widths[0], 'A shared-row image is sized to half the content width minus padding.' );
+		$this->assertSame( $widths[0], $widths[1], 'Images sharing a row share a width.' );
+
+		// The lone trailing image spans the full row: the whole content width minus its padding.
+		$expected_full = $layout_width - ( 2 * $cell_padding );
+		$this->assertSame( $expected_full, $widths[2], 'A lone trailing image spans the full content width.' );
+
+		// The regression stretched images past the content width; every stamped width must stay within it.
+		foreach ( $widths as $width ) {
+			$this->assertGreaterThan( 0, $width, 'A stamped width is positive.' );
+			$this->assertLessThanOrEqual( $layout_width, $width, 'A stamped width never exceeds the content width.' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Fixes [NL-737](https://linear.app/a8c/issue/NL-737/newsletter-emails-appear-too-wide-in-gmail): newsletter emails render too wide in Gmail desktop when a post contains galleries.

**Root cause.** Email gallery images were emitted with only `max-width:100%` and **no `width` attribute**. Gmail desktop (and Outlook) then ignore the gallery's `table-layout:fixed` / percentage cell widths and fall back to each image's *intrinsic* size (e.g. a `?w=1024` CDN image), stretching the whole email past its content width. Standalone (core/image) images don't have this problem because the image renderer stamps a concrete `width` via `add_image_dimensions()`; the gallery renderer only *clamped down* oversized widths and left width-less images responsive.

Confirmed from the reporter's Gmail source: single images carry `width="580"` and stay constrained, while the 2-up gallery images carry no `width` — and Gmail's own overlay coordinates put the right-hand gallery image far wider than a full-width single image.

**Fix.** In `class-gallery.php::normalize_image_for_email()`, when a gallery image has no explicit width, stamp `width = cell content width` (the cell minus its `8px` padding on each side), mirroring the single-image renderer. `max-width:100%` is preserved so images still shrink on mobile.

Behavior deliberately preserved:
- Oversized explicit widths still clamp down (Outlook), scaling height to keep the aspect ratio.
- Images already sized at/below the cell are untouched.
- CSS-cropped images (aspect-ratio crop with no server-side rewrite) stay dimensionless so `object-fit` can crop without distortion — detected by the `object-fit` the crop adds.
- Server-cropped images already carry a concrete width, so the new branch never touches them.

The `8px` cell padding is now a shared `Gallery::CELL_PADDING` constant so the cell markup and the stamped width can't drift.

### Backward compatibility

Renderer-internal HTML output only. No changes to public classes, methods, hooks, or filters. The `woocommerce_email_editor_gallery_cropped_image_url` filter and server-crop path are unaffected.

### Screenshots or screen recordings:

Rendering-layer change (HTML attribute). Verified via the rendered markup rather than a client screenshot — see testing below.

### How to test the changes in this Pull Request:

1. In the post editor, create/edit a post and add a **Gallery** block with 2+ columns using reasonably large images (e.g. 1024px wide originals).
2. Send/preview the email and open it in **Gmail desktop**.
3. **Before:** the email stretches wider than its content width; you must scroll horizontally to read text. **After:** the email stays at its content width and gallery images sit within it.
4. Inspect the rendered gallery `<img>` tags — each now carries an explicit `width="…"` attribute sized to its cell (with `max-width:100%` retained for mobile).

### Testing that has already taken place:

- New unit test `testItStampsCellWidthOnImagesWithoutAnExplicitWidth` asserts a width-less gallery image is stamped with the cell content width (half-row and full-row cases) and that no stamped width exceeds the content width.
- Full email-editor integration suite passes: **444 tests, 1634 assertions** (4 pre-existing, unrelated skips). Existing CSS-crop / server-crop / clamp-down / ampersand tests continue to pass unchanged.
- Faithful runtime reproduction on the reporter's actual gallery markup (CDN `?w=768`/`?w=1024` srcs, `max-width:100%`, no width, no aspect ratio) through the real `Gallery` renderer + theme: at a 612px content width, both images are now stamped `width="290"` instead of expanding to 768/1024.
- `phpcs` (email-editor package's stricter ruleset) is clean on the changed files. PHPStan level 9 applies to the plugin `src/`, not this package.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry is already included in the branch (`packages/php/email-editor/changelog/fix-nl-737-gallery-image-width-gmail`), so the auto-create job is not needed.
