### PR TITLE
Fix product CSV importer breaking when file path contains special characters

### DIFF
--- a/plugins/woocommerce/changelog/fix-29727-csv-importer-plus-in-path
+++ b/plugins/woocommerce/changelog/fix-29727-csv-importer-plus-in-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product CSV importer failing between steps when the file path contains special characters such as '+', and show a clear error when the CSV file cannot be opened.

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -213,13 +213,14 @@ class WC_Product_CSV_Importer_Controller {
 			return '';
 		}
 
+		// add_query_arg() does not encode values, so characters like '+' in request-derived strings would be decoded as a space on the next request.
 		$params = array(
 			'step'               => $keys[ $step_index + 1 ],
-			'file'               => str_replace( DIRECTORY_SEPARATOR, '/', $this->file ),
-			'delimiter'          => $this->delimiter,
+			'file'               => rawurlencode( str_replace( DIRECTORY_SEPARATOR, '/', $this->file ) ),
+			'delimiter'          => rawurlencode( $this->delimiter ),
 			'update_existing'    => $this->update_existing,
 			'map_preferences'    => $this->map_preferences,
-			'character_encoding' => $this->character_encoding,
+			'character_encoding' => rawurlencode( $this->character_encoding ),
 			'_wpnonce'           => wp_create_nonce( 'woocommerce-csv-importer' ), // wp_nonce_url() escapes & to &amp; breaking redirects.
 		);
 

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -109,46 +109,48 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 		$handle = fopen( $this->file, 'r' ); // @codingStandardsIgnoreLine.
 
-		if ( false !== $handle ) {
-			$this->raw_keys = array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ); // @codingStandardsIgnoreLine
+		if ( false === $handle ) {
+			wp_die( esc_html__( 'Unable to open the CSV file, please try again with a new file.', 'woocommerce' ) );
+		}
 
-			if ( ArrayUtil::is_truthy( $this->params, 'character_encoding' ) ) {
-				$this->raw_keys = array_map( array( $this, 'adjust_character_encoding' ), $this->raw_keys );
-			}
+		$this->raw_keys = array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ); // @codingStandardsIgnoreLine
 
-			// Remove line breaks in keys, to avoid mismatch mapping of keys.
-			$this->raw_keys = wc_clean( wp_unslash( $this->raw_keys ) );
+		if ( ArrayUtil::is_truthy( $this->params, 'character_encoding' ) ) {
+			$this->raw_keys = array_map( array( $this, 'adjust_character_encoding' ), $this->raw_keys );
+		}
 
-			// Remove BOM signature from the first item.
-			if ( isset( $this->raw_keys[0] ) ) {
-				$this->raw_keys[0] = $this->remove_utf8_bom( $this->raw_keys[0] );
-			}
+		// Remove line breaks in keys, to avoid mismatch mapping of keys.
+		$this->raw_keys = wc_clean( wp_unslash( $this->raw_keys ) );
 
-			if ( 0 !== $this->params['start_pos'] ) {
-				fseek( $handle, (int) $this->params['start_pos'] );
-			}
+		// Remove BOM signature from the first item.
+		if ( isset( $this->raw_keys[0] ) ) {
+			$this->raw_keys[0] = $this->remove_utf8_bom( $this->raw_keys[0] );
+		}
 
-			while ( 1 ) {
-				$row = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ); // @codingStandardsIgnoreLine
+		if ( 0 !== $this->params['start_pos'] ) {
+			fseek( $handle, (int) $this->params['start_pos'] );
+		}
 
-				if ( false !== $row ) {
-					if ( ArrayUtil::is_truthy( $this->params, 'character_encoding' ) ) {
-						$row = array_map( array( $this, 'adjust_character_encoding' ), $row );
-					}
+		while ( 1 ) {
+			$row = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ); // @codingStandardsIgnoreLine
 
-					$this->raw_data[]                                 = $row;
-					$this->file_positions[ count( $this->raw_data ) ] = ftell( $handle );
+			if ( false !== $row ) {
+				if ( ArrayUtil::is_truthy( $this->params, 'character_encoding' ) ) {
+					$row = array_map( array( $this, 'adjust_character_encoding' ), $row );
+				}
 
-					if ( ( $this->params['end_pos'] > 0 && ftell( $handle ) >= $this->params['end_pos'] ) || 0 === --$this->params['lines'] ) {
-						break;
-					}
-				} else {
+				$this->raw_data[]                                 = $row;
+				$this->file_positions[ count( $this->raw_data ) ] = ftell( $handle );
+
+				if ( ( $this->params['end_pos'] > 0 && ftell( $handle ) >= $this->params['end_pos'] ) || 0 === --$this->params['lines'] ) {
 					break;
 				}
+			} else {
+				break;
 			}
-
-			$this->file_position = ftell( $handle );
 		}
+
+		$this->file_position = ftell( $handle );
 
 		if ( ! empty( $this->params['mapping'] ) ) {
 			$this->set_mapped_keys();

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -101,6 +101,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 	/**
 	 * Read file.
+	 *
+	 * @throws RuntimeException When the file cannot be opened.
 	 */
 	protected function read_file() {
 		if ( ! WC_Product_CSV_Importer_Controller::is_file_valid_csv( $this->file ) ) {
@@ -110,7 +112,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		$handle = fopen( $this->file, 'r' ); // @codingStandardsIgnoreLine.
 
 		if ( false === $handle ) {
-			wp_die( esc_html__( 'Unable to open the CSV file, please try again with a new file.', 'woocommerce' ) );
+			// An exception rather than wp_die(), so callers in any context (admin, AJAX, REST, CLI) can catch and present it appropriately.
+			throw new RuntimeException( esc_html__( 'Unable to open the CSV file, please try again with a new file.', 'woocommerce' ) );
 		}
 
 		$headers = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ); // @codingStandardsIgnoreLine

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -113,7 +113,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			wp_die( esc_html__( 'Unable to open the CSV file, please try again with a new file.', 'woocommerce' ) );
 		}
 
-		$this->raw_keys = array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ); // @codingStandardsIgnoreLine
+		$headers = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ); // @codingStandardsIgnoreLine
+
+		// fgetcsv() returns false for an empty file; leave the keys empty so the empty-file error can be shown instead of fataling on array_map().
+		$this->raw_keys = is_array( $headers ) ? array_map( 'trim', $headers ) : array();
 
 		if ( ArrayUtil::is_truthy( $this->params, 'character_encoding' ) ) {
 			$this->raw_keys = array_map( array( $this, 'adjust_character_encoding' ), $this->raw_keys );

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -155,6 +155,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 		$this->file_position = ftell( $handle );
 
+		fclose( $handle ); // @codingStandardsIgnoreLine.
+
 		if ( ! empty( $this->params['mapping'] ) ) {
 			$this->set_mapped_keys();
 		}

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -109,7 +109,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			wp_die( esc_html__( 'Invalid file type. The importer supports CSV and TXT file formats.', 'woocommerce' ) );
 		}
 
-		$handle = fopen( $this->file, 'r' ); // @codingStandardsIgnoreLine.
+		$handle = @fopen( $this->file, 'r' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- warning suppressed so a strict error handler cannot preempt the RuntimeException below.
 
 		if ( false === $handle ) {
 			// An exception rather than wp_die(), so callers in any context (admin, AJAX, REST, CLI) can catch and present it appropriately.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -38902,18 +38902,6 @@ parameters:
 			path: src/Admin/API/OnboardingProfile.php
 
 		-
-			message: '#^Access to offset ''imported'' on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_Error\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/API/OnboardingTasks.php
-
-		-
-			message: '#^Access to offset ''imported'' on an unknown class Automattic\\WooCommerce\\Admin\\API\\WP_REST_Response\.$#'
-			identifier: class.notFound
-			count: 3
-			path: src/Admin/API/OnboardingTasks.php
-
-		-
 			message: '#^Call to an undefined method object\:\:dismiss\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -20281,12 +20281,6 @@ parameters:
 			path: includes/import/class-wc-product-csv-importer.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_map expects array, list\<string\|null\>\|false\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/import/class-wc-product-csv-importer.php
-
-		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, list\<string\|null\>\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -39190,24 +39190,6 @@ parameters:
 			path: src/Admin/API/OnboardingTasks.php
 
 		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks\:\:import_sample_products_from_csv\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\WP_Error\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/OnboardingTasks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks\:\:import_sample_products_from_csv\(\) has invalid return type Automattic\\WooCommerce\\Admin\\API\\WP_REST_Response\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Admin/API/OnboardingTasks.php
-
-		-
-			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks\:\:import_sample_products_from_csv\(\) should return Automattic\\WooCommerce\\Admin\\API\\WP_Error\|Automattic\\WooCommerce\\Admin\\API\\WP_REST_Response but returns WP_Error\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Admin/API/OnboardingTasks.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Admin\\API\\OnboardingTasks\:\:register_routes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -316,7 +316,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * Import sample products from given CSV path.
 	 *
 	 * @param  string $csv_file CSV file path.
-	 * @return WP_Error|WP_REST_Response
+	 * @return \WP_Error|array
 	 */
 	public static function import_sample_products_from_csv( $csv_file ) {
 		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
@@ -325,15 +325,29 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			// Override locale so we can return mappings from WooCommerce in English language stores.
 			add_filter( 'locale', '__return_false', 9999 );
 			$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
-			$args           = array(
-				'parse'   => true,
-				'mapping' => self::get_header_mappings( $csv_file ),
-			);
-			$args           = apply_filters( 'woocommerce_product_csv_importer_args', $args, $importer_class );
 
-			$importer = new $importer_class( $csv_file, $args );
-			$import   = $importer->import();
-			return $import;
+			try {
+				$args = array(
+					'parse'   => true,
+					'mapping' => self::get_header_mappings( $csv_file ),
+				);
+
+				/**
+				 * Filter the arguments used by the product CSV importer.
+				 *
+				 * @since 3.1.0
+				 *
+				 * @param array  $args           Importer arguments.
+				 * @param string $importer_class Importer class name.
+				 */
+				$args = apply_filters( 'woocommerce_product_csv_importer_args', $args, $importer_class );
+
+				$importer = new $importer_class( $csv_file, $args );
+				$import   = $importer->import();
+				return $import;
+			} catch ( \RuntimeException $e ) {
+				return new \WP_Error( 'woocommerce_rest_import_error', $e->getMessage() );
+			}
 		} else {
 			return new \WP_Error( 'woocommerce_rest_import_error', __( 'Sorry, the sample products data file was not found.', 'woocommerce' ) );
 		}

--- a/plugins/woocommerce/tests/php/includes/admin/importers/class-wc-product-csv-importer-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/importers/class-wc-product-csv-importer-controller-test.php
@@ -57,4 +57,28 @@ class WC_Product_CSV_Importer_Controller_Test extends WC_Unit_Test_Case {
 			$columns
 		);
 	}
+
+	/**
+	 * @testdox Should URL-encode request-derived values in the next step link so special characters like '+' survive the round trip.
+	 */
+	public function test_get_next_step_link_url_encodes_request_derived_params(): void {
+		$file      = '/tmp/+dir with spaces/import.csv';
+		$delimiter = '+';
+
+		$_REQUEST['step']      = 'upload';
+		$_REQUEST['file']      = $file;
+		$_REQUEST['delimiter'] = $delimiter;
+
+		try {
+			$controller = new WC_Product_CSV_Importer_Controller();
+			$url        = $controller->get_next_step_link();
+		} finally {
+			unset( $_REQUEST['step'], $_REQUEST['file'], $_REQUEST['delimiter'] );
+		}
+
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $params );
+
+		$this->assertSame( $file, $params['file'], 'The file path should survive the query string round trip unchanged' );
+		$this->assertSame( $delimiter, $params['delimiter'], 'The delimiter should survive the query string round trip unchanged' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/importers/class-wc-product-csv-importer-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/importers/class-wc-product-csv-importer-controller-test.php
@@ -62,23 +62,26 @@ class WC_Product_CSV_Importer_Controller_Test extends WC_Unit_Test_Case {
 	 * @testdox Should URL-encode request-derived values in the next step link so special characters like '+' survive the round trip.
 	 */
 	public function test_get_next_step_link_url_encodes_request_derived_params(): void {
-		$file      = '/tmp/+dir with spaces/import.csv';
-		$delimiter = '+';
+		$file               = '/tmp/+dir with spaces/import.csv';
+		$delimiter          = '+';
+		$character_encoding = 'UTF-8+custom';
 
-		$_REQUEST['step']      = 'upload';
-		$_REQUEST['file']      = $file;
-		$_REQUEST['delimiter'] = $delimiter;
+		$_REQUEST['step']               = 'upload';
+		$_REQUEST['file']               = $file;
+		$_REQUEST['delimiter']          = $delimiter;
+		$_REQUEST['character_encoding'] = $character_encoding;
 
 		try {
 			$controller = new WC_Product_CSV_Importer_Controller();
 			$url        = $controller->get_next_step_link();
 		} finally {
-			unset( $_REQUEST['step'], $_REQUEST['file'], $_REQUEST['delimiter'] );
+			unset( $_REQUEST['step'], $_REQUEST['file'], $_REQUEST['delimiter'], $_REQUEST['character_encoding'] );
 		}
 
 		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $params );
 
 		$this->assertSame( $file, $params['file'], 'The file path should survive the query string round trip unchanged' );
 		$this->assertSame( $delimiter, $params['delimiter'], 'The delimiter should survive the query string round trip unchanged' );
+		$this->assertSame( $character_encoding, $params['character_encoding'], 'The character encoding should survive the query string round trip unchanged' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -475,10 +475,10 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	 * @testdox Constructing the importer with a CSV file that cannot be opened should fail with a clear error.
 	 */
 	public function test_unopenable_csv_file_fails_with_clear_error() {
-		$this->expectException( WPDieException::class );
+		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Unable to open the CSV file, please try again with a new file.' );
 
-		// Silence the fopen() warning, which PHPUnit would otherwise convert into an error before wp_die() is reached.
+		// Silence the fopen() warning, which PHPUnit would otherwise convert into an error before the exception is thrown.
 		set_error_handler( static fn() => true, E_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- test-scoped warning suppression, restored below.
 
 		try {

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -489,6 +489,23 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Importing an empty CSV file should yield empty keys and data instead of fataling.
+	 */
+	public function test_empty_csv_file_yields_empty_keys_and_data() {
+		$empty_csv = sys_get_temp_dir() . '/empty-import.csv';
+		file_put_contents( $empty_csv, '' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture.
+
+		try {
+			$importer = new WC_Product_CSV_Importer( $empty_csv );
+
+			$this->assertSame( array(), $importer->get_raw_keys(), 'An empty CSV file should produce no raw keys' );
+			$this->assertSame( array(), $importer->get_raw_data(), 'An empty CSV file should produce no raw data' );
+		} finally {
+			unlink( $empty_csv ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- test fixture.
+		}
+	}
+
+	/**
 	 * @testdox adjust_character_encoding should convert values from the configured encoding to UTF-8 (issue #38541).
 	 * @dataProvider provider_adjust_character_encoding
 	 *

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -472,6 +472,23 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Constructing the importer with a CSV file that cannot be opened should fail with a clear error.
+	 */
+	public function test_unopenable_csv_file_fails_with_clear_error() {
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessage( 'Unable to open the CSV file, please try again with a new file.' );
+
+		// Silence the fopen() warning, which PHPUnit would otherwise convert into an error before wp_die() is reached.
+		set_error_handler( static fn() => true, E_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- test-scoped warning suppression, restored below.
+
+		try {
+			new WC_Product_CSV_Importer( __DIR__ . '/does-not-exist.csv' );
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	/**
 	 * @testdox adjust_character_encoding should convert values from the configured encoding to UTF-8 (issue #38541).
 	 * @dataProvider provider_adjust_character_encoding
 	 *

--- a/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
+++ b/plugins/woocommerce/tests/php/includes/importer/class-wc-product-csv-importer-test.php
@@ -478,14 +478,7 @@ class WC_Product_CSV_Importer_Test extends \WC_Unit_Test_Case {
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Unable to open the CSV file, please try again with a new file.' );
 
-		// Silence the fopen() warning, which PHPUnit would otherwise convert into an error before the exception is thrown.
-		set_error_handler( static fn() => true, E_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- test-scoped warning suppression, restored below.
-
-		try {
-			new WC_Product_CSV_Importer( __DIR__ . '/does-not-exist.csv' );
-		} finally {
-			restore_error_handler();
-		}
+		new WC_Product_CSV_Importer( __DIR__ . '/does-not-exist.csv' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The importer passes the uploaded file path between steps in the query string via `add_query_arg()`, which does not URL-encode values, so a `+` in the path (e.g. an uploads directory containing `+`) is decoded as a space on the next step and the import fails. This PR URL-encodes the request-derived values (`file`, `delimiter`, `character_encoding`) in `get_next_step_link()`, and makes `WC_Product_CSV_Importer::read_file()` fail with a clear "Unable to open the CSV file" message instead of silently continuing (which previously surfaced as a misleading "file is empty or wrong encoding" error).

BC note: code constructing `WC_Product_CSV_Importer` directly with an unreadable file now gets a `RuntimeException` instead of an empty import; the admin UI and AJAX flows catch it and show the message inline, and `OnboardingTasks::import_sample_products_from_csv()` catches it and returns a `WP_Error`.

Closes #29727, closes WOOPLUG-384

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Add `define( 'UPLOADS', 'wp-content/+test' );` to `wp-config.php`.
2. Save the following as `products.csv`:

```csv
Name,SKU,Regular price
Test Product,test-sku-1,10
```

3. Go to Products > All Products > Import, upload `products.csv`, and click Continue.
4. Confirm the column mapping step loads (before this fix it failed with "File path provided for import is invalid.").
5. Finish the import and confirm "Test Product" is created.

### Testing that has already taken place:

-   Reproduced the bug and verified the fix end to end on a local site (Valet, trunk) with an uploads path containing `+`, both headlessly via `wp eval` and through the admin import flow.
-   Unit tests for the importer/controller pass in wp-env; phpcs and PHPStan clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

