### PR TITLE
Fix Storefront activation in performance env init script

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7174-perf-env-storefront-activate
+++ b/plugins/woocommerce/changelog/wooplug-7174-perf-env-storefront-activate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Explicitly activate Storefront in the performance env init script instead of relying on `theme install --activate`, which skips activation when the theme is pre-provisioned.
+

--- a/plugins/woocommerce/tests/performance/bin/init-environment.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-environment.sh
@@ -34,8 +34,9 @@ $wp_cli wp wc --user=admin tool run install_pages
 # Importing WooCommerce sample products"
 $wp_cli wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
 
-# install Storefront
-$wp_cli wp theme install storefront --activate
+# Activate Storefront (pre-provisioned via .wp-env.e2e.json themes[]; `theme install
+# --activate` would skip activation on the already-installed path).
+$wp_cli wp theme activate storefront || { echo "Error: failed to activate storefront." >&2; exit 1; }
 
 # Pin order storage to the legacy posts table (HPOS off) for deterministic runs.
 # These performance requests assert the classic post.php order-edit screens,


### PR DESCRIPTION
Closes #66895. Bug introduced in PR #66859.

### Changes proposed in this Pull Request:

Since #66859 pre-provisions Storefront via `.wp-env.e2e.json` `themes[]`, the performance env's `wp theme install storefront --activate` deterministically hits WP-CLI's "already installed" path, which skips activation — perf runs silently measured twentytwentythree instead of Storefront, shifting baselines with no visible failure.

Replace it with an explicit `wp theme activate storefront` that fails loudly if activation doesn't succeed, consistent with the script's other hard-stop checks.

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, start the E2E environment and run `tests/performance/bin/init-environment.sh`.
2. Run `wp-env --config .wp-env.e2e.json run cli wp theme list --status=active` and confirm `storefront` is active (before this fix it remained `twentytwentythree`).
3. Optionally, remove storefront from `themes[]` in `.wp-env.e2e.json`, recreate the env, and re-run the init script: it now exits non-zero with `Error: failed to activate storefront.` instead of printing the final success message.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
