### PR TITLE
Fix: Persist nav-menu hidden snapshot so later plugin boxes stay visible

### DIFF
--- a/plugins/woocommerce/changelog/66952-fix-nav-menu-hidden-snapshot
+++ b/plugins/woocommerce/changelog/66952-fix-nav-menu-hidden-snapshot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Persist the default nav-menu hidden meta box snapshot on a user's first visit to Appearance > Menus, so meta boxes registered by plugins installed after that visit stay visible by default instead of being hidden on every recompute.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -32,22 +32,6 @@ class WC_Admin_Menus {
 	const HIDE_CSS_CLASS = 'hide-if-js';
 
 	/**
-	 * Cached hidden meta box IDs from the first read of this request.
-	 *
-	 * The metaboxhidden_nav-menus option is read more than once per page load:
-	 * once before admin_head fires and again inside do_accordion_sections()
-	 * after admin_head-nav-menus.php has fired. Memoizing the computed list
-	 * keeps the value stable across those reads, so a box registered late
-	 * (e.g. the "WooCommerce endpoints" box) is not swept into the hidden list
-	 * on the second read. This mirrors how core persists the snapshot before
-	 * admin_head, and fixes the general case for third-party boxes too.
-	 *
-	 * @since 11.1.0
-	 * @var string[]|null
-	 */
-	private $last_computed_hidden_boxes = null;
-
-	/**
 	 * Hook in tabs.
 	 */
 	public function __construct() {
@@ -455,10 +439,12 @@ class WC_Admin_Menus {
 	 * taxonomy boxes, so WP's existing-user guard short-circuits and leaves
 	 * them visible.
 	 *
-	 * The hidden list is computed once per request and cached on the instance,
-	 * so every read of the option within the same page load returns the same
-	 * value. This keeps late-registered boxes out of the hidden list and restores
-	 * the snapshot timing core relied on before admin_head.
+	 * The computed list is persisted to user meta on that first read, mirroring
+	 * core's wp_initial_nav_menu_meta_boxes(). This keeps the snapshot stable
+	 * across the multiple reads in a single page load and, crucially, across
+	 * later requests: boxes registered by plugins installed after the first
+	 * visit stay visible, matching vanilla WordPress instead of defaulting to
+	 * hidden on every recompute.
 	 *
 	 * @since 11.1.0
 	 *
@@ -486,16 +472,15 @@ class WC_Admin_Menus {
 	public function filter_default_nav_menu_hidden_meta_boxes( $result, $option, $user ) {
 		global $wp_meta_boxes;
 
+		// Once a snapshot exists the option reads non-false, so this early return
+		// also makes the update_user_meta() call below idempotent: a re-entrant read
+		// bails here instead of persisting again.
 		if ( false !== $result ) {
 			return $result;
 		}
 
 		if ( ! $user || ! isset( $wp_meta_boxes['nav-menus'] ) || ! is_array( $wp_meta_boxes['nav-menus'] ) ) {
 			return $result;
-		}
-
-		if ( null !== $this->last_computed_hidden_boxes ) {
-			return $this->last_computed_hidden_boxes;
 		}
 
 		$visible = array(
@@ -523,7 +508,10 @@ class WC_Admin_Menus {
 			}
 		}
 
-		$this->last_computed_hidden_boxes = $hidden;
+		// Persist the snapshot, mirroring core's wp_initial_nav_menu_meta_boxes(),
+		// so later reads in this request and in future requests return this same
+		// list instead of recomputing it against a changed meta box registry.
+		update_user_meta( $user->ID, 'metaboxhidden_nav-menus', $hidden );
 
 		return $hidden;
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-admin-menus-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-admin-menus-test.php
@@ -202,8 +202,8 @@ class WC_Admin_Menus_Test extends WC_Unit_Test_Case {
 	 * A box registered after admin_head-nav-menus.php fires (the "WooCommerce
 	 * endpoints" box) must stay visible. The option is read twice on the same
 	 * page load: once before admin_head and again inside do_accordion_sections()
-	 * after admin_head-nav-menus.php. Memoization keeps the hidden list stable
-	 * across both reads so the late-registered box is not swept into it.
+	 * after admin_head-nav-menus.php. The persisted snapshot keeps the hidden
+	 * list stable across both reads so the late-registered box is not swept into it.
 	 */
 	public function test_filter_keeps_endpoints_box_visible_after_late_registration() {
 		$GLOBALS['wp_meta_boxes'] = $this->get_nav_meta_boxes();  // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -228,5 +228,88 @@ class WC_Admin_Menus_Test extends WC_Unit_Test_Case {
 		$this->assertIsArray( $hidden_after );
 		$this->assertSame( $hidden_before, $hidden_after );
 		$this->assertNotContains( 'woocommerce_endpoints_nav_link', $hidden_after );
+	}
+
+	/**
+	 * A non-whitelisted box registered late in the same request must not be
+	 * swept into the hidden list on the second read. The snapshot is captured
+	 * on the first read; a box that did not exist then stays out of it, matching
+	 * WordPress core, which snapshots once before admin_head fires. This guards
+	 * the stability mechanism with a box the visible allowlist does not exclude.
+	 */
+	public function test_filter_keeps_late_registered_third_party_box_out_of_snapshot() {
+		$GLOBALS['wp_meta_boxes'] = $this->get_nav_meta_boxes();  // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$user_id                  = $this->factory->user->create();
+
+		$menus = new WC_Admin_Menus();
+		$menus->register_default_nav_menu_meta_boxes_filter();
+
+		$hidden_before = get_user_option( 'metaboxhidden_nav-menus', $user_id );
+
+		// Simulate a third-party box registered late (e.g. on admin_head-nav-menus.php).
+		$GLOBALS['wp_meta_boxes']['nav-menus']['side']['low']['add-late-third-party'] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			'id'    => 'add-late-third-party',
+			'title' => 'Late third party',
+		);
+
+		$hidden_after = get_user_option( 'metaboxhidden_nav-menus', $user_id );
+
+		$this->assertSame( $hidden_before, $hidden_after );
+		$this->assertNotContains( 'add-late-third-party', $hidden_after );
+	}
+
+	/**
+	 * On a first-time user's visit the filter must persist the computed hidden
+	 * snapshot to user meta, mirroring WordPress core's wp_initial_nav_menu_meta_boxes().
+	 * Without persistence, the option reads false on every later request and the
+	 * hidden list is recomputed from the live meta box registry each time.
+	 */
+	public function test_filter_persists_hidden_snapshot_on_first_visit() {
+		$GLOBALS['wp_meta_boxes'] = $this->get_nav_meta_boxes();  // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$user_id                  = $this->factory->user->create();
+
+		$menus = new WC_Admin_Menus();
+		$menus->register_default_nav_menu_meta_boxes_filter();
+
+		get_user_option( 'metaboxhidden_nav-menus', $user_id );
+
+		$persisted = get_user_meta( $user_id, 'metaboxhidden_nav-menus', true );
+
+		$this->assertIsArray( $persisted );
+		$this->assertContains( 'add-post-type-news', $persisted );
+		$this->assertNotContains( 'add-product_cat', $persisted );
+	}
+
+	/**
+	 * Once a snapshot is persisted, a third-party box registered on a later
+	 * request must stay visible, matching vanilla WordPress. The persisted
+	 * snapshot short-circuits the recompute, so the newly registered box is
+	 * not added to the hidden list.
+	 */
+	public function test_snapshot_persists_so_later_registered_third_party_box_stays_visible() {
+		$GLOBALS['wp_meta_boxes'] = $this->get_nav_meta_boxes();  // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$user_id                  = $this->factory->user->create();
+
+		// First request: user visits the nav-menus screen for the first time.
+		$first_visit = new WC_Admin_Menus();
+		$first_visit->register_default_nav_menu_meta_boxes_filter();
+		get_user_option( 'metaboxhidden_nav-menus', $user_id );
+
+		// End of the first request: its hooks and instance no longer exist.
+		remove_all_filters( 'get_user_option_metaboxhidden_nav-menus' );
+
+		// A plugin registers a nav-menus meta box after that first visit.
+		$GLOBALS['wp_meta_boxes']['nav-menus']['side']['default']['add-later-plugin-box'] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			'id'    => 'add-later-plugin-box',
+			'title' => 'Later plugin box',
+		);
+
+		// Second request: a fresh instance handles the later page load.
+		$second_visit = new WC_Admin_Menus();
+		$second_visit->register_default_nav_menu_meta_boxes_filter();
+		$hidden = get_user_option( 'metaboxhidden_nav-menus', $user_id );
+
+		$this->assertIsArray( $hidden );
+		$this->assertNotContains( 'add-later-plugin-box', $hidden );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-admin-menus-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-admin-menus-test.php
@@ -295,8 +295,9 @@ class WC_Admin_Menus_Test extends WC_Unit_Test_Case {
 		$first_visit->register_default_nav_menu_meta_boxes_filter();
 		get_user_option( 'metaboxhidden_nav-menus', $user_id );
 
-		// End of the first request: its hooks and instance no longer exist.
-		remove_all_filters( 'get_user_option_metaboxhidden_nav-menus' );
+		// End of the first request: its hook and instance no longer exist. Remove
+		// only this instance's callback so the test stays isolated from other hooks.
+		remove_filter( 'get_user_option_metaboxhidden_nav-menus', array( $first_visit, 'filter_default_nav_menu_hidden_meta_boxes' ), 10 );
 
 		// A plugin registers a nav-menus meta box after that first visit.
 		$GLOBALS['wp_meta_boxes']['nav-menus']['side']['default']['add-later-plugin-box'] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
### Changes proposed in this Pull Request

Closes woocommerce/woocommerce#66952. Bug introduced in PR woocommerce/woocommerce#65990.

The first-visit filter for `metaboxhidden_nav-menus` returned a computed hidden list but never persisted it. Because the option then read non-`false`, core's `wp_initial_nav_menu_meta_boxes()` short-circuited and skipped its own `update_user_meta()` snapshot — so for admins with no saved preference the hidden list was recomputed from the live meta box registry on *every* load. The upshot: a nav-menus box registered by a plugin installed *after* the admin's first visit defaulted to **hidden**, where vanilla WordPress leaves it visible.

The fix persists the computed snapshot on that first read, mirroring core. The WooCommerce taxonomy boxes (Product Categories, Product Tags, Brands) stay visible by default — the original intent of woocommerce/woocommerce#65990 — while later-registered third-party boxes behave like vanilla WP again. The per-request memoization is dropped, since persistence supersedes it.

### How to test the changes in this Pull Request

**Prerequisites** — drop this in as an mu-plugin (`wp-content/mu-plugins/dummy-box.php`). It registers a taxonomy that gets its own nav-menus box, standing in for "a plugin installed later":

```php
<?php
add_action( 'init', function () {
	register_taxonomy( 'dummy_flavor', 'post', array(
		'label'             => 'Dummy Flavors',
		'public'            => true,
		'show_in_nav_menus' => true,
	) );
} );
```

The timing is the whole point here — the box has to appear *after* the admin's first visit, so keep the snippet out until step 3.

1. **Clean slate.** As a fresh admin (or after `wp user meta delete <id> metaboxhidden_nav-menus`), and with the snippet **not** yet added, open **Appearance → Menus**. This is the first visit — Product Categories, Product Tags, and Brands are visible, no Dummy Flavors yet.
2. **Add the snippet** — this simulates installing a plugin later.
3. **Reload Appearance → Menus.** "Dummy Flavors" stays **visible** by default. On trunk it'd be hidden here — nothing was persisted at step 1, so the reload recomputes the hidden list and sweeps the new box in.

To replicate the issue: Run the same three steps on `trunk` and **watch step 3 hide the box.**

### Screenshots

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/5a853203-d967-456f-b98e-e87881701f9a " alt="before-menu-fix" width="948" data-linear-height="1148" /></td>
<td><img src="https://github.com/user-attachments/assets/df4f4822-75a4-475f-94a8-6e248eed9102 " alt="after-menu-fix" width="949" data-linear-height="1192" /></td>
</tr>
</tbody>
</table>

### Testing that has already taken place

* `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Admin_Menus_Test` — 9 tests, 28 assertions, green. Two new tests were written failing first (`test_filter_persists_hidden_snapshot_on_first_visit`, `test_snapshot_persists_so_later_registered_third_party_box_stays_visible`); a third guards snapshot stability with a non-whitelisted late-registered box.
* `phpcs` and PHPStan clean on the changed file.
* Manually verified the trunk → fix before/after on a local Storefront site.

### Changelog entry

- [X] Added manually (`plugins/woocommerce/changelog/66952-fix-nav-menu-hidden-snapshot`).

### Milestone

- [X] Automatically assign milestone for the next WooCommerce version.