### PR TITLE
Fix fatal errors when updating malformed gateway settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-66828-non-array-gateway-settings
+++ b/plugins/woocommerce/changelog/fix-66828-non-array-gateway-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when updating malformed payment gateway settings.

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -191,7 +191,21 @@ class WC_Payment_Gateways {
 	 */
 	private function payment_gateway_settings_option_changed( $gateway, $value, $option, $old_value = null ) {
 		if ( ! is_array( $value ) || ( null !== $old_value && ! is_array( $old_value ) ) ) {
-			return;
+			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
+
+			if ( ! is_array( $value ) ) {
+				$logger->warning(
+					sprintf( 'Payment gateway transition handling skipped because the new value for "%s" is not an array.', $option ),
+					array( 'source' => 'payment-gateways' )
+				);
+				return;
+			}
+
+			$logger->warning(
+				sprintf( 'Previous payment gateway settings for "%s" were not an array; treating the gateway as disabled.', $option ),
+				array( 'source' => 'payment-gateways' )
+			);
+			$old_value = array( 'enabled' => 'no' );
 		}
 
 		if ( $this->was_gateway_enabled( $value, $old_value ) ) {

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -190,6 +190,10 @@ class WC_Payment_Gateways {
 	 * @since 8.5.0
 	 */
 	private function payment_gateway_settings_option_changed( $gateway, $value, $option, $old_value = null ) {
+		if ( ! is_array( $value ) || ( null !== $old_value && ! is_array( $old_value ) ) ) {
+			return;
+		}
+
 		if ( $this->was_gateway_enabled( $value, $old_value ) ) {
 			$logger = wc_get_container()->get( LegacyProxy::class )->call_function( 'wc_get_logger' );
 			$logger->info( sprintf( 'Payment gateway enabled: "%s"', $gateway->get_method_title() ) );

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -38,6 +38,31 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Gateway settings updates do not throw for non-array values.
+	 */
+	public function test_gateway_settings_updates_do_not_throw_for_non_array_values(): void {
+		$option_name    = 'woocommerce_cod_settings';
+		$valid_settings = array( 'enabled' => 'no' );
+
+		delete_option( $option_name );
+		add_option( $option_name, $valid_settings );
+
+		$this->assertTrue(
+			update_option( $option_name, '{"enabled":"yes"}' ),
+			'Gateway settings should update to a non-array value.'
+		);
+		$this->assertTrue(
+			update_option( $option_name, $valid_settings ),
+			'Gateway settings should update from a non-array value.'
+		);
+		$this->assertSame(
+			$valid_settings,
+			get_option( $option_name ),
+			'Valid gateway settings should be stored after a malformed value.'
+		);
+	}
+
+	/**
 	 * @testdox Enabling a gateway fires the notification action and logs the event.
 	 */
 	public function test_wc_payment_gateway_enabled_notification(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -38,28 +38,106 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Gateway settings updates do not throw for non-array values.
+	 * @testdox Gateway settings updates diagnose malformed values and track enabled repairs.
 	 */
-	public function test_gateway_settings_updates_do_not_throw_for_non_array_values(): void {
-		$option_name    = 'woocommerce_cod_settings';
-		$valid_settings = array( 'enabled' => 'no' );
+	public function test_gateway_settings_updates_handle_non_array_values(): void {
+		$option_name       = 'woocommerce_cod_settings';
+		$disabled_settings = array( 'enabled' => 'no' );
+		$enabled_settings  = array( 'enabled' => 'yes' );
+		$tracking_option   = get_option( 'woocommerce_allow_tracking', null );
+		$current_user_id   = get_current_user_id();
 
-		delete_option( $option_name );
-		add_option( $option_name, $valid_settings );
+		// phpcs:disable Squiz.Commenting
+		$fake_logger = new class() {
+			public $infos    = array();
+			public $warnings = array();
 
-		$this->assertTrue(
-			update_option( $option_name, '{"enabled":"yes"}' ),
-			'Gateway settings should update to a non-array value.'
+			public function info( $message, $data = array() ) {
+				$this->infos[] = array(
+					'message' => $message,
+					'data'    => $data,
+				);
+			}
+
+			public function warning( $message, $data = array() ) {
+				$this->warnings[] = array(
+					'message' => $message,
+					'data'    => $data,
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_get_logger' => function () use ( $fake_logger ) {
+					return $fake_logger;
+				},
+			)
 		);
-		$this->assertTrue(
-			update_option( $option_name, $valid_settings ),
-			'Gateway settings should update from a non-array value.'
-		);
-		$this->assertSame(
-			$valid_settings,
-			get_option( $option_name ),
-			'Valid gateway settings should be stored after a malformed value.'
-		);
+
+		$providers_service = $this->createStub( \Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders::class );
+		$providers_service->method( 'get_payment_gateway_details' )->willReturn( array() );
+		wc_get_container()->replace( \Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders::class, $providers_service );
+
+		$enabled_gateways = array();
+		$action_watcher   = function ( $gateway ) use ( &$enabled_gateways ) {
+			$enabled_gateways[] = $gateway;
+		};
+		add_action( 'woocommerce_payment_gateway_enabled', $action_watcher );
+
+		try {
+			wp_set_current_user( 0 );
+			update_option( 'woocommerce_allow_tracking', 'yes' );
+			$this->clear_tracks_events();
+
+			delete_option( $option_name );
+			add_option( $option_name, $disabled_settings );
+
+			update_option( $option_name, '{"enabled":"yes"}' );
+			$malformed_value        = get_option( $option_name );
+			$malformed_info_count   = count( $fake_logger->infos );
+			$malformed_action_count = count( $enabled_gateways );
+			$malformed_tracks_count = count( $this->get_tracks_events( 'wcadmin_settings_payments_provider_enable' ) );
+
+			update_option( $option_name, $enabled_settings );
+
+			$this->assertSame( '{"enabled":"yes"}', $malformed_value, 'The malformed gateway settings should remain a string.' );
+			$this->assertSame( 0, $malformed_info_count, 'A malformed new value should not log an enable transition.' );
+			$this->assertSame( 0, $malformed_action_count, 'A malformed new value should not fire the gateway-enabled action.' );
+			$this->assertSame( 0, $malformed_tracks_count, 'A malformed new value should not record an enable event.' );
+
+			$this->assertSame( $enabled_settings, get_option( $option_name ), 'Valid gateway settings should be stored after a malformed value.' );
+			$this->assertCount( 2, $fake_logger->warnings, 'Both malformed transition values should produce diagnostic warnings.' );
+			$this->assertSame(
+				'Payment gateway transition handling skipped because the new value for "woocommerce_cod_settings" is not an array.',
+				$fake_logger->warnings[0]['message'],
+				'The malformed new value warning should identify the affected option.'
+			);
+			$this->assertSame(
+				'Previous payment gateway settings for "woocommerce_cod_settings" were not an array; treating the gateway as disabled.',
+				$fake_logger->warnings[1]['message'],
+				'The malformed old value warning should describe the repair behavior.'
+			);
+			$this->assertCount( 1, $fake_logger->infos, 'Repairing to enabled settings should log one enable transition.' );
+			$this->assertCount( 1, $enabled_gateways, 'Repairing to enabled settings should fire the gateway-enabled action once.' );
+			$this->assertSame( 'cod', $enabled_gateways[0]->id, 'The gateway-enabled action should receive the repaired gateway.' );
+			$this->assertCount(
+				1,
+				$this->get_tracks_events( 'wcadmin_settings_payments_provider_enable' ),
+				'Repairing to enabled settings should record one enable event.'
+			);
+		} finally {
+			remove_action( 'woocommerce_payment_gateway_enabled', $action_watcher );
+			wc_get_container()->reset_replacement( \Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders::class );
+			$this->clear_tracks_events();
+			wp_set_current_user( $current_user_id );
+
+			if ( null === $tracking_option ) {
+				delete_option( 'woocommerce_allow_tracking' );
+			} else {
+				update_option( 'woocommerce_allow_tracking', $tracking_option );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Payment gateway option hooks can receive non-array settings values from external writers. Passing those values to `ArrayUtil::get_value_or_default()` causes a fatal error after WordPress has already persisted the update, including when the WooCommerce CLI attempts to repair malformed settings.

This adds defensive handling at the option-change tracking boundary. Non-array new values skip transition side effects with a diagnostic warning, while non-array old values are treated as disabled so a valid enabled repair follows the normal logging, notification, and analytics path. Stored values are never decoded or otherwise reinterpreted. One regression test covers both array-to-string and string-to-array updates through the real WordPress option hooks.

Backward compatibility: no public signatures, hook names, or hook arguments change. Valid array-backed add and update flows retain their existing behavior. The option remains site-scoped as before; multisite behavior was not tested separately.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66828.

Bug introduced in PR #41645.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the WooCommerce test environment and run the focused test class:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce env:test:start
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Payment_Gateways_Test
   ```

   - [ ] Confirm PHPUnit reports 4 tests and 30 assertions with no failures or errors.

2. Start the development environment and establish valid array-backed COD settings:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce env:dev:start
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option update woocommerce_cod_settings '{"enabled":"no","title":"Cash on Delivery"}' --format=json
   ```

3. Replace the valid array with a raw JSON-looking string:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option update woocommerce_cod_settings '{"enabled":"yes","title":"Cash on Delivery"}'
   ```

   - [ ] Confirm the command succeeds without an `ArrayUtil::get_value_or_default()` `TypeError`.

4. Repair the malformed value through the supported WooCommerce CLI:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp wc payment_gateway update cod --enabled=true --user=admin
   pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option get woocommerce_cod_settings --format=json
   ```

   - [ ] Confirm the recovery command succeeds without a fatal error.
   - [ ] Confirm the final output is a JSON object containing `"enabled":"yes"`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit in the isolated Core `wp-env`: 4 tests, 30 assertions, no failures or errors on PHP 8.1.34.
- Reproduced both malformed update directions and the WooCommerce CLI recovery flow through WP-CLI. The recovery completed successfully and restored an array-backed option.
- `lint:php:changes` and `lint:changes:branch` completed successfully.
- PHPStan reported no errors for the modified production file.
- Three independent review passes checked correctness and compatibility, test necessity and runtime, and WooCommerce conventions; none requested changes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"
</details>
