### PR TITLE
Fix hidden Save button on Settings UI fallback pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-66908-settings-ui-fallback-body-class
+++ b/plugins/woocommerce/changelog/fix-66908-settings-ui-fallback-body-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the Save button when an experimental Settings UI page falls back to the legacy renderer.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -146,9 +146,13 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 					return $classes;
 				}
 
-				$is_rendering_drill_down = $context->is_drill_down()
-					&& ! $context->has_schema_failed()
-					&& ! $context->has_script_handles_failed();
+				// The legacy fallback renderer needs the classic styling: the settings UI
+				// body class hides the legacy Save button via CSS.
+				if ( $context->has_schema_failed() || $context->has_script_handles_failed() ) {
+					return $classes;
+				}
+
+				$is_rendering_drill_down = $context->is_drill_down();
 			} catch ( \Throwable $e ) {
 				return $classes;
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -462,9 +462,9 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not add the drill-down body class when schema generation falls back to legacy rendering.
+	 * @testdox Should not add the Settings UI body classes when schema generation falls back to legacy rendering.
 	 */
-	public function test_settings_ui_drill_down_body_class_is_not_added_when_schema_generation_fails(): void {
+	public function test_settings_ui_body_classes_are_not_added_when_schema_generation_fails(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
 
 		global $current_section, $current_tab;
@@ -474,14 +474,13 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 
 		$classes = $page->add_settings_ui_body_class( 'existing-class' );
 
-		$this->assertStringContainsString( 'woocommerce-settings-ui-page', $classes );
-		$this->assertStringNotContainsString( 'woocommerce-settings-ui-drill-down', $classes );
+		$this->assertSame( 'existing-class', $classes, 'The fallback page should keep the classic body classes so the legacy Save button stays visible' );
 	}
 
 	/**
-	 * @testdox Should not add the drill-down body class when script handle resolution falls back to legacy rendering.
+	 * @testdox Should not add the Settings UI body classes when script handle resolution falls back to legacy rendering.
 	 */
-	public function test_settings_ui_drill_down_body_class_is_not_added_when_script_handle_resolution_fails(): void {
+	public function test_settings_ui_body_classes_are_not_added_when_script_handle_resolution_fails(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
 
 		global $current_section, $current_tab;
@@ -491,8 +490,23 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 
 		$classes = $page->add_settings_ui_body_class( 'existing-class' );
 
-		$this->assertStringContainsString( 'woocommerce-settings-ui-page', $classes );
-		$this->assertStringNotContainsString( 'woocommerce-settings-ui-drill-down', $classes );
+		$this->assertSame( 'existing-class', $classes, 'The fallback page should keep the classic body classes so the legacy Save button stays visible' );
+	}
+
+	/**
+	 * @testdox Should not add the Settings UI body class when a top-level page falls back to legacy rendering.
+	 */
+	public function test_settings_ui_body_class_is_not_added_when_a_top_level_page_falls_back(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		$current_section = 'failing_section';
+		$current_tab     = 'settings_ui_flag_test';
+		$page            = $this->get_settings_ui_test_page_with_failing_schema();
+
+		$classes = $page->add_settings_ui_body_class( 'existing-class' );
+
+		$this->assertSame( 'existing-class', $classes, 'The fallback page should keep the classic body classes so the legacy Save button stays visible' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When an experimental Settings UI page fails to build its schema or script handles, `output()` falls back to the legacy renderer, but the `woocommerce-settings-ui-page` body class was still added. The Settings UI stylesheet hides the legacy Save button under that class, so the fallback page rendered settings the merchant could not save.

* Skip all Settings UI body classes when the request context reports a schema or script-handle failure, using the same gate the drill-down class already applied.
* The fallback page now keeps the full classic styling, including the visible Save button.
* Update the body-class unit tests for the new fallback behavior and add a top-level fallback case.

No public signature or hook changes; only the body classes rendered on fallback change, and the whole surface sits behind the experimental `settings-ui` feature flag.

Closes woocommerce/woocommerce#66908.  <br>Closes woocommerce/woocommerce#66908.

Bug introduced in PR [#64387](<https://github.com/woocommerce/woocommerce/issues/64387>).

### How to test the changes in this Pull Request:

1. Add a small test plugin that enables the `settings-ui` feature and registers a settings page whose schema generation throws:

```php
add_filter( 'woocommerce_admin_features', function ( $features ) {
	$features[] = 'settings-ui';
	return $features;
} );

add_filter( 'woocommerce_get_settings_pages', function ( $pages ) {
	$ui_page = new class() implements \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
		public function get_page_id(): string { return 'fallback_test'; }
		public function get_schema( string $section ): array { throw new \RuntimeException( 'Schema failure test' ); }
		public function get_script_handles( string $section ): array { return array(); }
		public function get_save_adapter( string $section ): string { return 'form_post'; }
	};
	$pages[] = new class( $ui_page ) extends WC_Settings_Page {
		private $ui_page;
		public function __construct( $ui_page ) {
			$this->id      = 'fallback_test';
			$this->label   = 'Fallback test';
			$this->ui_page = $ui_page;
			parent::__construct();
		}
		public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
			return $this->ui_page;
		}
		protected function get_settings_for_default_section() {
			return array(
				array( 'title' => 'Fallback test', 'type' => 'title', 'id' => 'fallback_test_options' ),
				array( 'title' => 'Test field', 'type' => 'text', 'id' => 'fallback_test_text' ),
				array( 'type' => 'sectionend', 'id' => 'fallback_test_options' ),
			);
		}
	};
	return $pages;
} );
```

2. Go to **WooCommerce > Settings** and open the **Fallback test** tab.
3. Confirm the page renders the classic tabs, the **Test field**, and a visible **Save changes** button (on trunk the button is hidden).
4. Confirm the `body` element does not carry the `woocommerce-settings-ui-page` class.
5. **Regression: working Settings UI page.** With the feature flag still enabled, open the **Products** tab and confirm it still renders the Settings UI (the `body` carries `woocommerce-settings-ui-page` and no legacy Save button appears).
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter SettingsUIFeatureFlagTest` and confirm all tests pass.

### Testing that has already taken place:

* `SettingsUIFeatureFlagTest` passed locally on wp-env with PHP unit tests: 23 tests, 57 assertions.
* Browser-tested on a local Docker site with a provider whose `get_schema()` throws: before the fix the fallback page rendered navigation and fields with the Save button hidden by CSS; after the fix the Save button is visible and classic styling is restored.
* Confirmed the success path is unchanged: a working Settings UI page (Products) still renders the modern UI with the body class and no legacy Save button.
* `phpcs` on the changed files and the full branch diff, and PHPStan on `class-wc-settings-page.php`: clean.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `plugins/woocommerce/changelog/fix-66908-settings-ui-fallback-body-class`.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>