### PR TITLE
Stop sending request-derived props into cacheable analytics page output

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/fix-cacheable-page-request-derived-props
+++ b/packages/php/woocommerce-analytics/changelog/fix-cacheable-page-request-derived-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Stop emitting request-derived properties into cacheable front-end page HTML.

--- a/packages/php/woocommerce-analytics/src/class-universal.php
+++ b/packages/php/woocommerce-analytics/src/class-universal.php
@@ -76,7 +76,9 @@ class Universal {
 		$is_clickhouse_enabled     = Features::is_clickhouse_enabled();
 		$is_proxy_tracking_enabled = Features::is_proxy_tracking_enabled();
 		// When proxy tracking is enabled, we don't need to send the common properties to the client.
-		$common_properties = $is_proxy_tracking_enabled ? array() : $this->get_common_properties();
+		// Otherwise send only the page-safe properties: this markup is cacheable, so nothing
+		// derived from the current request may go into it.
+		$common_properties = $is_proxy_tracking_enabled ? array() : $this->get_page_common_properties();
 		?>
 		<script type="text/javascript">
 			(function() {

--- a/packages/php/woocommerce-analytics/src/class-universal.php
+++ b/packages/php/woocommerce-analytics/src/class-universal.php
@@ -538,6 +538,10 @@ class Universal {
 
 	/**
 	 * Capture a search event.
+	 *
+	 * The term is capped because this event is assembled here but fired by the
+	 * client, so it travels through the page markup and then reaches the pixel
+	 * URL. See `cap_page_string()`.
 	 */
 	public function capture_search_query() {
 		if ( is_search() ) {
@@ -545,7 +549,7 @@ class Universal {
 			$this->enqueue_event(
 				'search',
 				array(
-					'search_query' => $wp_query->get( 's' ),
+					'search_query' => $this->cap_page_string( $wp_query->get( 's' ) ),
 					'qty'          => $wp_query->found_posts,
 				)
 			);

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -239,35 +239,52 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the common properties for the event.
 	 *
+	 * Includes the request-derived properties from `get_server_details()`, so this
+	 * is only safe for events the server fires itself on an uncached request. The
+	 * cacheable page output must use `get_page_common_properties()` instead — see
+	 * the note there before adding any property here.
+	 *
 	 * @return array The common properties.
 	 */
 	public static function get_common_properties() {
+		return array_merge( self::get_page_common_properties(), self::get_server_details() );
+	}
+
+	/**
+	 * Get the common properties that are safe to embed in cacheable page HTML.
+	 *
+	 * Everything returned here is derived from the store, not from the current
+	 * request, because the page output this feeds is cached and replayed to later
+	 * visitors. Request headers are not part of the CDN cache key, so a property
+	 * derived from one would be attributed to every subsequent visitor of the
+	 * cached page. Anything request-derived belongs in `get_server_details()`,
+	 * which only reaches the server-fired pixel path.
+	 *
+	 * @since 0.16.7
+	 *
+	 * @return array The common properties.
+	 */
+	public static function get_page_common_properties() {
 		$blog_user_id    = self::get_blog_user_id();
-		$server_details  = self::get_server_details();
 		$blog_details    = self::get_blog_details();
 		$session_details = self::get_session_details();
 
-		$common_properties = array_merge(
-			array(
-				'session_id'     => $session_details['session_id'] ?? null,
-				'landing_page'   => $session_details['landing_page'] ?? null,
-				'is_engaged'     => $session_details['is_engaged'] ?? null,
-				'ui'             => $blog_user_id,
-				'blog_id'        => $blog_details['blog_id'] ?? null,
-				'store_id'       => $blog_details['store_id'] ?? null,
-				'url'            => $blog_details['url'] ?? null,
-				'woo_version'    => $blog_details['wc_version'] ?? null,
-				'wp_version'     => get_bloginfo( 'version' ),
-				'store_admin'    => count( array_intersect( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles ) ) > 0 ? 1 : 0,
-				'device'         => self::get_device_type(),
-				'store_currency' => $blog_details['store_currency'] ?? null,
-				'timezone'       => wp_timezone_string(),
-				'is_guest'       => ( $blog_user_id === null || $blog_user_id === 0 ) ? 1 : 0,
-			),
-			$server_details
+		return array(
+			'session_id'     => $session_details['session_id'] ?? null,
+			'landing_page'   => $session_details['landing_page'] ?? null,
+			'is_engaged'     => $session_details['is_engaged'] ?? null,
+			'ui'             => $blog_user_id,
+			'blog_id'        => $blog_details['blog_id'] ?? null,
+			'store_id'       => $blog_details['store_id'] ?? null,
+			'url'            => $blog_details['url'] ?? null,
+			'woo_version'    => $blog_details['wc_version'] ?? null,
+			'wp_version'     => get_bloginfo( 'version' ),
+			'store_admin'    => count( array_intersect( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles ) ) > 0 ? 1 : 0,
+			'device'         => self::get_device_type(),
+			'store_currency' => $blog_details['store_currency'] ?? null,
+			'timezone'       => wp_timezone_string(),
+			'is_guest'       => ( $blog_user_id === null || $blog_user_id === 0 ) ? 1 : 0,
 		);
-
-		return is_array( $common_properties ) ? $common_properties : array();
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -237,13 +237,11 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Get the common properties for the event.
+	 * Request-scoped — not for page output, see `get_page_common_properties()`.
 	 *
-	 * Includes the properties taken from the current request — the session cookie
-	 * and `get_server_details()` — so this is only safe for events the server fires
-	 * itself on an uncached request, which includes the proxy tracking endpoint.
-	 * The cacheable page output must use `get_page_common_properties()` instead —
-	 * see the note there before adding any property here.
+	 * Includes the session cookie and `get_server_details()`, so this is only safe
+	 * for events the server fires itself on an uncached request, which includes the
+	 * proxy tracking endpoint.
 	 *
 	 * @return array The common properties.
 	 */
@@ -279,13 +277,15 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the common properties that are safe to embed in cacheable page HTML.
 	 *
-	 * Everything returned here is derived from the store, not from the current
-	 * request, because the page output this feeds is cached and replayed to later
-	 * visitors. Neither request headers nor cookies are part of the CDN cache key,
-	 * so a property derived from one would be attributed to every subsequent
-	 * visitor of the cached page. Anything request-derived belongs in
-	 * `get_session_properties()` or `get_server_details()`, which only reach the
-	 * server-fired path.
+	 * Request headers and cookies are not part of the CDN cache key, so a property
+	 * derived from one is attributed to every later visitor of the cached page.
+	 * Anything request-derived belongs in `get_session_properties()` or
+	 * `get_server_details()`, which only reach the server-fired path.
+	 *
+	 * Two exceptions, neither of them licence to add a third: `device` is
+	 * User-Agent derived and a known gap, tracked for a client-side follow-up;
+	 * `ui`, `is_guest` and `store_admin` are safe only because caches bypass
+	 * logged-in requests.
 	 *
 	 * @since 0.16.7
 	 *

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -239,15 +239,41 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the common properties for the event.
 	 *
-	 * Includes the request-derived properties from `get_server_details()`, so this
-	 * is only safe for events the server fires itself on an uncached request. The
-	 * cacheable page output must use `get_page_common_properties()` instead — see
-	 * the note there before adding any property here.
+	 * Includes the properties taken from the current request — the session cookie
+	 * and `get_server_details()` — so this is only safe for events the server fires
+	 * itself on an uncached request, which includes the proxy tracking endpoint.
+	 * The cacheable page output must use `get_page_common_properties()` instead —
+	 * see the note there before adding any property here.
 	 *
 	 * @return array The common properties.
 	 */
 	public static function get_common_properties() {
-		return array_merge( self::get_page_common_properties(), self::get_server_details() );
+		return array_merge(
+			self::get_session_properties(),
+			self::get_page_common_properties(),
+			self::get_server_details()
+		);
+	}
+
+	/**
+	 * Get the visitor's session properties from the session cookie.
+	 *
+	 * Request-derived, so these are for the server-fired path only. The cookie is
+	 * written and read by the client's own SessionManager, which supplies these
+	 * properties directly on events it sends.
+	 *
+	 * @since 0.16.7
+	 *
+	 * @return array The session properties.
+	 */
+	private static function get_session_properties() {
+		$session_details = self::get_session_details();
+
+		return array(
+			'session_id'   => $session_details['session_id'] ?? null,
+			'landing_page' => $session_details['landing_page'] ?? null,
+			'is_engaged'   => $session_details['is_engaged'] ?? null,
+		);
 	}
 
 	/**
@@ -255,24 +281,21 @@ class WC_Analytics_Tracking {
 	 *
 	 * Everything returned here is derived from the store, not from the current
 	 * request, because the page output this feeds is cached and replayed to later
-	 * visitors. Request headers are not part of the CDN cache key, so a property
-	 * derived from one would be attributed to every subsequent visitor of the
-	 * cached page. Anything request-derived belongs in `get_server_details()`,
-	 * which only reaches the server-fired pixel path.
+	 * visitors. Neither request headers nor cookies are part of the CDN cache key,
+	 * so a property derived from one would be attributed to every subsequent
+	 * visitor of the cached page. Anything request-derived belongs in
+	 * `get_session_properties()` or `get_server_details()`, which only reach the
+	 * server-fired path.
 	 *
 	 * @since 0.16.7
 	 *
 	 * @return array The common properties.
 	 */
 	public static function get_page_common_properties() {
-		$blog_user_id    = self::get_blog_user_id();
-		$blog_details    = self::get_blog_details();
-		$session_details = self::get_session_details();
+		$blog_user_id = self::get_blog_user_id();
+		$blog_details = self::get_blog_details();
 
 		return array(
-			'session_id'     => $session_details['session_id'] ?? null,
-			'landing_page'   => $session_details['landing_page'] ?? null,
-			'is_engaged'     => $session_details['is_engaged'] ?? null,
 			'ui'             => $blog_user_id,
 			'blog_id'        => $blog_details['blog_id'] ?? null,
 			'store_id'       => $blog_details['store_id'] ?? null,

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -254,7 +254,10 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
-	 * Default event properties which should be included with all events.
+	 * Request-scoped — not for page output, see `get_page_common_properties()`.
+	 *
+	 * Default event properties for events the server fires itself on an uncached
+	 * request. See `WC_Analytics_Tracking::get_common_properties()`.
 	 *
 	 * @return array Array of standard event props.
 	 */
@@ -637,12 +640,13 @@ trait Woo_Analytics_Trait {
 	/**
 	 * Limit the length of a caller-influenced string bound for the page output.
 	 *
-	 * The values this caps — breadcrumb titles and the search term — are short in
-	 * practice, but on a search page both derive from the request URL. Without a
-	 * limit a single long request would push an arbitrary amount of text into the
-	 * cached copy of the page, and the search term reaches the pixel twice (as
-	 * `search_query` and inside the browser's own `_dl`), where an oversized URL
-	 * risks the event being rejected rather than merely bloated.
+	 * Breadcrumb titles come from `post_title`, which core does not bound, so this
+	 * is their only limit. The search term is already blanked by
+	 * `WP_Query::parse_query()` above 1600 bytes; capping it further keeps the
+	 * search pixel URL, which carries the term twice, from being rejected outright.
+	 *
+	 * Truncated values keep an ellipsis so they stay distinguishable downstream
+	 * from a value that genuinely ended at the limit.
 	 *
 	 * @since 0.16.7
 	 *
@@ -654,7 +658,11 @@ trait Woo_Analytics_Trait {
 
 		$value = (string) $value;
 
-		return mb_strlen( $value ) > $max_length ? mb_substr( $value, 0, $max_length ) : $value;
+		if ( mb_strlen( $value ) <= $max_length ) {
+			return $value;
+		}
+
+		return mb_substr( $value, 0, $max_length - 1 ) . '…';
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -626,33 +626,35 @@ trait Woo_Analytics_Trait {
 	 * - For regular pages, it builds the breadcrumb from the page's ancestors, ordered from top-level to current.
 	 * - For all other cases, it returns the current page's title.
 	 *
-	 * Titles are capped before being returned; see `cap_breadcrumb_title()`.
+	 * Titles are capped before being returned; see `cap_page_string()`.
 	 *
 	 * @return array The breadcrumb trail as an array of titles.
 	 */
 	private function get_breadcrumb_titles() {
-		return array_map( array( $this, 'cap_breadcrumb_title' ), $this->build_breadcrumb_titles() );
+		return array_map( array( $this, 'cap_page_string' ), $this->build_breadcrumb_titles() );
 	}
 
 	/**
-	 * Limit the length of a single breadcrumb title.
+	 * Limit the length of a caller-influenced string bound for the page output.
 	 *
-	 * Breadcrumb titles are page and product names, which are short in practice.
-	 * The cap exists because one crumb is not: on a search page the trail embeds
-	 * the raw search term, so without a limit a single long request URL would
-	 * push an arbitrary amount of text into the cached copy of the page.
+	 * The values this caps — breadcrumb titles and the search term — are short in
+	 * practice, but on a search page both derive from the request URL. Without a
+	 * limit a single long request would push an arbitrary amount of text into the
+	 * cached copy of the page, and the search term reaches the pixel twice (as
+	 * `search_query` and inside the browser's own `_dl`), where an oversized URL
+	 * risks the event being rejected rather than merely bloated.
 	 *
 	 * @since 0.16.7
 	 *
-	 * @param string $title The breadcrumb title.
-	 * @return string The title, truncated if it exceeded the limit.
+	 * @param string $value The value bound for the page output.
+	 * @return string The value, truncated if it exceeded the limit.
 	 */
-	private function cap_breadcrumb_title( $title ) {
+	private function cap_page_string( $value ) {
 		$max_length = 200;
 
-		$title = (string) $title;
+		$value = (string) $value;
 
-		return mb_strlen( $title ) > $max_length ? mb_substr( $title, 0, $max_length ) : $title;
+		return mb_strlen( $value ) > $max_length ? mb_substr( $value, 0, $max_length ) : $value;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -278,6 +278,28 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Default event properties for the client, excluding anything derived from
+	 * the current request.
+	 *
+	 * Used for the properties embedded in front-end page HTML, which is cached
+	 * and replayed to later visitors. See
+	 * `WC_Analytics_Tracking::get_page_common_properties()`.
+	 *
+	 * @since 0.16.7
+	 *
+	 * @return array Array of standard event props.
+	 */
+	public function get_page_common_properties() {
+		$common_properties = WC_Analytics_Tracking::get_page_common_properties();
+
+		/** This filter is documented in src/class-woo-analytics-trait.php */
+		return apply_filters(
+			'jetpack_woocommerce_analytics_event_props',
+			$common_properties
+		);
+	}
+
+	/**
 	 * Enqueue an event with optional product and custom properties.
 	 *
 	 * @param string       $event_name The name of the event to record.
@@ -604,9 +626,41 @@ trait Woo_Analytics_Trait {
 	 * - For regular pages, it builds the breadcrumb from the page's ancestors, ordered from top-level to current.
 	 * - For all other cases, it returns the current page's title.
 	 *
+	 * Titles are capped before being returned; see `cap_breadcrumb_title()`.
+	 *
 	 * @return array The breadcrumb trail as an array of titles.
 	 */
 	private function get_breadcrumb_titles() {
+		return array_map( array( $this, 'cap_breadcrumb_title' ), $this->build_breadcrumb_titles() );
+	}
+
+	/**
+	 * Limit the length of a single breadcrumb title.
+	 *
+	 * Breadcrumb titles are page and product names, which are short in practice.
+	 * The cap exists because one crumb is not: on a search page the trail embeds
+	 * the raw search term, so without a limit a single long request URL would
+	 * push an arbitrary amount of text into the cached copy of the page.
+	 *
+	 * @since 0.16.7
+	 *
+	 * @param string $title The breadcrumb title.
+	 * @return string The title, truncated if it exceeded the limit.
+	 */
+	private function cap_breadcrumb_title( $title ) {
+		$max_length = 200;
+
+		$title = (string) $title;
+
+		return mb_strlen( $title ) > $max_length ? mb_substr( $title, 0, $max_length ) : $title;
+	}
+
+	/**
+	 * Build the uncapped breadcrumb trail. See `get_breadcrumb_titles()`.
+	 *
+	 * @return array The breadcrumb trail as an array of titles.
+	 */
+	private function build_breadcrumb_titles() {
 		if ( is_front_page() ) {
 			return array( __( 'Home', 'woocommerce-analytics' ) );
 		}

--- a/packages/php/woocommerce-analytics/src/client/analytics.ts
+++ b/packages/php/woocommerce-analytics/src/client/analytics.ts
@@ -62,15 +62,16 @@ export class Analytics {
 			consentManager.addConsentChangeListener( this.handleConsentChange );
 
 			this.sessionManager.init();
-			const { sessionId, landingPage, isNewSession } = this.sessionManager;
+			const { sessionId, landingPage, isEngaged, isNewSession } = this.sessionManager;
 
-			// Not needed if proxy tracking is enabled.
+			// Not needed if proxy tracking is enabled: that request carries the session cookie itself.
 			if ( ! this.features.proxy ) {
-				// Add session ID and landing page to common properties.
+				// The page markup is cacheable, so the server cannot send these.
 				this.commonProps = {
 					...this.commonProps,
 					session_id: sessionId,
 					landing_page: landingPage,
+					is_engaged: isEngaged,
 				};
 			}
 

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -30,6 +30,15 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	private const REQUEST_DERIVED_PROPERTIES = array( '_via_ip', '_via_ua', '_via_ref', '_dr', '_dl', '_lg' );
 
 	/**
+	 * Properties read from the visitor's session cookie. The client owns this
+	 * cookie and reads it itself, so these must not reach cacheable page output
+	 * either.
+	 *
+	 * @var string[]
+	 */
+	private const SESSION_PROPERTIES = array( 'session_id', 'landing_page', 'is_engaged' );
+
+	/**
 	 * Request header values used to poison the page, keyed by superglobal key.
 	 * Each is distinctive enough to grep the whole response body for.
 	 *
@@ -43,8 +52,15 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	);
 
 	/**
-	 * Send every request through the poisoned headers, and clear the cached IP
-	 * so each test resolves them afresh.
+	 * A session cookie value carrying another visitor's session.
+	 *
+	 * @var string
+	 */
+	private const POISONED_SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+	/**
+	 * Send every request through the poisoned headers and a session cookie, and
+	 * clear the cached IP so each test resolves them afresh.
 	 */
 	public function set_up(): void {
 		parent::set_up();
@@ -53,20 +69,78 @@ class Universal_Page_Output_Test extends BaseTestCase {
 			$_SERVER[ $key ] = $value;
 		}
 
+		$_COOKIE['woocommerceanalytics_session'] = rawurlencode(
+			(string) wp_json_encode(
+				array(
+					'session_id'   => self::POISONED_SESSION_ID,
+					'landing_page' => '["Someone else\'s landing page"]',
+					'is_engaged'   => true,
+				)
+			)
+		);
+
 		$this->reset_cached_ip();
 	}
 
 	/**
-	 * Remove the poisoned headers so they cannot leak into other test classes.
+	 * Remove the poisoned headers and cookie so they cannot leak into other
+	 * test classes.
 	 */
 	public function tear_down(): void {
 		foreach ( array_keys( self::POISONED_HEADERS ) as $key ) {
 			unset( $_SERVER[ $key ] );
 		}
 
+		unset( $_COOKIE['woocommerceanalytics_session'] );
+
 		$this->reset_cached_ip();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Test that the visitor's session properties stay out of the page output.
+	 *
+	 * The client reads the same cookie through its own SessionManager, so these
+	 * are redundant in the markup — and the markup is cached, which would pin
+	 * one visitor's session identifier onto everyone served the cached copy.
+	 */
+	public function test_page_output_omits_session_properties(): void {
+		$output = $this->render_analytics_data();
+
+		foreach ( self::SESSION_PROPERTIES as $property ) {
+			$this->assertStringNotContainsString(
+				'"' . $property . '"',
+				$output,
+				sprintf( 'The "%s" session property must not reach cacheable page output.', $property )
+			);
+		}
+
+		$this->assertStringNotContainsString(
+			self::POISONED_SESSION_ID,
+			$output,
+			'A session identifier from the request cookie must not be reflected into cacheable page output.'
+		);
+	}
+
+	/**
+	 * Test that the server-fired path keeps the session properties. It runs on
+	 * uncached requests — including the proxy tracking endpoint — where the
+	 * cookie genuinely belongs to the visitor being recorded.
+	 */
+	public function test_server_fired_properties_retain_session_details(): void {
+		$properties = WC_Analytics_Tracking::get_common_properties();
+
+		foreach ( self::SESSION_PROPERTIES as $property ) {
+			$this->assertArrayHasKey(
+				$property,
+				$properties,
+				sprintf( 'The server-fired path still needs the "%s" property.', $property )
+			);
+		}
+
+		$this->assertSame( self::POISONED_SESSION_ID, $properties['session_id'] );
+		$this->assertTrue( $properties['is_engaged'] );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Tests for the analytics payload injected into front-end page HTML.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests that the cacheable page output carries no request-derived properties.
+ *
+ * `inject_analytics_data()` writes into front-end HTML, which CDNs cache and
+ * replay to later visitors. Request headers such as `Referer` and
+ * `Cf-Connecting-Ip` are not part of the cache key, so any property derived
+ * from them that reaches the page body is served back to everyone who hits
+ * the cached copy — one unauthenticated request would otherwise decide what
+ * every subsequent visitor reports as their own IP, user agent and referrer.
+ */
+class Universal_Page_Output_Test extends BaseTestCase {
+
+	/**
+	 * Properties that `get_server_details()` derives from the current request.
+	 * None of them may appear in cacheable page output.
+	 *
+	 * @var string[]
+	 */
+	private const REQUEST_DERIVED_PROPERTIES = array( '_via_ip', '_via_ua', '_via_ref', '_dr', '_dl', '_lg' );
+
+	/**
+	 * Request header values used to poison the page, keyed by superglobal key.
+	 * Each is distinctive enough to grep the whole response body for.
+	 *
+	 * @var array<string, string>
+	 */
+	private const POISONED_HEADERS = array(
+		'HTTP_REFERER'          => 'https://attacker.example/poisoned-referrer',
+		'HTTP_CF_CONNECTING_IP' => '203.0.113.199',
+		'HTTP_USER_AGENT'       => 'PoisonedUserAgent/1.0',
+		'HTTP_ACCEPT_LANGUAGE'  => 'zz-ZZ',
+	);
+
+	/**
+	 * Send every request through the poisoned headers, and clear the cached IP
+	 * so each test resolves them afresh.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		foreach ( self::POISONED_HEADERS as $key => $value ) {
+			$_SERVER[ $key ] = $value;
+		}
+
+		$this->reset_cached_ip();
+	}
+
+	/**
+	 * Remove the poisoned headers so they cannot leak into other test classes.
+	 */
+	public function tear_down(): void {
+		foreach ( array_keys( self::POISONED_HEADERS ) as $key ) {
+			unset( $_SERVER[ $key ] );
+		}
+
+		$this->reset_cached_ip();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that no request-derived property name reaches the page output.
+	 */
+	public function test_page_output_omits_request_derived_property_names(): void {
+		$output = $this->render_analytics_data();
+
+		foreach ( self::REQUEST_DERIVED_PROPERTIES as $property ) {
+			$this->assertStringNotContainsString(
+				'"' . $property . '"',
+				$output,
+				sprintf(
+					'The "%s" property is derived from the current request and must not reach cacheable page output.',
+					$property
+				)
+			);
+		}
+	}
+
+	/**
+	 * Test that no value taken from a request header reaches the page output.
+	 *
+	 * This is the poisoning check: headers outside the CDN cache key must not
+	 * influence the cached response body at all.
+	 */
+	public function test_page_output_omits_request_header_values(): void {
+		$output = $this->render_analytics_data();
+
+		foreach ( self::POISONED_HEADERS as $key => $value ) {
+			$this->assertStringNotContainsString(
+				$value,
+				$output,
+				sprintf( 'The %s request header must not be reflected into cacheable page output.', $key )
+			);
+		}
+	}
+
+	/**
+	 * Test that store-level properties survive, so the assertions above cannot
+	 * pass merely because the payload went empty.
+	 */
+	public function test_page_output_retains_store_properties(): void {
+		$output = $this->render_analytics_data();
+
+		foreach ( array( 'timezone', 'wp_version', 'store_currency' ) as $property ) {
+			$this->assertStringContainsString(
+				'"' . $property . '"',
+				$output,
+				sprintf( 'The store-level "%s" property should still be sent to the client.', $property )
+			);
+		}
+	}
+
+	/**
+	 * Test that a breadcrumb title cannot inflate the page.
+	 *
+	 * On search pages the breadcrumb trail embeds the raw search term, so a
+	 * long request can otherwise push an arbitrary amount of text into every
+	 * copy of the cached response.
+	 */
+	public function test_page_output_caps_long_breadcrumb_titles(): void {
+		$GLOBALS['post'] = new \WP_Post(
+			(object) array(
+				'ID'         => 1,
+				'post_title' => str_repeat( 'A', 5000 ),
+				'post_type'  => 'post',
+				'filter'     => 'raw',
+			)
+		);
+
+		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
+
+		unset( $GLOBALS['post'] );
+
+		$this->assertNotEmpty( $breadcrumbs, 'The breadcrumb trail should still be rendered.' );
+
+		foreach ( $breadcrumbs as $title ) {
+			$this->assertLessThanOrEqual(
+				200,
+				mb_strlen( $title ),
+				'A breadcrumb title should be capped before it reaches cacheable page output.'
+			);
+		}
+	}
+
+	/**
+	 * Test that a breadcrumb title short enough to keep is left untouched.
+	 */
+	public function test_page_output_keeps_short_breadcrumb_titles_intact(): void {
+		$title = 'Perfectly Ordinary Product Name';
+
+		$GLOBALS['post'] = new \WP_Post(
+			(object) array(
+				'ID'         => 1,
+				'post_title' => $title,
+				'post_type'  => 'post',
+				'filter'     => 'raw',
+			)
+		);
+
+		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
+
+		unset( $GLOBALS['post'] );
+
+		$this->assertSame( array( $title ), $breadcrumbs, 'Ordinary titles should be sent unchanged.' );
+	}
+
+	/**
+	 * Test that proxy mode still sends an empty payload. It reaches the same
+	 * cacheable markup, and the pixel is fired server-side from the visitor's
+	 * own uncached request instead.
+	 */
+	public function test_page_output_is_empty_under_proxy_tracking(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		$output = $this->render_analytics_data();
+
+		remove_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		$this->assertStringContainsString(
+			'wcAnalytics.commonProps = [];',
+			$output,
+			'Proxy mode should send no common properties to the client.'
+		);
+	}
+
+	/**
+	 * Test that the server-fired pixel path keeps its request-derived
+	 * properties. That path runs on uncached requests and is the only place
+	 * where pixel.wp.com can learn the visitor's real IP, user agent and
+	 * referrer, so narrowing the page output must not narrow it too.
+	 */
+	public function test_server_fired_properties_retain_request_details(): void {
+		$properties = WC_Analytics_Tracking::get_common_properties();
+
+		foreach ( self::REQUEST_DERIVED_PROPERTIES as $property ) {
+			$this->assertArrayHasKey(
+				$property,
+				$properties,
+				sprintf( 'The server-fired pixel path still needs the "%s" property.', $property )
+			);
+		}
+
+		$this->assertSame( self::POISONED_HEADERS['HTTP_CF_CONNECTING_IP'], $properties['_via_ip'] );
+		$this->assertSame( self::POISONED_HEADERS['HTTP_USER_AGENT'], $properties['_via_ua'] );
+		$this->assertSame( self::POISONED_HEADERS['HTTP_REFERER'], $properties['_via_ref'] );
+	}
+
+	/**
+	 * Render the injected analytics script and return its markup.
+	 *
+	 * @return string The markup written by `inject_analytics_data()`.
+	 */
+	private function render_analytics_data(): string {
+		$universal = new Universal();
+
+		ob_start();
+		$universal->inject_analytics_data();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Pull the breadcrumb trail back out of the rendered markup.
+	 *
+	 * @param string $output The markup written by `inject_analytics_data()`.
+	 * @return array The decoded breadcrumb titles.
+	 */
+	private function get_rendered_breadcrumbs( string $output ): array {
+		$matched = preg_match( '/wcAnalytics\.breadcrumbs = (.+);$/m', $output, $matches );
+
+		$this->assertSame( 1, $matched, 'The rendered markup should assign wcAnalytics.breadcrumbs.' );
+
+		return (array) json_decode( $matches[1], true );
+	}
+
+	/**
+	 * Clear the `cached_ip` static so a test's headers are resolved rather than
+	 * a value another test left behind.
+	 */
+	private function reset_cached_ip(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'cached_ip' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+}

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -59,13 +59,33 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	private const POISONED_SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 
 	/**
+	 * Globals this class overwrites, captured before the first change so
+	 * `tear_down()` can put back exactly what it found. `null` records a key
+	 * that was absent.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_globals = array();
+
+	/**
 	 * Send every request through the poisoned headers and a session cookie, and
 	 * clear the cached IP so each test resolves them afresh.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 
+		global $wp_query;
+
+		$this->original_globals = array(
+			'cookie'      => $_COOKIE['woocommerceanalytics_session'] ?? null,
+			'post'        => $GLOBALS['post'] ?? null,
+			'is_search'   => $wp_query->is_search,
+			'search_term' => $wp_query->get( 's' ),
+		);
+
 		foreach ( self::POISONED_HEADERS as $key => $value ) {
+			$this->original_globals[ 'server:' . $key ] = $_SERVER[ $key ] ?? null;
+
 			$_SERVER[ $key ] = $value;
 		}
 
@@ -83,22 +103,40 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Remove the poisoned headers and cookie so they cannot leak into other
-	 * test classes.
+	 * Put back every global this class touched, so a later test sees the state
+	 * it would have seen had this class not run.
 	 */
 	public function tear_down(): void {
+		global $wp_query;
+
+		// Superglobals cannot be passed by reference, so each is restored inline.
 		foreach ( array_keys( self::POISONED_HEADERS ) as $key ) {
-			unset( $_SERVER[ $key ] );
+			if ( $this->original_globals[ 'server:' . $key ] === null ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $this->original_globals[ 'server:' . $key ];
+			}
 		}
 
-		unset( $_COOKIE['woocommerceanalytics_session'] );
+		if ( $this->original_globals['cookie'] === null ) {
+			unset( $_COOKIE['woocommerceanalytics_session'] );
+		} else {
+			$_COOKIE['woocommerceanalytics_session'] = $this->original_globals['cookie'];
+		}
+
+		if ( $this->original_globals['post'] === null ) {
+			unset( $GLOBALS['post'] );
+		} else {
+			$GLOBALS['post'] = $this->original_globals['post'];
+		}
+
+		$wp_query->is_search = $this->original_globals['is_search'];
+		$wp_query->set( 's', $this->original_globals['search_term'] );
+
+		$this->original_globals = array();
 
 		$this->reset_cached_ip();
 		$this->reset_event_queue();
-
-		global $wp_query;
-		$wp_query->is_search = false;
-		$wp_query->set( 's', '' );
 
 		parent::tear_down();
 	}
@@ -219,8 +257,6 @@ class Universal_Page_Output_Test extends BaseTestCase {
 
 		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
 
-		unset( $GLOBALS['post'] );
-
 		$this->assertNotEmpty( $breadcrumbs, 'The breadcrumb trail should still be rendered.' );
 
 		foreach ( $breadcrumbs as $title ) {
@@ -248,8 +284,6 @@ class Universal_Page_Output_Test extends BaseTestCase {
 		);
 
 		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
-
-		unset( $GLOBALS['post'] );
 
 		$this->assertSame( array( $title ), $breadcrumbs, 'Ordinary titles should be sent unchanged.' );
 	}
@@ -372,11 +406,19 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	 * @return array The decoded breadcrumb titles.
 	 */
 	private function get_rendered_breadcrumbs( string $output ): array {
-		$matched = preg_match( '/wcAnalytics\.breadcrumbs = (.+);$/m', $output, $matches );
+		$assignment = 'wcAnalytics.breadcrumbs = ';
 
-		$this->assertSame( 1, $matched, 'The rendered markup should assign wcAnalytics.breadcrumbs.' );
+		$start = strpos( $output, $assignment );
+		$this->assertNotFalse( $start, 'The rendered markup should assign wcAnalytics.breadcrumbs.' );
 
-		return (array) json_decode( $matches[1], true );
+		$start += strlen( $assignment );
+		$end    = strpos( $output, "\n", $start );
+		$this->assertNotFalse( $end, 'The breadcrumb assignment should end with a line break.' );
+
+		// Take the rest of the line and drop the statement's trailing semicolon.
+		$json = rtrim( trim( substr( $output, $start, $end - $start ) ), ';' );
+
+		return (array) json_decode( $json, true );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -239,33 +239,45 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that a breadcrumb title cannot inflate the page.
-	 *
-	 * On search pages the breadcrumb trail embeds the raw search term, so a
-	 * long request can otherwise push an arbitrary amount of text into every
-	 * copy of the cached response.
+	 * Test that a breadcrumb title cannot inflate the page. Titles come from
+	 * `post_title`, which core does not bound.
 	 */
 	public function test_page_output_caps_long_breadcrumb_titles(): void {
-		$GLOBALS['post'] = new \WP_Post(
-			(object) array(
-				'ID'         => 1,
-				'post_title' => str_repeat( 'A', 5000 ),
-				'post_type'  => 'post',
-				'filter'     => 'raw',
-			)
+		$breadcrumbs = $this->render_breadcrumbs_for_title( str_repeat( 'A', 5000 ) );
+
+		$this->assertSame(
+			array( str_repeat( 'A', 199 ) . '…' ),
+			$breadcrumbs,
+			'A breadcrumb title should be capped before it reaches cacheable page output.'
 		);
+	}
 
-		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
+	/**
+	 * Test that the cap counts characters rather than bytes. A byte-wise cut
+	 * splits the final UTF-8 sequence, which `wp_json_encode()` silently rewrites
+	 * to a replacement character.
+	 */
+	public function test_page_output_caps_breadcrumb_titles_by_character(): void {
+		$breadcrumbs = $this->render_breadcrumbs_for_title( str_repeat( '日', 250 ) );
 
-		$this->assertNotEmpty( $breadcrumbs, 'The breadcrumb trail should still be rendered.' );
+		$this->assertSame(
+			array( str_repeat( '日', 199 ) . '…' ),
+			$breadcrumbs,
+			'A breadcrumb title should be capped by character, not by byte.'
+		);
+	}
 
-		foreach ( $breadcrumbs as $title ) {
-			$this->assertLessThanOrEqual(
-				200,
-				mb_strlen( $title ),
-				'A breadcrumb title should be capped before it reaches cacheable page output.'
-			);
-		}
+	/**
+	 * Test that a title sitting exactly on the limit is not truncated.
+	 */
+	public function test_page_output_keeps_breadcrumb_titles_at_the_limit_intact(): void {
+		$title = str_repeat( 'A', 200 );
+
+		$this->assertSame(
+			array( $title ),
+			$this->render_breadcrumbs_for_title( $title ),
+			'A title exactly at the limit should be sent unchanged.'
+		);
 	}
 
 	/**
@@ -274,18 +286,11 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	public function test_page_output_keeps_short_breadcrumb_titles_intact(): void {
 		$title = 'Perfectly Ordinary Product Name';
 
-		$GLOBALS['post'] = new \WP_Post(
-			(object) array(
-				'ID'         => 1,
-				'post_title' => $title,
-				'post_type'  => 'post',
-				'filter'     => 'raw',
-			)
+		$this->assertSame(
+			array( $title ),
+			$this->render_breadcrumbs_for_title( $title ),
+			'Ordinary titles should be sent unchanged.'
 		);
-
-		$breadcrumbs = $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
-
-		$this->assertSame( array( $title ), $breadcrumbs, 'Ordinary titles should be sent unchanged.' );
 	}
 
 	/**
@@ -330,20 +335,18 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that a long search term is capped before it is queued for the page.
+	 * Test that a long search term is capped before it is queued for the page. The
+	 * term reaches the pixel twice — as `search_query` and inside the browser's own
+	 * `_dl` — so an uncapped term can push the URL past what a server will accept.
 	 *
-	 * The search event is assembled server-side and fired by the client, so the
-	 * term travels through the markup. It also reaches the pixel twice — once as
-	 * `search_query` and again inside the browser's own `_dl` — so an uncapped
-	 * term can push the pixel URL past what a server will accept, losing the
-	 * event outright.
+	 * 1500 characters is deliberately under the 1600 bytes above which
+	 * `WP_Query::parse_query()` blanks `s`, so this is an input a request can
+	 * actually produce.
 	 */
 	public function test_queued_search_event_caps_long_search_query(): void {
-		$search_query = $this->capture_search_event( str_repeat( 'A', 5000 ) );
-
-		$this->assertLessThanOrEqual(
-			200,
-			mb_strlen( $search_query ),
+		$this->assertSame(
+			str_repeat( 'A', 199 ) . '…',
+			$this->capture_search_event( str_repeat( 'A', 1500 ) ),
 			'A search term should be capped before it is queued into page output.'
 		);
 	}
@@ -397,6 +400,25 @@ class Universal_Page_Output_Test extends BaseTestCase {
 		ob_start();
 		$universal->inject_analytics_data();
 		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the page payload for a post with the given title.
+	 *
+	 * @param string $title The post title the breadcrumb trail is built from.
+	 * @return array The decoded breadcrumb titles.
+	 */
+	private function render_breadcrumbs_for_title( string $title ): array {
+		$GLOBALS['post'] = new \WP_Post(
+			(object) array(
+				'ID'         => 1,
+				'post_title' => $title,
+				'post_type'  => 'post',
+				'filter'     => 'raw',
+			)
+		);
+
+		return $this->get_rendered_breadcrumbs( $this->render_analytics_data() );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -94,6 +94,11 @@ class Universal_Page_Output_Test extends BaseTestCase {
 		unset( $_COOKIE['woocommerceanalytics_session'] );
 
 		$this->reset_cached_ip();
+		$this->reset_event_queue();
+
+		global $wp_query;
+		$wp_query->is_search = false;
+		$wp_query->set( 's', '' );
 
 		parent::tear_down();
 	}
@@ -291,6 +296,63 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that a long search term is capped before it is queued for the page.
+	 *
+	 * The search event is assembled server-side and fired by the client, so the
+	 * term travels through the markup. It also reaches the pixel twice — once as
+	 * `search_query` and again inside the browser's own `_dl` — so an uncapped
+	 * term can push the pixel URL past what a server will accept, losing the
+	 * event outright.
+	 */
+	public function test_queued_search_event_caps_long_search_query(): void {
+		$search_query = $this->capture_search_event( str_repeat( 'A', 5000 ) );
+
+		$this->assertLessThanOrEqual(
+			200,
+			mb_strlen( $search_query ),
+			'A search term should be capped before it is queued into page output.'
+		);
+	}
+
+	/**
+	 * Test that an ordinary search term is queued unchanged.
+	 */
+	public function test_queued_search_event_keeps_ordinary_search_query_intact(): void {
+		$term = 'blue cotton t-shirt';
+
+		$this->assertSame(
+			$term,
+			$this->capture_search_event( $term ),
+			'Ordinary search terms should be recorded unchanged.'
+		);
+	}
+
+	/**
+	 * Run a search request through `capture_search_query()` and return the
+	 * `search_query` property it queued for the page.
+	 *
+	 * @param string $term The search term the visitor requested.
+	 * @return string The queued search query.
+	 */
+	private function capture_search_event( string $term ): string {
+		global $wp_query;
+
+		$wp_query->is_search = true;
+		$wp_query->set( 's', $term );
+
+		$universal = new Universal();
+		$universal->capture_search_query();
+
+		$queue = WC_Analytics_Tracking::get_event_queue();
+		$this->assertNotEmpty( $queue, 'A search event should have been queued.' );
+
+		$event = end( $queue );
+		$this->assertSame( 'search', $event['eventName'], 'The queued event should be the search event.' );
+
+		return (string) ( $event['props']['search_query'] ?? '' );
+	}
+
+	/**
 	 * Render the injected analytics script and return its markup.
 	 *
 	 * @return string The markup written by `inject_analytics_data()`.
@@ -315,6 +377,17 @@ class Universal_Page_Output_Test extends BaseTestCase {
 		$this->assertSame( 1, $matched, 'The rendered markup should assign wcAnalytics.breadcrumbs.' );
 
 		return (array) json_decode( $matches[1], true );
+	}
+
+	/**
+	 * Clear the `event_queue` static so a queued event cannot leak into another
+	 * test's rendered output.
+	 */
+	private function reset_event_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'event_queue' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/mocks/woocommerce-functions.php
+++ b/packages/php/woocommerce-analytics/tests/php/mocks/woocommerce-functions.php
@@ -54,3 +54,25 @@ if ( ! function_exists( 'WC' ) ) {
 		};
 	}
 }
+
+if ( ! function_exists( 'is_cart' ) ) {
+	/**
+	 * Mock is_cart function.
+	 *
+	 * @return bool Always false; tests exercise generic front-end pages.
+	 */
+	function is_cart() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'is_account_page' ) ) {
+	/**
+	 * Mock is_account_page function.
+	 *
+	 * @return bool Always false; tests exercise generic front-end pages.
+	 */
+	function is_account_page() {
+		return false;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part 1 of 2 for WOOA7S-1800. Page output only.

#### Problem

`get_common_properties()` is shared by two consumers with different safety requirements:

| Consumer                                | Runs on                        | Needs request data?                                   |
| --------------------------------------- | ------------------------------ | ----------------------------------------------------- |
| Server-fired pixel (`record_event()`)   | Uncached POST/dynamic requests | **Yes** — pixel.wp.com only sees the _server's_ IP/UA |
| Page output (`inject_analytics_data()`) | **Cacheable HTML**             | No                                                    |

Two groups of request-derived props ended up in front-end HTML:

1. **Request headers** — `_via_ip`, `_via_ua`, `_via_ref`, `_dr`, `_dl`, `_lg`.
2. **The session cookie** — `session_id`, `landing_page`, `is_engaged`.

Neither headers nor cookies are in the CDN cache key, so whichever request fills the cache decides what every later visitor reports as their own IP, UA, referrer — and session identifier. The referrer was embedded twice and hex-escaped, which also inflated the response.

Both groups are redundant on the page, because the client already has better values:

| Props                            | Who really supplies them                                                                         |
| -------------------------------- | ------------------------------------------------------------------------------------------------ |
| `_dr`, `_dl`, `_lg`              | `s.js` overwrites them with browser values before sending                                        |
| `_via_ip`, `_via_ua`, `_via_ref` | The browser's own pixel request already carries these                                            |
| `session_id`, `landing_page`     | `SessionManager` reads the same cookie and **already overwrote** the PHP values (`analytics.ts`) |
| `is_engaged`                     | `SessionManager` has it; this PR adds it to the client's props                                   |

PHP only ever _reads_ that session cookie — the client is its sole writer — so the server was echoing back data the client had all along. Proxy mode already sent an empty `commonProps`; this makes default mode match.

#### Changes

- New `get_page_common_properties()` (store-level only) for the page output, plus `get_session_properties()` alongside `get_server_details()` for the request-derived half. `get_common_properties()` composes all three, keeping identical keys and ordering, so **the server-fired path — including the proxy tracking endpoint — is unchanged**.
- Same accessor on `Woo_Analytics_Trait`, still applying `jetpack_woocommerce_analytics_event_props`.
- Both `get_common_properties()` docblocks now lead with a not-for-page-output warning, since that is the name reached for by default. `get_page_common_properties()` names the two groups that are _not_ store-derived — `device`, and the identity props — so the guardrail doesn't overstate what it guarantees.
- `analytics.ts` adds `is_engaged` to the session props it already sets, so nothing is lost from events.
- Capped breadcrumb titles and the queued `search_query` at 200 chars (shared `cap_page_string()`), with an ellipsis on truncated values so they stay distinguishable downstream from one that genuinely ended at the limit. Analytics payload only; visible breadcrumbs unchanged.
- `Universal_Page_Output_Test` covering both modes, including tests that the server-fired path _keeps_ both the header and session props.

The page payload goes from 20 props to 11, all store-level.

##### On the search term cap

The `search` event is assembled server-side but _fired by the client_ from `wcAnalytics.eventQueue`, so the term has to travel through the markup today. It then reaches the pixel twice — as `search_query` and again inside the browser's own `_dl`. Measured with a 1500-character term, the search pixel URL went from **4,006 to 2,435 characters**.

Worth being explicit about the limit: `_dl` is set by `s.js` from `document.location`, so it still carries the full search URL and the pixel URL stays bounded by the page URL no matter what we cap. The cap removes one of the two copies rather than making the URL small. That still matters, because an oversized GET pixel risks being rejected at a server's request-line limit — losing the event outright, not just bloating it.

Also worth being explicit about how much the cap can be reached for: `WP_Query::parse_query()` blanks `s` entirely above 1600 bytes (WP 3.7+, well under our 6.9 floor), so on the search path the cap only ever acts between 201 characters and that clamp. Breadcrumb titles are the unbounded caller — they come from `post_title`, which core does not limit — so the cap earns its place there rather than here.

The cleaner fix is to evaluate moving the `search` event to server-side firing, so the term never enters cacheable markup at all. Left for a follow-up: the client can't simply derive the term from `location.search`, since `$wp_query->get( 's' )` is WordPress's parsed value and can differ from the raw query parameter.

#### Left out

Each needs a behavioural decision rather than a contained fix; all tracked on WOOA7S-1800.

- **`device`** is UA-derived, so a cached page pins one visitor's device class onto later ones. Not a leak (three-value bucket), but the same cache-correctness class. Fix = derive client-side. Named as a known gap in the `get_page_common_properties()` docblock.
- **`ui`, `is_guest`, `store_admin`** remain server-derived. Safe only because caches bypass logged-in requests, which is a property of the caching layer rather than of this code — also called out in that docblock.
- The **filter** still runs on page props, so an extension could re-add request-derived data. The docblock is the guardrail. This is unchanged from `trunk` — `inject_analytics_data()` already went through `get_common_properties()`, which applies the same filter, so the page path was never filter-free. Giving the page props their own hook name would _remove_ existing callbacks from that path, which is why it isn't done here.

#### Minor behavioural note

When ClickHouse is disabled, `sessionTracking` is off, so the client never initialises `SessionManager` — but it is also the only thing that writes the session cookie, so the server previously read nothing and sent `session_id: null`. Those keys are now absent rather than null. No session tracking happens in that configuration either way.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR Automattic/jetpack#45208.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

No UI changes — this only affects the inline analytics payload. For reference, the inline `commonProps` object on a front-end page:

| Before                                                                                                                                                                                                                                                                                                 | After                                                                                                                                                      |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `{"session_id":"<visitor session>","landing_page":"<visitor landing page>","is_engaged":<visitor>,"ui":0,...,"is_guest":1,"_via_ua":"<request User-Agent>","_via_ip":"<request IP>","_lg":"<request Accept-Language>","_dr":"<request Referer>","_dl":"<request URL>","_via_ref":"<request Referer>"}` | `{"ui":0,"blog_id":…,"store_id":…,"url":…,"woo_version":…,"wp_version":…,"store_admin":0,"device":"desktop","store_currency":…,"timezone":…,"is_guest":1}` |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Setup

This package doesn't run from the monorepo directly — it ships as the composer package `automattic/woocommerce-analytics`, vendored inside plugins. So it has to be deployed onto a site before it can be tested.

**1. Prepare a store.** Local or Jurassic Ninja, with:

- WooCommerce active
- Jetpack active **and connected** to WordPress.com — the tracker self-gates on the connection and `s.js` won't load without it
- A published product and shop page to browse
- If a consent plugin (WP Consent API) is installed, allow statistics — otherwise consent defaults to granted and nothing is needed

Front-end tracking only initialises on front-end requests: admin, AJAX, feeds and WP-CLI are all skipped by design.

**2. Find the copy the site actually loads.** The package is vendored into each consuming plugin, and the Jetpack autoloader picks the highest version across active plugins:

```
wp-content/plugins/jetpack/jetpack_vendor/automattic/woocommerce-analytics/
wp-content/plugins/premium-analytics/jetpack_vendor/automattic/woocommerce-analytics/   # if installed
```

> [!IMPORTANT]
> **If `premium-analytics` is installed, deactivate it for this test** (or patch both copies). Both ship 0.16.6, so with equal versions which copy wins depends on plugin load order — and the tracker is idempotent, so only the first one to initialise takes effect. Deactivating it also keeps the configuration predictable: `premium-analytics` force-enables the ClickHouse pipeline, which changes which session properties exist.

**3. Build and deploy this branch.** `build:composer-package` produces exactly the tree that gets published, so this mirrors what a real install looks like:

```bash
cd packages/php/woocommerce-analytics
pnpm install
pnpm run build:composer-package          # builds JS + assembles the publishable tree

DIST="$PWD/build/Automattic/woocommerce-analytics"
DEST="$(wp eval 'echo WP_PLUGIN_DIR;')/jetpack/jetpack_vendor/automattic/woocommerce-analytics"

rsync -a --delete "$DIST/src/"    "$DEST/src/"
rsync -a          "$DIST/build/"  "$DEST/build/"
```

Notes:

- **Rebuilding the JS is required**, not optional — this PR changes `src/client/analytics.ts`, which is what restores the session properties on the client. Deploying only `src/` will make the events look broken.
- No autoloader regeneration needed: this PR adds methods, not classes, so the vendored `jetpack_autoload_classmap.php` stays valid.
- On a Jurassic Ninja or other remote site, `rsync -a … user@host:<path>` to the same two directories.
- If the site runs opcache with a long revalidation window, restart PHP-FPM after deploying.

**4. Add a mode switcher.** Drop this in `wp-content/mu-plugins/wca-test-modes.php` so the three configurations can be flipped without editing plugin code:

```php
<?php
// ?wca_ch=1    → enable the ClickHouse pipeline (what premium-analytics does)
// ?wca_proxy=1 → enable proxy tracking
add_action( 'plugins_loaded', function () {
	if ( isset( $_GET['wca_ch'] ) ) {
		add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
	}
	if ( isset( $_GET['wca_proxy'] ) ) {
		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
	}
}, 0 );
```

Both flags are off by default, which is the configuration the reported issue was found in.

#### Tests

**A. The page no longer carries request data (default mode)**

1. Browse the front end, then view any page's source. Confirm `wcAnalytics.commonProps` contains only the 11 store-level properties — `ui`, `blog_id`, `store_id`, `url`, `woo_version`, `wp_version`, `store_admin`, `device`, `store_currency`, `timezone`, `is_guest` — and none of `_via_ip`, `_via_ua`, `_via_ref`, `_dr`, `_dl`, `_lg`, `session_id`, `landing_page`, `is_engaged`.
2. Request the same page with marker headers and a session cookie:

   ```bash
   curl -s https://example.com/ \
     -H 'Referer: https://marker.example/abc' \
     -H 'Cf-Connecting-Ip: 203.0.113.199' \
     -H 'Cookie: woocommerceanalytics_session=<paste yours from devtools>' \
     | grep -c 'marker.example'
   ```

   Expect `0`, and no session id anywhere in the body. Repeat with `?wca_ch=1` and `?wca_proxy=1` — still no marker in either. With `?wca_proxy=1`, `commonProps` should be `{}`.

3. Optional, to see what was fixed: repeat step 2 on `trunk`. The marker referrer appears twice and the IP once.

**B. Events still carry complete data**

4. With `?wca_ch=1` (session tracking is ClickHouse-gated, so the session properties only exist in this configuration), browse from the shop page into a product page with the Network tab open and inspect the request to `pixel.wp.com`. Confirm:
   - `session_id`, `landing_page` and `is_engaged` are present — now supplied by the client's `SessionManager` rather than the page
   - `_dr` = the page you came from, `_dl` = the current page, `_lg` = your real browser language — now supplied by `s.js`
   - no `_via_*` parameters
   - referrer attribution (`lr` / `or` / `r3d`) and product properties (`pi` / `pn` / `pc` / `pp` / `pt`) are unchanged
5. In the default configuration (no flags), confirm events still fire. Session properties are absent here — they always were, since nothing writes the session cookie when ClickHouse is off.
6. With `?wca_proxy=1`, confirm events are delivered via `POST /wp-json/woocommerce-analytics/v1/track` (HTTP 200) and that the server still records session data from the cookie on that request.

**C. Search term caps**

7. Search the store for a 500-character term — keep it under 1600 bytes, because core blanks `s` above that and the search event would then carry nothing to cap. Confirm each entry in `wcAnalytics.breadcrumbs` and the `search_query` in `wcAnalytics.eventQueue` are at most 200 characters and end in `…`, the visible breadcrumb trail and search results page are unchanged, and the `search` pixel still fires. Then search an ordinary term and confirm it is recorded in full, with no ellipsis. A CJK term of 250 characters should come back as 199 characters plus the ellipsis, not a byte-wise cut.

**D. Package checks**

8. ```bash
   cd packages/php/woocommerce-analytics
   composer install && ./vendor/bin/phpunit
   pnpm run typecheck
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

**Automated:** 91 tests / 164 assertions pass in the package suite (78 pre-existing, 13 new). `tsc --noEmit` is clean and the webpack bundle builds. `phpcs` reports no new issues — the only findings are pre-existing and unrelated to this change (unused parameters and boolean precedence in `class-universal.php`), identical in count before and after.

The cap tests were checked by mutation rather than by eye, since an earlier revision of them stayed green under both: swapping `mb_substr`/`mb_strlen` for their byte-wise counterparts now fails `test_page_output_caps_breadcrumb_titles_by_character`, and loosening `<=` to `<` now fails `test_page_output_keeps_breadcrumb_titles_at_the_limit_intact`. Worth noting that a byte-wise cut does _not_ break the inline script — `wp_json_encode()` rewrites the split UTF-8 sequence to a replacement character rather than returning `false` — so the assertions have to compare the exact string, not just check that the output is valid UTF-8.

**Manual, on a local store** (WooCommerce 11.0.0-dev, WordPress 7.0, Jetpack 16.1-a.3 loading woocommerce-analytics 0.16.6, storefront over HTTPS via a tunnel, both tracking modes exercised via a temporary filter, rebuilt client bundle deployed):

- Reproduced the issue before the change: marker `Referer`, `Cf-Connecting-Ip`, `User-Agent` and `Accept-Language` values all appeared in the inline `commonProps`, with the referrer present twice.
- Measured the amplification before the change: a 6 KB `Referer` header grew the response from 118,380 to 190,390 bytes (about 72 KB of added markup, roughly 12× the header, consistent with hex-escaping plus double embedding). After the change the same comparison is a 0 byte difference.
- After the change, sent a request carrying both marker headers and a session cookie, then scanned the entire response body in both tracking modes — none of the marker values, the session id, or any of the nine property names were present. `commonProps` was the expected 11 store-level properties (empty in proxy mode).
- Confirmed in the browser that events still fire with complete data: a `session_engagement` / `page_view` pixel carried `session_id`, `landing_page` and `is_engaged=false` from the client's `SessionManager`, and `_dr`, `_dl`, `_lg` from `s.js` (`_dr` = the page navigated from, `_dl` = current page, `_lg` = real browser language), with no `_via_*` parameters. Client-side referrer attribution (`lr`/`or`/`r3d`) and product properties (`pi`/`pn`/`pc`/`pp`/`pt`) were unaffected.
- Confirmed proxy mode still delivers events via the REST endpoint (HTTP 200), with no console errors in either mode.
- Verified both caps against the real `WC_Breadcrumb` search trail: search terms of 500 and 1500 characters produced a 200-character crumb and a 200-character `search_query`, while 20-character terms passed through untouched. This run predates the ellipsis, so the truncated values were 200 characters of the term rather than 199 plus `…`; the ellipsis itself is covered by the package suite.
- Measured the search pixel with a 1500-character term: URL length dropped from 4,006 to 2,435 characters (`search_query` 1500 → 200, `_dl` unchanged at 1,563 as expected), still HTTP 200.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

The changelog entry was created manually and is included in this branch: `packages/php/woocommerce-analytics/changelog/fix-cacheable-page-request-derived-props` (Significance: patch, Type: security).

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>


