### PR TITLE
Fix Store API nonce bootstrap timestamp config key

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-nonce-timestamp-config-key
+++ b/plugins/woocommerce/changelog/fix-store-api-nonce-timestamp-config-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Store API nonce bootstrap timestamp config key so the nonce middleware can compare nonce freshness correctly on cached pages.

--- a/plugins/woocommerce/changelog/fix-store-api-nonce-timestamp-config-key
+++ b/plugins/woocommerce/changelog/fix-store-api-nonce-timestamp-config-key
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the Store API nonce bootstrap timestamp config key so the nonce middleware can compare nonce freshness correctly on cached pages.
+Fix the Store API nonce bootstrap timestamp config key so nonce freshness is compared correctly on cached pages, and always trust nonces returned in Store API response headers over a stored nonce whose timestamp is ahead of the server's.

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-nonce.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-nonce.js
@@ -41,8 +41,11 @@ export const isStoreApiRequest = ( options ) => {
  *                                  that may have been served from a cache.
  */
 const updateNonce = ( nonce, timestamp, trusted = false ) => {
-	// If the "new" nonce matches the current nonce, we don't need to update.
-	if ( nonce === currentNonce ) {
+	// If the "new" nonce matches the current nonce, we don't need to update,
+	// unless it comes from a live server response: the stored timestamp may
+	// be wrong (e.g. ahead of server time) and must be refreshed even when
+	// the nonce itself has not rotated.
+	if ( nonce === currentNonce && ! trusted ) {
 		return;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-nonce.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/store-api-nonce.js
@@ -34,22 +34,31 @@ export const isStoreApiRequest = ( options ) => {
 /**
  * Updates the stored nonce within localStorage so it is persisted between page loads.
  *
- * @param {string} nonce     Incoming nonce string.
- * @param {number} timestamp Timestamp from server of nonce.
+ * @param {string}        nonce     Incoming nonce string.
+ * @param {number|string} timestamp Timestamp from server of nonce.
+ * @param {boolean}       trusted   True when the nonce comes from a live
+ *                                  server response rather than page markup
+ *                                  that may have been served from a cache.
  */
-const updateNonce = ( nonce, timestamp ) => {
+const updateNonce = ( nonce, timestamp, trusted = false ) => {
 	// If the "new" nonce matches the current nonce, we don't need to update.
 	if ( nonce === currentNonce ) {
 		return;
 	}
 
-	// Only update the nonce if newer. It might be coming from cache.
-	if ( currentTimestamp && timestamp < currentTimestamp ) {
+	const parsedTimestamp = Number( timestamp ) || 0;
+
+	// Nonces embedded in page markup can come from cached HTML, so only accept
+	// them when newer than the stored one. Live server responses always win:
+	// their timestamp is the current server time, so a stored timestamp ahead
+	// of it cannot be legitimate (e.g. clock skew or a previously stored
+	// client-generated timestamp) and must not block the fresh nonce.
+	if ( ! trusted && currentTimestamp && parsedTimestamp < currentTimestamp ) {
 		return;
 	}
 
 	currentNonce = nonce;
-	currentTimestamp = timestamp || Date.now() / 1000; // Convert ms to seconds to match php time()
+	currentTimestamp = parsedTimestamp || Date.now() / 1000; // Convert ms to seconds to match php time()
 
 	// Update the persisted values.
 	window.localStorage.setItem(
@@ -77,7 +86,9 @@ const setNonce = ( headers ) => {
 			: headers[ 'Nonce-Timestamp' ];
 
 	if ( nonce ) {
-		updateNonce( nonce, timestamp );
+		// Headers come from a live server response, so trust them over the
+		// stored nonce regardless of the stored timestamp.
+		updateNonce( nonce, timestamp, true );
 	}
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/test/store-api-nonce.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/test/store-api-nonce.js
@@ -92,6 +92,21 @@ describe( 'Store API nonce middleware', () => {
 		} );
 	} );
 
+	it( 'refreshes a wrong stored timestamp when a trusted response carries the same nonce', () => {
+		storeNonce( 'same-nonce', 999999 );
+
+		const apiFetch = loadMiddleware( 'same-nonce', 100 );
+		apiFetch.setNonce( {
+			Nonce: 'same-nonce',
+			'Nonce-Timestamp': '300',
+		} );
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'same-nonce',
+			timestamp: 300,
+		} );
+	} );
+
 	it( 'accepts nonces from a plain headers object', () => {
 		const apiFetch = loadMiddleware( 'page-nonce', 100 );
 		apiFetch.setNonce( {

--- a/plugins/woocommerce/client/blocks/assets/js/middleware/test/store-api-nonce.js
+++ b/plugins/woocommerce/client/blocks/assets/js/middleware/test/store-api-nonce.js
@@ -1,0 +1,130 @@
+const STORAGE_KEY = 'storeApiNonce';
+
+const getStoredNonce = () =>
+	JSON.parse( window.localStorage.getItem( STORAGE_KEY ) );
+
+/**
+ * Loads the middleware in an isolated module registry so the module-level
+ * nonce state (and the `apiFetch` instance it patches) is reset for every
+ * test. The bootstrap values mirror the inline `wcBlocksMiddlewareConfig`
+ * printed by `AssetsController`.
+ *
+ * @param {string} nonce     Page-embedded nonce.
+ * @param {number} timestamp Page-embedded nonce timestamp.
+ * @return {Function} The `apiFetch` instance patched by the middleware.
+ */
+const loadMiddleware = ( nonce, timestamp ) => {
+	global.wcBlocksMiddlewareConfig = {
+		storeApiNonce: nonce,
+		storeApiNonceTimestamp: String( timestamp ),
+	};
+
+	let apiFetch;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		apiFetch = require( '@wordpress/api-fetch' ).default;
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		require( '../store-api-nonce' );
+	} );
+	return apiFetch;
+};
+
+const storeNonce = ( nonce, timestamp ) =>
+	window.localStorage.setItem(
+		STORAGE_KEY,
+		JSON.stringify( { nonce, timestamp } )
+	);
+
+describe( 'Store API nonce middleware', () => {
+	beforeEach( () => {
+		window.localStorage.clear();
+	} );
+
+	afterAll( () => {
+		delete global.wcBlocksMiddlewareConfig;
+	} );
+
+	it( 'stores the page-embedded nonce when nothing is stored yet', () => {
+		loadMiddleware( 'page-nonce', 100 );
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'page-nonce',
+			timestamp: 100,
+		} );
+	} );
+
+	it( 'keeps the stored nonce when the page-embedded nonce is older', () => {
+		storeNonce( 'fresh-nonce', 200 );
+
+		loadMiddleware( 'cached-page-nonce', 100 );
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'fresh-nonce',
+			timestamp: 200,
+		} );
+	} );
+
+	it( 'replaces the stored nonce when the page-embedded nonce is newer', () => {
+		storeNonce( 'old-nonce', 100 );
+
+		loadMiddleware( 'page-nonce', 200 );
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'page-nonce',
+			timestamp: 200,
+		} );
+	} );
+
+	it( 'trusts a nonce from response headers even when the stored timestamp is ahead', () => {
+		storeNonce( 'skewed-nonce', 999999 );
+
+		const apiFetch = loadMiddleware( 'page-nonce', 100 );
+		apiFetch.setNonce(
+			new Headers( {
+				Nonce: 'server-nonce',
+				'Nonce-Timestamp': '300',
+			} )
+		);
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'server-nonce',
+			timestamp: 300,
+		} );
+	} );
+
+	it( 'accepts nonces from a plain headers object', () => {
+		const apiFetch = loadMiddleware( 'page-nonce', 100 );
+		apiFetch.setNonce( {
+			Nonce: 'server-nonce',
+			'Nonce-Timestamp': '300',
+		} );
+
+		expect( getStoredNonce() ).toEqual( {
+			nonce: 'server-nonce',
+			timestamp: 300,
+		} );
+	} );
+
+	it( 'sends the trusted server nonce on subsequent Store API requests', async () => {
+		storeNonce( 'skewed-nonce', 999999 );
+
+		const apiFetch = loadMiddleware( 'page-nonce', 100 );
+		apiFetch.setNonce( {
+			Nonce: 'server-nonce',
+			'Nonce-Timestamp': '300',
+		} );
+
+		const fetchHandler = jest.fn( ( options ) => options );
+		apiFetch.setFetchHandler( fetchHandler );
+		await apiFetch( {
+			path: '/wc/store/v1/cart/add-item',
+			method: 'POST',
+		} );
+
+		expect( fetchHandler ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				headers: expect.objectContaining( { Nonce: 'server-nonce' } ),
+			} )
+		);
+	} );
+} );

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -109,7 +109,7 @@ final class AssetsController {
 			"
 			var wcBlocksMiddlewareConfig = {
 				storeApiNonce: '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "',
-				wcStoreApiNonceTimestamp: '" . esc_js( time() ) . "'
+				storeApiNonceTimestamp: '" . esc_js( time() ) . "'
 			};
 			",
 			'before'

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -113,7 +113,7 @@ final class AssetsController {
 			"
 			var wcBlocksMiddlewareConfig = {
 				storeApiNonce: '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "',
-				wcStoreApiNonceTimestamp: '" . esc_js( time() ) . "'
+				storeApiNonceTimestamp: '" . esc_js( time() ) . "'
 			};
 			",
 			'before'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

**1. Fix the bootstrap timestamp config key**

The inline `wcBlocksMiddlewareConfig` bootstrap printed by `AssetsController` uses the key `wcStoreApiNonceTimestamp`, but the Store API nonce middleware (`middleware/store-api-nonce.js`) reads `wcBlocksMiddlewareConfig.storeApiNonceTimestamp`. The timestamp is therefore always `undefined`, and `updateNonce()` falls back to `Date.now() / 1000` — stamping the page-embedded nonce as if it were issued "now".

The practical consequence shows up with page caching: a nonce baked into a cached page's HTML always overwrites a fresher nonce persisted in `localStorage` (the freshness comparison always favors the embedded nonce because its timestamp is faked to the current time). Shoppers on cached pages can then hit `woocommerce_rest_invalid_nonce` errors on their first cart mutation even though a valid nonce had already been stored.

This renames the printed key to `storeApiNonceTimestamp` so it matches what the middleware consumes. The mismatch predates the monorepo merge (it was carried over from the woocommerce-blocks repository).

**2. Trust nonces from Store API response headers over the stored timestamp**

Once the key is fixed, the "only update if newer" check in `updateNonce()` actually runs, which exposes the scenario @jorgeatorres raised in review: if the timestamp stored in `localStorage` is ahead of the one the server sends, a freshly issued server nonce would be rejected and every Store API mutation would keep failing with an invalid nonce.

This is not purely hypothetical. Because of the bug above, existing visitors already have a client-generated `Date.now() / 1000` timestamp stored, which can be ahead of server time (clock skew, or simply a client clock that runs fast).

`updateNonce()` now takes a `trusted` flag:

- `setNonce( headers )`, which receives live Store API response headers (`Nonce` / `Nonce-Timestamp`), passes `trusted = true`. A nonce from a live response always replaces the stored one; its timestamp is the current server time, so a stored timestamp ahead of it cannot be legitimate.
- The bootstrap call from page markup stays untrusted, so a nonce from cached HTML still has to be newer than the stored one.

Timestamps are also parsed with `Number()` since header values arrive as strings. Any stale client-clock timestamp left over from the old behaviour self-heals on the first Store API response.

Unit tests for the middleware are added in `middleware/test/store-api-nonce.js`.

### How to test the changes in this Pull Request:

1. Log out (or use a private window) and load any shop page.
2. View the page source and locate the `wcBlocksMiddlewareConfig` inline script (attached to `wc-blocks-middleware`).
3. Confirm the object contains `storeApiNonceTimestamp` (previously `wcStoreApiNonceTimestamp`).
4. In the browser console, run `JSON.parse(localStorage.getItem('storeApiNonce'))` after loading the cart page and confirm the `timestamp` value is an integer server timestamp (previously it was a client-generated float, e.g. `1784768314.897`).
5. Add a product to the cart and change its quantity on the cart page to confirm cart mutations still work.
6. Simulate a stored timestamp ahead of the server: in the console run `localStorage.setItem('storeApiNonce', JSON.stringify({ nonce: 'bogus', timestamp: 9999999999 }))`, reload the cart page, and change a quantity. The request is sent with the bogus nonce and fails with "Nonce is invalid." (expected). The 403 response carries a fresh `Nonce` / `Nonce-Timestamp`, which now replaces the stored one: confirm `JSON.parse(localStorage.getItem('storeApiNonce'))` holds the real nonce and a current server timestamp. Change the quantity again and it succeeds. Before this PR, the stored timestamp kept winning and every retry failed.
7. Run the unit tests: `pnpm --filter=@woocommerce/block-library test:js assets/js/middleware`.

### Testing that has already taken place:

Tested on a local `wp-env` site with a page cache (batcache) in front of cart/checkout: before the fix, a stale nonce embedded in a cached page overwrote the fresher localStorage nonce and the first cart mutation failed with "Nonce is invalid."; after the fix the freshness comparison works and the stale embedded nonce no longer wins.

The ahead-of-server case is covered by the new unit tests (`middleware/test/store-api-nonce.js`), which pass locally along with eslint.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
