### PR TITLE
Fix auto-add blank attribute row when attributes tab is shown in legacy product editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-38547-auto-attribute-tab
+++ b/plugins/woocommerce/changelog/fix-38547-auto-attribute-tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop auto-adding blank attribute row when attributes tab is shown in legacy product editor

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -460,20 +460,6 @@ jQuery( function ( $ ) {
 	// Set up attributes, if current page has the attributes list.
 	const $product_attributes = $( '.product_attributes' );
 	if ( $product_attributes.length === 1 ) {
-		// When the attributes tab is shown, add an empty attribute to be filled out by the user.
-		$( '#product_attributes' ).on( 'woocommerce_tab_shown', function () {
-			remove_blank_custom_attribute_if_no_other_attributes();
-
-			const woocommerce_attribute_items = $product_attributes
-				.find( '.woocommerce_attribute' )
-				.get();
-
-			// If the product has no attributes, add an empty attribute to be filled out by the user.
-			if ( woocommerce_attribute_items.length === 0 ) {
-				add_custom_attribute_to_list();
-			}
-		} );
-
 		const woocommerce_attribute_items = $product_attributes
 			.find( '.woocommerce_attribute' )
 			.get();


### PR DESCRIPTION
### Submission Review Guidelines:

- [X] I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
- [X] I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
- [X] I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Fixes woocommerce/woocommerce#38547 — The legacy product editor's attributes tab automatically adds a blank "New Attribute" row whenever the tab is shown and the attribute list is empty. This causes the "Save attributes" button to be disabled (because the blank row has empty fields), forcing users to manually remove the phantom row before they can edit existing attributes or save.

**Root cause:** An event handler on `woocommerce_tab_shown` checked for zero `.woocommerce_attribute` elements in the DOM and auto-added one via `add_custom_attribute_to_list()`.

**Fix:** Removed the auto-add event handler. Users now click the **"Add new"** button to add an attribute, giving them full control over when to create one.

### How to test the changes in this Pull Request:

1. Go to **Products > Attributes** and delete all global attributes (if any exist).
2. Create a new variable product.
3. Open the **Attributes** tab.
4. **Before fix:** A blank "New Attribute" row auto-appears with Save disabled.
5. **After fix:** The attributes area is empty, and the "Add new" button can be clicked to add an attribute.
6. Also verify that editing an existing variable product with saved attributes still works correctly — saved attributes should display normally when the tab is opened.

### Testing that has already taken place:

* Manual testing in wp-admin on product add/edit screens confirmed the fix works as expected.
* ESLint passes cleanly on the modified file.
* Both `lint:php:changes` and `eslint-branch.sh upstream/trunk` pass.

### Changelog entry

Changelog entry added manually (`plugins/woocommerce/changelog/fix-38547-auto-attribute-tab`, type `fix`, significance `patch`).

- [X] Automatically create a changelog entry from the details below.