### PR TITLE
Fix package release failing on npm 12 by pinning npm to v11

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -34,5 +34,8 @@ jobs:
 
       - name: Execute script
         run: |
-          npm install -g npm@latest # Need NPM 11.5.1+ for OIDC support. pnpm publish passes through to npm.
+          # Need NPM 11.5.1+ for OIDC support: pnpm publish passes through to npm.
+          # Pinned to 11 because npm 12 hard-errors (EUNKNOWNCONFIG) on the pnpm-only
+          # flags (e.g. --publish-branch) that pnpm <11 forwards to npm.
+          npm install -g npm@11
           ./tools/package-release/bin/dev publish ${{ github.event.inputs.packages }} --branch=${{ github.ref_name }} ${{ ( github.event.inputs.dry_run == 'true' && '--dry-run' ) || '' }} --skip-install


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Package release workflow is currently broken — the [latest run](https://github.com/woocommerce/woocommerce/actions/runs/30358771064/job/90273106719) failed while publishing `@woocommerce/email-editor` with:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --publish-branch
```

The workflow installs `npm@latest` before publishing, which now resolves to **npm 12**. npm 12 turned unknown CLI flags from a warning into a hard error. Our pnpm (v10) delegates `pnpm publish` to the npm CLI and forwards its own flags — like `--publish-branch` — along the way, so the publish now fails before uploading anything.

This PR pins the install to `npm@11` (currently 11.18.0), which keeps the OIDC support (needs 11.5.1+) and still only warns on the forwarded flags.

Longer term, upgrading the monorepo to pnpm 11 removes the npm delegation entirely (`pnpm publish` is implemented natively there) — that's out of scope here.

(For Bug Fixes) Bug introduced in PR #62056.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. After merge, run the [Package release workflow](https://github.com/woocommerce/woocommerce/actions/workflows/package-release.yml) from `trunk` with the dry run option enabled.
2. Confirm the publish step no longer fails with `EUNKNOWNCONFIG` on `--publish-branch`.

<!-- End testing instructions -->

### Testing that has already taken place:

- Verified `npm@latest` now resolves to 12.0.1 and that npm 12 hard-errors on unknown CLI flags (previously a warning in npm 11).
- Verified `npm@11` resolves to 11.18.0, which satisfies the 11.5.1+ OIDC requirement.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Release tooling / CI workflow change only, nothing shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>