### PR TITLE
Remove unused Core Breadcrumbs initialization

### DIFF
--- a/plugins/woocommerce/src/Blocks/CoreBreadcrumbsCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/CoreBreadcrumbsCompatibility.php
@@ -9,30 +9,6 @@ namespace Automattic\WooCommerce\Blocks;
  * @internal
  */
 final class CoreBreadcrumbsCompatibility {
-
-	/**
-	 * Whether the compatibility hooks have been initialized.
-	 *
-	 * @var bool
-	 */
-	private $is_initialized = false;
-
-	/**
-	 * Initialize Core Breadcrumbs compatibility hooks.
-	 *
-	 * @internal
-	 */
-	public function init(): void {
-		if ( $this->is_initialized ) {
-			return;
-		}
-
-		add_filter( 'block_core_breadcrumbs_post_type_settings', array( $this, 'set_product_breadcrumbs_preferred_taxonomy' ), 10, 3 );
-		add_filter( 'block_core_breadcrumbs_items', array( $this, 'apply_woocommerce_breadcrumb_filters' ), 10, 1 );
-
-		$this->is_initialized = true;
-	}
-
 	/*
 	 * Compatibility methods.
 	 */

--- a/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/CoreBreadcrumbsCompatibilityTest.php
@@ -134,8 +134,6 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		global $wp;
 
-		remove_filter( 'block_core_breadcrumbs_post_type_settings', array( $this->sut, 'set_product_breadcrumbs_preferred_taxonomy' ), 10 );
-		remove_filter( 'block_core_breadcrumbs_items', array( $this->sut, 'apply_woocommerce_breadcrumb_filters' ), 10 );
 		remove_filter( 'woocommerce_is_account_page', '__return_true' );
 
 		update_option( 'woocommerce_shop_page_id', $this->original_shop_page_id );
@@ -158,17 +156,6 @@ class CoreBreadcrumbsCompatibilityTest extends WC_Unit_Test_Case {
 		}
 
 		parent::tearDown();
-	}
-
-	/**
-	 * @testdox Should register Core Breadcrumbs compatibility filters.
-	 */
-	public function test_init_registers_core_breadcrumbs_filters(): void {
-		$this->sut->init();
-		$this->sut->init();
-
-		$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_post_type_settings', array( $this->sut, 'set_product_breadcrumbs_preferred_taxonomy' ) ), 'Product breadcrumb settings filter should be registered.' );
-		$this->assertSame( 10, has_filter( 'block_core_breadcrumbs_items', array( $this->sut, 'apply_woocommerce_breadcrumb_filters' ) ), 'Breadcrumb items filter should be registered.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked for other open pull requests covering the same change.
* I have reviewed the change for security best practices.

### Changes proposed in this Pull Request:

Remove the unused `CoreBreadcrumbsCompatibility::init()` path, which could duplicate callbacks now registered by `BlockTypesController`.

Backward compatibility: the `@internal` method was added during the unreleased 11.1 cycle and has no production caller.

Closes woocommerce/woocommerce#66860.

Bug introduced in PR woocommerce/woocommerce#66822.

### How to test the changes in this Pull Request:

N/A

### Testing that has already taken place:

PHPCS, PHPStan, PHP syntax, and `git diff --check` passed. PHPUnit was not run because `wp-env` was not initialized.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

Follow-up cleanup for unreleased code; no released behavior changes.

</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**