### PR TITLE
Fix test helper deleting pre-existing attribute terms

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-helper-attribute-term-deletion
+++ b/plugins/woocommerce/changelog/fix-test-helper-attribute-term-deletion
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Stop WC_Helper_Product::create_attribute() from deleting and re-creating pre-existing attribute terms, which stripped the terms from every product/variation already referencing them; reuse the existing term and normalize term_exists() string IDs to ints so they are not mistaken for term names (test framework only, no runtime change).

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -383,14 +383,17 @@ class WC_Helper_Product {
 		);
 
 		foreach ( $terms as $term ) {
+			// Reuse pre-existing terms: deleting and re-creating them would strip the
+			// term from every product/variation that already references it.
 			$result = term_exists( $term, $attribute->slug );
-			if ( $result ) {
-				// Delete pre-existing term data to guarantee clean testing environment.
-				wp_delete_term( $result['term_id'], $attribute->slug );
+
+			if ( ! $result ) {
+				$result = wp_insert_term( $term, $attribute->slug );
 			}
 
-			$result               = wp_insert_term( $term, $attribute->slug );
-			$return['term_ids'][] = $result['term_id'];
+			// Cast to int: term_exists() returns term_id as a string, and non-int
+			// values are treated as term names further down the line.
+			$return['term_ids'][] = (int) $result['term_id'];
 		}
 
 		return $return;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`WC_Helper_Product::create_attribute()` was changed in #66084 to delete and re-create any pre-existing attribute term "to guarantee a clean testing environment". `wp_delete_term()` strips the term from every object that references it, so each subsequent `create_variation_product()` call (~250 call sites across the suite) silently wiped the attribute term relationships of previously created products and their variations.

This PR reuses the existing term instead, and casts `term_exists()`'s string `term_id` to int. The cast fixes the latent quirk the delete was papering over: non-int values flow into `WC_Product_Attribute` options, where `get_terms()` treats them as term *names* and `wp_insert_term()` creates phantom terms named after the term IDs (e.g. terms literally named "21", "22", "23"). Without the cast, `WC_Product_Variable_Data_Store_CPT_Test::test_read_variation_attributes_fetches_on_cache_miss` fails; with it, the whole class passes.

Test framework only — no runtime change.

(For Bug Fixes) Bug introduced in PR #66084.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Variable_Data_Store_CPT_Test` and confirm all 65 tests pass.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter FiltererTest` and confirm all tests pass.
3. Optionally, in a test create two variable products via `WC_Helper_Product::create_variation_product()` and assert the first product's `wc_get_object_terms( $id, 'pa_size' )` is still non-empty after the second is created (it came back empty before this fix).

### Testing that has already taken place:

- `WC_Product_Variable_Data_Store_CPT_Test`: OK (65 tests, 181 assertions) — the class that fails with a plain revert of the delete (phantom-term slugs `21,22,23` instead of `0,1,2`).
- `FiltererTest`: OK (144 tests), `WC_Tests_Product_Data*`: OK (50 tests), `WC_Tests_Product_Functions`: OK (35 tests) — suites that lean heavily on `create_variation_product()`.
- phpcs clean on changed lines; PHPStan error count on the file drops from 28 to 25 (no new errors).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)