### PR TITLE
Fix CSV re-imports deleting terms attached to existing variations

### DIFF
--- a/plugins/woocommerce/changelog/66940-fix-csv-import-variation-term-deletion
+++ b/plugins/woocommerce/changelog/66940-fix-csv-import-variation-term-deletion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve category and tag terms attached to existing variations when re-importing them via CSV with "update existing" enabled, instead of unconditionally deleting them on every variation row.

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -184,6 +184,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			try {
 				// Prevent getting "variation_invalid_id" error message from Variation Data Store.
 				if ( ProductType::VARIATION === $data['type'] ) {
+					$was_variation = $id && 'product_variation' === get_post_type( $id );
+
 					$id = wp_update_post(
 						array(
 							'ID'        => $id,
@@ -195,8 +197,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 					// simple product, so the product data store may have assigned it
 					// the default product category. Variations must not carry
 					// product_cat/product_tag terms, and WordPress does not clear
-					// them when the post type changes, so remove them here.
-					if ( $id && ! is_wp_error( $id ) ) {
+					// them when the post type changes, so remove them here — but
+					// only when the post was just converted into a variation.
+					// Pre-existing variations (e.g. re-imports with "update
+					// existing" enabled) must keep any terms attached to them.
+					if ( $id && ! is_wp_error( $id ) && ! $was_variation ) {
 						wp_delete_object_term_relationships( $id, array( 'product_cat', 'product_tag' ) );
 					}
 				}

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -318,6 +318,67 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Re-importing an existing variation with update_existing enabled preserves taxonomy terms attached to it.
+	 */
+	public function test_reimporting_existing_variation_preserves_attached_terms() {
+		// Term creation during import requires the manage_product_terms capability.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$imported_ids = array();
+		$term_id      = 0;
+
+		try {
+			// Build the header-to-field mapping the way the admin import UI does.
+			$csv_file   = __DIR__ . '/variation-category-31815.csv';
+			$headers    = ( new WC_Product_CSV_Importer( $csv_file, array( 'parse' => false ) ) )->get_raw_keys();
+			$controller = new WC_Product_CSV_Importer_Controller();
+			$auto_map   = new ReflectionMethod( $controller, 'auto_map_columns' );
+			$auto_map->setAccessible( true );
+			$mapping = array_combine( $headers, $auto_map->invoke( $controller, $headers ) );
+
+			$data = ( new WC_Product_CSV_Importer(
+				$csv_file,
+				array(
+					'parse'   => true,
+					'mapping' => $mapping,
+				)
+			) )->import();
+
+			$imported_ids = array_merge( $data['imported'], $data['imported_variations'] );
+			$this->assertCount( 2, $data['imported_variations'], 'Expected 2 variations to be imported.' );
+
+			// Simulate an extension attaching a category to an existing variation.
+			$inserted     = wp_insert_term( 'Variation Extension Category', 'product_cat' );
+			$term_id      = is_wp_error( $inserted ) ? (int) $inserted->get_error_data( 'term_exists' ) : $inserted['term_id'];
+			$variation_id = $data['imported_variations'][0];
+			wp_set_object_terms( $variation_id, array( $term_id ), 'product_cat' );
+
+			$update = ( new WC_Product_CSV_Importer(
+				$csv_file,
+				array(
+					'parse'           => true,
+					'mapping'         => $mapping,
+					'update_existing' => true,
+				)
+			) )->import();
+
+			$this->assertContains( $variation_id, $update['updated'], 'Expected the existing variation to be updated by the re-import.' );
+			$this->assertSame(
+				array( $term_id ),
+				wp_get_object_terms( $variation_id, 'product_cat', array( 'fields' => 'ids' ) ),
+				'Terms attached to an existing variation must survive a re-import that updates it.'
+			);
+		} finally {
+			foreach ( $imported_ids as $id ) {
+				WC_Helper_Product::delete_product( $id );
+			}
+			if ( $term_id ) {
+				wp_delete_term( $term_id, 'product_cat' );
+			}
+		}
+	}
+
+	/**
 	 * @testdox parse_float_field should respect the store's decimal separator setting (issue #38116).
 	 * @dataProvider provider_parse_float_field_decimal_separator
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The variation-placeholder cleanup added in woocommerce/woocommerce#66255 (for [#31815](<https://github.com/woocommerce/woocommerce/issues/31815>)) calls `wp_delete_object_term_relationships()` for **every** CSV row with `Type=variation` and a valid ID — including re-imports with "Update existing products" enabled. On that path the ID resolves to a pre-existing variation, so any `product_cat`/`product_tag` terms attached to it (e.g. by an extension) were silently wiped while the row reported success.

This PR captures whether the post was already a `product_variation` *before* the importer's post-type flip and only deletes terms when the post was just converted into a variation (the freshly-created simple placeholder that may have inherited `default_product_cat`). Pre-existing variations keep their terms; the [#31815](<https://github.com/woocommerce/woocommerce/issues/31815>) fix remains intact (its regression test still passes).

No public contract changes: no hooks, signatures, or schemas are touched — only the internal condition guarding the term cleanup inside `get_product_object()`.

Closes woocommerce/woocommerce#66940.

(For Bug Fixes) Bug introduced in PR woocommerce/woocommerce#66255.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_CSV_Importer_Test` and confirm all 16 tests pass, including the new `test_reimporting_existing_variation_preserves_attached_terms` and the existing [#31815](<https://github.com/woocommerce/woocommerce/issues/31815>) test.
2. To verify manually: import [this CSV](<https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/php/includes/importer/variation-category-31815.csv>) via **Products > Import**, then attach a `product_cat` term to one of the created variations (e.g. `wp post term add <variation_id> product_cat <term-slug>` via WP-CLI, simulating an extension).
3. Re-import the same CSV with **Update existing products** checked.
4. Confirm the term is still attached to the variation (`wp post term list <variation_id> product_cat`). Before this fix it was removed.
5. Confirm a fresh import (without update) still leaves variations with no `product_cat`/`product_tag` terms even when a default product category is configured ([#31815](<https://github.com/woocommerce/woocommerce/issues/31815>) behavior).

### Testing that has already taken place:

* New regression test `test_reimporting_existing_variation_preserves_attached_terms` fails on trunk (term wiped on re-import) and passes with this change.
* `WC_Product_CSV_Importer_Test`: OK (16 tests, 37 assertions); all importer-related suites (`--filter Importer`): OK (65 tests, 242 assertions).
* phpcs clean on the branch diff; PHPStan reports no errors for `includes/import/abstract-wc-product-importer.php`.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)