### PR TITLE
Exclude already selected products from product search results

### DIFF
--- a/plugins/woocommerce/changelog/32085-prevent-product-search-deselect
+++ b/plugins/woocommerce/changelog/32085-prevent-product-search-deselect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enhanced product search multi-selects (e.g. Linked Products) no longer list products that are already selected, so re-clicking a product in the results can no longer silently remove it from the selection.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -268,6 +268,24 @@ jQuery( function ( $ ) {
 								dataType: 'json',
 								delay: 250,
 								data: function ( params ) {
+									var exclude = [];
+
+									if ( $( this ).data( 'exclude' ) ) {
+										exclude = String(
+											$( this ).data( 'exclude' )
+										).split( ',' );
+									}
+
+									// Hide already selected options from the results, so a re-click cannot silently deselect them.
+									if (
+										$( this ).prop( 'multiple' ) &&
+										$( this ).val()
+									) {
+										exclude = exclude.concat(
+											$( this ).val()
+										);
+									}
+
 									return {
 										term: params.term,
 										action:
@@ -275,7 +293,7 @@ jQuery( function ( $ ) {
 											'woocommerce_json_search_products_and_variations',
 										security:
 											wc_enhanced_select_params.search_products_nonce,
-										exclude: $( this ).data( 'exclude' ),
+										exclude: exclude,
 										exclude_type:
 											$( this ).data( 'exclude_type' ),
 										include: $( this ).data( 'include' ),

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -268,22 +268,20 @@ jQuery( function ( $ ) {
 								dataType: 'json',
 								delay: 250,
 								data: function ( params ) {
-									var exclude = [];
+									let exclude = $( this ).data( 'exclude' );
+									const currentValue = $( this ).val();
 
-									if ( $( this ).data( 'exclude' ) ) {
-										exclude = String(
-											$( this ).data( 'exclude' )
-										).split( ',' );
-									}
-
-									// Hide already selected options from the results, so a re-click cannot silently deselect them.
+									// Hide already selected options from the results in multiple selects.
 									if (
-										$( this ).prop( 'multiple' ) &&
-										$( this ).val()
+										Array.isArray( currentValue ) &&
+										$( this ).prop( 'multiple' )
 									) {
-										exclude = exclude.concat(
-											$( this ).val()
-										);
+										const defaultExcluded =
+											String( exclude ).split( ',' );
+										exclude = [
+											...defaultExcluded,
+											...currentValue,
+										];
 									}
 
 									return {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -276,8 +276,9 @@ jQuery( function ( $ ) {
 										Array.isArray( currentValue ) &&
 										$( this ).prop( 'multiple' )
 									) {
-										const defaultExcluded =
-											String( exclude ).split( ',' );
+										const defaultExcluded = exclude
+											? String( exclude ).split( ',' )
+											: [];
 										exclude = [
 											...defaultExcluded,
 											...currentValue,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

selectWoo toggles a multi-select option when it is clicked in the results, so clicking an already selected product in a `wc-product-search` field (Linked Products, coupon restrictions) silently removed it. The AJAX search now merges the field's current selections into the `exclude` parameter, so already selected products are hidden from the results, matching how Gutenberg token selectors behave.

- The chips above the field remain the indicator of what is selected; removal works as before (chip `×`, clear button, backspace).
- A removed product immediately reappears in the search results.
- No PHP changes: `WC_AJAX::json_search_products()` already accepts an array of IDs. Single selects are unchanged.
- BC note: the `exclude` request parameter is now always sent as an array (`exclude[]=...`) instead of a scalar. Core handlers `(array)`-cast and are unaffected; custom `data-action` handlers should accept both shapes. Comma-separated `data-exclude` values are now split client-side, so every listed ID is excluded rather than only the first.

Closes #32085 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create three products with a common name prefix, e.g. "Test Product Alpha", "Test Product Beta", "Test Product Gamma".
2. Edit Alpha, open **Linked Products**, and in **Upsells** type "Test": Beta and Gamma appear (Alpha should not).
3. Select Beta, then type "Test" again: only Gamma should be listed (before this fix, Beta was listed and clicking it removed it from the selection).
4. Remove Beta via its chip `×`, search "Test" again, and confirm Beta reappears in the results.
5. Select Beta and Gamma, confirm both chips remain, and update the product to confirm the upsells persist.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified red to green in wp-env (browser-driven) against the PR's base commit: on base, the selected product stayed in the results and re-clicking it emptied the selection; on this branch, it no longer appears while selected, reappears after removal via its chip `×`, and the saved product persists the right upsells. Also verified the server-side exclusion directly by calling `woocommerce_json_search_products_and_variations` with `exclude[]` values. ESLint passes on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>






