### PR TITLE
Fix shipping line names changing on order save

### DIFF
--- a/plugins/woocommerce/changelog/fix-66847-preserve-shipping-line-name
+++ b/plugins/woocommerce/changelog/fix-66847-preserve-shipping-line-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve existing order shipping line names that match the default Shipping label.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -430,7 +430,7 @@ function wc_save_order_items( $order_id, $items ) {
 
 			if (
 				! empty( $item_data['shipping_method'] ) &&
-				in_array( $item_data['shipping_method_title'], array( '', __( 'Shipping', 'woocommerce' ) ), true )
+				'' === $item_data['shipping_method_title']
 			) {
 				if ( null === $shipping_methods ) {
 					$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -583,11 +583,11 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox wc_save_order_items() should use the shipping method title when the posted shipping title is the default label.
+	 * @testdox wc_save_order_items() should use the shipping method title when the posted shipping title is empty.
 	 *
 	 * @link https://github.com/woocommerce/woocommerce/issues/36049
 	 */
-	public function test_wc_save_order_items_uses_shipping_method_title_when_posted_shipping_title_is_default_label(): void {
+	public function test_wc_save_order_items_uses_shipping_method_title_when_posted_shipping_title_is_empty(): void {
 		$order         = WC_Helper_Order::create_order();
 		$shipping_item = new WC_Order_Item_Shipping();
 		$shipping_item->set_order_id( $order->get_id() );
@@ -596,7 +596,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$items = array(
 			'shipping_method_id'    => array( $item_id ),
 			'shipping_method'       => array( $item_id => 'free_shipping' ),
-			'shipping_method_title' => array( $item_id => __( 'Shipping', 'woocommerce' ) ),
+			'shipping_method_title' => array( $item_id => '' ),
 			'shipping_cost'         => array( $item_id => 0 ),
 			'shipping_taxes'        => array( $item_id => array() ),
 		);
@@ -608,7 +608,39 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertSame(
 			'Free shipping',
 			$saved_item->get_name(),
-			'Known shipping methods should use their title when the posted title is the default label'
+			'Known shipping methods should use their title when the posted title is empty'
+		);
+	}
+
+	/**
+	 * @testdox wc_save_order_items() should preserve an existing shipping line named Shipping.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/66847
+	 */
+	public function test_wc_save_order_items_preserves_existing_shipping_line_named_shipping(): void {
+		$order         = WC_Helper_Order::create_order();
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_order_id( $order->get_id() );
+		$shipping_item->set_method_id( 'flat_rate' );
+		$shipping_item->set_method_title( __( 'Shipping', 'woocommerce' ) );
+		$item_id = $shipping_item->save();
+
+		$items = array(
+			'shipping_method_id'    => array( $item_id ),
+			'shipping_method'       => array( $item_id => 'flat_rate' ),
+			'shipping_method_title' => array( $item_id => __( 'Shipping', 'woocommerce' ) ),
+			'shipping_cost'         => array( $item_id => 0 ),
+			'shipping_taxes'        => array( $item_id => array() ),
+		);
+
+		wc_save_order_items( $order->get_id(), $items );
+
+		$saved_item = new WC_Order_Item_Shipping( $item_id );
+
+		$this->assertSame(
+			__( 'Shipping', 'woocommerce' ),
+			$saved_item->get_name(),
+			'Existing shipping lines named Shipping should not be replaced with the generic method title'
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Existing checkout orders can legitimately store a shipping line named `Shipping` when the merchant-configured shipping rate label is `Shipping`. Limit the admin order-item save fallback to truly empty shipping titles so unrelated order edits do not replace those existing customer-facing labels with the generic shipping method title.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66847.

Bug introduced in PR #66811.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A; this changes backend order item save behavior only.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Configure a Flat rate shipping method and set its merchant-facing rate label to `Shipping`.
2. Place a customer order using that shipping rate.
3. In wp-admin, open the order and save an unrelated order item change, or recalculate/save the order items without editing the shipping row.
4. Confirm the shipping line remains named `Shipping` and is not replaced with `Flat rate`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm run test:php:env -- --filter WC_Admin_Functions_Test`: 14 tests, 45 assertions.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes`: passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`: passed.
- `composer exec -- phpstan analyse includes/admin/wc-admin-functions.php --memory-limit=2G`: no errors.
- PHP syntax checks and `git diff --check`: passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
