### PR TITLE
Fix drill-down settings pages losing navigation on legacy fallback

### DIFF
--- a/plugins/woocommerce/changelog/fix-66664-drill-down-fallback-navigation
+++ b/plugins/woocommerce/changelog/fix-66664-drill-down-fallback-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep the settings tabs and section links when a Settings UI drill-down page falls back to legacy rendering.

--- a/plugins/woocommerce/includes/admin/views/html-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-settings.php
@@ -50,15 +50,22 @@ try {
 }
 
 // Drill-down pages replace the top-level settings tabs with their own header.
+// When schema or script resolution fails, output falls back to the legacy
+// renderer without the shell header, so the classic navigation must stay.
+$settings_ui_drill_down = $settings_ui_context
+	&& $settings_ui_context->is_drill_down()
+	&& ! $settings_ui_context->has_schema_failed()
+	&& ! $settings_ui_context->has_script_handles_failed();
+
 $hide_nav = ( 'checkout' === $current_tab && in_array( $current_section, array( 'offline', 'bacs', 'cheque', 'cod' ), true ) )
-	|| ( $settings_ui_context && $settings_ui_context->is_drill_down() );
+	|| $settings_ui_drill_down;
 
 $settings_ui_settings_page = $settings_ui_context ? $settings_ui_context->get_settings_page() : null;
 $is_settings_ui_page       = null !== $settings_ui_settings_page;
 
 // Drill-down pages replace the section links with header breadcrumbs. Top-level
 // pages keep the classic section links.
-if ( $settings_ui_settings_page instanceof WC_Settings_Page && $settings_ui_context->is_drill_down() ) {
+if ( $settings_ui_settings_page instanceof WC_Settings_Page && $settings_ui_drill_down ) {
 	remove_action( 'woocommerce_sections_' . $current_tab, array( $settings_ui_settings_page, 'output_sections' ) );
 }
 

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
@@ -358,38 +358,58 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
 		SettingsSectionRegistry::get_instance()->register( $this->get_registered_section_with_native_settings_ui_page() );
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-
-		global $current_section, $current_tab;
-		$current_tab     = 'checkout';
-		$current_section = 'acme_payments';
-		$_GET['page']    = 'wc-settings';
-		$_GET['tab']     = 'checkout';
-		$_GET['section'] = 'acme_payments';
-		// PHP builds $_REQUEST once at request start, so runtime $_GET changes need mirroring.
-		$_REQUEST['section'] = 'acme_payments';
-
-		$page                   = $this->get_parent_page();
-		$original_settings      = $this->replace_wc_admin_settings_pages( array( $page ) );
-		$tabs                   = array( 'checkout' => 'Payments' );
-		$original_sections_hook = $this->replace_hook_callbacks( 'woocommerce_sections_checkout' );
-		$original_settings_hook = $this->replace_hook_callbacks( 'woocommerce_settings_checkout' );
-
-		add_action( 'woocommerce_sections_checkout', array( $page, 'output_sections' ) );
-		add_action( 'woocommerce_settings_checkout', array( $page, 'output' ) );
-
-		try {
-			ob_start();
-			include WC_ABSPATH . 'includes/admin/views/html-admin-settings.php';
-			$output = ob_get_clean();
-		} finally {
-			$this->restore_hook_callbacks( 'woocommerce_sections_checkout', $original_sections_hook );
-			$this->restore_hook_callbacks( 'woocommerce_settings_checkout', $original_settings_hook );
-			$this->replace_wc_admin_settings_pages( $original_settings );
-		}
+		$output = $this->render_settings_view_for_checkout_section( 'acme_payments' );
 
 		$this->assertStringContainsString( 'data-wc-settings-page="acme_native"', $output );
 		$this->assertStringNotContainsString( 'class="subsubsub"', $output );
+	}
+
+	/**
+	 * @testdox Should hide the top-level tabs for drill-down Settings UI pages.
+	 */
+	public function test_hides_top_level_tabs_for_drill_down_settings_ui_pages(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		SettingsSectionRegistry::get_instance()->register( $this->get_registered_section_with_native_settings_ui_page() );
+
+		$output = $this->render_settings_view_for_checkout_section( 'acme_payments' );
+
+		$this->assertStringContainsString( 'data-wc-settings-page="acme_native"', $output );
+		$this->assertStringNotContainsString( 'nav-tab-wrapper', $output, 'Drill-down pages replace the top-level tabs with the shell header' );
+	}
+
+	/**
+	 * @testdox Should keep the classic navigation when drill-down schema resolution falls back to legacy rendering.
+	 */
+	public function test_keeps_navigation_when_drill_down_schema_resolution_fails(): void {
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		SettingsSectionRegistry::get_instance()->register(
+			$this->get_registered_section_with_native_settings_ui_page( null, null, new \RuntimeException( 'Unable to build settings UI schema.' ) )
+		);
+
+		$output = $this->render_settings_view_for_checkout_section( 'acme_payments' );
+
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertStringContainsString( 'name="registered_acme_payments_setting"', $output, 'Legacy fields should render when schema resolution fails' );
+		$this->assertStringContainsString( 'nav-tab-wrapper', $output, 'Top-level tabs should stay when rendering falls back to legacy output' );
+		$this->assertStringContainsString( 'class="subsubsub"', $output, 'Classic section links should stay when rendering falls back to legacy output' );
+	}
+
+	/**
+	 * @testdox Should keep the classic navigation when drill-down script handle resolution falls back to legacy rendering.
+	 */
+	public function test_keeps_navigation_when_drill_down_script_handle_resolution_fails(): void {
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		SettingsSectionRegistry::get_instance()->register(
+			$this->get_registered_section_with_native_settings_ui_page( null, null, null, new \RuntimeException( 'Unable to load extension script handles.' ) )
+		);
+
+		$output = $this->render_settings_view_for_checkout_section( 'acme_payments' );
+
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertStringContainsString( 'nav-tab-wrapper', $output, 'Top-level tabs should stay when rendering falls back to legacy output' );
+		$this->assertStringContainsString( 'class="subsubsub"', $output, 'Classic section links should stay when rendering falls back to legacy output' );
 	}
 
 	/**
@@ -425,6 +445,44 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $result );
 		$this->assertNull( SettingsSectionRegistry::get_instance()->get_registered( 'checkout', 'bacs' ) );
+	}
+
+	/**
+	 * Render the admin settings view for a checkout section as an administrator.
+	 *
+	 * @param string $section Section id.
+	 * @return string
+	 */
+	private function render_settings_view_for_checkout_section( string $section ): string {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		global $current_section, $current_tab;
+		$current_tab     = 'checkout';
+		$current_section = $section;
+		$_GET['page']    = 'wc-settings';
+		$_GET['tab']     = 'checkout';
+		$_GET['section'] = $section;
+		// PHP builds $_REQUEST once at request start, so runtime $_GET changes need mirroring.
+		$_REQUEST['section'] = $section;
+
+		$page                   = $this->get_parent_page();
+		$original_settings      = $this->replace_wc_admin_settings_pages( array( $page ) );
+		$tabs                   = array( 'checkout' => 'Payments' );
+		$original_sections_hook = $this->replace_hook_callbacks( 'woocommerce_sections_checkout' );
+		$original_settings_hook = $this->replace_hook_callbacks( 'woocommerce_settings_checkout' );
+
+		add_action( 'woocommerce_sections_checkout', array( $page, 'output_sections' ) );
+		add_action( 'woocommerce_settings_checkout', array( $page, 'output' ) );
+
+		try {
+			ob_start();
+			include WC_ABSPATH . 'includes/admin/views/html-admin-settings.php';
+			return (string) ob_get_clean();
+		} finally {
+			$this->restore_hook_callbacks( 'woocommerce_sections_checkout', $original_sections_hook );
+			$this->restore_hook_callbacks( 'woocommerce_settings_checkout', $original_settings_hook );
+			$this->replace_wc_admin_settings_pages( $original_settings );
+		}
 	}
 
 	/**
@@ -562,12 +620,14 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 	/**
 	 * Build a registered section that provides a native Settings UI page.
 	 *
-	 * @param callable|null $on_settings_ui_page_call Callback invoked every time the Settings UI page provider runs.
-	 * @param array|null    $shell Schema shell for the native page. Null uses the fixture default with custom section navigation.
+	 * @param callable|null   $on_settings_ui_page_call Callback invoked every time the Settings UI page provider runs.
+	 * @param array|null      $shell Schema shell for the native page, or null for the fixture default.
+	 * @param \Throwable|null $schema_failure Throwable the native page schema provider should throw, if any.
+	 * @param \Throwable|null $script_handles_failure Throwable the native page script handle provider should throw, if any.
 	 * @return SettingsSectionInterface
 	 */
-	private function get_registered_section_with_native_settings_ui_page( ?callable $on_settings_ui_page_call = null, ?array $shell = null ): SettingsSectionInterface {
-		return new class( $on_settings_ui_page_call, $shell ) extends SettingsSection {
+	private function get_registered_section_with_native_settings_ui_page( ?callable $on_settings_ui_page_call = null, ?array $shell = null, ?\Throwable $schema_failure = null, ?\Throwable $script_handles_failure = null ): SettingsSectionInterface {
+		return new class( $on_settings_ui_page_call, $shell, $schema_failure, $script_handles_failure ) extends SettingsSection {
 			/**
 			 * Callback invoked every time the Settings UI page provider runs.
 			 *
@@ -583,14 +643,32 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 			private ?array $shell;
 
 			/**
+			 * Throwable the native page schema provider should throw, if any.
+			 *
+			 * @var \Throwable|null
+			 */
+			private ?\Throwable $schema_failure;
+
+			/**
+			 * Throwable the native page script handle provider should throw, if any.
+			 *
+			 * @var \Throwable|null
+			 */
+			private ?\Throwable $script_handles_failure;
+
+			/**
 			 * Constructor.
 			 *
-			 * @param callable|null $on_settings_ui_page_call Callback invoked every time the Settings UI page provider runs.
-			 * @param array|null    $shell Schema shell for the native page, or null for the fixture default.
+			 * @param callable|null   $on_settings_ui_page_call Callback invoked every time the Settings UI page provider runs.
+			 * @param array|null      $shell Schema shell for the native page, or null for the fixture default.
+			 * @param \Throwable|null $schema_failure Throwable the native page schema provider should throw, if any.
+			 * @param \Throwable|null $script_handles_failure Throwable the native page script handle provider should throw, if any.
 			 */
-			public function __construct( ?callable $on_settings_ui_page_call, ?array $shell ) {
+			public function __construct( ?callable $on_settings_ui_page_call, ?array $shell, ?\Throwable $schema_failure, ?\Throwable $script_handles_failure ) {
 				$this->on_settings_ui_page_call = $on_settings_ui_page_call;
 				$this->shell                    = $shell;
+				$this->schema_failure           = $schema_failure;
+				$this->script_handles_failure   = $script_handles_failure;
 			}
 
 			/**
@@ -647,7 +725,7 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 					( $this->on_settings_ui_page_call )();
 				}
 
-				return new class( $this->shell ) implements SettingsUIPageInterface {
+				return new class( $this->shell, $this->schema_failure, $this->script_handles_failure ) implements SettingsUIPageInterface {
 					/**
 					 * Schema shell, or null for the fixture default.
 					 *
@@ -656,12 +734,30 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 					private ?array $shell;
 
 					/**
+					 * Throwable the schema provider should throw, if any.
+					 *
+					 * @var \Throwable|null
+					 */
+					private ?\Throwable $schema_failure;
+
+					/**
+					 * Throwable the script handle provider should throw, if any.
+					 *
+					 * @var \Throwable|null
+					 */
+					private ?\Throwable $script_handles_failure;
+
+					/**
 					 * Constructor.
 					 *
-					 * @param array|null $shell Schema shell, or null for the fixture default.
+					 * @param array|null      $shell Schema shell, or null for the fixture default.
+					 * @param \Throwable|null $schema_failure Throwable the schema provider should throw, if any.
+					 * @param \Throwable|null $script_handles_failure Throwable the script handle provider should throw, if any.
 					 */
-					public function __construct( ?array $shell ) {
-						$this->shell = $shell;
+					public function __construct( ?array $shell, ?\Throwable $schema_failure, ?\Throwable $script_handles_failure ) {
+						$this->shell                  = $shell;
+						$this->schema_failure         = $schema_failure;
+						$this->script_handles_failure = $script_handles_failure;
 					}
 
 					/**
@@ -680,6 +776,10 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 					 * @return array
 					 */
 					public function get_schema( string $section ): array {
+						if ( $this->schema_failure ) {
+							throw $this->schema_failure;
+						}
+
 						return array(
 							'id'      => 'acme_native',
 							'title'   => 'Acme native settings',
@@ -716,6 +816,10 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 					 * @return string[]
 					 */
 					public function get_script_handles( string $section ): array {
+						if ( $this->script_handles_failure ) {
+							throw $this->script_handles_failure;
+						}
+
 						return array( 'acme-native-settings-ui' );
 					}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

With the experimental `settings-ui` feature enabled, drill-down settings pages hide the top-level tabs and remove the classic section links based on `is_drill_down()` alone. When schema or script handle resolution fails, `WC_Settings_Page::output()` falls back to the legacy renderer, so the shell header never mounts and the page renders with no tabs, no section links, and no breadcrumbs. The only way out is the browser back button.

- Hide the drill-down navigation only when the Settings UI will actually render: `is_drill_down()` plus successful schema and script handle resolution. Both results are memoized in `SettingsUIRequestContext`, so checking them in the view adds no repeated work.
- Add regression tests covering the schema failure, script handle failure, and successful drill-down render paths.

Closes #66664.

Bug introduced in PR #66437.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The `settings-ui` feature flag must be enabled (it is off by default), and you need a registered checkout-tab section that renders through the Settings UI.

**Regression: failing drill-down falls back with navigation**

1. Register a checkout-tab section whose `SettingsUIPageInterface::get_schema()` throws.
2. Open `wp-admin/admin.php?page=wc-settings&tab=checkout&section=<that section>`.
3. Confirm the page renders the legacy fields with the top-level settings tabs and the section links visible.

**Happy path: successful drill-down unchanged**

1. Open a working Settings UI drill-down section under the Payments tab.
2. Confirm the shell header renders with breadcrumbs, and the top-level tabs and classic section links stay hidden.

Alternatively, the new unit tests cover both paths:

```sh
pnpm test:php:env -- --filter SettingsSectionRegistryTest
```

<!-- End testing instructions -->

### Testing that has already taken place:

- New PHPUnit coverage: `SettingsSectionRegistryTest` renders `html-admin-settings.php` for a drill-down section and asserts navigation is kept on schema failure and script handle failure, and hidden on a successful render (20 tests, 59 assertions, all passing in wp-env).
- Verified the failure-path tests fail against trunk without the view change.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the changed view file are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)