### PR TITLE
Add order withdrawal rate limiting

### DIFF
--- a/plugins/woocommerce/changelog/add-order-withdrawal-rate-limit
+++ b/plugins/woocommerce/changelog/add-order-withdrawal-rate-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rate limit order withdrawal requests by IP address and email.

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -251,9 +251,13 @@ final class OrderWithdrawalFormProcessor {
 	 * @param array<string,string> $data Form data.
 	 */
 	private function submit_order_withdrawal( array $data ): bool {
-		if ( ! $this->check_and_set_rate_limits( $data ) ) {
+		$rate_limit_ids = $this->get_rate_limit_ids( $data );
+
+		if ( ! $this->check_rate_limits( $rate_limit_ids ) ) {
 			return false;
 		}
+
+		$this->set_rate_limits( $rate_limit_ids );
 
 		$matched_order = $this->get_matching_order( $data );
 
@@ -263,6 +267,8 @@ final class OrderWithdrawalFormProcessor {
 					__( 'A withdrawal request has already been submitted for this order. Please contact us if you need help or want to make changes.', 'woocommerce' ),
 					'error'
 				);
+
+				$this->clear_rate_limits( $rate_limit_ids );
 
 				return false;
 			}
@@ -274,6 +280,7 @@ final class OrderWithdrawalFormProcessor {
 
 		if ( ! $this->send_order_withdrawal_emails( $data, $matched_order ) ) {
 			wc_add_notice( __( 'We could not submit your withdrawal request. Please try again or contact us if the problem continues.', 'woocommerce' ), 'error' );
+			$this->clear_rate_limits( $rate_limit_ids );
 
 			return false;
 		}
@@ -286,13 +293,11 @@ final class OrderWithdrawalFormProcessor {
 	}
 
 	/**
-	 * Check and set order withdrawal submission rate limits.
+	 * Check order withdrawal submission rate limits.
 	 *
-	 * @param array<string,string> $data Form data.
+	 * @param string[] $rate_limit_ids Rate limit IDs.
 	 */
-	private function check_and_set_rate_limits( array $data ): bool {
-		$rate_limit_ids = $this->get_rate_limit_ids( $data );
-
+	private function check_rate_limits( array $rate_limit_ids ): bool {
 		foreach ( $rate_limit_ids as $rate_limit_id ) {
 			if ( WC_Rate_Limiter::retried_too_soon( $rate_limit_id ) ) {
 				wc_add_notice( __( 'Please wait before submitting another withdrawal request.', 'woocommerce' ), 'error' );
@@ -301,11 +306,29 @@ final class OrderWithdrawalFormProcessor {
 			}
 		}
 
+		return true;
+	}
+
+	/**
+	 * Set order withdrawal submission rate limits.
+	 *
+	 * @param string[] $rate_limit_ids Rate limit IDs.
+	 */
+	private function set_rate_limits( array $rate_limit_ids ): void {
 		foreach ( $rate_limit_ids as $rate_limit_id ) {
 			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, self::RATE_LIMIT_DELAY );
 		}
+	}
 
-		return true;
+	/**
+	 * Clear order withdrawal submission rate limits.
+	 *
+	 * @param string[] $rate_limit_ids Rate limit IDs.
+	 */
+	private function clear_rate_limits( array $rate_limit_ids ): void {
+		foreach ( $rate_limit_ids as $rate_limit_id ) {
+			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, -1 );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\OrderWithdrawal;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 use Throwable;
 use WC_Order;
+use WC_Rate_Limiter;
 
 /**
  * Processes order withdrawal form requests.
@@ -35,6 +36,9 @@ final class OrderWithdrawalFormProcessor {
 	private const LOGGER_SOURCE                       = 'order-withdrawal';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const ORDER_WITHDRAWAL_REQUESTED_VALUE    = 'yes';
+	private const RATE_LIMIT_IP_PREFIX                = 'order_withdrawal_ip_';
+	private const RATE_LIMIT_EMAIL_PREFIX             = 'order_withdrawal_email_';
+	private const RATE_LIMIT_DELAY                    = MINUTE_IN_SECONDS / 2;
 
 	/**
 	 * Process the current order withdrawal request.
@@ -247,6 +251,10 @@ final class OrderWithdrawalFormProcessor {
 	 * @param array<string,string> $data Form data.
 	 */
 	private function submit_order_withdrawal( array $data ): bool {
+		if ( ! $this->check_and_set_rate_limits( $data ) ) {
+			return false;
+		}
+
 		$matched_order = $this->get_matching_order( $data );
 
 		if ( $matched_order ) {
@@ -258,7 +266,9 @@ final class OrderWithdrawalFormProcessor {
 
 				return false;
 			}
+		}
 
+		if ( $matched_order ) {
 			$this->add_order_withdrawal_note( $matched_order, $data );
 		}
 
@@ -273,6 +283,65 @@ final class OrderWithdrawalFormProcessor {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check and set order withdrawal submission rate limits.
+	 *
+	 * @param array<string,string> $data Form data.
+	 */
+	private function check_and_set_rate_limits( array $data ): bool {
+		$rate_limit_ids = $this->get_rate_limit_ids( $data );
+
+		foreach ( $rate_limit_ids as $rate_limit_id ) {
+			if ( WC_Rate_Limiter::retried_too_soon( $rate_limit_id ) ) {
+				wc_add_notice( __( 'Please wait before submitting another withdrawal request.', 'woocommerce' ), 'error' );
+
+				return false;
+			}
+		}
+
+		foreach ( $rate_limit_ids as $rate_limit_id ) {
+			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, self::RATE_LIMIT_DELAY );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get order withdrawal rate limit identifiers for the current request.
+	 *
+	 * @param array<string,string> $data Form data.
+	 * @return string[]
+	 */
+	private function get_rate_limit_ids( array $data ): array {
+		$rate_limit_ids = array();
+		$ip_address     = $this->get_request_ip_address();
+		$email          = strtolower( trim( $data[ self::FIELD_EMAIL ] ) );
+
+		if ( '' !== $ip_address ) {
+			$rate_limit_ids[] = self::RATE_LIMIT_IP_PREFIX . hash( 'sha256', $ip_address );
+		}
+
+		if ( '' !== $email ) {
+			$rate_limit_ids[] = self::RATE_LIMIT_EMAIL_PREFIX . hash( 'sha256', $email );
+		}
+
+		return $rate_limit_ids;
+	}
+
+	/**
+	 * Get the request IP address for rate limiting.
+	 */
+	private function get_request_ip_address(): string {
+		if ( empty( $_SERVER['REMOTE_ADDR'] ) ) {
+			return '';
+		}
+
+		$value = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+		$value = trim( current( preg_split( '/,/', $value ) ) );
+
+		return (string) rest_is_ip_address( $value );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -272,9 +272,7 @@ final class OrderWithdrawalFormProcessor {
 
 				return false;
 			}
-		}
 
-		if ( $matched_order ) {
 			$this->add_order_withdrawal_note( $matched_order, $data );
 		}
 

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -258,7 +258,11 @@ final class OrderWithdrawalFormProcessor {
 			return false;
 		}
 
-		$this->apply_rate_limits( $rate_limit_ids );
+		if ( ! $this->apply_rate_limits( $rate_limit_ids ) ) {
+			wc_add_notice( __( 'We could not submit your withdrawal request. Please try again or contact us if the problem continues.', 'woocommerce' ), 'error' );
+
+			return false;
+		}
 
 		$matched_order = $this->get_matching_order( $data );
 
@@ -313,11 +317,24 @@ final class OrderWithdrawalFormProcessor {
 	 *
 	 * @param string[] $rate_limit_ids Rate limit IDs.
 	 * @param int      $delay          Delay in seconds for the rate limit. Use -1 to clear the rate limit.
+	 * @return bool True if all rate limits were applied, false otherwise.
 	 */
-	private function apply_rate_limits( array $rate_limit_ids, $delay = self::RATE_LIMIT_DELAY ): void {
+	private function apply_rate_limits( array $rate_limit_ids, int $delay = self::RATE_LIMIT_DELAY ): bool {
+		$applied_rate_limit_ids = array();
+
 		foreach ( $rate_limit_ids as $rate_limit_id ) {
-			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, $delay );
+			if ( ! WC_Rate_Limiter::set_rate_limit( $rate_limit_id, $delay ) ) {
+				foreach ( $applied_rate_limit_ids as $applied_rate_limit_id ) {
+					WC_Rate_Limiter::set_rate_limit( $applied_rate_limit_id, -1 );
+				}
+
+				return false;
+			}
+
+			$applied_rate_limit_ids[] = $rate_limit_id;
 		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -257,7 +257,7 @@ final class OrderWithdrawalFormProcessor {
 			return false;
 		}
 
-		$this->set_rate_limits( $rate_limit_ids );
+		$this->apply_rate_limits( $rate_limit_ids );
 
 		$matched_order = $this->get_matching_order( $data );
 
@@ -268,8 +268,8 @@ final class OrderWithdrawalFormProcessor {
 					'error'
 				);
 
-				$this->clear_rate_limits( $rate_limit_ids );
-
+				$this->apply_rate_limits( $rate_limit_ids, -1 );
+	
 				return false;
 			}
 
@@ -278,7 +278,7 @@ final class OrderWithdrawalFormProcessor {
 
 		if ( ! $this->send_order_withdrawal_emails( $data, $matched_order ) ) {
 			wc_add_notice( __( 'We could not submit your withdrawal request. Please try again or contact us if the problem continues.', 'woocommerce' ), 'error' );
-			$this->clear_rate_limits( $rate_limit_ids );
+			$this->apply_rate_limits( $rate_limit_ids, -1 );
 
 			return false;
 		}
@@ -308,24 +308,14 @@ final class OrderWithdrawalFormProcessor {
 	}
 
 	/**
-	 * Set order withdrawal submission rate limits.
+	 * Set or clear the order withdrawal submission rate limits.
 	 *
 	 * @param string[] $rate_limit_ids Rate limit IDs.
+	 * @param int      $delay          Delay in seconds for the rate limit. Use -1 to clear the rate limit.
 	 */
-	private function set_rate_limits( array $rate_limit_ids ): void {
+	private function apply_rate_limits( array $rate_limit_ids, $delay = self::RATE_LIMIT_DELAY ): void {
 		foreach ( $rate_limit_ids as $rate_limit_id ) {
-			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, self::RATE_LIMIT_DELAY );
-		}
-	}
-
-	/**
-	 * Clear order withdrawal submission rate limits.
-	 *
-	 * @param string[] $rate_limit_ids Rate limit IDs.
-	 */
-	private function clear_rate_limits( array $rate_limit_ids ): void {
-		foreach ( $rate_limit_ids as $rate_limit_id ) {
-			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, -1 );
+			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, $delay );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Internal\OrderWithdrawal;
 
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 use Throwable;
+use WC_Geolocation;
 use WC_Order;
 use WC_Rate_Limiter;
 
@@ -327,7 +328,7 @@ final class OrderWithdrawalFormProcessor {
 	 */
 	private function get_rate_limit_ids( array $data ): array {
 		$rate_limit_ids = array();
-		$ip_address     = $this->get_request_ip_address();
+		$ip_address     = WC_Geolocation::get_ip_address();
 		$email          = strtolower( trim( $data[ self::FIELD_EMAIL ] ) );
 
 		if ( '' !== $ip_address ) {
@@ -339,20 +340,6 @@ final class OrderWithdrawalFormProcessor {
 		}
 
 		return $rate_limit_ids;
-	}
-
-	/**
-	 * Get the request IP address for rate limiting.
-	 */
-	private function get_request_ip_address(): string {
-		if ( empty( $_SERVER['REMOTE_ADDR'] ) ) {
-			return '';
-		}
-
-		$value = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
-		$value = trim( explode( ',', $value )[0] );
-
-		return (string) rest_is_ip_address( $value );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -339,7 +339,7 @@ final class OrderWithdrawalFormProcessor {
 		}
 
 		$value = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
-		$value = trim( current( preg_split( '/,/', $value ) ) );
+		$value = trim( explode( ',', $value )[0] );
 
 		return (string) rest_is_ip_address( $value );
 	}

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -274,7 +274,7 @@ final class OrderWithdrawalFormProcessor {
 				);
 
 				$this->apply_rate_limits( $rate_limit_ids, -1 );
-	
+
 				return false;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -365,6 +365,19 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertStringContainsString( 'already been submitted for this order', $error_notices[0]['notice'], 'The notice should explain that the order already has a withdrawal request.' );
 			$this->assertCount( 0, $capture['captures'], 'Duplicate matched submissions should not send notification emails.' );
 			$this->assertFalse( $this->order_has_note_containing( $order, 'Order withdrawal requested' ), 'Duplicate matched submissions should not add another order note.' );
+
+			wc_clear_notices();
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$second_state         = $this->sut->process_current_request();
+			$second_error_notices = wc_get_notices( 'error' );
+
+			$this->assertSame( 'review', $second_state->screen, 'Duplicate matched submissions should not leave behind a rate limit.' );
+			$this->assertCount( 1, $second_error_notices, 'The second duplicate submission should add only the duplicate-order error notice.' );
+			$this->assertStringContainsString( 'already been submitted for this order', $second_error_notices[0]['notice'], 'The released rate limit should allow duplicate-order validation to run again.' );
 		} finally {
 			$capture['remove']();
 		}
@@ -454,6 +467,20 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertCount( 2, $capture['captures'], 'The processor should attempt both notification emails before surfacing the failure.' );
 			$this->assertNotEmpty( $error_notices, 'Email failures should add an error notice.' );
 			$this->assertStringContainsString( 'We could not submit your withdrawal request.', $error_notices[0]['notice'], 'The error notice should tell the user the submission did not complete.' );
+
+			wc_clear_notices();
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999999' )
+			);
+
+			$second_state         = $this->sut->process_current_request();
+			$second_error_notices = wc_get_notices( 'error' );
+
+			$this->assertSame( 'review', $second_state->screen, 'Email failures should not leave behind a rate limit.' );
+			$this->assertCount( 4, $capture['captures'], 'The second failed submission should attempt notification emails again.' );
+			$this->assertNotEmpty( $second_error_notices, 'The second email failure should add an error notice.' );
+			$this->assertStringContainsString( 'We could not submit your withdrawal request.', $second_error_notices[0]['notice'], 'The released rate limit should allow email delivery to be attempted again.' );
 		} finally {
 			$capture['remove']();
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormProcessor
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormState;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormView;
 use WC_Order;
+use WC_Rate_Limiter;
 use WC_Unit_Test_Case;
 
 /**
@@ -19,6 +20,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	private const FLUSH_QUEUE_OPTION                  = 'woocommerce_queue_flush_rewrite_rules';
 	private const MISSING_OPTION_MARK                 = '__woocommerce_order_withdrawal_missing_option__';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
+	private const RATE_LIMIT_PREFIX                   = 'order_withdrawal_';
 
 	/**
 	 * The System Under Test.
@@ -47,6 +49,20 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	 * @var bool
 	 */
 	private bool $had_request_method = false;
+
+	/**
+	 * Original REMOTE_ADDR value.
+	 *
+	 * @var string|null
+	 */
+	private ?string $original_remote_addr = null;
+
+	/**
+	 * Whether REMOTE_ADDR existed before the test.
+	 *
+	 * @var bool
+	 */
+	private bool $had_remote_addr = false;
 
 	/**
 	 * Original WooCommerce session.
@@ -93,6 +109,8 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		$this->original_post               = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$this->had_request_method          = filter_has_var( INPUT_SERVER, 'REQUEST_METHOD' );
 		$this->original_request_method     = $this->had_request_method ? filter_input( INPUT_SERVER, 'REQUEST_METHOD', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : null;
+		$this->had_remote_addr             = array_key_exists( 'REMOTE_ADDR', $_SERVER );
+		$this->original_remote_addr        = $this->had_remote_addr ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : null;
 		$this->original_session            = WC()->session;
 		$this->original_feature_option     = get_option( self::FEATURE_OPTION, self::MISSING_OPTION_MARK );
 		$this->original_endpoint_option    = get_option( self::ENDPOINT_OPTION, self::MISSING_OPTION_MARK );
@@ -104,6 +122,8 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 
 		$_POST                     = array();
 		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REMOTE_ADDR']    = '203.0.113.10';
+		$this->clear_order_withdrawal_rate_limits();
 		$this->disable_feature();
 		delete_option( self::ENDPOINT_OPTION );
 		delete_option( self::FLUSH_QUEUE_OPTION );
@@ -122,10 +142,17 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			unset( $_SERVER['REQUEST_METHOD'] );
 		}
 
+		if ( $this->had_remote_addr ) {
+			$_SERVER['REMOTE_ADDR'] = (string) $this->original_remote_addr;
+		} else {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		}
+
 		$this->restore_option( self::FEATURE_OPTION, $this->original_feature_option );
 		$this->restore_option( self::ENDPOINT_OPTION, $this->original_endpoint_option );
 		$this->restore_option( self::FLUSH_QUEUE_OPTION, $this->original_flush_queue_option );
 		wc_clear_notices();
+		$this->clear_order_withdrawal_rate_limits();
 		$this->delete_created_orders();
 		WC()->session = $this->original_session;
 
@@ -433,6 +460,75 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should rate limit confirmed submissions by IP address before sending emails.
+	 */
+	public function test_process_current_request_rate_limits_confirmed_submissions_by_ip_address(): void {
+		$capture = $this->capture_wp_mail();
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999998' )
+			);
+
+			$first_state = $this->sut->process_current_request();
+
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array(
+					OrderWithdrawalFormProcessor::FIELD_EMAIL              => 'another@example.test',
+					OrderWithdrawalFormProcessor::FIELD_EMAIL_CONFIRMATION => 'another@example.test',
+					OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER       => '999999999',
+				)
+			);
+
+			$second_state  = $this->sut->process_current_request();
+			$error_notices = wc_get_notices( 'error' );
+
+			$this->assertSame( 'confirmation', $first_state->screen, 'The first confirmed submission should complete.' );
+			$this->assertSame( 'review', $second_state->screen, 'A repeated submission from the same IP should return to the review screen.' );
+			$this->assertCount( 2, $capture['captures'], 'The rate-limited submission should not send additional notification emails.' );
+			$this->assertNotEmpty( $error_notices, 'Rate-limited submissions should add an error notice.' );
+			$this->assertStringContainsString( 'Please wait before submitting another withdrawal request.', $error_notices[0]['notice'], 'The notice should ask the customer to wait.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should rate limit confirmed submissions by email before sending emails.
+	 */
+	public function test_process_current_request_rate_limits_confirmed_submissions_by_email(): void {
+		$capture = $this->capture_wp_mail();
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999998' )
+			);
+
+			$first_state = $this->sut->process_current_request();
+
+			$_SERVER['REMOTE_ADDR'] = '203.0.113.11';
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999999' )
+			);
+
+			$second_state  = $this->sut->process_current_request();
+			$error_notices = wc_get_notices( 'error' );
+
+			$this->assertSame( 'confirmation', $first_state->screen, 'The first confirmed submission should complete.' );
+			$this->assertSame( 'review', $second_state->screen, 'A repeated submission for the same email should return to the review screen.' );
+			$this->assertCount( 2, $capture['captures'], 'The rate-limited submission should not send additional notification emails.' );
+			$this->assertNotEmpty( $error_notices, 'Rate-limited submissions should add an error notice.' );
+			$this->assertStringContainsString( 'Please wait before submitting another withdrawal request.', $error_notices[0]['notice'], 'The notice should ask the customer to wait.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
 	 * @testdox Should reject specific-item withdrawals that do not list the items.
 	 */
 	public function test_process_current_request_requires_details_for_specific_item_withdrawals(): void {
@@ -687,6 +783,22 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		}
 
 		$this->created_order_ids = array();
+	}
+
+	/**
+	 * Clear order withdrawal rate limits created during tests.
+	 */
+	private function clear_order_withdrawal_rate_limits(): void {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}wc_rate_limits WHERE rate_limit_key LIKE %s",
+				$wpdb->esc_like( self::RATE_LIMIT_PREFIX ) . '%'
+			)
+		);
+
+		\WC_Cache_Helper::invalidate_cache_group( WC_Rate_Limiter::CACHE_GROUP );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a short `WC_Rate_Limiter` guard before order withdrawal processing. Confirmed submissions are throttled by hashed IP address and hashed email address to reduce repeated email sends.

Closes [WOOPRD-3618](https://linear.app/a8c/issue/WOOPRD-3618/rate-limit-submissions)

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the order withdrawal feature and visit `/my-account/withdraw-order`
2. Submit a valid order withdrawal request and verify the confirmation screen is shown
3. Submit another valid request within 30 seconds and verify it returns to review with a wait notice and does not send more emails.
5. Submit another valid request after 30 seconds and verify it submits successfully

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Manual tests above
- Unit tests

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
