### PR TITLE
Resolve the analytics visitor IP without trusting forgeable headers

### DIFF
--- a/packages/php/woocommerce-analytics/changelog/fix-visitor-ip-header-trust
+++ b/packages/php/woocommerce-analytics/changelog/fix-visitor-ip-header-trust
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Resolve the visitor IP without trusting forgeable proxy request headers.

--- a/packages/php/woocommerce-analytics/changelog/fix-visitor-ip-header-trust
+++ b/packages/php/woocommerce-analytics/changelog/fix-visitor-ip-header-trust
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Resolve the visitor IP without trusting forgeable proxy request headers.
+Resolve the visitor IP from the connecting address or its proxy, never from a forgeable request header.

--- a/packages/php/woocommerce-analytics/composer.json
+++ b/packages/php/woocommerce-analytics/composer.json
@@ -10,6 +10,7 @@
 		"automattic/jetpack-connection": "^8.1",
 		"automattic/jetpack-constants": "^3.0",
 		"automattic/jetpack-device-detection": "^3.4",
+		"automattic/jetpack-ip": "^0.5",
 		"automattic/block-delimiter": "^0.3"
 	},
 	"require-dev": {

--- a/packages/php/woocommerce-analytics/composer.lock
+++ b/packages/php/woocommerce-analytics/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8db8667282290c9a2a06b56b4263a59d",
+    "content-hash": "ea5b5168003a45b1c471e66bcdc66e24",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -405,6 +405,61 @@
                 "source": "https://github.com/Automattic/jetpack-device-detection/tree/v3.4.5"
             },
             "time": "2026-06-15T12:14:47+00:00"
+        },
+        {
+            "name": "automattic/jetpack-ip",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-ip.git",
+                "reference": "ce3ace356ae9ea091fc942f54e702c4f12f7247f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-ip/zipball/ce3ace356ae9ea091fc942f54e702c4f12f7247f",
+                "reference": "ce3ace356ae9ea091fc942f54e702c4f12f7247f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "^1.0.9",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "textdomain": "jetpack-ip",
+                "mirror-repo": "Automattic/jetpack-ip",
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-ip/tree/v0.5.0"
+            },
+            "time": "2026-07-09T11:05:56+00:00"
         },
         {
             "name": "automattic/jetpack-redirect",

--- a/packages/php/woocommerce-analytics/src/class-pixel-builder.php
+++ b/packages/php/woocommerce-analytics/src/class-pixel-builder.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Woocommerce_Analytics;
 
+use Automattic\Jetpack\IP\Utils as IP_Utils;
 use WP_Error;
 
 /**
@@ -122,7 +123,7 @@ class Pixel_Builder {
 		}
 
 		// Delete non-routable IP addresses (geoip would discard these anyway).
-		if ( isset( $properties['_via_ip'] ) && preg_match( '/^192\.168|^10\./', $properties['_via_ip'] ) ) {
+		if ( isset( $properties['_via_ip'] ) && ! IP_Utils::ip_is_public( $properties['_via_ip'] ) ) {
 			unset( $properties['_via_ip'] );
 		}
 

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -546,18 +546,25 @@ class WC_Analytics_Tracking {
 	 * trusting them unconditionally lets any client choose the address we report — and in
 	 * proxy tracking mode that address feeds the visitor id hash.
 	 *
-	 * When `REMOTE_ADDR` itself — the address we actually terminated the connection on, not
-	 * whatever `get_ip()` resolved — is non-routable, the request reached us through a proxy
-	 * on the local network — an external client cannot fake that — so the last entry of
-	 * `X-Forwarded-For`, the one the proxy wrote itself, is worth reading. See
-	 * `get_proxy_written_ip_address()` for why only that entry is trusted. `get_ip()`'s result
-	 * is not usable for this check: when `trusted_ip_header` is configured it is selected out
-	 * of a client-supplied list, so it can be made non-public by an external attacker too.
+	 * Only when that resolution produced nothing usable does a forwarded value come into play,
+	 * and then only on the further condition that `REMOTE_ADDR` — the address we actually
+	 * terminated the connection on, not whatever `get_ip()` resolved — is present, parseable
+	 * and non-routable. Both halves are required. The second half is the proof that a proxy on
+	 * the local network is in front of us, since an external client cannot fake it; the first
+	 * half keeps that recovery from overwriting a good answer, because a site that configured
+	 * `trusted_ip_header` correctly has already produced the visitor address and its
+	 * `REMOTE_ADDR` is private precisely because the proxy it declared is doing its job. An
+	 * absent or malformed `REMOTE_ADDR` proves nothing either way, so it fails closed. See
+	 * `get_proxy_written_ip_address()` for why only the last `X-Forwarded-For` entry is read.
+	 * `get_ip()`'s result is not usable as the proxy proof: when `trusted_ip_header` is
+	 * configured it is selected out of a client-supplied list, so an external attacker can
+	 * drive it non-public too.
 	 *
 	 * @since 0.16.8 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
 	 *               unconditionally.
 	 * @since 0.16.8 Recover the visitor address from the last `X-Forwarded-For` entry when
-	 *               `REMOTE_ADDR` is non-routable, instead of losing it entirely.
+	 *               nothing resolved and `REMOTE_ADDR` is non-routable, instead of losing it
+	 *               entirely.
 	 *
 	 * @return string The user's IP address. An empty string when no public address resolved.
 	 */
@@ -575,12 +582,16 @@ class WC_Analytics_Tracking {
 			? IP_Utils::clean_ip( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
 			: false;
 
-		// The address we terminated on — never the resolved one, which may have been selected
-		// out of a client-supplied list by a configured trusted_ip_header. Only REMOTE_ADDR
-		// being non-routable proves a local proxy is in front of us, and that proof is what
-		// makes the forwarded value usable. A missing or malformed REMOTE_ADDR takes the same
-		// path as a private one.
-		if ( ! is_string( $remote_addr ) || ! IP_Utils::ip_is_public( $remote_addr ) ) {
+		// The forwarded value only fills a gap; it never replaces an answer. So this runs when
+		// resolution produced nothing usable AND REMOTE_ADDR — the address we terminated on,
+		// never the resolved one, which a configured trusted_ip_header may have selected out
+		// of a client-supplied list — is present, parseable and non-routable, which is what
+		// proves a local proxy is in front of us. A site whose trusted_ip_header already gave
+		// us the visitor address keeps it, even though its REMOTE_ADDR is private; an absent
+		// or malformed REMOTE_ADDR is no evidence of a proxy at all, so it fails closed.
+		if ( ! IP_Utils::ip_is_public( $ip )
+			&& is_string( $remote_addr )
+			&& ! IP_Utils::ip_is_public( $remote_addr ) ) {
 			$proxy_written = self::get_proxy_written_ip_address();
 
 			if ( '' !== $proxy_written ) {
@@ -616,7 +627,8 @@ class WC_Analytics_Tracking {
 	 * back into forged input, so a private last entry (chained internal proxies) correctly
 	 * yields nothing.
 	 *
-	 * Only called once `REMOTE_ADDR` has been shown to be non-routable. `Cf-Connecting-IP`
+	 * Only called once resolution has produced nothing usable and `REMOTE_ADDR` has been shown
+	 * to be present, parseable and non-routable. `Cf-Connecting-IP`
 	 * and `X-Real-IP` are deliberately not consulted: an internal proxy forwards client
 	 * headers verbatim unless configured otherwise, so those stay client-controlled.
 	 *

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -12,6 +12,7 @@ namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Jetpack\Device_Detection;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use Automattic\Jetpack\IP\Utils as IP_Utils;
 use WP_Error;
 
 /**
@@ -539,41 +540,41 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the user's IP address.
 	 *
-	 * @return string The user's IP address. An empty string if no valid IP address is found.
+	 * Resolution defaults to `REMOTE_ADDR`. A proxy header is only consulted when the site
+	 * has declared one trustworthy through Jetpack's `trusted_ip_header` site option, which
+	 * is determined by observation rather than guesswork. Request headers are forgeable, so
+	 * trusting them unconditionally lets any client choose the address we report — and in
+	 * proxy tracking mode that address feeds the visitor id hash.
+	 *
+	 * @since 0.16.7 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
+	 *               unconditionally.
+	 *
+	 * @return string The user's IP address. An empty string when no public address resolved.
 	 */
 	private static function get_user_ip_address() {
-		// Return cached IP if available
+		// Return cached IP if available.
 		if ( null !== self::$cached_ip ) {
 			return self::$cached_ip;
 		}
 
-		$ip_headers = array(
-			'HTTP_CF_CONNECTING_IP', // Cloudflare specific header.
-			'HTTP_X_FORWARDED_FOR',
-			'REMOTE_ADDR',
-			'HTTP_CLIENT_IP',
-		);
+		$ip = IP_Utils::get_ip();
 
-		foreach ( $ip_headers as $header ) {
-			if ( isset( $_SERVER[ $header ] ) ) {
-				$ip_list = explode( ',', wp_unslash( $_SERVER[ $header ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				foreach ( $ip_list as $ip_candidate ) {
-					$ip_candidate = trim( $ip_candidate );
-					if ( filter_var(
-						$ip_candidate,
-						FILTER_VALIDATE_IP,
-						array( FILTER_FLAG_NO_RES_RANGE, FILTER_FLAG_IPV6 )
-					) ) {
-						// Cache the resolved IP
-						self::$cached_ip = $ip_candidate;
-						return self::$cached_ip;
-					}
-				}
-			}
-		}
+		/**
+		 * Filters the visitor IP address used for analytics.
+		 *
+		 * For sites behind a proxy this package cannot identify on its own. The returned value
+		 * must be the visitor's own address; it is still required to be public and globally
+		 * routable, so passing a request header through verbatim reintroduces the spoofing this
+		 * resolution exists to prevent.
+		 *
+		 * @since 0.16.7
+		 *
+		 * @param string $ip Resolved visitor IP, or an empty string when none was determined.
+		 */
+		$ip = apply_filters( 'woocommerce_analytics_visitor_ip', is_string( $ip ) ? $ip : '' );
 
-		// Cache empty result
-		self::$cached_ip = '';
+		self::$cached_ip = ( is_string( $ip ) && IP_Utils::ip_is_public( $ip ) ) ? $ip : '';
+
 		return self::$cached_ip;
 	}
 

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -540,31 +540,20 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the user's IP address.
 	 *
-	 * Resolution defaults to `REMOTE_ADDR`. A proxy header is only consulted when the site
-	 * has declared one trustworthy through Jetpack's `trusted_ip_header` site option, which
-	 * is determined by observation rather than guesswork. Request headers are forgeable, so
-	 * trusting them unconditionally lets any client choose the address we report — and in
-	 * proxy tracking mode that address feeds the visitor id hash.
+	 * Defaults to `REMOTE_ADDR`; a proxy header is only used when the site declared one through
+	 * Jetpack's `trusted_ip_header` site option. Headers are forgeable, and this address feeds
+	 * both `_via_ip` and the proxy-mode visitor id hash, so reading one unconditionally lets any
+	 * client choose the identity we report.
 	 *
-	 * Only when that resolution produced nothing usable does a forwarded value come into play,
-	 * and then only on the further condition that `REMOTE_ADDR` — the address we actually
-	 * terminated the connection on, not whatever `get_ip()` resolved — is present, parseable
-	 * and non-routable. Both halves are required. The second half is the proof that a proxy on
-	 * the local network is in front of us, since an external client cannot fake it; the first
-	 * half keeps that recovery from overwriting a good answer, because a site that configured
-	 * `trusted_ip_header` correctly has already produced the visitor address and its
-	 * `REMOTE_ADDR` is private precisely because the proxy it declared is doing its job. An
-	 * absent or malformed `REMOTE_ADDR` proves nothing either way, so it fails closed. See
-	 * `get_proxy_written_ip_address()` for why only the last `X-Forwarded-For` entry is read.
-	 * `get_ip()`'s result is not usable as the proxy proof: when `trusted_ip_header` is
-	 * configured it is selected out of a client-supplied list, so an external attacker can
-	 * drive it non-public too.
+	 * The `X-Forwarded-For` fallback needs both of its conditions. A non-routable `REMOTE_ADDR`
+	 * is the proof that a proxy on the local network is in front of us, since an external client
+	 * cannot fake it; `get_ip()`'s result cannot serve as that proof, because a configured
+	 * `trusted_ip_header` selects it out of a client-supplied list. Requiring the resolved
+	 * address to be unusable first stops the fallback overwriting the answer a correctly
+	 * configured site already produced.
 	 *
-	 * @since 0.16.8 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
-	 *               unconditionally.
-	 * @since 0.16.8 Recover the visitor address from the last `X-Forwarded-For` entry when
-	 *               nothing resolved and `REMOTE_ADDR` is non-routable, instead of losing it
-	 *               entirely.
+	 * @since 0.16.8 Resolve from the connecting address instead of trusting `Cf-Connecting-IP`,
+	 *               `X-Forwarded-For` and `Client-IP` unconditionally.
 	 *
 	 * @return string The user's IP address. An empty string when no public address resolved.
 	 */
@@ -582,13 +571,9 @@ class WC_Analytics_Tracking {
 			? IP_Utils::clean_ip( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
 			: false;
 
-		// The forwarded value only fills a gap; it never replaces an answer. So this runs when
-		// resolution produced nothing usable AND REMOTE_ADDR — the address we terminated on,
-		// never the resolved one, which a configured trusted_ip_header may have selected out
-		// of a client-supplied list — is present, parseable and non-routable, which is what
-		// proves a local proxy is in front of us. A site whose trusted_ip_header already gave
-		// us the visitor address keeps it, even though its REMOTE_ADDR is private; an absent
-		// or malformed REMOTE_ADDR is no evidence of a proxy at all, so it fails closed.
+		// Fill a gap, never replace an answer: only when nothing usable resolved, and only when
+		// REMOTE_ADDR itself proves a local proxy is in front of us. An absent or unparseable
+		// REMOTE_ADDR proves nothing, so it fails closed.
 		if ( ! IP_Utils::ip_is_public( $ip )
 			&& is_string( $remote_addr )
 			&& ! IP_Utils::ip_is_public( $remote_addr ) ) {
@@ -602,10 +587,9 @@ class WC_Analytics_Tracking {
 		/**
 		 * Filters the visitor IP address used for analytics.
 		 *
-		 * For sites behind a proxy this package cannot identify on its own. The returned value
-		 * must be the visitor's own address; it is still required to be public and globally
-		 * routable, so passing a request header through verbatim reintroduces the spoofing this
-		 * resolution exists to prevent.
+		 * For proxy topologies this package cannot identify on its own. The value is still
+		 * required to be public and globally routable, so returning a request header verbatim
+		 * reintroduces the spoofing this resolution exists to prevent.
 		 *
 		 * @since 0.16.8
 		 *
@@ -621,29 +605,18 @@ class WC_Analytics_Tracking {
 	/**
 	 * The address the nearest proxy recorded, from the last `X-Forwarded-For` entry.
 	 *
-	 * Only the last entry is usable. Proxies append the address they observed, so everything
-	 * to its left — including anything the client sent as its own `X-Forwarded-For` — is
-	 * client-controlled. Scanning leftwards for the first public address would walk straight
-	 * back into forged input, so a private last entry (chained internal proxies) correctly
-	 * yields nothing.
+	 * Proxies append the address they observed, so only the last entry is proxy-written;
+	 * everything left of it, including an `X-Forwarded-For` the client sent itself, is
+	 * client-controlled. Scanning leftwards for the first public address would walk back into
+	 * forged input, so a private last entry (chained proxies) correctly yields nothing.
+	 * `Cf-Connecting-IP` and `X-Real-IP` are not read at all: a proxy forwards client headers
+	 * verbatim unless configured to overwrite them.
 	 *
-	 * Only called once resolution has produced nothing usable and `REMOTE_ADDR` has been shown
-	 * to be present, parseable and non-routable. `Cf-Connecting-IP`
-	 * and `X-Real-IP` are deliberately not consulted: an internal proxy forwards client
-	 * headers verbatim unless configured otherwise, so those stay client-controlled.
-	 *
-	 * This still assumes the proxy in front of us is the one that wrote `X-Forwarded-For`,
-	 * and that assumption can be wrong. An nginx configured with only
-	 * `proxy_set_header X-Real-IP $remote_addr;`, for instance, leaves `X-Forwarded-For`
-	 * untouched and forwards whatever the client sent, verbatim — so the last entry is
-	 * attacker-chosen even though `REMOTE_ADDR` is private, and nothing observable from PHP
-	 * tells that configuration apart from one where a proxy really did write the header.
-	 * This is not a regression, though: the code this replaced trusted the first
-	 * `X-Forwarded-For` entry unconditionally on the same misconfigured setup, which handed
-	 * the attacker an even easier win. A site in that situation needs to populate the
-	 * `trusted_ip_header` site option — Jetpack Brute Force Protection does this by asking
-	 * WordPress.com which header is actually trustworthy — or to supply a value of its own
-	 * through the `woocommerce_analytics_visitor_ip` filter.
+	 * Known limitation: this assumes the proxy in front of us wrote `X-Forwarded-For`. An nginx
+	 * setting only `proxy_set_header X-Real-IP $remote_addr;` leaves it untouched and forwards
+	 * the client's, and nothing observable from PHP tells the two apart. Such a site needs to
+	 * populate `trusted_ip_header` — Jetpack Brute Force Protection does — or supply its own
+	 * value through the `woocommerce_analytics_visitor_ip` filter.
 	 *
 	 * @since 0.16.8
 	 *

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -546,10 +546,13 @@ class WC_Analytics_Tracking {
 	 * trusting them unconditionally lets any client choose the address we report — and in
 	 * proxy tracking mode that address feeds the visitor id hash.
 	 *
-	 * When `REMOTE_ADDR` itself is non-routable, the request reached us through a proxy on
-	 * the local network — an external client cannot fake that — so the last entry of
+	 * When `REMOTE_ADDR` itself — the address we actually terminated the connection on, not
+	 * whatever `get_ip()` resolved — is non-routable, the request reached us through a proxy
+	 * on the local network — an external client cannot fake that — so the last entry of
 	 * `X-Forwarded-For`, the one the proxy wrote itself, is worth reading. See
-	 * `get_proxy_written_ip_address()` for why only that entry is trusted.
+	 * `get_proxy_written_ip_address()` for why only that entry is trusted. `get_ip()`'s result
+	 * is not usable for this check: when `trusted_ip_header` is configured it is selected out
+	 * of a client-supplied list, so it can be made non-public by an external attacker too.
 	 *
 	 * @since 0.16.8 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
 	 *               unconditionally.
@@ -567,10 +570,17 @@ class WC_Analytics_Tracking {
 		$ip = IP_Utils::get_ip();
 		$ip = is_string( $ip ) ? $ip : '';
 
-		// A non-routable terminating address is proof the request reached us through a proxy
-		// on the local network: an external client cannot make REMOTE_ADDR private. Only then
-		// is a forwarded value worth reading, and only the one the proxy wrote itself.
-		if ( ! IP_Utils::ip_is_public( $ip ) ) {
+		$remote_addr = isset( $_SERVER['REMOTE_ADDR'] )
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- IP_Utils::clean_ip() validates.
+			? IP_Utils::clean_ip( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
+			: false;
+
+		// The address we terminated on — never the resolved one, which may have been selected
+		// out of a client-supplied list by a configured trusted_ip_header. Only REMOTE_ADDR
+		// being non-routable proves a local proxy is in front of us, and that proof is what
+		// makes the forwarded value usable. A missing or malformed REMOTE_ADDR takes the same
+		// path as a private one.
+		if ( ! is_string( $remote_addr ) || ! IP_Utils::ip_is_public( $remote_addr ) ) {
 			$proxy_written = self::get_proxy_written_ip_address();
 
 			if ( '' !== $proxy_written ) {

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -546,7 +546,7 @@ class WC_Analytics_Tracking {
 	 * trusting them unconditionally lets any client choose the address we report — and in
 	 * proxy tracking mode that address feeds the visitor id hash.
 	 *
-	 * @since 0.16.7 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
+	 * @since 0.16.8 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
 	 *               unconditionally.
 	 *
 	 * @return string The user's IP address. An empty string when no public address resolved.
@@ -567,7 +567,7 @@ class WC_Analytics_Tracking {
 		 * routable, so passing a request header through verbatim reintroduces the spoofing this
 		 * resolution exists to prevent.
 		 *
-		 * @since 0.16.7
+		 * @since 0.16.8
 		 *
 		 * @param string $ip Resolved visitor IP, or an empty string when none was determined.
 		 */

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -620,6 +620,19 @@ class WC_Analytics_Tracking {
 	 * and `X-Real-IP` are deliberately not consulted: an internal proxy forwards client
 	 * headers verbatim unless configured otherwise, so those stay client-controlled.
 	 *
+	 * This still assumes the proxy in front of us is the one that wrote `X-Forwarded-For`,
+	 * and that assumption can be wrong. An nginx configured with only
+	 * `proxy_set_header X-Real-IP $remote_addr;`, for instance, leaves `X-Forwarded-For`
+	 * untouched and forwards whatever the client sent, verbatim — so the last entry is
+	 * attacker-chosen even though `REMOTE_ADDR` is private, and nothing observable from PHP
+	 * tells that configuration apart from one where a proxy really did write the header.
+	 * This is not a regression, though: the code this replaced trusted the first
+	 * `X-Forwarded-For` entry unconditionally on the same misconfigured setup, which handed
+	 * the attacker an even easier win. A site in that situation needs to populate the
+	 * `trusted_ip_header` site option — Jetpack Brute Force Protection does this by asking
+	 * WordPress.com which header is actually trustworthy — or to supply a value of its own
+	 * through the `woocommerce_analytics_visitor_ip` filter.
+	 *
 	 * @since 0.16.8
 	 *
 	 * @return string The proxy-written address, or an empty string when there is none.

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -546,8 +546,15 @@ class WC_Analytics_Tracking {
 	 * trusting them unconditionally lets any client choose the address we report — and in
 	 * proxy tracking mode that address feeds the visitor id hash.
 	 *
+	 * When `REMOTE_ADDR` itself is non-routable, the request reached us through a proxy on
+	 * the local network — an external client cannot fake that — so the last entry of
+	 * `X-Forwarded-For`, the one the proxy wrote itself, is worth reading. See
+	 * `get_proxy_written_ip_address()` for why only that entry is trusted.
+	 *
 	 * @since 0.16.8 Stopped trusting `Cf-Connecting-IP`, `X-Forwarded-For` and `Client-IP`
 	 *               unconditionally.
+	 * @since 0.16.8 Recover the visitor address from the last `X-Forwarded-For` entry when
+	 *               `REMOTE_ADDR` is non-routable, instead of losing it entirely.
 	 *
 	 * @return string The user's IP address. An empty string when no public address resolved.
 	 */
@@ -558,6 +565,18 @@ class WC_Analytics_Tracking {
 		}
 
 		$ip = IP_Utils::get_ip();
+		$ip = is_string( $ip ) ? $ip : '';
+
+		// A non-routable terminating address is proof the request reached us through a proxy
+		// on the local network: an external client cannot make REMOTE_ADDR private. Only then
+		// is a forwarded value worth reading, and only the one the proxy wrote itself.
+		if ( ! IP_Utils::ip_is_public( $ip ) ) {
+			$proxy_written = self::get_proxy_written_ip_address();
+
+			if ( '' !== $proxy_written ) {
+				$ip = $proxy_written;
+			}
+		}
 
 		/**
 		 * Filters the visitor IP address used for analytics.
@@ -576,6 +595,35 @@ class WC_Analytics_Tracking {
 		self::$cached_ip = ( is_string( $ip ) && IP_Utils::ip_is_public( $ip ) ) ? $ip : '';
 
 		return self::$cached_ip;
+	}
+
+	/**
+	 * The address the nearest proxy recorded, from the last `X-Forwarded-For` entry.
+	 *
+	 * Only the last entry is usable. Proxies append the address they observed, so everything
+	 * to its left — including anything the client sent as its own `X-Forwarded-For` — is
+	 * client-controlled. Scanning leftwards for the first public address would walk straight
+	 * back into forged input, so a private last entry (chained internal proxies) correctly
+	 * yields nothing.
+	 *
+	 * Only called once `REMOTE_ADDR` has been shown to be non-routable. `Cf-Connecting-IP`
+	 * and `X-Real-IP` are deliberately not consulted: an internal proxy forwards client
+	 * headers verbatim unless configured otherwise, so those stay client-controlled.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @return string The proxy-written address, or an empty string when there is none.
+	 */
+	private static function get_proxy_written_ip_address() {
+		if ( empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- IP_Utils::clean_ip() validates below.
+		$forwarded = explode( ',', wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+		$written   = IP_Utils::clean_ip( end( $forwarded ) );
+
+		return is_string( $written ) ? $written : '';
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -326,12 +326,76 @@ class Ip_Address_Test extends BaseTestCase {
 	/**
 	 * Chained internal proxies leave a private address in the last entry. Scanning further
 	 * left would walk into client-supplied values, so no IP is the correct answer.
+	 *
+	 * Asserted directly against get_proxy_written_ip_address() rather than only through
+	 * resolved_ip(): the final ip_is_public() gate zeroes both "helper returned ''" and
+	 * "helper returned 10.0.0.6" the same way, so that assertion alone cannot prove the
+	 * helper read the last entry rather than, say, discarding a private one. A reflection
+	 * call on the helper pins that it returns the last entry verbatim (10.0.0.6, still
+	 * private) rather than scanning left for '203.0.113.10' — the mutation this test exists
+	 * to catch.
 	 */
 	public function test_chained_internal_proxies_yield_no_address(): void {
 		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.10, 10.0.0.6';
 
 		$this->assertSame( '', $this->resolved_ip() );
+
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$method     = $reflection->getMethod( 'get_proxy_written_ip_address' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			'10.0.0.6',
+			$method->invoke( null ),
+			'The helper must read the last entry verbatim, not scan left for a public-looking one.'
+		);
+	}
+
+	/**
+	 * A malformed REMOTE_ADDR (missing or unparsable) must be treated the same as a private
+	 * one: it cannot be proof of anything, so it must not itself unlock the forwarded header
+	 * in a way that later trusts unrelated attacker input differently than a clean private
+	 * REMOTE_ADDR would.
+	 */
+	public function test_trailing_comma_yields_no_address(): void {
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.10,';
+
+		$this->assertSame(
+			'',
+			$this->resolved_ip(),
+			'An empty last entry must resolve to no address, not silently fall back to an earlier one.'
+		);
+	}
+
+	/**
+	 * Regression: get_ip() must never be the value tested for "is REMOTE_ADDR private". With
+	 * trusted_ip_header configured, get_ip() selects a segment out of a client-supplied
+	 * X-Forwarded-For list, so it can be driven non-public by an attacker connecting directly
+	 * (a public REMOTE_ADDR) who simply prepends a private-looking address of their choosing.
+	 * If the proxy-recovery branch keyed off get_ip()'s result instead of REMOTE_ADDR itself,
+	 * this would then read the *last* X-Forwarded-For entry — also attacker-controlled here,
+	 * since there is no real proxy in front of this request — and report it as the visitor IP.
+	 */
+	public function test_forwarded_header_is_ignored_when_get_ip_result_is_private_but_remote_addr_is_public(): void {
+		update_site_option(
+			'trusted_ip_header',
+			(object) array(
+				'trusted_header' => 'HTTP_X_FORWARDED_FOR',
+				'segments'       => 2,
+				'reverse'        => false,
+			)
+		);
+
+		$_SERVER['REMOTE_ADDR']          = '198.51.100.66';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1, 8.8.8.8';
+
+		$this->assertNotSame(
+			'8.8.8.8',
+			$this->resolved_ip(),
+			'REMOTE_ADDR is public and directly connected, so no forwarded value may be trusted.'
+		);
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -71,6 +71,7 @@ class Ip_Address_Test extends BaseTestCase {
 			'HTTP_X_FORWARDED_FOR',
 			'HTTP_CLIENT_IP',
 			'HTTP_USER_AGENT',
+			'HTTP_X_REAL_IP',
 		);
 	}
 
@@ -269,6 +270,106 @@ class Ip_Address_Test extends BaseTestCase {
 		$this->assertNull(
 			$method->invoke( null ),
 			'A non-public IP must not produce an IP-derived visitor id in proxy mode.'
+		);
+	}
+
+	/**
+	 * A private REMOTE_ADDR proves the request came through a proxy on the local network,
+	 * so the address that proxy recorded is usable.
+	 */
+	public function test_internal_proxy_supplies_the_visitor_address(): void {
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.10';
+
+		$this->assertSame( '203.0.113.10', $this->resolved_ip() );
+	}
+
+	/**
+	 * The client-supplied end of the list must lose. A client sending its own
+	 * X-Forwarded-For produces "<forged>, <real>" once the proxy appends what it saw.
+	 */
+	public function test_forged_forwarded_entry_loses_to_the_proxy_written_one(): void {
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.99, 203.0.113.10';
+
+		$this->assertSame(
+			'203.0.113.10',
+			$this->resolved_ip(),
+			'Only the last X-Forwarded-For entry is written by the proxy.'
+		);
+	}
+
+	/**
+	 * With a public REMOTE_ADDR the client is talking to us directly, so any forwarded
+	 * header it sends is its own invention and must be ignored outright.
+	 */
+	public function test_forwarded_header_is_ignored_when_remote_addr_is_public(): void {
+		$_SERVER['REMOTE_ADDR']          = '203.0.113.10';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.99';
+
+		$this->assertSame( '203.0.113.10', $this->resolved_ip() );
+	}
+
+	/**
+	 * Cf-Connecting-IP and X-Real-IP are passed through verbatim by an internal proxy
+	 * unless it is configured to overwrite them, so they stay client-controlled and
+	 * unusable even on a private REMOTE_ADDR.
+	 */
+	public function test_other_forwarded_headers_are_never_trusted(): void {
+		$_SERVER['REMOTE_ADDR']           = '10.0.0.5';
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = '198.51.100.99';
+		$_SERVER['HTTP_X_REAL_IP']        = '198.51.100.98';
+
+		$this->assertSame( '', $this->resolved_ip() );
+	}
+
+	/**
+	 * Chained internal proxies leave a private address in the last entry. Scanning further
+	 * left would walk into client-supplied values, so no IP is the correct answer.
+	 */
+	public function test_chained_internal_proxies_yield_no_address(): void {
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.10, 10.0.0.6';
+
+		$this->assertSame( '', $this->resolved_ip() );
+	}
+
+	/**
+	 * A private REMOTE_ADDR with nothing forwarded stays unresolved.
+	 */
+	public function test_private_remote_addr_without_forwarded_header_yields_no_address(): void {
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.5';
+
+		$this->assertSame( '', $this->resolved_ip() );
+	}
+
+	/**
+	 * Proxies write ports and bracketed IPv6; clean_ip() normalises both.
+	 *
+	 * @dataProvider forwarded_address_format_provider
+	 *
+	 * @param string $forwarded Raw last X-Forwarded-For entry.
+	 * @param string $expected  Normalised address.
+	 */
+	public function test_forwarded_address_formats_are_normalised( string $forwarded, string $expected ): void {
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = $forwarded;
+
+		$this->assertSame( $expected, $this->resolved_ip() );
+	}
+
+	/**
+	 * Address forms a proxy can legitimately write.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function forwarded_address_format_provider(): array {
+		return array(
+			'plain IPv4'          => array( '203.0.113.10', '203.0.113.10' ),
+			'IPv4 with port'      => array( '203.0.113.10:51234', '203.0.113.10' ),
+			'spaced list'         => array( '198.51.100.99 , 203.0.113.10', '203.0.113.10' ),
+			'bracketed IPv6'      => array( '[2001:db8::1]:443', '2001:db8::1' ),
+			'IPv4-mapped IPv6'    => array( '::ffff:203.0.113.10', '203.0.113.10' ),
 		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -327,13 +327,8 @@ class Ip_Address_Test extends BaseTestCase {
 	 * Chained internal proxies leave a private address in the last entry. Scanning further
 	 * left would walk into client-supplied values, so no IP is the correct answer.
 	 *
-	 * Asserted directly against get_proxy_written_ip_address() rather than only through
-	 * resolved_ip(): the final ip_is_public() gate zeroes both "helper returned ''" and
-	 * "helper returned 10.0.0.6" the same way, so that assertion alone cannot prove the
-	 * helper read the last entry rather than, say, discarding a private one. A reflection
-	 * call on the helper pins that it returns the last entry verbatim (10.0.0.6, still
-	 * private) rather than scanning left for '203.0.113.10' — the mutation this test exists
-	 * to catch.
+	 * The helper is asserted directly because the final gate zeroes both "returned ''" and
+	 * "returned 10.0.0.6", so resolved_ip() alone cannot tell a left-scan from a correct read.
 	 */
 	public function test_chained_internal_proxies_yield_no_address(): void {
 		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
@@ -353,10 +348,8 @@ class Ip_Address_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A trailing comma in `X-Forwarded-For` leaves the last entry empty. That empty entry
-	 * must resolve to no address rather than being skipped in favor of the earlier,
-	 * client-controlled entry in front of it — the same left-of-the-proxy value a real
-	 * attacker would put there to be picked up if the code fell back to it.
+	 * A trailing comma leaves the last `X-Forwarded-For` entry empty. It must resolve to no
+	 * address rather than fall back to the client-controlled entry in front of it.
 	 */
 	public function test_trailing_comma_yields_no_address(): void {
 		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
@@ -370,13 +363,10 @@ class Ip_Address_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Regression: get_ip() must never be the value tested for "is REMOTE_ADDR private". With
-	 * trusted_ip_header configured, get_ip() selects a segment out of a client-supplied
-	 * X-Forwarded-For list, so it can be driven non-public by an attacker connecting directly
-	 * (a public REMOTE_ADDR) who simply prepends a private-looking address of their choosing.
-	 * If the proxy-recovery branch keyed off get_ip()'s result instead of REMOTE_ADDR itself,
-	 * this would then read the *last* X-Forwarded-For entry — also attacker-controlled here,
-	 * since there is no real proxy in front of this request — and report it as the visitor IP.
+	 * Regression: the fallback must key off REMOTE_ADDR, never off get_ip()'s result. With
+	 * trusted_ip_header configured, get_ip() picks a segment out of a client-supplied list, so
+	 * an attacker connecting directly can prepend a private-looking entry to drive it non-public
+	 * and have their own last entry reported back as the visitor IP.
 	 */
 	public function test_forwarded_header_is_ignored_when_get_ip_result_is_private_but_remote_addr_is_public(): void {
 		update_site_option(
@@ -399,12 +389,10 @@ class Ip_Address_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The configured header wins over the forwarded fallback. This is the nginx setup the
-	 * fallback's own docs tell sites to fix this way: nginx sets only X-Real-IP, forwards the
-	 * client's X-Forwarded-For verbatim, and REMOTE_ADDR is the loopback address nginx
-	 * connected from. Resolution already produced the real visitor, so the fallback — which
-	 * exists to supply an answer where there is none — must not run and overwrite it with the
-	 * attacker's value.
+	 * The configured header wins over the forwarded fallback — exactly the nginx setup the
+	 * fallback's own docs tell sites to fix this way, where only X-Real-IP is written and the
+	 * client's X-Forwarded-For is passed through. Resolution already has the real visitor, so
+	 * the fallback must not overwrite it with the attacker's value.
 	 */
 	public function test_configured_trusted_header_wins_over_the_forwarded_fallback(): void {
 		update_site_option(

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -483,15 +483,20 @@ class Ip_Address_Test extends BaseTestCase {
 	/**
 	 * Address forms a proxy can legitimately write.
 	 *
+	 * These resolve through the public-address gate, so every address here has to be one
+	 * PHP classifies the same way on every supported version. Notably the IPv6 documentation
+	 * range `2001:db8::/32` does not qualify — 8.1 treats it as reserved and 8.4 does not —
+	 * so it cannot appear in this provider or in `non_public_address_provider()`.
+	 *
 	 * @return array<string, array{0: string, 1: string}>
 	 */
 	public function forwarded_address_format_provider(): array {
 		return array(
-			'plain IPv4'          => array( '203.0.113.10', '203.0.113.10' ),
-			'IPv4 with port'      => array( '203.0.113.10:51234', '203.0.113.10' ),
-			'spaced list'         => array( '198.51.100.99 , 203.0.113.10', '203.0.113.10' ),
-			'bracketed IPv6'      => array( '[2001:db8::1]:443', '2001:db8::1' ),
-			'IPv4-mapped IPv6'    => array( '::ffff:203.0.113.10', '203.0.113.10' ),
+			'plain IPv4'       => array( '203.0.113.10', '203.0.113.10' ),
+			'IPv4 with port'   => array( '203.0.113.10:51234', '203.0.113.10' ),
+			'spaced list'      => array( '198.51.100.99 , 203.0.113.10', '203.0.113.10' ),
+			'bracketed IPv6'   => array( '[2606:4700:4700::1111]:443', '2606:4700:4700::1111' ),
+			'IPv4-mapped IPv6' => array( '::ffff:203.0.113.10', '203.0.113.10' ),
 		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -391,10 +391,80 @@ class Ip_Address_Test extends BaseTestCase {
 		$_SERVER['REMOTE_ADDR']          = '198.51.100.66';
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1, 8.8.8.8';
 
-		$this->assertNotSame(
-			'8.8.8.8',
+		$this->assertSame(
+			'',
 			$this->resolved_ip(),
 			'REMOTE_ADDR is public and directly connected, so no forwarded value may be trusted.'
+		);
+	}
+
+	/**
+	 * The configured header wins over the forwarded fallback. This is the nginx setup the
+	 * fallback's own docs tell sites to fix this way: nginx sets only X-Real-IP, forwards the
+	 * client's X-Forwarded-For verbatim, and REMOTE_ADDR is the loopback address nginx
+	 * connected from. Resolution already produced the real visitor, so the fallback — which
+	 * exists to supply an answer where there is none — must not run and overwrite it with the
+	 * attacker's value.
+	 */
+	public function test_configured_trusted_header_wins_over_the_forwarded_fallback(): void {
+		update_site_option(
+			'trusted_ip_header',
+			(object) array(
+				'trusted_header' => 'HTTP_X_REAL_IP',
+				'segments'       => 1,
+				'reverse'        => false,
+			)
+		);
+
+		$_SERVER['REMOTE_ADDR']          = '127.0.0.1';
+		$_SERVER['HTTP_X_REAL_IP']       = '203.0.113.77';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4';
+
+		$this->assertSame(
+			'203.0.113.77',
+			$this->resolved_ip(),
+			'A site-declared header that resolved must not be discarded for a client-supplied one.'
+		);
+	}
+
+	/**
+	 * Same rule with the segment selection: the site declared which X-Forwarded-For entry to
+	 * believe, that entry resolved to a public address, and the fallback's last-entry rule
+	 * (which here is the proxy's own address) must not silently override the configuration.
+	 */
+	public function test_trusted_header_segment_selection_wins_over_the_forwarded_fallback(): void {
+		update_site_option(
+			'trusted_ip_header',
+			(object) array(
+				'trusted_header' => 'HTTP_X_FORWARDED_FOR',
+				'segments'       => 2,
+				'reverse'        => false,
+			)
+		);
+
+		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.77, 198.51.100.9';
+
+		$this->assertSame(
+			'203.0.113.77',
+			$this->resolved_ip(),
+			'The segment the site declared trustworthy must survive a private REMOTE_ADDR.'
+		);
+	}
+
+	/**
+	 * An absent REMOTE_ADDR is not evidence of a local proxy, it is the absence of any
+	 * evidence, so the forwarded fallback must stay shut rather than treat it like a private
+	 * address.
+	 */
+	public function test_absent_remote_addr_does_not_open_the_forwarded_fallback(): void {
+		unset( $_SERVER['REMOTE_ADDR'] );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '5.6.7.8';
+
+		$this->assertSame(
+			'',
+			$this->resolved_ip(),
+			'With no REMOTE_ADDR there is no proof of a proxy, so nothing forwarded may be trusted.'
 		);
 	}
 

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Tests for visitor IP resolution.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the visitor IP that reaches `_via_ip` and the proxy-mode visitor id.
+ *
+ * Request headers are forgeable, so resolution must default to REMOTE_ADDR and only
+ * consult a proxy header the site has explicitly declared trustworthy.
+ */
+class Ip_Address_Test extends BaseTestCase {
+
+	/**
+	 * Prior state of every $_SERVER key this class touches, recording absence as well
+	 * as value so tear_down() can restore rather than blanket-unset.
+	 *
+	 * @var array<string, array{0: bool, 1: mixed}>
+	 */
+	private $server_snapshot = array();
+
+	/**
+	 * Filters added by a test, removed in tear_down() so they cannot leak between cases.
+	 *
+	 * @var array<int, array{0: string, 1: callable}>
+	 */
+	private $added_filters = array();
+
+	/**
+	 * Set up.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->snapshot_server();
+		$this->reset_tracking_static_state();
+		unset( $_COOKIE['tk_ai'] );
+		delete_site_option( 'trusted_ip_header' );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->added_filters as $entry ) {
+			remove_filter( $entry[0], $entry[1] );
+		}
+		$this->added_filters = array();
+
+		$this->restore_server();
+		$this->reset_tracking_static_state();
+		unset( $_COOKIE['tk_ai'] );
+		delete_site_option( 'trusted_ip_header' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The $_SERVER keys this class mutates.
+	 *
+	 * @return string[]
+	 */
+	private function mutated_server_keys(): array {
+		return array(
+			'REMOTE_ADDR',
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_CLIENT_IP',
+			'HTTP_USER_AGENT',
+		);
+	}
+
+	/**
+	 * Record whether each mutated key exists and what it holds.
+	 */
+	private function snapshot_server(): void {
+		$this->server_snapshot = array();
+		foreach ( $this->mutated_server_keys() as $key ) {
+			$this->server_snapshot[ $key ] = array_key_exists( $key, $_SERVER )
+				? array( true, $_SERVER[ $key ] )
+				: array( false, null );
+		}
+	}
+
+	/**
+	 * Put every mutated key back exactly as it was, removing only keys that were absent.
+	 */
+	private function restore_server(): void {
+		foreach ( $this->server_snapshot as $key => $state ) {
+			if ( $state[0] ) {
+				$_SERVER[ $key ] = $state[1];
+			} else {
+				unset( $_SERVER[ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Clear the per-request static caches so each case resolves from scratch.
+	 */
+	private function reset_tracking_static_state(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		foreach ( array( 'cached_ip', 'cached_visitor_id' ) as $name ) {
+			$property = $reflection->getProperty( $name );
+			$property->setAccessible( true );
+			$property->setValue( null, null );
+		}
+	}
+
+	/**
+	 * Add a filter and register it for automatic removal in tear_down().
+	 *
+	 * @param string   $hook     Hook name.
+	 * @param callable $callback Callback.
+	 */
+	private function add_temporary_filter( string $hook, callable $callback ): void {
+		add_filter( $hook, $callback );
+		$this->added_filters[] = array( $hook, $callback );
+	}
+
+	/**
+	 * Resolve the visitor IP through its public caller.
+	 *
+	 * @return string
+	 */
+	private function resolved_ip(): string {
+		$this->reset_tracking_static_state();
+		$details = WC_Analytics_Tracking::get_server_details();
+		return $details['_via_ip'];
+	}
+
+	/**
+	 * A public REMOTE_ADDR is reported as-is.
+	 */
+	public function test_public_remote_addr_is_used(): void {
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+
+		$this->assertSame( '203.0.113.10', $this->resolved_ip() );
+	}
+
+	/**
+	 * The core of this change: proxy headers are forgeable, so without a site-declared
+	 * trusted header none of them may displace REMOTE_ADDR.
+	 */
+	public function test_proxy_headers_are_ignored_without_a_trusted_header(): void {
+		$_SERVER['REMOTE_ADDR']           = '203.0.113.10';
+		$_SERVER['HTTP_CF_CONNECTING_IP'] = '198.51.100.99';
+		$_SERVER['HTTP_X_FORWARDED_FOR']  = '198.51.100.98';
+		$_SERVER['HTTP_CLIENT_IP']        = '198.51.100.97';
+
+		$this->assertSame(
+			'203.0.113.10',
+			$this->resolved_ip(),
+			'A forged proxy header must not displace REMOTE_ADDR.'
+		);
+	}
+
+	/**
+	 * A site that has declared a trusted header still gets the real visitor address,
+	 * including the segment selection that says which entry of the list to believe.
+	 */
+	public function test_configured_trusted_header_is_honoured(): void {
+		update_site_option(
+			'trusted_ip_header',
+			(object) array(
+				'trusted_header' => 'HTTP_X_FORWARDED_FOR',
+				'segments'       => 2,
+				'reverse'        => false,
+			)
+		);
+
+		$_SERVER['REMOTE_ADDR']          = '203.0.113.10';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.5, 203.0.113.7';
+
+		$this->assertSame( '198.51.100.5', $this->resolved_ip() );
+	}
+
+	/**
+	 * The escape hatch for proxy topologies this package cannot detect.
+	 */
+	public function test_filter_overrides_the_resolved_ip(): void {
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+
+		$this->add_temporary_filter(
+			'woocommerce_analytics_visitor_ip',
+			function () {
+				return '198.51.100.42';
+			}
+		);
+
+		$this->assertSame( '198.51.100.42', $this->resolved_ip() );
+	}
+
+	/**
+	 * Ordering guarantee: the public-address gate runs after the filter, so no callback
+	 * can reintroduce an address geoip would discard.
+	 */
+	public function test_filter_cannot_reintroduce_a_non_public_address(): void {
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+
+		$this->add_temporary_filter(
+			'woocommerce_analytics_visitor_ip',
+			function () {
+				return '10.0.0.1';
+			}
+		);
+
+		$this->assertSame(
+			'',
+			$this->resolved_ip(),
+			'ip_is_public() must gate the filtered value, not just the resolved one.'
+		);
+	}
+
+	/**
+	 * Non-public addresses resolve to an empty string.
+	 *
+	 * @dataProvider non_public_address_provider
+	 *
+	 * @param string $ip   Address to place in REMOTE_ADDR.
+	 * @param string $note Why this case matters.
+	 */
+	public function test_non_public_addresses_resolve_to_empty_string( string $ip, string $note ): void {
+		$_SERVER['REMOTE_ADDR'] = $ip;
+
+		$this->assertSame( '', $this->resolved_ip(), $note );
+	}
+
+	/**
+	 * The last three rows are why the dependency is constrained to ^0.5: PHP's
+	 * FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE accepts all three, and
+	 * jetpack-ip 0.4.x's ip_is_private() only knows five hard-coded IPv4 ranges that
+	 * do not include them. Only ip_is_public() rejects them.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function non_public_address_provider(): array {
+		return array(
+			'private class A' => array( '10.0.0.1', 'RFC 1918 class A' ),
+			'private class B' => array( '172.16.0.1', 'RFC 1918 class B, missed by the old preg_match' ),
+			'loopback'        => array( '127.0.0.1', 'Loopback, missed by the old preg_match' ),
+			'link-local'      => array( '169.254.169.254', 'Cloud metadata address' ),
+			'IPv6 ULA'        => array( 'fd00::1', 'IPv6 unique local address' ),
+			'CGNAT'           => array( '100.64.0.1', 'RFC 6598 — only ip_is_public() rejects this' ),
+			'multicast'       => array( '224.0.0.1', 'RFC 5771 — only ip_is_public() rejects this' ),
+			'benchmarking'    => array( '198.18.0.1', 'RFC 2544 — only ip_is_public() rejects this' ),
+		);
+	}
+
+	/**
+	 * In proxy mode the IP feeds the visitor id hash. With no tk_ai cookie and no public
+	 * address there is no stable id, so the event must be skipped rather than attributed
+	 * to a fabricated visitor.
+	 */
+	public function test_proxy_mode_skips_event_without_a_public_ip(): void {
+		$_SERVER['REMOTE_ADDR']     = '10.0.0.1';
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)';
+		unset( $_COOKIE['tk_ai'] );
+
+		$this->add_temporary_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		$captured = array();
+		$capture  = function ( $pre, $args, $url ) use ( &$captured ) {
+			if ( false !== strpos( $url, 'pixel.wp.com' ) ) {
+				$captured[] = $url;
+			}
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+		};
+		add_filter( 'pre_http_request', $capture, 10, 3 );
+
+		$result = WC_Analytics_Tracking::record_event( 'add_to_cart' );
+
+		remove_filter( 'pre_http_request', $capture, 10 );
+
+		$this->assertTrue( $result, 'record_event should skip when no stable visitor id exists.' );
+		$this->assertCount( 0, $captured, 'No pixel should fire without a stable visitor id.' );
+	}
+}

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -353,10 +353,10 @@ class Ip_Address_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A malformed REMOTE_ADDR (missing or unparsable) must be treated the same as a private
-	 * one: it cannot be proof of anything, so it must not itself unlock the forwarded header
-	 * in a way that later trusts unrelated attacker input differently than a clean private
-	 * REMOTE_ADDR would.
+	 * A trailing comma in `X-Forwarded-For` leaves the last entry empty. That empty entry
+	 * must resolve to no address rather than being skipped in favor of the earlier,
+	 * client-controlled entry in front of it — the same left-of-the-proxy value a real
+	 * attacker would put there to be picked up if the code fell back to it.
 	 */
 	public function test_trailing_comma_yields_no_address(): void {
 		$_SERVER['REMOTE_ADDR']          = '10.0.0.5';

--- a/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Ip_Address_Test.php
@@ -253,33 +253,22 @@ class Ip_Address_Test extends BaseTestCase {
 
 	/**
 	 * In proxy mode the IP feeds the visitor id hash. With no tk_ai cookie and no public
-	 * address there is no stable id, so the event must be skipped rather than attributed
-	 * to a fabricated visitor.
+	 * address there is no stable id to attribute an event to, so resolution must return
+	 * null rather than fabricate a visitor.
 	 */
-	public function test_proxy_mode_skips_event_without_a_public_ip(): void {
-		$_SERVER['REMOTE_ADDR']     = '10.0.0.1';
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)';
+	public function test_proxy_mode_has_no_visitor_id_without_a_public_ip(): void {
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.1';
 		unset( $_COOKIE['tk_ai'] );
 
 		$this->add_temporary_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 
-		$captured = array();
-		$capture  = function ( $pre, $args, $url ) use ( &$captured ) {
-			if ( false !== strpos( $url, 'pixel.wp.com' ) ) {
-				$captured[] = $url;
-			}
-			return array(
-				'response' => array( 'code' => 200 ),
-				'body'     => '',
-			);
-		};
-		add_filter( 'pre_http_request', $capture, 10, 3 );
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$method     = $reflection->getMethod( 'get_visitor_id' );
+		$method->setAccessible( true );
 
-		$result = WC_Analytics_Tracking::record_event( 'add_to_cart' );
-
-		remove_filter( 'pre_http_request', $capture, 10 );
-
-		$this->assertTrue( $result, 'record_event should skip when no stable visitor id exists.' );
-		$this->assertCount( 0, $captured, 'No pixel should fire without a stable visitor id.' );
+		$this->assertNull(
+			$method->invoke( null ),
+			'A non-public IP must not produce an IP-derived visitor id in proxy mode.'
+		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -341,9 +341,8 @@ class Pixel_Builder_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An unresolved IP is an empty string, which is noise in the pixel URL. Dropping the
-	 * key is an intended consequence of switching to ip_is_public(): the old preg_match
-	 * kept `_via_ip=` in the query string.
+	 * An unresolved IP is an empty string. Dropping the key rather than sending `_via_ip=`,
+	 * as the old preg_match did, is an intended consequence of switching to ip_is_public().
 	 */
 	public function test_validate_and_sanitize_removes_empty_via_ip(): void {
 		$properties = array(

--- a/packages/php/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -306,6 +306,58 @@ class Pixel_Builder_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The old check was `preg_match( '/^192\.168|^10\./', ... )`, which let every other
+	 * non-routable range through. Each address below reached pixel.wp.com before this fix.
+	 *
+	 * @dataProvider non_routable_ip_provider
+	 *
+	 * @param string $ip Address to place in `_via_ip`.
+	 */
+	public function test_validate_and_sanitize_removes_all_non_routable_ips( string $ip ): void {
+		$properties = array(
+			'_en'     => 'woocommerceanalytics_test_event',
+			'_via_ip' => $ip,
+		);
+
+		$result = Pixel_Builder::validate_and_sanitize( $properties );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( '_via_ip', $result, $ip . ' must not reach the pixel.' );
+	}
+
+	/**
+	 * Non-routable addresses the previous `preg_match` did not catch.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function non_routable_ip_provider(): array {
+		return array(
+			'private class B' => array( '172.16.0.1' ),
+			'loopback'        => array( '127.0.0.1' ),
+			'link-local'      => array( '169.254.169.254' ),
+			'IPv6 ULA'        => array( 'fd00::1' ),
+			'CGNAT'           => array( '100.64.0.1' ),
+		);
+	}
+
+	/**
+	 * An unresolved IP is an empty string, which is noise in the pixel URL. Dropping the
+	 * key is an intended consequence of switching to ip_is_public(): the old preg_match
+	 * kept `_via_ip=` in the query string.
+	 */
+	public function test_validate_and_sanitize_removes_empty_via_ip(): void {
+		$properties = array(
+			'_en'     => 'woocommerceanalytics_test_event',
+			'_via_ip' => '',
+		);
+
+		$result = Pixel_Builder::validate_and_sanitize( $properties );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( '_via_ip', $result );
+	}
+
+	/**
 	 * Test validate_and_sanitize handles indexed arrays.
 	 */
 	public function test_validate_and_sanitize_handles_indexed_arrays(): void {

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -52,6 +52,14 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	);
 
 	/**
+	 * The connecting address the web server reports. Unlike the poisoned headers this is
+	 * not client-supplied, so it is the only source `_via_ip` may legitimately come from.
+	 *
+	 * @var string
+	 */
+	private const CONNECTING_IP = '198.51.100.10';
+
+	/**
 	 * A session cookie value carrying another visitor's session.
 	 *
 	 * @var string
@@ -89,6 +97,10 @@ class Universal_Page_Output_Test extends BaseTestCase {
 			$_SERVER[ $key ] = $value;
 		}
 
+		$this->original_globals['server:REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? null;
+
+		$_SERVER['REMOTE_ADDR'] = self::CONNECTING_IP;
+
 		$_COOKIE['woocommerceanalytics_session'] = rawurlencode(
 			(string) wp_json_encode(
 				array(
@@ -110,7 +122,7 @@ class Universal_Page_Output_Test extends BaseTestCase {
 		global $wp_query;
 
 		// Superglobals cannot be passed by reference, so each is restored inline.
-		foreach ( array_keys( self::POISONED_HEADERS ) as $key ) {
+		foreach ( array_merge( array_keys( self::POISONED_HEADERS ), array( 'REMOTE_ADDR' ) ) as $key ) {
 			if ( $this->original_globals[ 'server:' . $key ] === null ) {
 				unset( $_SERVER[ $key ] );
 			} else {
@@ -315,8 +327,12 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	/**
 	 * Test that the server-fired pixel path keeps its request-derived
 	 * properties. That path runs on uncached requests and is the only place
-	 * where pixel.wp.com can learn the visitor's real IP, user agent and
-	 * referrer, so narrowing the page output must not narrow it too.
+	 * where pixel.wp.com can learn the visitor's user agent and referrer, so
+	 * narrowing the page output must not narrow it too. The IP, however, must
+	 * come from the connecting address rather than a client-forgeable header:
+	 * `_via_ip` is sourced through `Automattic\Jetpack\IP\Utils::get_ip()`,
+	 * which only trusts a proxy header when the site has explicitly declared
+	 * it via the `trusted_ip_header` site option.
 	 */
 	public function test_server_fired_properties_retain_request_details(): void {
 		$properties = WC_Analytics_Tracking::get_common_properties();
@@ -329,7 +345,12 @@ class Universal_Page_Output_Test extends BaseTestCase {
 			);
 		}
 
-		$this->assertSame( self::POISONED_HEADERS['HTTP_CF_CONNECTING_IP'], $properties['_via_ip'] );
+		$this->assertSame( self::CONNECTING_IP, $properties['_via_ip'] );
+		$this->assertNotSame(
+			self::POISONED_HEADERS['HTTP_CF_CONNECTING_IP'],
+			$properties['_via_ip'],
+			'A forged Cf-Connecting-IP must not reach the server-fired pixel.'
+		);
 		$this->assertSame( self::POISONED_HEADERS['HTTP_USER_AGENT'], $properties['_via_ua'] );
 		$this->assertSame( self::POISONED_HEADERS['HTTP_REFERER'], $properties['_via_ref'] );
 	}

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Page_Output_Test.php
@@ -328,11 +328,9 @@ class Universal_Page_Output_Test extends BaseTestCase {
 	 * Test that the server-fired pixel path keeps its request-derived
 	 * properties. That path runs on uncached requests and is the only place
 	 * where pixel.wp.com can learn the visitor's user agent and referrer, so
-	 * narrowing the page output must not narrow it too. The IP, however, must
-	 * come from the connecting address rather than a client-forgeable header:
-	 * `_via_ip` is sourced through `Automattic\Jetpack\IP\Utils::get_ip()`,
-	 * which only trusts a proxy header when the site has explicitly declared
-	 * it via the `trusted_ip_header` site option.
+	 * narrowing the page output must not narrow it too. The IP is the
+	 * exception: it comes from the connecting address, never a forgeable
+	 * header.
 	 */
 	public function test_server_fired_properties_retain_request_details(): void {
 		$properties = WC_Analytics_Tracking::get_common_properties();


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

PR #67003 stopped request-derived data from leaking into cacheable page output. This PR addresses the second issue from the same report: server-side analytics trusted visitor IP headers that a client can spoof.

`get_user_ip_address()` previously returned the first valid value from `Cf-Connecting-IP`, `X-Forwarded-For`, `REMOTE_ADDR`, or `Client-IP`. A forged value could therefore affect:

- `_via_ip`, producing incorrect geo data in Tracks and ClickHouse.
- The proxy-mode visitor ID, which includes the IP in its hash and feeds session counting (WOOA7S-929).

This PR changes resolution as follows:

1. Use `Automattic\Jetpack\IP\Utils::get_ip()`, which defaults to `REMOTE_ADDR` and only uses a proxy header declared by the site's `trusted_ip_header` option.
2. If no usable address resolves and `REMOTE_ADDR` is non-routable, use the last `X-Forwarded-For` entry. A local `REMOTE_ADDR` shows that a proxy is in front of PHP, and an appending proxy writes the last entry.
3. Add the `woocommerce_analytics_visitor_ip` filter for proxy topologies that cannot be detected automatically.
4. Apply `IP_Utils::ip_is_public()` after the filter and in `Pixel_Builder::validate_and_sanitize()`, preventing non-public addresses from reaching the pixel.

There is an intentional trade-off here. Rejecting every forwarded header unless `trusted_ip_header` is configured would be the strictest option, but stores behind an undeclared internal proxy would lose useful IP attribution. The fallback preserves that data while narrowing trust to the value most likely written by the proxy. Its remaining limitation is documented below.

This also replaces two incomplete checks: the old `filter_var()` flags were passed incorrectly and therefore never applied, while the pixel sanitizer only rejected `10/8` and `192.168/16`.

#### Expected tracking impact

- Direct connections, configured trusted headers, and internal proxies that append `X-Forwarded-For` should retain the visitor IP.
- When a `tk_ai` cookie is present, an unresolved IP only removes `_via_ip`; the event still has a stable visitor ID and continues to be recorded.
- Additional event loss is limited to proxy tracking requests that have neither a `tk_ai` cookie nor a resolvable public IP. Those requests can no longer produce the IP-based visitor ID required to record the event.
- Behind an undeclared public CDN or WAF, `_via_ip` may resolve to the edge address instead of the visitor. Geo attribution becomes less precise, and cookie-less proxy-mode visitors sharing an edge IP and User-Agent may collide.
- Removing private or reserved addresses should have little useful-data cost because GeoIP cannot meaningfully process them.

#### Backward compatibility

- The new `woocommerce_analytics_visitor_ip` filter is additive.
- `_via_ip` may change or become empty behind an undeclared proxy. For example, Cloudflare without `trusted_ip_header` reports the edge address instead of the visitor address. Sites can enable Jetpack Brute Force Protection to populate the option or use the new filter.
- `_via_ip` is omitted instead of sent as an empty query parameter when no public address resolves.
- This adds `automattic/jetpack-ip: ^0.5`, where `ip_is_public()` was introduced.
- No method signatures or visibility change.

On multisite, the trusted-header configuration remains network-scoped because Jetpack reads it with `get_site_option()`. This has not been manually tested on multisite.

#### Known limitation

The fallback assumes the proxy appends to `X-Forwarded-For`. A proxy that leaves a client-supplied header untouched can still make the last entry attacker-controlled. PHP cannot distinguish that configuration from a correctly appending proxy. We accept this residual risk to avoid dropping analytics data on common internally proxied setups; affected sites can remove the ambiguity by configuring `trusted_ip_header` or using `woocommerce_analytics_visitor_ip`. This still improves on the previous implementation, which trusted the first forwarded value unconditionally.

#### Rollout considerations

Representative managed-hosting environments are not readily available for manual testing, and host-level proxy configuration can change independently of this package. The automated suite therefore models the relevant topologies directly: public and private `REMOTE_ADDR`, configured trusted headers, appended and forged forwarded chains, chained internal proxies, absent or malformed addresses, and filter overrides.

For release, a staged rollout is preferred where possible. Compare the rate of events without `_via_ip`, server-fired event volume, and visitor/session trends with the previous version. An unexpected increase in unresolved IPs or a material drop in proxy-mode events should trigger investigation or rollback.

#### Out of scope

- Length limits for `_dr`, `_via_ref`, and `_via_ua`.
- The unauthenticated tracking proxy endpoint accepting body-supplied properties, tracked separately in WOOA7S-1803.

Closes WOOA7S-1806.

Bug introduced in PR Automattic/jetpack#45208.

### Screenshots or screen recordings

No UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

#### Setup

This package doesn't run from the monorepo directly — it ships as the composer package `automattic/woocommerce-analytics`, vendored inside plugins. So it has to be deployed onto a site before it can be tested.

**1. Prepare a store.** Local or Jurassic Ninja, with:

- WooCommerce active
- Jetpack active **and connected** to WordPress.com — the tracker self-gates on the connection
- If a consent plugin (WP Consent API) is installed, allow statistics — otherwise consent defaults to granted and nothing is needed

Front-end tracking only initialises on front-end requests: admin, AJAX, feeds and WP-CLI are all skipped by design.

**2. Find the copy the site actually loads.** The package is vendored into each consuming plugin (Jetpack, and `premium-analytics` if installed) and the Jetpack autoloader picks a winner across them. Rather than guessing the path, ask the site:

```bash
wp eval 'echo ( new ReflectionClass( "Automattic\\Woocommerce_Analytics\\WC_Analytics_Tracking" ) )->getFileName() . "\n";'
```

**3. Confirm `jetpack-ip` is new enough.** This PR needs `ip_is_public()`, added in 0.5.0. If this prints `false`, deploy `automattic/jetpack-ip` 0.5.0 or later next to the package before continuing:

```bash
wp eval 'var_export( method_exists( "Automattic\\Jetpack\\IP\\Utils", "ip_is_public" ) );'
```

**4. Deploy this branch's `src/`** over the path from step 2:

```bash
DEST=<path from step 2, up to and including .../woocommerce-analytics>
rsync -a --delete packages/php/woocommerce-analytics/src/ "$DEST/src/"
```

Notes:

- **No JS build needed.** This PR is PHP-only — unlike #67003, nothing in `src/client/` changes, so `build/` can be left alone.
- No autoloader regeneration needed: this PR adds a private method, not a class, so the vendored `jetpack_autoload_classmap.php` stays valid.
- If the site runs opcache with a long revalidation window, restart PHP-FPM after deploying.

**5. Add a probe.** Drop this in `wp-content/mu-plugins/wca-ip-probe.php`. Requesting any front-end URL with `?wca_ip_probe=1` logs what the resolver saw and what the event actually queued, which is the only practical way to observe this — see the two gotchas below.

```php
<?php
// Temporary probe for PR #67019. Delete after testing.
add_action( 'wp', function () {
	if ( ! isset( $_GET['wca_ip_probe'] ) ) {
		return;
	}

	$tracking = 'Automattic\Woocommerce_Analytics\WC_Analytics_Tracking';
	$ref      = new ReflectionClass( $tracking );
	$log      = WP_CONTENT_DIR . '/wca-ip-probe.log';

	$get_ip = $ref->getMethod( 'get_user_ip_address' );
	$get_ip->setAccessible( true );
	$vid = $ref->getMethod( 'get_ip_based_visitor_id' );
	$vid->setAccessible( true );

	$out = array(
		'---- ' . gmdate( 'H:i:s' ) . ' ----',
		'REMOTE_ADDR:      ' . ( $_SERVER['REMOTE_ADDR'] ?? '(none)' ),
		'X-Forwarded-For:  ' . ( $_SERVER['HTTP_X_FORWARDED_FOR'] ?? '(none)' ),
		'Cf-Connecting-Ip: ' . ( $_SERVER['HTTP_CF_CONNECTING_IP'] ?? '(none)' ),
		'Client-IP:        ' . ( $_SERVER['HTTP_CLIENT_IP'] ?? '(none)' ),
		'resolved IP:      ' . var_export( $get_ip->invoke( null ), true ),
		'proxy visitor id: ' . var_export( $vid->invoke( null ), true ),
		'proxy mode:       ' . var_export( apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false ), true ),
	);

	$result = $tracking::record_event( 'ip_probe_event' );
	$out[]  = 'record_event:     ' . ( is_wp_error( $result ) ? 'WP_Error: ' . $result->get_error_message() : var_export( $result, true ) );

	// Pixels are dispatched at shutdown via Requests::request_multiple(), so read the queue.
	$queue_prop = $ref->getProperty( 'pixel_batch_queue' );
	$queue_prop->setAccessible( true );
	foreach ( $queue_prop->getValue() as $pixel ) {
		preg_match( '/_via_ip=([^&]*)/', $pixel, $m );
		preg_match( '/[?&]_ui=([^&]*)/', $pixel, $u );
		$out[] = '  pixel _via_ip=' . ( $m[1] ?? '(absent)' ) . '  _ui=' . ( $u[1] ?? '(absent)' );
	}

	file_put_contents( $log, implode( "\n", $out ) . "\n", FILE_APPEND );
}, 1 );
```

> [!IMPORTANT]
> Two things make this hard to observe without the probe, and both cost time if you find them the slow way:
>
> - **`pre_http_request` does not see the pixels.** `send_pixels_batched()` goes through `WpOrg\Requests\Requests::request_multiple()`, which bypasses the WP HTTP API filters entirely. Read `WC_Analytics_Tracking::$pixel_batch_queue` instead, as the probe does.
> - **`wp eval` cannot exercise proxy mode.** `get_visitor_id()` returns `null` under `WP_CLI` and cron before it ever reaches the proxy branch, so proxy-mode events never fire from the CLI. Everything in section E has to go over real HTTP.
>
> Also note `record_event()` returns early — with `true` — for a bot User-Agent or when no visitor id resolves. Send a browser UA (`curl -A "Mozilla/5.0 …"`) and, for default mode, a `tk_ai` cookie, or you'll see "no pixels" and read it as a failure.

**6. Pick a request path that gives you the `REMOTE_ADDR` you need.** The fallback in section B only engages when `REMOTE_ADDR` is non-routable, so how you reach the site decides which branch you're testing:

- **Public `REMOTE_ADDR`** (sections A, C, D): request the site normally over its public hostname.
- **Loopback `REMOTE_ADDR`** (section B): request the web server directly and pass the site's host name yourself, e.g. `curl -H 'Host: example.com' http://127.0.0.1:8885/…`.

> [!WARNING]
> A dev tunnel (Jurassic Ninja, ngrok, jurassic.tube) is its own proxy: it gives PHP `REMOTE_ADDR: 127.0.0.1` and rewrites `X-Forwarded-For`, usually appending its own private address. Any header you send is replaced before PHP sees it, and the private last entry means the fallback correctly yields nothing — so through a tunnel every case looks like "empty `_via_ip`". Use the direct loopback request above for section B.

#### Tests

Replay `wp-content/wca-ip-probe.log` after each request. `BASE` below is `https://example.com/?wca_ip_probe=1`, and `UA` is any browser User-Agent string.

**A. Forged headers no longer decide the visitor IP** — on a request whose `REMOTE_ADDR` is public

1. ```bash
   curl -s -o /dev/null -A "$UA" -b 'tk_ai=probe-1' \
     -H 'Cf-Connecting-Ip: 1.2.3.4' \
     -H 'X-Forwarded-For: 5.6.7.8' \
     -H 'Client-IP: 9.9.9.9' "$BASE"
   ```

   Expect `resolved IP` and the queued `_via_ip` to be the real connecting address, with none of `1.2.3.4`, `5.6.7.8`, `9.9.9.9` anywhere in the log.

2. Repeat with `Cf-Connecting-Ip` only, then with `X-Forwarded-For` only. Same result each time — the forged value never wins.

**B. The local-proxy fallback still recovers a visitor IP** — request `http://127.0.0.1:<port>/` with a `Host:` header so `REMOTE_ADDR` is `127.0.0.1`

3. `-H 'X-Forwarded-For: 1.1.1.1, 203.0.113.77'` → `_via_ip=203.0.113.77`. The **last** entry is the one the proxy wrote; `1.1.1.1` sits in the client-controlled part of the header and is ignored.
4. `-H 'X-Forwarded-For: 203.0.113.77, 10.0.0.9'` → `_via_ip` absent. A private last entry means chained proxies, and scanning left would walk back into forged input.
5. `-H 'Cf-Connecting-Ip: 1.2.3.4'` with no `X-Forwarded-For` → `_via_ip` absent. The fallback reads `X-Forwarded-For` only.
6. Send no proxy headers at all → `_via_ip` absent, and the event still records (`record_event: true`).

**C. A declared trusted header takes precedence.** Set Jetpack's option, then repeat step 1:

```bash
wp eval 'update_site_option( "trusted_ip_header", (object) array( "trusted_header" => "HTTP_X_FORWARDED_FOR", "segments" => 1, "reverse" => false ) );'
```

7. `-H 'X-Forwarded-For: 198.51.100.20'` now resolves to `198.51.100.20` even though `REMOTE_ADDR` is public — the site declared it trusts that header. Clean up with `wp eval 'delete_site_option( "trusted_ip_header" );'` before continuing.

**D. The `woocommerce_analytics_visitor_ip` filter.** Add to the probe mu-plugin:

```php
add_filter( 'woocommerce_analytics_visitor_ip', fn() => '198.51.100.42' );
```

8. Confirm `_via_ip=198.51.100.42`, whatever the request headers say.
9. Return `10.0.0.1` instead → `_via_ip` absent; the public-address requirement is applied after the filter, so a filter cannot reintroduce a private or spoofed value. Same for a non-string return.
10. Remove the filter again before section E.

**E. Events still fire in both modes**

11. Default mode, with a `tk_ai` cookie and a public `REMOTE_ADDR`: `record_event: true` and two queued pixels (Tracks + ClickHouse), both carrying the real `_via_ip`.
12. Proxy mode — add `add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );` to the probe mu-plugin, drop the `tk_ai` cookie, and repeat step 3. Expect `record_event: true`, a non-null `proxy visitor id`, and pixels whose `_ui` is that id. Send a different forged `Cf-Connecting-Ip` on each of two requests and confirm `_ui` **does not change** — the id follows the connecting address, not the header.
13. Proxy mode with no resolvable IP (step 5's request): `proxy visitor id` is `NULL` and no pixels queue. The event is skipped rather than attributed to a forged identity.

**F. Optional — see what was fixed.** Deploy `trunk`'s two files over the same destination and replay steps 1 and 3:

```bash
git show origin/trunk:packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php > "$DEST/src/class-wc-analytics-tracking.php"
git show origin/trunk:packages/php/woocommerce-analytics/src/class-pixel-builder.php      > "$DEST/src/class-pixel-builder.php"
```

Before the change, step 1 reports `_via_ip=1.2.3.4` and step 3 reports `_via_ip=1.1.1.1` — both attacker-chosen. Re-deploy this branch's `src/` afterwards.

**G. Package checks**

14. ```bash
    cd packages/php/woocommerce-analytics
    composer install && ./vendor/bin/phpunit
    ```

**Clean up:** delete `wp-content/mu-plugins/wca-ip-probe.php` and `wp-content/wca-ip-probe.log`, and restore the vendored `src/` you overwrote.

<!-- End testing instructions -->

### Testing that has already taken place

**Automated:** 127 tests / 208 assertions pass in the package suite, on CI (PHP 8.1, latest WordPress) and locally on PHP 8.4. `composer phpcs` reports no findings in the changed files and `composer validate` passes. Mutation testing confirmed the security cases fail if the implementation trusts the first forwarded entry, consults it for a public or absent `REMOTE_ADDR`, or lets it overwrite a configured trusted header.

**Manual, on a local store** (WooCommerce 11.1.0-dev, Jetpack 16.1-a.3, `premium-analytics` 0.1.0-alpha supplying the vendored `woocommerce-analytics` copy the autoloader wins with, `jetpack-ip` 0.5.0, nginx, PHP 8.4, proxy tracking enabled, this branch's `src/` deployed over the vendored 0.16.6 tree):

- **Reproduced the issue before the change.** On `trunk`, a request carrying `Cf-Connecting-Ip: 1.2.3.4` produced `_via_ip=1.2.3.4` on both queued pixels and a proxy visitor id derived from it; `X-Forwarded-For: 1.1.1.1, 203.0.113.77` produced `_via_ip=1.1.1.1` — the attacker-chosen first entry. After the change the same two requests give no `_via_ip` and `_via_ip=203.0.113.77` respectively.
- **Resolution matrix, 28 cases, all as designed** — driven through the deployed code with `$_SERVER` set per case and the static cache reset between them: forged `Cf-Connecting-IP` / `X-Forwarded-For` / `Client-IP` never beat a public `REMOTE_ADDR`; an absent or unparseable `REMOTE_ADDR` fails closed; the fallback takes the last `X-Forwarded-For` entry only when `REMOTE_ADDR` is non-routable and yields nothing when that entry is private; a configured `trusted_ip_header` (both `X-Forwarded-For` with segments and `Cf-Connecting-IP`) wins over a public `REMOTE_ADDR` and is not overwritten by the fallback; the filter's return is accepted only when public, with private, non-string and empty returns all resolving to no IP.
- **Pixel sanitisation.** `validate_and_sanitize()` drops `_via_ip` for `10.0.0.1`, `192.168.1.5`, `172.16.0.1`, `127.0.0.1`, `169.254.169.254`, `100.64.0.1`, `0.0.0.0` and a malformed string, and keeps `203.0.113.5` and `8.8.8.8`. The three CGNAT/link-local/`0.0.0.0` cases are ones the previous `^192\.168|^10\.` check let through.
- **`_via_ip` is omitted, not emptied.** The built Tracks URL carries `_via_ip=203.0.113.5` when an address resolves and has no `_via_ip` parameter at all when none does — verified against the actual `build_tracks_url()` output, with the forged value absent from the whole URL.
- **Events still succeed in both modes,** over real HTTP rather than WP-CLI (`get_visitor_id()` short-circuits under `WP_CLI`, so proxy mode is not reachable from `wp eval`). Default mode with a `tk_ai` cookie: `record_event()` returns `true` and queues two pixels carrying the real address. Proxy mode: `true`, a non-null visitor id, and `_ui` unchanged across two requests sending different forged `Cf-Connecting-Ip` values. Proxy mode with no resolvable address: visitor id `NULL`, no pixels queued, event skipped rather than attributed to a forged identity. No PHP notices, warnings or fatals in `debug.log` throughout, and the storefront, shop and my-account pages all returned 200.
- **Observed the documented trade-off in the wild.** Through a dev tunnel the store sees `REMOTE_ADDR: 127.0.0.1` and `X-Forwarded-For: <real client>, <tunnel private address>` — the tunnel appends itself, so the last entry is private and `_via_ip` is dropped where `trunk` would have reported the real client address. This is the chained-proxy case described under Known limitation, and it is what a site behind an undeclared internal proxy will see until it configures `trusted_ip_header` or uses the new filter.

Not covered: multisite, and a real Cloudflare-fronted store (the Cloudflare behaviour described above is reasoned from `Cf-Connecting-IP` no longer being read, not measured).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually and included in this branch: `packages/php/woocommerce-analytics/changelog/fix-visitor-ip-header-trust` (Significance: patch, Type: security).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>

<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze this PR and post a draft comment for review.

</details>

