### PR TITLE
Prevent ghost 0.00 refund when partial refunds sum above the order total

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-fully-refunded-ghost-zero-refund
+++ b/plugins/woocommerce/changelog/fix-order-fully-refunded-ghost-zero-refund
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a ghost 0.00 "Order fully refunded" refund from being created when partial refunds sum a float epsilon above the stored order total.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -914,7 +914,10 @@ function wc_order_fully_refunded( $order_id ) {
 	$order      = wc_get_order( $order_id );
 	$max_refund = wc_format_decimal( $order->get_total() - $order->get_total_refunded() );
 
-	if ( ! $max_refund ) {
+	// Numeric comparison, not truthiness: when prior refunds sum a float epsilon
+	// above the order total, the difference formats to '-0' — a truthy string that
+	// is numerically zero — which would otherwise create a ghost 0.00 refund below.
+	if ( (float) $max_refund <= 0 ) {
 		return;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1446,6 +1446,72 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Fully refunding an order through partial refunds does not create a ghost 0.00 refund when a sub-cent residue remains.
+	 *
+	 * The order total can sit a fraction of a cent below the sum of its refunds
+	 * (the float sum of refund amounts lands epsilon-high on meta-based storage:
+	 * 25.94 + 51.88 = 77.820000000000007 vs a 77.82 total). The refunded-status
+	 * transition then computes a tiny negative remainder that wc_format_decimal()
+	 * renders as '-0' — a truthy string that is numerically zero — and
+	 * wc_order_fully_refunded() used to turn it into a third, ghost refund of
+	 * 0.00 with reason "Order fully refunded." The epsilon depends on the data
+	 * store's SUM precision, so the test pins it via the order total getter.
+	 */
+	public function test_wc_order_fully_refunded_ignores_negative_zero_remainder() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 12.97 );
+		$product->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product, 6 );
+		$order->calculate_totals( true );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+		$this->assertEquals( 77.82, (float) $order->get_total() );
+
+		$item_id = array_keys( $order->get_items( 'line_item' ) )[0];
+
+		// Reproduce the epsilon deterministically on every data store: the total reads
+		// a hair below the 77.82 the two refunds sum to, so the remainder after the
+		// final refund is a tiny negative that wc_format_decimal() renders as '-0'.
+		$force_epsilon_total = function () {
+			return 77.81999999;
+		};
+		add_filter( 'woocommerce_order_get_total', $force_epsilon_total );
+
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 25.94,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 2,
+						'refund_total' => 25.94,
+					),
+				),
+			)
+		);
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 51.88,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 4,
+						'refund_total' => 51.88,
+					),
+				),
+			)
+		);
+
+		remove_filter( 'woocommerce_order_get_total', $force_epsilon_total );
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertEquals( OrderStatus::REFUNDED, $order->get_status(), 'The second refund consumes the rounded remainder and flips the order to refunded.' );
+		$this->assertCount( 2, $order->get_refunds(), 'Only the two real refunds exist — no ghost 0.00 "Order fully refunded." record.' );
+	}
+
+	/**
 	 * @testdox Creating a refund advances the parent order modified date.
 	 *
 	 * @link https://github.com/woocommerce/woocommerce/issues/28969


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When partial refunds fully consume an order, the order flips to the refunded status and `wc_order_fully_refunded()` (hooked to `woocommerce_order_status_refunded`) computes the unrefunded remainder to decide whether a residual refund is needed. That remainder can be a tiny **negative** float: on post-meta storage, `get_total_refunded()` sums refund amounts as SQL doubles, and e.g. `25.94 + 51.88 = 77.820000000000007` lands a float epsilon above a `77.82` order total (sub-cent skew in stored order totals produces the same situation on any storage).

`wc_format_decimal()` renders that tiny negative as the string `'-0'` (the dp-less float path sprintf's at rounding precision, then trims trailing zeros). `'-0'` then defeats every guard in the chain: it is a **truthy** string, so the `if ( ! $max_refund )` early return doesn't fire, yet it compares **numerically equal to zero**, so both `wc_create_refund()` guards (`0 > $amount`, `$amount > $remaining`) pass. The result is a third, ghost refund of **$0.00** with reason "Order fully refunded." attached to the order — confusing in wp-admin and in any API consumer listing refunds. Only the epsilon-high case creates the ghost (an exact or epsilon-low remainder formats to the falsy `'0'`), which is why it reproduces with some amount splits and not others.

The fix makes the guard numeric instead of truthy: `if ( (float) $max_refund <= 0 ) { return; }`. Positive remainders behave exactly as before.

The regression test drives two partial refunds (25.94 + 51.88) that consume a 77.82 order and pins the epsilon via the order total getter, so it reproduces the `'-0'` path deterministically on both HPOS (whose DECIMAL column sums are exact) and post-meta storage. It fails on trunk with a third refund created, and passes with this fix.

This is long-standing behavior, observed in the field during the Woo POS refunds call for testing and reproducible from wp-admin alone with the same two refund amounts.

Issue: [WOOMOB-3653](https://linear.app/a8c/issue/WOOMOB-3653/core-wc-order-fully-refunded-creates-ghost-dollar000-refund-when), reported in pdfdoF-9gL#comment-10714.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a store using post-meta order storage (WooCommerce > Settings > Advanced > Features > order data storage), create an order for 6 units of a 12.97 product with no tax (order total 77.82) and mark it completed/paid.
2. In wp-admin, refund 2 units (25.94) via the order screen's Refund button.
3. Refund the remaining 4 units (51.88).
4. Before this fix, a third refund row of 0.00 with reason "Order fully refunded." appears next to the two real refunds. With the fix, only the two real refunds exist and the order status is refunded.
5. Stores using HPOS sum refunds over a DECIMAL column, so step 4 may not reproduce through the UI there; the new unit test (`test_wc_order_fully_refunded_ignores_negative_zero_remainder`) pins the behavior deterministically on both storage backends.

<!-- End testing instructions -->

### Testing that has already taken place:

- New regression test verified to fail on trunk (a ghost third refund is created) and pass with the fix.
- Full `WC_Tests_Order_Functions` (50 tests) and `WC_Tests_CRUD_Orders` (143 tests) suites pass via `wp-env` under HPOS.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` (see `plugins/woocommerce/changelog/fix-order-fully-refunded-ghost-zero-refund`), so the automatic entry is not needed.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
