### PR TITLE
Fix PHPStan annotations not appearing on the diff

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -58,7 +58,18 @@ jobs:
               run: |
                   set +e  # Don't exit immediately on error
                   set -o pipefail  # But do capture pipeline exit codes
-                  pnpm --filter='@woocommerce/plugin-woocommerce' phpstan 2>&1 | tee /tmp/phpstan-output.txt
+                  # PHPStan detects GitHub Actions and emits '::error file=,line=,col=::' workflow
+                  # commands on its own, but its paths are relative to this working directory while
+                  # GitHub resolves annotation paths from the repo root. Without this rewrite the
+                  # annotations are emitted and then silently dropped, never showing up on the diff.
+                  #
+                  # The pattern is anchored so it only ever touches the path of a file-scoped error.
+                  # PHPStan's other two output shapes - '::error ::message' for errors that belong to
+                  # no file, and '::warning ::message' - carry no path, and a stray 'file=' inside one
+                  # of their messages must not be rewritten into a bogus path.
+                  pnpm --filter='@woocommerce/plugin-woocommerce' phpstan 2>&1 \
+                      | sed -u 's|^::error file=|::error file=plugins/woocommerce/|' \
+                      | tee /tmp/phpstan-output.txt
                   PHPSTAN_EXIT=${PIPESTATUS[0]}
                   if [[ $PHPSTAN_EXIT -ne 0 ]]; then
                       if grep -q "was not matched in reported errors" /tmp/phpstan-output.txt; then


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PHPStan already emits inline annotations on its own; it detects GitHub Actions and switches to its `github` error formatter. They just never reach the diff, because the paths are wrong. PHPStan runs from `plugins/woocommerce` and reports paths relative to that, while GitHub resolves annotation paths from the repo root; `src/Internal/Foo.php` matches nothing there, so the annotation is dropped. The errors end up in the job log and nowhere else.

This rewrites the paths to be repo-root-relative before they reach the runner. The `sed` only matches lines beginning with `::error file=`, so it can only ever rewrite the path of a file-scoped error. PHPStan's two other output shapes, `::error ::message` for errors that belong to no file and `::warning ::message`, carry no path at all; a stray `file=` inside one of those messages is left alone. `PIPESTATUS[0]` still points at `pnpm`; the exit code and baseline checks below it are unchanged.

<!-- Begin testing instructions -->

### Screenshots
<img width="584" height="390" alt="Screenshot 2026-07-24 at 16 10 45" src="https://github.com/user-attachments/assets/11513a4e-2de2-4912-aac7-5f4103d5d4b2" />


### How to test the changes in this Pull Request:

1. Open a PR adding a PHP file with a PHPStan error that isn't in the baseline; an untyped method parameter is enough.
2. Wait for the **PHPStan Analysis** check to fail.
3. Open **Files changed**. The error should show up inline on the offending line.
4. Without this change, the annotation is missing there and only visible in the job log.

<!-- End testing instructions -->

### Testing that has already taken place:

Reproduced on a live run against a deliberately broken file. The check-run annotations API returned the PHPStan errors with `path: src/Internal/…`, which is why none of them rendered.

Validated on #66992, a scratch PR with a wrong return type and a call to an undefined method. With the fix in place the annotations API returns `plugins/woocommerce/src/Internal/PhpstanAnnotationCheck.php` at lines 25 and 34, and both errors show up inline under "Files changed."


### Use of AI Tools

I used Claude Code to trace why the annotations weren't rendering and to draft the change. I reviewed and tested it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI workflow only; nothing ships to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
