### PR TITLE
Add value-interception extension point to email editor Personalizer

### DIFF
--- a/packages/php/email-editor/changelog/personalizer-value-interception
+++ b/packages/php/email-editor/changelog/personalizer-value-interception
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a value-interception extension point to the Personalizer.

--- a/packages/php/email-editor/docs/personalization-tags.md
+++ b/packages/php/email-editor/docs/personalization-tags.md
@@ -10,6 +10,7 @@
 -   [Format](#format)
 -   [Context](#context)
 -   [Rendering Context and Escaping](#rendering-context-and-escaping)
+-   [Value Interceptor](#value-interceptor)
 -   [Core Components](#core-components)
 -   [Creating Custom Tags](#creating-custom-tags)
 -   [Usage with Renderer](#usage-with-renderer)
@@ -168,6 +169,29 @@ Note: the `esc_html()` call does not double-encode existing entities, so a raw t
 
 The default, `Personalization_Tag::VALUE_TYPE_HTML`, inserts the value untouched in every rendering context — including plain-text output; the callback owns escaping and any per-context differences (in the `text` rendering context it must return raw plain text without markup or entities).
 
+## Value Interceptor
+
+The Personalizer offers an advanced extension point that intercepts every resolved tag value just before it is written into the content:
+
+```php
+$previous = $personalizer->set_value_interceptor(
+    function ( string $value, string $source, string $rendering_context ): string {
+        // Record the value externally, substitute a placeholder, etc.
+        return $value;
+    }
+);
+```
+
+The interceptor receives:
+
+-   `$value` — the resolved value, after any context-driven escaping (e.g. `esc_html()` for `VALUE_TYPE_TEXT` tags in HTML content).
+-   `$source` — the raw source text being replaced: the trimmed tag token including arguments, the raw `data-link-href` attribute value, or the tag token found inside a plain `href`.
+-   `$rendering_context` — the `RENDERING_CONTEXT_*` constant of the replacement site.
+
+Its return value is written instead of the resolved value and must be a string — anything else throws a `TypeError`. In the `html` and `text` rendering contexts it is written verbatim. In the `href` rendering context it ends up in the `href` attribute, which WordPress escapes with `esc_url()`: characters not allowed in URLs (such as curly braces) are stripped and a missing scheme is prepended, so a `{{placeholder}}` return comes out as `http://placeholder`. An empty return in the `href` rendering context means no replacement — the link is left untouched, just like an empty resolved value.
+
+The interceptor persists until cleared by passing `null`, and the Personalizer instance obtained from the DI container is shared — WooCommerce core's transactional emails personalize through the same instance. Clear the interceptor (or restore the previous one returned by `set_value_interceptor()`) in a `finally` block, so an exception cannot leave it registered for unrelated emails.
+
 ## Core Components
 
 ### Personalization_Tags_Registry
@@ -257,6 +281,7 @@ Main engine for replacing tags with values in email content.
 -   `set_context(array $context)`: Set the personalization context
 -   `get_context()`: Get the current context
 -   `personalize_content(string $content, string $rendering_context = Personalizer::RENDERING_CONTEXT_HTML)`: Process and personalize content; pass `Personalizer::RENDERING_CONTEXT_TEXT` for plain-text content such as subjects or plain-text bodies
+-   `set_value_interceptor(?callable $interceptor)`: Register a callback intercepting each resolved value before it is written, or clear it with `null`; returns the previously registered interceptor (see [Value Interceptor](#value-interceptor))
 
 **Example Usage:**
 

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -252,6 +252,7 @@ class Personalizer {
 			}
 
 			$value = $tag->execute_callback( $this->get_callback_context( self::RENDERING_CONTEXT_HREF ), $token['arguments'] );
+			$value = $this->intercept_value( $value, $token_string, self::RENDERING_CONTEXT_HREF );
 			if ( '' !== $value ) {
 				$replacements[ $token_string ] = $value;
 			}

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -206,6 +206,7 @@ class Personalizer {
 
 				$value = $tag->execute_callback( $this->get_callback_context( self::RENDERING_CONTEXT_HREF ), $token['arguments'] );
 				$value = $this->replace_link_href( $href, $tag->get_token(), $value );
+				$value = $this->intercept_value( $value, $href, self::RENDERING_CONTEXT_HREF );
 				if ( '' !== $value ) {
 					$content_processor->set_attribute( 'href', $value );
 					$content_processor->remove_attribute( 'data-link-href' );

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -72,6 +72,14 @@ class Personalizer {
 	private array $context;
 
 	/**
+	 * Optional callback intercepting each resolved personalization tag value before
+	 * it is written into the content.
+	 *
+	 * @var (callable(string, string, string): string)|null
+	 */
+	private $value_interceptor = null;
+
+	/**
 	 * Class constructor with required dependencies.
 	 *
 	 * @param Personalization_Tags_Registry $tags_registry Personalization tags registry.
@@ -113,6 +121,44 @@ class Personalizer {
 	}
 
 	/**
+	 * Set a callback intercepting each resolved personalization tag value before it is written.
+	 *
+	 * The interceptor receives the resolved value (after any context-driven escaping),
+	 * the raw source text being replaced (the trimmed tag token including arguments,
+	 * the raw data-link-href attribute value, or the tag token found inside a plain href),
+	 * and the rendering context of the replacement site — one of the RENDERING_CONTEXT_HTML,
+	 * RENDERING_CONTEXT_TEXT, or RENDERING_CONTEXT_HREF constants. Its return value is
+	 * written instead of the resolved value. In the href rendering context an empty
+	 * return value means no replacement — the link is left untouched, just like an
+	 * empty resolved value. This allows consumers (e.g. bulk-sending integrations)
+	 * to substitute placeholders for values while recording the values externally.
+	 *
+	 * The interceptor persists until cleared by passing null.
+	 *
+	 * @param callable|null $interceptor The interceptor callback or null to clear. The callback receives
+	 *                                    the resolved value, the raw source token, and a RENDERING_CONTEXT_* constant.
+	 * @return void
+	 */
+	public function set_value_interceptor( ?callable $interceptor ): void {
+		$this->value_interceptor = $interceptor;
+	}
+
+	/**
+	 * Run a resolved value through the registered interceptor, if any.
+	 *
+	 * @param string $value The resolved personalization tag value about to be written.
+	 * @param string $source The raw source text being replaced.
+	 * @param string $rendering_context One of the RENDERING_CONTEXT_* constants.
+	 * @return string The value to write.
+	 */
+	private function intercept_value( string $value, string $source, string $rendering_context ): string {
+		if ( null === $this->value_interceptor ) {
+			return $value;
+		}
+		return ( $this->value_interceptor )( $value, $source, $rendering_context );
+	}
+
+	/**
 	 * Personalize the content by replacing the personalization tags with their values.
 	 *
 	 * @param string $content The content to personalize.
@@ -139,6 +185,7 @@ class Personalizer {
 				if ( self::RENDERING_CONTEXT_HTML === $rendering_context && Personalization_Tag::VALUE_TYPE_TEXT === $tag->get_value_type() ) {
 					$value = esc_html( $value );
 				}
+				$value = $this->intercept_value( (string) $value, trim( $modifiable_text ), $rendering_context );
 				$content_processor->replace_token( $value );
 
 			} elseif ( $content_processor->get_token_type() === '#tag' && $content_processor->get_tag() === 'TITLE' ) {

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -128,9 +128,13 @@ class Personalizer {
 	 * the raw data-link-href attribute value, or the tag token found inside a plain href),
 	 * and the rendering context of the replacement site — one of the RENDERING_CONTEXT_HTML,
 	 * RENDERING_CONTEXT_TEXT, or RENDERING_CONTEXT_HREF constants. Its return value is
-	 * written instead of the resolved value. In the href rendering context an empty
-	 * return value means no replacement — the link is left untouched, just like an
-	 * empty resolved value. This allows consumers (e.g. bulk-sending integrations)
+	 * written instead of the resolved value — verbatim in the html and text rendering
+	 * contexts. In the href rendering context the return value ends up in the href
+	 * attribute, which WordPress escapes with esc_url(): characters not allowed in URLs
+	 * (such as curly braces) are stripped and a missing scheme is prepended, so a
+	 * "{{placeholder}}" return comes out as "http://placeholder". An empty return value
+	 * in the href rendering context means no replacement — the link is left untouched,
+	 * just like an empty resolved value. This allows consumers (e.g. bulk-sending integrations)
 	 * to substitute placeholders for values while recording the values externally.
 	 *
 	 * The interceptor persists until cleared by passing null.

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -137,14 +137,19 @@ class Personalizer {
 	 * just like an empty resolved value. This allows consumers (e.g. bulk-sending integrations)
 	 * to substitute placeholders for values while recording the values externally.
 	 *
-	 * The interceptor persists until cleared by passing null.
+	 * The interceptor persists until cleared by passing null, and the Personalizer
+	 * instance may be shared with other consumers, so clear or restore the interceptor
+	 * (e.g. in a finally block) as soon as the work it was registered for is done.
+	 * The previously registered interceptor is returned to support restoring it.
 	 *
 	 * @param callable|null $interceptor The interceptor callback or null to clear. The callback receives
 	 *                                    the resolved value, the raw source token, and a RENDERING_CONTEXT_* constant.
-	 * @return void
+	 * @return callable|null The previously registered interceptor, or null when none was set.
 	 */
-	public function set_value_interceptor( ?callable $interceptor ): void {
+	public function set_value_interceptor( ?callable $interceptor ): ?callable {
+		$previous                = $this->value_interceptor;
 		$this->value_interceptor = $interceptor;
+		return $previous;
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -1119,4 +1119,87 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$calls
 		);
 	}
+
+	/**
+	 * Test that the interceptor receives the resolved value, the tag token found in
+	 * the href, and the href rendering context for a plain anchor with an embedded
+	 * tag, and that its return value is written as the href.
+	 */
+	public function testValueInterceptorForPlainHrefTag(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Store URL',
+				'woocommerce/store-url',
+				'Store',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters unused in this test.
+					return 'https://example.com/store';
+				}
+			)
+		);
+
+		$calls = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string {
+				$calls[] = array( $value, $source, $rendering_context );
+				return 'https://intercepted.example.com';
+			}
+		);
+
+		$html_content = '<a href="http://[woocommerce/store-url]">Click here</a>';
+		$this->assertSame( '<a href="https://intercepted.example.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame(
+			array(
+				array( 'https://example.com/store', '[woocommerce/store-url]', Personalizer::RENDERING_CONTEXT_HREF ),
+			),
+			$calls
+		);
+	}
+
+	/**
+	 * Test that the interceptor is called once per tag token embedded in a plain
+	 * href and that each return value replaces its token in the URL.
+	 */
+	public function testValueInterceptorForMultipleHrefTokens(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'One',
+				'test/one',
+				'Test',
+				function () {
+					return 'first-value';
+				}
+			)
+		);
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Two',
+				'test/two',
+				'Test',
+				function () {
+					return 'second-value';
+				}
+			)
+		);
+
+		$calls = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string {
+				$calls[] = array( $value, $source, $rendering_context );
+				return '[test/one]' === $source ? 'ONE' : 'TWO';
+			}
+		);
+
+		// Note: WordPress encodes & as &#038; in URLs.
+		$this->assertSame(
+			'<a href="https://example.com/?a=ONE&#038;b=TWO">Click</a>',
+			$this->personalizer->personalize_content( '<a href="https://example.com/?a=[test/one]&b=[test/two]">Click</a>' )
+		);
+		$this->assertSame(
+			array(
+				array( 'first-value', '[test/one]', Personalizer::RENDERING_CONTEXT_HREF ),
+				array( 'second-value', '[test/two]', Personalizer::RENDERING_CONTEXT_HREF ),
+			),
+			$calls
+		);
+	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -1238,4 +1238,21 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			'The plain-href site should write the interceptor return through esc_url()'
 		);
 	}
+
+	/**
+	 * Test that set_value_interceptor() returns the previously registered interceptor
+	 * so a consumer replacing it temporarily can restore it.
+	 */
+	public function testValueInterceptorSetterReturnsPrevious(): void {
+		$first  = function (): string {
+			return 'first';
+		};
+		$second = function (): string {
+			return 'second';
+		};
+
+		$this->assertNull( $this->personalizer->set_value_interceptor( $first ) );
+		$this->assertSame( $first, $this->personalizer->set_value_interceptor( $second ) );
+		$this->assertSame( $second, $this->personalizer->set_value_interceptor( null ) );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -1203,4 +1203,39 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$calls
 		);
 	}
+
+	/**
+	 * Test that an interceptor return value at the href sites is escaped as a URL when
+	 * written into the href attribute: esc_url() strips characters not allowed in URLs
+	 * (such as curly braces) and prepends a missing scheme.
+	 */
+	public function testValueInterceptorHrefReturnIsEscapedAsUrl(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Store URL',
+				'test/store-url',
+				'Test',
+				function () {
+					return 'https://example.com/store';
+				}
+			)
+		);
+
+		$this->personalizer->set_value_interceptor(
+			function (): string {
+				return '{{placeholder-1}}';
+			}
+		);
+
+		$this->assertSame(
+			'<a  href="http://placeholder-1">Click here</a>',
+			$this->personalizer->personalize_content( '<a data-link-href="[test/store-url]" href="#">Click here</a>' ),
+			'The data-link-href site should write the interceptor return through esc_url()'
+		);
+		$this->assertSame(
+			'<a href="https://example.com/?ref=placeholder-1">Click here</a>',
+			$this->personalizer->personalize_content( '<a href="https://example.com/?ref=[test/store-url]">Click here</a>' ),
+			'The plain-href site should write the interceptor return through esc_url()'
+		);
+	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -1081,4 +1081,42 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$calls
 		);
 	}
+
+	/**
+	 * Test that the interceptor receives the fully resolved href, the raw
+	 * data-link-href source, and the href rendering context, and that its return
+	 * value is written as the href.
+	 */
+	public function testValueInterceptorForDataLinkHref(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Store URL',
+				'woocommerce/store-url',
+				'Store',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters unused in this test.
+					return 'https://example.com/store';
+				}
+			)
+		);
+
+		$calls = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string {
+				$calls[] = array( $value, $source, $rendering_context );
+				return 'https://intercepted.example.com';
+			}
+		);
+
+		$html_content = '<a data-link-href="[woocommerce/store-url]" href="#" contenteditable="true">Click here</a>';
+		$result       = $this->personalizer->personalize_content( $html_content );
+		$this->assertStringContainsString( 'href="https://intercepted.example.com"', $result );
+		$this->assertStringNotContainsString( 'data-link-href', $result );
+		$this->assertStringNotContainsString( 'contenteditable', $result );
+		$this->assertSame(
+			array(
+				array( 'https://example.com/store', '[woocommerce/store-url]', Personalizer::RENDERING_CONTEXT_HREF ),
+			),
+			$calls
+		);
+	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -992,6 +992,7 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 		);
 		$html_content = '<p>Hello, <!--[user-firstname]-->!</p>';
 		$this->assertSame( '<p>Hello, {placeholder-1}!</p>', $this->personalizer->personalize_content( $html_content ) );
+		// The second call verifies that the interceptor persists across personalize_content() calls.
 		$this->assertSame( '<p>Hello, {placeholder-1}!</p>', $this->personalizer->personalize_content( $html_content ) );
 
 		$this->personalizer->set_value_interceptor( null );

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -933,4 +933,152 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertSame( '', $result['token'] );
 		$this->assertEmpty( $result['arguments'] );
 	}
+
+	/**
+	 * Test that a registered value interceptor receives the resolved value, the raw
+	 * source token, and the html rendering context for a content tag, and that its
+	 * return value is written instead of the resolved value.
+	 */
+	public function testValueInterceptorForContentTag(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'first_name',
+				'user-firstname',
+				'User',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $args parameter is not used in this test.
+					return $context['subscriber_name'] ?? 'Default Name';
+				}
+			)
+		);
+
+		$calls = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string {
+				$calls[] = array( $value, $source, $rendering_context );
+				return '{placeholder-1}';
+			}
+		);
+
+		$this->personalizer->set_context( array( 'subscriber_name' => 'John' ) );
+		$html_content = '<p>Hello, <!--[user-firstname default="Guest"]-->!</p>';
+		$this->assertSame( '<p>Hello, {placeholder-1}!</p>', $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame(
+			array(
+				array( 'John', '[user-firstname default="Guest"]', Personalizer::RENDERING_CONTEXT_HTML ),
+			),
+			$calls
+		);
+	}
+
+	/**
+	 * Test that clearing the value interceptor with null restores default behavior.
+	 */
+	public function testValueInterceptorCanBeCleared(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'first_name',
+				'user-firstname',
+				'User',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $context parameter is not used in this test.
+					return 'John';
+				}
+			)
+		);
+
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters unused in this test.
+				return '{placeholder-1}';
+			}
+		);
+		$html_content = '<p>Hello, <!--[user-firstname]-->!</p>';
+		$this->assertSame( '<p>Hello, {placeholder-1}!</p>', $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame( '<p>Hello, {placeholder-1}!</p>', $this->personalizer->personalize_content( $html_content ) );
+
+		$this->personalizer->set_value_interceptor( null );
+		$this->assertSame( '<p>Hello, John!</p>', $this->personalizer->personalize_content( $html_content ) );
+	}
+
+	/**
+	 * Test that the interceptor is not called for tokens without a registered tag.
+	 */
+	public function testValueInterceptorNotCalledForUnknownTag(): void {
+		$calls = 0;
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters unused in this test.
+				++$calls;
+				return $value;
+			}
+		);
+
+		$html_content = '<p>Hello, <!--[mailpoet/unknown-tag]-->!</p>';
+		$this->assertSame( $html_content, $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame( 0, $calls );
+	}
+
+	/**
+	 * Test that the interceptor receives the text rendering context for tags inside
+	 * <title> and the html rendering context for tags in the body.
+	 */
+	public function testValueInterceptorReceivesTextContextInTitle(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'first_name',
+				'user-firstname',
+				'User',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters unused in this test.
+					return 'John';
+				}
+			)
+		);
+
+		$contexts = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$contexts ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $source parameter is not used in this test.
+				$contexts[] = $rendering_context;
+				return Personalizer::RENDERING_CONTEXT_TEXT === $rendering_context ? '{title-placeholder}' : $value;
+			}
+		);
+
+		$html_content = '<html><head><title>Hi <!--[user-firstname]-->!</title></head><body><p>Hi <!--[user-firstname]-->!</p></body></html>';
+		$result       = $this->personalizer->personalize_content( $html_content );
+		$this->assertSame( '<html><head><title>Hi {title-placeholder}!</title></head><body><p>Hi John!</p></body></html>', $result );
+		$this->assertSame( array( Personalizer::RENDERING_CONTEXT_TEXT, Personalizer::RENDERING_CONTEXT_HTML ), $contexts );
+	}
+
+	/**
+	 * Test that the interceptor receives the escaped value of a text value type tag
+	 * in the html rendering context and that its return value is written verbatim.
+	 */
+	public function testValueInterceptorReceivesEscapedTextValue(): void {
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'shop_name',
+				'test/shop-name',
+				'Test',
+				function () {
+					return 'Tom & Jerry';
+				},
+				array(),
+				null,
+				array(),
+				Personalization_Tag::VALUE_TYPE_TEXT
+			)
+		);
+
+		$calls = array();
+		$this->personalizer->set_value_interceptor(
+			function ( string $value, string $source, string $rendering_context ) use ( &$calls ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- The $source parameter is not used in this test.
+				$calls[] = array( $value, $rendering_context );
+				return '{shop-placeholder}';
+			}
+		);
+
+		$this->assertSame( '<p>{shop-placeholder}</p>', $this->personalizer->personalize_content( '<p><!--[test/shop-name]--></p>' ) );
+		$this->assertSame(
+			array(
+				array( 'Tom &amp; Jerry', Personalizer::RENDERING_CONTEXT_HTML ),
+			),
+			$calls
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

MailPoet's templated bulk sending (one shared template + per-recipient substitutions, see mailpoet/mailpoet#6886) needs to intercept each personalization tag value at the moment it is resolved — recording the value per recipient and writing a placeholder instead. Because `Personalizer` had no extension point for this, MailPoet forked its entire content-walking loop. With these changes, MailPoet could use Personalizer directly.

#### Changes

This PR adds an extension point to `Automattic\WooCommerce\EmailEditor\Engine\Personalizer`: `set_value_interceptor( ?callable )`. The interceptor receives `( string $value, string $source, string $rendering_context )` and its return value is written instead. This allows capturing real values and providing placeholders instead. Details of the contract:

- `$rendering_context` is one of the existing `RENDERING_CONTEXT_*` constants: `html` for body content, `text` for plain-text runs and `<title>`, `href` for both link replacement sites.
- Interception runs after the context-driven `esc_html()` of `VALUE_TYPE_TEXT` values, so the interceptor sees the value as it would be written and its return value lands in the content verbatim.
- At the plain-href site interception is per token — `$source` is the tag token found in the URL and the return value replaces only that token; at the data-link-href site the interceptor receives the whole resolved href with the raw attribute value as `$source`.

**Backward compatibility:** additive only — one new public method; no new constants, no signature changes, no new interfaces, no hook changes. With no interceptor registered, output is byte-identical.

Closes WOOPRD-3581

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `packages/php/email-editor/`, run `composer run env:start` and then `composer run test:integration -- --filter Personalizer_Test` — all 36 tests should pass. The 8 new interceptor tests cover all interception sites, the reported rendering contexts (including `text` inside `<title>` vs `html` in the body), interception after escaping, per-token interception with multiple tokens in one href, and clearing/persistence of the interceptor.
2. To verify default behavior is unchanged, note the pre-existing `Personalizer_Test` cases pass unmodified with no interceptor registered.
3. Optional smoke test of the API: register an interceptor and personalize a snippet, e.g.

   ```php
   $personalizer->set_value_interceptor(
       fn ( string $value, string $source, string $rendering_context ): string => '{{placeholder}}'
   );
   $html = $personalizer->personalize_content( '<p>Hi <!--[user-firstname]-->!</p>' );
   // → '<p>Hi {{placeholder}}!</p>'
   $personalizer->set_value_interceptor( null ); // restores default behavior
   ```


### Testing that has already taken place:

- All 36 `Personalizer_Test` integration tests pass in wp-env (28 pre-existing, including the #66937 context tests, plus 8 new interceptor tests).
- `phpcs` clean (0 errors, 0 warnings) on both changed files; PHPStan clean; no baseline changes.
- Cross-checked the extension point against the intended consumer (MailPoet's `TemplatePersonalizer` fork) site by site — the values, dedupe sources, and contexts exposed here are sufficient for the fork to be deleted in a MailPoet follow-up.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
