### PR TITLE
[3/3] Add can_be_refunded to wc/v3 order responses

### DIFF
--- a/plugins/woocommerce/changelog/add-v3-orders-can-be-refunded
+++ b/plugins/woocommerce/changelog/add-v3-orders-can-be-refunded
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a read-only can_be_refunded field to wc/v3 order responses, at order level and on product, shipping, and fee lines.

--- a/plugins/woocommerce/changelog/fix-can-be-refunded-remaining-value
+++ b/plugins/woocommerce/changelog/fix-can-be-refunded-remaining-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+can_be_refunded on product lines now accounts for remaining monetary value, so lines exhausted by amount-only refunds are no longer advertised as refundable.

--- a/plugins/woocommerce/changelog/v3-refunds-preview-review-fixes
+++ b/plugins/woocommerce/changelog/v3-refunds-preview-review-fixes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Review follow-ups for the unreleased wc/v3 refund preview endpoint: schema/doc polish and additional test coverage. No user-facing change.

--- a/plugins/woocommerce/changelog/v3-refunds-shared-preview-pipeline
+++ b/plugins/woocommerce/changelog/v3-refunds-shared-preview-pipeline
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Deduplicate the refund preview pipeline and arg schema between the wc/v3 and wc/v4 endpoints into the shared DataUtils engine. No behavior change.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -36,6 +36,9 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	/**
 	 * Register the routes for order refunds, including the refund preview route.
 	 *
+	 * The override is new in 11.1.0 even though the parent method is not, hence
+	 * the tag per the convention for public methods.
+	 *
 	 * @return void
 	 *
 	 * @since 11.1.0
@@ -94,78 +97,18 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 			return new WP_Error( 'woocommerce_rest_invalid_order_id', __( 'Invalid order ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		// Round caller-supplied refund_total values once, up front, so validation and
-		// the computed preview use the same precision the create flow stores. Reused
-		// for both validate and build below.
-		$line_items = $this->data_utils()->normalize_refund_totals( $request['line_items'] );
-
-		$validation_error = $this->data_utils()->validate_preview_line_items( $line_items, $order );
-
-		// The WP_Error already carries its HTTP status in the error data; returning
-		// it directly lets the REST server respond with that status. The shared
-		// validation engine emits unprefixed codes (the wc/v4 convention); they are
-		// prefixed here at the v3 boundary so this endpoint follows the
+		// The shared engine runs the whole pipeline: normalize, validate, build,
+		// and the aggregate guards. Its WP_Errors carry their HTTP status in the
+		// error data and use unprefixed codes (the engine is convention neutral);
+		// they are prefixed here at the v3 boundary so this endpoint follows the
 		// `woocommerce_rest_*` convention of the rest of the v3 surface.
-		if ( is_wp_error( $validation_error ) ) {
-			return $this->prefix_error_code( $validation_error );
+		$preview = $this->data_utils()->compute_refund_preview_or_error( $order, $request['line_items'], 'wc-rest-refunds' );
+
+		if ( is_wp_error( $preview ) ) {
+			return $this->prefix_error_code( $preview );
 		}
 
-		try {
-			$preview = $this->data_utils()->build_refund_preview( $order, $line_items );
-		} catch ( InvalidArgumentException $e ) {
-			// validate_preview_line_items above should have caught any bad input.
-			// If build_refund_preview still throws InvalidArgumentException, treat
-			// it as a server-side invariant violation, log for observability, and
-			// return a generic message (do not leak internal IDs to clients).
-			wc_get_logger()->error(
-				sprintf( 'Refund preview invariant violation on order %d: %s', $order->get_id(), $e->getMessage() ),
-				array( 'source' => 'wc-rest-refunds' )
-			);
-			return new WP_Error(
-				'woocommerce_rest_invalid_preview_request',
-				__( 'The refund preview could not be generated due to an unexpected error.', 'woocommerce' ),
-				array( 'status' => 500 )
-			);
-		} catch ( Throwable $e ) {
-			wc_get_logger()->error(
-				sprintf( 'Refund preview unexpected error on order %d: %s', $order->get_id(), $e->getMessage() ),
-				array( 'source' => 'wc-rest-refunds' )
-			);
-			return new WP_Error(
-				'woocommerce_rest_unexpected_preview_error',
-				__( 'An unexpected error occurred while generating the refund preview.', 'woocommerce' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		// Reject a non-positive aggregate total up front. A refund of only a negative
-		// discount line, or a product plus discount that nets to zero, would otherwise
-		// preview successfully and then fail at create time.
-		if ( (float) $preview['total'] <= 0 ) {
-			return new WP_Error(
-				'woocommerce_rest_invalid_refund_amount',
-				__( 'Refund total must be greater than zero.', 'woocommerce' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Final guard: even when per-line validation passes, the aggregate
-		// preview total can still exceed the order's remaining refundable
-		// amount (e.g. an amount-only partial refund applied previously).
-		// `total` is already tax-inclusive; compare directly against max_refundable.
-		$preview_total_with_tax = abs( (float) $preview['total'] );
-		if ( $preview_total_with_tax > (float) $preview['max_refundable'] ) {
-			return new WP_Error(
-				'woocommerce_rest_preview_exceeds_max_refundable',
-				sprintf(
-					/* translators: 1: requested preview total including tax, 2: remaining refundable */
-					__( 'Requested refund preview (%1$s) exceeds the remaining refundable amount (%2$s).', 'woocommerce' ),
-					wc_format_decimal( $preview_total_with_tax, wc_get_price_decimals() ),
-					$preview['max_refundable']
-				),
-				array( 'status' => 422 )
-			);
-		}
+		$preview = $this->add_preview_additional_fields( $preview, $request );
 
 		/**
 		 * Filters the refund preview data before it is returned.
@@ -182,6 +125,100 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	}
 
 	/**
+	 * Populate fields registered for the preview object type into a response.
+	 *
+	 * The stock add_additional_fields_to_object() resolves the object type from
+	 * this controller's item schema (`order_refund`), so it would populate the
+	 * wrong field set; the preview publishes its schema as
+	 * `order_refund_preview` and must populate the fields registered for that
+	 * type. Mirrors core's `_fields` handling: callbacks for fields the request
+	 * excludes are not executed, so extension callbacks do not run for
+	 * responses that will not carry their field. Runs before the response
+	 * filter so filters see the complete payload.
+	 *
+	 * @param array           $preview Preview response data.
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return array
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 */
+	private function add_preview_additional_fields( array $preview, $request ): array {
+		$additional_fields = $this->get_additional_fields( 'order_refund_preview' );
+
+		if ( empty( $additional_fields ) ) {
+			return $preview;
+		}
+
+		$fields_for_response = $this->get_preview_fields_for_response( $request );
+
+		foreach ( $additional_fields as $field_name => $field_options ) {
+			if ( empty( $field_options['get_callback'] ) || ! is_callable( $field_options['get_callback'] ) ) {
+				continue;
+			}
+
+			if ( ! in_array( $field_name, $fields_for_response, true ) ) {
+				continue;
+			}
+
+			$preview[ $field_name ] = call_user_func( $field_options['get_callback'], $preview, $field_name, $request, 'order_refund_preview' );
+		}
+
+		return $preview;
+	}
+
+	/**
+	 * Get the preview fields a request asks for, mirroring core's
+	 * get_fields_for_response() against the preview schema instead of the
+	 * controller's item schema.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return string[]
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 */
+	private function get_preview_fields_for_response( $request ): array {
+		$schema     = $this->get_public_preview_schema();
+		$properties = isset( $schema['properties'] ) && is_array( $schema['properties'] ) ? $schema['properties'] : array();
+
+		// For back-compat, include any registered field with an empty schema, as
+		// core's get_fields_for_response() does: without a schema the field never
+		// reaches the published properties, but its callback must still run.
+		foreach ( $this->get_additional_fields( 'order_refund_preview' ) as $field_name => $field_options ) {
+			if ( is_null( $field_options['schema'] ) ) {
+				$properties[ $field_name ] = $field_options;
+			}
+		}
+
+		$fields = array_map( 'strval', array_keys( $properties ) );
+
+		if ( ! isset( $request['_fields'] ) || empty( $request['_fields'] ) ) {
+			return $fields;
+		}
+
+		$requested_fields = array_map(
+			static function ( $field ): string {
+				return trim( (string) $field );
+			},
+			wp_parse_list( $request['_fields'] )
+		);
+
+		if ( 0 === count( $requested_fields ) ) {
+			return $fields;
+		}
+
+		return array_values(
+			array_filter(
+				$fields,
+				function ( string $field ) use ( $requested_fields ): bool {
+					return rest_is_field_included( $field, $requested_fields );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Get the public schema for the refund preview endpoint.
 	 *
 	 * @return array
@@ -192,56 +229,29 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 		$schema          = wc_get_container()->get( RefundPreviewSchema::class )->get_item_schema();
 		$schema['title'] = 'order_refund_preview';
 
-		return $schema;
+		// Like the sibling v3 schema getters: fields registered via
+		// register_rest_field() must appear in the published schema.
+		return $this->add_additional_fields_schema( $schema );
 	}
 
 	/**
 	 * Get the argument schema for the preview route's line_items parameter.
 	 *
-	 * Mirrors the wc/v4 preview endpoint's argument schema (including the
-	 * line_item_id key naming) so clients can send the same payload to both
-	 * API versions.
+	 * Shared with the wc/v4 preview endpoint (including the line_item_id key
+	 * naming) so clients can send the same payload to both API versions and
+	 * the accepted shape cannot drift between them.
+	 *
+	 * Note the two deliberate differences from this controller's create
+	 * endpoint: the preview keys lines by `line_item_id` where the create
+	 * uses `id`, and the preview's `refund_total` is tax-inclusive where the
+	 * create's classic `refund_total` is net with taxes supplied separately
+	 * via `refund_tax` (the compute_totals create shares the preview's
+	 * tax-inclusive semantics).
 	 *
 	 * @return array
-	 *
-	 * @since 11.1.0
 	 */
 	private function get_preview_line_items_arg_schema() {
-		return array(
-			'description'       => __( 'Line items to include in the refund preview.', 'woocommerce' ),
-			'type'              => 'array',
-			'required'          => true,
-			'minItems'          => 1,
-			'validate_callback' => 'rest_validate_request_arg',
-			'items'             => array(
-				'type'                 => 'object',
-				'required'             => array( 'line_item_id' ),
-				'additionalProperties' => false,
-				'properties'           => array(
-					'line_item_id' => array(
-						'description' => __( 'ID of the original order line item.', 'woocommerce' ),
-						'type'        => 'integer',
-						'minimum'     => 1,
-					),
-					'quantity'     => array(
-						'description' => __( 'Quantity to refund. Required when refund_total is omitted.', 'woocommerce' ),
-						'type'        => 'integer',
-						'minimum'     => 1,
-					),
-					'refund_total' => array(
-						// No `minimum` here on purpose: validate_preview_line_items() owns
-						// the sign rule and returns the actionable `invalid_refund_total`
-						// code. A refund_total must be non-zero and match the line's sign —
-						// negative is valid for a discount/credit line, positive for a normal
-						// line; zero and wrong-sign values are rejected. A schema `minimum`
-						// would wrongly forbid the negative form, and a generic
-						// `rest_invalid_param` is less useful to clients.
-						'description' => __( 'Tax-inclusive amount to refund for this line item. Must be non-zero and match the line\'s sign (negative for discount or credit lines, positive otherwise). Required when quantity is omitted.', 'woocommerce' ),
-						'type'        => array( 'number', 'null' ),
-					),
-				),
-			),
-		);
+		return $this->data_utils()->get_preview_line_items_arg_schema();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -10,8 +10,10 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
+use Automattic\WooCommerce\Internal\RestApi\Routes\V4\Refunds\DataUtils;
 use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\NumberUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Utilities\MetaDataUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
@@ -391,6 +393,24 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			'context'     => array( 'edit' ),
 		);
 
+		$schema['properties']['can_be_refunded'] = array(
+			'description' => __( 'Whether the order can be refunded, based on its status and remaining refundable amount.', 'woocommerce' ),
+			'type'        => 'boolean',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$line_can_be_refunded_schema = array(
+			'description' => __( 'Whether this line has remaining refundable quantity or amount.', 'woocommerce' ),
+			'type'        => 'boolean',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['line_items']['items']['properties']['can_be_refunded']     = $line_can_be_refunded_schema;
+		$schema['properties']['shipping_lines']['items']['properties']['can_be_refunded'] = $line_can_be_refunded_schema;
+		$schema['properties']['fee_lines']['items']['properties']['can_be_refunded']      = $line_can_be_refunded_schema;
+
 		if ( $this->cogs_is_enabled() ) {
 			$schema = $this->add_cogs_related_schema( $schema );
 		}
@@ -495,6 +515,87 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		if ( $cogs_is_enabled ) {
 			$data['cost_of_goods_sold']['total_value'] = $order->get_cogs_total_value();
+		}
+
+		if ( $order instanceof WC_Order ) {
+			$data = $this->add_can_be_refunded_fields( $data, $order, $request );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Add the can_be_refunded field to the order response, at order level and on
+	 * product/shipping/fee lines.
+	 *
+	 * The computation mirrors the wc/v4 Orders schema so both API versions report
+	 * identical refundability: order level requires a refundable status and a
+	 * remaining refundable amount; product lines require remaining refundable
+	 * quantity; shipping and fee lines require a remaining refundable amount at
+	 * currency precision, compared on a tax-inclusive absolute basis so
+	 * discount/negative lines are handled.
+	 *
+	 * @param array           $data    Prepared response data.
+	 * @param WC_Order        $order   Order object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Response data with can_be_refunded fields added.
+	 *
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+	 *
+	 * @since 11.1.0
+	 */
+	private function add_can_be_refunded_fields( array $data, WC_Order $order, $request ): array {
+		$fields = $this->get_fields_for_response( $request );
+
+		if ( rest_is_field_included( 'can_be_refunded', $fields ) ) {
+			$data['can_be_refunded'] = in_array( $order->get_status(), DataUtils::REFUNDABLE_STATUSES, true )
+				&& (float) $order->get_remaining_refund_amount() > 0;
+		}
+
+		$line_sections = array_intersect( array( 'line_items', 'shipping_lines', 'fee_lines' ), array_keys( $data ) );
+		if ( empty( $line_sections ) ) {
+			return $data;
+		}
+
+		// Computed once per order; with no refunds this reduces to a single cached
+		// get_refunds() call, so the common case adds no per-refund item loads.
+		$refund_data = wc_get_container()->get( DataUtils::class )->compute_refunded_quantities_and_totals( $order );
+		$decimals    = wc_get_price_decimals();
+
+		// Read from the order item objects, not the prepared response data: the
+		// response zeroes product_id when the product has been deleted, while
+		// refundability follows the stored line (a deleted product's line is still
+		// refundable by quantity), matching the wc/v4 Orders schema.
+		$order_items = $order->get_items( array( 'line_item', 'shipping', 'fee' ) );
+
+		if ( isset( $data['line_items'] ) ) {
+			foreach ( $data['line_items'] as &$line_item_data ) {
+				$item = $order_items[ $line_item_data['id'] ] ?? null;
+
+				$line_item_data['can_be_refunded'] = $item instanceof WC_Order_Item_Product
+					&& 0 !== $item->get_product_id()
+					&& ( $item->get_quantity() + ( $refund_data['qtys'][ $item->get_id() ] ?? 0 ) ) > 0;
+			}
+			unset( $line_item_data );
+		}
+
+		foreach ( array( 'shipping_lines', 'fee_lines' ) as $section ) {
+			if ( ! isset( $data[ $section ] ) ) {
+				continue;
+			}
+			foreach ( $data[ $section ] as &$line_data ) {
+				$item = $order_items[ $line_data['id'] ] ?? null;
+				if ( ! $item instanceof WC_Order_Item_Shipping && ! $item instanceof WC_Order_Item_Fee ) {
+					$line_data['can_be_refunded'] = false;
+					continue;
+				}
+
+				$refunded  = abs( (float) ( $refund_data['totals'][ $item->get_id() ] ?? 0.0 ) );
+				$remaining = abs( (float) $item->get_total() + (float) $item->get_total_tax() ) - $refunded;
+
+				$line_data['can_be_refunded'] = NumberUtil::round( $remaining, $decimals ) > 0;
+			}
+			unset( $line_data );
 		}
 
 		return $data;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -572,9 +572,24 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			foreach ( $data['line_items'] as &$line_item_data ) {
 				$item = $order_items[ $line_item_data['id'] ] ?? null;
 
-				$line_item_data['can_be_refunded'] = $item instanceof WC_Order_Item_Product
-					&& 0 !== $item->get_product_id()
-					&& ( $item->get_quantity() + ( $refund_data['qtys'][ $item->get_id() ] ?? 0 ) ) > 0;
+				if ( ! $item instanceof WC_Order_Item_Product ) {
+					$line_item_data['can_be_refunded'] = false;
+					continue;
+				}
+
+				// A product line is refundable when it has remaining quantity AND remaining
+				// monetary value. Amount-only refunds (qty 0) can exhaust a line's value
+				// while leaving its quantity untouched; without the value check the field
+				// would advertise a line the refund endpoints reject as already refunded.
+				// Zero-priced lines carry no value, so they stay refundable by quantity
+				// alone (a restock-only refund). Mirrors the wc/v4 Orders schema.
+				$line_gross          = NumberUtil::round( abs( (float) $item->get_total() + (float) $item->get_total_tax() ), $decimals );
+				$line_refunded       = abs( (float) ( $refund_data['totals'][ $item->get_id() ] ?? 0.0 ) );
+				$has_remaining_value = 0.0 === $line_gross || NumberUtil::round( $line_gross - $line_refunded, $decimals ) > 0;
+
+				$line_item_data['can_be_refunded'] = 0 !== $item->get_product_id()
+					&& ( $item->get_quantity() + ( $refund_data['qtys'][ $item->get_id() ] ?? 0 ) ) > 0
+					&& $has_remaining_value;
 			}
 			unset( $line_item_data );
 		}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/Schema/OrderSchema.php
@@ -692,8 +692,19 @@ class OrderSchema extends AbstractSchema {
 			foreach ( $line_items as $line_item ) {
 				$item_data = $this->order_item_schema->get_item_response( $line_item, $request );
 
+				// A product line is refundable when it has remaining quantity AND remaining
+				// monetary value. Amount-only refunds (qty 0) can exhaust a line's value
+				// while leaving its quantity untouched; without the value check the field
+				// would advertise a line the refund endpoints reject as already refunded.
+				// Zero-priced lines carry no value, so they stay refundable by quantity
+				// alone (a restock-only refund).
+				$line_gross          = NumberUtil::round( abs( (float) $line_item->get_total() + (float) $line_item->get_total_tax() ), wc_get_price_decimals() );
+				$line_refunded       = abs( (float) ( $refund_data['totals'][ $line_item->get_id() ] ?? 0.0 ) );
+				$has_remaining_value = 0.0 === $line_gross || NumberUtil::round( $line_gross - $line_refunded, wc_get_price_decimals() ) > 0;
+
 				$item_data['can_be_refunded'] = 0 !== $line_item->get_product_id()
-					&& ( $line_item->get_quantity() + ( $refund_data['qtys'][ $line_item->get_id() ] ?? 0 ) ) > 0;
+					&& ( $line_item->get_quantity() + ( $refund_data['qtys'][ $line_item->get_id() ] ?? 0 ) ) > 0
+					&& $has_remaining_value;
 
 				$data['line_items'][] = $item_data;
 			}

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/Controller.php
@@ -187,41 +187,9 @@ class Controller extends AbstractController {
 							'minimum'           => 1,
 							'validate_callback' => 'rest_validate_request_arg',
 						),
-						'line_items' => array(
-							'description'       => __( 'Line items to include in the refund preview.', 'woocommerce' ),
-							'type'              => 'array',
-							'required'          => true,
-							'minItems'          => 1,
-							'validate_callback' => 'rest_validate_request_arg',
-							'items'             => array(
-								'type'                 => 'object',
-								'required'             => array( 'line_item_id' ),
-								'additionalProperties' => false,
-								'properties'           => array(
-									'line_item_id' => array(
-										'description' => __( 'ID of the original order line item.', 'woocommerce' ),
-										'type'        => 'integer',
-										'minimum'     => 1,
-									),
-									'quantity'     => array(
-										'description' => __( 'Quantity to refund. Required when refund_total is omitted.', 'woocommerce' ),
-										'type'        => 'integer',
-										'minimum'     => 1,
-									),
-									'refund_total' => array(
-										// No `minimum` here on purpose: validate_preview_line_items() owns
-										// the sign rule and returns the actionable `invalid_refund_total`
-										// code. A refund_total must be non-zero and match the line's sign —
-										// negative is valid for a discount/credit line, positive for a normal
-										// line; zero and wrong-sign values are rejected. A schema `minimum`
-										// would wrongly forbid the negative form, and a generic
-										// `rest_invalid_param` is less useful to clients.
-										'description' => __( 'Tax-inclusive amount to refund for this line item. Must be non-zero and match the line\'s sign (negative for discount or credit lines, positive otherwise). Required when quantity is omitted.', 'woocommerce' ),
-										'type'        => array( 'number', 'null' ),
-									),
-								),
-							),
-						),
+						// Shared with the wc/v3 preview endpoint so the accepted
+						// payload cannot drift between API versions.
+						'line_items' => $this->data_utils->get_preview_line_items_arg_schema(),
 					),
 				),
 				'schema' => array( $this, 'get_public_preview_schema' ),
@@ -544,76 +512,16 @@ class Controller extends AbstractController {
 			return $this->get_route_error_by_code( self::INVALID_ID );
 		}
 
-		// Round caller-supplied refund_total values once, up front, so validation and
-		// the computed preview use the same precision the create flow stores. Reused
-		// for both validate and build below.
-		$line_items = $this->data_utils->normalize_refund_totals( $request['line_items'] );
+		// The shared engine runs the whole pipeline: normalize, validate, build,
+		// and the aggregate guards. Its WP_Errors carry their HTTP status in the
+		// error data; wrap them in this controller's error envelope, as the
+		// validation branch always has.
+		$preview = $this->data_utils->compute_refund_preview_or_error( $order, $request['line_items'], 'wc-v4-refunds' );
 
-		$validation_error = $this->data_utils->validate_preview_line_items( $line_items, $order );
-
-		if ( is_wp_error( $validation_error ) ) {
-			$error_data = $validation_error->get_error_data();
+		if ( is_wp_error( $preview ) ) {
+			$error_data = $preview->get_error_data();
 			$status     = is_array( $error_data ) && isset( $error_data['status'] ) ? (int) $error_data['status'] : WP_Http::BAD_REQUEST;
-			return $this->get_route_error_response_from_object( $validation_error, $status );
-		}
-
-		try {
-			$preview = $this->data_utils->build_refund_preview( $order, $line_items );
-		} catch ( \InvalidArgumentException $e ) {
-			// validate_preview_line_items above should have caught any bad input.
-			// If build_refund_preview still throws InvalidArgumentException, treat
-			// it as a server-side invariant violation, log for observability, and
-			// return a generic message (do not leak internal IDs to clients).
-			wc_get_logger()->error(
-				sprintf( 'Refund preview invariant violation on order %d: %s', $order->get_id(), $e->getMessage() ),
-				array( 'source' => 'wc-v4-refunds' )
-			);
-			return $this->get_route_error_response(
-				'invalid_preview_request',
-				__( 'The refund preview could not be generated due to an unexpected error.', 'woocommerce' ),
-				WP_Http::INTERNAL_SERVER_ERROR
-			);
-		} catch ( \Throwable $e ) {
-			wc_get_logger()->error(
-				sprintf( 'Refund preview unexpected error on order %d: %s', $order->get_id(), $e->getMessage() ),
-				array( 'source' => 'wc-v4-refunds' )
-			);
-			return $this->get_route_error_response(
-				'unexpected_preview_error',
-				__( 'An unexpected error occurred while generating the refund preview.', 'woocommerce' ),
-				WP_Http::INTERNAL_SERVER_ERROR
-			);
-		}
-
-		// Reject a non-positive aggregate total up front, mirroring create_item()'s
-		// `0 > $refund_amount || ! $refund_amount` guard. A refund of only a negative
-		// discount line, or a product plus discount that nets to zero, would otherwise
-		// preview successfully and then fail at create with 'invalid_refund_amount'.
-		if ( (float) $preview['total'] <= 0 ) {
-			return $this->get_route_error_response(
-				'invalid_refund_amount',
-				__( 'Refund total must be greater than zero.', 'woocommerce' )
-			);
-		}
-
-		// Final guard: even when per-line validation passes, the aggregate
-		// preview total can still exceed the order's remaining refundable
-		// amount (e.g. an amount-only partial refund applied previously).
-		// Reject up-front so the eventual create call doesn't fail with the
-		// generic 'cannot_create_refund' error from wc_create_refund.
-		// `total` is already tax-inclusive; compare directly against max_refundable.
-		$preview_total_with_tax = abs( (float) $preview['total'] );
-		if ( $preview_total_with_tax > (float) $preview['max_refundable'] ) {
-			return $this->get_route_error_response(
-				'preview_exceeds_max_refundable',
-				sprintf(
-					/* translators: 1: requested preview total including tax, 2: remaining refundable */
-					__( 'Requested refund preview (%1$s) exceeds the remaining refundable amount (%2$s).', 'woocommerce' ),
-					wc_format_decimal( $preview_total_with_tax, wc_get_price_decimals() ),
-					$preview['max_refundable']
-				),
-				WP_Http::UNPROCESSABLE_ENTITY
-			);
+			return $this->get_route_error_response_from_object( $preview, $status );
 		}
 
 		return rest_ensure_response( $preview );

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -1226,6 +1226,144 @@ class DataUtils {
 	}
 
 	/**
+	 * Run the full refund preview pipeline for one request.
+	 *
+	 * Normalizes the caller-supplied refund_total values, validates the line
+	 * items, builds the preview, and applies the two aggregate guards (a
+	 * non-positive total, and a total exceeding the order's remaining
+	 * refundable amount). Shared by the wc/v3 and wc/v4 preview endpoints so
+	 * a fix lands once; error codes are emitted unprefixed and each caller
+	 * applies its own surface convention (wc/v3 prefixes with
+	 * `woocommerce_rest_`, wc/v4 wraps in its error envelope).
+	 *
+	 * @param WC_Order $order      The order the preview is computed for.
+	 * @param array    $line_items Line items in schema format (line_item_id keyed).
+	 * @param string   $log_source Log source for invariant violations, per caller.
+	 * @return array|WP_Error Preview data, or WP_Error carrying its HTTP status in the error data.
+	 *
+	 * @since 11.1.0
+	 */
+	public function compute_refund_preview_or_error( WC_Order $order, array $line_items, string $log_source ) {
+		// Round caller-supplied refund_total values once, up front, so validation and
+		// the computed preview use the same precision the create flow stores. Reused
+		// for both validate and build below.
+		$line_items = $this->normalize_refund_totals( $line_items );
+
+		$validation_error = $this->validate_preview_line_items( $line_items, $order );
+
+		if ( is_wp_error( $validation_error ) ) {
+			return $validation_error;
+		}
+
+		try {
+			$preview = $this->build_refund_preview( $order, $line_items );
+		} catch ( \InvalidArgumentException $e ) {
+			// validate_preview_line_items above should have caught any bad input.
+			// If build_refund_preview still throws InvalidArgumentException, treat
+			// it as a server-side invariant violation, log for observability, and
+			// return a generic message (do not leak internal IDs to clients).
+			wc_get_logger()->error(
+				sprintf( 'Refund preview invariant violation on order %d: %s', $order->get_id(), $e->getMessage() ),
+				array( 'source' => $log_source )
+			);
+			return new WP_Error(
+				'invalid_preview_request',
+				__( 'The refund preview could not be generated due to an unexpected error.', 'woocommerce' ),
+				array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
+			);
+		} catch ( \Throwable $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Refund preview unexpected error on order %d: %s', $order->get_id(), $e->getMessage() ),
+				array( 'source' => $log_source )
+			);
+			return new WP_Error(
+				'unexpected_preview_error',
+				__( 'An unexpected error occurred while generating the refund preview.', 'woocommerce' ),
+				array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
+			);
+		}
+
+		// Reject a non-positive aggregate total up front. A refund of only a negative
+		// discount line, or a product plus discount that nets to zero, would otherwise
+		// preview successfully and then fail at create time.
+		if ( (float) $preview['total'] <= 0 ) {
+			return new WP_Error(
+				'invalid_refund_amount',
+				__( 'Refund total must be greater than zero.', 'woocommerce' ),
+				array( 'status' => WP_Http::BAD_REQUEST )
+			);
+		}
+
+		// Final guard: even when per-line validation passes, the aggregate
+		// preview total can still exceed the order's remaining refundable
+		// amount (e.g. an amount-only partial refund applied previously).
+		// `total` is already tax-inclusive; compare directly against max_refundable.
+		$preview_total_with_tax = abs( (float) $preview['total'] );
+		if ( $preview_total_with_tax > (float) $preview['max_refundable'] ) {
+			return new WP_Error(
+				'preview_exceeds_max_refundable',
+				sprintf(
+					/* translators: 1: requested preview total including tax, 2: remaining refundable */
+					__( 'Requested refund preview (%1$s) exceeds the remaining refundable amount (%2$s).', 'woocommerce' ),
+					wc_format_decimal( $preview_total_with_tax, wc_get_price_decimals() ),
+					$preview['max_refundable']
+				),
+				array( 'status' => WP_Http::UNPROCESSABLE_ENTITY )
+			);
+		}
+
+		return $preview;
+	}
+
+	/**
+	 * Get the REST argument schema for a preview request's line_items parameter.
+	 *
+	 * Shared by the wc/v3 and wc/v4 preview endpoints so the accepted payload
+	 * cannot drift between versions.
+	 *
+	 * @return array
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_preview_line_items_arg_schema(): array {
+		return array(
+			'description'       => __( 'Line items to include in the refund preview.', 'woocommerce' ),
+			'type'              => 'array',
+			'required'          => true,
+			'minItems'          => 1,
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type'                 => 'object',
+				'required'             => array( 'line_item_id' ),
+				'additionalProperties' => false,
+				'properties'           => array(
+					'line_item_id' => array(
+						'description' => __( 'ID of the original order line item.', 'woocommerce' ),
+						'type'        => 'integer',
+						'minimum'     => 1,
+					),
+					'quantity'     => array(
+						'description' => __( 'Quantity to refund. Required when refund_total is omitted.', 'woocommerce' ),
+						'type'        => 'integer',
+						'minimum'     => 1,
+					),
+					'refund_total' => array(
+						// No `minimum` here on purpose: validate_preview_line_items() owns
+						// the sign rule and returns the actionable `invalid_refund_total`
+						// code. A refund_total must be non-zero and match the line's sign —
+						// negative is valid for a discount/credit line, positive for a normal
+						// line; zero and wrong-sign values are rejected. A schema `minimum`
+						// would wrongly forbid the negative form, and a generic
+						// `rest_invalid_param` is less useful to clients.
+						'description' => __( 'Tax-inclusive amount to refund for this line item. Must be non-zero and match the line\'s sign (negative for discount or credit lines, positive otherwise). Required when quantity is omitted.', 'woocommerce' ),
+						'type'        => array( 'number', 'null' ),
+					),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Pre-compute refund data for all line items in an order.
 	 *
 	 * Loads refunds once and builds lookup maps for refunded quantities and totals per item ID,

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -693,6 +693,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 				'id'  => 0,
 				'src' => '',
 			),
+			'can_be_refunded'  => false,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -1175,8 +1176,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 47, count( $properties ) );
+		$this->assertEquals( 48, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'can_be_refunded', $properties );
 	}
 
 	/**
@@ -1191,8 +1193,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 17, count( $line_item_properties ) );
+		$this->assertEquals( 18, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
+		$this->assertArrayHasKey( 'can_be_refunded', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
 		$this->assertSame( array( 'string', 'null' ), $line_item_properties['parent_name']['type'] );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-preview-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-preview-test.php
@@ -64,6 +64,9 @@ class WC_REST_Order_Refunds_Preview_Test extends WC_REST_Unit_Test_Case {
 	public function tearDown(): void {
 		remove_all_filters( 'woocommerce_rest_prepare_order_refund_preview' );
 
+		global $wp_rest_additional_fields;
+		unset( $wp_rest_additional_fields['order_refund_preview'] );
+
 		parent::tearDown();
 	}
 
@@ -781,6 +784,122 @@ class WC_REST_Order_Refunds_Preview_Test extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A field registered for order_refund_preview is populated in the response and advertised in the schema.
+	 */
+	public function test_preview_registered_rest_field_in_response_and_schema(): void {
+		register_rest_field(
+			'order_refund_preview',
+			'registered_field',
+			array(
+				'get_callback' => function () {
+					return 'registered_value';
+				},
+				'schema'       => array(
+					'description' => 'Test field.',
+					'type'        => 'string',
+				),
+			)
+		);
+
+		$order   = $this->create_order_with_product( 10.00, 1 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+				),
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'registered_value', $response->get_data()['registered_field'] );
+
+		$options = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders/' . $order->get_id() . '/refunds/preview' );
+		$schema  = $this->server->dispatch( $options )->get_data()['schema'];
+		$this->assertArrayHasKey( 'registered_field', $schema['properties'] );
+	}
+
+	/**
+	 * @testdox A registered field without a schema is still populated, matching core back-compat.
+	 */
+	public function test_preview_schema_less_registered_field_is_populated(): void {
+		register_rest_field(
+			'order_refund_preview',
+			'schema_less_field',
+			array(
+				'get_callback' => function () {
+					return 'schema_less_value';
+				},
+			)
+		);
+
+		$order   = $this->create_order_with_product( 10.00, 1 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+				),
+			)
+		);
+
+		// Core deliberately includes fields registered without a schema; a
+		// schema-derived allowlist alone would silently drop them.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'schema_less_value', $response->get_data()['schema_less_field'] );
+	}
+
+	/**
+	 * @testdox A registered field's callback does not run when _fields excludes it.
+	 */
+	public function test_preview_registered_field_callback_skipped_when_not_requested(): void {
+		$executed = false;
+		register_rest_field(
+			'order_refund_preview',
+			'expensive_field',
+			array(
+				'get_callback' => function () use ( &$executed ) {
+					$executed = true;
+					return 'expensive_value';
+				},
+				'schema'       => array(
+					'description' => 'Test field.',
+					'type'        => 'string',
+				),
+			)
+		);
+
+		$order   = $this->create_order_with_product( 10.00, 1 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() . '/refunds/preview' );
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'line_item_id' => $item_id,
+						'quantity'     => 1,
+					),
+				),
+			)
+		);
+		$request->set_param( '_fields', 'total' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $executed, 'The excluded field callback must not execute.' );
+		$data = rest_filter_response_fields( $response, $this->server, $request )->get_data();
+		$this->assertArrayNotHasKey( 'expensive_field', $data );
+		$this->assertArrayHasKey( 'total', $data );
+	}
+
+	/**
 	 * @testdox The woocommerce_rest_prepare_order_refund_preview filter can mutate the response.
 	 */
 	public function test_preview_filter_can_mutate_response(): void {
@@ -823,6 +942,114 @@ class WC_REST_Order_Refunds_Preview_Test extends WC_REST_Unit_Test_Case {
 		foreach ( array( 'breakdown', 'subtotal', 'tax', 'total', 'max_refundable' ) as $property ) {
 			$this->assertArrayHasKey( $property, $data['schema']['properties'], "Schema should declare the {$property} property." );
 		}
+	}
+
+	/**
+	 * @testdox A negative refund_total is accepted for a discount line when the aggregate stays positive.
+	 */
+	public function test_preview_negative_refund_total_on_discount_line(): void {
+		$order = $this->create_order_with_product_and_discount( 50.00, 1, -10.00 );
+
+		$product_item_id  = $this->get_first_line_item_id( $order );
+		$discount_item_id = 0;
+		foreach ( $order->get_items( 'fee' ) as $item ) {
+			$discount_item_id = $item->get_id();
+		}
+		$this->assertGreaterThan( 0, $discount_item_id, 'Order should carry a discount fee line.' );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $product_item_id,
+					'quantity'     => 1,
+				),
+				array(
+					'line_item_id' => $discount_item_id,
+					'refund_total' => -10.00,
+				),
+			)
+		);
+
+		// The discount line's negative amount nets against the product: 50 - 10 = 40.
+		// A discount-only preview would be rejected by the aggregate guard by design;
+		// this pairing is where the per-line sign rule and that guard interact.
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( '40.00', $data['total'] );
+	}
+
+	/**
+	 * @testdox An unknown key inside a line item is rejected by the argument schema.
+	 */
+	public function test_preview_unknown_line_item_key_rejected(): void {
+		$order   = $this->create_order_with_product( 10.00, 1 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+					'unexpected'   => 'value',
+				),
+			)
+		);
+
+		// additionalProperties => false: clients relying on strict payloads (the
+		// mobile apps send exactly the declared keys) get an explicit rejection
+		// rather than silently ignored input.
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @testdox GET on the preview route is rejected; only POST is registered.
+	 */
+	public function test_preview_get_method_rejected(): void {
+		$order = $this->create_order_with_product( 10.00, 1 );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/refunds/preview' );
+		$response = $this->server->dispatch( $request );
+
+		// WP answers a wrong method on this route with `rest_no_route` — the same
+		// code clients use as the "endpoint missing" signal, so a client mistakenly
+		// issuing GET would look like an ineligible store rather than a client bug.
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'rest_no_route', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @testdox max_refundable reflects the remaining refundable amount after a prior partial refund.
+	 */
+	public function test_preview_max_refundable_value_after_partial_refund(): void {
+		$order   = $this->create_order_with_product( 50.00, 2 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 30.00,
+				'reason'   => 'Partial refund',
+			)
+		);
+		$this->assertNotWPError( $refund );
+
+		$response = $this->do_preview_request(
+			$order->get_id(),
+			array(
+				array(
+					'line_item_id' => $item_id,
+					'quantity'     => 1,
+				),
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( '50.00', $data['total'] );
+		$this->assertEquals( '70.00', $data['max_refundable'] );
 	}
 
 	/**
@@ -937,6 +1164,39 @@ class WC_REST_Order_Refunds_Preview_Test extends WC_REST_Unit_Test_Case {
 		$fee->save();
 		$order->add_item( $fee );
 		$order->set_total( $total );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Create a completed order with a product line and a negative (discount) fee line.
+	 *
+	 * @param float $unit_price Product unit price.
+	 * @param int   $quantity   Product quantity.
+	 * @param float $discount   Negative fee total representing the discount.
+	 * @return WC_Order
+	 */
+	private function create_order_with_product_and_discount( float $unit_price, int $quantity, float $discount ): WC_Order {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( $unit_price );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, $quantity );
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'  => 'Discount',
+				'total' => $discount,
+			)
+		);
+		$fee->save();
+		$order->add_item( $fee );
+
+		$order->calculate_totals();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-can-be-refunded-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-can-be-refunded-test.php
@@ -1,0 +1,496 @@
+<?php
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+
+/**
+ * Integration tests for the can_be_refunded field on wc/v3 order responses.
+ *
+ * @group orders-can-be-refunded
+ */
+class WC_REST_Orders_Can_Be_Refunded_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Shared admin user ID. Created once per class to avoid the wp_insert_user cost
+	 * on every test.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Create the shared admin user once per class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'v3_cbr_admin_' . wp_generate_password( 6, false ),
+				'user_email' => 'v3_cbr_admin_' . wp_generate_password( 6, false ) . '@example.com',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		if ( is_wp_error( self::$user_id ) ) {
+			self::fail( 'Could not create test admin user: ' . self::$user_id->get_error_message() );
+		}
+		self::$user_id = (int) self::$user_id;
+	}
+
+	/**
+	 * Delete the shared admin user once per class.
+	 */
+	public static function tearDownAfterClass(): void {
+		if ( self::$user_id ) {
+			wp_delete_user( self::$user_id );
+			self::$user_id = 0;
+		}
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * @testdox A fresh unrefunded order has can_be_refunded true at order and line item level.
+	 */
+	public function test_fresh_order_can_be_refunded(): void {
+		$order = $this->create_order_with_product( 25.00, 2 );
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['can_be_refunded'] );
+		$this->assertTrue( $data['line_items'][0]['can_be_refunded'] );
+	}
+
+	/**
+	 * @testdox A fully refunded order has can_be_refunded false at order and line item level.
+	 */
+	public function test_fully_refunded_order(): void {
+		$order   = $this->create_order_with_product( 25.00, 1 );
+		$item_id = $this->get_first_line_item_id( $order );
+
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 25.00,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 1,
+						'refund_total' => 25.00,
+					),
+				),
+			)
+		);
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertFalse( $data['can_be_refunded'] );
+		$this->assertFalse( $data['line_items'][0]['can_be_refunded'] );
+	}
+
+	/**
+	 * @testdox A partially refunded order has mixed can_be_refunded values per line.
+	 */
+	public function test_partially_refunded_order_has_mixed_line_values(): void {
+		$order = wc_create_order();
+
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_a->set_regular_price( 20.00 );
+		$product_a->save();
+		$product_b = WC_Helper_Product::create_simple_product();
+		$product_b->set_regular_price( 30.00 );
+		$product_b->save();
+
+		$item_ids = array();
+		foreach ( array( $product_a, $product_b ) as $product ) {
+			$item = new WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => 1,
+					'subtotal' => (float) $product->get_regular_price(),
+					'total'    => (float) $product->get_regular_price(),
+				)
+			);
+			$item->save();
+			$order->add_item( $item );
+			$item_ids[] = $item->get_id();
+		}
+		$order->set_total( 50.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 20.00,
+				'line_items' => array(
+					$item_ids[0] => array(
+						'qty'          => 1,
+						'refund_total' => 20.00,
+					),
+				),
+			)
+		);
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['can_be_refunded'], 'Order with remaining amount should be refundable.' );
+
+		$lines_by_id = array_column( $data['line_items'], null, 'id' );
+		$this->assertFalse( $lines_by_id[ $item_ids[0] ]['can_be_refunded'], 'Fully refunded line should not be refundable.' );
+		$this->assertTrue( $lines_by_id[ $item_ids[1] ]['can_be_refunded'], 'Untouched line should stay refundable.' );
+
+		$product_a->delete( true );
+		$product_b->delete( true );
+	}
+
+	/**
+	 * @testdox Non-refundable statuses report can_be_refunded false and refundable statuses true.
+	 * @dataProvider status_provider
+	 *
+	 * @param string $status   Order status.
+	 * @param bool   $expected Expected can_be_refunded value.
+	 */
+	public function test_status_gating( string $status, bool $expected ): void {
+		$order = $this->create_order_with_product( 25.00, 1 );
+		$order->set_status( $status );
+		$order->save();
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertSame( $expected, $data['can_be_refunded'], "Status {$status} should report can_be_refunded as " . ( $expected ? 'true' : 'false' ) . '.' );
+	}
+
+	/**
+	 * Data provider for status gating.
+	 *
+	 * @return array
+	 */
+	public function status_provider(): array {
+		return array(
+			'completed'  => array( OrderStatus::COMPLETED, true ),
+			'processing' => array( OrderStatus::PROCESSING, true ),
+			'on-hold'    => array( OrderStatus::ON_HOLD, true ),
+			'pending'    => array( OrderStatus::PENDING, false ),
+			'cancelled'  => array( OrderStatus::CANCELLED, false ),
+			'failed'     => array( OrderStatus::FAILED, false ),
+		);
+	}
+
+	/**
+	 * @testdox A custom line item without a product has can_be_refunded false.
+	 */
+	public function test_line_item_without_product_not_refundable(): void {
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'name'     => 'Custom item',
+				'quantity' => 1,
+				'subtotal' => 10.00,
+				'total'    => 10.00,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertFalse( $data['line_items'][0]['can_be_refunded'], 'A line without a product cannot be refunded by quantity.' );
+	}
+
+	/**
+	 * @testdox A zero-priced product line item follows quantity logic.
+	 */
+	public function test_zero_priced_item_follows_quantity_logic(): void {
+		$order = $this->create_order_with_product( 0.00, 1 );
+		// Unrelated remaining amount so the order stays refundable.
+		$order->set_total( 10.00 );
+		$order->save();
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['line_items'][0]['can_be_refunded'], 'A zero-priced line with unrefunded quantity should be refundable.' );
+	}
+
+	/**
+	 * @testdox Shipping and fee lines with remaining amounts have can_be_refunded true.
+	 */
+	public function test_shipping_and_fee_lines_refundable(): void {
+		$order = $this->create_order_with_shipping_and_fee( 15.00, 7.50 );
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['shipping_lines'][0]['can_be_refunded'] );
+		$this->assertTrue( $data['fee_lines'][0]['can_be_refunded'] );
+	}
+
+	/**
+	 * @testdox Fully refunded shipping and fee lines have can_be_refunded false.
+	 */
+	public function test_fully_refunded_shipping_and_fee_lines(): void {
+		$order = $this->create_order_with_shipping_and_fee( 15.00, 7.50 );
+
+		$line_items = array();
+		foreach ( $order->get_items( array( 'shipping', 'fee' ) ) as $item_id => $item ) {
+			$line_items[ $item_id ] = array(
+				'qty'          => 0,
+				'refund_total' => (float) $item->get_total(),
+			);
+		}
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 22.50,
+				'line_items' => $line_items,
+			)
+		);
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertFalse( $data['shipping_lines'][0]['can_be_refunded'] );
+		$this->assertFalse( $data['fee_lines'][0]['can_be_refunded'] );
+	}
+
+	/**
+	 * @testdox A discount (negative-total) fee line with no prior refund reports can_be_refunded true.
+	 */
+	public function test_negative_fee_line_can_be_refunded(): void {
+		$order = wc_create_order();
+		$fee   = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'  => 'Discount',
+				'total' => -5.00,
+			)
+		);
+		$fee->save();
+		$order->add_item( $fee );
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['fee_lines'][0]['can_be_refunded'], 'Negative fee lines are compared on an absolute basis.' );
+	}
+
+	/**
+	 * @testdox The list endpoint returns can_be_refunded for all orders.
+	 */
+	public function test_list_endpoint_returns_field(): void {
+		$refundable = $this->create_order_with_product( 25.00, 1 );
+		$pending    = $this->create_order_with_product( 25.00, 1 );
+		$pending->set_status( OrderStatus::PENDING );
+		$pending->save();
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$orders_by_id = array_column( $response->get_data(), null, 'id' );
+		$this->assertTrue( $orders_by_id[ $refundable->get_id() ]['can_be_refunded'] );
+		$this->assertFalse( $orders_by_id[ $pending->get_id() ]['can_be_refunded'] );
+	}
+
+	/**
+	 * @testdox The can_be_refunded field is read-only and ignored in write requests.
+	 */
+	public function test_field_is_read_only(): void {
+		$order = $this->create_order_with_product( 25.00, 1 );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_body_params( array( 'can_be_refunded' => true ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $response->get_data()['can_be_refunded'], 'A client-supplied can_be_refunded value must be ignored.' );
+	}
+
+	/**
+	 * @testdox The field respects _fields filtering in both directions.
+	 */
+	public function test_fields_filtering(): void {
+		$order = $this->create_order_with_product( 25.00, 1 );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_param( '_fields', 'id,can_be_refunded' );
+		$data = $this->server->dispatch( $request )->get_data();
+		$this->assertArrayHasKey( 'can_be_refunded', $data );
+		$this->assertTrue( $data['can_be_refunded'] );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_param( '_fields', 'id,status' );
+		$data = $this->server->dispatch( $request )->get_data();
+		$this->assertArrayNotHasKey( 'can_be_refunded', $data );
+	}
+
+	/**
+	 * @testdox The wc/v2 orders endpoint does not contain the field.
+	 */
+	public function test_v2_endpoint_does_not_contain_field(): void {
+		$order = $this->create_order_with_product( 25.00, 1 );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayNotHasKey( 'can_be_refunded', $data );
+		$this->assertArrayNotHasKey( 'can_be_refunded', $data['line_items'][0] );
+	}
+
+	/**
+	 * @testdox The schema declares can_be_refunded as a read-only boolean at order and line level.
+	 */
+	public function test_schema_declares_field(): void {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders' );
+		$response = $this->server->dispatch( $request );
+		$schema   = $response->get_data()['schema'];
+
+		$this->assertSame( 'boolean', $schema['properties']['can_be_refunded']['type'] );
+		$this->assertTrue( $schema['properties']['can_be_refunded']['readonly'] );
+		foreach ( array( 'line_items', 'shipping_lines', 'fee_lines' ) as $section ) {
+			$this->assertArrayHasKey( 'can_be_refunded', $schema['properties'][ $section ]['items']['properties'], "The {$section} item schema should declare can_be_refunded." );
+		}
+	}
+
+	/**
+	 * @testdox A fully refunded fee line with tax is not refundable at zero-decimal precision.
+	 */
+	public function test_zero_decimal_currency_fee_line(): void {
+		$order = $this->create_order_with_shipping_and_fee( 0.00, 100.00 );
+		$items = $order->get_items( 'fee' );
+		$fee   = reset( $items );
+
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 100.00,
+				'line_items' => array(
+					$fee->get_id() => array(
+						'qty'          => 0,
+						'refund_total' => 100.00,
+					),
+				),
+			)
+		);
+
+		add_filter( 'wc_get_price_decimals', '__return_zero' );
+
+		try {
+			$data = $this->get_order_response( $order->get_id() );
+
+			$this->assertFalse( $data['fee_lines'][0]['can_be_refunded'], 'A fully refunded fee line must not be refundable at 0dp.' );
+		} finally {
+			remove_filter( 'wc_get_price_decimals', '__return_zero' );
+		}
+	}
+
+	/**
+	 * Create a completed order with a single product line item.
+	 *
+	 * @param float $unit_price Unit price.
+	 * @param int   $quantity   Quantity.
+	 * @return WC_Order
+	 */
+	private function create_order_with_product( float $unit_price, int $quantity ): WC_Order {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( $unit_price );
+		$product->save();
+
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => $quantity,
+				'subtotal' => $unit_price * $quantity,
+				'total'    => $unit_price * $quantity,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_total( $unit_price * $quantity );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Create a completed order with one shipping line and one fee line.
+	 *
+	 * @param float $shipping_total Shipping total.
+	 * @param float $fee_total      Fee total.
+	 * @return WC_Order
+	 */
+	private function create_order_with_shipping_and_fee( float $shipping_total, float $fee_total ): WC_Order {
+		$order = wc_create_order();
+
+		$shipping = new WC_Order_Item_Shipping();
+		$shipping->set_props(
+			array(
+				'method_title' => 'Flat Rate',
+				'total'        => $shipping_total,
+			)
+		);
+		$shipping->save();
+		$order->add_item( $shipping );
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'  => 'Service fee',
+				'total' => $fee_total,
+			)
+		);
+		$fee->save();
+		$order->add_item( $fee );
+
+		$order->set_total( $shipping_total + $fee_total );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Get the first line item ID from an order.
+	 *
+	 * @param WC_Order $order Order instance.
+	 * @return int Line item ID.
+	 */
+	private function get_first_line_item_id( WC_Order $order ): int {
+		$items = $order->get_items( 'line_item' );
+		$item  = reset( $items );
+		return $item->get_id();
+	}
+
+	/**
+	 * Fetch a single order through the v3 REST API and return the response data.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return array
+	 */
+	private function get_order_response( int $order_id ): array {
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order_id );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		return $response->get_data();
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-can-be-refunded-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-can-be-refunded-test.php
@@ -154,6 +154,38 @@ class WC_REST_Orders_Can_Be_Refunded_Test extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A product line whose value is exhausted by an amount-only refund is not refundable despite remaining quantity.
+	 */
+	public function test_value_exhausted_line_not_refundable_despite_remaining_quantity(): void {
+		$order = $this->create_order_with_product( 50.00, 1 );
+		// Extra unallocated amount keeps the order refundable after the line is exhausted,
+		// so the order-level flag does not mask the line-level one.
+		$order->set_total( 60.00 );
+		$order->save();
+		$item_id = $this->get_first_line_item_id( $order );
+
+		// Amount-only refund (qty 0) consumes the line's full monetary value while
+		// leaving its quantity untouched.
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 50.00,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 0,
+						'refund_total' => 50.00,
+					),
+				),
+			)
+		);
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['can_be_refunded'], 'Order with a remaining amount should stay refundable.' );
+		$this->assertFalse( $data['line_items'][0]['can_be_refunded'], 'A line with no remaining value must not be refundable even with remaining quantity.' );
+	}
+
+	/**
 	 * @testdox Non-refundable statuses report can_be_refunded false and refundable statuses true.
 	 * @dataProvider status_provider
 	 *

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -125,6 +125,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			'is_editable',
 			'needs_payment',
 			'needs_processing',
+			'can_be_refunded',
 		);
 
 		if ( $with_cogs_enabled ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-can-be-refunded-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version4/Orders/class-wc-rest-orders-v4-can-be-refunded-test.php
@@ -143,6 +143,37 @@ class WC_REST_Orders_V4_Can_Be_Refunded_Test extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A product line whose value is exhausted by an amount-only refund is not refundable despite remaining quantity.
+	 */
+	public function test_value_exhausted_line_not_refundable_despite_remaining_quantity(): void {
+		$order      = $this->create_order_with_product();
+		$line_item  = current( $order->get_items() );
+		$line_total = (float) $line_item->get_total() + (float) $line_item->get_total_tax();
+
+		// Amount-only refund (qty 0) consumes the line's full monetary value while
+		// leaving its quantity untouched. The order keeps a remaining amount
+		// (shipping), so the order-level flag does not mask the line-level one.
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $line_total,
+				'line_items' => array(
+					$line_item->get_id() => array(
+						'qty'          => 0,
+						'refund_total' => $line_total,
+						'refund_tax'   => array(),
+					),
+				),
+			)
+		);
+
+		$data = $this->get_order_response( $order->get_id() );
+
+		$this->assertTrue( $data['can_be_refunded'], 'Order with a remaining amount should stay refundable' );
+		$this->assertFalse( $data['line_items'][0]['can_be_refunded'], 'A line with no remaining value must not be refundable even with remaining quantity' );
+	}
+
+	/**
 	 * @testdox Partially refunded order has mixed can_be_refunded values.
 	 */
 	public function test_partially_refunded_order(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Linear: [WOOMOB-3715](https://linear.app/a8c/issue/WOOMOB-3715/port-the-refunds-enhancements-to-wcv3-option-a)

**Stacked on #67043** (third of three PRs porting the wc/v4 refunds enhancements to wc/v3).

Adds a read only `can_be_refunded` boolean to wc/v3 order responses, at order level (status in completed, processing, or on-hold, and a remaining refundable amount above zero) and on product, shipping, and fee lines (remaining refundable quantity or amount). API clients currently compute this client side for every rendered order, loading each order's refunds to do it.

The computation mirrors the wc/v4 Orders schema. Values are read from the order item objects rather than the prepared response data, so the result reflects the stored line data and matches wc/v4 (including lines whose stored `product_id` is 0, which are not refundable by quantity). Shipping and fee lines are compared on a tax inclusive absolute basis rounded to currency precision, which handles negative (discount) lines and sub cent residues. Computation is lazy: the order level value is guarded by `rest_is_field_included`, and per line refund data is computed once per order only when line sections are present in the response, reducing to a single cached `get_refunds()` call for orders with no refunds.

Response time impact was measured with seeded cohorts (orders with no refunds and orders with several partial refunds each, on list and single requests): query counts were identical with and without the field, and latency differences stayed within run to run noise. The refund data the field needs is already loaded for the existing `refunds` response field.

Review follow-up: product lines now also require remaining monetary value, not just remaining quantity. An amount-only refund (quantity 0) can exhaust a line's value while leaving its quantity untouched; the field previously advertised such lines as refundable while the refund endpoints reject them as already refunded. Zero-priced lines keep their quantity-only behavior (restock-only refunds). The same rule is applied to the wc/v4 Orders schema so both versions stay consistent (changelog entry included; v4 is feature-flagged off in production).

**Backward compatibility impact:** additive read only response fields on wc/v3 only; wc/v2 is unchanged and covered by a test. No request parameters or hooks change. Clients using `_fields` are unaffected unless they request the new field. Not tested under multisite; the change reads only per order data through standard order APIs, no site scoped or network scoped state is involved.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order with two product lines, a shipping line, and a fee line; set it to `completed`.
2. `GET /wp-json/wc/v3/orders/<id>` and verify `can_be_refunded` is `true` at order level and on every line.
3. Fully refund one product line and verify only that line flips to `false` while the order stays `true`; fully refund the order and verify everything reports `false`.
4. Verify `GET /wp-json/wc/v3/orders/<id>?_fields=id,status` omits the field and `_fields=id,can_be_refunded` includes it.
5. Verify `GET /wp-json/wc/v2/orders/<id>` does not contain the field.
6. Run `pnpm test:php:env -- --filter WC_REST_Orders_Can_Be_Refunded_Test`.

<!-- End testing instructions -->

### Testing that has already taken place:

- Integration tests: status gating, fully and partially refunded orders and lines, product-less and zero priced lines, negative fee lines, shipping and fee lines with tax, list endpoint coverage, read only enforcement, `_fields` filtering, wc/v2 absence, and currency precision. The legacy v3 API test expectations were updated for the new field.
- The response time measurement described above.
- phpcs and PHPStan pass on the changed files.
- Verified on a local wp-env store running a production zip build of this branch.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually: `plugins/woocommerce/changelog/add-v3-orders-can-be-refunded`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
