### PR TITLE
Restore rel key in loop add-to-cart filter arguments

### DIFF
--- a/plugins/woocommerce/changelog/fix-loop-add-to-cart-rel-compat
+++ b/plugins/woocommerce/changelog/fix-loop-add-to-cart-rel-compat
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: This is a compatibility follow-up to #66743. The user-facing change is already covered by its existing changelog entry.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1461,6 +1461,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 			'data-product_id'  => $product->get_id(),
 			'data-product_sku' => $product->get_sku(),
 			'aria-label'       => $product->add_to_cart_description(),
+			'rel'              => '',
 		);
 
 		if ( $product->get_permalink() !== $product->add_to_cart_url() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -168,6 +168,7 @@ class ProductButton extends AbstractBlock {
 			$add_to_cart_url = $product->add_to_cart_url();
 			$attributes      = array(
 				'href' => esc_url( $add_to_cart_url ),
+				'rel'  => '',
 			);
 
 			if ( $product->get_permalink() !== $add_to_cart_url ) {

--- a/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-template-functions-test.php
@@ -179,7 +179,30 @@ class WC_Template_Functions_Tests extends \WC_Unit_Test_Case {
 		$markup  = $this->render_loop_add_to_cart( $product );
 
 		$this->assertStringContainsString( 'href="' . esc_url( $product->get_permalink() ) . '"', $markup );
-		$this->assertStringNotContainsString( 'rel="nofollow"', $markup );
+		$this->assertStringContainsString( 'rel=""', $markup );
+	}
+
+	/**
+	 * @testdox Loop button filter arguments retain an empty rel attribute for product permalink links.
+	 */
+	public function test_loop_button_product_permalink_filter_args_include_empty_rel(): void {
+		$product       = WC_Helper_Product::create_variation_product();
+		$filtered_args = null;
+		$filter        = static function ( array $args ) use ( &$filtered_args ): array {
+			$filtered_args = $args;
+			return $args;
+		};
+
+		add_filter( 'woocommerce_loop_add_to_cart_args', $filter );
+		try {
+			$this->render_loop_add_to_cart( $product );
+		} finally {
+			remove_filter( 'woocommerce_loop_add_to_cart_args', $filter );
+		}
+
+		$this->assertIsArray( $filtered_args );
+		$this->assertArrayHasKey( 'rel', $filtered_args['attributes'] );
+		$this->assertSame( '', $filtered_args['attributes']['rel'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductButton.php
@@ -65,7 +65,30 @@ class ProductButton extends \WP_UnitTestCase {
 		$markup  = $this->render_product_button( $product );
 
 		$this->assertStringContainsString( 'href="' . esc_url( $product->get_permalink() ) . '"', $markup );
-		$this->assertStringNotContainsString( 'rel="nofollow"', $markup );
+		$this->assertStringContainsString( 'rel=""', $markup );
+	}
+
+	/**
+	 * @testdox Product Button filter arguments retain an empty rel attribute for product permalink links.
+	 */
+	public function test_product_permalink_filter_args_include_empty_rel(): void {
+		$product       = WC_Helper_Product::create_variation_product();
+		$filtered_args = null;
+		$filter        = static function ( array $args ) use ( &$filtered_args ): array {
+			$filtered_args = $args;
+			return $args;
+		};
+
+		add_filter( 'woocommerce_loop_add_to_cart_args', $filter );
+		try {
+			$this->render_product_button( $product );
+		} finally {
+			remove_filter( 'woocommerce_loop_add_to_cart_args', $filter );
+		}
+
+		$this->assertIsArray( $filtered_args );
+		$this->assertArrayHasKey( 'rel', $filtered_args['attributes'] );
+		$this->assertSame( '', $filtered_args['attributes']['rel'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #66743 `rel` was conditionally removed from Product Button. But we should not change established shape of the public `woocommerce_loop_add_to_cart_args` filter arguments. This restores the `rel` key with an empty value for permalink anchors in the classic and Product Button PHP paths, while retaining `nofollow` for direct add-to-cart and external links.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66855.

Bug introduced in PR #66743.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add a callback to `woocommerce_loop_add_to_cart_args` that appends ` sponsored` to `$args['attributes']['rel']` without first checking whether the key exists:

```
add_filter(
	'woocommerce_loop_add_to_cart_args',
	function ( $args ) {
		$args['attributes']['rel'] .= ' sponsored';
		return $args;
	}
);
```

3. View a variable product in both a classic Shop archive and a Product Collection. Confirm there is no undefined-array-key warning and the rendered permalink button includes the appended `sponsored` relationship without `nofollow`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHP syntax checks passed for all four changed PHP files.
- Changed-file PHP lint passed.
- Full committed branch PHP lint passed.
- PHPStan completed with no errors for the two changed production files.
- Targeted PHPUnit was not run locally because this worktree does not have its Composer and Node dependencies installed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
