### PR TITLE
Product Price: support responsive styling

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-price-block-responsive-styles
+++ b/plugins/woocommerce/changelog/fix-product-price-block-responsive-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Product Price: support Responsive Styling.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.json
@@ -26,7 +26,8 @@
 		"color": {
 			"text": true,
 			"background": true,
-			"link": false
+			"link": false,
+			"__experimentalSkipSerialization": true
 		},
 		"typography": {
 			"fontSize": true,
@@ -34,13 +35,21 @@
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalLetterSpacing": true,
+			"__experimentalSkipSerialization": true
 		},
-		"__experimentalSelector": ".wp-block-woocommerce-product-price .wc-block-components-product-price",
 		"email": true,
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalSkipSerialization": [ "padding" ]
+		}
+	},
+	"selectors": {
+		"root": ".wp-block-woocommerce-product-price .wc-block-components-product-price",
+		"spacing": {
+			"margin": ".wp-block-woocommerce-product-price",
+			"padding": ".wp-block-woocommerce-product-price .wc-block-components-product-price"
 		}
 	},
 	"ancestor": [

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -95,39 +95,50 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		parentName ===
 		'woocommerce/add-to-cart-with-options-grouped-product-item';
 
-	// If the block is not a descendant of the All Products block, we are
-	// already printing the styles from the PHP side (in the frontend) and the
-	// `edit.tsx` file (in the editor).
-	const computedStyles = useStyleProps( props );
-	let styleProps = {
-		className: '',
-		style: {},
+	const styleProps = useStyleProps( props );
+	const {
+		margin,
+		marginTop,
+		marginRight,
+		marginBottom,
+		marginLeft,
+		...priceStyle
+	} = styleProps.style;
+	const blockMarginStyle = {
+		margin,
+		marginTop,
+		marginRight,
+		marginBottom,
+		marginLeft,
 	};
-	if ( isDescendentOfAllProductsBlock ) {
-		styleProps = computedStyles;
-	}
 
 	const showPricePreview =
 		( isDescendentOfSingleProductTemplate &&
 			! isDescendentOfAddToCartGroupedProductSelectorBlock ) ||
 		! product;
 
-	const wrapperClassName = clsx(
-		'wc-block-components-product-price',
-		className,
-		styleProps.className,
-		{
-			[ `${ parentClassName }__product-price` ]: parentClassName,
-		}
+	const blockClassName = clsx(
+		'wp-block-woocommerce-product-price',
+		className
 	);
+	const wrapperClassName = clsx( styleProps.className, {
+		[ `${ parentClassName }__product-price` ]: parentClassName,
+	} );
 
 	if ( ! product?.id && ! isDescendentOfSingleProductTemplate ) {
 		const productPriceComponent = (
-			<ProductPrice align={ textAlign } className={ wrapperClassName } />
+			<ProductPrice
+				align={ textAlign }
+				className={ wrapperClassName }
+				style={ priceStyle }
+			/>
 		);
 		if ( isDescendentOfAllProductsBlock ) {
 			return (
-				<div className="wp-block-woocommerce-product-price">
+				<div
+					className={ blockClassName }
+					style={ isAdmin ? undefined : blockMarginStyle }
+				>
 					{ productPriceComponent }
 				</div>
 			);
@@ -190,9 +201,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		<ProductPrice
 			align={ textAlign }
 			className={ wrapperClassName }
-			style={ styleProps.style }
-			regularPriceStyle={ styleProps.style }
-			priceStyle={ styleProps.style }
+			style={ priceStyle }
 			priceClassName={ priceClassName }
 			currency={ currency }
 			price={ showPricePreview ? pricePreview : prices.price }
@@ -211,7 +220,10 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	);
 	if ( isDescendentOfAllProductsBlock ) {
 		return (
-			<div className="wp-block-woocommerce-product-price">
+			<div
+				className={ blockClassName }
+				style={ isAdmin ? undefined : blockMarginStyle }
+			>
 				{ productPriceComponent }
 			</div>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -239,14 +239,9 @@ export interface ProductPriceProps {
 	 */
 	regularPriceStyle?: React.CSSProperties | undefined;
 	/**
-	 * Custom margin to apply to the price wrapper.
+	 * Custom styles to apply to the price wrapper.
 	 */
-	style?:
-		| Pick<
-				React.CSSProperties,
-				'marginTop' | 'marginRight' | 'marginBottom' | 'marginLeft'
-		  >
-		| undefined;
+	style?: React.CSSProperties | undefined;
 }
 
 const ProductPrice = ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -65,7 +65,8 @@ class ProductPrice extends AbstractBlock {
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
-			$styles_and_classes = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+			$wrapper_class      = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );
+			$styles_and_classes = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes', 'margin' ) );
 
 			$is_descendant_of_product_collection       = isset( $block->context['query']['isProductCollectionBlock'] );
 			$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
@@ -83,8 +84,7 @@ class ProductPrice extends AbstractBlock {
 			}
 
 			$wrapper_attributes     = array(
-				'style' => $styles_and_classes['styles'] ?? '',
-				'class' => $styles_and_classes['classes'] ?? '',
+				'class' => $wrapper_class,
 			);
 			$interactive_attributes = '';
 			$context_directive      = '';
@@ -101,11 +101,13 @@ class ProductPrice extends AbstractBlock {
 			}
 
 			return sprintf(
-				'<div %1$s %2$s><div class="wc-block-components-product-price wc-block-grid__product-price" %3$s>
-					%4$s
+				'<div %1$s %2$s><div class="wc-block-components-product-price wc-block-grid__product-price %3$s" style="%4$s" %5$s>
+					%6$s
 				</div></div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
 				$context_directive,
+				esc_attr( $styles_and_classes['classes'] ?? '' ),
+				esc_attr( $styles_and_classes['styles'] ?? '' ),
 				$interactive_attributes,
 				$product->get_price_html()
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This pull request updates the Product Price block to support responsive styling. Additionally, we are fixing some inconsistencies regarding the block's styling targets. Color, typography, background, and padding support classes/styles move from the outer Product Price block wrapper to .wc-block-components-product-price. Margin and custom block classes remain on the outer wrapper. DOM structure and saved attributes are unchanged.

This fix may break some themes if they are relying on the block support classes, but it is not the recommended way to customize a block anyway. I think that we should accept that small risk of backward compatibility for consistency in block styling across the editor and frontend, across the block style and the global style.

Part of woocommerce/woocommerce#66546

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/c80b9afd-1710-4e97-a19e-88eb919a281a

### How to test the changes in this Pull Request:

1. Use a block theme and activate Gutenberg `23.5.0-rc.2` or newer. Ensure the store has at least three published products.
2. Create and publish a page containing a Product Collection block with Product Image, Product Title, and Product Price inside its Product Template.
3. Select Product Price and configure these local Desktop styles:
   * Text/background: `#111111` / `#f6f7f7`
   * Typography: `32px`, normal, weight `700`, line height `1.2`, letter spacing `1px`
   * Padding: `24px` on every side
   * Margin: top `0px`, bottom `28px`
4. From the editor’s View menu, enable Responsive editing, switch to Tablet, and configure:
   * Text/background: `#007cba` / `#e7f5ff`
   * Typography: `26px`, italic, weight `600`, line height `1.35`, letter spacing `2px`
   * Padding: `16px` on every side
   * Margin: top `0px`, bottom `20px`
5. Switch to Mobile and configure:
   * Text/background: `#d63638` / `#fff0f0`
   * Typography: `20px`, normal, weight `500`, line height `1.5`, letter spacing `3px`
   * Padding: `8px` on every side
   * Margin: top `0px`, bottom `12px`
6. Switch among Desktop, Tablet, and Mobile previews. Verify each preview displays its corresponding typography, colors, padding, and margin without changing the other states.
7. Inspect Product Price in each editor preview. Verify margin is on the outer `.wp-block-woocommerce-product-price` wrapper, while typography, text/background colors, and padding are on the inner `.wc-block-components-product-price`; the inner element must have `0px` margin.
8. Save and view the page. At widths above `782px`, between `481px` and `782px`, and at or below `480px`, verify the frontend matches the Desktop, Tablet, and Mobile values respectively.
9. Inspect the frontend markup and generated block-support CSS. Verify the outer wrapper has a native `wp-states-*` class, responsive margin rules target that state class directly, and responsive typography/color/padding rules target `.wp-states-* .wc-block-components-product-price`.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>