### PR TITLE
Fix order-review moderation guard missing legacy reviews of variable-product variations

### DIFF
--- a/plugins/woocommerce/changelog/fix-legacy-review-rejected-check-variations
+++ b/plugins/woocommerce/changelog/fix-legacy-review-rejected-check-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the order-review moderation guard missing legacy reviews of variable-product variations.

--- a/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/SubmissionHandler.php
@@ -330,24 +330,6 @@ class SubmissionHandler {
 			return false;
 		}
 
-		// Pre-10.9.0 reviews have no VARIATION_META_KEY row; treat that as 0.
-		$variation_clause = 0 === $variation_id
-			? array(
-				'relation' => 'OR',
-				array(
-					'key'   => ItemEligibility::VARIATION_META_KEY,
-					'value' => '0',
-				),
-				array(
-					'key'     => ItemEligibility::VARIATION_META_KEY,
-					'compare' => 'NOT EXISTS',
-				),
-			)
-			: array(
-				'key'   => ItemEligibility::VARIATION_META_KEY,
-				'value' => (string) $variation_id,
-			);
-
 		$comments = get_comments(
 			array(
 				'post_id'      => $product_id,
@@ -361,7 +343,18 @@ class SubmissionHandler {
 						'key'   => ItemEligibility::ORDER_META_KEY,
 						'value' => (string) $order->get_id(),
 					),
-					$variation_clause,
+					array(
+						'relation' => 'OR',
+						array(
+							'key'   => ItemEligibility::VARIATION_META_KEY,
+							'value' => (string) $variation_id,
+						),
+						array(
+							// Pre-10.9.0 reviews have no VARIATION_META_KEY row at all.
+							'key'     => ItemEligibility::VARIATION_META_KEY,
+							'compare' => 'NOT EXISTS',
+						),
+					),
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerTest.php
@@ -498,15 +498,20 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A spam verdict recorded against one variation's explicit meta value must not block a sibling variation.
+	 * A spam verdict recorded against one variation's explicit meta value is scoped to that variation and
+	 * doesn't block a sibling. A verdict on a review predating VARIATION_META_KEY (pre-10.9.0) has no
+	 * per-variation identity to scope to, so it blocks the whole product on that order instead.
 	 *
-	 * @testWith ["A", "error"]
-	 *           ["B", "ok"]
+	 * @testWith [true, "A", "error"]
+	 *           [true, "B", "ok"]
+	 *           [false, "A", "error"]
+	 *           [false, "B", "error"]
 	 *
+	 * @param bool   $with_variation_meta False simulates a review written before 10.9.0, with no VARIATION_META_KEY row.
 	 * @param string $resubmit Which variation, "A" or "B", resubmits a review.
 	 * @param string $expected_status Expected row status for that resubmission.
 	 */
-	public function test_resubmit_after_spam_verdict_is_scoped_to_its_variation( string $resubmit, string $expected_status ): void {
+	public function test_resubmit_after_spam_verdict_is_scoped_to_its_variation( bool $with_variation_meta, string $resubmit, string $expected_status ): void {
 		$variable      = WC_Helper_Product::create_variation_product();
 		$variation_ids = $variable->get_children();
 		$variation_a   = wc_get_product( $variation_ids[0] );
@@ -533,8 +538,11 @@ class SubmissionHandlerTest extends WC_Unit_Test_Case {
 			)
 		);
 		add_comment_meta( $comment_id, ItemEligibility::ORDER_META_KEY, (int) $order->get_id(), true );
-		add_comment_meta( $comment_id, ItemEligibility::VARIATION_META_KEY, (int) $variation_a->get_id(), true );
+		if ( $with_variation_meta ) {
+			add_comment_meta( $comment_id, ItemEligibility::VARIATION_META_KEY, (int) $variation_a->get_id(), true );
+		}
 		wp_spam_comment( $comment_id );
+		ItemEligibility::reset_cache();
 
 		$target = 'A' === $resubmit ? $variation_a : $variation_b;
 		$item   = 'A' === $resubmit ? $item_a : $item_b;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#66897 fixed the moderation guard for reviews written before 10.9 (before `_review_variation_id` existed), but only for simple products (`variation_id === 0`).
A pre-10.9 review of a variable product variation was still missed and a customer could resubmit after a moderator marked it spam/trash and silently override the moderation decision.

This PR extends the same check to any variation.

> [!NOTE]
> A pre-10.9 review has no way to record which variation it was for. So a rejected pre-10.9 review now blocks resubmission for every variation of that product on the order, not just the one that was actually rejected. I think that's fine, since a legacy review can't be scoped any tighter than that, and blocking too much is safer than letting the bypass back in.

Closes #67067.

(For Bug Fixes) Bug introduced in PR #66897.

### How to test the changes in this Pull Request:

1. Enable order reviews:
   ```
   wp option update woocommerce_feature_customer_review_request_enabled yes
   ```
1. Create a **completed** order for a **variable product** (a specific variation) in the admin. Make sure it has a **billing email** address set.
1. Get the order's review URL:
   ```
   wp eval 'echo Automattic\WooCommerce\Internal\OrderReviews\Endpoint::get_url( wc_get_order( ORDER_ID ) );'
   ```
   Open this URL in an incognito window.
1. Submit a review with a rating for the variation.
1. As admin:
   1. Go to **WC > Products > Reviews** and find this review. Note the comment ID.
   1. Mark the review as spam.
   1. Simulate the pre-10.9 metadata situation for this comment:
      ```
      wp comment meta delete <COMMENT_ID> _review_variation_id
      ```
1. Back in the incognito window, attempt to submit another review for the same variation. It should fail with an error.
1. (Optional) To confirm the bug is still present without this fix:
   1. Check out `trunk`.
   1. Repeat step 6 above in the incognito window. This time submission will succeed.

### Milestone

- [x] Automatically assign milestone for the next WooCommerce version