### PR TITLE
Fix malformed gateway settings transition events

### DIFF
--- a/plugins/woocommerce/changelog/fix-66861-malformed-gateway-transition-defaults
+++ b/plugins/woocommerce/changelog/fix-66861-malformed-gateway-transition-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use gateway defaults when detecting enabled-state transitions from malformed settings.

--- a/plugins/woocommerce/includes/class-wc-payment-gateways.php
+++ b/plugins/woocommerce/includes/class-wc-payment-gateways.php
@@ -195,17 +195,22 @@ class WC_Payment_Gateways {
 
 			if ( ! is_array( $value ) ) {
 				$logger->warning(
-					sprintf( 'Payment gateway transition handling skipped because the new value for "%s" is not an array.', $option ),
+					sprintf( 'New payment gateway settings for "%s" were not an array; using gateway defaults for transition handling.', $option ),
 					array( 'source' => 'payment-gateways' )
 				);
-				return;
 			}
 
-			$logger->warning(
-				sprintf( 'Previous payment gateway settings for "%s" were not an array; treating the gateway as disabled.', $option ),
-				array( 'source' => 'payment-gateways' )
-			);
-			$old_value = array( 'enabled' => 'no' );
+			if ( null !== $old_value && ! is_array( $old_value ) ) {
+				$logger->warning(
+					sprintf( 'Previous payment gateway settings for "%s" were not an array; using gateway defaults for transition handling.', $option ),
+					array( 'source' => 'payment-gateways' )
+				);
+			}
+
+			$value = $this->normalize_gateway_settings_for_transition( $gateway, $value );
+			if ( null !== $old_value ) {
+				$old_value = $this->normalize_gateway_settings_for_transition( $gateway, $old_value );
+			}
 		}
 
 		if ( $this->was_gateway_enabled( $value, $old_value ) ) {
@@ -233,6 +238,25 @@ class WC_Payment_Gateways {
 			// This is a change to a payment gateway's settings and it was just disabled. Let's track it.
 			$this->record_gateway_event( 'disable', $gateway );
 		}
+	}
+
+	/**
+	 * Normalize gateway settings for transition handling.
+	 *
+	 * @param WC_Payment_Gateway $gateway  Payment gateway.
+	 * @param mixed              $settings Gateway settings.
+	 * @return array Normalized gateway settings.
+	 */
+	private function normalize_gateway_settings_for_transition( $gateway, $settings ) {
+		if ( is_array( $settings ) ) {
+			return $settings;
+		}
+
+		$form_fields     = $gateway->get_form_fields();
+		$enabled_field   = $form_fields['enabled'] ?? array();
+		$enabled_default = $gateway->get_field_default( $enabled_field );
+
+		return array( 'enabled' => 'yes' === $enabled_default ? 'yes' : 'no' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-payment-gateways-test.php
@@ -38,14 +38,38 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Gateway settings updates diagnose malformed values and track enabled repairs.
+	 * @testdox Gateway settings option changes use gateway defaults for malformed transition values.
+	 * @dataProvider provider_malformed_gateway_settings_transitions
+	 *
+	 * @param string|null $enabled_default     The gateway's enabled form-field default, or null to remove the field.
+	 * @param mixed       $old_value           The previously stored option value, or null for an added option.
+	 * @param mixed       $new_value           The option value to add or update.
+	 * @param string[]    $warning_sides       The malformed transition sides expected to produce warnings.
+	 * @param int         $info_count          The expected number of informational log entries.
+	 * @param int         $action_count        The expected number of gateway-enabled actions.
+	 * @param int         $enable_tracks_count The expected number of gateway-enable Tracks events.
+	 * @param int         $disable_tracks_count The expected number of gateway-disable Tracks events.
 	 */
-	public function test_gateway_settings_updates_handle_non_array_values(): void {
-		$option_name       = 'woocommerce_cod_settings';
-		$disabled_settings = array( 'enabled' => 'no' );
-		$enabled_settings  = array( 'enabled' => 'yes' );
-		$tracking_option   = get_option( 'woocommerce_allow_tracking', null );
-		$current_user_id   = get_current_user_id();
+	public function test_gateway_settings_option_changes_handle_non_array_values(
+		?string $enabled_default,
+		$old_value,
+		$new_value,
+		array $warning_sides,
+		int $info_count,
+		int $action_count,
+		int $enable_tracks_count,
+		int $disable_tracks_count
+	): void {
+		$option_name     = 'woocommerce_cod_settings';
+		$gateway         = $this->sut->payment_gateways()['cod'];
+		$tracking_option = get_option( 'woocommerce_allow_tracking', null );
+		$current_user_id = get_current_user_id();
+
+		if ( null === $enabled_default ) {
+			unset( $gateway->form_fields['enabled'] );
+		} else {
+			$gateway->form_fields['enabled']['default'] = $enabled_default;
+		}
 
 		// phpcs:disable Squiz.Commenting
 		$fake_logger = new class() {
@@ -88,44 +112,50 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 		try {
 			wp_set_current_user( 0 );
 			update_option( 'woocommerce_allow_tracking', 'yes' );
-			$this->clear_tracks_events();
 
 			delete_option( $option_name );
-			add_option( $option_name, $disabled_settings );
+			if ( null === $old_value ) {
+				$this->clear_tracks_events();
+				add_option( $option_name, $new_value );
+			} else {
+				add_option( $option_name, $old_value );
+				$fake_logger->infos    = array();
+				$fake_logger->warnings = array();
+				$enabled_gateways      = array();
+				$this->clear_tracks_events();
 
-			update_option( $option_name, '{"enabled":"yes"}' );
-			$malformed_value        = get_option( $option_name );
-			$malformed_info_count   = count( $fake_logger->infos );
-			$malformed_action_count = count( $enabled_gateways );
-			$malformed_tracks_count = count( $this->get_tracks_events( 'wcadmin_settings_payments_provider_enable' ) );
+				update_option( $option_name, $new_value );
+			}
 
-			update_option( $option_name, $enabled_settings );
-
-			$this->assertSame( '{"enabled":"yes"}', $malformed_value, 'The malformed gateway settings should remain a string.' );
-			$this->assertSame( 0, $malformed_info_count, 'A malformed new value should not log an enable transition.' );
-			$this->assertSame( 0, $malformed_action_count, 'A malformed new value should not fire the gateway-enabled action.' );
-			$this->assertSame( 0, $malformed_tracks_count, 'A malformed new value should not record an enable event.' );
-
-			$this->assertSame( $enabled_settings, get_option( $option_name ), 'Valid gateway settings should be stored after a malformed value.' );
-			$this->assertCount( 2, $fake_logger->warnings, 'Both malformed transition values should produce diagnostic warnings.' );
-			$this->assertSame(
-				'Payment gateway transition handling skipped because the new value for "woocommerce_cod_settings" is not an array.',
-				$fake_logger->warnings[0]['message'],
-				'The malformed new value warning should identify the affected option.'
-			);
-			$this->assertSame(
-				'Previous payment gateway settings for "woocommerce_cod_settings" were not an array; treating the gateway as disabled.',
-				$fake_logger->warnings[1]['message'],
-				'The malformed old value warning should describe the repair behavior.'
-			);
-			$this->assertCount( 1, $fake_logger->infos, 'Repairing to enabled settings should log one enable transition.' );
-			$this->assertCount( 1, $enabled_gateways, 'Repairing to enabled settings should fire the gateway-enabled action once.' );
-			$this->assertSame( 'cod', $enabled_gateways[0]->id, 'The gateway-enabled action should receive the repaired gateway.' );
+			$this->assertSame( $new_value, get_option( $option_name ), 'The option hook should not rewrite or decode the stored settings value.' );
+			$this->assertCount( $info_count, $fake_logger->infos, 'The transition should produce the expected number of informational log entries.' );
+			$this->assertCount( $action_count, $enabled_gateways, 'The transition should fire the gateway-enabled action the expected number of times.' );
+			if ( 1 === $action_count ) {
+				$this->assertSame( $gateway, $enabled_gateways[0], 'The gateway-enabled action should receive the COD gateway instance.' );
+			}
 			$this->assertCount(
-				1,
+				$enable_tracks_count,
 				$this->get_tracks_events( 'wcadmin_settings_payments_provider_enable' ),
-				'Repairing to enabled settings should record one enable event.'
+				'The transition should record the expected number of gateway-enable events.'
 			);
+			$this->assertCount(
+				$disable_tracks_count,
+				$this->get_tracks_events( 'wcadmin_settings_payments_provider_disable' ),
+				'The transition should record the expected number of gateway-disable events.'
+			);
+			if ( 1 === $info_count ) {
+				$this->assertSame( 'Payment gateway enabled: "Cash on delivery"', $fake_logger->infos[0]['message'], 'The informational log should identify the enabled gateway.' );
+			}
+
+			$this->assertCount( count( $warning_sides ), $fake_logger->warnings, 'Each malformed transition side should produce one warning.' );
+			foreach ( $warning_sides as $warning_index => $warning_side ) {
+				$expected_warning = 'new' === $warning_side
+					? sprintf( 'New payment gateway settings for "%s" were not an array; using gateway defaults for transition handling.', $option_name )
+					: sprintf( 'Previous payment gateway settings for "%s" were not an array; using gateway defaults for transition handling.', $option_name );
+
+				$this->assertSame( $expected_warning, $fake_logger->warnings[ $warning_index ]['message'], "The malformed {$warning_side} value warning should describe the fallback behavior." );
+				$this->assertSame( array( 'source' => 'payment-gateways' ), $fake_logger->warnings[ $warning_index ]['data'], "The malformed {$warning_side} value warning should use the payment-gateways source." );
+			}
 		} finally {
 			remove_action( 'woocommerce_payment_gateway_enabled', $action_watcher );
 			wc_get_container()->reset_replacement( \Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders::class );
@@ -138,6 +168,32 @@ class WC_Payment_Gateways_Test extends WC_Unit_Test_Case {
 				update_option( 'woocommerce_allow_tracking', $tracking_option );
 			}
 		}
+	}
+
+	/**
+	 * Provides malformed gateway settings transitions.
+	 *
+	 * @return array<string, array{0: string|null, 1: mixed, 2: mixed, 3: string[], 4: int, 5: int, 6: int, 7: int}>
+	 */
+	public function provider_malformed_gateway_settings_transitions(): array {
+		$malformed_old = '{"enabled":"yes"}';
+		$malformed_new = '{"enabled":"no"}';
+		$disabled      = array( 'enabled' => 'no' );
+		$enabled       = array( 'enabled' => 'yes' );
+
+		return array(
+			'default disabled: malformed to explicit disabled' => array( 'no', $malformed_old, $disabled, array( 'old' ), 0, 0, 0, 0 ),
+			'default disabled: malformed to explicit enabled' => array( 'no', $malformed_old, $enabled, array( 'old' ), 1, 1, 1, 0 ),
+			'default enabled: malformed to explicit enabled' => array( 'yes', $malformed_old, $enabled, array( 'old' ), 0, 0, 0, 0 ),
+			'default enabled: malformed to explicit disabled' => array( 'yes', $malformed_old, $disabled, array( 'old' ), 0, 0, 0, 1 ),
+			'default disabled: explicit disabled to malformed' => array( 'no', $disabled, $malformed_new, array( 'new' ), 0, 0, 0, 0 ),
+			'default enabled: explicit disabled to malformed' => array( 'yes', $disabled, $malformed_new, array( 'new' ), 1, 1, 1, 0 ),
+			'default disabled: explicit enabled to malformed' => array( 'no', $enabled, $malformed_new, array( 'new' ), 0, 0, 0, 1 ),
+			'default enabled: explicit enabled to malformed' => array( 'yes', $enabled, $malformed_new, array( 'new' ), 0, 0, 0, 0 ),
+			'default enabled: distinct malformed values'  => array( 'yes', $malformed_old, $malformed_new, array( 'new', 'old' ), 0, 0, 0, 0 ),
+			'missing enabled field: enabled to malformed' => array( null, $enabled, $malformed_new, array( 'new' ), 0, 0, 0, 1 ),
+			'add malformed value with enabled default'    => array( 'yes', null, $malformed_new, array( 'new' ), 0, 0, 0, 0 ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Malformed payment gateway settings fall back to the gateway's form-field defaults at runtime, but transition tracking currently treats every malformed old value as disabled and skips malformed new values. This can send a false gateway-enabled notification and Tracks event, or miss a real effective disable transition.

This change normalizes malformed old and new values to the gateway's `enabled` default only for transition comparison. Stored values are never decoded or rewritten, the add-option sentinel and valid array behavior remain unchanged, and a data-driven test covers both gateway defaults and malformed directions.

Backward compatibility: no public signatures, hook names, or hook arguments change. The occurrence of `woocommerce_payment_gateway_enabled` and enable/disable Tracks events changes only for malformed settings boundaries introduced by PR #66848, so those side effects reflect the effective default-backed state. Site-scoped option storage is unchanged; multisite was not separately tested.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66861.

Bug introduced in PR #66848.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the WooCommerce test environment:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce env:test:start
   ```

2. Run the complete payment-gateways test class:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Payment_Gateways_Test
   ```

   - [ ] Confirm PHPUnit reports 14 tests and 112 assertions with no failures or errors.

3. Run the malformed-settings transition matrix with test descriptions:

   ```bash
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --testdox --filter test_gateway_settings_option_changes_handle_non_array_values
   ```

   - [ ] Confirm repairs from malformed settings do not emit a gateway-enabled action or Tracks event when the gateway default is already enabled.
   - [ ] Confirm replacing explicit enabled settings with malformed settings records a disable event when the gateway default is disabled.
   - [ ] Confirm malformed old and new values emit side-specific warnings while the raw option value remains unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit 9.6.29 under PHP 8.1.34 in an isolated Core `wp-env`: 14 tests, 112 assertions, no failures or errors.
- `lint:php:changes` and `lint:changes:branch` completed successfully.
- PHPStan reported no errors for the modified production file.
- Targeted mutation testing covered the legacy gateway class; no escaped mutant intersected the changed callback or normalization helper.
- Independent spec-compliance and code-quality reviews found no changed-code issues.
- Multisite was not tested separately.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"
</details>
