### PR TITLE
Fix boolean and visibility canonicalization in Settings UI schemas

### DIFF
--- a/plugins/woocommerce/changelog/fix-66934-settings-ui-boolean-canonicalization
+++ b/plugins/woocommerce/changelog/fix-66934-settings-ui-boolean-canonicalization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Convert boolean Settings UI schema values the way the client does and canonicalize visibility values alongside their controller field.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/RegisteredSettingsSectionAdapter.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/RegisteredSettingsSectionAdapter.php
@@ -47,7 +47,7 @@ class RegisteredSettingsSectionAdapter extends LegacySettingsPageAdapter {
 	 * @param string $section Unused. This adapter wraps a single registered section.
 	 * @return array
 	 *
-	 * @since 11.1.0
+	 * @since 11.0.0
 	 */
 	public function get_schema( string $section ): array {
 		$schema = parent::get_schema( $section );

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -273,7 +273,7 @@ class SettingsUIRequestContext {
 	 * settings tabs. Pages registered at the top level of settings are not
 	 * drill-downs: they hide the header and keep the tabs.
 	 *
-	 * @since 11.1.0
+	 * @since 11.0.0
 	 *
 	 * @return bool
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -148,7 +148,7 @@ class SettingsUISchema {
 	 * them are cast here to the string the client's own String() coercion
 	 * produces. Malformed entries remain unchanged for the provider to fix.
 	 *
-	 * @since 11.1.0
+	 * @since 11.0.0
 	 *
 	 * @param array $schema Settings UI schema.
 	 * @return array Schema with scalar option values canonicalized to strings.
@@ -258,7 +258,7 @@ class SettingsUISchema {
 					esc_html__( 'A Settings UI schema provider supplied non-string option, field, or visibility values that WooCommerce converted for compatibility: %s. Update the provider to supply string values.', 'woocommerce' ),
 					esc_html( implode( ', ', array_unique( $converted_fields ) ) )
 				),
-				'11.1.0'
+				'11.0.0'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -221,15 +221,11 @@ class SettingsUISchema {
 			}
 
 			foreach ( $group['fields'] as &$field ) {
-				if (
-					! is_array( $field ) ||
-					! isset( $field['id'], $field['visibility'] ) ||
-					! is_string( $field['id'] ) ||
-					! is_array( $field['visibility'] ) ||
-					! isset( $field['visibility']['controller'] ) ||
-					! in_array( $field['visibility']['controller'], $option_field_ids, true ) ||
-					! array_key_exists( 'value', $field['visibility'] )
-				) {
+				if ( ! is_array( $field ) || ! isset( $field['id'] ) || ! is_string( $field['id'] ) ) {
+					continue;
+				}
+
+				if ( ! self::is_canonicalizable_visibility_rule( $field['visibility'] ?? null, $option_field_ids ) ) {
 					continue;
 				}
 
@@ -289,6 +285,19 @@ class SettingsUISchema {
 		}
 
 		return $needs_conversion ? array_map( array( __CLASS__, 'to_canonical_string' ), $values ) : null;
+	}
+
+	/**
+	 * Whether a visibility rule carries a value compared against an options field.
+	 *
+	 * @param mixed $rule Candidate visibility rule.
+	 * @param array $option_field_ids Ids of fields carrying an options array.
+	 * @return bool
+	 */
+	private static function is_canonicalizable_visibility_rule( $rule, array $option_field_ids ): bool {
+		return is_array( $rule )
+			&& array_key_exists( 'value', $rule )
+			&& in_array( $rule['controller'] ?? null, $option_field_ids, true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -296,6 +296,8 @@ class SettingsUISchema {
 	 * canonicalizing a value never changes which option or visibility rule it
 	 * matches. PHP casts diverge from String() for booleans: (string) true is
 	 * '1' and (string) false is '', while String() gives 'true' and 'false'.
+	 * Floats convert through wc_float_to_string() because a plain cast is
+	 * locale-sensitive before PHP 8.0 and String() never emits a comma.
 	 *
 	 * @param bool|int|float|string $value Scalar value.
 	 * @return string
@@ -303,6 +305,10 @@ class SettingsUISchema {
 	private static function to_canonical_string( $value ): string {
 		if ( is_bool( $value ) ) {
 			return $value ? 'true' : 'false';
+		}
+
+		if ( is_float( $value ) ) {
+			return wc_float_to_string( $value );
 		}
 
 		return (string) $value;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -144,8 +144,9 @@ class SettingsUISchema {
 	 * Schemas built from legacy settings always carry string option values, but
 	 * native providers can supply any scalar. The client matches options against
 	 * the stored value with strict string comparison, so scalar option values
-	 * and the selected values they match are cast to strings here. Malformed
-	 * entries remain unchanged for the provider to fix.
+	 * and the selected values they match are cast here to the string the
+	 * client's own String() coercion produces. Malformed entries remain
+	 * unchanged for the provider to fix.
 	 *
 	 * @since 11.1.0
 	 *
@@ -186,14 +187,14 @@ class SettingsUISchema {
 						continue;
 					}
 
-					$option['value'] = (string) $option['value'];
+					$option['value'] = self::to_canonical_string( $option['value'] );
 					$converted       = true;
 				}
 				unset( $option );
 
 				if ( array_key_exists( 'value', $field ) ) {
 					if ( is_scalar( $field['value'] ) && ! is_string( $field['value'] ) ) {
-						$field['value'] = (string) $field['value'];
+						$field['value'] = self::to_canonical_string( $field['value'] );
 						$converted      = true;
 					} elseif ( is_array( $field['value'] ) ) {
 						$canonical_list = self::canonicalize_scalar_list( $field['value'] );
@@ -250,7 +251,24 @@ class SettingsUISchema {
 			}
 		}
 
-		return $needs_conversion ? array_map( 'strval', $values ) : null;
+		return $needs_conversion ? array_map( array( __CLASS__, 'to_canonical_string' ), $values ) : null;
+	}
+
+	/**
+	 * Cast a scalar to the string the client's String() coercion produces, so
+	 * canonicalizing a value never changes which option or visibility rule it
+	 * matches. PHP casts diverge from String() for booleans: (string) true is
+	 * '1' and (string) false is '', while String() gives 'true' and 'false'.
+	 *
+	 * @param bool|int|float|string $value Scalar value.
+	 * @return string
+	 */
+	private static function to_canonical_string( $value ): string {
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+
+		return (string) $value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -143,10 +143,10 @@ class SettingsUISchema {
 	 *
 	 * Schemas built from legacy settings always carry string option values, but
 	 * native providers can supply any scalar. The client matches options against
-	 * the stored value with strict string comparison, so scalar option values
-	 * and the selected values they match are cast here to the string the
-	 * client's own String() coercion produces. Malformed entries remain
-	 * unchanged for the provider to fix.
+	 * the stored value with strict string comparison, so scalar option values,
+	 * the selected values they match, and visibility values compared against
+	 * them are cast here to the string the client's own String() coercion
+	 * produces. Malformed entries remain unchanged for the provider to fix.
 	 *
 	 * @since 11.1.0
 	 *
@@ -159,6 +159,7 @@ class SettingsUISchema {
 		}
 
 		$converted_fields = array();
+		$option_field_ids = array();
 
 		foreach ( $schema['groups'] as &$group ) {
 			if ( ! is_array( $group ) || ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) ) {
@@ -175,7 +176,8 @@ class SettingsUISchema {
 					continue;
 				}
 
-				$converted = false;
+				$option_field_ids[] = $field['id'];
+				$converted          = false;
 
 				foreach ( $field['options'] as &$option ) {
 					if (
@@ -213,12 +215,47 @@ class SettingsUISchema {
 		}
 		unset( $group );
 
+		foreach ( $schema['groups'] as &$group ) {
+			if ( ! is_array( $group ) || ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) ) {
+				continue;
+			}
+
+			foreach ( $group['fields'] as &$field ) {
+				if (
+					! is_array( $field ) ||
+					! isset( $field['id'], $field['visibility'] ) ||
+					! is_string( $field['id'] ) ||
+					! is_array( $field['visibility'] ) ||
+					! isset( $field['visibility']['controller'] ) ||
+					! in_array( $field['visibility']['controller'], $option_field_ids, true ) ||
+					! array_key_exists( 'value', $field['visibility'] )
+				) {
+					continue;
+				}
+
+				$rule_value = $field['visibility']['value'];
+
+				if ( is_scalar( $rule_value ) && ! is_string( $rule_value ) ) {
+					$field['visibility']['value'] = self::to_canonical_string( $rule_value );
+					$converted_fields[]           = $field['id'];
+				} elseif ( is_array( $rule_value ) ) {
+					$canonical_list = self::canonicalize_scalar_list( $rule_value );
+					if ( null !== $canonical_list ) {
+						$field['visibility']['value'] = $canonical_list;
+						$converted_fields[]           = $field['id'];
+					}
+				}
+			}
+			unset( $field );
+		}
+		unset( $group );
+
 		if ( ! empty( $converted_fields ) ) {
 			wc_doing_it_wrong(
 				__METHOD__,
 				sprintf(
 					/* translators: %s: comma-separated field ids. */
-					esc_html__( 'A Settings UI schema provider supplied non-string option or field values that WooCommerce converted for compatibility: %s. Update the provider to supply string values.', 'woocommerce' ),
+					esc_html__( 'A Settings UI schema provider supplied non-string option, field, or visibility values that WooCommerce converted for compatibility: %s. Update the provider to supply string values.', 'woocommerce' ),
 					esc_html( implode( ', ', array_unique( $converted_fields ) ) )
 				),
 				'11.1.0'

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -426,7 +426,50 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		$field = $schema['groups']['main']['fields'][0];
 
 		$this->assertSame( '1', $field['value'] );
-		$this->assertSame( array( '1', '1' ), array_column( $field['options'], 'value' ), 'Boolean option values should use the PHP string cast, matching stored values.' );
+		$this->assertSame( array( '1', 'true' ), array_column( $field['options'], 'value' ), 'Boolean option values should convert like the client String() coercion, not the PHP string cast.' );
+	}
+
+	/**
+	 * @testdox It canonicalizes boolean values to the strings the client String() coercion produced before conversion.
+	 */
+	public function test_canonicalize_option_values_matches_client_coercion_for_booleans(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_option_values' );
+
+		$string_options = array(
+			array(
+				'label' => 'On',
+				'value' => 'true',
+			),
+			array(
+				'label' => 'Off',
+				'value' => 'false',
+			),
+		);
+
+		$schema = SettingsUISchema::canonicalize_option_values(
+			$this->get_native_schema_with_fields(
+				array(
+					array(
+						'id'      => 'acme_enabled',
+						'type'    => 'select',
+						'value'   => true,
+						'options' => $string_options,
+					),
+					array(
+						'id'      => 'acme_disabled',
+						'type'    => 'select',
+						'value'   => false,
+						'options' => $string_options,
+					),
+				)
+			)
+		);
+
+		$fields = $schema['groups']['main']['fields'];
+
+		$this->assertSame( 'true', $fields[0]['value'], 'A true value must keep matching the string option the client matched before canonicalization.' );
+		$this->assertSame( 'false', $fields[1]['value'], 'A false value must not collapse to the empty no-selection string.' );
+		$this->assertSame( array( 'true', 'false' ), array_column( $fields[0]['options'], 'value' ), 'String option values should pass through unchanged.' );
 	}
 
 	/**
@@ -564,13 +607,23 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	 * @return array
 	 */
 	private function get_native_schema_with_field( array $field ): array {
+		return $this->get_native_schema_with_fields( array( $field ) );
+	}
+
+	/**
+	 * Build a minimal native schema with the given fields.
+	 *
+	 * @param array $fields Field definitions.
+	 * @return array
+	 */
+	private function get_native_schema_with_fields( array $fields ): array {
 		return array(
 			'id'     => 'acme',
 			'title'  => 'Acme',
 			'groups' => array(
 				'main' => array(
 					'id'     => 'main',
-					'fields' => array( $field ),
+					'fields' => $fields,
 				),
 			),
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -473,7 +473,7 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox It canonicalizes float option values with the PHP string cast.
+	 * @testdox It canonicalizes float option values locale-independently.
 	 */
 	public function test_canonicalize_option_values_stringifies_float_values(): void {
 		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_option_values' );
@@ -501,7 +501,7 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		$field = $schema['groups']['main']['fields'][0];
 
 		$this->assertSame( '1.5', $field['value'] );
-		$this->assertSame( array( '0.5', '1.5' ), array_column( $field['options'], 'value' ), 'Float option values should use the PHP string cast, matching stored values.' );
+		$this->assertSame( array( '0.5', '1.5' ), array_column( $field['options'], 'value' ), 'Float option values should convert with a dot decimal separator in any locale, matching the client String() coercion.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -580,6 +580,84 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox It canonicalizes visibility values compared against an options field.
+	 */
+	public function test_canonicalize_option_values_stringifies_visibility_values_for_option_controllers(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_option_values' );
+
+		$schema = SettingsUISchema::canonicalize_option_values(
+			$this->get_native_schema_with_fields(
+				array(
+					array(
+						'id'      => 'acme_tier',
+						'type'    => 'select',
+						'value'   => 1,
+						'options' => array(
+							array(
+								'label' => 'One',
+								'value' => 1,
+							),
+							array(
+								'label' => 'Two',
+								'value' => 2,
+							),
+						),
+					),
+					array(
+						'id'         => 'acme_tier_notes',
+						'type'       => 'text',
+						'value'      => '',
+						'visibility' => array(
+							'controller' => 'acme_tier',
+							'value'      => 1,
+						),
+					),
+					array(
+						'id'         => 'acme_tier_badge',
+						'type'       => 'text',
+						'value'      => '',
+						'visibility' => array(
+							'controller' => 'acme_tier',
+							'value'      => array( 1, true ),
+						),
+					),
+				)
+			)
+		);
+
+		$fields = $schema['groups']['main']['fields'];
+
+		$this->assertSame( '1', $fields[1]['visibility']['value'], 'Scalar visibility values must convert with the controller value they are compared against.' );
+		$this->assertSame( array( '1', 'true' ), $fields[2]['visibility']['value'], 'Visibility value lists must convert with the controller value they are compared against.' );
+	}
+
+	/**
+	 * @testdox It leaves visibility values unchanged when the controller has no options.
+	 */
+	public function test_canonicalize_option_values_leaves_visibility_values_for_non_option_controllers(): void {
+		$schema = $this->get_native_schema_with_fields(
+			array(
+				array(
+					'id'    => 'acme_enabled',
+					'type'  => 'checkbox',
+					'value' => true,
+				),
+				array(
+					'id'         => 'acme_enabled_notes',
+					'type'       => 'text',
+					'value'      => '',
+					'visibility' => array(
+						'controller' => 'acme_enabled',
+						'value'      => true,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( $schema, SettingsUISchema::canonicalize_option_values( $schema ), 'Checkbox controllers compare boolean values, so their visibility rules should pass through unchanged.' );
+	}
+
+	/**
 	 * @testdox It leaves associative value arrays unchanged.
 	 */
 	public function test_canonicalize_option_values_leaves_associative_values_unchanged(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -632,6 +632,38 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox It leaves visibility value lists containing a non-scalar member unchanged.
+	 */
+	public function test_canonicalize_option_values_leaves_visibility_value_lists_with_non_scalar_members_unchanged(): void {
+		$schema = $this->get_native_schema_with_fields(
+			array(
+				array(
+					'id'      => 'acme_tier',
+					'type'    => 'select',
+					'value'   => '1',
+					'options' => array(
+						array(
+							'label' => 'One',
+							'value' => '1',
+						),
+					),
+				),
+				array(
+					'id'         => 'acme_tier_notes',
+					'type'       => 'text',
+					'value'      => '',
+					'visibility' => array(
+						'controller' => 'acme_tier',
+						'value'      => array( 1, array( 'not-scalar' ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( $schema, SettingsUISchema::canonicalize_option_values( $schema ), 'Visibility value lists with a non-scalar member should pass through whole, scalar members included, for the provider to fix.' );
+	}
+
+	/**
 	 * @testdox It leaves visibility values unchanged when the controller has no options.
 	 */
 	public function test_canonicalize_option_values_leaves_visibility_values_for_non_option_controllers(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Settings UI schema canonicalization converts non-string scalars with the PHP string cast, but the client matches values with the JS String() coercion. The two disagree on booleans: `(string) true` is `'1'` and `(string) false` is `''`, while String() gives `'true'` and `'false'`. A boolean field value that matched a `'true'`/`'false'` string option before conversion rendered blank after it, and distinct options like `1` and `true` collapsed to the same string. Canonicalization also left visibility rules untouched, so a numeric rule pointing at a canonicalized controller stopped matching and its dependent field flipped visibility.

* Convert scalars with a helper that mirrors the client String() coercion, so canonicalizing a value never changes which option it matches.
* Convert floats through `wc_float_to_string()`, since a plain cast follows the locale before PHP 8.0 and String() never emits a comma.
* Canonicalize visibility values whose controller field carries options, and name those fields in the doing-it-wrong notice. Rules on controllers without options, like checkboxes, pass through unchanged.
* Correct the Settings UI `@since` tags and the notice version to 11.0.0. The feature ships in 11.0.0 through the release/11.0 backports, and a sweep of that branch found four stale 11.1.0 markers.

**Backward compatibility:** boolean and float schema values now convert to the strings the client would have produced from the raw value, so nothing that matched before canonicalization stops matching. The previous conversion has not shipped in a release. Providers supplying non-string values still get the doing-it-wrong notice asking them to move to strings.

Closes woocommerce/woocommerce#66934.<br>Closes woocommerce/woocommerce#66934.<br>Refs woocommerce/woocommerce#66935.<br>Refs woocommerce/woocommerce#66935.

Bug introduced in PR woocommerce/woocommerce#66906.

### How to test the changes in this Pull Request:

1. Use a WordPress test site running this branch with WooCommerce activated. Enable debug logging in `wp-config.php` (`WP_DEBUG` and `WP_DEBUG_LOG` set to `true`) for step 8.
2. Create `wp-content/mu-plugins/settings-ui-boolean-test.php` with the following contents. It enables the `settings-ui` feature and registers a Payments drill-down whose schema supplies a boolean select value and an int visibility rule:

```php
<?php
/**
 * Plugin Name: Settings UI boolean canonicalization test
 */

use Automattic\WooCommerce\Admin\Features\Features;
use Automattic\WooCommerce\Admin\Settings\SettingsSection;
use Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry;
use Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface;

add_filter(
    'woocommerce_admin_features',
    static function ( array $features ): array {
        $features[] = 'settings-ui';
        return array_values( array_unique( $features ) );
    }
);

add_action(
    'woocommerce_settings_sections_registration',
    static function ( SettingsSectionRegistry $registry ): void {
        if ( ! Features::is_enabled( 'settings-ui' ) ) {
            return;
        }

        $registry->register(
            new class() extends SettingsSection {
                public function get_parent_page_id(): string {
                    return 'checkout';
                }

                public function get_id(): string {
                    return 'acme_bool';
                }

                public function get_label(): string {
                    return 'Acme Bool';
                }

                public function get_settings( \WC_Settings_Page $parent_page ): array {
                    return array(
                        array(
                            'title' => 'Acme bool',
                            'type'  => 'title',
                            'id'    => 'acme_bool_options',
                        ),
                        array(
                            'title'   => 'Switch',
                            'id'      => 'acme_bool_switch',
                            'type'    => 'select',
                            'options' => array(
                                'true'  => 'On',
                                'false' => 'Off',
                            ),
                            'default' => 'true',
                        ),
                        array(
                            'type' => 'sectionend',
                            'id'   => 'acme_bool_options',
                        ),
                    );
                }

                public function get_settings_ui_page( \WC_Settings_Page $parent_page ): ?SettingsUIPageInterface {
                    return new class() implements SettingsUIPageInterface {
                        public function get_page_id(): string {
                            return 'acme_bool';
                        }

                        public function get_schema( string $section ): array {
                            return array(
                                'id'     => 'acme_bool',
                                'title'  => 'Acme Bool',
                                'shell'  => array( 'title' => 'Acme Bool' ),
                                'groups' => array(
                                    'main' => array(
                                        'id'     => 'main',
                                        'title'  => 'Boolean and visibility cases',
                                        'fields' => array(
                                            array(
                                                'id'      => 'acme_bool_switch',
                                                'label'   => 'Switch',
                                                'type'    => 'select',
                                                // Boolean on purpose: without this fix the select renders blank.
                                                'value'   => true,
                                                'options' => array(
                                                    array(
                                                        'label' => 'On',
                                                        'value' => 'true',
                                                    ),
                                                    array(
                                                        'label' => 'Off',
                                                        'value' => 'false',
                                                    ),
                                                ),
                                                'save'    => array(
                                                    'adapter' => 'form_post',
                                                    'name'    => 'acme_bool_switch',
                                                ),
                                            ),
                                            array(
                                                'id'      => 'acme_bool_tier',
                                                'label'   => 'Tier',
                                                'type'    => 'select',
                                                // Int on purpose, with an int visibility rule below.
                                                'value'   => (int) get_option( 'acme_bool_tier', 2 ),
                                                'options' => array(
                                                    array(
                                                        'label' => 'Bronze',
                                                        'value' => 1,
                                                    ),
                                                    array(
                                                        'label' => 'Silver',
                                                        'value' => 2,
                                                    ),
                                                    array(
                                                        'label' => 'Gold',
                                                        'value' => 3,
                                                    ),
                                                ),
                                                'save'    => array(
                                                    'adapter' => 'form_post',
                                                    'name'    => 'acme_bool_tier',
                                                ),
                                            ),
                                            array(
                                                'id'         => 'acme_bool_silver_note',
                                                'label'      => 'Silver note',
                                                'type'       => 'text',
                                                'value'      => 'Only visible on the Silver tier',
                                                'visibility' => array(
                                                    'controller' => 'acme_bool_tier',
                                                    'value'      => 2,
                                                ),
                                                'save'       => array(
                                                    'adapter' => 'form_post',
                                                    'name'    => 'acme_bool_silver_note',
                                                ),
                                            ),
                                        ),
                                    ),
                                ),
                                'save'   => array( 'adapter' => 'form_post' ),
                            );
                        }

                        public function get_script_handles( string $section ): array {
                            return array();
                        }

                        public function get_save_adapter( string $section ): string {
                            return 'form_post';
                        }
                    };
                }
            }
        );
    }
);
```

**Boolean select shows its saved selection**

3. Open `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=acme_bool`. You should see an "Acme Bool" page with three fields: Switch, Tier, and Silver note.
4. Confirm the **Switch** select shows **On**. On trunk without this fix it renders with no selection, because the boolean `true` is converted to `'1'` and matches neither option.

**Visibility follows the canonicalized controller**

5. Confirm **Tier** shows **Silver** and the **Silver note** text field is visible below it. On trunk without this fix the Silver note field never appears, because the rule value stays the int `2` while the controller value becomes the string `'2'`.
6. Change **Tier** to **Gold** and confirm the **Silver note** field disappears. Change it back to **Silver** and confirm it returns.

**Doing-it-wrong notice**

7. Open `wp-content/debug.log` and confirm it contains a notice from `canonicalize_option_values` naming `acme_bool_switch`, `acme_bool_tier`, and `acme_bool_silver_note` as converted fields.
8. Remove `settings-ui-boolean-test.php` after testing.

Alternatively, run the tests: `pnpm test:php:env -- --filter SettingsUISchemaTest`.

### Testing that has already taken place:

* PHPUnit: 21 tests and 47 assertions pass in `SettingsUISchemaTest`, including new cases for boolean coercion, `false` not collapsing to the empty string, and visibility canonicalization. `SettingsSectionRegistryTest` also passes.
* PHPCS on the changed files, the branch lint pass, and PHPStan pass.
* A browser smoke test with the mu-plugin above: the boolean select rendered **On** instead of blank, the Silver note field showed on Silver and hid after switching to Gold, and saving stayed functional.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

</details>