### PR TITLE
Fix duplicate headers on Settings UI drill-down pages

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3585-settings-ui-drill-down-header
+++ b/plugins/woocommerce/changelog/wooprd-3585-settings-ui-drill-down-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate headers on Settings UI drill-down pages.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -3,6 +3,16 @@
 body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	background-color: var(--wpds-color-background-surface-neutral);
 
+	&.woocommerce-settings-ui-drill-down {
+		#wpbody {
+			margin-top: 0;
+		}
+
+		.woocommerce-layout__header {
+			display: none;
+		}
+	}
+
 	#mainform,
 	#wpcontent,
 	#wpbody-content,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -145,15 +145,18 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 				return $classes;
 			}
 
-			if ( ! str_contains( $classes, 'woocommerce-settings-ui-page' ) ) {
-				$classes .= ' woocommerce-settings-ui-page';
+			$body_classes = explode( ' ', $classes );
+
+			if ( ! in_array( 'woocommerce-settings-ui-page', $body_classes, true ) ) {
+				$classes       .= ' woocommerce-settings-ui-page';
+				$body_classes[] = 'woocommerce-settings-ui-page';
 			}
 
 			if (
 				$context->is_drill_down()
 				&& ! $context->has_schema_failed()
 				&& ! $context->has_script_handles_failed()
-				&& ! str_contains( $classes, 'woocommerce-settings-ui-drill-down' )
+				&& ! in_array( 'woocommerce-settings-ui-drill-down', $body_classes, true )
 			) {
 				$classes .= ' woocommerce-settings-ui-drill-down';
 			}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -145,11 +145,20 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 				return $classes;
 			}
 
-			if ( str_contains( $classes, 'woocommerce-settings-ui-page' ) ) {
-				return $classes;
+			if ( ! str_contains( $classes, 'woocommerce-settings-ui-page' ) ) {
+				$classes .= ' woocommerce-settings-ui-page';
 			}
 
-			return "$classes woocommerce-settings-ui-page";
+			if (
+				$context->is_drill_down()
+				&& ! $context->has_schema_failed()
+				&& ! $context->has_script_handles_failed()
+				&& ! str_contains( $classes, 'woocommerce-settings-ui-drill-down' )
+			) {
+				$classes .= ' woocommerce-settings-ui-drill-down';
+			}
+
+			return $classes;
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -408,7 +408,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * It adds the settings UI body class when the feature flag is enabled.
+	 * @testdox Should add only the top-level Settings UI body class for top-level pages.
 	 */
 	public function test_settings_ui_body_class_is_added_when_feature_flag_is_enabled(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
@@ -421,6 +421,59 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 
 		$this->assertStringContainsString( 'existing-class', $classes );
 		$this->assertStringContainsString( 'woocommerce-settings-ui-page', $classes );
+		$this->assertStringNotContainsString( 'woocommerce-settings-ui-drill-down', $classes );
+	}
+
+	/**
+	 * @testdox Should add the drill-down body class for Settings UI drill-down pages.
+	 */
+	public function test_settings_ui_drill_down_body_class_is_added_for_drill_down_pages(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		$current_section = 'test_gateway';
+		$current_tab     = 'checkout';
+		$page            = $this->get_settings_ui_test_page_for_drill_down();
+
+		$classes = $page->add_settings_ui_body_class( 'existing-class woocommerce-settings-ui-page' );
+
+		$this->assertStringContainsString( 'existing-class', $classes );
+		$this->assertSame( 1, substr_count( $classes, 'woocommerce-settings-ui-page' ) );
+		$this->assertSame( 1, substr_count( $classes, 'woocommerce-settings-ui-drill-down' ) );
+	}
+
+	/**
+	 * @testdox Should not add the drill-down body class when schema generation falls back to legacy rendering.
+	 */
+	public function test_settings_ui_drill_down_body_class_is_not_added_when_schema_generation_fails(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		$current_section = 'test_gateway';
+		$current_tab     = 'checkout';
+		$page            = $this->get_settings_ui_test_page_with_failing_schema( 'checkout' );
+
+		$classes = $page->add_settings_ui_body_class( 'existing-class' );
+
+		$this->assertStringContainsString( 'woocommerce-settings-ui-page', $classes );
+		$this->assertStringNotContainsString( 'woocommerce-settings-ui-drill-down', $classes );
+	}
+
+	/**
+	 * @testdox Should not add the drill-down body class when script handle resolution falls back to legacy rendering.
+	 */
+	public function test_settings_ui_drill_down_body_class_is_not_added_when_script_handle_resolution_fails(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		$current_section = 'test_gateway';
+		$current_tab     = 'checkout';
+		$page            = $this->get_settings_ui_test_page_with_failing_script_handles( 'checkout' );
+
+		$classes = $page->add_settings_ui_body_class( 'existing-class' );
+
+		$this->assertStringContainsString( 'woocommerce-settings-ui-page', $classes );
+		$this->assertStringNotContainsString( 'woocommerce-settings-ui-drill-down', $classes );
 	}
 
 	/**
@@ -649,15 +702,18 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	/**
 	 * Build a settings page whose settings UI adapter cannot provide script handles.
 	 *
+	 * @param string $page_id Page id.
 	 * @return \WC_Settings_Page
 	 */
-	private function get_settings_ui_test_page_with_failing_script_handles(): \WC_Settings_Page {
-		return new class() extends \WC_Settings_Page {
+	private function get_settings_ui_test_page_with_failing_script_handles( string $page_id = 'settings_ui_flag_test' ): \WC_Settings_Page {
+		return new class( $page_id ) extends \WC_Settings_Page {
 			/**
 			 * Constructor.
+			 *
+			 * @param string $page_id Page id.
 			 */
-			public function __construct() {
-				$this->id    = 'settings_ui_flag_test';
+			public function __construct( string $page_id ) {
+				$this->id    = $page_id;
 				$this->label = 'Settings UI flag test';
 			}
 
@@ -675,7 +731,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 					 * @return array
 					 */
 					public function get_script_handles( string $section_id ): array {
-						if ( 'advanced' === $section_id ) {
+						if ( '' !== $section_id ) {
 							throw new \RuntimeException( 'Unable to load extension script handles.' );
 						}
 
@@ -705,15 +761,18 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	/**
 	 * Build a settings page whose settings UI adapter cannot provide a schema.
 	 *
+	 * @param string $page_id Page id.
 	 * @return \WC_Settings_Page
 	 */
-	private function get_settings_ui_test_page_with_failing_schema(): \WC_Settings_Page {
-		return new class() extends \WC_Settings_Page {
+	private function get_settings_ui_test_page_with_failing_schema( string $page_id = 'settings_ui_flag_test' ): \WC_Settings_Page {
+		return new class( $page_id ) extends \WC_Settings_Page {
 			/**
 			 * Constructor.
+			 *
+			 * @param string $page_id Page id.
 			 */
-			public function __construct() {
-				$this->id    = 'settings_ui_flag_test';
+			public function __construct( string $page_id ) {
+				$this->id    = $page_id;
 				$this->label = 'Settings UI flag test';
 			}
 
@@ -731,7 +790,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 					 * @return array
 					 */
 					public function get_schema( string $section_id ): array {
-						if ( 'advanced' === $section_id ) {
+						if ( '' !== $section_id ) {
 							throw new \RuntimeException( 'Unable to build settings UI schema.' );
 						}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -443,6 +443,25 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should add the exact Settings UI body classes even when a similarly prefixed class is already present.
+	 */
+	public function test_settings_ui_body_classes_use_exact_token_matching_against_prefixed_classes(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		$current_section = 'test_gateway';
+		$current_tab     = 'checkout';
+		$page            = $this->get_settings_ui_test_page_for_drill_down();
+
+		$classes      = $page->add_settings_ui_body_class( 'existing-class woocommerce-settings-ui-page-preview' );
+		$body_classes = explode( ' ', $classes );
+
+		$this->assertContains( 'woocommerce-settings-ui-page-preview', $body_classes );
+		$this->assertCount( 1, array_keys( $body_classes, 'woocommerce-settings-ui-page', true ) );
+		$this->assertCount( 1, array_keys( $body_classes, 'woocommerce-settings-ui-drill-down', true ) );
+	}
+
+	/**
 	 * @testdox Should not add the drill-down body class when schema generation falls back to legacy rendering.
 	 */
 	public function test_settings_ui_drill_down_body_class_is_not_added_when_schema_generation_fails(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Settings UI drill-downs previously showed the fixed wc-admin “Settings” header above their own shell header, leaving duplicate navigation and an extra vertical offset. They now show only the drill-down header while top-level and legacy fallback pages retain the existing header.

The legacy header is intentionally still generated. PHP adds a scoped drill-down body class only after the Settings UI schema and script handles resolve successfully; CSS uses that class to suppress the legacy header and its reserved spacing. If Settings UI rendering falls back to the legacy renderer, the class is absent and the legacy header remains visible.

Fixes WOOPRD-3585.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Build the WooCommerce admin assets:

   ```sh
   pnpm wc:build:admin
   ```

2. In the test site's `wp-content/mu-plugins` directory, create `settings-ui-drill-down-test.php` containing:

   ```php
   <?php
   /**
    * Plugin Name: Settings UI drill-down test
    */

   add_filter(
       'woocommerce_admin_features',
       static function ( array $features ): array {
           $features[] = 'settings-ui';
           return array_values( array_unique( $features ) );
       }
   );

   add_action(
       'woocommerce_settings_sections_registration',
       static function ( $registry ): void {
           $registry->register(
               new class() extends \Automattic\WooCommerce\Admin\Settings\SettingsSection {
                   public function get_parent_page_id(): string {
                       return 'checkout';
                   }

                   public function get_id(): string {
                       return 'settings_ui_drill_down_test';
                   }

                   public function get_label(): string {
                       return 'Drill-down test';
                   }

                   public function get_settings( \WC_Settings_Page $parent_page ): array {
                       return array(
                           array(
                               'id'    => 'settings_ui_drill_down_test_value',
                               'type'  => 'text',
                               'title' => 'Test setting',
                           ),
                       );
                   }
               }
           );
       }
   );
   ```

3. Open `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=settings_ui_drill_down_test`.
4. Confirm that the Settings UI header contains the breadcrumb, “Drill-down test” title, and Save button; the fixed “Settings” header is absent; no empty header spacing remains; and the test field is visible.
5. Open WooCommerce → Settings → Products and confirm that the normal top-level Settings header and tabs remain visible.
6. Remove the temporary MU plugin after testing.

<!-- End testing instructions -->

### Testing that has already taken place:

- Built the production admin assets with `pnpm wc:build:admin`.
- Ran `SettingsUIFeatureFlagTest`: 21 tests and 55 assertions passed.
- Tested locally with the Settings UI flag enabled and a registered Payments drill-down. Before the fix, both headers and the 60px offset were present; after the fix, only the shell header remained and the offset was removed.
- Confirmed the legacy header remains available when Settings UI schema or script-handle resolution falls back.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A patch-level fix changelog entry is included in the branch.

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**
