### PR TITLE
Add missing test env paths to blocks e2e CI job triggers

### DIFF
--- a/plugins/woocommerce/changelog/dev-blocks-e2e-run-on-env-config-changes
+++ b/plugins/woocommerce/changelog/dev-blocks-e2e-run-on-env-config-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Run blocks e2e CI jobs when .wp-env.e2e.json or shared e2e bin setup scripts change.
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -803,15 +803,18 @@
 						"src/Blocks/**/*.php",
 						"templates/**/*.php",
 						"templates/**/*.html",
-						"tests/e2e/bin/blocks/**",
+						"sample-data/sample_products.xml",
+						"tests/e2e/bin/**",
 						"tests/e2e/fixtures/blocks-setup.ts",
 						"tests/e2e/playwright.config.ts",
 						"tests/e2e/content-templates/blocks/**",
 						"tests/e2e/test-data/blocks/**",
-						"tests/e2e/test-plugins/blocks/**",
+						"tests/e2e/test-data/images/**",
+						"tests/e2e/test-plugins/**",
 						"tests/e2e/tests/blocks/**",
 						"tests/e2e/themes/blocks/**",
-						"tests/e2e/utils/blocks/**"
+						"tests/e2e/utils/blocks/**",
+						".wp-env.e2e.json"
 					],
 					"onlyForDependencies": [
 						"@woocommerce/block-library"
@@ -853,15 +856,18 @@
 						"--shard=10/10"
 					],
 					"changes": [
-						"tests/e2e/bin/blocks/**",
+						"sample-data/sample_products.xml",
+						"tests/e2e/bin/**",
 						"tests/e2e/fixtures/blocks-setup.ts",
 						"tests/e2e/playwright.config.ts",
 						"tests/e2e/content-templates/blocks/**",
 						"tests/e2e/test-data/blocks/**",
-						"tests/e2e/test-plugins/blocks/**",
+						"tests/e2e/test-data/images/**",
+						"tests/e2e/test-plugins/**",
 						"tests/e2e/tests/blocks/**",
 						"tests/e2e/themes/blocks/**",
-						"tests/e2e/utils/blocks/**"
+						"tests/e2e/utils/blocks/**",
+						".wp-env.e2e.json"
 					],
 					"onlyForDependencies": [],
 					"testEnv": {
@@ -901,15 +907,18 @@
 						"--shard=10/10"
 					],
 					"changes": [
-						"tests/e2e/bin/blocks/**",
+						"sample-data/sample_products.xml",
+						"tests/e2e/bin/**",
 						"tests/e2e/fixtures/blocks-setup.ts",
 						"tests/e2e/playwright.config.ts",
 						"tests/e2e/content-templates/blocks/**",
 						"tests/e2e/test-data/blocks/**",
-						"tests/e2e/test-plugins/blocks/**",
+						"tests/e2e/test-data/images/**",
+						"tests/e2e/test-plugins/**",
 						"tests/e2e/tests/blocks/**",
 						"tests/e2e/themes/blocks/**",
-						"tests/e2e/utils/blocks/**"
+						"tests/e2e/utils/blocks/**",
+						".wp-env.e2e.json"
 					],
 					"onlyForDependencies": [],
 					"testEnv": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The three Blocks e2e CI jobs start their test environment from `.wp-env.e2e.json` (whose `afterStart`/`afterClean` lifecycle runs `tests/e2e/bin/test-env-setup.sh`, which in turn runs `tests/e2e/bin/blocks/test-env-setup.sh`), but their `changes` glob arrays in `plugins/woocommerce/package.json` did not list most of these inputs — so PRs editing the env config, the shared setup scripts, the mounted test plugins, the seeded product catalog, or the imported test images never triggered the blocks suite.

This PR adds the missing paths to all three jobs (Blocks e2e tests, WP pre-release, WP latest-1), identically:

- `tests/e2e/bin/**` (widened from `tests/e2e/bin/blocks/**` — the whole dir is bind-mounted into the env and the shared lifecycle script lives at its root)
- `.wp-env.e2e.json`
- `tests/e2e/test-plugins/**` (replaces `tests/e2e/test-plugins/blocks/**`; the env mounts helpers outside `blocks/` too)
- `tests/e2e/test-data/images/**` (mounted and imported at env setup)
- `sample-data/sample_products.xml` (seeds the deterministic product catalog via `tests/e2e/bin/blocks/scripts/products.sh`)


### How to test the changes in this Pull Request:

1. Check out this branch and create a commit that touches one of the newly covered paths, e.g. `plugins/woocommerce/.wp-env.e2e.json` (a trailing newline is enough).
2. From the repo root, run `pnpm utils ci-jobs --base-ref <this branch> --event pull_request --list` — the same command the CI workflow uses to build the job matrix.
3. Observe the `Blocks e2e tests 1/10 … 10/10` shards listed. Repeat from `trunk` to confirm the same touch does not schedule them there.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
