### PR TITLE
Allow showing messages and error notices on the same run, instead on only several errors or several messages

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -159,7 +159,8 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				foreach ( self::$errors as $error ) {
 					echo '<div id="message" class="error inline"><p><strong>' . esc_html( $error ) . '</strong></p></div>';
 				}
-			} elseif ( count( self::$messages ) > 0 ) {
+			}
+			if ( count( self::$messages ) > 0 ) {
 				foreach ( self::$messages as $message ) {
 					echo '<div id="message" class="updated inline"><p><strong>' . esc_html( $message ) . '</strong></p></div>';
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Currently, WooCommerce will only show errors or messages added with `WC_Admin_Settings` `add_error` or `add_message` methods, but not both, although it does allow it to show several errors OR several messages.

This PR allows showing them both.

Closes woocommerce/woocommerce#53397

### Screenshots or screen recordings:

After:

<img src="https://github.com/user-attachments/assets/db45c9e0-7b39-4cf4-8223-59c3a9999231 " alt="image" width="719" data-linear-height="202" />

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Add several errors and messages with `WC_Admin_Settings` `add_error` or `add_message` methods
2. Without this PR only errors show up
3. With this PR they all show up

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [X] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [X] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [X] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Allow showing messages and error notices on the same run, instead on only several errors or several messages

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>