### PR TITLE
Fix order-review moderation guard missing reviews written before 10.9.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-legacy-review-rejected-check
+++ b/plugins/woocommerce/changelog/fix-legacy-review-rejected-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the order-review moderation guard missing reviews written before 10.9.0.

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -330,6 +330,24 @@ class SubmissionHandler {
 			return false;
 		}
 
+		// Pre-10.9.0 reviews have no VARIATION_META_KEY row; treat that as 0.
+		$variation_clause = 0 === $variation_id
+			? array(
+				'relation' => 'OR',
+				array(
+					'key'   => ItemEligibility::VARIATION_META_KEY,
+					'value' => '0',
+				),
+				array(
+					'key'     => ItemEligibility::VARIATION_META_KEY,
+					'compare' => 'NOT EXISTS',
+				),
+			)
+			: array(
+				'key'   => ItemEligibility::VARIATION_META_KEY,
+				'value' => (string) $variation_id,
+			);
+
 		$comments = get_comments(
 			array(
 				'post_id'      => $product_id,
@@ -343,10 +361,7 @@ class SubmissionHandler {
 						'key'   => ItemEligibility::ORDER_META_KEY,
 						'value' => (string) $order->get_id(),
 					),
-					array(
-						'key'   => ItemEligibility::VARIATION_META_KEY,
-						'value' => (string) $variation_id,
-					),
+					$variation_clause,
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
@@ -445,36 +445,39 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A second submission after a moderator's spam/trash verdict cannot auto-approve.
+	 * A second submission after a moderator's spam/trash verdict cannot auto-approve, whether the
+	 * spammed review has a normal VARIATION_META_KEY value or predates that meta key entirely.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $with_variation_meta False simulates a review written before 10.9.0, with no VARIATION_META_KEY row.
 	 */
-	public function test_resubmit_after_spam_verdict_cannot_autoapprove(): void {
+	public function test_resubmit_after_spam_verdict_cannot_autoapprove( bool $with_variation_meta ): void {
 		$built      = $this->make_order( 1 );
 		$order      = $built['order'];
 		$product_id = $built['product_ids'][0];
 		$item_id    = $built['item_ids'][0];
 
-		$_POST      = array(
-			'order_id' => $order->get_id(),
-			'key'      => $order->get_order_key(),
-			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
-			'reviews'  => array(
-				array(
-					'product_id'    => $product_id,
-					'order_item_id' => $item_id,
-					'rating'        => 5,
-					'text'          => 'Original review text.',
-				),
-			),
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $product_id,
+				'comment_author'       => 'Jane Doe',
+				'comment_author_email' => $order->get_billing_email(),
+				'comment_content'      => 'Original review text.',
+				'comment_type'         => 'review',
+				'comment_approved'     => 1,
+			)
 		);
-		$first      = $this->dispatch();
-		$comment_id = (int) reset( $first['data']['results'] )['comment_id'];
-
-		// A moderator marks the review as spam.
+		add_comment_meta( $comment_id, ItemEligibility::ORDER_META_KEY, (int) $order->get_id(), true );
+		if ( $with_variation_meta ) {
+			add_comment_meta( $comment_id, ItemEligibility::VARIATION_META_KEY, '0', true );
+		}
 		wp_spam_comment( $comment_id );
-		$this->assertSame( 'spam', wp_get_comment_status( $comment_id ) );
+		ItemEligibility::reset_cache();
 
 		// The customer resubmits the same row.
-		$_POST  = array(
+		$_POST    = array(
 			'order_id' => $order->get_id(),
 			'key'      => $order->get_order_key(),
 			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
@@ -487,11 +490,72 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 				),
 			),
 		);
-		$second = $this->dispatch();
-		$row    = reset( $second['data']['results'] );
+		$response = $this->dispatch();
+		$row      = reset( $response['data']['results'] );
 
 		$this->assertSame( 'error', $row['status'] );
 		$this->assertSame( 'spam', wp_get_comment_status( $comment_id ), 'Moderator decision must stick; a second submission must not auto-approve.' );
+	}
+
+	/**
+	 * A spam verdict recorded against one variation's explicit meta value must not block a sibling variation.
+	 *
+	 * @testWith ["A", "error"]
+	 *           ["B", "ok"]
+	 *
+	 * @param string $resubmit Which variation, "A" or "B", resubmits a review.
+	 * @param string $expected_status Expected row status for that resubmission.
+	 */
+	public function test_resubmit_after_spam_verdict_is_scoped_to_its_variation( string $resubmit, string $expected_status ): void {
+		$variable      = WC_Helper_Product::create_variation_product();
+		$variation_ids = $variable->get_children();
+		$variation_a   = wc_get_product( $variation_ids[0] );
+		$variation_b   = wc_get_product( $variation_ids[1] );
+
+		$order = $this->make_empty_order();
+		$order->add_product( $variation_a, 1 );
+		$order->add_product( $variation_b, 1 );
+		$order->save();
+
+		$items  = array_values( $order->get_items() );
+		$item_a = $items[0];
+		$item_b = $items[1];
+
+		// A moderator marks variation A's review as spam.
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $variable->get_id(),
+				'comment_author'       => 'Jane Doe',
+				'comment_author_email' => $order->get_billing_email(),
+				'comment_content'      => 'Original review text.',
+				'comment_type'         => 'review',
+				'comment_approved'     => 1,
+			)
+		);
+		add_comment_meta( $comment_id, ItemEligibility::ORDER_META_KEY, (int) $order->get_id(), true );
+		add_comment_meta( $comment_id, ItemEligibility::VARIATION_META_KEY, (int) $variation_a->get_id(), true );
+		wp_spam_comment( $comment_id );
+
+		$target = 'A' === $resubmit ? $variation_a : $variation_b;
+		$item   = 'A' === $resubmit ? $item_a : $item_b;
+
+		$_POST    = array(
+			'order_id' => $order->get_id(),
+			'key'      => $order->get_order_key(),
+			'_wcnonce' => wp_create_nonce( SubmissionHandler::ACTION ),
+			'reviews'  => array(
+				array(
+					'product_id'    => $target->get_id(),
+					'order_item_id' => $item->get_id(),
+					'rating'        => 5,
+					'text'          => 'Trying again.',
+				),
+			),
+		);
+		$response = $this->dispatch();
+		$row      = reset( $response['data']['results'] );
+
+		$this->assertSame( $expected_status, $row['status'] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Prior to 10.9, reviews submitted via the `review-order` page (experimental feature) didn't include a variation ID meta with value `0` for simple products.

In #66881, we introduced a guard that assumes this is the value for simple products, but it would miss any reviews written between 10.8 and 10.9, which wouldn't carry the metadata used by the guard. It's unlikely this is even a problem given the feature is experimental and it would've been a problem only during 1 release window, but fixing the guard is also easy and would cover all cases.
 

Closes #66886.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable order reviews:
   ```
   wp option update woocommerce_feature_customer_review_request_enabled yes
   ```
1. Create a **completed** order for a simple product in the admin. Make sure it has a **billing email** address set.
1. Get the order's review URL:
   ```
   wp eval 'echo Automattic\WooCommerce\Internal\OrderReviews\Endpoint::get_url( wc_get_order( ORDER_ID ) );'
   ```

   Open this URL in an incognito window.
1. Submit a review with a rating for the product.
1. As admin:
   1. Go to **WC > Products > Reviews** and find this review. Observe the edit URL and take note of the comment ID.
   1. Mark the review as spam.
   1. Simulate the 10.8 metadata situation for this comment:
      ```
      wp comment meta delete <COMMENT_ID> _review_variation_id
      ```
1. Back in the incognito window, attempt to submit another review. It should fail with an error.
1. (Optional) To confirm the bug on `trunk`:
   1. Check out `trunk`.
   1. Repeat step 6 above in the incognito window, but this time submission will succeed.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.
