### PR TITLE
ci: stop running Metrics and PHP 7.4 WP latest-1 on PRs; cap CI artifact retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,7 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
           overwrite: true
+          retention-days: 3
 
       - name: 'Upload artifacts'
         if: ${{ always() && matrix.report.resultsPath != '' }}
@@ -386,6 +387,7 @@ jobs:
         with:
           name: '${{ matrix.report.resultsBlobName }}__${{ strategy.job-index }}'
           path: ${{ env.ARTIFACTS_PATH }}
+          retention-days: 7
 
   evaluate-project-jobs:
     # In order to add a required status check we need a consistent job that we can grab onto.
@@ -495,6 +497,7 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           pattern: ${{ matrix.report }}__*
           delete-merged: true
+          retention-days: 14
 
       - name: 'Publish report to dashboard'
         if: ${{ !! steps.merge-artifacts.outputs.artifact-id }}

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -182,6 +182,7 @@ jobs:
         with:
           name: contributors-release-${{ needs.extract-versions.outputs.current_version }}
           path: ${{ steps.generate-contributors-list.outputs.filepath }}
+          retention-days: 30
 
       - name: Output artifact URL
         id: output-artifact-url

--- a/plugins/woocommerce/changelog/dev-trim-pr-ci-matrix
+++ b/plugins/woocommerce/changelog/dev-trim-pr-ci-matrix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo CI: run the Metrics and PHP 7.4 WP latest-1 checks on trunk pushes and on-demand triggers only (no longer on pull requests), and cap artifact retention for CI test results and release contributor reports.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -197,7 +197,6 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"push",
 						"php-unit-php-7.4-wp-latest-1"
 					]
@@ -774,7 +773,6 @@
 					},
 					"events": [
 						"push",
-						"pull_request",
 						"perf-metrics"
 					],
 					"report": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of the GH Actions cost-reduction effort discussed in [You've hit 100% of your budget](https://wooengineering.wordpress.com/2026/07/23/youve-hit-100-of-your-budget/). Implements two of the recommendations from that thread plus artifact-retention caps:

1. **`Metrics` no longer runs on `pull_request`** (still runs on trunk pushes and via the `perf-metrics` on-demand trigger). It is an optional check whose failures never block PRs, estimated at ~17,400 runner minutes/month. Endorsed by @adrianmoldovanwp in the thread. Note: the newer `Metrics - unified editor assets` check is `pull_request`-only by design and is intentionally left untouched (removing its only event would make it run on *every* trigger).
2. **`PHP: 7.4 WP: latest - 1` no longer runs on `pull_request`** (still runs on trunk pushes and via the `php-unit-php-7.4-wp-latest-1` on-demand trigger), estimated at ~25,800 runner minutes/month.
3. **Artifact retention caps** on uploads that inherited the 90-day default: Playwright last-run info (3d), test-result blobs (7d), merged reports (14d) in `ci.yml`, and the release contributors HTML (30d).

⚠️ **Reviewer decision needed (item 2):** this is a *coverage-policy* change — PHP 7.4 unit tests would gate trunk pushes but not PRs. Rationale from the P2 thread: it caught nothing in the last two months, the identical check still runs on every trunk push, and PHPCompatibility lints continue to run on every PR. Mechanically safe: branch protection requires only the aggregate `Evaluate Project Job Statuses` check, so PRs will not hang. Per @adrianmoldovanwp's alerting concern, note that failures of this check now surface only via trunk-push runs reported to #woo-tests-reports — if that channel's visibility is considered insufficient, we should improve alerting before or alongside merging item 2. It is a one-line revert if the team prefers to keep it on PRs.

*Not* included, per the thread discussion: removing `PHP: 7.4 WP: pre-release` from PRs (Adrian: keep at least one PHP × WP-prerelease combination on PRs; it only runs when a WP pre-release exists) and the trunk `max-parallel` cap (Adrian: post-merge feedback speed matters — left as an open question for QualityOps).

### How to test the changes in this Pull Request:

1. `node tools/monorepo-utils/bin/run ci-jobs --event pull_request --list` — `Metrics` and `PHP: 7.4 WP: latest - 1` are absent; the job list is otherwise identical to trunk (verified locally: the diff against trunk shows exactly those two removals).
2. `node tools/monorepo-utils/bin/run ci-jobs --event push --list` — both checks still present.
3. `node tools/monorepo-utils/bin/run ci-jobs --event perf-metrics --list` / `--event php-unit-php-7.4-wp-latest-1` — on-demand triggers still produce each job.
4. This PR's own CI run doubles as a live test: both checks should be absent from the checks list while `Evaluate Project Job Statuses` passes.
5. After merge: confirm the first trunk-push run still executes both checks, and that a nightly `tests-on-release` run is unchanged.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

A changelog entry is already included in the branch: `plugins/woocommerce/changelog/dev-trim-pr-ci-matrix` (Significance: patch, Type: dev).


