### PR TITLE
Fix show_in_order_confirmation not hiding address fields

### DIFF
--- a/plugins/woocommerce/changelog/fix-additional-checkout-fields-order-confirmation-address
+++ b/plugins/woocommerce/changelog/fix-additional-checkout-fields-order-confirmation-address
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide additional address fields with show_in_order_confirmation set to false from the order confirmation block theme thank you page, classic theme order details, and My Account order details.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53548,12 +53548,6 @@ parameters:
 			path: src/Blocks/Domain/Services/CheckoutFields.php
 
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(mixed\)\: array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/CheckoutFields.php
-
-		-
 			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, array given\.$#'
 			identifier: argument.type
 			count: 2

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53500,12 +53500,6 @@ parameters:
 			path: src/Blocks/Domain/Package.php
 
 		-
-			message: '#^@param tag must not be named \$this\. Choose a descriptive alias, for example \$instance\.$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/Domain/Services/CheckoutFields.php
-
-		-
 			message: '#^Instanceof between WC_Data and WC_Data will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
@@ -53550,18 +53544,6 @@ parameters:
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\CheckoutFields\:\:sync_order_additional_fields_with_customer\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Blocks/Domain/Services/CheckoutFields.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(CheckoutFields \$this    The CheckoutFields instance\.\)\: Unexpected token "\$this", expected variable at offset 732 on line 14$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/Blocks/Domain/Services/CheckoutFields.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(bool                    Whether the field should be shown\.\)\: Unexpected token "Whether", expected variable at offset 333 on line 10$#'
-			identifier: phpDoc.parseError
 			count: 1
 			path: src/Blocks/Domain/Services/CheckoutFields.php
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -36,7 +36,15 @@ class BillingAddress extends AbstractOrderConfirmationBlock {
 
 		$controller = Package::container()->get( CheckoutFields::class );
 		$custom     = $this->render_additional_fields(
-			$controller->get_order_additional_fields_with_values( $order, 'address', 'billing', 'view' )
+			$controller->filter_fields_for_order_confirmation(
+				$controller->get_order_additional_fields_with_values( $order, 'address', 'billing', 'view' ),
+				array(
+					'caller'     => 'BillingAddress::render_content',
+					'order'      => $order,
+					'permission' => $permission,
+					'attributes' => $attributes,
+				)
+			)
 		);
 
 		return $address . $phone . $custom;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
@@ -36,7 +36,15 @@ class ShippingAddress extends AbstractOrderConfirmationBlock {
 
 		$controller = Package::container()->get( CheckoutFields::class );
 		$custom     = $this->render_additional_fields(
-			$controller->get_order_additional_fields_with_values( $order, 'address', 'shipping', 'view' )
+			$controller->filter_fields_for_order_confirmation(
+				$controller->get_order_additional_fields_with_values( $order, 'address', 'shipping', 'view' ),
+				array(
+					'caller'     => 'ShippingAddress::render_content',
+					'order'      => $order,
+					'permission' => $permission,
+					'attributes' => $attributes,
+				)
+			)
 		);
 
 		return $address . $phone . $custom;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -1401,13 +1401,16 @@ class CheckoutFields {
 				 * WC_Email::additional_checkout_fields
 				 * WC_Email::additional_address_fields
 				 * CheckoutFieldsFrontend::render_order_other_fields
+				 * CheckoutFieldsFrontend::render_order_address_fields
 				 * AdditionalFields::render_content
+				 * BillingAddress::render_content
+				 * ShippingAddress::render_content
 				 *
-				 * @param bool                    Whether the field should be shown.
-				 * @param array          $field   Field data.
-				 * @param array          $fields  All fields for better context when field should be shown or hidden based on other fields values.
-				 * @param array          $context Additional context for the filter. Data depends in which method filter_fields_for_order_confirmation is called.
-				 * @param CheckoutFields $this    The CheckoutFields instance.
+				 * @param bool           $show_field Whether the field should be shown.
+				 * @param array          $field      Field data.
+				 * @param array          $fields     All fields for better context when field should be shown or hidden based on other fields values.
+				 * @param array          $context    Additional context for the filter. Data depends in which method filter_fields_for_order_confirmation is called.
+				 * @param CheckoutFields $instance   The CheckoutFields instance.
 				 * @since 10.1.0
 				 */
 				return apply_filters( 'woocommerce_filter_fields_for_order_confirmation', ! empty( $field['show_in_order_confirmation'] ), $field, $fields, $context, $this );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -78,8 +78,18 @@ class CheckoutFieldsFrontend {
 	 * @param WC_Order $order Order object.
 	 */
 	public function render_order_address_fields( $address_type, $order ) {
+		$fields = $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'address', $address_type, 'view' );
+
+		$context = array(
+			'caller'       => 'CheckoutFieldsFrontend::render_order_address_fields',
+			'address_type' => $address_type,
+			'order'        => $order,
+		);
+
+		$fields = $this->checkout_fields_controller->filter_fields_for_order_confirmation( $fields, $context );
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $this->render_additional_fields( $this->checkout_fields_controller->get_order_additional_fields_with_values( $order, 'address', $address_type, 'view' ) );
+		echo $this->render_additional_fields( $fields );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -1,0 +1,97 @@
+<?php declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\BillingAddress as BillingAddressBlock;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Blocks\Package;
+
+/**
+ * Test BillingAddress block class.
+ */
+final class BillingAddress extends \WP_UnitTestCase {
+	/**
+	 * Field id registered for the duration of a test.
+	 *
+	 * @var string
+	 */
+	private $field_id = 'plugin-namespace/billing-confirmation-field';
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		__internal_woocommerce_blocks_deregister_checkout_field( $this->field_id );
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox Additional address field values with show_in_order_confirmation set to false are hidden from the block.
+	 */
+	public function test_hides_field_when_show_in_order_confirmation_is_false(): void {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                         => $this->field_id,
+				'label'                      => 'Hidden on confirmation',
+				'location'                   => 'address',
+				'show_in_order_confirmation' => false,
+			)
+		);
+
+		$order = $this->create_order_with_field_value( 'secret value' );
+
+		$this->assertStringNotContainsString( 'secret value', $this->render( $order ) );
+	}
+
+	/**
+	 * @testdox Additional address field values with show_in_order_confirmation set to true (the default) are shown in the block.
+	 */
+	public function test_shows_field_when_show_in_order_confirmation_is_true(): void {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $this->field_id,
+				'label'    => 'Shown on confirmation',
+				'location' => 'address',
+			)
+		);
+
+		$order = $this->create_order_with_field_value( 'visible value' );
+
+		$this->assertStringContainsString( 'visible value', $this->render( $order ) );
+	}
+
+	/**
+	 * Create an order placed via the Store API with a value persisted for the billing group of the test field.
+	 *
+	 * @param string $value Field value.
+	 * @return \WC_Order
+	 */
+	private function create_order_with_field_value( string $value ): \WC_Order {
+		$order = \WC_Helper_Order::create_order();
+		$order->set_created_via( 'store-api' );
+		Package::container()->get( CheckoutFields::class )->persist_field_for_order( $this->field_id, $value, $order, 'billing', false );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Render the billing address block content for the given order with full view permissions.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return string
+	 */
+	private function render( \WC_Order $order ): string {
+		$proxy = new class() extends BillingAddressBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission ) {
+				return $this->render_content( $order, $permission );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, 'full' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/ShippingAddress.php
@@ -1,0 +1,104 @@
+<?php declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\ShippingAddress as ShippingAddressBlock;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Blocks\Package;
+
+/**
+ * Test ShippingAddress block class.
+ */
+final class ShippingAddress extends \WP_UnitTestCase {
+	/**
+	 * Field id registered for the duration of a test.
+	 *
+	 * @var string
+	 */
+	private $field_id = 'plugin-namespace/shipping-confirmation-field';
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		__internal_woocommerce_blocks_deregister_checkout_field( $this->field_id );
+		parent::tear_down();
+	}
+
+	/**
+	 * @testdox Additional address field values with show_in_order_confirmation set to false are hidden from the block.
+	 */
+	public function test_hides_field_when_show_in_order_confirmation_is_false(): void {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                         => $this->field_id,
+				'label'                      => 'Hidden on confirmation',
+				'location'                   => 'address',
+				'show_in_order_confirmation' => false,
+			)
+		);
+
+		$order = $this->create_order_with_field_value( 'secret value' );
+
+		$this->assertStringNotContainsString( 'secret value', $this->render( $order ) );
+	}
+
+	/**
+	 * @testdox Additional address field values with show_in_order_confirmation set to true (the default) are shown in the block.
+	 */
+	public function test_shows_field_when_show_in_order_confirmation_is_true(): void {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $this->field_id,
+				'label'    => 'Shown on confirmation',
+				'location' => 'address',
+			)
+		);
+
+		$order = $this->create_order_with_field_value( 'visible value' );
+
+		$this->assertStringContainsString( 'visible value', $this->render( $order ) );
+	}
+
+	/**
+	 * Create an order placed via the Store API, with a shipping address and a value persisted for the shipping group of the test field.
+	 *
+	 * @param string $value Field value.
+	 * @return \WC_Order
+	 */
+	private function create_order_with_field_value( string $value ): \WC_Order {
+		$order = \WC_Helper_Order::create_order();
+		$order->set_created_via( 'store-api' );
+		$order->set_shipping_first_name( 'Jeroen' );
+		$order->set_shipping_last_name( 'Sormani' );
+		$order->set_shipping_address_1( 'WooAddress' );
+		$order->set_shipping_city( 'WooCity' );
+		$order->set_shipping_state( 'NY' );
+		$order->set_shipping_postcode( '12345' );
+		$order->set_shipping_country( 'US' );
+		Package::container()->get( CheckoutFields::class )->persist_field_for_order( $this->field_id, $value, $order, 'shipping', false );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Render the shipping address block content for the given order with full view permissions.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return string
+	 */
+	private function render( \WC_Order $order ): string {
+		$proxy = new class() extends ShippingAddressBlock {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function __construct() {
+			}
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function render_content_proxy( $order, $permission ) {
+				return $this->render_content( $order, $permission );
+			}
+		};
+
+		return $proxy->render_content_proxy( $order, 'full' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
@@ -358,4 +358,57 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/optional_field' );
 	}
+
+	/**
+	 * @testDox Additional address field values with show_in_order_confirmation set to false are hidden when rendering order details.
+	 */
+	public function test_render_order_address_fields_hides_field_when_show_in_order_confirmation_is_false() {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                         => 'mynamespace/billing_confirmation_field',
+				'label'                      => 'Hidden on confirmation',
+				'location'                   => 'address',
+				'show_in_order_confirmation' => false,
+			)
+		);
+
+		$order = \WC_Helper_Order::create_order();
+		$order->set_created_via( 'store-api' );
+		$this->controller->persist_field_for_order( 'mynamespace/billing_confirmation_field', 'secret value', $order, 'billing', false );
+		$order->save();
+
+		ob_start();
+		$this->sut->render_order_address_fields( 'billing', $order );
+		$content = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'secret value', $content );
+
+		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/billing_confirmation_field' );
+	}
+
+	/**
+	 * @testDox Additional address field values with show_in_order_confirmation set to true (the default) are shown when rendering order details.
+	 */
+	public function test_render_order_address_fields_shows_field_when_show_in_order_confirmation_is_true() {
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => 'mynamespace/billing_confirmation_field',
+				'label'    => 'Shown on confirmation',
+				'location' => 'address',
+			)
+		);
+
+		$order = \WC_Helper_Order::create_order();
+		$order->set_created_via( 'store-api' );
+		$this->controller->persist_field_for_order( 'mynamespace/billing_confirmation_field', 'visible value', $order, 'billing', false );
+		$order->save();
+
+		ob_start();
+		$this->sut->render_order_address_fields( 'billing', $order );
+		$content = ob_get_clean();
+
+		$this->assertStringContainsString( 'visible value', $content );
+
+		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/billing_confirmation_field' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
@@ -30,6 +30,13 @@ class CheckoutFieldsFrontendTest extends TestCase {
 	private $controller;
 
 	/**
+	 * Field IDs registered during a test, to be deregistered in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private $registered_fields = [];
+
+	/**
 	 * Setup.
 	 */
 	public function setUp(): void {
@@ -50,6 +57,21 @@ class CheckoutFieldsFrontendTest extends TestCase {
 		remove_filter( 'woocommerce_add_notice', [ $this, 'capture_notice' ] );
 		remove_filter( 'woocommerce_add_error', [ $this, 'capture_error' ] );
 		remove_filter( 'woocommerce_add_success', [ $this, 'capture_success' ] );
+
+		foreach ( $this->registered_fields as $field_id ) {
+			__internal_woocommerce_blocks_deregister_checkout_field( $field_id );
+		}
+		$this->registered_fields = [];
+	}
+
+	/**
+	 * Register a checkout field and track it for cleanup in tearDown.
+	 *
+	 * @param array $args Field registration arguments.
+	 */
+	private function register_checkout_field( array $args ): void {
+		woocommerce_register_additional_checkout_field( $args );
+		$this->registered_fields[] = $args['id'];
 	}
 
 	/**
@@ -124,7 +146,7 @@ class CheckoutFieldsFrontendTest extends TestCase {
 	 */
 	public function test_save_account_form_fields_contact_generic_validation_error() {
 
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'                => 'mynamespace/generic_validation_error',
 				'label'             => 'Optional field with validation',
@@ -161,8 +183,6 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		$value = $this->controller->get_field_from_object( 'mynamespace/generic_validation_error', new WC_Customer( 1 ) );
 		$this->assertEquals( '', $value );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/generic_validation_error' );
 	}
 
 	/**
@@ -170,7 +190,7 @@ class CheckoutFieldsFrontendTest extends TestCase {
 	 */
 	public function test_save_account_form_fields_contact_location_validation_error() {
 
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'       => 'mynamespace/location_validation_error',
 				'label'    => 'Impossible contact field',
@@ -197,8 +217,6 @@ class CheckoutFieldsFrontendTest extends TestCase {
 		$value = $this->controller->get_field_from_object( 'mynamespace/required_field', new WC_Customer( 1 ) );
 		$this->assertEquals( '', $value );
 
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/location_validation_error' );
-
 		remove_action( 'woocommerce_blocks_validate_location_contact_fields', $e_thrower );
 	}
 
@@ -207,7 +225,7 @@ class CheckoutFieldsFrontendTest extends TestCase {
 	 */
 	public function test_save_account_form_fields_contact_save_required_field() {
 
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'       => 'mynamespace/required_field',
 				'label'    => 'Required field',
@@ -238,8 +256,6 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		$value = $this->controller->get_field_from_object( 'mynamespace/required_field', new WC_Customer( 1 ) );
 		$this->assertEquals( $hash, $value );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/required_field' );
 	}
 
 	/**
@@ -247,7 +263,7 @@ class CheckoutFieldsFrontendTest extends TestCase {
 	 */
 	public function test_save_account_form_fields_contact_save_optional_field() {
 
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'       => 'mynamespace/optional_field',
 				'label'    => 'Optional field',
@@ -275,15 +291,13 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		$value = $this->controller->get_field_from_object( 'mynamespace/optional_field', new WC_Customer( 1 ) );
 		$this->assertEquals( $hash, $value );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/optional_field' );
 	}
 
 	/**
 	 * @testDox Contact additional field validation error for an optional email field to ensure validation rules are applied.
 	 */
 	public function test_save_account_form_fields_contact_email_validation_error_optional_field() {
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'                => 'mynamespace/email_validation_error',
 				'label'             => 'Optional field with validation',
@@ -325,15 +339,13 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		$value = $this->controller->get_field_from_object( 'mynamespace/email_validation_error', new WC_Customer( 1 ) );
 		$this->assertEquals( '', $value );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/email_validation_error' );
 	}
 
 	/**
 	 * @testDox Optional field with existing value can be cleared by submitting empty value.
 	 */
 	public function test_save_account_form_fields_optional_field_can_be_cleared() {
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'       => 'mynamespace/optional_field',
 				'label'    => 'Optional field',
@@ -355,15 +367,13 @@ class CheckoutFieldsFrontendTest extends TestCase {
 
 		$value = $this->controller->get_field_from_object( 'mynamespace/optional_field', new WC_Customer( 1 ) );
 		$this->assertEquals( '', $value );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/optional_field' );
 	}
 
 	/**
 	 * @testDox Additional address field values with show_in_order_confirmation set to false are hidden when rendering order details.
 	 */
 	public function test_render_order_address_fields_hides_field_when_show_in_order_confirmation_is_false() {
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'                         => 'mynamespace/billing_confirmation_field',
 				'label'                      => 'Hidden on confirmation',
@@ -382,15 +392,13 @@ class CheckoutFieldsFrontendTest extends TestCase {
 		$content = ob_get_clean();
 
 		$this->assertStringNotContainsString( 'secret value', $content );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/billing_confirmation_field' );
 	}
 
 	/**
 	 * @testDox Additional address field values with show_in_order_confirmation set to true (the default) are shown when rendering order details.
 	 */
 	public function test_render_order_address_fields_shows_field_when_show_in_order_confirmation_is_true() {
-		woocommerce_register_additional_checkout_field(
+		$this->register_checkout_field(
 			array(
 				'id'       => 'mynamespace/billing_confirmation_field',
 				'label'    => 'Shown on confirmation',
@@ -408,7 +416,5 @@ class CheckoutFieldsFrontendTest extends TestCase {
 		$content = ob_get_clean();
 
 		$this->assertStringContainsString( 'visible value', $content );
-
-		__internal_woocommerce_blocks_deregister_checkout_field( 'mynamespace/billing_confirmation_field' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up to [#58623](<https://github.com/woocommerce/woocommerce/issues/58623>) this PR hides additional fields marked for hiding in address location.

Closes woocommerce/woocommerce#51258.

### How to test the changes in this Pull Request:

1. Register three additional checkout fields with `woocommerce_blocks_register_checkout_field()`, one each on the `contact`, `address`, and `order` locations, all with `show_in_order_confirmation` set to `false`.

```php
  add_action( 'init', function() {

        // Contact location field.
        woocommerce_register_additional_checkout_field(
                array(
                        'id'                         => 'plugin-namespace/contact-note',
                        'label'                      => 'Contact note',
                        'location'                   => 'contact',
                        'type'                       => 'text',
                        'required'                   => false,
                        'show_in_order_confirmation' => false,
                )
        );
  
        // Address location field.
        woocommerce_register_additional_checkout_field(
                array(
                        'id'                         => 'plugin-namespace/gate-code',
                        'label'                      => 'Gate code',
                        'location'                   => 'address',
                        'type'                       => 'text',
                        'required'                   => false,
                        'show_in_order_confirmation' => false,
                )
        );
  
        // Order location field.
        woocommerce_register_additional_checkout_field(
                array(
                        'id'                         => 'plugin-namespace/leave-on-porch',
                        'label'                      => 'Leave on porch if not home',
                        'location'                   => 'order',
                        'type'                       => 'checkbox',
                        'show_in_order_confirmation' => false,
                )
        );

  } );
```

2. Place an order via the block-based checkout, once with a block theme (e.g. Twenty Twenty-Four) and once with a classic theme (e.g. Storefront).
3. Confirm all three fields, including the address field, are hidden on the order confirmation ("Thank you") page for both themes.
4. Confirm the address field is also hidden under My Account > Orders > order details.
5. Confirm all three fields remain hidden in the order confirmation email.
6. Register a field without `show_in_order_confirmation` (defaults to `true`) and confirm it still shows in all of the above locations.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)