### PR TITLE
Correct the legacy price-hash serialization docblock

### DIFF
--- a/plugins/woocommerce/changelog/docs-clarify-legacy-price-hash-serialization
+++ b/plugins/woocommerce/changelog/docs-clarify-legacy-price-hash-serialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct the woocommerce_use_legacy_get_variations_price_hash docblock: the legacy algorithm JSON encodes the callback array, so it captures only public object properties, not private or protected ones as previously documented.

--- a/plugins/woocommerce/changelog/docs-clarify-legacy-price-hash-serialization
+++ b/plugins/woocommerce/changelog/docs-clarify-legacy-price-hash-serialization
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Correct the woocommerce_use_legacy_get_variations_price_hash docblock: the legacy algorithm JSON encodes the callback array, so it captures only public object properties, not private or protected ones as previously documented.
+Correct the woocommerce_use_legacy_get_variations_price_hash docblock: the legacy hash is JSON-encoded, so only a callback object's public properties affect it.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -637,11 +637,13 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		 * Filters whether to use the legacy callback serialization algorithm.
 		 *
 		 * By default, WooCommerce will use the legacy algorithm to get the callback signatures
-		 * for variation price hash calculation. This algorithm serializes the entire callback
-		 * array as it comes from $wp_filter, which means that for callbacks that are class methods
-		 * the entire object will be serialized, including the current values of the class variables.
-		 * This implies that a change in these variables will change the price hash,
-		 * even if they do not affect the price calculation.
+		 * for variation price hash calculation. That algorithm includes the callback array as it
+		 * comes from $wp_filter in the hashed data, which is then JSON encoded. For callbacks that
+		 * are class methods, JSON encoding captures the object's PUBLIC property values only;
+		 * private and protected properties are not captured. Note that dynamically created
+		 * properties are public, and that a class implementing JsonSerializable controls what is
+		 * captured through its jsonSerialize() method. A change in any captured value will change
+		 * the price hash, even if it does not affect the price calculation.
 		 *
 		 * This filter allows using CallbackUtil instead, which generates a more stable signature
 		 * that does not depend on the internal state of objects, but only on the method names and


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Documentation only. The `woocommerce_use_legacy_get_variations_price_hash` docblock in `WC_Product_Variable_Data_Store_CPT` currently says:

> This algorithm serializes the entire callback array as it comes from `$wp_filter`, which means that for callbacks that are class methods **the entire object will be serialized, including the current values of the class variables**. This implies that a change in these variables will change the price hash, even if they do not affect the price calculation.

That is not what happens. `get_price_hash()` ends in `md5( wp_json_encode( $price_hash ) )`, and `json_encode()` emits only **public** instance properties — private and protected state never reaches the hash.

This matters because the docblock is the only description of the behaviour, and it points the reader in the opposite direction from reality. Reasoning from it, I concluded that a pricing extension memoising into a `private` property would destabilise the variation price cache, and said so publicly in #37629 before measuring. It does not, because the state is invisible to `json_encode()`. Correcting the wording so the next person doesn't repeat that.

Verified on PHP 8.5, hashing the callback array exactly as `get_price_hash()` does:

| change made to the hooked object | hash |
|---|---|
| public property value changed | **changes** |
| private property value changed | unchanged |
| protected property value changed | unchanged |
| dynamic property added | **changes** (dynamic properties are public) |
| `JsonSerializable` exposing private state | **changes** (`jsonSerialize()` decides) |

The corrected text says only public property values are captured, and adds the two cases a reader would otherwise get wrong: dynamically created properties are public and therefore captured, and a class implementing `JsonSerializable` controls what is captured.

No behaviour change, no API change.

Related to #37629. Independent of #66882, which touches `CallbackUtil` rather than this file.

### How to test the changes in this Pull Request:

1. Read the amended docblock above `apply_filters( 'woocommerce_use_legacy_get_variations_price_hash', ... )` and confirm it matches what `get_price_hash()` does — in particular the final `md5( wp_json_encode( $price_hash ) )`.
2. Optionally confirm the underlying behaviour: hook a class-method callback onto `woocommerce_variation_prices_price` whose object holds a `private` property, mutate that property between two `get_price_hash()` calls, and observe the hash is unchanged. Repeat with a `public` property and observe that it changes.

### Testing that has already taken place:

The table above — each row exercised directly against `md5( wp_json_encode( ... ) )` of the callback array on PHP 8.5. No code paths are altered by this PR.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
