### PR TITLE
Fix Product Collection filter query clauses

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-collection-query-clauses
+++ b/plugins/woocommerce/changelog/fix-product-collection-query-clauses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Migrate Product Collection filtering to the shared Product Filters QueryClauses implementation.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AttributeFilter;
-use Automattic\WooCommerce\Blocks\BlockTypes\PriceFilter;
 use Automattic\WooCommerce\Blocks\BlockTypes\RatingFilter;
-use Automattic\WooCommerce\Blocks\BlockTypes\StockFilter;
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
+use Automattic\WooCommerce\Internal\ProductFilters\QueryClauses;
 use WP_Query;
 use WC_Tax;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
@@ -52,6 +52,14 @@ class QueryBuilder {
 	public function __construct() {
 		$this->valid_query_vars = $this->get_valid_query_vars();
 		add_filter( 'posts_clauses', array( $this, 'add_price_range_filter_posts_clauses' ), 10, 2 );
+		add_filter(
+			'posts_clauses',
+			function ( $clauses, $query ) {
+				return $this->apply_product_filter_query_clauses( $clauses, $query );
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -291,7 +299,7 @@ class QueryBuilder {
 			$collection_query = array();
 		}
 
-		return $this->merge_queries(
+		$final_query = $this->merge_queries(
 			$common_query_values,
 			$orderby_query,
 			$on_sale_query,
@@ -303,6 +311,15 @@ class QueryBuilder {
 			$handpicked_query,
 			$collection_query
 		);
+
+		$final_query['isProductCollection'] = true;
+
+		if ( ! $is_exclude_applied_filters ) {
+			$applied_filter_query_vars = $this->get_applied_filter_query_vars();
+			$final_query               = array_merge( $final_query, $applied_filter_query_vars );
+		}
+
+		return $final_query;
 	}
 
 	/**
@@ -458,50 +475,54 @@ class QueryBuilder {
 	}
 
 	/**
-	 * Return a query that filters products by price.
+	 * Return a query that filters products by rating.
 	 *
 	 * @return array
 	 */
-	private function get_filter_by_price_query() {
-		$min_price = get_query_var( PriceFilter::MIN_PRICE_QUERY_VAR );
-		$max_price = get_query_var( PriceFilter::MAX_PRICE_QUERY_VAR );
-
-		$max_price_query = empty( $max_price ) ? array() : array(
-			'key'     => '_price',
-			'value'   => $max_price,
-			'compare' => '<=',
-			'type'    => 'numeric',
-		);
-
-		$min_price_query = empty( $min_price ) ? array() : array(
-			'key'     => '_price',
-			'value'   => $min_price,
-			'compare' => '>=',
-			'type'    => 'numeric',
-		);
-
-		if ( empty( $min_price_query ) && empty( $max_price_query ) ) {
+	private function get_filter_by_rating_query() {
+		$filter_rating_values = get_query_var( RatingFilter::RATING_QUERY_VAR );
+		if ( empty( $filter_rating_values ) ) {
 			return array();
 		}
 
+		$parsed_filter_rating_values = explode( ',', $filter_rating_values );
+		$product_visibility_terms    = wc_get_product_visibility_term_ids();
+
+		if ( empty( $parsed_filter_rating_values ) || empty( $product_visibility_terms ) ) {
+			return array();
+		}
+
+		$rating_terms = array_map(
+			function ( $rating ) use ( $product_visibility_terms ) {
+				return $product_visibility_terms[ 'rated-' . $rating ];
+			},
+			$parsed_filter_rating_values
+		);
+
 		return array(
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query' => array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery
+			'tax_query' => array(
 				array(
-					'relation' => 'AND',
-					$max_price_query,
-					$min_price_query,
+					'field'         => 'term_taxonomy_id',
+					'taxonomy'      => 'product_visibility',
+					'terms'         => $rating_terms,
+					'operator'      => 'IN',
+					'rating_filter' => true,
 				),
 			),
 		);
 	}
 
 	/**
-	 * Return a query that filters products by attributes.
+	 * Return an attribute taxonomy query when the lookup table is disabled.
 	 *
 	 * @return array
 	 */
 	private function get_filter_by_attributes_query() {
+		if ( 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' ) ) {
+			return array();
+		}
+
 		$attributes_filter_query_args = $this->get_filter_by_attributes_query_vars();
 
 		$queries = array_reduce(
@@ -548,21 +569,9 @@ class QueryBuilder {
 	}
 
 	/**
-	 * Get all the query args related to the filter by attributes block.
+	 * Get the query variables for all registered product attributes.
 	 *
 	 * @return array
-	 * [color] => Array
-	 *   (
-	 *        [filter] => filter_color
-	 *        [query_type] => query_type_color
-	 *    )
-	 *
-	 * [size] => Array
-	 *    (
-	 *        [filter] => filter_size
-	 *        [query_type] => query_type_size
-	 *    )
-	 * )
 	 */
 	private function get_filter_by_attributes_query_vars() {
 		if ( ! empty( $this->attributes_filter_query_args ) ) {
@@ -582,141 +591,6 @@ class QueryBuilder {
 		);
 
 		return $this->attributes_filter_query_args;
-	}
-
-	/**
-	 * Return a query that filters products by stock status.
-	 *
-	 * @return array
-	 */
-	private function get_filter_by_stock_status_query() {
-		$filter_stock_status_values = get_query_var( StockFilter::STOCK_STATUS_QUERY_VAR );
-
-		if ( empty( $filter_stock_status_values ) ) {
-			return array();
-		}
-
-		$filtered_stock_status_values = array_filter(
-			explode( ',', $filter_stock_status_values ),
-			function ( $stock_status ) {
-				return in_array( $stock_status, StockFilter::get_stock_status_query_var_values(), true );
-			}
-		);
-
-		if ( empty( $filtered_stock_status_values ) ) {
-			return array();
-		}
-
-		return array(
-			// Ignoring the warning of not using meta queries.
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query' => array(
-				array(
-					'key'      => '_stock_status',
-					'value'    => $filtered_stock_status_values,
-					'operator' => 'IN',
-				),
-			),
-		);
-	}
-
-	/**
-	 * Return a query that filters products by rating.
-	 *
-	 * @return array
-	 */
-	private function get_filter_by_rating_query() {
-		$filter_rating_values = get_query_var( RatingFilter::RATING_QUERY_VAR );
-		if ( empty( $filter_rating_values ) ) {
-			return array();
-		}
-
-		$parsed_filter_rating_values = explode( ',', $filter_rating_values );
-		$product_visibility_terms    = wc_get_product_visibility_term_ids();
-
-		if ( empty( $parsed_filter_rating_values ) || empty( $product_visibility_terms ) ) {
-			return array();
-		}
-
-		$rating_terms = array_map(
-			function ( $rating ) use ( $product_visibility_terms ) {
-				return $product_visibility_terms[ 'rated-' . $rating ];
-			},
-			$parsed_filter_rating_values
-		);
-
-		return array(
-			// phpcs:ignore WordPress.DB.SlowDBQuery
-			'tax_query' => array(
-				array(
-					'field'         => 'term_taxonomy_id',
-					'taxonomy'      => 'product_visibility',
-					'terms'         => $rating_terms,
-					'operator'      => 'IN',
-					'rating_filter' => true,
-				),
-			),
-		);
-	}
-
-	/**
-	 * Return a query that filters products by taxonomy terms.
-	 *
-	 * @since 10.6.0
-	 *
-	 * @return array
-	 */
-	private function get_filter_by_taxonomy_query() {
-
-		$container       = wc_get_container();
-		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
-		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
-
-		if ( empty( $taxonomy_params ) ) {
-			return array();
-		}
-
-		$tax_queries = array();
-
-		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
-			$param_value = get_query_var( $param_key );
-
-			// Adding is_string check to avoid invalid query parameters for the taxonomy.
-			if ( ! is_string( $param_value ) || empty( $param_value ) ) {
-				continue;
-			}
-
-			// Define $term_values by exploding the string.
-			$term_values = explode( ',', $param_value );
-
-			// Sanitize and filter (removes empty strings).
-			$term_slugs = array_values( array_filter( array_map( 'sanitize_title', $term_values ) ) );
-
-			if ( empty( $term_slugs ) ) {
-				continue;
-			}
-
-			$tax_queries[] = array(
-				'taxonomy' => $taxonomy_slug,
-				'field'    => 'slug',
-				'terms'    => $term_slugs,
-				'operator' => 'IN',
-			);
-		}
-
-		if ( empty( $tax_queries ) ) {
-			return array();
-		}
-
-		return array(
-			// phpcs:ignore WordPress.DB.SlowDBQuery
-			'tax_query' => array(
-				array(
-					'relation' => 'AND',
-					...$tax_queries,
-				),
-			),
-		);
 	}
 
 	/**
@@ -791,12 +665,71 @@ class QueryBuilder {
 	 */
 	private function get_queries_by_applied_filters() {
 		return array(
-			'price_filter'        => $this->get_filter_by_price_query(),
-			'attributes_filter'   => $this->get_filter_by_attributes_query(),
-			'stock_status_filter' => $this->get_filter_by_stock_status_query(),
-			'rating_filter'       => $this->get_filter_by_rating_query(),
-			'taxonomy_filter'     => $this->get_filter_by_taxonomy_query(),
+			'attributes_filter' => $this->get_filter_by_attributes_query(),
+			'rating_filter'     => $this->get_filter_by_rating_query(),
 		);
+	}
+
+	/**
+	 * Get the active Product Filter URL query variables.
+	 *
+	 * @return array
+	 */
+	private function get_applied_filter_query_vars(): array {
+		$params                          = wc_get_container()->get( Params::class );
+		$filter_query_vars               = array();
+		$registered_attribute_params     = $params->get_param( 'attribute' );
+		$registered_query_type_params    = array_map(
+			function ( $attribute_name ) {
+				return AttributeFilter::QUERY_TYPE_QUERY_VAR_PREFIX . $attribute_name;
+			},
+			array_keys( $registered_attribute_params )
+		);
+		$registered_attribute_param_keys = array_merge( array_values( $registered_attribute_params ), $registered_query_type_params );
+		$use_attribute_lookup            = 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' );
+
+		foreach ( $params->get_param_keys() as $param_key ) {
+			if ( in_array( $param_key, $registered_attribute_param_keys, true ) ) {
+				continue;
+			}
+
+			$value = get_query_var( $param_key );
+
+			if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+				continue;
+			}
+
+			$value = (string) $value;
+			if ( '' !== $value ) {
+				$filter_query_vars[ $param_key ] = $value;
+			}
+		}
+
+		if ( $use_attribute_lookup ) {
+			foreach ( $this->get_filter_by_attributes_query_vars() as $query_args ) {
+				$filter_param     = $query_args['filter'];
+				$filter_value     = get_query_var( $filter_param );
+				$query_type_value = get_query_var( $query_args['query_type'] );
+
+				if ( ! is_string( $filter_value ) && ! is_numeric( $filter_value ) ) {
+					continue;
+				}
+
+				$filter_value = (string) $filter_value;
+				if ( '' === $filter_value ) {
+					continue;
+				}
+
+				$attribute_name                         = str_replace( AttributeFilter::FILTER_QUERY_VAR_PREFIX, '', $filter_param );
+				$query_type_param                       = AttributeFilter::QUERY_TYPE_QUERY_VAR_PREFIX . $attribute_name;
+				$filter_query_vars[ $filter_param ]     = $filter_value;
+				$filter_query_vars[ $query_type_param ] = is_string( $query_type_value ) && '' !== $query_type_value
+					? $query_type_value
+					: 'or';
+			}
+		}
+
+		return $filter_query_vars;
 	}
 
 	/**
@@ -927,6 +860,21 @@ class QueryBuilder {
 		}
 
 		return $clauses;
+	}
+
+	/**
+	 * Apply Product Filter clauses to Product Collection queries.
+	 *
+	 * @param array    $clauses The query clauses.
+	 * @param WP_Query $query   The WP_Query instance.
+	 * @return array
+	 */
+	private function apply_product_filter_query_clauses( $clauses, $query ) {
+		if ( ! ( $query->query_vars['isProductCollection'] ?? false ) ) {
+			return $clauses;
+		}
+
+		return wc_get_container()->get( QueryClauses::class )->add_query_clauses( $clauses, $query );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -514,27 +514,27 @@ class QueryBuilder {
 	}
 
 	/**
-	 * Return an attribute taxonomy query when the lookup table is disabled.
+	 * Return attribute taxonomy queries that need the legacy filtering path.
 	 *
 	 * @return array
 	 */
 	private function get_filter_by_attributes_query() {
-		if ( 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' ) ) {
-			return array();
-		}
-
 		$attributes_filter_query_args = $this->get_filter_by_attributes_query_vars();
+		$use_attribute_lookup         = 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' );
 
 		$queries = array_reduce(
 			$attributes_filter_query_args,
-			function ( $acc, $query_args ) {
+			function ( $acc, $query_args ) use ( $use_attribute_lookup ) {
 				$attribute_name       = $query_args['filter'];
 				$attribute_query_type = $query_args['query_type'];
 
 				$attribute_value = get_query_var( $attribute_name );
 				$attribute_query = get_query_var( $attribute_query_type );
 
-				if ( empty( $attribute_value ) ) {
+				$is_canonical_filter = 0 === strpos( $attribute_name, AttributeFilter::FILTER_QUERY_VAR_PREFIX );
+				$is_and_filter       = 'and' === $attribute_query;
+
+				if ( empty( $attribute_value ) || ( $use_attribute_lookup && $is_canonical_filter && ! $is_and_filter ) ) {
 					return $acc;
 				}
 
@@ -720,10 +720,14 @@ class QueryBuilder {
 					continue;
 				}
 
+				if ( 0 !== strpos( $filter_param, AttributeFilter::FILTER_QUERY_VAR_PREFIX ) || 'and' === $query_type_value ) {
+					continue;
+				}
+
 				$attribute_name                         = str_replace( AttributeFilter::FILTER_QUERY_VAR_PREFIX, '', $filter_param );
 				$query_type_param                       = AttributeFilter::QUERY_TYPE_QUERY_VAR_PREFIX . $attribute_name;
 				$filter_query_vars[ $filter_param ]     = $filter_value;
-				$filter_query_vars[ $query_type_param ] = is_string( $query_type_value ) && '' !== $query_type_value
+				$filter_query_vars[ $query_type_param ] = is_string( $query_type_value ) && in_array( $query_type_value, array( 'and', 'or' ), true )
 					? $query_type_value
 					: 'or';
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -532,9 +532,9 @@ class QueryBuilder {
 				$attribute_query = get_query_var( $attribute_query_type );
 
 				$is_canonical_filter = 0 === strpos( $attribute_name, AttributeFilter::FILTER_QUERY_VAR_PREFIX );
-				$is_and_filter       = 'and' === $attribute_query;
+				$is_multi_term_and   = 'and' === $attribute_query && count( array_filter( explode( ',', (string) $attribute_value ) ) ) > 1;
 
-				if ( empty( $attribute_value ) || ( $use_attribute_lookup && $is_canonical_filter && ! $is_and_filter ) ) {
+				if ( empty( $attribute_value ) || ( $use_attribute_lookup && $is_canonical_filter && ! $is_multi_term_and ) ) {
 					return $acc;
 				}
 
@@ -720,7 +720,9 @@ class QueryBuilder {
 					continue;
 				}
 
-				if ( 0 !== strpos( $filter_param, AttributeFilter::FILTER_QUERY_VAR_PREFIX ) || 'and' === $query_type_value ) {
+				$is_multi_term_and = 'and' === $query_type_value && count( array_filter( explode( ',', $filter_value ) ) ) > 1;
+
+				if ( 0 !== strpos( $filter_param, AttributeFilter::FILTER_QUERY_VAR_PREFIX ) || $is_multi_term_and ) {
 					continue;
 				}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -167,7 +167,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		$args['join']     = $this->append_product_sorting_table_join( $args['join'] );
 
 		if ( isset( $price_range['min_price'] ) ) {
-			$min_price_filter = intval( $price_range['min_price'] );
+			$min_price_filter = (float) wc_format_decimal( $price_range['min_price'] );
 
 			if ( $adjust_for_taxes ) {
 				$args['where'] .= $this->get_price_filter_query_for_displayed_taxes( $min_price_filter, 'max_price', '>=' );
@@ -177,7 +177,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		}
 
 		if ( isset( $price_range['max_price'] ) ) {
-			$max_price_filter = intval( $price_range['max_price'] );
+			$max_price_filter = (float) wc_format_decimal( $price_range['max_price'] );
 
 			if ( $adjust_for_taxes ) {
 				$args['where'] .= $this->get_price_filter_query_for_displayed_taxes( $max_price_filter, 'min_price', '<=' );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\ProductCollection;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection\Utils as ProductCollectionUtils;
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Tests\Blocks\BlockTypes\ProductCollection\Utils;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\ProductCollectionMock;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use WC_Helper_Product;
@@ -25,11 +27,51 @@ class QueryBuilder extends \WP_UnitTestCase {
 	private $block_instance;
 
 	/**
+	 * Color attribute fixture.
+	 *
+	 * @var array
+	 */
+	private $color_attribute;
+
+	/**
+	 * Original attribute lookup setting.
+	 *
+	 * @var mixed
+	 */
+	private $attribute_lookup_enabled;
+
+	/**
 	 * Initiate the mock object.
 	 */
-	protected function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
-		$this->block_instance = new ProductCollectionMock();
+
+		$this->attribute_lookup_enabled = get_option( 'woocommerce_attribute_lookup_enabled', null );
+		$this->color_attribute          = FixtureData::get_product_attribute( 'color', array( 'red', 'yellow', 'black' ) );
+		$this->block_instance           = new ProductCollectionMock();
+
+		update_option( 'woocommerce_attribute_lookup_enabled', 'yes' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		foreach ( array( 'min_price', 'max_price', 'filter_stock_status', 'filter_color', 'query_type_color', 'categories', 'tags', 'brands' ) as $query_var ) {
+			set_query_var( $query_var, '' );
+		}
+
+		$wpdb->delete( $wpdb->prefix . 'wc_product_attributes_lookup', array( 'taxonomy' => 'pa_color' ), array( '%s' ) );
+
+		if ( null === $this->attribute_lookup_enabled ) {
+			delete_option( 'woocommerce_attribute_lookup_enabled' );
+		} else {
+			update_option( 'woocommerce_attribute_lookup_enabled', $this->attribute_lookup_enabled );
+		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -254,19 +296,8 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertContainsEquals(
-			array(
-				array(
-					'key'     => '_price',
-					'value'   => 100,
-					'compare' => '<=',
-					'type'    => 'numeric',
-				),
-				array(),
-				'relation' => 'AND',
-			),
-			$merged_query['meta_query']
-		);
+		$this->assertSame( '100', $merged_query['max_price'] );
+		$this->assertEmpty( $merged_query['meta_query'] );
 		set_query_var( 'max_price', '' );
 	}
 
@@ -278,19 +309,8 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertContainsEquals(
-			array(
-				array(),
-				array(
-					'key'     => '_price',
-					'value'   => 20,
-					'compare' => '>=',
-					'type'    => 'numeric',
-				),
-				'relation' => 'AND',
-			),
-			$merged_query['meta_query']
-		);
+		$this->assertSame( '20', $merged_query['min_price'] );
+		$this->assertEmpty( $merged_query['meta_query'] );
 		set_query_var( 'min_price', '' );
 	}
 
@@ -303,24 +323,9 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertContainsEquals(
-			array(
-				array(
-					'key'     => '_price',
-					'value'   => 100,
-					'compare' => '<=',
-					'type'    => 'numeric',
-				),
-				array(
-					'key'     => '_price',
-					'value'   => 20,
-					'compare' => '>=',
-					'type'    => 'numeric',
-				),
-				'relation' => 'AND',
-			),
-			$merged_query['meta_query']
-		);
+		$this->assertSame( '100', $merged_query['max_price'] );
+		$this->assertSame( '20', $merged_query['min_price'] );
+		$this->assertEmpty( $merged_query['meta_query'] );
 
 		set_query_var( 'max_price', '' );
 		set_query_var( 'min_price', '' );
@@ -334,14 +339,8 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertContainsEquals(
-			array(
-				'operator' => 'IN',
-				'key'      => '_stock_status',
-				'value'    => array( ProductStockStatus::IN_STOCK ),
-			),
-			$merged_query['meta_query']
-		);
+		$this->assertSame( ProductStockStatus::IN_STOCK, $merged_query['filter_stock_status'] );
+		$this->assertEmpty( $merged_query['meta_query'] );
 
 		set_query_var( 'filter_stock_status', '' );
 	}
@@ -395,72 +394,154 @@ class QueryBuilder extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test merging filter by stock status queries.
+	 * @testdox Should pass custom attribute filter mappings to QueryClauses.
 	 */
 	public function test_merging_filter_by_attribute_queries() {
-		// Mock the attribute data.
 		$this->block_instance->set_attributes_filter_query_args(
 			array(
-				array(
+				'color' => array(
 					'filter'     => 'filter_color',
-					'query_type' => 'query_type_color',
-				),
-				array(
-					'filter'     => 'filter_size',
-					'query_type' => 'query_type_size',
+					'query_type' => 'custom_query_type_color',
 				),
 			)
 		);
 
-		set_query_var( 'filter_color', 'blue' );
-		set_query_var( 'query_type_color', 'or' );
-		set_query_var( 'filter_size', 'xl,xxl' );
-		set_query_var( 'query_type_size', 'and' );
+		set_query_var( 'filter_color', 'red-slug,black-slug' );
+		set_query_var( 'custom_query_type_color', 'and' );
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
-		$tax_queries  = $merged_query['tax_query'];
 
-		$and_query = array();
-		foreach ( $tax_queries as $tax_query ) {
-			if ( isset( $tax_query['relation'] ) && 'AND' === $tax_query['relation'] ) {
-				$and_query = $tax_query;
-			}
-		}
+		$this->assertSame( 'red-slug,black-slug', $merged_query['filter_color'] );
+		$this->assertSame( 'and', $merged_query['query_type_color'] );
+		$this->assertSame( true, $merged_query['isProductCollection'] );
 
-		// Check if the AND query is an array.
-		$this->assertIsArray( $and_query );
+		set_query_var( 'filter_color', '' );
+		set_query_var( 'custom_query_type_color', '' );
+	}
 
-		$attribute_queries = array();
-		foreach ( $and_query as $and_query_item ) {
-			if ( is_array( $and_query_item ) ) {
-				$attribute_queries = $and_query_item;
-			}
-		}
+	/**
+	 * @testdox Should filter variable products by attributes used by real variations in custom collections.
+	 */
+	public function test_attribute_filter_uses_variation_lookup_data_for_custom_collections(): void {
+		$fixture_data   = new FixtureData();
+		$product        = $fixture_data->get_variable_product(
+			array(
+				'name'         => 'Red and black product',
+				'stock_status' => ProductStockStatus::IN_STOCK,
+			),
+			array( $this->color_attribute )
+		);
+		$yellow_product = $fixture_data->get_variable_product(
+			array(
+				'name'         => 'Yellow product',
+				'stock_status' => ProductStockStatus::IN_STOCK,
+			),
+			array( $this->color_attribute )
+		);
 
-		$this->assertContainsEquals(
+		$fixture_data->get_variation_product(
+			$product->get_id(),
+			array( 'pa_color' => 'red-slug' ),
+			array( 'stock_status' => ProductStockStatus::IN_STOCK )
+		);
+		$fixture_data->get_variation_product(
+			$product->get_id(),
+			array( 'pa_color' => 'black-slug' ),
+			array( 'stock_status' => ProductStockStatus::IN_STOCK )
+		);
+		$fixture_data->get_variation_product(
+			$yellow_product->get_id(),
+			array( 'pa_color' => 'yellow-slug' ),
+			array( 'stock_status' => ProductStockStatus::IN_STOCK )
+		);
+
+		\WC_Product_Variable::sync( $product );
+		\WC_Product_Variable::sync( $yellow_product );
+
+		$lookup_data_store = wc_get_container()->get( LookupDataStore::class );
+		$lookup_data_store->create_data_for_product( $product );
+		$lookup_data_store->create_data_for_product( $yellow_product );
+
+		$parsed_block                                 = Utils::get_base_parsed_block();
+		$parsed_block['attrs']['query']['inherit']    = false;
+		$parsed_block['attrs']['query']['filterable'] = true;
+		$parsed_block['attrs']['query']['orderBy']    = 'title';
+		$parsed_block['attrs']['query']['order']      = 'asc';
+
+		set_query_var( 'filter_color', 'yellow-slug' );
+		set_query_var( 'query_type_color', 'or' );
+		$yellow_query_args = Utils::initialize_merged_query( $this->block_instance, $parsed_block );
+		$yellow_query      = new WP_Query( array_merge( $yellow_query_args, array( 'fields' => 'ids' ) ) );
+
+		$this->assertTrue( $yellow_query_args['isProductCollection'], 'Custom Product Collection queries should be marked for shared filtering.' );
+		$this->assertNotContains( $product->get_id(), array_map( 'absint', $yellow_query->posts ), 'A parent-only yellow term must not match.' );
+		$this->assertContains( $yellow_product->get_id(), array_map( 'absint', $yellow_query->posts ), 'A real yellow variation should match.' );
+
+		set_query_var( 'filter_color', 'red-slug' );
+		$red_query = new WP_Query(
+			array_merge(
+				Utils::initialize_merged_query( $this->block_instance, $parsed_block ),
+				array( 'fields' => 'ids' )
+			)
+		);
+
+		$this->assertContains( $product->get_id(), array_map( 'absint', $red_query->posts ), 'A real red variation should match.' );
+
+		set_query_var( 'filter_color', 'red-slug,yellow-slug' );
+		set_query_var( 'query_type_color', '' );
+		$default_or_query_args = Utils::initialize_merged_query( $this->block_instance, $parsed_block );
+		$default_or_query      = new WP_Query( array_merge( $default_or_query_args, array( 'fields' => 'ids' ) ) );
+
+		$this->assertSame( 'or', $default_or_query_args['query_type_color'], 'Missing attribute query types should retain Product Collection OR behavior.' );
+		$this->assertContains( $product->get_id(), array_map( 'absint', $default_or_query->posts ), 'The default OR query should match the red variation.' );
+		$this->assertContains( $yellow_product->get_id(), array_map( 'absint', $default_or_query->posts ), 'The default OR query should match the yellow variation.' );
+	}
+
+	/**
+	 * @testdox Should retain taxonomy filtering when the attribute lookup table is disabled.
+	 */
+	public function test_attribute_filter_falls_back_to_taxonomy_query(): void {
+		update_option( 'woocommerce_attribute_lookup_enabled', 'no' );
+		set_query_var( 'filter_color', 'yellow-slug' );
+
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
+
+		$this->assertArrayNotHasKey( 'filter_color', $merged_query );
+		$this->assertSame(
 			array(
 				'taxonomy' => 'pa_color',
 				'field'    => 'slug',
-				'terms'    => array( 'blue' ),
+				'terms'    => array( 'yellow-slug' ),
 				'operator' => 'IN',
 			),
-			$attribute_queries
+			$this->find_tax_query_by_taxonomy( $merged_query['tax_query'], 'pa_color' )
 		);
+	}
 
-		$this->assertContainsEquals(
-			array(
-				'taxonomy' => 'pa_size',
-				'field'    => 'slug',
-				'terms'    => array( 'xl', 'xxl' ),
-				'operator' => 'AND',
-			),
-			$attribute_queries
-		);
+	/**
+	 * Find a taxonomy clause in a nested tax query.
+	 *
+	 * @param array  $queries  Tax query clauses.
+	 * @param string $taxonomy Taxonomy name.
+	 * @return array
+	 */
+	private function find_tax_query_by_taxonomy( array $queries, string $taxonomy ): array {
+		foreach ( $queries as $query ) {
+			if ( ! is_array( $query ) ) {
+				continue;
+			}
 
-		set_query_var( 'filter_color', '' );
-		set_query_var( 'query_type_color', '' );
-		set_query_var( 'filter_size', '' );
-		set_query_var( 'query_type_size', '' );
+			if ( ( $query['taxonomy'] ?? null ) === $taxonomy ) {
+				return $query;
+			}
+
+			$found_query = $this->find_tax_query_by_taxonomy( $query, $taxonomy );
+			if ( ! empty( $found_query ) ) {
+				return $found_query;
+			}
+		}
+
+		return array();
 	}
 
 	/**
@@ -473,33 +554,10 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertContainsEquals(
-			array(
-				'operator' => 'IN',
-				'key'      => '_stock_status',
-				'value'    => array( ProductStockStatus::IN_STOCK ),
-			),
-			$merged_query['meta_query']
-		);
-
-		$this->assertContainsEquals(
-			array(
-				array(
-					'key'     => '_price',
-					'value'   => 100,
-					'compare' => '<=',
-					'type'    => 'numeric',
-				),
-				array(
-					'key'     => '_price',
-					'value'   => 20,
-					'compare' => '>=',
-					'type'    => 'numeric',
-				),
-				'relation' => 'AND',
-			),
-			$merged_query['meta_query']
-		);
+		$this->assertSame( '100', $merged_query['max_price'] );
+		$this->assertSame( '20', $merged_query['min_price'] );
+		$this->assertSame( ProductStockStatus::IN_STOCK, $merged_query['filter_stock_status'] );
+		$this->assertEmpty( $merged_query['meta_query'] );
 
 		set_query_var( 'max_price', '' );
 		set_query_var( 'min_price', '' );
@@ -1125,175 +1183,57 @@ class QueryBuilder extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test merging filter queries by Category Slug (e.g. ?categories=accessories).
+	 * @testdox Should use shared taxonomy clauses to include products from child categories.
 	 */
-	public function test_merging_filter_by_category_slug() {
-		// Set the URL query variables.
-		set_query_var( 'categories', 'accessories' );
-
-		// Execute the query builder.
-		$merged_query   = Utils::initialize_merged_query( $this->block_instance );
-		$filter_clauses = $this->extract_filter_clauses( $merged_query['tax_query'] );
-
-		// Assertions.
-		$this->assertContainsEquals(
+	public function test_category_filter_includes_products_from_child_categories(): void {
+		$parent_category = wp_insert_term( 'Clothing', 'product_cat', array( 'slug' => 'clothing' ) );
+		$child_category  = wp_insert_term(
+			'T-shirts',
+			'product_cat',
 			array(
-				'taxonomy' => 'product_cat',
-				'field'    => 'slug',
-				'terms'    => array( 'accessories' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should contain correct product_cat tax query using slug.'
+				'parent' => $parent_category['term_id'],
+				'slug'   => 't-shirts',
+			)
+		);
+		$product         = ( new FixtureData() )->get_simple_product(
+			array(
+				'name'         => 'Child category product',
+				'category_ids' => array( $child_category['term_id'] ),
+			)
 		);
 
-		// Clean up.
-		set_query_var( 'categories', '' );
+		set_query_var( 'categories', 'clothing' );
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
+		$query        = new WP_Query( array_merge( $merged_query, array( 'fields' => 'ids' ) ) );
+
+		$this->assertTrue( $merged_query['isProductCollection'], 'Default Product Collection queries should be marked for shared filtering.' );
+		$this->assertContains( $product->get_id(), array_map( 'absint', $query->posts ), 'A parent category filter should include products assigned to child categories.' );
 	}
 
 	/**
-	 * Test merging filter queries specifically for Tags.
-	 * Scenario: ?tags=tag-new (Slug)
-	 */
-	public function test_merging_filter_by_tags() {
-		// Set the URL query variables.
-		set_query_var( 'tags', 'tag-new' );
-
-		// Execute the query builder.
-		$merged_query   = Utils::initialize_merged_query( $this->block_instance );
-		$filter_clauses = $this->extract_filter_clauses( $merged_query['tax_query'] );
-
-		// Assertions.
-		$this->assertContainsEquals(
-			array(
-				'taxonomy' => 'product_tag',
-				'field'    => 'slug',
-				'terms'    => array( 'tag-new' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should contain correct product_tag tax query with IN operator.'
-		);
-
-		// Clean up.
-		set_query_var( 'tags', '' );
-	}
-
-	/**
-	 * Test merging filter queries for Categories, Tags, and Brands simultaneously.
-	 * Scenario: ?categories=accessories&tags=tag-new&brands=nike
+	 * @testdox Should pass all taxonomy filter variables to QueryClauses.
 	 */
 	public function test_merging_filter_by_all_taxonomies_together() {
-		// Set the URL query variables.
 		set_query_var( 'categories', 'accessories' );
 		set_query_var( 'tags', 'tag-new' );
 		set_query_var( 'brands', 'nike' );
 
-		// Execute the query builder.
-		$merged_query   = Utils::initialize_merged_query( $this->block_instance );
-		$filter_clauses = $this->extract_filter_clauses( $merged_query['tax_query'] );
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		// Assertions.
-		// Verify Category.
-		$this->assertContainsEquals(
-			array(
-				'taxonomy' => 'product_cat',
-				'field'    => 'slug',
-				'terms'    => array( 'accessories' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should contain correct product_cat tax query.'
-		);
-
-		// Verify Tag.
-		$this->assertContainsEquals(
-			array(
-				'taxonomy' => 'product_tag',
-				'field'    => 'slug',
-				'terms'    => array( 'tag-new' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should contain correct product_tag tax query.'
-		);
-
-		// Verify Brand.
-		$this->assertContainsEquals(
-			array(
-				'taxonomy' => 'product_brand',
-				'field'    => 'slug',
-				'terms'    => array( 'nike' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should contain correct product_brand tax query.'
-		);
-
-		// Clean up global state.
-		set_query_var( 'categories', '' );
-		set_query_var( 'tags', '' );
-		set_query_var( 'brands', '' );
+		$this->assertSame( 'accessories', $merged_query['categories'] );
+		$this->assertSame( 'tag-new', $merged_query['tags'] );
+		$this->assertSame( 'nike', $merged_query['brands'] );
 	}
 
 	/**
-	 * Test that the strictly string-based filter logic works and SAFELY ignores arrays.
-	 * Matches logic: if ( ! is_string($param_value) ) continue;
+	 * @testdox Should ignore non-scalar Product Filter query variables.
 	 */
 	public function test_filter_strict_string_handling() {
-		// Scenario: Array Input (Should be IGNORED).
-		// ?categories[]=hats.
 		set_query_var( 'categories', array( 'hats' ) );
 
-		// Execute.
-		$merged_query   = Utils::initialize_merged_query( $this->block_instance );
-		$tax_queries    = $merged_query['tax_query'] ?? array();
-		$filter_clauses = $this->extract_filter_clauses( $tax_queries );
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		// Assertion: The array input should have been ignored.
-		$this->assertNotContainsEquals(
-			array(
-				'taxonomy' => 'product_cat',
-				'field'    => 'slug',
-				'terms'    => array( 'hats' ),
-				'operator' => 'IN',
-			),
-			$filter_clauses,
-			'Should not contain product_cat tax query because array input should be ignored.'
-		);
-
-		// Clean up.
-		set_query_var( 'categories', '' );
-	}
-
-	/**
-	 * Helper to extract filter clauses from the tax_query array.
-	 *
-	 * @param array $tax_queries The tax_query array from the merged query.
-	 * @return array The extracted filter clauses.
-	 */
-	private function extract_filter_clauses( array $tax_queries ) {
-
-		$and_query = array();
-
-		// Find the 'AND' relation group where filters are stored.
-		foreach ( $tax_queries as $tax_query ) {
-			if ( isset( $tax_query['relation'] ) && 'AND' === $tax_query['relation'] ) {
-				$and_query = $tax_query;
-				break;
-			}
-		}
-
-		$clauses = array();
-		if ( ! empty( $and_query ) ) {
-			foreach ( $and_query as $item ) {
-				if ( is_array( $item ) ) {
-					$clauses[] = $item;
-				}
-			}
-		}
-
-		return $clauses;
+		$this->assertArrayNotHasKey( 'categories', $merged_query );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -59,7 +59,21 @@ class QueryBuilder extends \WP_UnitTestCase {
 	public function tearDown(): void {
 		global $wpdb;
 
-		foreach ( array( 'min_price', 'max_price', 'filter_stock_status', 'filter_color', 'query_type_color', 'categories', 'tags', 'brands' ) as $query_var ) {
+		$query_vars = array(
+			'min_price',
+			'max_price',
+			'filter_stock_status',
+			'filter_color',
+			'query_type_color',
+			'custom_query_type_color',
+			'pa_color',
+			'custom_color_mode',
+			'categories',
+			'tags',
+			'brands',
+		);
+
+		foreach ( $query_vars as $query_var ) {
 			set_query_var( $query_var, '' );
 		}
 
@@ -394,9 +408,9 @@ class QueryBuilder extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @testdox Should pass custom attribute filter mappings to QueryClauses.
+	 * @testdox Should retain legacy attribute filtering for AND queries.
 	 */
-	public function test_merging_filter_by_attribute_queries() {
+	public function test_attribute_and_filter_uses_taxonomy_query(): void {
 		$this->block_instance->set_attributes_filter_query_args(
 			array(
 				'color' => array(
@@ -411,12 +425,69 @@ class QueryBuilder extends \WP_UnitTestCase {
 
 		$merged_query = Utils::initialize_merged_query( $this->block_instance );
 
-		$this->assertSame( 'red-slug,black-slug', $merged_query['filter_color'] );
-		$this->assertSame( 'and', $merged_query['query_type_color'] );
+		$this->assertArrayNotHasKey( 'filter_color', $merged_query );
+		$this->assertSame(
+			array(
+				'taxonomy' => 'pa_color',
+				'field'    => 'slug',
+				'terms'    => array( 'red-slug', 'black-slug' ),
+				'operator' => 'AND',
+			),
+			$this->find_tax_query_by_taxonomy( $merged_query['tax_query'], 'pa_color' )
+		);
 		$this->assertSame( true, $merged_query['isProductCollection'] );
+	}
 
-		set_query_var( 'filter_color', '' );
-		set_query_var( 'custom_query_type_color', '' );
+	/**
+	 * @testdox Should map custom attribute query-type variables to shared clauses.
+	 */
+	public function test_custom_attribute_query_type_mapping_uses_shared_clauses(): void {
+		$this->block_instance->set_attributes_filter_query_args(
+			array(
+				'color' => array(
+					'filter'     => 'filter_color',
+					'query_type' => 'custom_query_type_color',
+				),
+			)
+		);
+
+		set_query_var( 'filter_color', 'red-slug,black-slug' );
+		set_query_var( 'custom_query_type_color', 'or' );
+
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
+
+		$this->assertSame( 'red-slug,black-slug', $merged_query['filter_color'] );
+		$this->assertSame( 'or', $merged_query['query_type_color'] );
+	}
+
+	/**
+	 * @testdox Should preserve noncanonical public attribute filter mappings.
+	 */
+	public function test_noncanonical_attribute_mapping_uses_taxonomy_query(): void {
+		$this->block_instance->set_attributes_filter_query_args(
+			array(
+				'color' => array(
+					'filter'     => 'pa_color',
+					'query_type' => 'custom_color_mode',
+				),
+			)
+		);
+
+		set_query_var( 'pa_color', 'red-slug' );
+		set_query_var( 'custom_color_mode', 'or' );
+
+		$merged_query = Utils::initialize_merged_query( $this->block_instance );
+
+		$this->assertArrayNotHasKey( 'filter_color', $merged_query );
+		$this->assertSame(
+			array(
+				'taxonomy' => 'pa_color',
+				'field'    => 'slug',
+				'terms'    => array( 'red-slug' ),
+				'operator' => 'IN',
+			),
+			$this->find_tax_query_by_taxonomy( $merged_query['tax_query'], 'pa_color' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -540,11 +540,13 @@ class QueryBuilder extends \WP_UnitTestCase {
 		$parsed_block['attrs']['query']['order']      = 'asc';
 
 		set_query_var( 'filter_color', 'yellow-slug' );
-		set_query_var( 'query_type_color', 'or' );
+		set_query_var( 'query_type_color', 'and' );
 		$yellow_query_args = Utils::initialize_merged_query( $this->block_instance, $parsed_block );
 		$yellow_query      = new WP_Query( array_merge( $yellow_query_args, array( 'fields' => 'ids' ) ) );
 
 		$this->assertTrue( $yellow_query_args['isProductCollection'], 'Custom Product Collection queries should be marked for shared filtering.' );
+		$this->assertSame( 'yellow-slug', $yellow_query_args['filter_color'], 'Single-term AND filters should use shared filtering.' );
+		$this->assertSame( 'and', $yellow_query_args['query_type_color'], 'Single-term AND query types should be forwarded.' );
 		$this->assertNotContains( $product->get_id(), array_map( 'absint', $yellow_query->posts ), 'A parent-only yellow term must not match.' );
 		$this->assertContains( $yellow_product->get_id(), array_map( 'absint', $yellow_query->posts ), 'A real yellow variation should match.' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
@@ -37,6 +37,7 @@ class QueryClausesTest extends AbstractProductFiltersTest {
 	 * @testdox Test the product query with post clauses containing price clauses.
 	 *
 	 * @testWith [{"min_price": 20}]
+	 *           [{"min_price": 20.5}]
 	 *           [{"max_price": 50}]
 	 *           [{"min_price": 20,"max_price": 50}]
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Product Collections used filter queries. This migrates applicable filters to the shared `QueryClauses` implementation while preserving rating filtering and custom attribute mappings.

As a side effect, this allowed parent-level attributes to match when no real variation used them, e.g.

- parent: red, blue
    - variation: red

Before: filter blue would show the product
After: fil blue does not show the product

Backward compatibility: no public signatures or hooks change; `set_attributes_filter_query_args()` remains honored.

Closes #63056. Fixes the variation behavior reported in #53550.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Preconditions

1. Go to **WooCommerce > Settings > Products > Advanced** and enable **Use the product attributes lookup table for catalog filtering**. This is needed to verify attribute filters.
2. If needed, regenerate the table under **WooCommerce > Status > Tools**.
3. Create a post or page and add a **Product Collection** and click "create your own"
4. Inside the Product Collection, add **Product Filters**

#### Regression testing

Play around with the tests and verify they are applied correctly.

1. Price
2. Rating
3. Attribute
4. Taxonomy
5. Stock status

#### Bug-fix test

1. Create a global **Color** attribute with **Red** and **Blue** terms.
2. Create these products:
   - **Blue variation**: variable product, parent attribute values **Red** and **Blue**, but create only one **Blue** variation. 
   - **Red variation**: variable product with one **Red** variation.
   - **Simple control**: simple product
3. Select **Red** in the Color filter.
   - Confirm **Red variation** remains.
   - Confirm **Blue variation** is excluded even though its parent declares Red, because it has no purchasable Red variation.
6. Clear the filter, select **Blue**, and confirm only **Blue variation** remains.

> [!IMPORTANT]
> The displayed attribute counts may be incorrect but they use a separate counting path and are outside this PR's scope; validate the products returned by the collection.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit: 34 tests, 114 assertions.
- PHP lint, branch lint, and PHPStan pass.
- Local browser test: Red, Blue, and Clear filters passed with no console errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>