### PR TITLE
[Email Editor] Reduce typing latency in the editor canvas

### DIFF
--- a/packages/js/email-editor/changelog/performance-editor-canvas-typing-latency
+++ b/packages/js/email-editor/changelog/performance-editor-canvas-typing-latency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Stop regenerating the global styles stylesheet and re-filtering personalization tags on every render, which made typing in the editor canvas sluggish.

--- a/packages/js/email-editor/src/hooks/test/use-user-theme.spec.ts
+++ b/packages/js/email-editor/src/hooks/test/use-user-theme.spec.ts
@@ -77,9 +77,12 @@ describe( 'useUserTheme', () => {
 		expect( result.current.userTheme ).toBe( first );
 	} );
 
-	// The counterpart: editing styles must still produce a new object, or the
-	// canvas would never restyle.
-	it( 'returns a new userTheme when the styles change', () => {
+	// The counterpart: an edit must still produce a new object, or the canvas
+	// would never restyle. Both values are checked because
+	// `useGlobalStylesOutputWithConfig` bails out to an empty stylesheet unless
+	// it has styles *and* settings, so a stale `settings` drops the generated
+	// CSS entirely rather than just leaving it out of date.
+	it( 'returns a new userTheme when the styles or the settings change', () => {
 		const settings = { color: { palette: [] } };
 		mockGlobalStylePost( {
 			id: 1,
@@ -96,6 +99,18 @@ describe( 'useUserTheme', () => {
 
 		expect( result.current.userTheme ).not.toBe( first );
 		expect( result.current.userTheme.styles ).toBe( updatedStyles );
+
+		const afterStyles = result.current.userTheme;
+		const updatedSettings = { color: { palette: [ { slug: 'accent' } ] } };
+		mockGlobalStylePost( {
+			id: 1,
+			styles: updatedStyles,
+			settings: updatedSettings,
+		} );
+		rerender();
+
+		expect( result.current.userTheme ).not.toBe( afterStyles );
+		expect( result.current.userTheme.settings ).toBe( updatedSettings );
 	} );
 
 	// The post is absent until it resolves, which is when the editor first

--- a/packages/js/email-editor/src/hooks/test/use-user-theme.spec.ts
+++ b/packages/js/email-editor/src/hooks/test/use-user-theme.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useUserTheme } from '../use-user-theme';
+import { storeName } from '../../store/constants';
+
+jest.mock( '@wordpress/data', () => {
+	const actual =
+		jest.requireActual< typeof import('@wordpress/data') >(
+			'@wordpress/data'
+		);
+
+	return Object.create( actual, {
+		useSelect: { value: jest.fn() },
+		dispatch: {
+			value: jest.fn( () => ( { editEntityRecord: jest.fn() } ) ),
+		},
+	} );
+} );
+
+jest.mock( '@wordpress/core-data', () => ( { store: { name: 'core' } } ) );
+
+// The store barrel pulls in `@wordpress/components` through the events module,
+// which Jest cannot transform. Re-export the real constant so the store name
+// stays linked to `src/store/constants.ts`.
+jest.mock( '../../store', () => ( {
+	storeName: jest.requireActual< typeof import('../../store/constants') >(
+		'../../store/constants'
+	).storeName,
+} ) );
+
+const mockedUseSelect = useSelect as unknown as jest.Mock;
+
+/**
+ * Runs the hook's own `mapSelect` against a stub store, so the store it selects
+ * and its `|| null` normalisation are exercised rather than stubbed over.
+ *
+ * @param post Global styles post the stubbed selector should return.
+ */
+function mockGlobalStylePost( post: unknown ) {
+	mockedUseSelect.mockImplementation(
+		( mapSelect: ( s: unknown ) => unknown ) =>
+			mapSelect( ( store: unknown ) => {
+				if ( store !== storeName ) {
+					throw new Error( `Unexpected store: ${ String( store ) }` );
+				}
+				return { getGlobalEmailStylesPost: () => post };
+			} )
+	);
+}
+
+describe( 'useUserTheme', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// Consumers use `userTheme` as a memo dependency for regenerating the global
+	// stylesheet, so a fresh object per render makes those memos always miss.
+	it( 'keeps the same userTheme across re-renders when nothing changed', () => {
+		mockGlobalStylePost( {
+			id: 1,
+			styles: { color: { background: '#fff' } },
+			settings: { color: { palette: [] } },
+		} );
+
+		const { result, rerender } = renderHook( () => useUserTheme() );
+		const first = result.current.userTheme;
+
+		rerender();
+
+		expect( result.current.userTheme ).toBe( first );
+	} );
+
+	// The counterpart: editing styles must still produce a new object, or the
+	// canvas would never restyle.
+	it( 'returns a new userTheme when the styles change', () => {
+		const settings = { color: { palette: [] } };
+		mockGlobalStylePost( {
+			id: 1,
+			styles: { color: { background: '#fff' } },
+			settings,
+		} );
+
+		const { result, rerender } = renderHook( () => useUserTheme() );
+		const first = result.current.userTheme;
+
+		const updatedStyles = { color: { background: '#000' } };
+		mockGlobalStylePost( { id: 1, styles: updatedStyles, settings } );
+		rerender();
+
+		expect( result.current.userTheme ).not.toBe( first );
+		expect( result.current.userTheme.styles ).toBe( updatedStyles );
+	} );
+
+	// The post is absent until it resolves, which is when the editor first
+	// mounts and the stylesheet is generated.
+	it( 'keeps the same userTheme when there is no global styles post', () => {
+		mockGlobalStylePost( null );
+
+		const { result, rerender } = renderHook( () => useUserTheme() );
+		const first = result.current.userTheme;
+
+		rerender();
+
+		expect( result.current.userTheme ).toBe( first );
+	} );
+} );

--- a/packages/js/email-editor/src/hooks/use-user-theme.ts
+++ b/packages/js/email-editor/src/hooks/use-user-theme.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -17,6 +17,18 @@ export function useUserTheme() {
 			globalStylePost: post,
 		};
 	}, [] );
+
+	// Consumers use this as a dependency for expensive work such as regenerating
+	// the global styles stylesheet, so the identity must only change when the
+	// styles or settings actually change. Editing styles goes through
+	// `editEntityRecord`, which replaces both values, so the memo still updates.
+	const userTheme = useMemo(
+		() => ( {
+			settings: globalStylePost?.settings,
+			styles: globalStylePost?.styles,
+		} ),
+		[ globalStylePost?.settings, globalStylePost?.styles ]
+	);
 
 	const updateGlobalStylesPost = useCallback(
 		( newTheme: EmailTheme ) => {
@@ -37,10 +49,7 @@ export function useUserTheme() {
 	);
 
 	return {
-		userTheme: {
-			settings: globalStylePost?.settings,
-			styles: globalStylePost?.styles,
-		},
+		userTheme,
 		updateUserTheme: updateGlobalStylesPost,
 	};
 }

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -9,6 +9,7 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import { storeName, PERSONALIZATION_TAG_ENTITY } from './constants';
+import { getPersonalizationTagsQuery } from './personalization-tags-query';
 import {
 	SendingPreviewStatus,
 	State,
@@ -55,23 +56,17 @@ export const setEmailPost =
 export const invalidatePersonalizationTagsCache =
 	() =>
 	async ( { registry } ) => {
-		// Get the current post ID to build the exact query params
+		// `invalidateResolution` matches resolver arguments structurally, so this
+		// has to be the same query the selector fetched with — hence the shared
+		// builder rather than a second literal.
 		const postId = registry.select( storeName ).getEmailPostId();
-		const queryParams: Record< string, unknown > = {
-			context: 'view',
-			per_page: -1,
-		};
-		if ( postId ) {
-			queryParams.post_id = postId;
-		}
 
-		// Invalidate the resolution for this specific query
 		registry
 			.dispatch( coreDataStore )
 			.invalidateResolution( 'getEntityRecords', [
 				PERSONALIZATION_TAG_ENTITY.kind,
 				PERSONALIZATION_TAG_ENTITY.name,
-				queryParams,
+				getPersonalizationTagsQuery( postId ),
 			] );
 	};
 

--- a/packages/js/email-editor/src/store/personalization-tags-query.ts
+++ b/packages/js/email-editor/src/store/personalization-tags-query.ts
@@ -1,0 +1,47 @@
+export type PersonalizationTagsQuery = {
+	context: string;
+	per_page: number;
+	post_id?: number | string;
+};
+
+// Keyed by post id, so alternating between posts does not thrash a single slot.
+// Bounded by the number of posts opened in one page load.
+const queryCache = new Map<
+	number | string | undefined,
+	PersonalizationTagsQuery
+>();
+
+/**
+ * Builds the entity query used to fetch personalization tags, returning the
+ * same object for a given post id.
+ *
+ * Two call sites depend on this being one definition. `getPersonalizationTagsList`
+ * runs once per block on every store change and passes the query to
+ * `getEntityRecords`, which forwards it to core-data's `getQueriedItems`; rememo
+ * memoizes that by argument reference, so a fresh object literal misses on every
+ * call and prepends a node to a list only discarded when the entity state
+ * changes. `invalidatePersonalizationTagsCache` passes the same query to
+ * `invalidateResolution`, which matches resolver arguments structurally — if the
+ * two shapes ever drifted, invalidation would silently stop matching rather than
+ * fail loudly.
+ *
+ * @param postId Id of the post being edited, when there is one.
+ * @return Query to pass to `getEntityRecords`.
+ */
+export function getPersonalizationTagsQuery(
+	postId: number | string | undefined
+): PersonalizationTagsQuery {
+	let query = queryCache.get( postId );
+
+	if ( ! query ) {
+		query = {
+			context: 'view',
+			per_page: -1,
+			// Include post_id for context-aware tag filtering (e.g., automation emails)
+			...( postId ? { post_id: postId } : {} ),
+		};
+		queryCache.set( postId, query );
+	}
+
+	return query;
+}

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -418,53 +418,109 @@ export function getPreviewState( state: State ): State[ 'preview' ] {
 	return state.preview;
 }
 
+const EMPTY_PERSONALIZATION_TAGS: PersonalizationTag[] = [];
+
+type PersonalizationTagsQuery = {
+	context: string;
+	per_page: number;
+	post_id?: number | string;
+};
+
 export const getPersonalizationTagsList = createRegistrySelector(
-	( select ) => () => {
-		const postId = select( storeName ).getEmailPostId();
-		const queryParams: Record< string, unknown > = {
-			context: 'view',
-			per_page: -1,
-		};
+	( select ) => {
+		// The block edit filter calls this selector once per block on every store
+		// change, so both the query and the filtered list are cached.
+		//
+		// `createRegistrySelector` resolves this factory once per registry, so the
+		// caches below are scoped to a registry rather than shared globally.
+		//
+		// The query object is reused because `getEntityRecords` forwards it to
+		// core-data's `getQueriedItems`, which is memoized by rememo and compares
+		// arguments by reference: a fresh object literal misses on every call and
+		// prepends a node to a list keyed on the entity's queried-data state, so
+		// the list grows until that state changes and every later call walks all
+		// of it. `getQueriedItems` also keeps a value-keyed cache (an
+		// `EquivalentKeyMap` per state), so the records array stays referentially
+		// stable across those misses — which is what lets `listCache` key on
+		// `tags` identity.
+		let queryCache: {
+			postId: number | string | undefined;
+			query: PersonalizationTagsQuery;
+		} | null = null;
 
-		// Include post_id for context-aware tag filtering (e.g., automation emails)
-		if ( postId ) {
-			queryParams.post_id = postId;
-		}
+		let listCache: {
+			tags: PersonalizationTag[];
+			postType: string;
+			templatePostTypes: string[] | undefined;
+			result: PersonalizationTag[];
+		} | null = null;
 
-		const tags = ( select( coreDataStore ).getEntityRecords(
-			PERSONALIZATION_TAG_ENTITY.kind,
-			PERSONALIZATION_TAG_ENTITY.name,
-			queryParams
-		) || [] ) as PersonalizationTag[];
+		return () => {
+			const postId = select( storeName ).getEmailPostId();
 
-		const postType = select( storeName ).getEmailPostType();
+			if ( ! queryCache || queryCache.postId !== postId ) {
+				queryCache = {
+					postId,
+					query: {
+						context: 'view',
+						per_page: -1,
+						// Include post_id for context-aware tag filtering (e.g., automation emails)
+						...( postId ? { post_id: postId } : {} ),
+					},
+				};
+			}
 
-		if ( ! postType ) {
-			return tags;
-		}
+			const tags = ( select( coreDataStore ).getEntityRecords(
+				PERSONALIZATION_TAG_ENTITY.kind,
+				PERSONALIZATION_TAG_ENTITY.name,
+				queryCache.query
+			) || EMPTY_PERSONALIZATION_TAGS ) as PersonalizationTag[];
 
-		// When postType is template, we filter tags by registered template postTypes.
-		if ( postType === 'wp_template' ) {
-			const postTemplate = select( storeName ).getCurrentTemplate();
-			return tags.filter( ( tag ) => {
-				return (
+			const postType = select( storeName ).getEmailPostType();
+
+			if ( ! postType ) {
+				return tags;
+			}
+
+			// When postType is template, we filter tags by registered template postTypes.
+			const templatePostTypes =
+				postType === 'wp_template'
+					? select( storeName ).getCurrentTemplate()?.post_types
+					: undefined;
+
+			if (
+				listCache &&
+				listCache.tags === tags &&
+				listCache.postType === postType &&
+				listCache.templatePostTypes === templatePostTypes
+			) {
+				return listCache.result;
+			}
+
+			const result = tags.filter( ( tag ) => {
+				if (
 					tag.postTypes === undefined ||
-					tag.postTypes.length === 0 ||
-					( Array.isArray( postTemplate.post_types ) &&
-						postTemplate.post_types.some( ( pt ) =>
-							tag.postTypes.includes( pt )
-						) )
-				);
-			} );
-		}
+					tag.postTypes.length === 0
+				) {
+					return true;
+				}
 
-		return tags.filter( ( tag ) => {
-			return (
-				tag.postTypes === undefined ||
-				tag.postTypes.length === 0 ||
-				tag.postTypes.includes( postType )
-			);
-		} );
+				if ( postType === 'wp_template' ) {
+					return (
+						Array.isArray( templatePostTypes ) &&
+						templatePostTypes.some( ( pt ) =>
+							tag.postTypes.includes( pt )
+						)
+					);
+				}
+
+				return tag.postTypes.includes( postType );
+			} );
+
+			listCache = { tags, postType, templatePostTypes, result };
+
+			return result;
+		};
 	}
 );
 

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -11,6 +11,7 @@ import { serialize, parse, BlockInstance } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { storeName, PERSONALIZATION_TAG_ENTITY } from './constants';
+import { getPersonalizationTagsQuery } from './personalization-tags-query';
 import {
 	State,
 	EmailTemplate,
@@ -420,34 +421,18 @@ export function getPreviewState( state: State ): State[ 'preview' ] {
 
 const EMPTY_PERSONALIZATION_TAGS: PersonalizationTag[] = [];
 
-type PersonalizationTagsQuery = {
-	context: string;
-	per_page: number;
-	post_id?: number | string;
-};
-
 export const getPersonalizationTagsList = createRegistrySelector(
 	( select ) => {
 		// The block edit filter calls this selector once per block on every store
-		// change, so both the query and the filtered list are cached.
+		// change, so the filtered list is cached alongside the shared query object
+		// from `getPersonalizationTagsQuery`.
 		//
 		// `createRegistrySelector` resolves this factory once per registry, so the
-		// caches below are scoped to a registry rather than shared globally.
+		// cache below is scoped to a registry rather than shared globally.
 		//
-		// The query object is reused because `getEntityRecords` forwards it to
-		// core-data's `getQueriedItems`, which is memoized by rememo and compares
-		// arguments by reference: a fresh object literal misses on every call and
-		// prepends a node to a list keyed on the entity's queried-data state, so
-		// the list grows until that state changes and every later call walks all
-		// of it. `getQueriedItems` also keeps a value-keyed cache (an
-		// `EquivalentKeyMap` per state), so the records array stays referentially
-		// stable across those misses — which is what lets `listCache` key on
-		// `tags` identity.
-		let queryCache: {
-			postId: number | string | undefined;
-			query: PersonalizationTagsQuery;
-		} | null = null;
-
+		// Keying on `tags` identity is sound because `getQueriedItems` keeps a
+		// value-keyed cache (an `EquivalentKeyMap` per state), so it hands back the
+		// same records array until the entity state itself changes.
 		let listCache: {
 			tags: PersonalizationTag[];
 			postType: string;
@@ -458,22 +443,10 @@ export const getPersonalizationTagsList = createRegistrySelector(
 		return () => {
 			const postId = select( storeName ).getEmailPostId();
 
-			if ( ! queryCache || queryCache.postId !== postId ) {
-				queryCache = {
-					postId,
-					query: {
-						context: 'view',
-						per_page: -1,
-						// Include post_id for context-aware tag filtering (e.g., automation emails)
-						...( postId ? { post_id: postId } : {} ),
-					},
-				};
-			}
-
 			const tags = ( select( coreDataStore ).getEntityRecords(
 				PERSONALIZATION_TAG_ENTITY.kind,
 				PERSONALIZATION_TAG_ENTITY.name,
-				queryCache.query
+				getPersonalizationTagsQuery( postId )
 			) || EMPTY_PERSONALIZATION_TAGS ) as PersonalizationTag[];
 
 			const postType = select( storeName ).getEmailPostType();

--- a/packages/js/email-editor/src/store/test/get-personalization-tags-list.spec.ts
+++ b/packages/js/email-editor/src/store/test/get-personalization-tags-list.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { getPersonalizationTagsList } from '../selectors';
+import { storeName } from '../constants';
+import { PersonalizationTag } from '../types';
+
+// Importing the selectors module pulls in the whole block editor, which Jest
+// cannot transform. Only the store descriptors are needed to route `select`.
+jest.mock( '@wordpress/core-data', () => ( { store: { name: 'core' } } ) );
+jest.mock( '@wordpress/editor', () => ( { store: { name: 'core/editor' } } ) );
+jest.mock( '@wordpress/preferences', () => ( {
+	store: { name: 'core/preferences' },
+} ) );
+jest.mock( '@wordpress/blocks', () => ( {
+	serialize: jest.fn(),
+	parse: jest.fn(),
+} ) );
+
+const makeTag = ( name: string, postTypes: string[] ): PersonalizationTag => ( {
+	name,
+	token: `[woocommerce/${ name }]`,
+	category: 'Test',
+	attributes: [],
+	valueToInsert: `[woocommerce/${ name }]`,
+	postTypes,
+} );
+
+type Registry = { select: jest.Mock };
+
+/**
+ * `createRegistrySelector` resolves the selector once per registry, so a fresh
+ * registry per test is what gives each test empty caches.
+ *
+ * @param options          Store values the selector reads.
+ * @param options.tags     Records returned by `getEntityRecords`.
+ * @param options.postType Post type currently being edited.
+ * @param options.template Result of `getCurrentTemplate()`.
+ */
+function buildRegistry( options: {
+	tags: PersonalizationTag[] | null;
+	postType: string | undefined;
+	template?: { post_types: string[] } | null;
+} ) {
+	const { tags, postType, template = null } = options;
+	const getEntityRecords = jest.fn().mockReturnValue( tags );
+
+	const registry: Registry = {
+		select: jest.fn( ( store ) => {
+			if ( store === storeName ) {
+				return {
+					getEmailPostId: () => 23,
+					getEmailPostType: () => postType,
+					getCurrentTemplate: () => template,
+				};
+			}
+			if ( store === coreDataStore ) {
+				return { getEntityRecords };
+			}
+			throw new Error( `Unexpected store: ${ String( store ) }` );
+		} ),
+	};
+
+	(
+		getPersonalizationTagsList as unknown as { registry: Registry }
+	 ).registry = registry;
+
+	return { getEntityRecords };
+}
+
+const names = () => getPersonalizationTagsList().map( ( tag ) => tag.name );
+
+describe( 'getPersonalizationTagsList', () => {
+	// Without this, a test that forgot `buildRegistry` would silently reuse the
+	// previous registry along with its warm caches.
+	afterEach( () => {
+		delete (
+			getPersonalizationTagsList as unknown as { registry?: Registry }
+		 ).registry;
+	} );
+
+	it( 'filters tags by the edited post type', () => {
+		buildRegistry( {
+			tags: [
+				makeTag( 'a', [ 'woo_email' ] ),
+				makeTag( 'b', [ 'other_type' ] ),
+				makeTag( 'c', [] ),
+			],
+			postType: 'woo_email',
+		} );
+
+		expect( names() ).toEqual( [ 'a', 'c' ] );
+	} );
+
+	it( 'filters tags by the template post types when editing a template', () => {
+		buildRegistry( {
+			tags: [
+				makeTag( 'a', [ 'woo_email' ] ),
+				makeTag( 'b', [ 'other_type' ] ),
+				makeTag( 'c', [] ),
+			],
+			postType: 'wp_template',
+			template: { post_types: [ 'other_type' ] },
+		} );
+
+		expect( names() ).toEqual( [ 'b', 'c' ] );
+	} );
+
+	// `getEditedPostTemplate` returns null while a template is unresolved, which
+	// the previous unguarded `postTemplate.post_types` threw a TypeError on.
+	it( 'keeps only untyped tags when the template is unresolved', () => {
+		buildRegistry( {
+			tags: [ makeTag( 'a', [ 'woo_email' ] ), makeTag( 'c', [] ) ],
+			postType: 'wp_template',
+			template: null,
+		} );
+
+		expect( names() ).toEqual( [ 'c' ] );
+	} );
+
+	it( 'returns a referentially stable list across repeated calls', () => {
+		buildRegistry( {
+			tags: [ makeTag( 'a', [ 'woo_email' ] ) ],
+			postType: 'woo_email',
+		} );
+
+		expect( getPersonalizationTagsList() ).toBe(
+			getPersonalizationTagsList()
+		);
+	} );
+
+	// The counterpart to the test above: stable is only correct while the
+	// records are unchanged.
+	it( 'recomputes when the records returned by core-data change', () => {
+		const { getEntityRecords } = buildRegistry( {
+			tags: [ makeTag( 'a', [ 'woo_email' ] ) ],
+			postType: 'woo_email',
+		} );
+		const before = getPersonalizationTagsList();
+
+		getEntityRecords.mockReturnValue( [
+			makeTag( 'a', [ 'woo_email' ] ),
+			makeTag( 'b', [ 'woo_email' ] ),
+		] );
+
+		expect( getPersonalizationTagsList() ).not.toBe( before );
+		expect( names() ).toEqual( [ 'a', 'b' ] );
+	} );
+
+	// Records are null until the request resolves, which is every call during
+	// initial load — a fresh array each time would defeat the memoization.
+	it( 'returns a stable empty list while the records are unresolved', () => {
+		buildRegistry( { tags: null, postType: 'woo_email' } );
+
+		expect( getPersonalizationTagsList() ).toStrictEqual( [] );
+		expect( getPersonalizationTagsList() ).toBe(
+			getPersonalizationTagsList()
+		);
+	} );
+} );

--- a/packages/js/email-editor/src/store/test/personalization-tags-query.spec.ts
+++ b/packages/js/email-editor/src/store/test/personalization-tags-query.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { getPersonalizationTagsQuery } from '../personalization-tags-query';
+
+describe( 'getPersonalizationTagsQuery', () => {
+	it( 'includes post_id when there is a post id', () => {
+		expect( getPersonalizationTagsQuery( 23 ) ).toStrictEqual( {
+			context: 'view',
+			per_page: -1,
+			post_id: 23,
+		} );
+	} );
+
+	it( 'omits post_id when there is no post id', () => {
+		expect( getPersonalizationTagsQuery( undefined ) ).toStrictEqual( {
+			context: 'view',
+			per_page: -1,
+		} );
+	} );
+
+	// The selector runs once per block on every store change, and core-data
+	// caches the query by argument reference.
+	it( 'returns the same object for the same post id', () => {
+		expect( getPersonalizationTagsQuery( 23 ) ).toBe(
+			getPersonalizationTagsQuery( 23 )
+		);
+	} );
+
+	// A single-slot cache would make alternating post ids miss every time,
+	// which is the problem this builder exists to avoid.
+	it( 'caches each post id independently', () => {
+		const first = getPersonalizationTagsQuery( 23 );
+		const second = getPersonalizationTagsQuery( 24 );
+
+		expect( second ).not.toBe( first );
+		expect( getPersonalizationTagsQuery( 23 ) ).toBe( first );
+	} );
+} );

--- a/plugins/woocommerce/changelog/performance-email-editor-canvas-typing-latency
+++ b/plugins/woocommerce/changelog/performance-email-editor-canvas-typing-latency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Email editor: reduce typing latency in the editor canvas.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Typing in the email editor canvas lags noticeably compared to the native post editor, and it gets worse as an email gains blocks. Profiling showed the cost is redundant per-keystroke work in this package rather than anything in Gutenberg core.

Two causes, fixed independently:

- **`useUserTheme` returned a fresh object literal on every render**, so the `mergedConfig` memo in `useEmailCss` could never hit. That re-ran `deepmerge` and `generateGlobalStyles()` on every render of `InnerEditor` and produced a new `styles` array, which replaced the entire `core/block-editor` settings object once per keystroke — invalidating memoization across the block editor even though the generated CSS was byte-identical. The memo is now keyed on the global styles post's `settings` and `styles`; editing styles goes through `editEntityRecord`, which replaces both, so the stylesheet still regenerates.
- **`getPersonalizationTagsList` rebuilt its entity query and re-filtered the tag list on every call** — roughly 90 calls per keystroke, since a `editor.BlockEdit` filter invokes it once per block. The query object is now shared and the filtered result memoized. The shared query builder is also used by `invalidatePersonalizationTagsCache`; `invalidateResolution` matches resolver arguments structurally, so had the two literals drifted, invalidation would have stopped matching silently.

Closes #67030 .

### Screenshots or screen recordings:

No visual change — the rendered canvas and the generated stylesheet are byte-identical before and after. The change is purely in how often that output is recomputed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block email editor at **WooCommerce → Settings → Advanced → Features**.
2. Go to **WooCommerce → Settings → Emails** and open any transactional email in the editor.
3. Type a sentence into a paragraph block in the canvas. Confirm it keeps up with the keyboard and feels comparable to the native post editor.
4. Confirm personalization tags still behave: type `[woocommerce/customer-first-name]` into a paragraph and check it renders as a tag chip.
5. Open the **Styles** sidebar → **Colors** → **Background** and pick a colour. Confirm the canvas restyles immediately — this is the path the memoization could have broken.
6. Open **Styles → Layout**, change padding, and confirm the canvas updates.
7. Open a **template** for editing (Template → Edit template) and confirm the personalization tag list contains tags and they can be inserted (e.g., to the footer).

<!-- End testing instructions -->

### Testing that has already taken place:

**Unit tests:** 72 pass in `@woocommerce/email-editor` (25 new). Verified they are genuine regression guards — reverting the source changes fails 10 of the 20 new assertions, and they fail on identity, not vacuously.

**Benchmark.** Post with 14 blocks and 32 personalization tags, `SCRIPT_DEBUG=false` (production React), heartbeat suppressed, hard reload with cache bypassed, 20 warm-up keystrokes discarded, then a traced 60-keystroke burst. Main-thread CPU is taken from the trace's sampled profile.

| Metric (60 keystrokes) | Before | After | Change |
| --- | --- | --- | --- |
| Main-thread CPU | 1554 ms | 1078 ms | **−31%** |
| …of which the email editor bundle | 406 ms | 88 ms | **−78%** |
| Median input latency | 32 ms | 24 ms | **−25%** |
| p90 input latency | 40 ms | 32 ms | −20% |
| `core/block-editor` settings object replaced | ~1 per keystroke | 0 | eliminated |

Run-to-run variance on the CPU figure was 1.2% across repeat runs, so the deltas are well outside noise. INP is deliberately not quoted: two back-to-back runs of an identical configuration gave 43 ms and 215 ms, so as a single-worst-interaction metric it is too noisy here to support a claim.

With `SCRIPT_DEBUG=true` the same benchmark shows −36% CPU and −29% median latency, but development React inflates those figures — the production row above is the honest number.

**Manual:** verified in wp-env that editing a colour and editing padding through the Styles sidebar both regenerate the stylesheet and repaint the canvas, and that the canvas CSS is unchanged from before the fix.

**Behaviour change worth flagging:** for a `wp_template` post whose template record has not resolved, `getPersonalizationTagsList` previously threw a `TypeError` (on a `null` template); it now filters out tags that declare post types. Covered by a new test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — entries are already committed for both `packages/js/email-editor` and `plugins/woocommerce`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
