### PR TITLE
Stop shipping unused Composer autoloader files in the release zip

### DIFF
--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -56,8 +56,12 @@ cd "$DEST_PATH" || exit
 # No --optimize: the plugin loads classes through the Jetpack autoloader, so the
 # optimized classmaps are never read at runtime and only bloat the zip.
 composer dump-autoload --no-dev --quiet || exit "$?"
-# Remove composer files from the build.
+# Remove composer files from the build. The installers plugin and installed.json
+# are needed while the dump runs above (so they can't go in .distignore), but
+# nothing reads them at runtime.
 rm composer.*
+rm -rf vendor/composer/installers
+rm -f vendor/composer/installed.json
 
 echo "Generating zip file..."
 cd "$BUILD_PATH" || exit

--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -53,7 +53,9 @@ rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PAT
 
 echo "Regenerating autoloader for production..."
 cd "$DEST_PATH" || exit
-composer dump-autoload --no-dev --quiet --optimize || exit "$?"
+# No --optimize: the plugin loads classes through the Jetpack autoloader, so the
+# optimized classmaps are never read at runtime and only bloat the zip.
+composer dump-autoload --no-dev --quiet || exit "$?"
 # Remove composer files from the build.
 rm composer.*
 

--- a/plugins/woocommerce/changelog/reduce-zip-composer-cleanup
+++ b/plugins/woocommerce/changelog/reduce-zip-composer-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Stop generating the unused optimized Composer classmaps in the release build and remove the composer/installers plugin and installed.json from the shipped zip.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The release build runs `composer dump-autoload --optimize`, which scans every package and writes a full class-to-file map into `vendor/composer/autoload_classmap.php` and `autoload_static.php` (about 840 KB combined). Nothing reads those files at runtime: the plugin loads classes through the Jetpack autoloader (`vendor/autoload_packages.php`), which has its own manifests, and the PSR-4 upgrade fallback added in 11.0 reads only the small `autoload_psr4.php`. The flag arrived in #48857 without a stated rationale, so dropping it just puts the built zip in the same autoload mode every development install already runs.

The build now also removes `vendor/composer/installers` (a Composer plugin that only computes install paths while `composer install` runs) and `installed.json` (Composer CLI metadata) after the autoload dump. They can't go in `.distignore` because Composer needs both present while the dump runs.

Together this trims about 1.3 MB from the installed plugin and about 140 KB from the zip, with no runtime behavior change. Code that requires `vendor/autoload.php` directly keeps working; it resolves classes through PSR-4 rules instead of a classmap.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Build the zip on this branch: `pnpm --filter=@woocommerce/plugin-woocommerce build:zip`.
2. Inspect `vendor/composer/` inside the zip: `installers/` and `installed.json` should be gone, `autoload_classmap.php` and `autoload_static.php` should be small stubs instead of ~400 KB each, and the Jetpack manifests (`jetpack_autoload_psr4.php`, `jetpack_autoload_classmap.php`) should be present.
3. Install the built zip on a test site, activate it, and smoke test: load the shop and checkout on the front end, open wp-admin (orders, settings, analytics), and place a test order. Everything should behave exactly as a trunk build.

### Testing that has already taken place:

Traced the runtime autoload path in the analysis that led to this PR: the bootstrap requires `vendor/autoload_packages.php` (`src/Autoloader.php`), and the PSR-4 fallback reads only `autoload_psr4.php` and `ClassLoader.php`, both of which the dump still generates. Built a zip without the flag and confirmed the Jetpack autoloader emits its PSR-4 manifest and every class from the old optimized classmap still resolves (the DeprecatedNotes aliases are loaded via `require_once` in `FeaturePlugin::init`, and the jetpack-autoloader internals ship as prefixed copies).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>