### PR TITLE
Allow building non-release branches in the release ZIP workflow

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -3,14 +3,10 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch (e.g. "release/9.8" or just "9.8").'
-        required: true
-      skip_verify:
-        description: 'Skip verification steps.'
-        type: boolean
+        description: 'Branch to build (e.g. "release/9.8" or "9.8"). Non-release branches just build a ZIP.'
         required: true
       create_github_release:
-        description: 'Create GitHub release.'
+        description: 'Create GitHub release (release branches only).'
         type: boolean
         default: false
   workflow_call:
@@ -48,6 +44,7 @@ jobs:
       contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     outputs:
       branch: ${{ steps.normalize-branch.outputs.branch }}
+      is-release-branch: ${{ steps.normalize-branch.outputs.is-release-branch }}
     steps:
       - name: Normalize branch input
         id: normalize-branch
@@ -60,8 +57,26 @@ jobs:
           fi
           echo "branch=$branch" >> $GITHUB_OUTPUT
 
-      - run: |
-          echo "Building WooCommerce ZIP: branch=${{ steps.normalize-branch.outputs.branch }}, skip_verify=${{ inputs.skip_verify }}, create_github_release=${{ inputs.create_github_release }}"          
+          is_release_branch=false
+          if [[ "$branch" == release/* ]]; then
+            is_release_branch=true
+          fi
+          echo "is-release-branch=$is_release_branch" >> $GITHUB_OUTPUT
+
+          # skip_verify only exists for workflow_call; manual dispatch always verifies before creating a release.
+          should_verify=false
+          if [ "$is_release_branch" = "true" ] && [ "${{ inputs.create_github_release }}" = "true" ] && [ "${{ inputs.skip_verify }}" != "true" ]; then
+            should_verify=true
+          fi
+          echo "should-verify=$should_verify" >> $GITHUB_OUTPUT
+
+      - env:
+          BRANCH: ${{ steps.normalize-branch.outputs.branch }}
+          IS_RELEASE_BRANCH: ${{ steps.normalize-branch.outputs.is-release-branch }}
+          SHOULD_VERIFY: ${{ steps.normalize-branch.outputs.should-verify }}
+          CREATE_GITHUB_RELEASE: ${{ inputs.create_github_release }}
+        run: |
+          echo "Building WooCommerce ZIP: branch=${BRANCH}, is_release_branch=${IS_RELEASE_BRANCH}, should_verify=${SHOULD_VERIFY}, create_github_release=${CREATE_GITHUB_RELEASE}"
 
       - name: Verify release branch
         env:
@@ -75,29 +90,31 @@ jobs:
       - name: Workflow checks
         env:
           BRANCH: ${{ steps.normalize-branch.outputs.branch }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
           # No special checks when running as a reusable workflow.
           if [ "${{ ! contains( github.workflow_ref, 'release-build-zip-file.yml' ) }}" = "true" ]; then
             exit 0
           fi
 
-          # Write summary header.
-          options=""
-          [ "${{ inputs.skip_verify }}" = "true" ] && options="skipping verification"
-          [ "${{ inputs.create_github_release }}" = "true" ] && options="${options:+$options, }creating release"
-          [ -n "$options" ] && options=" ($options)"
-          echo "🔨 Building WooCommerce ZIP from \`${BRANCH}\`${options}." >> $GITHUB_STEP_SUMMARY
+          # Write summary header early, so it's visible even if a later check fails.
+          echo "🔨 Building WooCommerce ZIP from \`${BRANCH}\`." >> $GITHUB_STEP_SUMMARY
 
           # Must run from trunk.
-          if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
+          if [ "$WORKFLOW_REF" != "refs/heads/trunk" ]; then
             echo "::error::This workflow must be run from the 'trunk' branch. Enter the release branch as input."
             exit 1
           fi
 
-          # Can not skip verification for actual releases.
-          if [ "${{ inputs.create_github_release }}" = "true" ] && [ "${{ inputs.skip_verify }}" = "true" ]; then
-            echo "::error::Verification cannot be skipped when building for a release."
-            exit 1
+          # Non-release branches: just build, no other verification.
+          if [ "${{ steps.normalize-branch.outputs.is-release-branch }}" != "true" ]; then
+            echo "⚠️ Not a release branch — skipping checks, won't create a release." >> $GITHUB_STEP_SUMMARY
+            echo "::notice::'${BRANCH}' is not a release branch — skipping checks, won't create a release."
+            exit 0
+          fi
+
+          if [ "${{ inputs.create_github_release }}" = "true" ]; then
+            echo "Creating a GitHub release." >> $GITHUB_STEP_SUMMARY
           fi
 
         # Checkout trunk.
@@ -108,7 +125,7 @@ jobs:
           sparse-checkout: |
             /.github/workflows/scripts/release-check-db-updates.js
           sparse-checkout-cone-mode: false
-        if: ${{ ! inputs.skip_verify }}
+        if: ${{ steps.normalize-branch.outputs.should-verify == 'true' }}
 
         # Checkout branch.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -119,11 +136,11 @@ jobs:
             /plugins/woocommerce/woocommerce.php
             /plugins/woocommerce/readme.txt
           sparse-checkout-cone-mode: false
-        if: ${{ ! inputs.skip_verify }}
+        if: ${{ steps.normalize-branch.outputs.should-verify == 'true' }}
 
       - name: 'Pre-build verification'
         id: pre-build-verification
-        if: ${{ ! inputs.skip_verify }}
+        if: ${{ steps.normalize-branch.outputs.should-verify == 'true' }}
         env:
           BRANCH: ${{ steps.normalize-branch.outputs.branch }}
           GH_TOKEN: ${{ github.token }}
@@ -201,7 +218,7 @@ jobs:
             echo "release_version=$branch_plugin_version" >> $GITHUB_OUTPUT
 
       - name: 'Pre-build verification: db updates'
-        if: ${{ ! inputs.skip_verify && ! contains( steps.pre-build-verification.outputs.release_version, '-dev' ) && ! contains( steps.pre-build-verification.outputs.release_version, '-beta.1' ) }}
+        if: ${{ steps.normalize-branch.outputs.should-verify == 'true' && ! contains( steps.pre-build-verification.outputs.release_version, '-dev' ) && ! contains( steps.pre-build-verification.outputs.release_version, '-beta.1' ) }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -262,8 +279,8 @@ jobs:
   create-release:
     name: Create GitHub release
     runs-on: ${{ github.repository == 'woocommerce/woocommerce' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
-    needs: [ build ]
-    if: ${{ inputs.create_github_release }}
+    needs: [ verify, build ]
+    if: ${{ inputs.create_github_release && needs.verify.outputs.is-release-branch == 'true' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The release ZIP workflow assumes every input branch is a release branch, so it can't be used to produce a test build from an arbitrary branch. This PR lets it build a ZIP from any branch, skipping release-related verification or GH release creation.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork `woocommerce/woocommerce` (or reuse an existing fork) and enable Actions.
2. Push this branch's content onto the fork's `trunk`, since both the "must run from trunk" guardrail and the reusable `workflow_call` from `release-code-freeze.yml` need the updated workflow file to live there: `git push <your-fork-url> release-build-workflow-changes:trunk --force`.
3. Push a throwaway branch (e.g. `test/scratch`) with a couple of trivial commits.
4. Run **Release: Build ZIP file** from `trunk` with Branch: `test/scratch`, Create GitHub release: unchecked. Confirm the run succeeds, the step summary shows "Not a release branch — skipping checks, won't create a release," a ZIP artifact is produced, and `checkout-trunk`/`checkout-branch`/`Pre-build verification`/`db updates` all show as skipped.
5. Re-run the same with Create GitHub release checked. Confirm the identical outcome: `create-release` shows as skipped, no release created despite the box being checked.
6. Create a new branch from `release/11.0`. Run the workflow with branch `release/11.0` and Create GitHub release unchecked. Confirm verification steps are skipped, the ZIP builds, and no release is created.
7. On `release/11.0`, set `woocommerce.php`'s Version header to `11.0.0-rc.3`. Run the workflow with Branch: `release/11.0` and Create GitHub release checked. Confirm `Pre-build verification` actually runs and passes, and a draft GitHub release named `11.0.0-rc.3` is created with the ZIP attached.
8. On `release/11.0`, set `woocommerce.php`'s Version header to `11.0.0-rc.3`. Remove the whole section under changelog and re-run the same. Confirm verification now catches it and fails with "changelog section... has no entries".
9. Run **Release: Enforce Feature Freeze**. Confirm that in the `build-dev-release` job's call, verification steps show as skipped yet a draft GitHub release still gets created.
10. Dispatch **Release: Build ZIP file** selecting a non-trunk branch as the "Use workflow from" source. Confirm it fails immediately.
11. Dispatch with a nonexistent branch name (e.g. `release/999.999`). Confirm it fails.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal CI workflow change (GitHub Actions), not shipped to merchants.

</details>