### PR TITLE
Prevent notice about wp-editor being enqueued from appearing in the Widgets screen

### DIFF
--- a/packages/js/email-editor/changelog/fix-47831-widget-editor-notice
+++ b/packages/js/email-editor/changelog/fix-47831-widget-editor-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove dependency on @wordpress/editor from useIsEmailEditor()
+
+

--- a/packages/js/email-editor/src/hooks/use-is-email-editor.ts
+++ b/packages/js/email-editor/src/hooks/use-is-email-editor.ts
@@ -10,11 +10,9 @@ import { storeName } from '../store';
 import { EmailTemplate } from '../store/types';
 
 /**
- * String store name for the WordPress editor store.
- *
- * Using a string instead of `import { store } from '@wordpress/editor'` avoids
- * adding the `wp-editor` script as a dependency of consumers that only need
- * this detection hook (e.g. Product Collection in the block editor).
+ * Store name of the WordPress editor store.
+ * Using a hardcoded string allows us to avoid the import.
+ * See: https://github.com/woocommerce/woocommerce/issues/47831
  */
 const CORE_EDITOR_STORE = 'core/editor';
 
@@ -41,13 +39,13 @@ export function useIsEmailEditor(): boolean {
 		const emailPostType = emailEditorStore.getEmailPostType();
 
 		// Get the current post information from the WordPress editor when available.
-		const editorStore = select( CORE_EDITOR_STORE );
-		if ( ! editorStore ) {
+		const editorSelectors = select( CORE_EDITOR_STORE );
+		if ( ! editorSelectors ) {
 			return false;
 		}
 
-		const currentPostId = editorStore.getCurrentPostId();
-		const currentPostType = editorStore.getCurrentPostType();
+		const currentPostId = editorSelectors.getCurrentPostId();
+		const currentPostType = editorSelectors.getCurrentPostType();
 
 		// Check if the current post matches the email editor post
 		const currentPostMatch =

--- a/packages/js/email-editor/src/hooks/use-is-email-editor.ts
+++ b/packages/js/email-editor/src/hooks/use-is-email-editor.ts
@@ -34,10 +34,6 @@ export function useIsEmailEditor(): boolean {
 			return false;
 		}
 
-		// Get the email editor store's post information
-		const emailPostId = emailEditorStore.getEmailPostId();
-		const emailPostType = emailEditorStore.getEmailPostType();
-
 		// Get the current post information from the WordPress editor when available.
 		const editorSelectors = select( CORE_EDITOR_STORE );
 		if ( ! editorSelectors ) {
@@ -46,6 +42,10 @@ export function useIsEmailEditor(): boolean {
 
 		const currentPostId = editorSelectors.getCurrentPostId();
 		const currentPostType = editorSelectors.getCurrentPostType();
+
+		// Get the email editor store's post information
+		const emailPostId = emailEditorStore.getEmailPostId();
+		const emailPostType = emailEditorStore.getEmailPostType();
 
 		// Check if the current post matches the email editor post
 		const currentPostMatch =

--- a/packages/js/email-editor/src/hooks/use-is-email-editor.ts
+++ b/packages/js/email-editor/src/hooks/use-is-email-editor.ts
@@ -2,13 +2,21 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { storeName } from '../store';
 import { EmailTemplate } from '../store/types';
+
+/**
+ * String store name for the WordPress editor store.
+ *
+ * Using a string instead of `import { store } from '@wordpress/editor'` avoids
+ * adding the `wp-editor` script as a dependency of consumers that only need
+ * this detection hook (e.g. Product Collection in the block editor).
+ */
+const CORE_EDITOR_STORE = 'core/editor';
 
 /**
  * Hook to detect if we are currently in the email editor context.
@@ -32,9 +40,14 @@ export function useIsEmailEditor(): boolean {
 		const emailPostId = emailEditorStore.getEmailPostId();
 		const emailPostType = emailEditorStore.getEmailPostType();
 
-		// Get the current post information from the WordPress editor
-		const currentPostId = select( editorStore ).getCurrentPostId();
-		const currentPostType = select( editorStore ).getCurrentPostType();
+		// Get the current post information from the WordPress editor when available.
+		const editorStore = select( CORE_EDITOR_STORE );
+		if ( ! editorStore ) {
+			return false;
+		}
+
+		const currentPostId = editorStore.getCurrentPostId();
+		const currentPostType = editorStore.getCurrentPostType();
 
 		// Check if the current post matches the email editor post
 		const currentPostMatch =

--- a/plugins/woocommerce/changelog/fix-47831-widget-editor-notice
+++ b/plugins/woocommerce/changelog/fix-47831-widget-editor-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent notice about wp-editor being enqueued from appearing in the Widgets screen

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -11,7 +11,7 @@ import {
 	BlockConfiguration,
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+import { CORE_EDITOR_STORE } from '@woocommerce/utils';
 import { isEmpty } from '@woocommerce/types';
 
 /**
@@ -106,7 +106,7 @@ export class BlockRegistrationManager {
 
 		// Main store subscription to detect which editor we're in
 		const unsubscribe = subscribe( () => {
-			const editorSelectors = select( editorStore );
+			const editorSelectors = select( CORE_EDITOR_STORE );
 
 			// Return if editor store is not available yet
 			if ( ! editorSelectors ) {
@@ -160,7 +160,7 @@ export class BlockRegistrationManager {
 					if ( previousTemplateId !== this.currentTemplateId ) {
 						this.handleTemplateChange( previousTemplateId );
 					}
-				}, editorStore );
+				}, CORE_EDITOR_STORE );
 
 				this.initialized = true;
 			}

--- a/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
@@ -34,6 +34,13 @@ export class Admin extends CoreAdmin {
 		const closeWelcomeGuide = this.page
 			.getByRole( 'dialog', { name: 'Welcome to block Widgets' } )
 			.getByRole( 'button', { name: 'Close' } );
+
+		// Verify the script `/wp-admin/js/editor.min.js` wasn't loaded.
+		// See: https://github.com/woocommerce/woocommerce/issues/47831
+		await expect(
+			this.page.locator( 'script[src*="/wp-admin/js/editor.min.js"]' )
+		).toHaveCount( 0 );
+
 		// The welcome guide only shows when it hasn't been dismissed before, so
 		// wait for it briefly and close it only when it actually appears.
 		const guideAppeared = await closeWelcomeGuide

--- a/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
@@ -35,11 +35,9 @@ export class Admin extends CoreAdmin {
 			.getByRole( 'dialog', { name: 'Welcome to block Widgets' } )
 			.getByRole( 'button', { name: 'Close' } );
 
-		// Verify the script `/wp-admin/js/editor.min.js` wasn't loaded.
+		// Verify the wp-editor script wasn't loaded.
 		// See: https://github.com/woocommerce/woocommerce/issues/47831
-		await expect(
-			this.page.locator( 'script[src*="/wp-admin/js/editor.min.js"]' )
-		).toHaveCount( 0 );
+		await expect( this.page.locator( '#wp-editor-js' ) ).toHaveCount( 0 );
 
 		// The welcome guide only shows when it hasn't been dismissed before, so
 		// wait for it briefly and close it only when it actually appears.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/47831.

We already fixed this issue some time ago in https://github.com/woocommerce/woocommerce/pull/62438, but it appeared again. I updated an e2e test util that should hopefully catch this regression if it happens again in the future.

### How to test the changes in this Pull Request:

1. Make sure you have `WP_DEBUG` set to `true`.
2. Go to the Widgets screen (`/wp-admin/widgets.php`).
3. Verify there is no notice saying:

> Notice: Function wp_enqueue_script() was called incorrectly. "wp-editor" script should not be enqueued together with the new widgets editor...

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->