### PR TITLE
[Do not merge] Deliberate PHPStan errors to verify CI annotations

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -58,7 +58,18 @@ jobs:
               run: |
                   set +e  # Don't exit immediately on error
                   set -o pipefail  # But do capture pipeline exit codes
-                  pnpm --filter='@woocommerce/plugin-woocommerce' phpstan 2>&1 | tee /tmp/phpstan-output.txt
+                  # PHPStan detects GitHub Actions and emits '::error file=,line=,col=::' workflow
+                  # commands on its own, but its paths are relative to this working directory while
+                  # GitHub resolves annotation paths from the repo root. Without this rewrite the
+                  # annotations are emitted and then silently dropped, never showing up on the diff.
+                  #
+                  # The pattern is anchored so it only ever touches the path of a file-scoped error.
+                  # PHPStan's other two output shapes - '::error ::message' for errors that belong to
+                  # no file, and '::warning ::message' - carry no path, and a stray 'file=' inside one
+                  # of their messages must not be rewritten into a bogus path.
+                  pnpm --filter='@woocommerce/plugin-woocommerce' phpstan 2>&1 \
+                      | sed -u 's|^::error file=|::error file=plugins/woocommerce/|' \
+                      | tee /tmp/phpstan-output.txt
                   PHPSTAN_EXIT=${PIPESTATUS[0]}
                   if [[ $PHPSTAN_EXIT -ne 0 ]]; then
                       if grep -q "was not matched in reported errors" /tmp/phpstan-output.txt; then

--- a/plugins/woocommerce/changelog/phpstan-annotation-check
+++ b/plugins/woocommerce/changelog/phpstan-annotation-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a throwaway class with deliberate PHPStan errors to verify CI annotations. Do not merge.

--- a/plugins/woocommerce/src/Internal/PhpstanAnnotationCheck.php
+++ b/plugins/woocommerce/src/Internal/PhpstanAnnotationCheck.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Throwaway file used to verify PHPStan CI annotations. Do not merge.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal;
+
+/**
+ * Class with deliberate static analysis errors.
+ *
+ * It exists only so a pull request contains PHPStan failures, which lets us confirm
+ * that the workflow's inline annotations land on the right file and line in the diff.
+ * Nothing loads this class, and it must never be merged.
+ */
+class PhpstanAnnotationCheck {
+
+	/**
+	 * Returns a string even though the signature promises an int.
+	 *
+	 * @return int
+	 */
+	public function wrong_return_type(): int {
+		return 'this is not an int';
+	}
+
+	/**
+	 * Calls a method that does not exist on this class.
+	 *
+	 * @return void
+	 */
+	public function undefined_method_call() {
+		$this->this_method_does_not_exist();
+	}
+}


### PR DESCRIPTION
**Do not merge.** This PR exists only to prove that the annotation fix in `fix/phpstan-annotation-paths` works, and it should be closed once we've seen the result.

### Changes proposed in this Pull Request

Adds `src/Internal/PhpstanAnnotationCheck.php`, a throwaway class with two deliberate PHPStan errors:

- `wrong_return_type()` declares `: int` and returns a string (line 25)
- `undefined_method_call()` calls a method that doesn't exist (line 34)

Nothing loads the class; it only needs to be inside `plugins/woocommerce/src/` so PHPStan analyses it, and inside the diff so GitHub can attach annotations to it.

### What we're verifying

PHPStan runs from `plugins/woocommerce`, so it emits paths relative to that directory:

```
::error file=src/Internal/PhpstanAnnotationCheck.php,line=25,col=0::Method ... should return int but returns string.
```

GitHub resolves annotation paths from the repo root, so it silently drops these. The base branch pipes PHPStan's output through `sed` to prepend `plugins/woocommerce/`:

```
::error file=plugins/woocommerce/src/Internal/PhpstanAnnotationCheck.php,line=25,col=0::...
```

### How to test the changes in this Pull Request

1. Wait for the **PHPStan Analysis** check to run.
2. Open the Files changed tab.
3. Both errors should appear as inline annotations on `PhpstanAnnotationCheck.php`, on lines 25 and 34.

Without the fix the job still fails, but the diff stays clean; that's the behaviour we're replacing.

### Testing that has already taken place

Ran PHPStan locally with `--error-format=github` and confirmed it reports both errors with `file=src/Internal/...`. Piped that output through the same `sed` and confirmed it produces a valid repo-root path.

Also checked the two other shapes PHPStan emits, since the pattern needs to leave them alone:

| Output | Result |
| --- | --- |
| `::error file=src/Internal/Foo.php,line=25,col=0::...` | rewritten |
| `::error ::Ignored error pattern in file=bar ...` | untouched |
| `::warning ::Result cache in file=tmp ...` | untouched |

PHPStan's `GithubErrorFormatter` only ever attaches `file=` to file-scoped errors; its warnings and its not-file-specific errors are emitted without a path. The pattern is anchored to `^::error file=` so a stray `file=` inside one of those messages can't be rewritten into a bogus path.

### Changelog entry

Added, so the changelog check stays green. It goes away with the branch.
