### PR TITLE
Fix WP-CLI exiting on missing `wp-cli/extension-command` package

### DIFF
--- a/plugins/woocommerce/changelog/35858-fix-wp-cli-exit-without-extension-command
+++ b/plugins/woocommerce/changelog/35858-fix-wp-cli-exit-without-extension-command
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-WP-CLI: don't terminate the whole CLI process when the optional wp-cli/extension-command package isn't installed; the `wc com extension` command is simply not registered instead.
+WP-CLI no longer exits the whole process when the optional wp-cli/extension-command package isn't installed.

--- a/plugins/woocommerce/changelog/35858-fix-wp-cli-exit-without-extension-command
+++ b/plugins/woocommerce/changelog/35858-fix-wp-cli-exit-without-extension-command
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WP-CLI: don't terminate the whole CLI process when the optional wp-cli/extension-command package isn't installed; the `wc com extension` command is simply not registered instead.

--- a/plugins/woocommerce/changelog/fix-wp-cli-blueprint-duplicate-class-load
+++ b/plugins/woocommerce/changelog/fix-wp-cli-blueprint-duplicate-class-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WP-CLI's blueprint command no longer risks a fatal error from loading its class twice.

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -65,7 +65,9 @@ class WC_CLI {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tracker_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Command::register_commands' );
-		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Extension_Command::register_commands' );
+		if ( class_exists( 'WC_CLI_COM_Extension_Command' ) ) {
+			WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Extension_Command::register_commands' );
+		}
 		if ( defined( 'WOOCOMMERCE_MIGRATOR_ENABLED' ) && WOOCOMMERCE_MIGRATOR_ENABLED ) {
 			WP_CLI::add_hook( 'after_wp_load', 'Automattic\WooCommerce\Internal\CLI\Migrator\Runner::register_commands' );
 		}

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -82,7 +82,6 @@ class WC_CLI {
 	 */
 	public function add_blueprint_cli_hook() {
 		if ( FeaturesUtil::feature_is_enabled( 'blueprint' ) && class_exists( \Automattic\WooCommerce\Blueprint\Cli::class ) ) {
-			require_once dirname( WC_PLUGIN_FILE ) . '/packages/blueprint/src/Cli.php';
 			WP_CLI::add_hook( 'after_wp_load', 'Automattic\WooCommerce\Blueprint\Cli::register_commands' );
 		}
 	}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'Plugin_Command' ) ) {
-	exit;
+	return;
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Our `wc com extension` CLI command exits the entire PHP process when the optional `wp-cli/extension-command` package (which provides `Plugin_Command`) isn't installed, silently killing every WP-CLI command instead of just skipping that one subcommand.

This PR swaps the `exit` for a `return` so only the missing command is skipped, and guards its hook registration so WP-CLI doesn't try to call an undefined class.

Closes #35858.

(For Bug Fixes) Bug introduced in PR #33775.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In an empty directory, set up a minimal Composer-based WP-CLI, deliberately leaving out `wp-cli/extension-command`:
   ```
   composer require wp-cli/wp-cli wp-cli/entity-command wp-cli/config-command
   ```
2. Point `./vendor/bin/wp` at a WordPress install with WooCommerce active, e.g. `./vendor/bin/wp --path=/path/to/wordpress option get siteurl`. This command should print the site URL normally.
3. (Optional) On `trunk`, the above step results in the command silently exiting, with nothing printed.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.