### PR TITLE
Make the Product DRI confirmation step executable in the release kickoff template

### DIFF
--- a/.linear/release-kickoff.md
+++ b/.linear/release-kickoff.md
@@ -19,7 +19,7 @@ This issue provides visibility on the progress of the release process of WooComm
 ⚠ Dear release lead:
 
 - Please read this issue carefully and familiarize yourself with the [release process documentation](https://developer.woocommerce.com/docs/contribution/releases/).
-- Confirm the Product DRI for this cycle and edit the line above with their name. The readiness review (RC sub-issue) and the go/no-go (stable sub-issue) need both of you.
+- Confirm the Product DRI for this cycle: ask `@woo-core-release` in `#woo-core-releases` to confirm the product-side owner for this release, then edit the line above with their name. The readiness review (RC sub-issue) and the go/no-go (stable sub-issue) need both of you.
 - Join the release channels in Slack (`#woo-core-releases`, `#woo-core-releases-notifications`), where discussions happen and notifications are sent.
 - For every release in the cycle, there's a corresponding sub-issue. On the date of each release (see schedule above), open the relevant issue and follow the instructions in it.
 - Any additional point/patch releases after the first stable must be tracked as well. Run the **[Release: Create Tracking Issue]({repository_url}/actions/workflows/release-create-tracking-issue.yml)** workflow with the version (e.g., `{release_main_version}.1`) to create the sub-issue.

--- a/docs/contribution/releases/readiness.md
+++ b/docs/contribution/releases/readiness.md
@@ -15,7 +15,7 @@ Each cycle has two named owners, listed on the parent tracking issue:
 * **Release lead** (engineering) - runs the release process end to end: builds, publishes, monitors, and executes the run-books.
 * **Product DRI** - the product-side counterpart. Joins the readiness review at RC and the go/no-go before stable, and owns the product read on open findings: what blocks the release, what waits for a point release, and what ships with a known-issues note.
 
-The release lead is assigned by rotation via the [Release: Assignment workflow](/docs/contribution/releases/workflows). The Product DRI is confirmed per cycle on the tracking issue.
+The release lead is assigned by rotation via the [Release: Assignment workflow](/docs/contribution/releases/workflows). The Product DRI is confirmed per cycle on the tracking issue: the release lead asks `@woo-core-release` in `#woo-core-releases`, and the group confirms the product-side owner for the release.
 
 ## Readiness review (at RC)
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#66805 added a "confirm the Product DRI" step to the release kickoff template without saying how to do it - someone running their first release has no move to make (raised by @jorgeatorres in https://github.com/woocommerce/woocommerce/pull/66805#issuecomment-5043743206).

### How to test the changes in this Pull Request:

1. Read `.linear/release-kickoff.md` - the "Confirm the Product DRI" bullet now states exactly what to do and where.
2. Read the release roles section of `docs/contribution/releases/readiness.md` - same mechanism, one sentence.
