### PR TITLE
[DO NOT MERGE] Testing pr-readiness-comment bot

### DIFF
--- a/plugins/woocommerce/PR_READINESS_DUMMY_SCRATCH.md
+++ b/plugins/woocommerce/PR_READINESS_DUMMY_SCRATCH.md
@@ -1,0 +1,8 @@
+# Scratch file
+This file intentionally has bad markdown.
+- item one
+- item two
+Some text right after a list with no blank line.
+```
+code fence with no language
+```

--- a/plugins/woocommerce/PR_READINESS_DUMMY_SCRATCH.md
+++ b/plugins/woocommerce/PR_READINESS_DUMMY_SCRATCH.md
@@ -1,8 +1,12 @@
 # Scratch file
-This file intentionally has bad markdown.
+
+This file used to have bad markdown, now fixed.
+
 - item one
 - item two
-Some text right after a list with no blank line.
-```
-code fence with no language
+
+Some text with a blank line before it.
+
+```text
+code fence with a language now
 ```

--- a/plugins/woocommerce/changelog/dev-pr-readiness-dummy-test
+++ b/plugins/woocommerce/changelog/dev-pr-readiness-dummy-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Scratch changelog entry for manually testing the pr-readiness-comment bot (see PR #67081). This PR is DO NOT MERGE.

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
@@ -1,0 +1,10 @@
+<?php
+namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
+
+class DummyLintFailure {
+	public function check(){
+		if(true){
+			return true;
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
@@ -6,6 +6,8 @@
  * @package Automattic\WooCommerce\Internal\PRReadinessDummy
  */
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
 
 /**
@@ -19,10 +21,6 @@ class DummyLintFailure {
 	 * @return bool
 	 */
 	public function check(): bool {
-		if ( true ) {
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 }

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
@@ -16,7 +16,7 @@ namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
 class DummyLintFailure {
 
 	/**
-	 * Always returns true.
+	 * Always returns true. No-op commit for the clear->clear test step.
 	 *
 	 * @return bool
 	 */

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyLintFailure.php
@@ -1,10 +1,28 @@
 <?php
+/**
+ * DO NOT MERGE. Scratch file used to manually verify the pr-readiness-comment
+ * bot (see PR #67081) against a live PR.
+ *
+ * @package Automattic\WooCommerce\Internal\PRReadinessDummy
+ */
+
 namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
 
+/**
+ * Formerly triggered a Lint failure; now WPCS-compliant.
+ */
 class DummyLintFailure {
-	public function check(){
-		if(true){
+
+	/**
+	 * Always returns true.
+	 *
+	 * @return bool
+	 */
+	public function check(): bool {
+		if ( true ) {
 			return true;
 		}
+
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * DO NOT MERGE. Scratch file used to manually verify the pr-readiness-comment
+ * bot (see PR #67081) against a live PR. Intentionally fails PHPStan.
+ *
+ * @package Automattic\WooCommerce\Internal\PRReadinessDummy
+ */
+
+namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
+
+/**
+ * Intentionally triggers a PHPStan error: calling a method on a null value.
+ */
+class DummyPHPStanFailure {
+
+	/**
+	 * Intentionally calls a method on null to trigger a PHPStan failure.
+	 *
+	 * @return int
+	 */
+	public function run(): int {
+		$value = null;
+		return $value->calculate();
+	}
+}

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
@@ -6,6 +6,8 @@
  * @package Automattic\WooCommerce\Internal\PRReadinessDummy
  */
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
 
 /**

--- a/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
+++ b/plugins/woocommerce/src/Internal/PRReadinessDummy/DummyPHPStanFailure.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * DO NOT MERGE. Scratch file used to manually verify the pr-readiness-comment
- * bot (see PR #67081) against a live PR. Intentionally fails PHPStan.
+ * bot (see PR #67081) against a live PR. Formerly triggered a PHPStan error;
+ * now fixed.
  *
  * @package Automattic\WooCommerce\Internal\PRReadinessDummy
  */
@@ -11,17 +12,16 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Internal\PRReadinessDummy;
 
 /**
- * Intentionally triggers a PHPStan error: calling a method on a null value.
+ * Formerly called a method on a null value; now fixed.
  */
 class DummyPHPStanFailure {
 
 	/**
-	 * Intentionally calls a method on null to trigger a PHPStan failure.
+	 * Returns a fixed value instead of calling a method on null.
 	 *
 	 * @return int
 	 */
 	public function run(): int {
-		$value = null;
-		return $value->calculate();
+		return 0;
 	}
 }

--- a/plugins/woocommerce/tests/e2e/tests/basic/pr-readiness-dummy-failure.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/basic/pr-readiness-dummy-failure.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe( 'DO NOT MERGE: pr-readiness-comment bot dummy failure (see PR #67081)', () => {
-	test( 'intentionally fails to exercise the readiness bot\'s "E2E tests" task', async () => {
-		expect( 1 ).toBe( 2 );
+	test( 'formerly intentionally failed; now fixed to exercise the readiness bot\'s "E2E tests" task', async () => {
+		expect( 1 ).toBe( 1 );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/basic/pr-readiness-dummy-failure.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/basic/pr-readiness-dummy-failure.spec.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe( 'DO NOT MERGE: pr-readiness-comment bot dummy failure (see PR #67081)', () => {
+	test( 'intentionally fails to exercise the readiness bot\'s "E2E tests" task', async () => {
+		expect( 1 ).toBe( 2 );
+	} );
+} );

--- a/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * DO NOT MERGE. Scratch test used to manually verify the pr-readiness-comment
- * bot (see PR #67081) against a live PR. Intentionally fails.
+ * bot (see PR #67081) against a live PR. Formerly failed intentionally; now
+ * fixed.
  *
  * @package Automattic\WooCommerce\Tests\Internal\PRReadinessDummy
  */
@@ -13,14 +14,14 @@ namespace Automattic\WooCommerce\Tests\Internal\PRReadinessDummy;
 use WC_Unit_Test_Case;
 
 /**
- * Intentionally failing unit test.
+ * Formerly an intentionally failing unit test; now fixed.
  */
 class DummyFailingTest extends WC_Unit_Test_Case {
 
 	/**
-	 * Intentionally fails to exercise the readiness bot's "Unit tests (PHP)" task.
+	 * Exercises the readiness bot's "Unit tests (PHP)" task; now passes.
 	 */
 	public function test_intentional_failure() {
-		$this->assertTrue( false, 'Intentional failure for PR readiness bot dummy test PR.' );
+		$this->assertTrue( true );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
@@ -6,6 +6,8 @@
  * @package Automattic\WooCommerce\Tests\Internal\PRReadinessDummy
  */
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Tests\Internal\PRReadinessDummy;
 
 use WC_Unit_Test_Case;

--- a/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PRReadinessDummy/DummyFailingTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * DO NOT MERGE. Scratch test used to manually verify the pr-readiness-comment
+ * bot (see PR #67081) against a live PR. Intentionally fails.
+ *
+ * @package Automattic\WooCommerce\Tests\Internal\PRReadinessDummy
+ */
+
+namespace Automattic\WooCommerce\Tests\Internal\PRReadinessDummy;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Intentionally failing unit test.
+ */
+class DummyFailingTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Intentionally fails to exercise the readiness bot's "Unit tests (PHP)" task.
+	 */
+	public function test_intentional_failure() {
+		$this->assertTrue( false, 'Intentional failure for PR readiness bot dummy test PR.' );
+	}
+}


### PR DESCRIPTION
Scratch PR to manually verify the pr-readiness-comment bot from #67081 against a live fork PR, since its `workflow_run` trigger can't fire until that PR merges to `trunk`.

This PR intentionally bakes in failures (lint, PHPStan, PHPUnit, markdown lint, missing changelog, missing milestone) and will be walked through several more commits to exercise every state transition. **Will be closed without merging.**

Closes # .