### PR TITLE
Fix webhooks REST API ignoring the offset parameter

### DIFF
--- a/plugins/woocommerce/changelog/fix-webhooks-rest-api-offset-ignored
+++ b/plugins/woocommerce/changelog/fix-webhooks-rest-api-offset-ignored
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Webhooks REST API silently ignoring the `offset` query parameter and always returning the first page of results.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -252,6 +252,8 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 
 		if ( empty( $request['offset'] ) ) {
 			$args['offset'] = 1 < $request['page'] ? ( $request['page'] - 1 ) * $args['limit'] : 0;
+		} else {
+			$args['offset'] = $request['offset'];
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller-tests.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * class WC_REST_Webhooks_Controller_Tests.
+ * Webhooks Controller tests for V3 REST API.
+ */
+class WC_REST_Webhooks_Controller_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Runs before any test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * @testdox An explicit `offset` query param is honored, instead of being silently ignored in favor of always returning the first page.
+	 */
+	public function test_get_items_honors_explicit_offset() {
+		wp_set_current_user( $this->user );
+
+		$webhook_ids = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$webhook = new WC_Webhook();
+			$webhook->set_name( 'Test webhook ' . $i );
+			$webhook->set_topic( 'order.created' );
+			$webhook->set_delivery_url( 'https://example.com/webhook' );
+			$webhook->save();
+			$webhook_ids[] = $webhook->get_id();
+		}
+
+		$query_params = array(
+			'per_page' => 1,
+			'orderby'  => 'id',
+			'order'    => 'asc',
+		);
+
+		$response_no_offset = $this->do_rest_get_request( 'webhooks', $query_params );
+		$this->assertSame( 200, $response_no_offset->get_status() );
+		$this->assertSame( $webhook_ids[0], $response_no_offset->get_data()[0]['id'] );
+
+		// An explicit offset of 1 should skip the first webhook and return the second one.
+		$response_with_offset = $this->do_rest_get_request( 'webhooks', array_merge( $query_params, array( 'offset' => 1 ) ) );
+		$this->assertSame( 200, $response_with_offset->get_status() );
+		$this->assertSame( $webhook_ids[1], $response_with_offset->get_data()[0]['id'] );
+
+		// A larger offset returns the third webhook, proving offset is not just being ignored in favor of the first page every time.
+		$response_with_larger_offset = $this->do_rest_get_request( 'webhooks', array_merge( $query_params, array( 'offset' => 2 ) ) );
+		$this->assertSame( 200, $response_with_larger_offset->get_status() );
+		$this->assertSame( $webhook_ids[2], $response_with_larger_offset->get_data()[0]['id'] );
+	}
+}


### PR DESCRIPTION
## What

Closes #66818

The `GET /wp-json/wc/v3/webhooks` endpoint documents `offset` as a supported parameter, but passing one had no effect. Every request returned the same first page of results, no matter what offset was used.

## Why

In `get_items()`, the request's `offset` value was only copied over when it was empty:

```php
if ( empty( $request['offset'] ) ) {
    $args['offset'] = 1 < $request['page'] ? ( $request['page'] - 1 ) * $args['limit'] : 0;
}
```

When a real offset was passed, this block was skipped, so `$args['offset']` never got set at all and quietly defaulted to `0` further down in `WC_Webhook_Data_Store::search_webhooks()`. The `page` parameter worked fine because it went through a different path.

## Fix

Added the missing branch so an explicit offset is used as given:

```php
if ( empty( $request['offset'] ) ) {
    $args['offset'] = 1 < $request['page'] ? ( $request['page'] - 1 ) * $args['limit'] : 0;
} else {
    $args['offset'] = $request['offset'];
}
```

This matches how the taxes, customers, and terms REST controllers already handle the same offset/page choice.

## Testing

- Created 200+ webhooks on a local WooCommerce install and confirmed the bug: `?per_page=50&offset=0`, `offset=50`, and `offset=100` all returned identical results.
- Applied the fix and confirmed each offset now returns a distinct, correctly-paginated set of webhooks.
- Confirmed `page`-based pagination still works exactly as before (same total count, same total pages, same results as the equivalent offset).
- Added a PHPUnit test covering this (`class-wc-rest-webhooks-controller-tests.php`).