### PR TITLE
Fix duplicate title ID on ID-less settings radio fields

### DIFF
--- a/plugins/woocommerce/changelog/66913-fix-radio-setting-empty-id
+++ b/plugins/woocommerce/changelog/66913-fix-radio-setting-empty-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent ID-less classic settings radio fields from sharing a single "-title" ID that could cross-label radio groups for assistive technology.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -513,9 +513,13 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value     = $value['value'];
 						$disabled_values  = $value['disabled'] ?? array();
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
-						// Only build a title ID when the field has an ID, so that multiple ID-less radio
-						// fields on the same page do not share a single "-title" ID and cross-label each other.
-						$radio_title_id = '' !== $value['id'] ? $value['id'] . '-title' : '';
+						// Only build a title ID when the field has a usable string ID, so that multiple
+						// ID-less radio fields on the same page do not share a single "-title" ID and
+						// cross-label each other. Extensions can pass a non-string id (e.g. false, an
+						// array, or an object); normalize it first so false and empty values collapse to
+						// no ID rather than a shared "-title", and non-scalars never reach string concat.
+						$normalized_id  = is_scalar( $value['id'] ) ? (string) $value['id'] : '';
+						$radio_title_id = '' !== $normalized_id ? $normalized_id . '-title' : '';
 
 						?>
 						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -513,13 +513,15 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value     = $value['value'];
 						$disabled_values  = $value['disabled'] ?? array();
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
-						$radio_title_id   = $value['id'] . '-title';
+						// Only build a title ID when the field has an ID, so that multiple ID-less radio
+						// fields on the same page do not share a single "-title" ID and cross-label each other.
+						$radio_title_id = '' !== $value['id'] ? $value['id'] . '-title' : '';
 
 						?>
 						<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
 							<th scope="row" class="titledesc">
 								<span class="wc-settings-radio-title">
-									<span id="<?php echo esc_attr( $radio_title_id ); ?>"><?php echo esc_html( $value['title'] ); ?></span>
+									<span<?php echo '' !== $radio_title_id ? ' id="' . esc_attr( $radio_title_id ) . '"' : ''; ?>><?php echo esc_html( $value['title'] ); ?></span>
 									<?php
 									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built by self::get_field_description(), which passes the tip through wc_help_tip(); that helper sanitizes the tip text and escapes the aria-label.
 									echo $tooltip_html;
@@ -527,7 +529,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								</span>
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
-								<fieldset aria-labelledby="<?php echo esc_attr( $radio_title_id ); ?>">
+								<fieldset<?php echo '' !== $radio_title_id ? ' aria-labelledby="' . esc_attr( $radio_title_id ) . '"' : ''; ?>>
 									<?php
 									if ( ! $show_desc_at_end ) {
 										echo wp_kses_post( $description );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -513,11 +513,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value     = $value['value'];
 						$disabled_values  = $value['disabled'] ?? array();
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
-						// Only build a title ID when the field has a usable string ID, so that multiple
-						// ID-less radio fields on the same page do not share a single "-title" ID and
-						// cross-label each other. Extensions can pass a non-string id (e.g. false, an
-						// array, or an object); normalize it first so false and empty values collapse to
-						// no ID rather than a shared "-title", and non-scalars never reach string concat.
+						// Only build a title ID when the field has a usable ID.
 						$normalized_id  = is_scalar( $value['id'] ) ? (string) $value['id'] : '';
 						$radio_title_id = '' !== $normalized_id ? $normalized_id . '-title' : '';
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -395,12 +395,7 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 	 * @testdox Should treat a non-string radio setting ID as no ID rather than a shared or malformed "-title".
 	 */
 	public function test_output_fields_normalizes_non_string_radio_ids(): void {
-		// An extension can pass a non-string id explicitly. output_fields() only defaults a
-		// *missing* id to '', so false, arrays, and objects reach the radio branch as-is: false
-		// would concatenate to a shared "-title" (the very collision this guards against), and
-		// arrays/objects would trigger an "Array/Object to string conversion" on concatenation.
-		// An explicit string field_name keeps the rest of the row rendering out of the way, so
-		// the assertions below exercise only the title-ID normalization.
+		// Explicit field names isolate title-ID normalization from input naming.
 		$options = array(
 			array(
 				'title'   => 'String zero ID radio',

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -341,6 +341,57 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not emit a shared "-title" ID for radio settings that have no ID.
+	 */
+	public function test_output_fields_does_not_cross_label_id_less_radio_settings(): void {
+		$options = array(
+			array(
+				'title'   => 'First radio',
+				'type'    => 'radio',
+				'value'   => 'a',
+				'options' => array( 'a' => 'First option' ),
+			),
+			array(
+				'title'   => 'Second radio',
+				'type'    => 'radio',
+				'value'   => 'b',
+				'options' => array( 'b' => 'Second option' ),
+			),
+		);
+
+		ob_start();
+		try {
+			WC_Admin_Settings::output_fields( $options );
+			$output = (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+
+		$document       = new DOMDocument();
+		$previous_state = libxml_use_internal_errors( true );
+		$loaded         = $document->loadHTML( '<table>' . $output . '</table>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_state );
+
+		$this->assertTrue( $loaded, 'The radio setting output should be valid enough for DOM parsing.' );
+
+		$xpath = new DOMXPath( $document );
+
+		$radio_title = '//th[contains(concat(" ", normalize-space(@class), " "), " titledesc ")]/span[contains(concat(" ", normalize-space(@class), " "), " wc-settings-radio-title ")]';
+		$fieldset    = '//td[contains(concat(" ", normalize-space(@class), " "), " forminp-radio ")]/fieldset';
+
+		// Both rows render, but neither emits the shared "-title" ID or an aria-labelledby pointing at it.
+		$this->assertSame( 2, $xpath->query( $radio_title )->length );
+		$this->assertSame( 2, $xpath->query( $fieldset )->length );
+		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id="-title"]' )->length );
+		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id]' )->length );
+		$this->assertSame( 0, $xpath->query( $fieldset . '[@aria-labelledby]' )->length );
+		// Visible titles are still rendered for both groups.
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="First radio"]' )->length );
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Second radio"]' )->length );
+	}
+
+	/**
 	 * Prepare globals used by WC_Admin_Settings::save().
 	 *
 	 * @param string|null $redirect_to Requested redirect target, or null to omit the Settings UI redirect field.

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -455,6 +455,8 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 4, $xpath->query( $radio_title )->length );
 		$this->assertSame( 4, $xpath->query( $fieldset )->length );
 		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id="-title"]' )->length );
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[@id]' )->length );
+		$this->assertSame( 1, $xpath->query( $fieldset . '[@aria-labelledby]' )->length );
 		$this->assertSame( 1, $xpath->query( $radio_title . '/span[@id="0-title"]' )->length );
 		$this->assertSame( 1, $xpath->query( $fieldset . '[@aria-labelledby="0-title"]' )->length );
 		// Visible titles are still rendered for every group.

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -392,6 +392,76 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should treat a non-string radio setting ID as no ID rather than a shared or malformed "-title".
+	 */
+	public function test_output_fields_normalizes_non_string_radio_ids(): void {
+		// An extension can pass a non-string id explicitly. output_fields() only defaults a
+		// *missing* id to '', so false, arrays, and objects reach the radio branch as-is: false
+		// would concatenate to a shared "-title" (the very collision this guards against), and
+		// arrays/objects would trigger an "Array/Object to string conversion" on concatenation.
+		// An explicit string field_name keeps the rest of the row rendering out of the way, so
+		// the assertions below exercise only the title-ID normalization.
+		$options = array(
+			array(
+				'title'      => 'Boolean ID radio',
+				'type'       => 'radio',
+				'id'         => false,
+				'field_name' => 'boolean_id_radio',
+				'value'      => 'a',
+				'options'    => array( 'a' => 'First option' ),
+			),
+			array(
+				'title'      => 'Array ID radio',
+				'type'       => 'radio',
+				'id'         => array( 'unexpected' ),
+				'field_name' => 'array_id_radio',
+				'value'      => 'b',
+				'options'    => array( 'b' => 'Second option' ),
+			),
+			array(
+				'title'      => 'Object ID radio',
+				'type'       => 'radio',
+				'id'         => new stdClass(),
+				'field_name' => 'object_id_radio',
+				'value'      => 'c',
+				'options'    => array( 'c' => 'Third option' ),
+			),
+		);
+
+		ob_start();
+		try {
+			WC_Admin_Settings::output_fields( $options );
+			$output = (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+
+		$document       = new DOMDocument();
+		$previous_state = libxml_use_internal_errors( true );
+		$loaded         = $document->loadHTML( '<table>' . $output . '</table>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_state );
+
+		$this->assertTrue( $loaded, 'The radio setting output should be valid enough for DOM parsing.' );
+
+		$xpath = new DOMXPath( $document );
+
+		$radio_title = '//th[contains(concat(" ", normalize-space(@class), " "), " titledesc ")]/span[contains(concat(" ", normalize-space(@class), " "), " wc-settings-radio-title ")]';
+		$fieldset    = '//td[contains(concat(" ", normalize-space(@class), " "), " forminp-radio ")]/fieldset';
+
+		// All three rows render, none emits a title ID or an aria-labelledby from the non-string id.
+		$this->assertSame( 3, $xpath->query( $radio_title )->length );
+		$this->assertSame( 3, $xpath->query( $fieldset )->length );
+		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id="-title"]' )->length );
+		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id]' )->length );
+		$this->assertSame( 0, $xpath->query( $fieldset . '[@aria-labelledby]' )->length );
+		// Visible titles are still rendered for every group.
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Boolean ID radio"]' )->length );
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Array ID radio"]' )->length );
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Object ID radio"]' )->length );
+	}
+
+	/**
 	 * Prepare globals used by WC_Admin_Settings::save().
 	 *
 	 * @param string|null $redirect_to Requested redirect target, or null to omit the Settings UI redirect field.

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-settings-test.php
@@ -403,6 +403,13 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 		// the assertions below exercise only the title-ID normalization.
 		$options = array(
 			array(
+				'title'   => 'String zero ID radio',
+				'type'    => 'radio',
+				'id'      => '0',
+				'value'   => 'd',
+				'options' => array( 'd' => 'Fourth option' ),
+			),
+			array(
 				'title'      => 'Boolean ID radio',
 				'type'       => 'radio',
 				'id'         => false,
@@ -449,13 +456,14 @@ class WC_Admin_Settings_Test extends WC_Unit_Test_Case {
 		$radio_title = '//th[contains(concat(" ", normalize-space(@class), " "), " titledesc ")]/span[contains(concat(" ", normalize-space(@class), " "), " wc-settings-radio-title ")]';
 		$fieldset    = '//td[contains(concat(" ", normalize-space(@class), " "), " forminp-radio ")]/fieldset';
 
-		// All three rows render, none emits a title ID or an aria-labelledby from the non-string id.
-		$this->assertSame( 3, $xpath->query( $radio_title )->length );
-		$this->assertSame( 3, $xpath->query( $fieldset )->length );
+		// All four rows render, with the string zero ID preserved and the non-string IDs omitted.
+		$this->assertSame( 4, $xpath->query( $radio_title )->length );
+		$this->assertSame( 4, $xpath->query( $fieldset )->length );
 		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id="-title"]' )->length );
-		$this->assertSame( 0, $xpath->query( $radio_title . '/span[@id]' )->length );
-		$this->assertSame( 0, $xpath->query( $fieldset . '[@aria-labelledby]' )->length );
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[@id="0-title"]' )->length );
+		$this->assertSame( 1, $xpath->query( $fieldset . '[@aria-labelledby="0-title"]' )->length );
 		// Visible titles are still rendered for every group.
+		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="String zero ID radio"]' )->length );
 		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Boolean ID radio"]' )->length );
 		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Array ID radio"]' )->length );
 		$this->assertSame( 1, $xpath->query( $radio_title . '/span[normalize-space(.)="Object ID radio"]' )->length );


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up hardening for woocommerce/woocommerce#66705 (the radio-label accessibility fix). `WC_Admin_Settings::output_fields()` normalizes a missing `id` to an empty string, so a radio setting registered without an `id` rendered `id="-title"` on its title `<span>` and `aria-labelledby="-title"` on its `<fieldset>`. Two such fields on one settings page produced duplicate `-title` IDs, and both fieldsets' `aria-labelledby` resolved to the first group's title — actively mislabeling the second group for assistive technology. (The pre-woocommerce/woocommerce#66705 `for=""` was inert, so this was a small regression from "unlabeled" to "mislabeled".)

This PR only builds the title ID — and only emits the `id` / `aria-labelledby` attributes — when the field has a non-empty `id`. ID-less radio groups fall back to no programmatic name, as before woocommerce/woocommerce#66705, instead of colliding on a shared ID. Radio fields with an `id` (every real setting) render identically. No public signature, hook, or filter changes; rendered HTML only.

Closes woocommerce/woocommerce#66913.

Bug introduced in PR woocommerce/woocommerce#66705.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Admin_Settings_Test` and confirm all tests pass (including `test_output_fields_does_not_cross_label_id_less_radio_settings`).
2. Open `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=options` and confirm a normal radio setting is unchanged: **Shipping destination** still renders `<span id="woocommerce_ship_to_destination-title">` and `<fieldset aria-labelledby="woocommerce_ship_to_destination-title">`.
3. Register two `type => radio` settings via `woocommerce_admin_fields()` with **no** `id` key, render the page, and confirm neither title `<span>` carries an `id` and neither `<fieldset>` carries an `aria-labelledby` (previously both were `-title`, cross-labelling the second group).

### Testing that has already taken place:

* Local Docker `wp-env` on PHP 8.1.34: `WC_Admin_Settings_Test` passed with 13 tests and 29 assertions.
* `phpcs` (changed lines) and PHPStan on `class-wc-admin-settings.php`: clean, no errors or warnings.
* Verified output is byte-identical for radio fields that carry an `id`; only ID-less radio fields change (they no longer emit a shared `-title` `id`/`aria-labelledby`).

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)