### PR TITLE
[Performance] Address edge-case concerns reported by an AI after merging #66084.

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -266,7 +266,9 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					)
 				);
 				foreach ( $prefetch as $row ) {
-					$attributes_values[ $row->meta_key ][] = $row->meta_value;
+					// Defensive: normalize non-canonical meta_key casing (e.g. attribute_pa_Size → attribute_pa_size).
+					// sanitize_title over wc_variation_attribute_name as the latter adds 'attribute_' prefix.
+					$attributes_values[ sanitize_title( $row->meta_key ) ][] = $row->meta_value;
 				}
 			}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -1883,4 +1883,35 @@ class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$product->delete();
 	}
+
+	/**
+	 * @testdox read_variation_attributes returns all assigned values even when a variation meta key is stored with non-canonical casing (e.g. attribute_pa_Size instead of attribute_pa_size).
+	 */
+	public function test_read_variation_attributes_non_canonical_meta_key_casing(): void {
+		global $wpdb;
+
+		$product    = WC_Helper_Product::create_variation_product();
+		$product_id = $product->get_id();
+
+		// Simulate legacy/third-party data: one variation's attribute meta key stored with non-canonical casing.
+		$variation_id = current( array_filter( $product->get_children(), static fn( $id ) => 'small' === get_post_meta( $id, 'attribute_pa_size', true ) ) );
+		$wpdb->update(
+			$wpdb->postmeta,
+			array(
+				'meta_key' => 'attribute_pa_Size', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			),
+			array(
+				'post_id'  => $variation_id,
+				'meta_key' => 'attribute_pa_size', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			)
+		);
+		WC_Cache_Helper::invalidate_cache_group( 'product_' . $product_id );
+		$product = wc_get_product( $product_id );
+
+		$sizes = ( new WC_Product_Variable_Data_Store_CPT() )->read_variation_attributes( $product )['pa_size'];
+
+		$this->assertSame( array( 'small', 'large', 'huge' ), $sizes );
+
+		$product->delete( true );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes #66852

Makes the attribute values grouping case-insensitive to address the reported concern. Skipping changelog entry as I've just merged #66084 and this PR has no point for a dedicated changelog entry.

> Why it's worth fixing: the `wc_update_220_attributes` migration left non-canonical postmeta keys in place, and `update_attributes()` never removes them due to CI collation masking in the `NOT IN` clause — so sites upgraded from pre-2.2 can carry `attribute_pa_Size`-style keys indefinitely. `LOWER(meta_key) AS meta_key` in the `SELECT` neutralizes this: regardless of how the key was stored, the grouping key is always canonical, matching the `wc_variation_attribute_name()` lookup exactly.

### How to test the changes in this Pull Request:

- CI checks shall pass (the change is covered by existing test coverage)
- No other testing required

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
See PR description.

</details>
