### PR TITLE
Restore WordPress defaults in the experimental Settings UI

### DIFF
--- a/packages/js/settings-ui/changelog/fix-preserve-wordpress-settings-behaviour
+++ b/packages/js/settings-ui/changelog/fix-preserve-wordpress-settings-behaviour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Identify current navigation links and preserve independently registered unload handlers in the Settings UI.

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -379,6 +379,9 @@ const ShellHeader = ( {
 											? 'wc-settings-ui-shell__tab is-active'
 											: 'wc-settings-ui-shell__tab'
 									}
+									aria-current={
+										item.active ? 'page' : undefined
+									}
 									href={ item.href }
 									key={ item.id }
 								>
@@ -402,6 +405,9 @@ const ShellHeader = ( {
 										item.active
 											? 'wc-settings-ui-shell__tab is-active'
 											: 'wc-settings-ui-shell__tab'
+									}
+									aria-current={
+										item.active ? 'page' : undefined
 									}
 									href={ item.href }
 									key={ item.id }

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -94,10 +94,6 @@ const getBadgeIntent = ( intent?: string ): SettingsUIShellBadgeIntent =>
 const getSaveStrategy = ( schema: SettingsUISchema ): SettingsUISaveStrategy =>
 	schema.save || { adapter: 'form_post' };
 
-const clearLegacyFormPrompt = () => {
-	window.onbeforeunload = null;
-};
-
 const setFormPostRedirectInput = ( form: HTMLFormElement, href: string ) => {
 	let redirectInput = form.querySelector< HTMLInputElement >(
 		`input[name="${ FORM_POST_REDIRECT_INPUT_NAME }"]`
@@ -480,7 +476,6 @@ export const SettingsUIPage = ( {
 
 	const allowNavigation = useCallback( () => {
 		allowNavigationRef.current = true;
-		clearLegacyFormPrompt();
 	}, [] );
 
 	const submitSettingsForm = useCallback(

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -578,7 +578,7 @@ describe( 'settings HTML rendering', () => {
 		}
 	} );
 
-	it( 'submits form-post saves with the pending destination', () => {
+	it( 'submits form-post saves without clearing another unload handler', () => {
 		const requestSubmit = jest
 			.spyOn( HTMLFormElement.prototype, 'requestSubmit' )
 			.mockImplementation( () => undefined );
@@ -615,6 +615,10 @@ describe( 'settings HTML rendering', () => {
 		const { container, form, root } = renderElementInMainForm(
 			<SettingsUIPage schema={ schema } />
 		);
+
+		const previousBeforeUnload = window.onbeforeunload;
+		const otherBeforeUnload = jest.fn();
+		window.onbeforeunload = otherBeforeUnload;
 
 		try {
 			const input = container.querySelector(
@@ -665,7 +669,15 @@ describe( 'settings HTML rendering', () => {
 			expect( requestSubmit ).toHaveBeenCalledWith(
 				container.querySelector( '.woocommerce-save-button' )
 			);
+			expect( window.onbeforeunload ).toBe( otherBeforeUnload );
+			const beforeUnloadEvent = new Event( 'beforeunload', {
+				cancelable: true,
+			} );
+			window.dispatchEvent( beforeUnloadEvent );
+			expect( otherBeforeUnload ).toHaveBeenCalledTimes( 1 );
+			expect( beforeUnloadEvent.defaultPrevented ).toBe( false );
 		} finally {
+			window.onbeforeunload = previousBeforeUnload;
 			act( () => root.unmount() );
 			form.remove();
 			requestSubmit.mockRestore();

--- a/packages/js/settings-ui/src/test/shell-header-visibility.test.tsx
+++ b/packages/js/settings-ui/src/test/shell-header-visibility.test.tsx
@@ -75,6 +75,49 @@ describe( 'settings UI shell header visibility', () => {
 		document.body.innerHTML = '';
 	} );
 
+	it.each( [
+		[ 'navigation', 'Settings pages' ],
+		[ 'sectionNavigation', 'Settings sections' ],
+	] )(
+		'marks only the active link as current in %s',
+		( navigation, label ) => {
+			const { container, root } = renderElement(
+				<SettingsUIPage
+					schema={ baseSchema( {
+						[ navigation ]: [
+							{ id: 'first', label: 'First', href: '#first' },
+							{
+								id: 'current',
+								label: 'Current',
+								href: '#current',
+								active: true,
+							},
+							{
+								id: 'last',
+								label: 'Last',
+								href: '#last',
+								active: false,
+							},
+						],
+					} ) }
+					page="test_page"
+				/>
+			);
+
+			const links = container.querySelectorAll(
+				`nav[aria-label="${ label }"] a`
+			);
+			expect(
+				Array.from( links, ( link ) =>
+					link.getAttribute( 'aria-current' )
+				)
+			).toEqual( [ null, 'page', null ] );
+
+			act( () => root.unmount() );
+			container.remove();
+		}
+	);
+
 	it( 'labels the shell region with a fallback when the schema has no title', () => {
 		const schema = baseSchema( {} );
 		delete schema.title;

--- a/plugins/woocommerce/changelog/fix-settings-ui-shell-tab-focus-ring
+++ b/plugins/woocommerce/changelog/fix-settings-ui-shell-tab-focus-ring
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore a visible keyboard focus indicator on the Settings UI shell tabs.

--- a/plugins/woocommerce/changelog/fix-settings-ui-shell-tab-focus-ring
+++ b/plugins/woocommerce/changelog/fix-settings-ui-shell-tab-focus-ring
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Restore a visible keyboard focus indicator on the Settings UI shell tabs.
+Restore WordPress focus and modal styling, identify current navigation links, and preserve other plugins' navigation warnings in the experimental Settings UI.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -127,6 +127,13 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 			outline: none;
 		}
 
+		// WPDS focus ring, inset so the tab bar's overflow clipping keeps it visible.
+		&:focus-visible {
+			border-radius: var(--wpds-border-radius-sm);
+			outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus);
+			outline-offset: calc(var(--wpds-border-width-focus, 2px) * -1);
+		}
+
 		&.is-active {
 			color: var(--wpds-color-foreground-interactive-neutral);
 

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -190,7 +190,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 			&::after {
 				background: var(--wpds-color-stroke-interactive-brand);
 				border-radius: 999px;
-				bottom: 0;
+				inset-block-end: calc(-1 * var(--wpds-dimension-padding-xs));
 				content: "";
 				height: var(--wpds-border-width-sm);
 				left: 0;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -213,29 +213,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		max-width: var(--wpds-dimension-surface-width-xl);
 	}
 
-	.wc-settings-ui__unsaved-changes-modal {
-		.components-modal__header {
-			min-height: 72px;
-			padding: 24px 32px 8px;
-		}
-
-		.components-modal__header-heading {
-			font-size: 20px;
-			font-weight: 500;
-			line-height: 24px;
-		}
-
-		.components-modal__content {
-			padding: 4px 32px 32px;
-		}
-
-		p {
-			font-size: 13px;
-			line-height: 20px;
-			margin: 0;
-		}
-	}
-
 	.wc-settings-ui__unsaved-changes-actions {
 		display: flex;
 		gap: 8px;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -160,7 +160,8 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		display: flex;
 		margin: 0 !important;
 		overflow-x: auto;
-		padding: 0 48px;
+		// Keep WordPress focus rings inside the scrolling tab bar.
+		padding: var(--wpds-dimension-padding-xs) 48px;
 		width: 100%;
 	}
 
@@ -180,16 +181,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		&:focus,
 		&:hover,
 		&:active {
-			box-shadow: none;
 			color: var(--wpds-color-foreground-interactive-brand);
-			outline: none;
-		}
-
-		// WPDS focus ring, inset so the tab bar's overflow clipping keeps it visible.
-		&:focus-visible {
-			border-radius: var(--wpds-border-radius-sm);
-			outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus);
-			outline-offset: calc(var(--wpds-border-width-focus, 2px) * -1);
 		}
 
 		&.is-active {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -185,6 +185,13 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 			outline: none;
 		}
 
+		// WPDS focus ring, inset so the tab bar's overflow clipping keeps it visible.
+		&:focus-visible {
+			border-radius: var(--wpds-border-radius-sm);
+			outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus);
+			outline-offset: calc(var(--wpds-border-width-focus, 2px) * -1);
+		}
+
 		&.is-active {
 			color: var(--wpds-color-foreground-interactive-neutral);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The experimental Settings UI suppresses WordPress's native focus styling, restyles the internals of its Modal, clears other code's unload handler, and marks the current route only visually.

- Restore native link focus styles, with 4px of vertical padding so the scrolling tab bar does not clip the ring. The bar is 8px taller and mouse focus follows WordPress's normal behaviour.
- Remove the Modal header, heading and content CSS overrides so WordPress controls their appearance.
- Remove the obsolete `window.onbeforeunload` reset. Classic dirty tracking is already disabled on Settings UI pages; saving and discarding should leave independently registered handlers intact.
- Add `aria-current="page"` to active page and section navigation links.

Existing form-post and custom save adapters remain supported. Settings UI still controls its own dirty-state prompt and prevents dismissal while a save is pending.

The focus resets, global unload reset and missing current-link semantics originated in PR #64387. The Modal overrides were reintroduced in PR #67369.

### Screenshots or screen recordings:

Captured in a local WordPress Settings UI page with a temporary extension fixture. The before image reapplies the original focus resets and zero vertical padding on the same page.

| Before | After |
| ------ | ----- |
| ![Focus suppressed by the original styles](https://github.com/user-attachments/assets/ab05c7e4-2bc6-4797-8043-6732d8e5e8fe) | ![Native WordPress focus ring](https://github.com/user-attachments/assets/5d515181-e610-446a-8875-184702541d0f) |

![Native focus ring inside a scrolling tab bar](https://github.com/user-attachments/assets/0c8e4445-10a5-4e32-8426-980f717ede60)

![WordPress focus outline in forced-colour mode](https://github.com/user-attachments/assets/37d077ef-a240-41c9-99b9-0bfb32057d5a)

The unsaved-changes modal now uses WordPress's default heading and spacing:

| Before | After |
| ------ | ----- |
| ![Modal with Settings UI styling overrides](https://github.com/user-attachments/assets/dc002380-f173-4bae-bc7f-d27f641e6f6d) | ![Native WordPress modal styling](https://github.com/user-attachments/assets/0a397d8d-d71c-421b-9f00-a73f4825bc4e) |

![Native modal at a narrow viewport](https://github.com/user-attachments/assets/1d5d6fa6-654f-4ac8-83c1-b5992879c26d)

### How to test the changes in this Pull Request:

1. Enable the `settings-ui` feature and open an opted-in settings page with page or section navigation links.
2. Use Tab and Shift+Tab through the links, including with a narrow window and forced colours. Confirm the native focus ring is visible on every side.
3. Inspect the accessibility tree. Only the active link in each navigation row should identify itself as the current page.
4. Edit a field and follow a shell navigation link. Confirm the unsaved-changes modal uses the standard WordPress layout, keeps keyboard focus inside it, and closes with Escape while returning focus to the link. Repeat at a narrow viewport.
5. Save through the form-post adapter and confirm the value persists after reload. Repeat through a custom save handler, including a rejected save. A failure should retain the unsaved value and navigation protection; a pending save should prevent dismissal.
6. Register an independent `window.onbeforeunload` handler and confirm saving or discarding does not replace it. Settings UI should release only its own navigation guard after a successful save or discard.

### Testing that has already taken place:

- All 112 Settings UI package tests pass. The extended form-post regression test fails before the unload-reset removal and passes afterwards.
- Package type check, package build, WooCommerce admin build, classic asset build and stylesheet lint pass. ESLint reports no errors; the touched test file has 35 existing warnings.
- Local WordPress fixture: form-post persistence after reload; custom save success, failure and pending state; discard; preservation of an independent unload handler; both navigation rows' current-link semantics; modal focus containment, Escape, focus restoration and narrow-screen layout.
- Focus styling checked with Tab/Shift+Tab, horizontal overflow, mouse focus, document RTL direction and Chromium forced-colour emulation. RTL was a document-direction check, not a full translated WordPress installation.
- Custom saves were exercised through a temporary extension handler, not a live payment integration.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)