### PR TITLE
feat(email-editor): render grid-layout Query Loop post-templates as email-safe columns

### DIFF
--- a/packages/php/email-editor/changelog/add-email-post-template-grid-renderer
+++ b/packages/php/email-editor/changelog/add-email-post-template-grid-renderer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Render a Query Loop's post-template grid as an email-safe table of columns. Grid layouts (e.g. a 3-column sponsor logo grid) previously collapsed to a single stacked column in email clients because CSS grid isn't supported; the post-template's items are now re-flowed into table columns matching the author's column count.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -35,10 +35,11 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
  */
 class Post_Template extends Abstract_Block_Renderer {
 	/**
-	 * Upper bound on grid columns, matching the range the core Gallery renderer allows. Keeps a very
-	 * wide grid from producing unreadably narrow cells while still honoring the author's column choice.
+	 * Upper bound on grid columns, matching the maximum the core grid layout control allows (its
+	 * Columns range control tops out at 16). Honors any column count an author can pick in the editor,
+	 * while still bounding an out-of-range hand-edited value so it can't emit a runaway number of cells.
 	 */
-	private const MAX_COLUMNS = 8;
+	private const MAX_COLUMNS = 16;
 
 	/**
 	 * Per-cell padding (px) that stands in for the grid's `gap` between items.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -291,8 +291,15 @@ class Post_Template extends Abstract_Block_Renderer {
 		$remove_targets = array();
 
 		foreach ( $item_dom->find_elements( 'img' ) as $img_element ) {
+			// Strip every image from the item up front so none can linger in the preserved remainder —
+			// whether we rebuild it below or drop it as unrenderable. Targets are computed now (before
+			// any removal) and applied after the loop, so the media counts stay accurate.
+			$remove_targets[] = $this->find_image_removal_target( $img_element );
+
 			$normalized_img = $this->normalize_image_for_email( $item_dom->get_outer_html( $img_element ), $cell_width );
 			if ( '' === $normalized_img ) {
+				// The image had no usable src (e.g. an unsafe URL esc_url rejected); drop it rather than
+				// leak the original unsanitized tag through the remainder.
 				continue;
 			}
 
@@ -302,7 +309,6 @@ class Post_Template extends Abstract_Block_Renderer {
 			} else {
 				$images[] = $normalized_img;
 			}
-			$remove_targets[] = $this->find_image_removal_target( $img_element );
 		}
 
 		if ( empty( $images ) ) {
@@ -412,6 +418,10 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * @return string Normalized `<img>` HTML, or an empty string when the image has no usable src.
 	 */
 	private function normalize_image_for_email( string $img_html, int $cell_width ): string {
+		if ( '' === $img_html ) {
+			return '';
+		}
+
 		$sanitized = Html_Processing_Helper::sanitize_image_html( $img_html );
 
 		$html = new \WP_HTML_Tag_Processor( $sanitized );

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -47,15 +47,25 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
-		$items = $this->extract_list_items( $block_content );
+		if ( '' === trim( $block_content ) ) {
+			return $block_content;
+		}
 
-		// If we can't find the expected list, leave the original content untouched so we never
+		$dom          = new Dom_Document_Helper( $block_content );
+		$list_element = $this->find_post_template_list( $dom );
+
+		// If we can't find the post-template list, leave the original content untouched so we never
 		// degrade output for markup shapes we don't recognize.
+		if ( null === $list_element ) {
+			return $block_content;
+		}
+
+		$items = $this->extract_list_items( $dom, $list_element );
 		if ( empty( $items ) ) {
 			return $block_content;
 		}
 
-		$columns = $this->get_column_count( $parsed_block, $block_content );
+		$columns = $this->get_column_count( $parsed_block, $dom, $list_element );
 
 		// Single-column (list/flow/constrained) layouts already stack correctly in email; only the
 		// multi-column grid/flex layouts need to be rebuilt as a table.
@@ -63,36 +73,42 @@ class Post_Template extends Abstract_Block_Renderer {
 			return $block_content;
 		}
 
-		return $this->build_grid_table( $items, $columns, $block_content );
+		return $this->build_grid_table( $items, $columns, $dom, $list_element );
+	}
+
+	/**
+	 * Locate the post-template list within the rendered content.
+	 *
+	 * The list is matched by its `wp-block-post-template` class rather than by being the first
+	 * `<ul>`, so a sibling list that happens to appear earlier in the markup can't be mistaken for
+	 * the repeater. Returns null when no such list is present.
+	 *
+	 * @param Dom_Document_Helper $dom Parsed block content.
+	 * @return \DOMElement|null
+	 */
+	private function find_post_template_list( Dom_Document_Helper $dom ): ?\DOMElement {
+		foreach ( $dom->find_elements( 'ul' ) as $list_element ) {
+			if ( false !== strpos( $dom->get_attribute_value( $list_element, 'class' ), 'wp-block-post-template' ) ) {
+				return $list_element;
+			}
+		}
+		return null;
 	}
 
 	/**
 	 * Extract the inner HTML of each direct-child `<li>` of the post-template list.
 	 *
-	 * Only the post-template's own list is handled: a nested list inside post content (e.g. a
-	 * `core/list` in an excerpt) must not be mistaken for the repeater, so the wrapper is required to
-	 * carry the `wp-block-post-template` class before its items are collected.
+	 * Only direct children are collected, so a nested list inside a post's content (e.g. a
+	 * `core/list` in an excerpt) contributes its markup to the item it lives in rather than being
+	 * mistaken for additional repeater items.
 	 *
-	 * @param string $block_content The rendered post-template block HTML.
+	 * @param Dom_Document_Helper $dom Parsed block content.
+	 * @param \DOMElement         $list_element The post-template list element.
 	 * @return array<int, string> Inner HTML of each list item, in document order.
 	 */
-	private function extract_list_items( string $block_content ): array {
-		if ( '' === trim( $block_content ) ) {
-			return array();
-		}
-
-		$dom  = new Dom_Document_Helper( $block_content );
-		$list = $dom->find_element( 'ul' );
-		if ( null === $list ) {
-			return array();
-		}
-
-		if ( false === strpos( $dom->get_attribute_value( $list, 'class' ), 'wp-block-post-template' ) ) {
-			return array();
-		}
-
+	private function extract_list_items( Dom_Document_Helper $dom, \DOMElement $list_element ): array {
 		$items = array();
-		foreach ( $list->childNodes as $node ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		foreach ( $list_element->childNodes as $node ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			if ( $node instanceof \DOMElement && 'li' === $node->tagName ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$items[] = $dom->get_element_inner_html( $node );
 			}
@@ -108,11 +124,12 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * WordPress core stamps on the rendered list, so it still works when the parsed attributes are
 	 * sparse. Non-grid/flex layouts always resolve to a single (stacked) column.
 	 *
-	 * @param array  $parsed_block Parsed block data.
-	 * @param string $block_content The rendered post-template block HTML.
+	 * @param array               $parsed_block Parsed block data.
+	 * @param Dom_Document_Helper $dom Parsed block content.
+	 * @param \DOMElement         $list_element The post-template list element.
 	 * @return int Column count (at least 1).
 	 */
-	private function get_column_count( array $parsed_block, string $block_content ): int {
+	private function get_column_count( array $parsed_block, Dom_Document_Helper $dom, \DOMElement $list_element ): int {
 		$layout = $parsed_block['attrs']['layout'] ?? array();
 		$type   = is_array( $layout ) && isset( $layout['type'] ) ? (string) $layout['type'] : '';
 
@@ -127,12 +144,8 @@ class Post_Template extends Abstract_Block_Renderer {
 		}
 
 		// Fallback: read the `columns-N` class WordPress core adds to the list wrapper.
-		if ( $columns < 1 ) {
-			$dom  = new Dom_Document_Helper( $block_content );
-			$list = $dom->find_element( 'ul' );
-			if ( $list && preg_match( '/(?:^|\s)columns-(\d+)(?:\s|$)/', $dom->get_attribute_value( $list, 'class' ), $matches ) ) {
-				$columns = (int) $matches[1];
-			}
+		if ( $columns < 1 && preg_match( '/(?:^|\s)columns-(\d+)(?:\s|$)/', $dom->get_attribute_value( $list_element, 'class' ), $matches ) ) {
+			$columns = (int) $matches[1];
 		}
 
 		if ( $columns < 1 ) {
@@ -149,12 +162,13 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * into rows of `$columns` and each row is its own fixed-layout table, so every cell keeps a
 	 * consistent width regardless of how many items the final (possibly partial) row holds.
 	 *
-	 * @param array<int, string> $items Inner HTML of each list item.
-	 * @param int                $columns Number of columns.
-	 * @param string             $block_content The original block HTML (for wrapper classes).
+	 * @param array<int, string>  $items Inner HTML of each list item.
+	 * @param int                 $columns Number of columns.
+	 * @param Dom_Document_Helper $dom Parsed block content.
+	 * @param \DOMElement         $list_element The post-template list element (for wrapper classes).
 	 * @return string Grid table HTML.
 	 */
-	private function build_grid_table( array $items, int $columns, string $block_content ): string {
+	private function build_grid_table( array $items, int $columns, Dom_Document_Helper $dom, \DOMElement $list_element ): string {
 		$rows       = array();
 		$item_count = count( $items );
 		for ( $i = 0; $i < $item_count; $i += $columns ) {
@@ -162,7 +176,7 @@ class Post_Template extends Abstract_Block_Renderer {
 		}
 		$grid_content = implode( '', $rows );
 
-		$original_class = ( new Dom_Document_Helper( $block_content ) )->get_attribute_value_by_tag_name( 'ul', 'class' ) ?? '';
+		$original_class = $dom->get_attribute_value( $list_element, 'class' );
 
 		$table_attrs = array(
 			'class' => trim( 'email-block-post-template ' . Html_Processing_Helper::clean_css_classes( $original_class ) ),

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -108,7 +108,11 @@ class Post_Template extends Abstract_Block_Renderer {
 	 */
 	private function find_post_template_list( Dom_Document_Helper $dom ): ?\DOMElement {
 		foreach ( $dom->find_elements( 'ul' ) as $list_element ) {
-			if ( false !== strpos( $dom->get_attribute_value( $list_element, 'class' ), 'wp-block-post-template' ) ) {
+			// Match `wp-block-post-template` as a whole class token, not a substring, so an unrelated
+			// list whose class merely contains the string (e.g. `my-wp-block-post-template-wrapper`)
+			// isn't mistaken for the repeater and rebuilt.
+			$classes = preg_split( '/\s+/', trim( $dom->get_attribute_value( $list_element, 'class' ) ) );
+			if ( is_array( $classes ) && in_array( 'wp-block-post-template', $classes, true ) ) {
 				return $list_element;
 			}
 		}
@@ -282,7 +286,10 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * @return string Cell content HTML.
 	 */
 	private function prepare_item_content( string $item_html, int $cell_width ): string {
-		if ( false === strpos( $item_html, '<img' ) ) {
+		// `stripos` (not `strpos`) so an uppercase `<IMG>` fast-path isn't skipped. In practice the
+		// item HTML arrives lowercased by DOM serialization, but this keeps the guard correct if a
+		// caller ever passes raw markup.
+		if ( false === stripos( $item_html, '<img' ) ) {
 			return $item_html;
 		}
 
@@ -291,9 +298,9 @@ class Post_Template extends Abstract_Block_Renderer {
 		$remove_targets = array();
 
 		foreach ( $item_dom->find_elements( 'img' ) as $img_element ) {
-			// Strip every image from the item up front so none can linger in the preserved remainder —
-			// whether we rebuild it below or drop it as unrenderable. Targets are computed now (before
-			// any removal) and applied after the loop, so the media counts stay accurate.
+			// Record every image up front so none can linger in the preserved remainder — whether we
+			// rebuild it below or drop it as unrenderable. Targets are computed now (before any removal)
+			// so the media counts stay accurate.
 			$remove_targets[] = $this->find_image_removal_target( $img_element );
 
 			$normalized_img = $this->normalize_image_for_email( $item_dom->get_outer_html( $img_element ), $cell_width );
@@ -311,12 +318,15 @@ class Post_Template extends Abstract_Block_Renderer {
 			}
 		}
 
-		if ( empty( $images ) ) {
+		// The `<img` match was not a real image element (e.g. it sat inside a comment); leave the
+		// content untouched.
+		if ( empty( $remove_targets ) ) {
 			return $item_html;
 		}
 
-		// Strip the images we've hoisted so they aren't duplicated, then keep whatever real content
-		// remains (title/date/excerpt). If only empty wrapper shells are left, drop them entirely.
+		// Strip every image found — including any we couldn't rebuild — so an unrenderable, unsanitized
+		// `<img>` (e.g. one carrying `onerror`) can never survive through the remainder, then keep
+		// whatever real content remains (title/date/excerpt). Empty wrapper shells are dropped.
 		foreach ( $remove_targets as $target ) {
 			$item_dom->remove_element( $target );
 		}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -384,6 +384,8 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	private function extract_remaining_content( Dom_Document_Helper $item_dom ): string {
+		$this->strip_unsafe_markup( $item_dom );
+
 		$remainder = $item_dom->get_root_html();
 
 		// Treat the remainder as empty unless it carries visible text or embedded media — otherwise it
@@ -394,6 +396,44 @@ class Post_Template extends Abstract_Block_Renderer {
 		}
 
 		return $remainder;
+	}
+
+	/**
+	 * Strip markup that has no place in an email from the preserved remainder: `<script>`/`<style>`
+	 * elements and inline event-handler (`on*`) attributes.
+	 *
+	 * The images beside this content are already sanitized when they're rebuilt, so this keeps the
+	 * reconstructed cell internally consistent. It intentionally leaves `style` attributes and all
+	 * structural markup in place, so legitimate card content (title/date/excerpt) renders unchanged —
+	 * core never emits scripts or handlers there, making this a no-op for real content. Scoped to this
+	 * renderer's grid path only; it operates on the local item DOM and touches no shared helper.
+	 *
+	 * @param Dom_Document_Helper $item_dom The item DOM to clean in place.
+	 */
+	private function strip_unsafe_markup( Dom_Document_Helper $item_dom ): void {
+		foreach ( array( 'script', 'style' ) as $tag_name ) {
+			foreach ( $item_dom->find_elements( $tag_name ) as $element ) {
+				$item_dom->remove_element( $element );
+			}
+		}
+
+		foreach ( $item_dom->find_elements( '*' ) as $element ) {
+			$attributes = $element->attributes;
+			if ( null === $attributes ) {
+				continue;
+			}
+			// Collect handler attribute names first, then remove — mutating the live attribute map
+			// mid-iteration would skip entries.
+			$handler_attributes = array();
+			foreach ( $attributes as $attribute ) {
+				if ( 0 === stripos( $attribute->name, 'on' ) ) {
+					$handler_attributes[] = $attribute->name;
+				}
+			}
+			foreach ( $handler_attributes as $attribute_name ) {
+				$element->removeAttribute( $attribute_name );
+			}
+		}
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -270,35 +270,25 @@ class Post_Template extends Abstract_Block_Renderer {
 	 *
 	 * Each image in the item is rebuilt as a clean, responsive `<img>` (preserving its link) sitting
 	 * directly in the cell, so its width resolves against the grid column instead of collapsing inside
-	 * the fixed-width wrapper tables WordPress renders around it. An item with no image is returned
-	 * unchanged — its text content stacks correctly without intervention.
+	 * the fixed-width wrapper tables WordPress renders around it. Any non-image content the card holds
+	 * (post title, date, excerpt) is kept below the image, so a post grid isn't reduced to bare images.
+	 *
+	 * When the card is image-only (e.g. a featured-image sponsor grid) the leftover is nothing but the
+	 * now-empty wrapper shells, which are dropped so the output stays a clean logo grid. An item with no
+	 * image at all is returned unchanged — its text stacks correctly without intervention.
 	 *
 	 * @param string $item_html Inner HTML of a single list item.
 	 * @param int    $cell_width Cell content width in px.
 	 * @return string Cell content HTML.
 	 */
 	private function prepare_item_content( string $item_html, int $cell_width ): string {
-		$images = $this->extract_item_images( $item_html, $cell_width );
-		if ( empty( $images ) ) {
+		if ( false === strpos( $item_html, '<img' ) ) {
 			return $item_html;
 		}
-		return implode( '', $images );
-	}
 
-	/**
-	 * Extract every image from a list item and rebuild it for email.
-	 *
-	 * @param string $item_html Inner HTML of a single list item.
-	 * @param int    $cell_width Cell content width in px.
-	 * @return array<int, string> Rebuilt image HTML strings, in document order.
-	 */
-	private function extract_item_images( string $item_html, int $cell_width ): array {
-		if ( false === strpos( $item_html, '<img' ) ) {
-			return array();
-		}
-
-		$item_dom = new Dom_Document_Helper( $item_html );
-		$images   = array();
+		$item_dom       = new Dom_Document_Helper( $item_html );
+		$images         = array();
+		$remove_targets = array();
 
 		foreach ( $item_dom->find_elements( 'img' ) as $img_element ) {
 			$normalized_img = $this->normalize_image_for_email( $item_dom->get_outer_html( $img_element ), $cell_width );
@@ -312,9 +302,82 @@ class Post_Template extends Abstract_Block_Renderer {
 			} else {
 				$images[] = $normalized_img;
 			}
+			$remove_targets[] = $this->find_image_removal_target( $img_element );
 		}
 
-		return $images;
+		if ( empty( $images ) ) {
+			return $item_html;
+		}
+
+		// Strip the images we've hoisted so they aren't duplicated, then keep whatever real content
+		// remains (title/date/excerpt). If only empty wrapper shells are left, drop them entirely.
+		foreach ( $remove_targets as $target ) {
+			$item_dom->remove_element( $target );
+		}
+
+		return implode( '', $images ) . $this->extract_remaining_content( $item_dom );
+	}
+
+	/**
+	 * Choose which element to strip when hoisting an image, so the preserved remainder is clean.
+	 *
+	 * Climbs from the image through every ancestor that wraps nothing but that single image — no text,
+	 * no other media — and returns the outermost such wrapper. This removes the whole empty
+	 * `<figure>`/`<a>`/layout-table shell WordPress renders around a featured image in one go, rather
+	 * than leaving hollow, padded cells behind. Climbing stops as soon as an ancestor holds real
+	 * content, so a sibling title/date (outside the image's wrapper) and a `<figcaption>` (whose text
+	 * lives on the figure) are both preserved.
+	 *
+	 * @param \DOMElement $img_element The image element being hoisted.
+	 * @return \DOMElement The element to remove from the item.
+	 */
+	private function find_image_removal_target( \DOMElement $img_element ): \DOMElement {
+		$target = $img_element;
+		$parent = $img_element->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		while ( $parent instanceof \DOMElement ) {
+			// Stop once the ancestor carries text (e.g. a caption or a sibling title) or wraps more
+			// than just this one image — removing it would take real content with it.
+			if ( '' !== trim( $parent->textContent ) || 1 !== $this->count_media_descendants( $parent ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				break;
+			}
+			$target = $parent;
+			$parent = $parent->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+		return $target;
+	}
+
+	/**
+	 * Count the media elements (images and embeds) contained within an element.
+	 *
+	 * @param \DOMElement $element The element to inspect.
+	 * @return int
+	 */
+	private function count_media_descendants( \DOMElement $element ): int {
+		$count = $element->getElementsByTagName( 'img' )->length;
+		foreach ( array( 'video', 'audio', 'iframe', 'svg' ) as $tag_name ) {
+			$count += $element->getElementsByTagName( $tag_name )->length;
+		}
+		return $count;
+	}
+
+	/**
+	 * Read back the card content left after the images were removed, or an empty string when nothing
+	 * but structural wrapper shells remain (so image-only cards stay a clean grid).
+	 *
+	 * @param Dom_Document_Helper $item_dom The item DOM after image removal.
+	 * @return string
+	 */
+	private function extract_remaining_content( Dom_Document_Helper $item_dom ): string {
+		$remainder = $item_dom->get_root_html();
+
+		// Treat the remainder as empty unless it carries visible text or embedded media — otherwise it
+		// is just the leftover wrapper markup (empty figures/tables) the image used to live in.
+		if ( '' === trim( str_replace( "\xc2\xa0", '', wp_strip_all_tags( $remainder ) ) )
+			&& ! preg_match( '/<(img|video|audio|iframe|svg)\b/i', $remainder ) ) {
+			return '';
+		}
+
+		return $remainder;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -131,7 +131,7 @@ class Post_Template extends Abstract_Block_Renderer {
 	 */
 	private function get_column_count( array $parsed_block, Dom_Document_Helper $dom, \DOMElement $list_element ): int {
 		$layout = $parsed_block['attrs']['layout'] ?? array();
-		$type   = is_array( $layout ) && isset( $layout['type'] ) ? (string) $layout['type'] : '';
+		$type   = is_array( $layout ) && isset( $layout['type'] ) && is_string( $layout['type'] ) ? $layout['type'] : '';
 
 		// A layout that is neither grid nor flex (default, constrained, flow) stacks in one column.
 		if ( '' !== $type && 'grid' !== $type && 'flex' !== $type ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Html_Processing_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 
 /**
@@ -23,8 +24,14 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
  * images (see {@see Gallery::build_gallery_table()}).
  *
  * The list items arrive already rendered (post-template is a dynamic block, so `$block_content`
- * holds the final `<ul><li>…</li></ul>`), so this renderer only rearranges them — it never
- * re-runs the query.
+ * holds the final `<ul><li>…</li></ul>`), so this renderer never re-runs the query. Each item's
+ * image is extracted and rebuilt as a clean, responsive `<img>` sitting directly in its grid cell —
+ * the same shape the Gallery renderer emits. This is deliberate: the images WordPress renders inside
+ * a post-template `<li>` are wrapped in fixed-width, auto-layout tables (`<td width="520">`) that
+ * were never sized for email, and a nested `width: 100%` image inside them collapses to a few pixels
+ * in Gmail (the width has no resolvable basis). Hoisting the image into the grid cell gives it a
+ * definite basis so it fills its column and scales down on mobile. An item with no image falls back
+ * to its original markup untouched (text content stacks correctly on its own).
  */
 class Post_Template extends Abstract_Block_Renderer {
 	/**
@@ -37,6 +44,14 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * Per-cell padding (px) that stands in for the grid's `gap` between items.
 	 */
 	private const CELL_PADDING = 8;
+
+	/**
+	 * Responsive image style applied to every rebuilt grid image. `width: 100%` fills the column,
+	 * `max-width: 100%` lets it scale down on narrow viewports, and `height: auto` keeps the ratio.
+	 * The explicit `width` attribute (set alongside this) is the Outlook fallback, since Outlook
+	 * ignores `max-width`.
+	 */
+	private const IMAGE_STYLE = 'border: 0; line-height: 100%; width: 100%; max-width: 100%; height: auto; display: block;';
 
 	/**
 	 * Renders the post-template block content using a table-based grid layout.
@@ -73,7 +88,11 @@ class Post_Template extends Abstract_Block_Renderer {
 			return $block_content;
 		}
 
-		return $this->build_grid_table( $items, $columns, $dom, $list_element );
+		// The layout width (minus the email's root padding) is what each cell's images are sized to,
+		// so an image CDN / Outlook get a concrete pixel width rather than the intrinsic file width.
+		$layout_width = (int) Styles_Helper::parse_value( $rendering_context->get_layout_width_without_padding() );
+
+		return $this->build_grid_table( $items, $columns, $dom, $list_element, $layout_width );
 	}
 
 	/**
@@ -166,13 +185,16 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * @param int                 $columns Number of columns.
 	 * @param Dom_Document_Helper $dom Parsed block content.
 	 * @param \DOMElement         $list_element The post-template list element (for wrapper classes).
+	 * @param int                 $layout_width Available layout width in px.
 	 * @return string Grid table HTML.
 	 */
-	private function build_grid_table( array $items, int $columns, Dom_Document_Helper $dom, \DOMElement $list_element ): string {
+	private function build_grid_table( array $items, int $columns, Dom_Document_Helper $dom, \DOMElement $list_element, int $layout_width ): string {
+		$cell_width = $this->get_cell_width( $layout_width, $columns );
+
 		$rows       = array();
 		$item_count = count( $items );
 		for ( $i = 0; $i < $item_count; $i += $columns ) {
-			$rows[] = $this->build_grid_row( array_slice( $items, $i, $columns ), $columns );
+			$rows[] = $this->build_grid_row( array_slice( $items, $i, $columns ), $columns, $cell_width );
 		}
 		$grid_content = implode( '', $rows );
 
@@ -188,6 +210,24 @@ class Post_Template extends Abstract_Block_Renderer {
 	}
 
 	/**
+	 * Estimate the rendered pixel width of a single grid cell's content area.
+	 *
+	 * The layout width is split evenly across the columns and the per-cell padding is removed from
+	 * both sides. Used to give each rebuilt image a concrete `width` attribute (the Outlook fallback)
+	 * instead of the intrinsic file width, which Outlook would otherwise honor literally and blow the
+	 * cell open.
+	 *
+	 * @param int $layout_width Available layout width in px.
+	 * @param int $columns Number of columns.
+	 * @return int Cell content width in px (at least 1).
+	 */
+	private function get_cell_width( int $layout_width, int $columns ): int {
+		$columns    = max( 1, $columns );
+		$cell_width = (int) floor( $layout_width / $columns ) - ( 2 * self::CELL_PADDING );
+		return max( 1, $cell_width );
+	}
+
+	/**
 	 * Build a single grid row as its own fixed-layout table.
 	 *
 	 * Every cell is a fixed `100 / $columns` percent wide and a partial final row is padded with
@@ -198,14 +238,16 @@ class Post_Template extends Abstract_Block_Renderer {
 	 *
 	 * @param array<int, string> $row_items Inner HTML of the items in this row.
 	 * @param int                $columns Total number of columns.
+	 * @param int                $cell_width Cell content width in px.
 	 * @return string Row table HTML.
 	 */
-	private function build_grid_row( array $row_items, int $columns ): string {
+	private function build_grid_row( array $row_items, int $columns, int $cell_width ): string {
 		$cell_width_percent = 100 / $columns;
 		$cells              = '';
 
 		for ( $col = 0; $col < $columns; $col++ ) {
-			$cell_attrs = array(
+			$cell_content = isset( $row_items[ $col ] ) ? $this->prepare_item_content( $row_items[ $col ], $cell_width ) : '';
+			$cell_attrs   = array(
 				'style'  => sprintf(
 					'width: %s; padding: %dpx; vertical-align: top; text-align: center;',
 					Html_Processing_Helper::sanitize_css_value( sprintf( '%.4f%%', $cell_width_percent ) ),
@@ -213,7 +255,7 @@ class Post_Template extends Abstract_Block_Renderer {
 				),
 				'valign' => 'top',
 			);
-			$cells     .= Table_Wrapper_Helper::render_table_cell( $row_items[ $col ] ?? '', $cell_attrs );
+			$cells       .= Table_Wrapper_Helper::render_table_cell( $cell_content, $cell_attrs );
 		}
 
 		return sprintf(
@@ -221,5 +263,125 @@ class Post_Template extends Abstract_Block_Renderer {
 			Html_Processing_Helper::sanitize_css_value( '100%' ),
 			$cells
 		);
+	}
+
+	/**
+	 * Turn a rendered `<li>`'s inner HTML into email-safe cell content.
+	 *
+	 * Each image in the item is rebuilt as a clean, responsive `<img>` (preserving its link) sitting
+	 * directly in the cell, so its width resolves against the grid column instead of collapsing inside
+	 * the fixed-width wrapper tables WordPress renders around it. An item with no image is returned
+	 * unchanged — its text content stacks correctly without intervention.
+	 *
+	 * @param string $item_html Inner HTML of a single list item.
+	 * @param int    $cell_width Cell content width in px.
+	 * @return string Cell content HTML.
+	 */
+	private function prepare_item_content( string $item_html, int $cell_width ): string {
+		$images = $this->extract_item_images( $item_html, $cell_width );
+		if ( empty( $images ) ) {
+			return $item_html;
+		}
+		return implode( '', $images );
+	}
+
+	/**
+	 * Extract every image from a list item and rebuild it for email.
+	 *
+	 * @param string $item_html Inner HTML of a single list item.
+	 * @param int    $cell_width Cell content width in px.
+	 * @return array<int, string> Rebuilt image HTML strings, in document order.
+	 */
+	private function extract_item_images( string $item_html, int $cell_width ): array {
+		if ( false === strpos( $item_html, '<img' ) ) {
+			return array();
+		}
+
+		$item_dom = new Dom_Document_Helper( $item_html );
+		$images   = array();
+
+		foreach ( $item_dom->find_elements( 'img' ) as $img_element ) {
+			$normalized_img = $this->normalize_image_for_email( $item_dom->get_outer_html( $img_element ), $cell_width );
+			if ( '' === $normalized_img ) {
+				continue;
+			}
+
+			$href = $this->find_link_href( $img_element );
+			if ( '' !== $href ) {
+				$images[] = '<a href="' . esc_url( $href ) . '">' . $normalized_img . '</a>';
+			} else {
+				$images[] = $normalized_img;
+			}
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Return the href of the nearest ancestor `<a>` of the given image, or an empty string.
+	 *
+	 * @param \DOMElement $img_element The image element.
+	 * @return string
+	 */
+	private function find_link_href( \DOMElement $img_element ): string {
+		$parent = $img_element->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		while ( $parent instanceof \DOMElement ) {
+			if ( 'a' === $parent->tagName ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				return $parent->getAttribute( 'href' );
+			}
+			$parent = $parent->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+		return '';
+	}
+
+	/**
+	 * Sanitize a raw `<img>` and normalize it for a grid cell.
+	 *
+	 * Reuses {@see Html_Processing_Helper::sanitize_image_html()} for the security pass (attribute
+	 * allowlist, URL/style sanitizing), then pins the display width to the cell and replaces the
+	 * web-only styling with the responsive email style. WordPress stores the intrinsic file width
+	 * (e.g. `width="1024"`) which Outlook honors literally, and the core web style carries a
+	 * `width: 100%` that collapses once the image is out of a CSS grid — so both are overwritten with
+	 * a concrete cell width plus {@see self::IMAGE_STYLE}.
+	 *
+	 * @param string $img_html Raw `<img>` HTML.
+	 * @param int    $cell_width Cell content width in px.
+	 * @return string Normalized `<img>` HTML, or an empty string when the image has no usable src.
+	 */
+	private function normalize_image_for_email( string $img_html, int $cell_width ): string {
+		$sanitized = Html_Processing_Helper::sanitize_image_html( $img_html );
+
+		$html = new \WP_HTML_Tag_Processor( $sanitized );
+		if ( ! $html->next_tag( array( 'tag_name' => 'img' ) ) ) {
+			return '';
+		}
+
+		$src = $html->get_attribute( 'src' );
+		if ( ! is_string( $src ) || '' === $src ) {
+			return '';
+		}
+
+		// Scale the stored height to the cell width so the image keeps its aspect ratio in clients
+		// that read the attributes (Outlook). A missing/oversized/non-numeric dimension just leaves
+		// the height to `height: auto` in the style.
+		$raw_width  = $html->get_attribute( 'width' );
+		$raw_height = $html->get_attribute( 'height' );
+		$width      = is_string( $raw_width ) && is_numeric( $raw_width ) ? (int) $raw_width : 0;
+		$height     = is_string( $raw_height ) && is_numeric( $raw_height ) ? (int) $raw_height : 0;
+		if ( $width > 0 && $height > 0 ) {
+			$scaled_height = max( 1, (int) round( $height * ( $cell_width / $width ) ) );
+			$html->set_attribute( 'height', esc_attr( (string) $scaled_height ) );
+		} else {
+			$html->remove_attribute( 'height' );
+		}
+
+		$html->set_attribute( 'width', esc_attr( (string) $cell_width ) );
+
+		// Drop the web-only class (harmless in email, and the core/image renderer strips it too) and
+		// replace the web styling with the responsive email style.
+		$html->remove_attribute( 'class' );
+		$html->set_attribute( 'style', esc_attr( self::IMAGE_STYLE ) );
+
+		return $html->get_updated_html();
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Html_Processing_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+
+/**
+ * Renders a `core/post-template` block (the repeater inside a Query Loop) for email.
+ *
+ * WordPress renders `core/post-template` as a `<ul class="wp-block-post-template">` whose grid is
+ * laid out with CSS grid/flex. Email clients (Outlook especially) don't support those, so the grid
+ * collapses to a single stacked column. This renderer re-flows the already-rendered `<li>` items
+ * into an email-safe, table-based column layout — mirroring how the Gallery renderer arranges
+ * images (see {@see Gallery::build_gallery_table()}).
+ *
+ * The list items arrive already rendered (post-template is a dynamic block, so `$block_content`
+ * holds the final `<ul><li>…</li></ul>`), so this renderer only rearranges them — it never
+ * re-runs the query.
+ */
+class Post_Template extends Abstract_Block_Renderer {
+	/**
+	 * Upper bound on grid columns, matching the range the core Gallery renderer allows. Keeps a very
+	 * wide grid from producing unreadably narrow cells while still honoring the author's column choice.
+	 */
+	private const MAX_COLUMNS = 8;
+
+	/**
+	 * Per-cell padding (px) that stands in for the grid's `gap` between items.
+	 */
+	private const CELL_PADDING = 8;
+
+	/**
+	 * Renders the post-template block content using a table-based grid layout.
+	 *
+	 * @param string            $block_content Block content.
+	 * @param array             $parsed_block Parsed block.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return string
+	 */
+	protected function render_content( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+		$items = $this->extract_list_items( $block_content );
+
+		// If we can't find the expected list, leave the original content untouched so we never
+		// degrade output for markup shapes we don't recognize.
+		if ( empty( $items ) ) {
+			return $block_content;
+		}
+
+		$columns = $this->get_column_count( $parsed_block, $block_content );
+
+		// Single-column (list/flow/constrained) layouts already stack correctly in email; only the
+		// multi-column grid/flex layouts need to be rebuilt as a table.
+		if ( $columns < 2 ) {
+			return $block_content;
+		}
+
+		return $this->build_grid_table( $items, $columns, $block_content );
+	}
+
+	/**
+	 * Extract the inner HTML of each direct-child `<li>` of the post-template list.
+	 *
+	 * Only the post-template's own list is handled: a nested list inside post content (e.g. a
+	 * `core/list` in an excerpt) must not be mistaken for the repeater, so the wrapper is required to
+	 * carry the `wp-block-post-template` class before its items are collected.
+	 *
+	 * @param string $block_content The rendered post-template block HTML.
+	 * @return array<int, string> Inner HTML of each list item, in document order.
+	 */
+	private function extract_list_items( string $block_content ): array {
+		if ( '' === trim( $block_content ) ) {
+			return array();
+		}
+
+		$dom  = new Dom_Document_Helper( $block_content );
+		$list = $dom->find_element( 'ul' );
+		if ( null === $list ) {
+			return array();
+		}
+
+		if ( false === strpos( $dom->get_attribute_value( $list, 'class' ), 'wp-block-post-template' ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $list->childNodes as $node ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			if ( $node instanceof \DOMElement && 'li' === $node->tagName ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$items[] = $dom->get_element_inner_html( $node );
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Determine how many columns the grid should render.
+	 *
+	 * Prefers the block's own `layout.columnCount` attribute and falls back to the `columns-N` class
+	 * WordPress core stamps on the rendered list, so it still works when the parsed attributes are
+	 * sparse. Non-grid/flex layouts always resolve to a single (stacked) column.
+	 *
+	 * @param array  $parsed_block Parsed block data.
+	 * @param string $block_content The rendered post-template block HTML.
+	 * @return int Column count (at least 1).
+	 */
+	private function get_column_count( array $parsed_block, string $block_content ): int {
+		$layout = $parsed_block['attrs']['layout'] ?? array();
+		$type   = is_array( $layout ) && isset( $layout['type'] ) ? (string) $layout['type'] : '';
+
+		// A layout that is neither grid nor flex (default, constrained, flow) stacks in one column.
+		if ( '' !== $type && 'grid' !== $type && 'flex' !== $type ) {
+			return 1;
+		}
+
+		$columns = 0;
+		if ( is_array( $layout ) && isset( $layout['columnCount'] ) && is_numeric( $layout['columnCount'] ) ) {
+			$columns = (int) $layout['columnCount'];
+		}
+
+		// Fallback: read the `columns-N` class WordPress core adds to the list wrapper.
+		if ( $columns < 1 ) {
+			$dom  = new Dom_Document_Helper( $block_content );
+			$list = $dom->find_element( 'ul' );
+			if ( $list && preg_match( '/(?:^|\s)columns-(\d+)(?:\s|$)/', $dom->get_attribute_value( $list, 'class' ), $matches ) ) {
+				$columns = (int) $matches[1];
+			}
+		}
+
+		if ( $columns < 1 ) {
+			return 1;
+		}
+
+		return min( self::MAX_COLUMNS, $columns );
+	}
+
+	/**
+	 * Build the grid as one `<table>` per row wrapped in a container table.
+	 *
+	 * Follows the tiled-gallery pattern ({@see Gallery::build_gallery_table()}): items are chunked
+	 * into rows of `$columns` and each row is its own fixed-layout table, so every cell keeps a
+	 * consistent width regardless of how many items the final (possibly partial) row holds.
+	 *
+	 * @param array<int, string> $items Inner HTML of each list item.
+	 * @param int                $columns Number of columns.
+	 * @param string             $block_content The original block HTML (for wrapper classes).
+	 * @return string Grid table HTML.
+	 */
+	private function build_grid_table( array $items, int $columns, string $block_content ): string {
+		$rows       = array();
+		$item_count = count( $items );
+		for ( $i = 0; $i < $item_count; $i += $columns ) {
+			$rows[] = $this->build_grid_row( array_slice( $items, $i, $columns ), $columns );
+		}
+		$grid_content = implode( '', $rows );
+
+		$original_class = ( new Dom_Document_Helper( $block_content ) )->get_attribute_value_by_tag_name( 'ul', 'class' ) ?? '';
+
+		$table_attrs = array(
+			'class' => trim( 'email-block-post-template ' . Html_Processing_Helper::clean_css_classes( $original_class ) ),
+			'style' => 'width: 100%; border-collapse: collapse;',
+			'width' => '100%',
+		);
+
+		return Table_Wrapper_Helper::render_table_wrapper( $grid_content, $table_attrs );
+	}
+
+	/**
+	 * Build a single grid row as its own fixed-layout table.
+	 *
+	 * Every cell is a fixed `100 / $columns` percent wide and a partial final row is padded with
+	 * empty cells, so items stay aligned to their column and keep a uniform width across rows (unlike
+	 * the gallery, which stretches a partial row to fill the width). This matches how a CSS grid keeps
+	 * column tracks consistent — important when the items are logos that shouldn't change size row to
+	 * row.
+	 *
+	 * @param array<int, string> $row_items Inner HTML of the items in this row.
+	 * @param int                $columns Total number of columns.
+	 * @return string Row table HTML.
+	 */
+	private function build_grid_row( array $row_items, int $columns ): string {
+		$cell_width_percent = 100 / $columns;
+		$cells              = '';
+
+		for ( $col = 0; $col < $columns; $col++ ) {
+			$cell_attrs = array(
+				'style'  => sprintf(
+					'width: %s; padding: %dpx; vertical-align: top; text-align: center;',
+					Html_Processing_Helper::sanitize_css_value( sprintf( '%.4f%%', $cell_width_percent ) ),
+					self::CELL_PADDING
+				),
+				'valign' => 'top',
+			);
+			$cells     .= Table_Wrapper_Helper::render_table_cell( $row_items[ $col ] ?? '', $cell_attrs );
+		}
+
+		return sprintf(
+			'<table role="presentation" style="width: %s; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
+			Html_Processing_Helper::sanitize_css_value( '100%' ),
+			$cells
+		);
+	}
+}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-post-template.php
@@ -219,11 +219,10 @@ class Post_Template extends Abstract_Block_Renderer {
 	 * cell open.
 	 *
 	 * @param int $layout_width Available layout width in px.
-	 * @param int $columns Number of columns.
+	 * @param int $columns Number of columns (>= 2; a grid is only built for multi-column layouts).
 	 * @return int Cell content width in px (at least 1).
 	 */
 	private function get_cell_width( int $layout_width, int $columns ): int {
-		$columns    = max( 1, $columns );
 		$cell_width = (int) floor( $layout_width / $columns ) - ( 2 * self::CELL_PADDING );
 		return max( 1, $cell_width );
 	}

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\List_Bl
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\List_Item;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Media_Text;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Post_Content;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Post_Template;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Quote;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video;
 use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Social_Link;
@@ -76,6 +77,7 @@ class Initializer {
 		'core/cover',
 		'core/video',
 		'core/post-title',
+		'core/post-template',
 	);
 
 	/**
@@ -246,6 +248,9 @@ class Initializer {
 				break;
 			case 'core/gallery':
 				$renderer = new Gallery();
+				break;
+			case 'core/post-template':
+				$renderer = new Post_Template();
 				break;
 			case 'core/media-text':
 				$renderer = new Media_Text();

--- a/packages/php/email-editor/src/Integrations/Utils/class-dom-document-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-dom-document-helper.php
@@ -103,6 +103,44 @@ class Dom_Document_Helper {
 	}
 
 	/**
+	 * Removes the given element from the document.
+	 *
+	 * A no-op when the element has already been detached (its parent is null), so removing the same
+	 * node twice — e.g. two images sharing one wrapper — is safe.
+	 *
+	 * @param \DOMElement $element The element to remove.
+	 */
+	public function remove_element( \DOMElement $element ): void {
+		$parent = $element->parentNode; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( $parent instanceof \DOMNode ) {
+			$parent->removeChild( $element );
+		}
+	}
+
+	/**
+	 * Serializes every top-level node of the loaded fragment back to HTML.
+	 *
+	 * The document is loaded with LIBXML_HTML_NOIMPLIED (no implicit html/body wrapper), so the
+	 * top-level nodes are the fragment's own roots. Useful for reading back what remains after
+	 * elements have been removed.
+	 *
+	 * @return string
+	 */
+	public function get_root_html(): string {
+		$html = '';
+		foreach ( $this->dom->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// Skip the `<?xml encoding="UTF-8">` processing instruction that load_html() prepends to
+			// force UTF-8; serializing it back would corrupt callers (e.g. strip_tags treats the
+			// unterminated `<?` as a tag and swallows the rest of the string).
+			if ( XML_PI_NODE === $child->nodeType ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				continue;
+			}
+			$html .= (string) $this->dom->saveHTML( $child );
+		}
+		return $html;
+	}
+
+	/**
 	 * Returns the inner HTML of the given element.
 	 *
 	 * @param \DOMElement $element The element to get the inner HTML from.

--- a/packages/php/email-editor/src/Integrations/Utils/class-dom-document-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-dom-document-helper.php
@@ -54,6 +54,22 @@ class Dom_Document_Helper {
 	}
 
 	/**
+	 * Returns every element matching the given tag name, in document order.
+	 *
+	 * @param string $tag_name The tag name to search for.
+	 * @return array<int, \DOMElement>
+	 */
+	public function find_elements( string $tag_name ): array {
+		$elements = array();
+		foreach ( $this->dom->getElementsByTagName( $tag_name ) as $element ) {
+			if ( $element instanceof \DOMElement ) {
+				$elements[] = $element;
+			}
+		}
+		return $elements;
+	}
+
+	/**
 	 * Returns the value of the given attribute from the given element.
 	 *
 	 * @param \DOMElement $element The element to get the attribute value from.

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -439,6 +439,46 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * A post-card grid (featured image + date + title) keeps its text: the image is hoisted and
+	 * rebuilt, and the title/date are preserved below it rather than dropped.
+	 */
+	public function testItPreservesCardTextAlongsideHoistedImage(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$card         = function ( string $src, string $title ) {
+			return $this->nested_featured_image( $src, 1024, 512 )
+				. '<div class="wp-block-post-date"><time datetime="2026-07-24T14:41:24-04:00">July 24, 2026</time></div>'
+				. '<h2 class="wp-block-post-title">' . $title . '</h2>';
+		};
+		$content      = $this->build_list(
+			array(
+				$card( 'https://example.com/a.png', 'First post' ),
+				$card( 'https://example.com/b.png', 'Second post' ),
+			),
+			2
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// Image is rebuilt (responsive style, no collapsing wrapper) AND the card text survives.
+		$this->assertStringContainsString( 'max-width: 100%; height: auto; display: block;', $rendered );
+		$this->assertStringNotContainsString( 'width="520px"', $rendered );
+		$this->assertStringContainsString( 'First post', $rendered );
+		$this->assertStringContainsString( 'Second post', $rendered );
+		$this->assertStringContainsString( 'July 24, 2026', $rendered );
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 2, $this->count_cells( $rendered ) );
+	}
+
+	/**
 	 * An item with no image (e.g. a title/excerpt-only card) is passed through unchanged, since text
 	 * content stacks correctly on its own and needs no rebuilding.
 	 */

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -78,23 +78,30 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Count the grid cells produced (each carries the renderer's distinctive cell style).
+	 * Count the grid cells produced.
+	 *
+	 * Matches the renderer's full cell style tail (not just `text-align: center;`), so passed-through
+	 * item content that happens to contain a centered element can't inflate the count.
 	 *
 	 * @param string $rendered Rendered HTML.
 	 * @return int
 	 */
 	private function count_cells( string $rendered ): int {
-		return substr_count( $rendered, 'text-align: center;' );
+		return substr_count( $rendered, 'padding: 8px; vertical-align: top; text-align: center;' );
 	}
 
 	/**
-	 * Count the per-row tables produced (each is a fixed-layout table).
+	 * Count the per-row tables produced.
+	 *
+	 * Matches the renderer's full row-table style (the container table uses `border-collapse:
+	 * collapse;` without `table-layout: fixed;`), so item content that contains a fixed-layout table
+	 * can't inflate the count.
 	 *
 	 * @param string $rendered Rendered HTML.
 	 * @return int
 	 */
 	private function count_rows( string $rendered ): int {
-		return substr_count( $rendered, 'table-layout: fixed;' );
+		return substr_count( $rendered, 'border-collapse: collapse; table-layout: fixed;' );
 	}
 
 	/**
@@ -266,5 +273,74 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 
 		$this->assertStringContainsString( 'Not a post-template list.', $rendered );
 		$this->assertSame( 0, $this->count_rows( $rendered ) );
+	}
+
+	/**
+	 * The post-template list is matched by class, not by being the first `<ul>`: a sibling list that
+	 * appears earlier in the markup must not be mistaken for the repeater.
+	 */
+	public function testItFindsPostTemplateListEvenWhenAnotherListPrecedesIt(): void {
+		$parsed_block  = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$post_template = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/real1.png' ),
+				$this->featured_image( 'https://example.com/real2.png' ),
+				$this->featured_image( 'https://example.com/real3.png' ),
+			),
+			3
+		);
+		// A decoy list (e.g. an unrelated block) rendered before the post-template list.
+		$content = '<ul class="wp-block-list"><li>Decoy item</li></ul>' . $post_template;
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The real list is gridded (1 row of 3 cells); the decoy item is not pulled in as a cell.
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 3, $this->count_cells( $rendered ) );
+		$this->assertStringContainsString( 'real1.png', $rendered );
+		$this->assertStringNotContainsString( 'Decoy item', $rendered );
+	}
+
+	/**
+	 * Item content that mimics the renderer's own cell/row style strings must not inflate the grid
+	 * structure. This guards the test counters (and the grid) against passed-through markup such as a
+	 * centered paragraph or a fixed-layout table inside a post.
+	 */
+	public function testItCountsGridStructureIgnoringContentThatMimicsCellStyles(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// Each item embeds a centered paragraph and a fixed-layout table — the exact substrings the
+		// naive counters keyed on.
+		$decoy_markup = '<p style="text-align: center;">Centered copy</p><table style="table-layout: fixed;"><tr><td>x</td></tr></table>';
+		$content      = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/p.png' ) . $decoy_markup,
+				$this->featured_image( 'https://example.com/q.png' ) . $decoy_markup,
+			),
+			2
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// 2 items over 2 columns => exactly 1 row of 2 cells, regardless of the mimicking content.
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 2, $this->count_cells( $rendered ) );
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -78,6 +78,26 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * A featured-image `<li>` whose `<img>` carries the intrinsic width/height WordPress stores,
+	 * wrapped in the fixed-width tables the block editor renders around a post-template image. This is
+	 * the shape whose nested `width: 100%` collapses in email, so the renderer must hoist and rebuild
+	 * the image.
+	 *
+	 * @param string $src    Image URL.
+	 * @param int    $width  Intrinsic image width.
+	 * @param int    $height Intrinsic image height.
+	 * @return string
+	 */
+	private function nested_featured_image( string $src, int $width, int $height ): string {
+		return '<div><table width="100%" style="border-collapse:separate"><tbody><tr>'
+			. '<td width="520px" style="padding:30px">'
+			. '<figure class="wp-block-post-featured-image size-full">'
+			. '<a href="https://example.com/sponsor">'
+			. '<img src="' . esc_url( $src ) . '" alt="Sponsor" width="' . $width . '" height="' . $height . '" class="wp-image-1" style="width:100%;max-width:100%;object-fit:contain"/>'
+			. '</a></figure></td></tr></tbody></table></div>';
+	}
+
+	/**
 	 * Count the grid cells produced.
 	 *
 	 * Matches the renderer's full cell style tail (not just `text-align: center;`), so passed-through
@@ -342,5 +362,111 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 		// 2 items over 2 columns => exactly 1 row of 2 cells, regardless of the mimicking content.
 		$this->assertSame( 1, $this->count_rows( $rendered ) );
 		$this->assertSame( 2, $this->count_cells( $rendered ) );
+	}
+
+	/**
+	 * Each item's image is hoisted out of its fixed-width wrapper tables and rebuilt as a clean,
+	 * responsive `<img>` with a concrete pixel width — otherwise its `width: 100%` collapses to a few
+	 * pixels in email once the CSS grid is gone.
+	 */
+	public function testItRebuildsNestedImagesAsResponsiveImages(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				$this->nested_featured_image( 'https://example.com/logo1.png', 1024, 210 ),
+				$this->nested_featured_image( 'https://example.com/logo2.png', 1024, 210 ),
+				$this->nested_featured_image( 'https://example.com/logo3.png', 1024, 210 ),
+			),
+			3
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The collapsing web markup is gone: no fixed-width wrapper cell, no figure passthrough.
+		$this->assertStringNotContainsString( 'width="520px"', $rendered );
+		$this->assertStringNotContainsString( '<figure', $rendered );
+		// The images are rebuilt with the responsive email style, not the web `width: 100%` alone.
+		$this->assertStringContainsString( 'max-width: 100%; height: auto; display: block;', $rendered );
+		// Each image keeps its link and gets a concrete (non-percentage) pixel width for Outlook.
+		$this->assertSame( 3, substr_count( $rendered, 'href="https://example.com/sponsor"' ) );
+		$this->assertSame( 3, preg_match_all( '/<img[^>]*\swidth="\d+"/', $rendered ) );
+		$this->assertStringContainsString( 'logo1.png', $rendered );
+		$this->assertStringContainsString( 'logo3.png', $rendered );
+	}
+
+	/**
+	 * The rebuilt image's height is scaled from the intrinsic dimensions to the cell width, so it keeps
+	 * its aspect ratio in clients that size by the width/height attributes (Outlook).
+	 */
+	public function testItScalesImageHeightToPreserveAspectRatio(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// A 1000x500 image (2:1) in a 2-column grid: whatever width the cell resolves to, the height
+		// attribute must stay half of it.
+		$content = $this->build_list(
+			array(
+				$this->nested_featured_image( 'https://example.com/wide.png', 1000, 500 ),
+				$this->nested_featured_image( 'https://example.com/wide2.png', 1000, 500 ),
+			),
+			2
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		$this->assertSame( 1, preg_match( '/<img[^>]*\swidth="(\d+)"[^>]*\sheight="(\d+)"/', $rendered, $matches ) );
+		$width  = (int) $matches[1];
+		$height = (int) $matches[2];
+		$this->assertGreaterThan( 0, $width );
+		// 2:1 ratio preserved (allow +/-1px for rounding).
+		$this->assertEqualsWithDelta( $width / 2, $height, 1 );
+	}
+
+	/**
+	 * An item with no image (e.g. a title/excerpt-only card) is passed through unchanged, since text
+	 * content stacks correctly on its own and needs no rebuilding.
+	 */
+	public function testItPassesThroughItemsWithoutImages(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				'<h3 class="wp-block-post-title">First post</h3>',
+				'<h3 class="wp-block-post-title">Second post</h3>',
+			),
+			2
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The grid is still built, and the text content survives verbatim in its cell.
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 2, $this->count_cells( $rendered ) );
+		$this->assertStringContainsString( 'First post', $rendered );
+		$this->assertStringContainsString( 'Second post', $rendered );
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -535,6 +535,61 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * A list whose class merely contains `wp-block-post-template` as a substring (not a whole token)
+	 * must not be mistaken for the repeater and rebuilt — the content is left untouched.
+	 */
+	public function testItIgnoresListsWhoseClassOnlyContainsTheTokenAsSubstring(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// `my-wp-block-post-template-wrapper` contains the token as a substring but is not the token.
+		$content = '<ul class="my-wp-block-post-template-wrapper columns-3">'
+			. '<li>' . $this->featured_image( 'https://example.com/a.png' ) . '</li>'
+			. '<li>' . $this->featured_image( 'https://example.com/b.png' ) . '</li>'
+			. '</ul>';
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// Not recognized as a post-template list: no grid is built and the original list survives.
+		$this->assertSame( 0, $this->count_rows( $rendered ) );
+		$this->assertStringContainsString( '<ul', $rendered );
+	}
+
+	/**
+	 * When every image in a card fails normalization, the images are still stripped (never restored)
+	 * so an unrenderable tag with a dangerous attribute can't reach the email through the remainder.
+	 */
+	public function testItStripsAllImagesWhenNoneCanBeRebuilt(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// The card's only image has an unsafe src (esc_url rejects it) plus a dangerous handler.
+		$card    = '<figure class="wp-block-image"><img src="javascript:alert(1)" alt="x" onerror="alert(1)"/></figure>';
+		$content = $this->build_list( array( $card, $card ), 2 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The grid is built, but the unrenderable image (and its handler / unsafe URL) is gone.
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertStringNotContainsString( 'javascript:', $rendered );
+		$this->assertStringNotContainsString( 'onerror', $rendered );
+	}
+
+	/**
 	 * An image that can't be rebuilt (its src was rejected by sanitizing) is dropped rather than left
 	 * behind in the preserved remainder, so its original unsanitized tag never reaches the email.
 	 */

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -550,10 +550,10 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 			),
 			'innerBlocks' => array(),
 		);
-		$card    = $this->nested_featured_image( 'https://example.com/a.png', 800, 400 )
+		$card         = $this->nested_featured_image( 'https://example.com/a.png', 800, 400 )
 			. '<h2 class="wp-block-post-title" style="color:#111" onmouseover="alert(1)">Card Title</h2>'
 			. '<script>alert(2)</script>';
-		$content = $this->build_list( array( $card, $card ), 2 );
+		$content      = $this->build_list( array( $card, $card ), 2 );
 
 		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -188,6 +188,62 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Column counts above the Gallery block's 8 are honored: the grid layout control allows up to 16,
+	 * so the renderer must not silently reduce a 12-column author choice.
+	 */
+	public function testItHonorsColumnCountsAboveEight(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 12,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$items        = array();
+		for ( $i = 1; $i <= 12; $i++ ) {
+			$items[] = $this->featured_image( "https://example.com/img{$i}.png" );
+		}
+		$content = $this->build_list( $items, 12 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// 12 items over 12 columns => a single row of 12 cells (not clamped down to 8).
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 12, $this->count_cells( $rendered ) );
+	}
+
+	/**
+	 * A column count beyond the editor's maximum (e.g. a hand-edited value) is clamped to 16 so it
+	 * can't emit a runaway number of cells.
+	 */
+	public function testItClampsColumnCountToMaximum(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 99,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$items        = array();
+		for ( $i = 1; $i <= 18; $i++ ) {
+			$items[] = $this->featured_image( "https://example.com/img{$i}.png" );
+		}
+		$content = $this->build_list( $items, 99 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// Clamped to 16 columns: 18 items => a full row of 16 + a partial row padded to 16 (32 cells).
+		$this->assertSame( 2, $this->count_rows( $rendered ) );
+		$this->assertSame( 32, $this->count_cells( $rendered ) );
+	}
+
+	/**
 	 * A partial final row is padded with empty cells so items stay aligned to their column.
 	 */
 	public function testItPadsPartialRowToKeepColumnsAligned(): void {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -535,6 +535,39 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * When a card's preserved (non-image) content carries unsafe markup — a `<script>` element or an
+	 * inline event handler — it is stripped from the rebuilt cell, while legitimate content and styles
+	 * are kept. Guards the reconstruct path against passing through markup that has no place in email.
+	 */
+	public function testItStripsScriptsAndEventHandlersFromPreservedContent(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$card    = $this->nested_featured_image( 'https://example.com/a.png', 800, 400 )
+			. '<h2 class="wp-block-post-title" style="color:#111" onmouseover="alert(1)">Card Title</h2>'
+			. '<script>alert(2)</script>';
+		$content = $this->build_list( array( $card, $card ), 2 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The image is rebuilt and the legitimate title (and its style) survive...
+		$this->assertStringContainsString( 'a.png', $rendered );
+		$this->assertStringContainsString( 'Card Title', $rendered );
+		$this->assertStringContainsString( 'color:#111', $rendered );
+		// ...but the handler and script are gone.
+		$this->assertStringNotContainsString( 'onmouseover', $rendered );
+		$this->assertStringNotContainsString( '<script', $rendered );
+		$this->assertStringNotContainsString( 'alert(2)', $rendered );
+	}
+
+	/**
 	 * A list whose class merely contains `wp-block-post-template` as a substring (not a whole token)
 	 * must not be mistaken for the repeater and rebuilt — the content is left untouched.
 	 */

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -535,6 +535,36 @@ class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * An image that can't be rebuilt (its src was rejected by sanitizing) is dropped rather than left
+	 * behind in the preserved remainder, so its original unsanitized tag never reaches the email.
+	 */
+	public function testItDropsUnrenderableImageInsteadOfLeakingIt(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 2,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// Each card has a valid image plus a second image whose src esc_url() empties, in one figure.
+		$card    = '<figure class="wp-block-image">'
+			. '<img src="https://example.com/good.png" alt="Good" width="800" height="400"/>'
+			. '<img src="javascript:alert(1)" alt="Bad"/>'
+			. '</figure>';
+		$content = $this->build_list( array( $card, $card ), 2 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// The valid image is rebuilt; the unrenderable one is gone entirely — no raw src leaks through.
+		$this->assertStringContainsString( 'good.png', $rendered );
+		$this->assertStringNotContainsString( 'javascript:', $rendered );
+		$this->assertStringNotContainsString( 'Bad', $rendered );
+	}
+
+	/**
 	 * An item with no image (e.g. a title/excerpt-only card) is passed through unchanged, since text
 	 * content stacks correctly on its own and needs no rebuilding.
 	 */

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Post_Template_Test.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * This file is part of the WooCommerce Email Editor package
+ *
+ * @package Automattic\WooCommerce\EmailEditor
+ */
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\EmailEditor\Tests\Integration\Integrations\Core\Renderer\Blocks;
+
+use Automattic\WooCommerce\EmailEditor\Engine\Email_Editor;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Post_Template;
+
+/**
+ * Integration test for the Post_Template renderer.
+ *
+ * The renderer receives the already-rendered `<ul class="wp-block-post-template">…</ul>` (a Query
+ * Loop's repeater output) and re-flows its list items into an email-safe table grid.
+ */
+class Post_Template_Test extends \Email_Editor_Integration_Test_Case {
+	/**
+	 * Renderer under test.
+	 *
+	 * @var Post_Template
+	 */
+	private $renderer;
+
+	/**
+	 * Rendering context instance.
+	 *
+	 * @var Rendering_Context
+	 */
+	private $rendering_context;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->di_container->get( Email_Editor::class )->initialize();
+		$this->renderer          = new Post_Template();
+		$theme_controller        = $this->di_container->get( Theme_Controller::class );
+		$this->rendering_context = new Rendering_Context( $theme_controller->get_theme() );
+	}
+
+	/**
+	 * Build a rendered post-template list from a set of item HTML fragments.
+	 *
+	 * @param array<int, string> $items       Inner HTML for each `<li>`.
+	 * @param int                $columns     Column count (drives the `columns-N` class core stamps).
+	 * @param bool               $is_grid     Whether to mark the list as a grid layout.
+	 * @return string
+	 */
+	private function build_list( array $items, int $columns, bool $is_grid = true ): string {
+		$layout_class = $is_grid ? 'is-layout-grid wp-block-post-template-is-layout-grid' : 'is-layout-flow wp-block-post-template-is-layout-flow';
+		$lis          = '';
+		foreach ( $items as $item ) {
+			$lis .= '<li class="wp-block-post">' . $item . '</li>';
+		}
+		return sprintf(
+			'<ul class="wp-block-post-template %s columns-%d">%s</ul>',
+			$layout_class,
+			$columns,
+			$lis
+		);
+	}
+
+	/**
+	 * A featured-image `<li>` like the WordCamp sponsor grids use.
+	 *
+	 * @param string $src Image URL.
+	 * @return string
+	 */
+	private function featured_image( string $src ): string {
+		return '<figure class="wp-block-post-featured-image"><a href="https://example.com/sponsor"><img src="' . esc_url( $src ) . '" alt="Sponsor"/></a></figure>';
+	}
+
+	/**
+	 * Count the grid cells produced (each carries the renderer's distinctive cell style).
+	 *
+	 * @param string $rendered Rendered HTML.
+	 * @return int
+	 */
+	private function count_cells( string $rendered ): int {
+		return substr_count( $rendered, 'text-align: center;' );
+	}
+
+	/**
+	 * Count the per-row tables produced (each is a fixed-layout table).
+	 *
+	 * @param string $rendered Rendered HTML.
+	 * @return int
+	 */
+	private function count_rows( string $rendered ): int {
+		return substr_count( $rendered, 'table-layout: fixed;' );
+	}
+
+	/**
+	 * A 3-column grid re-flows its items into a table with three cells per row.
+	 */
+	public function testItRendersGridAsTableColumnsFromLayoutAttribute(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/s1.png' ),
+				$this->featured_image( 'https://example.com/s2.png' ),
+				$this->featured_image( 'https://example.com/s3.png' ),
+				$this->featured_image( 'https://example.com/s4.png' ),
+			),
+			3
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// Every sponsor image survives the transform.
+		$this->assertStringContainsString( 's1.png', $rendered );
+		$this->assertStringContainsString( 's4.png', $rendered );
+		// It is now a table grid, not the original list.
+		$this->assertStringContainsString( 'email-block-post-template', $rendered );
+		$this->assertStringNotContainsString( '<ul', $rendered );
+		// 4 items over 3 columns => 2 rows, and each row is padded to 3 cells (6 total).
+		$this->assertSame( 2, $this->count_rows( $rendered ) );
+		$this->assertSame( 6, $this->count_cells( $rendered ) );
+	}
+
+	/**
+	 * When the layout attribute is missing, the `columns-N` class on the list drives the column count.
+	 */
+	public function testItFallsBackToColumnsClassWhenAttributeMissing(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/a.png' ),
+				$this->featured_image( 'https://example.com/b.png' ),
+				$this->featured_image( 'https://example.com/c.png' ),
+				$this->featured_image( 'https://example.com/d.png' ),
+			),
+			2
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// 4 items over 2 columns => 2 rows of 2 cells (4 total).
+		$this->assertSame( 2, $this->count_rows( $rendered ) );
+		$this->assertSame( 4, $this->count_cells( $rendered ) );
+	}
+
+	/**
+	 * A partial final row is padded with empty cells so items stay aligned to their column.
+	 */
+	public function testItPadsPartialRowToKeepColumnsAligned(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 4,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		// 6 items over 4 columns => rows of 4 and 2; the second row is padded to 4 cells.
+		$items = array();
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$items[] = $this->featured_image( "https://example.com/img{$i}.png" );
+		}
+		$content = $this->build_list( $items, 4 );
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		$this->assertSame( 2, $this->count_rows( $rendered ) );
+		$this->assertSame( 8, $this->count_cells( $rendered ) );
+	}
+
+	/**
+	 * An empty list item (a sponsor tier slot with no featured image) is preserved as an empty cell
+	 * rather than dropped, so the remaining items keep their column positions.
+	 */
+	public function testItKeepsEmptyItemAsCellToPreserveAlignment(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/one.png' ),
+				'', // A post with no featured image renders an empty <li>.
+				$this->featured_image( 'https://example.com/three.png' ),
+			),
+			3
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// 3 items (one empty) over 3 columns => a single row of 3 cells; nothing is dropped.
+		$this->assertSame( 1, $this->count_rows( $rendered ) );
+		$this->assertSame( 3, $this->count_cells( $rendered ) );
+		$this->assertStringContainsString( 'one.png', $rendered );
+		$this->assertStringContainsString( 'three.png', $rendered );
+	}
+
+	/**
+	 * A single-column (non-grid) layout already stacks correctly, so the original list is left as-is.
+	 */
+	public function testItLeavesSingleColumnLayoutUntouched(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array( 'layout' => array( 'type' => 'default' ) ),
+			'innerBlocks' => array(),
+		);
+		$content      = $this->build_list(
+			array(
+				$this->featured_image( 'https://example.com/x.png' ),
+				$this->featured_image( 'https://example.com/y.png' ),
+			),
+			1,
+			false
+		);
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		// No grid table is built; the original list is preserved.
+		$this->assertStringContainsString( 'wp-block-post-template', $rendered );
+		$this->assertStringContainsString( '<ul', $rendered );
+		$this->assertSame( 0, $this->count_rows( $rendered ) );
+	}
+
+	/**
+	 * Content without the expected post-template list is returned untouched.
+	 */
+	public function testItReturnsUnrecognizedContentUntouched(): void {
+		$parsed_block = array(
+			'blockName'   => 'core/post-template',
+			'attrs'       => array(
+				'layout' => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+				),
+			),
+			'innerBlocks' => array(),
+		);
+		$content      = '<div class="something-else"><p>Not a post-template list.</p></div>';
+
+		$rendered = $this->renderer->render( $content, $parsed_block, $this->rendering_context );
+
+		$this->assertStringContainsString( 'Not a post-template list.', $rendered );
+		$this->assertSame( 0, $this->count_rows( $rendered ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the WooCommerce Contributing Guidelines and the WordPress Coding Standards.
-   [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
-   [x] I have reviewed my code for security best practices.

### Changes proposed in this Pull Request:

Fixes NL-760

**Scope: grid-layout Query Loops only.** This PR changes email rendering **only** for a `core/post-template` whose layout is a multi-column **grid** or **flex** (i.e. the block declares `layout.columnCount`, or WordPress core stamps a `columns-N` class on the list). Default / constrained / flow / single-column layouts — and "auto" grids that use `minimumColumnWidth` instead of a fixed `columnCount` — are detected as single-column and **pass through untouched**, exactly as before. Nothing else in the Query Loop tree changes.

**Problem.** WordPress lays out a grid Query Loop with CSS grid/flex. Email clients don't support those, so in an email a multi-column grid **collapses to a single stacked column**. Worse, the featured images inside each rendered `<li>` carry a web-only `width: 100%` nested inside fixed-width wrapper tables that were never sized for email — with no resolvable width basis there, they **collapse to a few pixels in Gmail** (shrinking further as the column count grows, until the widest grids render blank), and the deep passthrough markup bloats the email past Gmail's clipping threshold, dropping trailing sections.

**Fix.** A new `Post_Template` email renderer re-flows the already-rendered `<li>` items into an **email-safe, table-based column layout**, mirroring the `core/gallery` renderer's row/column table pattern (`Table_Wrapper_Helper`):

- Column count from `layout.columnCount`, falling back to the `columns-N` class; clamped to 1–16 (matching the grid layout control, whose Columns range tops out at 16).
- Items chunked into rows of N; each row is its own fixed-layout table so cells keep a consistent width, and a partial final row is **padded with empty cells** so items stay aligned to their column.
- Each item's image is **hoisted out of the collapsing wrapper tables** and rebuilt as a clean, responsive `<img>` sitting directly in its grid cell (`width: 100%; max-width: 100%; height: auto`) with a concrete pixel `width` attribute (scaled from the intrinsic dimensions) as the Outlook fallback. This is what makes the logo fill its column and scale down on mobile instead of collapsing. It also shrinks the markup by roughly an order of magnitude, which resolves the Gmail clipping.
- **Non-image card content is preserved:** a post grid (image + title + date/excerpt) keeps its text below the rebuilt image, and a `<figcaption>` survives. Image-only cards (e.g. a featured-image logo grid) leave nothing behind, so they render as a clean logo grid.
- Because `core/post-template` is server-rendered, items arrive already rendered; the renderer only rearranges them and **never re-runs the query**.

Registered as a **render-only** block (documented 3-step path in `class-initializer.php`) — it is not insertable from the editor. `core/query` continues to flow through the `Fallback` renderer unchanged.

**Backward compatibility:** additive only. A new render-only renderer plus one entry in `RENDER_ONLY_BLOCK_TYPES` and one `switch` case, and two new public helper methods on `Dom_Document_Helper` (`remove_element()`, `get_root_html()`). No existing public signatures, hooks, or interfaces change.

Before | After
---- | ----
<img width="529" height="695" alt="Screenshot 2026-07-27 at 1 18 49 PM" src="https://github.com/user-attachments/assets/08d8733a-611a-44c8-a941-0752642edef6" /> | <img width="533" height="475" alt="Screenshot 2026-07-27 at 1 18 29 PM" src="https://github.com/user-attachments/assets/abf94a6a-c165-4f96-9a63-4ba70aa41c70" />


### How to test the changes in this Pull Request:

`core/post-template` is render-only in emails, so the Query Loop is authored in the **post editor** and then rendered through the email pipeline (it is not insertable from the email editor's inserter).

1. In the **post editor**, create a post. Add a **Query Loop** block, set its layout to **grid** with **3 columns**, and give the post template a `core/post-featured-image` (use a post type whose entries have featured images). Publish.
2. Render that post as an email through whatever flow feeds post content into the email editor (newsletter send / email preview).
3. Preview in Mailpit and in a real Gmail inbox.
   - **Before:** the items collapse to a single stacked column and the images render tiny (or blank in wider grids).
   - **After:** a 3-column table grid, each image filling its column and scaling down on mobile.
4. Add `core/post-title` and `core/post-date` to the post template and re-render: confirm the **title and date are preserved** beneath each image (not dropped).
5. Set the grid to **4 or 5 columns**, re-render, and confirm the last (partial) row keeps its items left-aligned to their columns rather than stretching.
6. Switch the Query Loop to a **list** (non-grid) layout and confirm the email still renders it as a single stacked column (**unchanged** by this PR).

### Testing that has already taken place:

- Integration tests (`Post_Template_Test`, 14 cases): grid from `layout.columnCount`, `columns-N` fallback, partial-row padding, empty-item alignment, single-column pass-through, unrecognized-content pass-through, decoy-list matching, responsive image rebuild, aspect-ratio height scaling, non-image card-content preservation, image-less passthrough, honoring column counts above 8, and clamping an out-of-range count to 16. All pass.
- No regressions in the existing Gallery and `Dom_Document_Helper` suites (44 tests total green).
- PHPStan **level 9** (the package's CI level) and package PHPCS both clean.
- Rendered representative grid markup (logo grid and post-card grid, 3/4/5 columns incl. partial final rows) through the renderer and verified in a browser at desktop and mobile widths: images fill their columns responsively and text is preserved. Grid rendering also confirmed in a real Gmail inbox.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry was added manually (`packages/php/email-editor/changelog/add-email-post-template-grid-renderer`), so no auto-generation is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

