### PR TITLE
Guard against malformed data from `woocommerce_variation_prices` filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-66528-strpos-typeerror-visual-attribute-admin
+++ b/plugins/woocommerce/changelog/fix-66528-strpos-typeerror-visual-attribute-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Guard against non-string screen ID in visual attribute script enqueue

--- a/plugins/woocommerce/changelog/fix-66851-malformed-variation-prices
+++ b/plugins/woocommerce/changelog/fix-66851-malformed-variation-prices
@@ -1,0 +1,5 @@
+Significance: minor
+Type: fix
+Comment: Add guard against malformed data from woocommerce_variation_prices filter
+
+Add validation and fallback for malformed data returned by the woocommerce_variation_prices filter in WC_Product_Variable_Data_Store_CPT::read_price_data.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -551,10 +551,21 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			 * @param WC_Product $product      The variable product object.
 			 * @param bool       $for_display  Whether prices are being retrieved for display.
 			 */
-			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $for_display );
+			$filtered = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $for_display );
+			if ( $this->validate_price_data_entry( $filtered ) ) {
+				$this->prices_array[ $price_hash ] = $filtered;
+			} else {
+				$this->prices_array[ $price_hash ] = $transient_cached_prices_array[ $price_hash ];
+			}
+
 			if ( ! is_null( $opposite_price_hash ) && $opposite_price_hash !== $price_hash ) {
 				// phpcs:ignore WooCommerce.Commenting.CommentHooks
-				$this->prices_array[ $opposite_price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $opposite_price_hash ], $product, ! $for_display );
+				$filtered_opposite = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $opposite_price_hash ], $product, ! $for_display );
+				if ( $this->validate_price_data_entry( $filtered_opposite ) ) {
+					$this->prices_array[ $opposite_price_hash ] = $filtered_opposite;
+				} else {
+					$this->prices_array[ $opposite_price_hash ] = $transient_cached_prices_array[ $opposite_price_hash ];
+				}
 			}
 		}
 		return $this->prices_array[ $price_hash ];
@@ -1106,6 +1117,34 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		// If price is empty, we want to rebuild the data.
 		if ( $price_data_is_empty ) {
 			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate the structure of a single price data entry.
+	 *
+	 * Ensures the entry matches the documented shape of the woocommerce_variation_prices filter
+	 * return value: an array with 'price', 'regular_price', and 'sale_price' keys, each
+	 * mapping to an array of variation_id => price pairs.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param mixed $entry The filter return value to validate.
+	 * @return bool True if the entry has the expected structure.
+	 */
+	protected function validate_price_data_entry( $entry ): bool {
+		if ( ! is_array( $entry ) ) {
+			return false;
+		}
+
+		$required_types = array( 'price', 'regular_price', 'sale_price' );
+
+		foreach ( $required_types as $type ) {
+			if ( ! isset( $entry[ $type ] ) || ! is_array( $entry[ $type ] ) ) {
+				return false;
+			}
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributes/VisualAttributeTermAdmin.php
@@ -314,7 +314,7 @@ class VisualAttributeTermAdmin implements RegisterHooksInterface {
 	public function enqueue_visual_attribute_script(): void {
 		$screen = get_current_screen();
 
-		if ( ! $screen ) {
+		if ( ! $screen || ! is_string( $screen->id ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributes/VisualAttributeTermAdminTest.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\ProductAttributes;
 
 use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermAdmin;
+use Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermMeta;
 use WC_Unit_Test_Case;
 
 /**
@@ -232,6 +233,48 @@ class VisualAttributeTermAdminTest extends WC_Unit_Test_Case {
 		} finally {
 			unregister_taxonomy( $taxonomy );
 			wc_delete_attribute( $attribute_id );
+		}
+	}
+
+	/**
+	 * @testdox Should not throw a TypeError when the current screen has a non-string id.
+	 *
+	 * Reproduces issue #66528: Visual Composer calls do_action('admin_enqueue_scripts', NULL),
+	 * which triggers enqueue_visual_attribute_script() in a context where get_current_screen()
+	 * may return a screen object whose id is an integer (post ID) rather than a string,
+	 * causing strpos(): Argument #1 ($haystack) must be of type string.
+	 */
+	public function test_does_not_fatal_on_non_string_screen_id(): void {
+		// We need the wc-visual attribute type available, same setup as other tests.
+		switch_theme( 'twentytwentyfour' );
+		delete_option( 'woocommerce_feature_wc_visual_attribute_enabled' );
+		wc_get_container()
+			->get( \Automattic\WooCommerce\Internal\Features\FeaturesController::class )
+			->change_feature_enable( 'wc-visual-attribute', true );
+
+		$instance = wc_get_container()->get( VisualAttributeTermAdmin::class );
+
+		// Simulate the scenario where get_current_screen() returns a screen with an integer id
+		// (e.g. a post ID), as happens when third-party code triggers admin_enqueue_scripts
+		// from outside the normal admin context.
+		$screen = \WP_Screen::get( 'test-screen' );
+		// Non-string, integer id like in the reported error.
+		$screen->id = 35202; // phpcs:ignore Generic.Formatting.MultipleStatementAlignment.IncorrectWarning
+
+		$original_screen           = isset( $GLOBALS['current_screen'] ) ? $GLOBALS['current_screen'] : null;
+		$GLOBALS['current_screen'] = $screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		try {
+			// This should not throw a TypeError even though $screen->id is an integer.
+			$instance->enqueue_visual_attribute_script();
+			// If we reach here, the method handled the non-string id gracefully.
+			$this->assertTrue( true );
+		} catch ( \TypeError $e ) {
+			$this->fail( 'TypeError thrown: ' . $e->getMessage() );
+		} finally {
+			$GLOBALS['current_screen'] = $original_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			delete_option( 'woocommerce_feature_wc_visual_attribute_enabled' );
+			switch_theme( $this->original_theme );
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When the `woocommerce_variation_prices` filter returns malformed data (non-array, or missing required `price`/`regular_price`/`sale_price` keys), downstream code in `WC_Product_Variable::get_variation_prices()` can produce a `TypeError` on `array_map()` or `foreach`.

This adds a `validate_price_data_entry()` method that checks the expected structure, and falls back to the original unfiltered price data when the filter returns unexpected data.

Closes #66851.

### How to test the changes in this Pull Request:

1. Apply the following filter to simulate malformed data returning:
   ```php
   add_filter( 'woocommerce_variation_prices', '__return_empty_array' );
   ```
2. View a variable product page that has variations with prices — it should not fatal.
3. Remove the filter and verify prices display correctly.

Alternatively, return a non-array:
   ```php
   add_filter( 'woocommerce_variation_prices', '__return_null' );
   ```
   The system should fall back to the unfiltered prices gracefully.

### Testing that has already taken place:

- PHP lint (phpcs) passes cleanly on the modified file
- PHPStan analysis passes with no new errors

### Milestone

-   [x] Automatically assign milestone for the next WooCommerce version

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.