### PR TITLE
Fix changelogger destroying major entries on package release

### DIFF
--- a/tools/changelogger/class-formatter.php
+++ b/tools/changelogger/class-formatter.php
@@ -27,6 +27,14 @@ class Formatter extends KeepAChangelogParser {
 	use PluginTrait;
 
 	/**
+	 * Marker appended after the significance of a major change. Written by format() and stripped by
+	 * parse(), so both sides must share this definition for a changelog to survive a round trip.
+	 *
+	 * @var string
+	 */
+	const BREAKING_CHANGE_MARKER = '[ **BREAKING CHANGE** ]';
+
+	/**
 	 * Bullet for changes.
 	 *
 	 * @var string
@@ -178,9 +186,14 @@ class Formatter extends KeepAChangelogParser {
 				$changes = array();
 				$rows    = explode( "\n", $content );
 				foreach ( $rows as $row ) {
-					$row          = trim( $row );
-					$row          = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
-					$row_segments = explode( ' - ', $row );
+					$row = trim( $row );
+					$row = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
+					// Drop the marker that format() appends after a major significance, otherwise it lands in the
+					// significance segment below and the entry is re-emitted with no significance at all.
+					$row = preg_replace( '/^(major)\s*' . preg_quote( self::BREAKING_CHANGE_MARKER, '/' ) . '/i', '$1', $row );
+
+					// Limit the split so that content containing " - " is not truncated at its own separator.
+					$row_segments = explode( ' - ', $row, 2 );
 					$significance = trim( strtolower( $row_segments[0] ) );
 
 					array_push(
@@ -253,7 +266,7 @@ class Formatter extends KeepAChangelogParser {
 			foreach ( $entry->getChangesBySubheading() as $heading => $changes ) {
 				foreach ( $changes as $change ) {
 					$significance    = $change->getSignificance();
-					$breaking_change = 'major' === $significance ? ' [ **BREAKING CHANGE** ]' : '';
+					$breaking_change = 'major' === $significance ? ' ' . self::BREAKING_CHANGE_MARKER : '';
 					$text            = trim( $change->getContent() );
 					if ( '' !== $text ) {
 						$preamble = $is_subentry ? '' : $bullet . ucfirst( $significance ) . $breaking_change . ' - ';

--- a/tools/changelogger/class-formatter.php
+++ b/tools/changelogger/class-formatter.php
@@ -187,7 +187,12 @@ class Formatter extends KeepAChangelogParser {
 				$rows    = explode( "\n", $content );
 				foreach ( $rows as $row ) {
 					$row = trim( $row );
-					$row = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
+					// Strip the bullet only as a literal prefix. It is configurable ('* ' in the legacy core
+					// formatter), so it is not safe to interpolate into a pattern, and removing a later
+					// occurrence would corrupt the entry text.
+					if ( 0 === strpos( $row, $this->bullet ) ) {
+						$row = substr( $row, strlen( $this->bullet ) );
+					}
 					// Drop the marker that format() appends after a major significance, otherwise it lands in the
 					// significance segment below and the entry is re-emitted with no significance at all.
 					$row = preg_replace( '/^(major)\s*' . preg_quote( self::BREAKING_CHANGE_MARKER, '/' ) . '/i', '$1', $row );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The changelogger rewrites a package's **entire** `CHANGELOG.md` on every release, so `parse()` has to read back exactly what `format()` writes. It doesn't, and released history is silently destroyed as a result.

Two ways it fails to round-trip:

-   **Breaking-change markers are lost.** `format()` writes `Major [ **BREAKING CHANGE** ] - …`, but `parse()` couldn't read the marker back, so the next release re-emitted the entry as `-    - …`. The annotation disappears from published history and the 5-space indent fails markdownlint (`MD007`).
-   **Entry text is truncated.** Any entry whose text contains `" - "` lost everything after it.

This already corrupted two entries in `@woocommerce/email-editor` and blocked the markdown check on the current release prep ([failed build](https://github.com/woocommerce/woocommerce/actions/runs/30347720683/job/90237808694?pr=67054)). It isn't limited to that package — **11 entries across 6 packages** carry the marker today and break the next time their package is released: `dependency-extraction-webpack-plugin` (4), `components` (2), `email-editor` (2), `customer-effort-score`, `data` and `currency` (1 each). Three further entries in `data`, `currency` and `onboarding` are set up to be truncated.

Both bugs have been there since the formatter was added. They went unnoticed because `major` entries are rare and nothing tests the round trip.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The meaningful test is running a real changelog through `parse()` → `format()` and confirming nothing changes.

1. Set up the harness below (the formatter needs `jetpack-changelogger`, which isn't vendored in the monorepo).
2. Run it against `trunk`: the two `Major [ **BREAKING CHANGE** ]` entries are reported as altered, alongside `ucfirst(null)` deprecation notices.
3. Run it against this branch: `altered: 0`, no deprecations.
4. Confirm normal entries are untouched, and that an entry containing `" - "` (e.g. `packages/js/currency/CHANGELOG.md:22`) keeps its full text.

<details>
<summary>Harness</summary>

```sh
mkdir /tmp/cltest && cd /tmp/cltest
composer require automattic/jetpack-changelogger:3.3.0
```

Save as `/tmp/cltest/roundtrip.php`, then run `php /tmp/cltest/roundtrip.php /path/to/woocommerce`:

```php
<?php
require __DIR__ . '/vendor/autoload.php';
$dir = $argv[1];
require_once $dir . '/tools/changelogger/class-formatter.php';
require_once $dir . '/tools/changelogger/class-package-formatter.php';
chdir( $dir . '/packages/js/email-editor' ); // release links are derived from cwd
$f    = new Automattic\WooCommerce\MonorepoTools\Changelogger\Package_Formatter();
$in   = file_get_contents( 'CHANGELOG.md' );
$out  = $f->format( $f->parse( $in ) );
$pick = fn( $t ) => array_filter( array_map( 'trim', explode( "\n", $t ) ), fn( $l ) => str_starts_with( $l, '-' ) );
$a = $pick( $in ); $b = $pick( $out );
sort( $a ); sort( $b );
$lost = array_diff( $a, $b );
echo 'entries in: ' . count( $a ) . ', altered: ' . count( $lost ) . "\n";
foreach ( $lost as $l ) { echo "  $l\n"; }
```

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

Ran the harness against the real `@woocommerce/email-editor` changelog (106 entries) on PHP 8.2.28:

| | Entries altered | `ucfirst(null)` deprecation |
| --- | --- | --- |
| `trunk` | 2 (both `Major`) | yes |
| This branch | 0 | no |

Also confirmed that a second consecutive run no longer perturbs the file, and that `phpcs` reports no new violations (the 3 `EscapeOutput` errors are pre-existing on `trunk`, in untouched code).

**Not covered:** no automated test guards this round trip, because `tools/changelogger/` has no test harness at all. Adding one is a larger change, deliberately out of scope here.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Internal release tooling under `tools/changelogger/`; nothing here ships to merchants. Matches the precedent of previous changelogger-only changes (#33645, #33800, #35642), none of which carried changelog entries.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
