### PR TITLE
Fix root-level path filtering in Analyze changes and gate the plugin artifact build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,16 @@ jobs:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: target-changes
         with:
+          # `**/` requires at least one leading directory, so a `**/`-only pattern silently
+          # misses repository-root files. Every root-anchored ignore below uses `{,**/}` so
+          # that e.g. `AGENTS.md` is excluded the same way `docs/foo.md` is.
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(docs/docs-manifest.json)|(**/changelog/*)|(.github/**)|(.husky/**)|(.cursor/**)|(.gitignore)|(**/readme.txt))'
+              - '!(({,**/}*.md)|(docs/docs-manifest.json)|({,**/}changelog/*)|(.github/**)|(.husky/**)|(.cursor/**)|(.gitignore)|({,**/}readme.txt))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!((changelog/*)|(readme.txt))'
             needs-markdown-validation:
+              - '*.md'
               - '!(.github/**)/**/*.md'
             needs-syncpack-validation:
               - '(.syncpackrc)|(pnpm-lock.yaml)'
@@ -158,8 +162,10 @@ jobs:
   woocommerce-plugin-build-artifact:
     name: "Build WooCommerce plugin artifact${{ needs.project-jobs.outputs.shared-plugin-build-has-required-consumers != 'true' && ' (optional)' || '' }}"
     runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
-    needs: 'project-jobs'
-    if: ${{ !cancelled() && needs.project-jobs.result == 'success' && inputs.artifactName == '' && needs.project-jobs.outputs.shared-plugin-build-needed == 'true' }}
+    needs: [ 'identify-jobs-to-run', 'project-jobs' ]
+    # The `needs-code-validation` clause mirrors `project-test-jobs`: without it this job builds a
+    # plugin zip for consumers that are themselves gated off, which is pure waste on docs-only PRs.
+    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.result == 'success' && inputs.artifactName == '' && needs.project-jobs.outputs.shared-plugin-build-needed == 'true' }}
     permissions:
       contents: read
     env:
@@ -200,7 +206,7 @@ jobs:
   project-test-jobs:
     name: '${{ matrix.name }}'
     runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
-    needs: [ 'project-jobs', 'woocommerce-plugin-build-artifact' ]
+    needs: [ 'identify-jobs-to-run', 'project-jobs', 'woocommerce-plugin-build-artifact' ]
     if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.outputs.test-jobs != '[]' && ( needs.woocommerce-plugin-build-artifact.result == 'success' || needs.woocommerce-plugin-build-artifact.result == 'skipped' || needs.project-jobs.outputs.shared-plugin-build-has-required-consumers != 'true' ) }}
     env: ${{ matrix.testEnv.envVars }}
     strategy:
@@ -475,7 +481,7 @@ jobs:
 
   test-reports:
     name: 'Test reports - ${{ matrix.report }}'
-    needs: ['project-jobs', 'project-test-jobs', 'evaluate-project-jobs']
+    needs: ['identify-jobs-to-run', 'project-jobs', 'project-test-jobs', 'evaluate-project-jobs']
     if: ${{ !cancelled() && github.repository == 'woocommerce/woocommerce' && ( github.event_name != 'pull_request' || ( needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' && ! github.event.pull_request.head.repo.fork ) ) && needs.project-jobs.outputs.report-jobs != '[]' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           filters: |
             needs-code-validation:
               - '!(({,**/}*.md)|(docs/docs-manifest.json)|({,**/}changelog/*)|(.github/**)|(.husky/**)|(.cursor/**)|(.gitignore)|({,**/}readme.txt))'
+              # `changelog/*` also covers real modules, e.g. code-freeze/commands/changelog/index.ts.
+              - '{,**/}changelog/*.{ts,tsx,js,jsx,mjs,cjs,php,json,scss,css}'
             needs-changelog-validation:
               - '{packages,plugins}/*/!((changelog/*)|(readme.txt))'
             needs-markdown-validation:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

> **Note:** this PR originally proposed a `pull_request` `paths` filter plus a companion `ci-skip.yml`. That was [rightly rejected](https://github.com/woocommerce/woocommerce/pull/66971#issuecomment-5070579243) as a design regression — a third layer of path filtering around the monorepo tooling. Digging into the runs behind it showed the waste came from ordinary bugs in that step, so the branch has been reset onto `trunk` and now contains only those fixes. No new workflow, no new filter.

**1. `Analyze changes` misses repository-root files.**

`needs-code-validation` negates `(**/*.md)`, `(**/changelog/*)` and `(**/readme.txt)`. Under picomatch, `**/` requires at least one leading directory, so none of those match a root-level path. #66835 changed only `AGENTS.md` and two nested `CLAUDE.md` files, and its `Analyze changes` log shows exactly why the full matrix ran:

```
Filter needs-code-validation = true
Matching files:
AGENTS.md [modified]
```

That one boolean unlocked `project-test-jobs` and ~56 runner-minutes of e2e ([run](https://github.com/woocommerce/woocommerce/actions/runs/29862918171)). Anchoring the three ignores with `{,**/}` excludes root files the same way nested ones are excluded.

`needs-markdown-validation` has the same blind spot in the other direction: `'!(.github/**)/**/*.md'` structurally cannot match a root path, so none of the seven root-level `.md` files (`AGENTS.md`, `CLAUDE.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `README.md`, `SECURITY.md`) are markdown-linted today. Adding `'*.md'` as a second pattern fixes that.

**2. `woocommerce-plugin-build-artifact` is not gated on `needs-code-validation`.**

It gates only on `shared-plugin-build-needed`, so it builds a plugin zip for consumers that are themselves gated off. On #66938 the filter worked correctly (`needs-code-validation = false`) and `project-test-jobs` was skipped, yet the artifact job still ran for 3m11s ([run](https://github.com/woocommerce/woocommerce/actions/runs/30013767721)). This adds the same clause `project-test-jobs` already uses.

**3. `changelog/*` swallows real source modules.**

`(**/changelog/*)` is negated wholesale, but the monorepo has modules sitting directly inside a `changelog` directory: `tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts` and `types.ts`. A PR touching only those two files resolves `needs-code-validation` to `false` today, so nothing lints or tests them. Changelog-directory files carrying a source extension are re-included; entries stay ignored, including extensionless ones with dots in the name (`43595-update-wireit-0.14.3`) and `.gitkeep`.

**4. `needs` lists made explicit.**

`project-test-jobs` and `test-reports` read `needs.identify-jobs-to-run.outputs.*` without listing that job in `needs`. `actionlint` flags both today:

```
property "identify-jobs-to-run" is not defined in object type {project-jobs: ...}
```

Listing it explicitly removes those two findings and stops the gate depending on transitive `needs` resolution.

### How to test the changes in this Pull Request:

1. Open a PR against this branch touching **only** a repository-root markdown file (e.g. `AGENTS.md`). Confirm `Analyze changes` reports `needs-code-validation = false`, `project-test-jobs` and `woocommerce-plugin-build-artifact` are skipped, `Validate markdown` runs and lints the root file, and `Evaluate Project Job Statuses` is green. Compare against [run 29862918171](https://github.com/woocommerce/woocommerce/actions/runs/29862918171), where the same shape of change ran the full e2e suite.
2. Open a PR touching one `.php` or `.ts` file **plus** one markdown file. Confirm full CI runs exactly as it does on `trunk` today — this is the regression that matters most.
3. Open a PR touching only source files. Confirm no change from today.
4. Open a PR touching only `tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts`. Confirm `needs-code-validation` is now `true` and the monorepo-utils lint/test jobs run — on `trunk` they do not.

### Testing that has already taken place:

- Glob behaviour verified against `picomatch@4.0.5` with `{ dot: true }` — the exact options [dorny/paths-filter v4 uses](https://github.com/dorny/paths-filter/blob/7b450fff21473bca461d4b92ce414b9d0420d706/src/filter.ts#L14-L17) — across 21 cases: root `.md`, nested `.md`, `docs/**.md`, `docs/docs-manifest.json`, root and nested `changelog/*`, root and nested `readme.txt`, `.github/**`, `.github/*.md`, `.husky`/`.cursor`, `.php`, `.ts`, `package.json`, and mixed root-md + code. Plus the changelog-module cases above. The patterns on `trunk` fail 6 of those cases; the patterns here pass all of them.
- `actionlint` on `ci.yml`: findings drop from 11 on `trunk` to 9, with no new ones. The two removed are the `identify-jobs-to-run` expression errors described above.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI workflow configuration only (`.github/**`); nothing shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
