### PR TITLE
Correct deferred order-item deletion version markers to 11.0.0

### DIFF
--- a/plugins/woocommerce/changelog/order-items-since-version-WOOPLUG-6799
+++ b/plugins/woocommerce/changelog/order-items-since-version-WOOPLUG-6799
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Correct @since and wc_doing_it_wrong version markers for the deferred order-item deletion work to 11.0.0 (the release it shipped in); no production behavior change.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -98,7 +98,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * replacement items. Superseded by $bulk_delete_all_items_pending, which removes
 	 * every item type.
 	 *
-	 * @since 10.9.0
+	 * @since 11.0.0
 	 * @var array<string>
 	 */
 	protected $item_types_to_bulk_delete = array();
@@ -109,7 +109,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Set by remove_order_items() when called with no type (so every item type
 	 * should be removed). Processed and reset in save_items().
 	 *
-	 * @since 10.9.0
+	 * @since 11.0.0
 	 * @var bool
 	 */
 	protected $bulk_delete_all_items_pending = false;
@@ -958,7 +958,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				__METHOD__,
 				/* translators: %s: PHP type that was passed instead of a string. */
 				sprintf( esc_html__( 'remove_order_items() expects a string item type or null; received %s.', 'woocommerce' ), esc_html( gettype( $type ) ) ),
-				'10.9.0'
+				'11.0.0'
 			);
 			return;
 		}
@@ -1024,7 +1024,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * woocommerce_order_type_to_group filter so extension-registered types are
 	 * included.
 	 *
-	 * @since 10.9.0
+	 * @since 11.0.0
 	 * @return array<string, string>
 	 */
 	protected function get_item_types_to_group() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Corrects stale version markers left behind by the deferred order-item deletion work in PR #64326.

That work merged to trunk during the `11.0.0-dev` cycle and first shipped in `11.0.0-beta.1`. It is not present in any `10.9.0` tag (including the final `10.9.0` release). Its version annotations, however, were written as `10.9.0`, one minor version too low. This corrects them so the release markers match where the code actually landed:

- `$item_types_to_bulk_delete` property `since` tag: `10.9.0` → `11.0.0`
- `$bulk_delete_all_items_pending` property `since` tag: `10.9.0` → `11.0.0`
- `get_item_types_to_group()` method `since` tag: `10.9.0` → `11.0.0`
- `wc_doing_it_wrong()` version argument on the `remove_order_items()` type guard: `10.9.0` → `11.0.0` (this one is developer-facing: it prints in debug logs when the guard fires)

Documentation and debug-notice string only. No production behavior changes.

Version annotations introduced in PR #64326.

Found while reviewing WOOPLUG-6799.

### How to test the changes in this Pull Request:

1. `git grep -n "10.9.0" plugins/woocommerce/includes/abstracts/abstract-wc-order.php` on this branch returns nothing for the deferred-deletion symbols.
2. Confirm the four markers now read `11.0.0`: the three `since` tags on `$item_types_to_bulk_delete`, `$bulk_delete_all_items_pending`, and `get_item_types_to_group()`, plus the `wc_doing_it_wrong()` version on `remove_order_items()`.
3. Confirm `git tag --contains 49441af86a` lists `11.0.0-*` tags and no `10.9.0` tag, verifying `11.0.0` is the correct value.

### Testing that has already taken place:

- Verified via `git tag`/`git merge-base --is-ancestor` that commit `49441af86a` is present in `11.0.0-beta.1`, `11.0.0-beta.2`, and `11.0.0-dev`, and absent from every `10.9.0` tag including the final release.
- `php -l` passes on the modified file. Changes are limited to docblock text and one string literal.

### Milestone

<!-- milestone-target-selection -->
Manually assigned to 11.0.0 (point release) so the correction ships alongside the release the code landed in. The auto-assign box is intentionally left unchecked because the "next version" is 11.1.0.
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually (`plugins/woocommerce/changelog/order-items-since-version-WOOPLUG-6799`, type `dev`, with a comment; no user-facing line since there is no merchant impact).

-   [ ] Automatically create a changelog entry from the details below.
