### PR TITLE
Display user avatar in Customer Account block

### DIFF
--- a/plugins/woocommerce/changelog/fix-42449-customer-account-avatar
+++ b/plugins/woocommerce/changelog/fix-42449-customer-account-avatar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Display user avatar in Customer Account block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/block.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import clsx from 'clsx';
 import { Icon } from '@wordpress/icons';
 import {
 	customerAccountStyle,
@@ -31,8 +32,34 @@ const AccountIcon = ( {
 	displayStyle: DisplayStyle;
 	iconClass: string;
 } ) => {
-	return displayStyle === DisplayStyle.TEXT_ONLY ? null : (
-		<Icon className={ iconClass } icon={ icons[ iconStyle ] } size={ 18 } />
+	if ( displayStyle === DisplayStyle.TEXT_ONLY ) {
+		return null;
+	}
+
+	const currentUserId = getSetting( 'currentUserId', null );
+	const avatarUrl = getSetting< string >( 'currentUserAvatarUrl', '' );
+
+	const avatar =
+		currentUserId && avatarUrl ? (
+			<img
+				className={ clsx(
+					'wc-block-customer-account__avatar',
+					iconClass
+				) }
+				src={ avatarUrl }
+				alt=""
+			/>
+		) : null;
+
+	return (
+		<div className="wc-block-customer-account__visual">
+			<Icon
+				className={ iconClass }
+				icon={ icons[ iconStyle ] }
+				size={ 18 }
+			/>
+			{ avatar }
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/block.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import clsx from 'clsx';
 import { Icon } from '@wordpress/icons';
 import {
 	customerAccountStyle,
@@ -32,35 +31,15 @@ const AccountIcon = ( {
 	displayStyle: DisplayStyle;
 	iconClass: string;
 } ) => {
-	if ( displayStyle === DisplayStyle.TEXT_ONLY ) {
-		return null;
-	}
-
-	const currentUserId = getSetting( 'currentUserId', null );
-	const avatarUrl = getSetting< string >( 'currentUserAvatarUrl', '' );
-
-	const avatar =
-		currentUserId && avatarUrl ? (
-			<img
-				className={ clsx(
-					'wc-block-customer-account__avatar',
-					iconClass
-				) }
-				src={ avatarUrl }
-				alt=""
-			/>
-		) : null;
-
-	return (
+	return displayStyle !== DisplayStyle.TEXT_ONLY ? (
 		<div className="wc-block-customer-account__visual">
 			<Icon
 				className={ iconClass }
 				icon={ icons[ iconStyle ] }
 				size={ 18 }
 			/>
-			{ avatar }
 		</div>
-	);
+	) : null;
 };
 
 const Label = ( { displayStyle }: { displayStyle: DisplayStyle } ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -109,6 +109,10 @@ export const BlockSettings = ( {
 								iconStyle: value,
 							} )
 						}
+						help={ __(
+							'When a logged-in customer has a profile photo, it replaces the icon.',
+							'woocommerce'
+						) }
 						className="wc-block-editor-customer-account__icon-style-toggle"
 					>
 						<ToggleGroupControlOption

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -71,21 +71,21 @@
 
 	:where(.icon),
 	.wc-block-customer-account__account-icon {
+		display: block;
 		width: em($grid-unit-30);
 		height: em($grid-unit-30);
-		display: block;
 	}
 
 	:where(.wc-block-customer-account__avatar) {
 		// SVG icons have some transparent spacing around the actual icon.
 		// So we add some spacing around the avatar to simulate a similar size.
 		$avatar_spacing: 4%;
-		
+
 		border-radius: 50%;
 		position: absolute;
+		left: 50%;
 		top: 50%;
-		transform: translateY(-50%);
-		left: $avatar_spacing;
+		transform: translate(-50%, -50%);
 		width: calc(100% - ($avatar_spacing * 2));
 		height: auto;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -76,17 +76,17 @@
 	}
 
 	.wc-block-customer-account__avatar {
+		// SVG icons have some transparent spacing around the actual icon.
+		// So we add some spacing around the avatar to simulate a similar size.
+		$avatar_spacing: 4%;
+		
 		border-radius: 50%;
 		position: absolute;
 		top: 50%;
-		left: 0;
 		transform: translateY(-50%);
-		width: 100%;
+		left: $avatar_spacing;
+		width: calc(100% - ($avatar_spacing * 2));
 		height: auto;
-		// SVG icons have some transparent spacing around the actual icon.
-		// So we add some transparent border around the avatar to simulate a
-		// similar size.
-		border: 4% solid transparent;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -61,9 +61,32 @@
 		text-decoration: underline;
 	}
 
+	.wc-block-customer-account__visual {
+		position: relative;
+	}
+
+	.wc-block-customer-account__visual + .label {
+		padding-left: em($gap-smallest);
+	}
+
 	.wc-block-customer-account__account-icon {
 		width: em($grid-unit-30);
 		height: em($grid-unit-30);
+		display: block;
+	}
+
+	.wc-block-customer-account__avatar {
+		border-radius: 50%;
+		position: absolute;
+		top: 50%;
+		left: 0;
+		transform: translateY(-50%);
+		width: 100%;
+		height: auto;
+		// SVG icons have some transparent spacing around the actual icon.
+		// So we add some transparent border around the avatar to simulate a
+		// similar size.
+		border: 4% solid transparent;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -69,7 +69,7 @@
 		padding-left: em($gap-smallest);
 	}
 
-	:where(.icon),
+	:where(.wc-block-customer-account__visual > svg),
 	.wc-block-customer-account__account-icon {
 		display: block;
 		width: em($grid-unit-30);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -61,22 +61,22 @@
 		text-decoration: underline;
 	}
 
-	.wc-block-customer-account__visual {
+	:where(.wc-block-customer-account__visual) {
 		position: relative;
 	}
 
-	.wc-block-customer-account__visual + .label {
+	:where(.wc-block-customer-account__visual + .label) {
 		padding-left: em($gap-smallest);
 	}
 
-	.icon,
+	:where(.icon),
 	.wc-block-customer-account__account-icon {
 		width: em($grid-unit-30);
 		height: em($grid-unit-30);
 		display: block;
 	}
 
-	.wc-block-customer-account__avatar {
+	:where(.wc-block-customer-account__avatar) {
 		// SVG icons have some transparent spacing around the actual icon.
 		// So we add some spacing around the avatar to simulate a similar size.
 		$avatar_spacing: 4%;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/customer-account/style.scss
@@ -69,6 +69,7 @@
 		padding-left: em($gap-smallest);
 	}
 
+	.icon,
 	.wc-block-customer-account__account-icon {
 		width: em($grid-unit-30);
 		height: em($grid-unit-30);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -112,6 +112,32 @@ class CustomerAccount extends AbstractBlock {
 	}
 
 	/**
+	 * Data passed through from server to client for block.
+	 *
+	 * @param array $attributes Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		if ( ! $this->asset_data_registry->exists( 'currentUserAvatarUrl' ) ) {
+			$avatar_url = '';
+			$user_id    = get_current_user_id();
+
+			if ( $user_id && get_option( 'show_avatars' ) ) {
+				$avatar_url = get_avatar_url(
+					$user_id,
+					array(
+						'size'    => 48,
+						'default' => 'blank',
+					)
+				);
+			}
+
+			$this->asset_data_registry->add( 'currentUserAvatarUrl', $avatar_url );
+		}
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -148,8 +174,6 @@ class CustomerAccount extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	private function render_link( $attributes, $classes_and_styles, $account_link, $aria_label, $label_markup ) {
-		$allowed_svg = $this->get_allowed_svg();
-
 		ob_start();
 		?>
 		<div
@@ -161,7 +185,7 @@ class CustomerAccount extends AbstractBlock {
 				href="<?php echo esc_url( $account_link ); ?>"
 				<?php echo $aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			>
-				<?php echo wp_kses( $this->render_icon( $attributes ), $allowed_svg ); ?>
+				<?php echo $this->render_visual( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo $label_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</a>
 		</div>
@@ -180,8 +204,6 @@ class CustomerAccount extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	private function render_dropdown( $attributes, $classes_and_styles, $aria_label, $label_markup ) {
-		$allowed_svg = $this->get_allowed_svg();
-
 		$context = array(
 			'isDropdownOpen' => false,
 			'showAbove'      => false,
@@ -213,7 +235,7 @@ class CustomerAccount extends AbstractBlock {
 				data-wp-bind--aria-expanded="context.isDropdownOpen"
 				data-wp-on--click="actions.toggleDropdown"
 			>
-				<?php echo wp_kses( $this->render_icon( $attributes ), $allowed_svg ); ?>
+				<?php echo $this->render_visual( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo $label_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo $this->render_caret_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</button>
@@ -301,42 +323,11 @@ class CustomerAccount extends AbstractBlock {
 	}
 
 	/**
-	 * Get the allowed SVG tags and attributes for wp_kses.
-	 *
-	 * @return array Allowed SVG elements and attributes.
-	 */
-	private function get_allowed_svg() {
-		return array(
-			'svg'    => array(
-				'class'   => true,
-				'xmlns'   => true,
-				'width'   => true,
-				'height'  => true,
-				'viewbox' => true,
-			),
-			'path'   => array(
-				'd'         => true,
-				'fill'      => true,
-				'fill-rule' => true,
-				'clip-rule' => true,
-			),
-			'circle' => array(
-				'cx'           => true,
-				'cy'           => true,
-				'r'            => true,
-				'stroke'       => true,
-				'stroke-width' => true,
-				'fill'         => true,
-			),
-		);
-	}
-
-	/**
 	 * Gets the icon to render depending on the iconStyle and displayStyle.
 	 *
 	 * @param array $attributes Block attributes.
 	 *
-	 * @return string Label to render on the block
+	 * @return string SVG icon markup.
 	 */
 	private function render_icon( $attributes ) {
 		if ( self::TEXT_ONLY === $attributes['displayStyle'] ) {
@@ -344,7 +335,7 @@ class CustomerAccount extends AbstractBlock {
 		}
 
 		if ( self::DISPLAY_LINE === $attributes['iconStyle'] ) {
-			return '<svg class="' . $attributes['iconClass'] . '" viewBox="1 1 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+			return '<svg class="' . esc_attr( $attributes['iconClass'] ) . '" viewBox="1 1 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<circle
 					cx="16"
 					cy="10.5"
@@ -363,7 +354,7 @@ class CustomerAccount extends AbstractBlock {
 		}
 
 		if ( self::DISPLAY_ALT === $attributes['iconStyle'] ) {
-			return '<svg class="' . $attributes['iconClass'] . '" xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 25 25">
+			return '<svg class="' . esc_attr( $attributes['iconClass'] ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 25 25">
 				<path
 					d="M9 0C4.03579 0 0 4.03579 0 9C0 13.9642 4.03579 18 9 18C13.9642 18 18 13.9642 18 9C18 4.03579 13.9642 0 9 0ZM9 4.32C10.5347 4.32 11.7664 5.57056 11.7664 7.08638C11.7664 8.62109 10.5158 9.85277 9 9.85277C7.4653 9.85277 6.23362 8.60221 6.23362 7.08638C6.23362 5.57056 7.46526 4.32 9 4.32ZM9 10.7242C11.1221 10.7242 12.96 12.2021 13.7937 14.4189C12.5242 15.5559 10.8379 16.238 9 16.238C7.16207 16.238 5.49474 15.5369 4.20632 14.4189C5.05891 12.2021 6.87793 10.7242 9 10.7242Z"
 					fill="currentColor"
@@ -371,7 +362,7 @@ class CustomerAccount extends AbstractBlock {
 			</svg>';
 		}
 
-		return '<svg class="' . $attributes['iconClass'] . '" xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 25 25">
+		return '<svg class="' . esc_attr( $attributes['iconClass'] ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 25 25">
 			<path
 				fill-rule="evenodd"
 				clip-rule="evenodd"
@@ -379,6 +370,38 @@ class CustomerAccount extends AbstractBlock {
 				fill="currentColor"
 			/>
 		</svg>';
+	}
+
+	/**
+	 * Render the user avatar image.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string Avatar image markup.
+	 */
+	private function render_visual( $attributes ) {
+		if ( self::TEXT_ONLY === $attributes['displayStyle'] ) {
+			return '';
+		}
+
+		$icon    = $this->render_icon( $attributes );
+		$user_id = get_current_user_id();
+		if ( $user_id ) {
+			$avatar = get_avatar(
+				$user_id,
+				48,
+				'blank',
+				'',
+				array(
+					'class' => 'wc-block-customer-account__avatar ' . $attributes['iconClass'],
+				)
+			);
+
+			if ( $avatar ) {
+				return '<div class="wc-block-customer-account__visual">' . $icon . wp_kses_post( $avatar ) . '</div>';
+			}
+		}
+		return '<div class="wc-block-customer-account__visual">' . $icon . '</div>';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -361,6 +361,7 @@ class CustomerAccount extends AbstractBlock {
 		$icon    = $this->render_icon( $attributes );
 		$user_id = get_current_user_id();
 		if ( $user_id ) {
+			// We use `blank` as the default so if the user has no avatar, the icon underneath is visible.
 			$avatar = get_avatar(
 				$user_id,
 				48,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -347,11 +347,11 @@ class CustomerAccount extends AbstractBlock {
 	}
 
 	/**
-	 * Render the user avatar image.
+	 * Render the user avatar and icon.
 	 *
 	 * @param array $attributes Block attributes.
 	 *
-	 * @return string Avatar image markup.
+	 * @return string Avatar and icon markup.
 	 */
 	private function render_visual( $attributes ) {
 		if ( self::TEXT_ONLY === $attributes['displayStyle'] ) {
@@ -367,7 +367,7 @@ class CustomerAccount extends AbstractBlock {
 				'blank',
 				'',
 				array(
-					'class' => 'wc-block-customer-account__avatar ' . $attributes['iconClass'],
+					'class' => 'wc-block-customer-account__avatar',
 				)
 			);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -112,32 +112,6 @@ class CustomerAccount extends AbstractBlock {
 	}
 
 	/**
-	 * Data passed through from server to client for block.
-	 *
-	 * @param array $attributes Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_data( array $attributes = [] ) {
-		parent::enqueue_data( $attributes );
-
-		if ( ! $this->asset_data_registry->exists( 'currentUserAvatarUrl' ) ) {
-			$avatar_url = '';
-			$user_id    = get_current_user_id();
-
-			if ( $user_id && get_option( 'show_avatars' ) ) {
-				$avatar_url = get_avatar_url(
-					$user_id,
-					array(
-						'size'    => 48,
-						'default' => 'blank',
-					)
-				);
-			}
-
-			$this->asset_data_registry->add( 'currentUserAvatarUrl', $avatar_url );
-		}
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
@@ -7,7 +7,7 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 use WP_UnitTestCase;
 
 /**
- * Tests for the Customer Account block type.
+ * Tests for the Customer Account block.
  */
 class CustomerAccountTest extends WP_UnitTestCase {
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
@@ -99,6 +99,14 @@ class CustomerAccountTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->user_id );
 		update_option( 'show_avatars', 0 );
 
+		add_filter(
+			'pre_get_avatar_data',
+			function ( $args ) {
+				$args['url'] = 'https://example.com/custom-avatar.jpg';
+				return $args;
+			}
+		);
+
 		$markup = $this->render_customer_account(
 			'{"iconClass":"wc-block-customer-account__account-icon"}'
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
@@ -93,6 +93,21 @@ class CustomerAccountTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Should not render avatar markup when show_avatars is disabled.
+	 */
+	public function test_does_not_render_avatar_when_show_avatars_is_disabled(): void {
+		wp_set_current_user( $this->user_id );
+		update_option( 'show_avatars', 0 );
+
+		$markup = $this->render_customer_account(
+			'{"iconClass":"wc-block-customer-account__account-icon"}'
+		);
+
+		$this->assertStringNotContainsString( 'wc-block-customer-account__avatar', $markup );
+		$this->assertStringNotContainsString( 'custom-avatar.jpg', $markup );
+	}
+
+	/**
 	 * Data provider for displayStyle attribute tests.
 	 *
 	 * @return array<string, array{string, bool, bool, bool}>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
@@ -49,12 +49,11 @@ class CustomerAccountTest extends WP_UnitTestCase {
 	/**
 	 * Render the Customer Account block via do_blocks().
 	 *
-	 * @param string $attrs_json JSON object string for block attributes.
+	 * @param string $attrs JSON object string for block attributes.
 	 * @return string Rendered markup.
 	 */
-	private function render_customer_account( string $attrs_json = '' ): string {
-		$attrs = '' !== $attrs_json ? ' ' . $attrs_json : '';
-		return do_blocks( "<!-- wp:woocommerce/customer-account{$attrs} /-->" );
+	private function render_customer_account( string $attrs = '' ): string {
+		return do_blocks( "<!-- wp:woocommerce/customer-account {$attrs} /-->" );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/CustomerAccountTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WP_UnitTestCase;
+
+/**
+ * Tests for the Customer Account block type.
+ */
+class CustomerAccountTest extends WP_UnitTestCase {
+
+	/**
+	 * User ID for tests.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Original show_avatars option value.
+	 *
+	 * @var mixed
+	 */
+	private $original_show_avatars;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->user_id               = $this->factory->user->create();
+		$this->original_show_avatars = get_option( 'show_avatars' );
+		update_option( 'show_avatars', 1 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'pre_get_avatar_data' );
+		wp_set_current_user( 0 );
+		wp_delete_user( $this->user_id );
+		update_option( 'show_avatars', $this->original_show_avatars );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the Customer Account block via do_blocks().
+	 *
+	 * @param string $attrs_json JSON object string for block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render_customer_account( string $attrs_json = '' ): string {
+		$attrs = '' !== $attrs_json ? ' ' . $attrs_json : '';
+		return do_blocks( "<!-- wp:woocommerce/customer-account{$attrs} /-->" );
+	}
+
+	/**
+	 * @testdox Should render the default account icon when the user is not logged in.
+	 */
+	public function test_renders_icon_when_user_is_not_logged_in(): void {
+		wp_set_current_user( 0 );
+
+		$markup = $this->render_customer_account(
+			'{"iconClass":"wc-block-customer-account__account-icon"}'
+		);
+
+		$this->assertStringContainsString( '<svg', $markup );
+		$this->assertStringNotContainsString( 'wc-block-customer-account__avatar', $markup );
+	}
+
+	/**
+	 * @testdox Should render the user avatar when a custom avatar is available.
+	 */
+	public function test_renders_avatar_when_user_has_custom_avatar(): void {
+		wp_set_current_user( $this->user_id );
+
+		add_filter(
+			'pre_get_avatar_data',
+			function ( $args ) {
+				$args['url'] = 'https://example.com/custom-avatar.jpg';
+				return $args;
+			}
+		);
+
+		$markup = $this->render_customer_account(
+			'{"iconClass":"wc-block-customer-account__account-icon"}'
+		);
+
+		$this->assertStringContainsString( 'wc-block-customer-account__avatar', $markup );
+		$this->assertStringContainsString( 'custom-avatar.jpg', $markup );
+	}
+
+	/**
+	 * Data provider for displayStyle attribute tests.
+	 *
+	 * @return array<string, array{string, bool, bool, bool}>
+	 */
+	public function provider_display_style(): array {
+		return array(
+			'icon and text' => array( 'icon_and_text', true, true, false ),
+			'text only'     => array( 'text_only', false, true, false ),
+			'icon only'     => array( 'icon_only', true, false, true ),
+		);
+	}
+
+	/**
+	 * @testdox Should render icon, label, and aria-label according to displayStyle.
+	 *
+	 * @dataProvider provider_display_style
+	 *
+	 * @param string $display_style Display style attribute.
+	 * @param bool   $has_icon      Whether an SVG icon is expected.
+	 * @param bool   $has_label     Whether a text label is expected.
+	 * @param bool   $has_aria      Whether an aria-label is expected.
+	 */
+	public function test_display_style( string $display_style, bool $has_icon, bool $has_label, bool $has_aria ): void {
+		$markup = $this->render_customer_account(
+			'{"displayStyle":"' . $display_style . '","iconClass":"wc-block-customer-account__account-icon"}'
+		);
+
+		$this->assertSame( $has_icon, str_contains( $markup, '<svg' ) );
+		$this->assertSame( $has_label, str_contains( $markup, 'class="label"' ) );
+		$this->assertSame( $has_aria, str_contains( $markup, 'aria-label=' ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #42449.
Closes #67064.

This PR adds avatars to the Customer Account block, only visible in the frontend, not in the editor. It also fixes a sizing issue with the block when it was missing the `.wc-block-customer-account_account-icon` class.

### How to test the changes in this Pull Request:

**#42449:**

1. Add the Customer Account block to a post or page.
2. Create a user with an email registered in Gravatar. Visit that post or page and verify the avatar is displayed.
3. Install a plugin like [Simple User Avatar](https://es.wordpress.org/plugins/simple-user-avatar/) and submit a custom avatar for a user. Verify it's displayed in the block as well.
4. Go to Settings > Discussion  and uncheck Show Avatars. Verify the user avatars are not displayed.

Without avatar | With avatar
--- | ---
<img width="328" height="531" alt="image" src="https://github.com/user-attachments/assets/244a6b2c-9c49-48fa-b34f-e7882ab1970b" /> | <img width="328" height="531" alt="image" src="https://github.com/user-attachments/assets/61783586-dcbb-45d0-8080-226bd8469148" />

**#67064:**

1. Add the Customer Account block without the `.wc-block-customer-account_account-icon` class:

```HTML
<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only"} /-->
```

2. Visit it in the frontend and verify the size of the icon is not huge.

Before | After
--- | ---
<img width="760" height="1045" alt="Image" src="https://github.com/user-attachments/assets/f3ea1d8f-21f1-42f5-9fb8-0ae5c8fc5839" /> | <img width="760" height="518" alt="imatge" src="https://github.com/user-attachments/assets/f54c175c-9d5d-40b4-8312-9c9cd3831a72" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->