### PR TITLE
Mark the settings UI as experimental in the docs

### DIFF
--- a/docs/extensions/settings-and-config/extend-wc-settings-page.md
+++ b/docs/extensions/settings-and-config/extend-wc-settings-page.md
@@ -344,6 +344,8 @@ For older WooCommerce versions, use the filter-based approach documented in [How
 
 ## Opt in to the React settings UI
 
+> **The settings UI is experimental** and subject to change. See the [settings UI status](./settings-ui.md#status) for details.
+
 `WC_Settings_Page` still owns registration, permissions, schema, and persistence when a page opts in to the React settings UI. To render a page with the React settings UI when the feature flag is enabled, return a settings UI adapter from `get_settings_ui_page()`.
 
 ```php

--- a/docs/extensions/settings-and-config/registering-settings-ui-components.md
+++ b/docs/extensions/settings-and-config/registering-settings-ui-components.md
@@ -6,6 +6,8 @@ sidebar_position: 8
 
 # Registering settings UI components
 
+> **The settings UI is experimental** and subject to change. See the [settings UI status](./settings-ui.md#status) for details.
+
 Use custom components when a WooCommerce settings field needs plugin-specific React UI that cannot be represented by a native field type.
 
 For most fields, prefer the native renderer. Custom components are best for specialized selectors, previews, or validation flows.

--- a/docs/extensions/settings-and-config/settings-ui.md
+++ b/docs/extensions/settings-and-config/settings-ui.md
@@ -6,11 +6,13 @@ sidebar_position: 7
 
 # Settings UI
 
-The settings UI is an opt-in path for rendering WooCommerce settings pages with React while keeping the existing `WC_Settings_Page` registration and save flow.
+The settings UI is an experimental, opt-in path for rendering WooCommerce settings pages with React while keeping the existing `WC_Settings_Page` registration and save flow.
 
 It is designed for extension authors who want to migrate incrementally. PHP still owns page registration, settings schema, permissions, script dependencies, and persistence. React owns field rendering and client-side interaction.
 
 ## Status
+
+> **The settings UI is experimental.** Until it is marked as stable, the PHP API under `Automattic\WooCommerce\Admin\Settings`, the schema format, and the `@woocommerce/settings-ui` package can change in backwards-incompatible ways in any release. Expect to update integrations between WooCommerce versions.
 
 -   The settings UI is behind the `settings-ui` feature flag.
 -   With the flag disabled, settings pages keep the legacy PHP renderer.

--- a/packages/js/settings-ui/README.md
+++ b/packages/js/settings-ui/README.md
@@ -2,6 +2,8 @@
 
 React utilities for WooCommerce settings pages that opt in to the settings UI renderer.
 
+> **This package is experimental.** Until it is marked as stable, its API and the settings UI schema can change in backwards-incompatible ways in any release.
+
 For the full integration guide, see [Settings UI](../../../docs/extensions/settings-and-config/settings-ui.md).
 
 ## Usage

--- a/packages/js/settings-ui/changelog/dev-mark-package-experimental
+++ b/packages/js/settings-ui/changelog/dev-mark-package-experimental
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Mark the settings UI package as experimental in the README.


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The settings UI docs describe the feature flag but never state the stability of the API. An extension author reading them could build against the PHP API, the schema format, or the JS package and expect them to hold between releases. The surface is still changing, so the docs should say so explicitly.

* Add an experimental notice to the Status section of the settings UI guide, covering the PHP API under `Automattic\WooCommerce\Admin\Settings`, the schema format, and the `@woocommerce/settings-ui` package.
* Add a short pointer to that notice in the component registration guide and in the `WC_Settings_Page` opt-in section.
* Mark the `@woocommerce/settings-ui` package as experimental in its README.

The wording follows the existing experimental notice in the dual API docs.

### How to test the changes in this Pull Request:

1. Open the four changed files in the Files tab and check the rendered markdown: `docs/extensions/settings-and-config/settings-ui.md`, `registering-settings-ui-components.md`, `extend-wc-settings-page.md`, and `packages/js/settings-ui/README.md`.
2. Confirm each notice renders as a blockquote and states the settings UI is experimental and subject to change.
3. Confirm the `[settings UI status](./settings-ui.md#status)` links in the two secondary docs resolve to the Status section of the settings UI guide.

### Testing that has already taken place:

* `markdownlint` passes on the four changed files.

### Milestone

- [x] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually for the `@woocommerce/settings-ui` package. The root `docs/` folder is not a changelog-tracked package.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

</details>
