### PR TITLE
Proposal: add an interface to allow payment methods to queue up styles

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md
@@ -328,7 +328,7 @@ final class MyPaymentMethodType extends AbstractPaymentMethodType {
 	/**
 	 * This should return whether the payment method is active or not. 
 	 * 
-	 * If false, the scripts will not be enqueued.
+	 * If false, the scripts and styles will not be enqueued.
 	 *
 	 * @return boolean
 	 */
@@ -368,6 +368,32 @@ final class MyPaymentMethodType extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_script_handles_for_admin() {
 		return $this->get_payment_method_script_handles();
+	}
+
+	/**
+	 * Returns an array of style handles to be enqueued for this payment method on the frontend.
+	 *
+	 * Register your payment method styles with `wp_register_style` before returning their handles. The styles will be
+	 * loaded when the Cart or Checkout block is rendered.
+	 */
+	public function get_payment_method_style_handles() {
+		wp_register_style(
+			'my-payment-method',
+			'path/to/your/styles/my-payment-method.css',
+			[],
+			'1.0.0'
+		);
+		return [ 'my-payment-method' ];
+	}
+
+	/**
+	 * Returns an array of style handles to be enqueued for the admin.
+	 *
+	 * Override this method when the payment method needs different styles in the editor. By default, the handles from
+	 * `get_payment_method_style_handles` are used.
+	 */
+	public function get_payment_method_style_handles_for_admin() {
+		return $this->get_payment_method_style_handles();
 	}
 
 	/**

--- a/plugins/woocommerce/changelog/add-payment-method-style-handles
+++ b/plugins/woocommerce/changelog/add-payment-method-style-handles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add APIs for payment method integrations to register frontend and editor style handles for the Cart and Checkout blocks.

--- a/plugins/woocommerce/src/Blocks/Payments/Api.php
+++ b/plugins/woocommerce/src/Blocks/Payments/Api.php
@@ -45,6 +45,7 @@ class Api {
 	public function init() {
 		add_action( 'init', array( $this->payment_method_registry, 'initialize' ), 5 );
 		add_filter( 'woocommerce_blocks_register_script_dependencies', array( $this, 'add_payment_method_script_dependencies' ), 10, 2 );
+		add_filter( 'register_block_type_args', array( $this, 'maybe_add_payment_method_style_handles' ), 10, 2 );
 		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
 		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
 		add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_integrations' ) );
@@ -63,6 +64,42 @@ class Api {
 			return $dependencies;
 		}
 		return array_merge( $dependencies, $this->payment_method_registry->get_all_active_payment_method_script_dependencies() );
+	}
+
+	/**
+	 * Add payment method style handles to the Cart and Checkout block types. Expected to hook into the `register_block_type_args` filter.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array  $args       Block type registration arguments.
+	 * @param string $block_type Block type name.
+	 * @return array
+	 */
+	public function maybe_add_payment_method_style_handles( $args, $block_type ) {
+		if ( ! is_array( $args ) ) {
+			return $args;
+		}
+
+		if ( ! in_array( $block_type, [ 'woocommerce/cart', 'woocommerce/checkout' ], true ) ) {
+			return $args;
+		}
+
+		$payment_method_style_handles = $this->payment_method_registry->get_all_active_payment_method_style_handles();
+
+		if ( [] === $payment_method_style_handles ) {
+			return $args;
+		}
+
+		$style_handles_property = is_admin() ? 'editor_style_handles' : 'view_style_handles';
+		$current_style_handles  = $args[ $style_handles_property ] ?? [];
+
+		$args[ $style_handles_property ] = array_values(
+			array_unique(
+				array_merge( $current_style_handles, $payment_method_style_handles )
+			)
+		);
+
+		return $args;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/plugins/woocommerce/src/Blocks/Payments/Integrations/AbstractPaymentMethodType.php
@@ -1,14 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeInterface;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeStyleInterface;
 
 /**
  * AbstractPaymentMethodType class.
  *
  * @since 2.6.0
  */
-abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
+abstract class AbstractPaymentMethodType implements PaymentMethodTypeStyleInterface {
 	/**
 	 * Payment method name defined by payment methods extending this class.
 	 *
@@ -42,7 +42,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	}
 
 	/**
-	 * Returns if this payment method should be active. If false, the scripts will not be enqueued.
+	 * Returns if this payment method should be active. If false, the scripts and styles will not be enqueued.
 	 *
 	 * @return boolean
 	 */
@@ -68,6 +68,28 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 */
 	public function get_payment_method_script_handles_for_admin() {
 		return $this->get_payment_method_script_handles();
+	}
+
+	/**
+	 * Returns an array of style handles to enqueue for this payment method in the frontend context.
+	 *
+	 * @return string[]
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_payment_method_style_handles() {
+		return [];
+	}
+
+	/**
+	 * Returns an array of style handles to enqueue for this payment method in the admin context.
+	 *
+	 * @return string[]
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_payment_method_style_handles_for_admin() {
+		return $this->get_payment_method_style_handles();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Payments/PaymentMethodRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Payments/PaymentMethodRegistry.php
@@ -50,6 +50,31 @@ final class PaymentMethodRegistry extends IntegrationRegistry {
 	}
 
 	/**
+	 * Gets all style handles registered by active payment methods that support styles.
+	 *
+	 * @return string[]
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_all_active_payment_method_style_handles() {
+		$style_handles   = [];
+		$payment_methods = $this->get_all_active_registered();
+
+		foreach ( $payment_methods as $payment_method ) {
+			if ( ! $payment_method instanceof PaymentMethodTypeStyleInterface ) {
+				continue;
+			}
+
+			$style_handles = array_merge(
+				$style_handles,
+				is_admin() ? $payment_method->get_payment_method_style_handles_for_admin() : $payment_method->get_payment_method_style_handles()
+			);
+		}
+
+		return array_values( array_unique( array_filter( $style_handles ) ) );
+	}
+
+	/**
 	 * Gets an array of all registered payment method script data, but only for active payment methods.
 	 *
 	 * @return array

--- a/plugins/woocommerce/src/Blocks/Payments/PaymentMethodTypeInterface.php
+++ b/plugins/woocommerce/src/Blocks/Payments/PaymentMethodTypeInterface.php
@@ -5,7 +5,7 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 
 interface PaymentMethodTypeInterface extends IntegrationInterface {
 	/**
-	 * Returns if this payment method should be active. If false, the scripts will not be enqueued.
+	 * Returns if this payment method should be active. If false, the scripts and styles will not be enqueued.
 	 *
 	 * @return boolean
 	 */

--- a/plugins/woocommerce/src/Blocks/Payments/PaymentMethodTypeStyleInterface.php
+++ b/plugins/woocommerce/src/Blocks/Payments/PaymentMethodTypeStyleInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\Payments;
+
+/**
+ * Defines style handles for payment method integrations.
+ *
+ * @since 11.1.0
+ */
+interface PaymentMethodTypeStyleInterface extends PaymentMethodTypeInterface {
+	/**
+	 * Returns an array of style handles to enqueue for this payment method in the frontend context.
+	 *
+	 * @return string[]
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_payment_method_style_handles();
+
+	/**
+	 * Returns an array of style handles to enqueue for this payment method in the admin context.
+	 *
+	 * @return string[]
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_payment_method_style_handles_for_admin();
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Payments/ApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Payments/ApiTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests for the payments API.
+ *
+ * @package WooCommerce\Tests\Blocks\Payments
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Payments;
+
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Payments\Api;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the payments API.
+ */
+class ApiTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		set_current_screen( 'front' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should append frontend styles to Cart and Checkout view style handles.
+	 *
+	 * @dataProvider cart_and_checkout_block_types
+	 *
+	 * @param string $block_type Block type name.
+	 */
+	public function test_appends_frontend_styles_to_cart_and_checkout_view_style_handles( $block_type ): void {
+		$payment_method_registry = new PaymentMethodRegistry();
+		$payment_method_registry->register(
+			$this->create_style_payment_method(
+				array( 'shared-style', 'payment-method-style' ),
+				array( 'payment-method-editor-style' )
+			)
+		);
+		$sut  = $this->get_blocks_payments_api( $payment_method_registry );
+		$args = array(
+			'style_handles'      => array( 'wc-blocks-style' ),
+			'view_style_handles' => array( 'shared-style' ),
+		);
+
+		$result = $sut->maybe_add_payment_method_style_handles( $args, $block_type );
+
+		$this->assertSame(
+			array( 'shared-style', 'payment-method-style' ),
+			$result['view_style_handles'],
+			'Payment method view styles should be appended without duplicates.'
+		);
+		$this->assertSame(
+			array( 'wc-blocks-style' ),
+			$result['style_handles'],
+			'Existing block styles should remain unchanged.'
+		);
+		$this->assertArrayNotHasKey( 'editor_style_handles', $result );
+	}
+
+	/**
+	 * @testdox Should append admin styles to editor style handles.
+	 */
+	public function test_appends_admin_styles_to_editor_style_handles(): void {
+		set_current_screen( 'edit-post' );
+
+		$payment_method_registry = new PaymentMethodRegistry();
+		$payment_method_registry->register(
+			$this->create_style_payment_method(
+				array( 'payment-method-style' ),
+				array( 'shared-editor-style', 'payment-method-editor-style' )
+			)
+		);
+		$api  = $this->get_blocks_payments_api( $payment_method_registry );
+		$args = array(
+			'style_handles'        => array( 'wc-blocks-style' ),
+			'editor_style_handles' => array( 'shared-editor-style' ),
+		);
+
+		$result = $api->maybe_add_payment_method_style_handles( $args, 'woocommerce/checkout' );
+
+		$this->assertSame(
+			array( 'shared-editor-style', 'payment-method-editor-style' ),
+			$result['editor_style_handles'],
+			'Payment method editor styles should be appended without duplicates.'
+		);
+		$this->assertSame(
+			array( 'wc-blocks-style' ),
+			$result['style_handles'],
+			'Existing block styles should remain unchanged.'
+		);
+		$this->assertArrayNotHasKey( 'view_style_handles', $result );
+	}
+
+	/**
+	 * @testdox Should leave unrelated block type arguments unchanged.
+	 */
+	public function test_leaves_unrelated_block_type_arguments_unchanged(): void {
+		$payment_method_registry = new PaymentMethodRegistry();
+		$payment_method_registry->register(
+			$this->create_style_payment_method(
+				array( 'payment-method-style' ),
+				array( 'payment-method-editor-style' )
+			)
+		);
+		$api  = $this->get_blocks_payments_api( $payment_method_registry );
+		$args = array(
+			'style_handles' => array( 'product-style' ),
+		);
+
+		$result = $api->maybe_add_payment_method_style_handles( $args, 'woocommerce/product-image' );
+
+		$this->assertSame( $args, $result, 'Unrelated block types should not receive payment method styles.' );
+	}
+
+	/**
+	 * Provide Cart and Checkout block type names.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public static function cart_and_checkout_block_types() {
+		return array(
+			'Cart'     => array( 'woocommerce/cart' ),
+			'Checkout' => array( 'woocommerce/checkout' ),
+		);
+	}
+
+	/**
+	 * Get the Blocks Payments API (the system under test).
+	 *
+	 * @param PaymentMethodRegistry $payment_method_registry Payment method registry.
+	 * @return Api
+	 */
+	private function get_blocks_payments_api( $payment_method_registry ): Api {
+		return new Api(
+			$payment_method_registry,
+			$this->createMock( AssetDataRegistry::class )
+		);
+	}
+
+	/**
+	 * Create a style-capable payment method.
+	 *
+	 * @param string[] $frontend_style_handles Frontend style handles.
+	 * @param string[] $admin_style_handles    Admin style handles.
+	 * @return AbstractPaymentMethodType
+	 */
+	private function create_style_payment_method( $frontend_style_handles, $admin_style_handles ) {
+		return new class( $frontend_style_handles, $admin_style_handles ) extends AbstractPaymentMethodType {
+			/**
+			 * Payment method name.
+			 *
+			 * @var string
+			 */
+			protected $name = 'test-payment-method';
+
+			/**
+			 * Frontend style handles.
+			 *
+			 * @var string[]
+			 */
+			private $frontend_style_handles;
+
+			/**
+			 * Admin style handles.
+			 *
+			 * @var string[]
+			 */
+			private $admin_style_handles;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string[] $frontend_style_handles Frontend style handles.
+			 * @param string[] $admin_style_handles    Admin style handles.
+			 */
+			public function __construct( $frontend_style_handles, $admin_style_handles ) {
+				$this->frontend_style_handles = $frontend_style_handles;
+				$this->admin_style_handles    = $admin_style_handles;
+			}
+
+			/**
+			 * Initialize the payment method.
+			 */
+			public function initialize() {
+			}
+
+			/**
+			 * Get frontend style handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_style_handles() {
+				return $this->frontend_style_handles;
+			}
+
+			/**
+			 * Get admin style handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_style_handles_for_admin() {
+				return $this->admin_style_handles;
+			}
+		};
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Payments/PaymentMethodRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Payments/PaymentMethodRegistryTest.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Tests for the payment method registry.
+ *
+ * @package WooCommerce\Tests\Blocks\Payments
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Payments;
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeInterface;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeStyleInterface;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the PaymentMethodRegistry class.
+ */
+class PaymentMethodRegistryTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		set_current_screen( 'front' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should provide empty default style handles to existing subclasses.
+	 */
+	public function test_abstract_payment_method_type_provides_empty_style_handle_defaults(): void {
+		$payment_method = new class() extends AbstractPaymentMethodType {
+			/**
+			 * Initialize the payment method.
+			 */
+			public function initialize() {
+			}
+		};
+
+		$this->assertInstanceOf( PaymentMethodTypeStyleInterface::class, $payment_method );
+		$this->assertSame( array(), $payment_method->get_payment_method_style_handles() );
+		$this->assertSame( array(), $payment_method->get_payment_method_style_handles_for_admin() );
+	}
+
+	/**
+	 * @testdox Should use frontend style handles as the default for the admin context.
+	 */
+	public function test_abstract_payment_method_type_uses_frontend_styles_for_admin_by_default(): void {
+		$payment_method = new class() extends AbstractPaymentMethodType {
+			/**
+			 * Initialize the payment method.
+			 */
+			public function initialize() {
+			}
+
+			/**
+			 * Get frontend style handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_style_handles() {
+				return array( 'payment-method-style' );
+			}
+		};
+
+		$this->assertSame( array( 'payment-method-style' ), $payment_method->get_payment_method_style_handles_for_admin() );
+	}
+
+	/**
+	 * @testdox Should collect unique frontend styles from active style-capable payment methods.
+	 */
+	public function test_collects_unique_frontend_styles_from_active_style_capable_payment_methods(): void {
+		$registry = $this->get_payment_method_registry();
+		$registry->register(
+			$this->create_style_payment_method(
+				'first',
+				array( 'first-style', '', 'shared-style' ),
+				array( 'first-admin-style' )
+			)
+		);
+		$registry->register(
+			$this->create_style_payment_method(
+				'second',
+				array( 'shared-style', 'second-style' ),
+				array( 'second-admin-style' )
+			)
+		);
+		$registry->register( $this->create_legacy_payment_method( 'legacy' ) );
+
+		$this->assertSame(
+			array( 'first-style', 'shared-style', 'second-style' ),
+			$registry->get_all_active_payment_method_style_handles(),
+			'Only unique, non-empty frontend style handles should be returned.'
+		);
+	}
+
+	/**
+	 * @testdox Should collect admin styles in the admin context.
+	 */
+	public function test_collects_admin_styles_in_admin_context(): void {
+		set_current_screen( 'edit-post' );
+		$registry = $this->get_payment_method_registry();
+		$registry->register(
+			$this->create_style_payment_method(
+				'payment-method',
+				array( 'frontend-style' ),
+				array( 'admin-style' )
+			)
+		);
+
+		$this->assertSame(
+			array( 'admin-style' ),
+			$registry->get_all_active_payment_method_style_handles(),
+			'Admin requests should use the payment method admin style handles.'
+		);
+	}
+
+	/**
+	 * @testdox Should ignore styles from inactive payment methods.
+	 */
+	public function test_ignores_styles_from_inactive_payment_methods(): void {
+		$registry = $this->get_payment_method_registry();
+		$registry->register(
+			$this->create_style_payment_method(
+				'inactive',
+				array( 'inactive-style' ),
+				array( 'inactive-admin-style' ),
+				false
+			)
+		);
+
+		$this->assertSame( array(), $registry->get_all_active_payment_method_style_handles() );
+	}
+
+	/**
+	 * Get the Payment Method Registry (the system under test).
+	 *
+	 * @return PaymentMethodRegistry
+	 */
+	private function get_payment_method_registry(): PaymentMethodRegistry {
+		return new PaymentMethodRegistry();
+	}
+
+	/**
+	 * Create a style-capable payment method.
+	 *
+	 * @param string   $name                  Payment method name.
+	 * @param string[] $frontend_style_handles Frontend style handles.
+	 * @param string[] $admin_style_handles    Admin style handles.
+	 * @param bool     $active                 Whether the payment method is active.
+	 * @return AbstractPaymentMethodType
+	 */
+	private function create_style_payment_method( $name, $frontend_style_handles, $admin_style_handles, $active = true ) {
+		return new class( $name, $frontend_style_handles, $admin_style_handles, $active ) extends AbstractPaymentMethodType {
+			/**
+			 * Frontend style handles.
+			 *
+			 * @var string[]
+			 */
+			private $frontend_style_handles;
+
+			/**
+			 * Admin style handles.
+			 *
+			 * @var string[]
+			 */
+			private $admin_style_handles;
+
+			/**
+			 * Whether the payment method is active.
+			 *
+			 * @var bool
+			 */
+			private $active;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string   $name                   Payment method name.
+			 * @param string[] $frontend_style_handles Frontend style handles.
+			 * @param string[] $admin_style_handles    Admin style handles.
+			 * @param bool     $active                 Whether the payment method is active.
+			 */
+			public function __construct( $name, $frontend_style_handles, $admin_style_handles, $active ) {
+				$this->name                   = $name;
+				$this->frontend_style_handles = $frontend_style_handles;
+				$this->admin_style_handles    = $admin_style_handles;
+				$this->active                 = $active;
+			}
+
+			/**
+			 * Initialize the payment method.
+			 */
+			public function initialize() {
+			}
+
+			/**
+			 * Return whether the payment method is active.
+			 *
+			 * @return bool
+			 */
+			public function is_active() {
+				return $this->active;
+			}
+
+			/**
+			 * Get frontend style handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_style_handles() {
+				return $this->frontend_style_handles;
+			}
+
+			/**
+			 * Get admin style handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_style_handles_for_admin() {
+				return $this->admin_style_handles;
+			}
+		};
+	}
+
+	/**
+	 * Create a payment method that implements only the existing interface.
+	 *
+	 * @param string $name Payment method name.
+	 * @return PaymentMethodTypeInterface
+	 */
+	private function create_legacy_payment_method( $name ) {
+		return new class( $name ) implements PaymentMethodTypeInterface {
+			/**
+			 * Payment method name.
+			 *
+			 * @var string
+			 */
+			private $name;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $name Payment method name.
+			 */
+			public function __construct( $name ) {
+				$this->name = $name;
+			}
+
+			/**
+			 * Get the payment method name.
+			 *
+			 * @return string
+			 */
+			public function get_name() {
+				return $this->name;
+			}
+
+			/**
+			 * Initialize the payment method.
+			 */
+			public function initialize() {
+			}
+
+			/**
+			 * Return whether the payment method is active.
+			 *
+			 * @return bool
+			 */
+			public function is_active() {
+				return true;
+			}
+
+			/**
+			 * Get frontend payment method script handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_script_handles() {
+				return array();
+			}
+
+			/**
+			 * Get admin payment method script handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_payment_method_script_handles_for_admin() {
+				return array();
+			}
+
+			/**
+			 * Get payment method data.
+			 *
+			 * @return array
+			 */
+			public function get_payment_method_data() {
+				return array();
+			}
+
+			/**
+			 * Get supported features.
+			 *
+			 * @return string[]
+			 */
+			public function get_supported_features() {
+				return array();
+			}
+
+			/**
+			 * Get frontend script handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_script_handles() {
+				return array();
+			}
+
+			/**
+			 * Get editor script handles.
+			 *
+			 * @return string[]
+			 */
+			public function get_editor_script_handles() {
+				return array();
+			}
+
+			/**
+			 * Get script data.
+			 *
+			 * @return array
+			 */
+			public function get_script_data() {
+				return array();
+			}
+		};
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR proposes a way for payment gateways to register styles as part of their block registration, and to then enqueue those styles only in contexts where the payment gateway would appear.

The key issue here was surfaced in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5742, where the Stripe payment gateway is _always_ enqueuing a small style file because it is calling `wp_enqueue_style()` from the `get_payment_method_script_handles()` callback, even in cases where the related blocks won't appear. This PR introduces a way to register block styles for a payment method, and then ensure that the registered styles are correctly enqueued.

Closes # .

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5742.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
