### PR TITLE
Fix stale paths, commands, and broken links in AI agent docs

### DIFF
--- a/.ai/skills/woocommerce-backend-dev/unit-tests.md
+++ b/.ai/skills/woocommerce-backend-dev/unit-tests.md
@@ -205,6 +205,8 @@ The `PaymentsExtensionSuggestionsTest` class demonstrates good testing practices
 
 ### Example Test Structure
 
+Adapted from the real `PaymentsExtensionSuggestionsTest` (`tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php`), which exercises `PaymentsExtensionSuggestions::get_country_extensions( string $country_code, string $context = '' ): array`:
+
 ```php
 class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
     /**
@@ -220,76 +222,47 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
     }
 
     /**
-     * @testdox Should return correct extension count for online merchants by country
-     * @dataProvider online_merchant_country_data
+     * @dataProvider data_provider_get_country_extensions_count_with_merchant_selling_online
+     *
+     * @param string $country        The country code.
+     * @param int    $expected_count The expected number of suggestions.
      */
-    public function test_get_country_extensions_count_for_online_merchants(
-        string $country_code,
-        int $expected_count
-    ) {
-        $merchant = array(
-            'country'       => $country_code,
-            'selling_venues' => 'online',
+    public function test_get_country_extensions_count_with_merchant_selling_online( string $country, int $expected_count ) {
+        update_option(
+            OnboardingProfile::DATA_OPTION,
+            array(
+                'business_choice'       => 'im_already_selling',
+                'selling_online_answer' => 'yes_im_selling_online',
+            )
         );
 
-        $result = $this->sut->get_country_extensions_count( $merchant );
+        $extensions = $this->sut->get_country_extensions( $country );
 
-        $this->assertSame(
-            $expected_count,
-            $result,
-            "Expected {$expected_count} extensions for online merchant in {$country_code}"
-        );
+        $this->assertCount( $expected_count, $extensions, "For merchant selling online, the country $country should have $expected_count suggestions." );
+
+        delete_option( OnboardingProfile::DATA_OPTION );
     }
 
     /**
-     * Data provider for online merchant tests.
+     * Data provider for test_get_country_extensions_count_with_merchant_selling_online.
      *
      * @return array
      */
-    public function online_merchant_country_data() {
-        return array(
-            'United States'    => array( 'US', 5 ),
-            'United Kingdom'   => array( 'GB', 4 ),
-            'Canada'           => array( 'CA', 3 ),
-            'Australia'        => array( 'AU', 3 ),
+    public function data_provider_get_country_extensions_count_with_merchant_selling_online(): array {
+        // Counts are based on the data in PaymentsExtensionSuggestions::$country_extensions.
+        $country_suggestions_count = array(
+            'CA' => 10,
+            'US' => 11,
+            'GB' => 14,
             // ... more countries
         );
-    }
 
-    /**
-     * @testdox Should return correct extension count for offline merchants by country
-     * @dataProvider offline_merchant_country_data
-     */
-    public function test_get_country_extensions_count_for_offline_merchants(
-        string $country_code,
-        int $expected_count
-    ) {
-        $merchant = array(
-            'country'        => $country_code,
-            'selling_venues' => 'offline',
-        );
+        $data = array();
+        foreach ( $country_suggestions_count as $country => $count ) {
+            $data[] = array( $country, $count );
+        }
 
-        $result = $this->sut->get_country_extensions_count( $merchant );
-
-        $this->assertSame(
-            $expected_count,
-            $result,
-            "Expected {$expected_count} extensions for offline merchant in {$country_code}"
-        );
-    }
-
-    /**
-     * Data provider for offline merchant tests.
-     *
-     * @return array
-     */
-    public function offline_merchant_country_data() {
-        return array(
-            'United States'  => array( 'US', 2 ),
-            'United Kingdom' => array( 'GB', 1 ),
-            'Canada'         => array( 'CA', 1 ),
-            // ... more countries
-        );
+        return $data;
     }
 }
 ```
@@ -298,10 +271,10 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 
 When working with payment extension suggestions:
 
-1. **Extension counts must match the implementation** in `src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php`
-2. **When adding new countries** to the implementation, update both data providers in the test file
-3. **Tests are separated by merchant type** (online vs offline) as they have different extension counts
-4. **Data providers use descriptive keys** (country names) for better test output
+1. **Extension counts must match the implementation** in `src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php` (`$country_extensions`)
+2. **When adding new countries** to the implementation, update the data provider(s) in the test file
+3. **Tests are separated by merchant type** (online vs offline, and both) since selling venue can affect which extensions are suggested
+4. This test file predates the project's `@testWith`-first convention for data-driven tests — new data-driven tests should still prefer `@testWith` over a `dataProvider` method where the dataset is simple enough to inline
 
 ## Mocking the WooCommerce Logger
 

--- a/.ai/skills/woocommerce-dev-cycle/code-quality.md
+++ b/.ai/skills/woocommerce-dev-cycle/code-quality.md
@@ -80,7 +80,7 @@ This command:
 - Identifies code style and potential issues
 - Does not modify files
 
-**Important:** The plugin-level `.eslintignore` excludes `client/blocks/`, so `lint:changes:branch:js` will not catch eslint or prettier issues in blocks code. For blocks changes, also run the blocks package lint:
+**Important:** The plugin-level `eslint.config.mjs` (flat config `ignores`) excludes `client/blocks/`, so `lint:changes:branch:js` will not catch eslint or prettier issues in blocks code. For blocks changes, also run the blocks package lint:
 
 ```bash
 # Check blocks JS/TS (includes prettier via eslint plugin)
@@ -237,7 +237,7 @@ pnpm run
 pnpm run lint           # Lint all files
 pnpm run lint:fix       # Fix all auto-fixable issues
 pnpm run lint:php       # PHP linting only
-pnpm run lint:js        # JavaScript linting only
+pnpm run lint:lang:js   # JavaScript linting only
 ```
 
 ## Troubleshooting

--- a/.ai/skills/woocommerce-dev-cycle/js-i18n-patterns.md
+++ b/.ai/skills/woocommerce-dev-cycle/js-i18n-patterns.md
@@ -280,8 +280,8 @@ npx eslint client/path/to/file.tsx
 # Fix specific file
 npx eslint --fix client/path/to/file.tsx
 
-# Type check
-pnpm run ts:check
+# Type check (ts:check is defined per-package, e.g. client/admin, not at repo root)
+pnpm --filter=@woocommerce/admin-library ts:check
 
 # ❌ NEVER lint entire codebase
 pnpm run lint  # NO - lints everything

--- a/.ai/skills/woocommerce-dev-cycle/markdown-linting.md
+++ b/.ai/skills/woocommerce-dev-cycle/markdown-linting.md
@@ -28,17 +28,17 @@ npm install -g markdownlint-cli
 
 ```bash
 # Check markdown file (run from repo root)
-markdownlint plugins/woocommerce/CLAUDE.md
+markdownlint AGENTS.md
 
 # RECOMMENDED: Auto-fix issues first (handles most errors)
-markdownlint --fix plugins/woocommerce/CLAUDE.md
+markdownlint --fix AGENTS.md
 
 # Check multiple files
-markdownlint packages/js/CLAUDE.md plugins/woocommerce/CLAUDE.md
+markdownlint packages/js/CLAUDE.md plugins/woocommerce/client/admin/CLAUDE.md
 
 # Lint all CLAUDE.md files
-markdownlint packages/js/CLAUDE.md plugins/woocommerce/CLAUDE.md \
-  plugins/woocommerce/client/admin/CLAUDE.md
+markdownlint packages/js/CLAUDE.md plugins/woocommerce/client/admin/CLAUDE.md \
+  plugins/woocommerce/client/blocks/CLAUDE.md
 ```
 
 ## Important: Always Run from Repository Root
@@ -50,10 +50,10 @@ Using absolute paths bypasses the config and may show incorrect errors.
 ```bash
 # ✅ CORRECT - run from repo root
 cd /path/to/woocommerce
-markdownlint plugins/woocommerce/CLAUDE.md
+markdownlint AGENTS.md
 
 # ❌ WRONG - bypasses config
-markdownlint /absolute/path/to/plugins/woocommerce/CLAUDE.md
+markdownlint /absolute/path/to/AGENTS.md
 ```
 
 ## Recommended Workflow
@@ -61,7 +61,7 @@ markdownlint /absolute/path/to/plugins/woocommerce/CLAUDE.md
 1. Make markdown changes
 2. Run `markdownlint --fix path/to/file.md` (auto-fixes most issues)
 3. Check remaining: `markdownlint path/to/file.md`
-4. Manually fix what remains (language specs, long lines)
+4. Manually fix what remains (mostly missing language specs)
 5. Verify clean, then commit
 
 ## Common Markdown Linting Issues
@@ -69,7 +69,7 @@ markdownlint /absolute/path/to/plugins/woocommerce/CLAUDE.md
 | Code | Issue | Description | Fix |
 |------|-------|-------------|-----|
 | **MD007** | List indentation | Wrong indentation level | Use 4 spaces for nested items |
-| **MD013** | Line length limit | Line exceeds 80 chars | Break into multiple lines |
+| **MD013** | Line length limit | Disabled (`line_length: 9999` in `.markdownlint.json`) | N/A |
 | **MD031** | Code blocks need blank lines | Missing blank lines | Add blank above/below code blocks |
 | **MD032** | Lists need blank lines | Missing blank lines | Add blank before/after lists |
 | **MD036** | Emphasis as heading | Using bold instead of heading | Use `###` not bold |
@@ -155,21 +155,6 @@ Common language specs:
 - `json` - JSON data
 - `markdown` or `md` - Markdown examples
 
-### Breaking Long Lines
-
-**Before:**
-
-```markdown
-This is a very long line that exceeds the 80 character limit and needs to be broken into multiple lines for better readability.
-```
-
-**After:**
-
-```markdown
-This is a very long line that exceeds the 80 character limit and needs to be
-broken into multiple lines for better readability.
-```
-
 ### Blank Lines Around Code Blocks
 
 **Before:**
@@ -198,5 +183,5 @@ More text
 
 - `markdownlint --fix` automatically handles most issues
 - CLAUDE.md files are AI assistant documentation and must be well-formatted for optimal parsing
-- Only a few issues require manual fixing (language specs, long lines)
+- Only a few issues require manual fixing (mostly missing language specs)
 - Always verify encoding after edits to prevent corruption

--- a/.ai/skills/woocommerce-dev-cycle/php-linting-patterns.md
+++ b/.ai/skills/woocommerce-dev-cycle/php-linting-patterns.md
@@ -191,7 +191,7 @@ When creating closures with parameters required by signature but unused, use `un
 - Array/filter callbacks where signature is fixed
 - Interface implementations with unused parameters
 
-**Reference:** `tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php:1647-1655`
+**Reference:** `tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php:1855-1856` (and `:1864-1865`)
 
 ## Array and Operator Alignment
 

--- a/.ai/skills/woocommerce-dev-cycle/running-tests.md
+++ b/.ai/skills/woocommerce-dev-cycle/running-tests.md
@@ -228,7 +228,7 @@ pnpm test:js -- --coverage
 ### Test File Locations
 
 - JavaScript/Jest tests: `client/admin/client/**/*.test.tsx` or `*.test.ts`
-- Jest configuration: `client/admin/jest.config.js`
+- Jest configuration: `client/admin/client/jest.config.js`
 
 ### Troubleshooting JavaScript Tests
 

--- a/.ai/skills/woocommerce-local-env/SKILL.md
+++ b/.ai/skills/woocommerce-local-env/SKILL.md
@@ -104,8 +104,9 @@ Recommend targeted watchers for focused work to reduce noise and startup time:
 ## Environment Details
 
 - Development URL: `http://localhost:8888/`
-- Test environment port: `8086`
-- wp-env config: `plugins/woocommerce/.wp-env.json`
+- PHPUnit test environment port: `8186` (config: `plugins/woocommerce/.wp-env.test.json`)
+- E2E test environment port: `8086` (config: `plugins/woocommerce/.wp-env.e2e.json`)
+- wp-env config (dev): `plugins/woocommerce/.wp-env.json`
 - wp-env PHP version: `8.1`
 - WooCommerce package: `@woocommerce/plugin-woocommerce`
 - Source README: `plugins/woocommerce/README.md`

--- a/.ai/skills/woocommerce-performance/options-cache-priming.md
+++ b/.ai/skills/woocommerce-performance/options-cache-priming.md
@@ -158,9 +158,9 @@ For multisite contexts, use `wp_prime_network_option_caches( $network_id, $keys 
 **WooCommerce settings API autoloads by default.** Any option registered and saved through `WC_Admin_Settings::save_fields()` is stored with `autoload = 'yes'` unless the field definition explicitly sets `'autoload' => false`. The relevant code is in `includes/admin/class-wc-admin-settings.php`:
 
 ```php
-// Line ~1035
+// Line ~1053
 $autoload_options[ $option_name ] = isset( $option['autoload'] ) ? (bool) $option['autoload'] : true;
-// Line ~1047
+// Line ~1065
 update_option( $name, $value, $autoload_options[ $name ] ? 'yes' : 'no' );
 ```
 

--- a/.ai/skills/woocommerce-store-api/variation-handling.md
+++ b/.ai/skills/woocommerce-store-api/variation-handling.md
@@ -39,7 +39,7 @@ The client has already picked a specific variation; `id` is its post ID. The `va
 { "id": 42, "variation": [ {"attribute": "pa_color", "value": "blue"}, {"attribute": "pa_size", "value": "medium"} ] }
 ```
 
-This is what the standard product page posts: `id` is the variable parent product, and the user's dropdown selections come along as the variation array. The server resolves to the matching variation via `WC_Data_Store::find_matching_product_variation()`.
+This is what the standard product page posts: `id` is the variable parent product, and the user's dropdown selections come along as the variation array. The server resolves to the matching variation via `WC_Data_Store::load( 'product' )->find_matching_product_variation()`.
 
 Simple (non-variable) products have `variation = []` and skip the reconciliation entirely.
 
@@ -116,4 +116,4 @@ The variation path is where future regressions are most likely to land. Tests ar
 - [`CartController::get_variation_id_from_variation_data()`](../../../plugins/woocommerce/src/StoreApi/Utilities/CartController.php) — resolves a variable parent + posted attributes to a specific variation ID.
 - `wc_get_product_variation_attributes()` (WooCommerce core) — returns canonical slugs for a variation, with `''` for "Any" slots.
 - `WC_Product_Attribute::get_slugs()` (WooCommerce core) — returns the allowed slug list for an attribute on the parent product.
-- `WC_Data_Store::find_matching_product_variation()` (WooCommerce core) — underlying lookup used by `get_variation_id_from_variation_data()`.
+- `find_matching_product_variation()` (instance method on the product data store, reached via `WC_Data_Store::load( 'product' )`, defined in `includes/data-stores/class-wc-product-data-store-cpt.php`) — underlying lookup used by `get_variation_id_from_variation_data()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ The `.ai/skills/` directory contains procedural HOW-TO instructions:
 - **`woocommerce-git-draft-pr`** - Create draft PRs with proper template, changelog, and milestone handling
 - **`woocommerce-email-editor`** - Email editor development setup and Mailpit configuration
 - **`woocommerce-performance`** - Performance guardrails. **Invoke when writing or reviewing PHP code.**
+- **`woocommerce-store-api`** - Store API (`/wc/store/v1/*`) route conventions
 
 ## Project Architecture
 
@@ -223,13 +224,13 @@ Reference: [WordPress Interactivity API - Private Stores](https://developer.word
 
 ```sh
 # Run specific test class
-pnpm test:php:env -- --filter TestClassName
+pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter TestClassName
 
 # Lint changed files
-pnpm lint:php:changes
+pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes
 
 # Fix linting issues
-pnpm lint:php:fix -- path/to/file.php
+pnpm --filter=@woocommerce/plugin-woocommerce lint:php:fix -- path/to/file.php
 ```
 
 For complete command reference and workflows, see `woocommerce-dev-cycle` skill.

--- a/plugins/woocommerce/client/admin/CLAUDE.md
+++ b/plugins/woocommerce/client/admin/CLAUDE.md
@@ -5,7 +5,7 @@
 
 **See also:**
 
-- `../../CLAUDE.md` - PHP tests and plugin-level documentation
+- `../../../../AGENTS.md` (repo root) - PHP tests and plugin-level documentation
 - `client/settings-payments/CLAUDE.md` - Settings Payments module patterns
 
 ## Quick Reference Commands
@@ -159,8 +159,8 @@ even when you pass file arguments. Use `npx eslint` directly for per-file lintin
 
 **JavaScript Linting Configuration:**
 
-- **Tool**: ESLint 8.x
-- **Config**: Uses `@woocommerce/eslint-plugin`
+- **Tool**: ESLint 10.x (flat config)
+- **Config**: `eslint.config.mjs`, uses `@woocommerce/eslint-plugin`
 - **Files**: `./client/**/*.{js,ts,tsx}`
 - **Cache**: `node_modules/.cache/eslint`
 - **Note**: ESLint may show warnings from other files during scans; ignore them
@@ -193,8 +193,8 @@ This runs `tsc --build` to check TypeScript types without emitting files.
 
 ### Markdown Linting
 
-For detailed markdown linting instructions, see the "Markdown Linting"
-section in `../../CLAUDE.md`.
+For detailed markdown linting instructions, see the `woocommerce-markdown`
+skill under `.ai/skills/`.
 
 ## Building
 
@@ -393,7 +393,7 @@ client/admin/
 - **`webpack.config.js`**: Webpack build configuration
 - **`tsconfig.json`**: TypeScript configuration
 - **`client/jest.config.js`**: Jest test configuration
-- **`.eslintrc.js`** or **`eslint.config.js`**: ESLint configuration
+- **`eslint.config.mjs`**: ESLint configuration
 - **`babel.config.js`**: Babel transpilation configuration
 
 ## Testing Patterns
@@ -449,7 +449,7 @@ Coverage reports help identify untested code paths.
 
 - Auto-fix what's possible: `pnpm run lint:fix`
 - Review remaining errors manually
-- Check `.eslintrc.js` for rule configuration
+- Check `eslint.config.mjs` for rule configuration
 
 **TypeScript errors:**
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/CLAUDE.md
+++ b/plugins/woocommerce/client/admin/client/settings-payments/CLAUDE.md
@@ -5,7 +5,7 @@
 
 **See also:**
 
-- `../CLAUDE.md` - Testing, linting, and build commands
+- `../../CLAUDE.md` - Testing, linting, and build commands
 - `packages/js/data/src/payment-settings/` - Data layer and types
 
 ## Quick Workflow

--- a/plugins/woocommerce/client/blocks/CLAUDE.md
+++ b/plugins/woocommerce/client/blocks/CLAUDE.md
@@ -5,7 +5,7 @@
 
 **See also:**
 
-- `../../CLAUDE.md` - Plugin-level docs, PHP workflow, changelog process
+- `../../../../AGENTS.md` (repo root) - Plugin-level docs, PHP workflow, changelog process
 - `../../src/Blocks/` - PHP block classes (registration, rendering, services)
 - `docs/README.md` - Full handbook (contributors, extensibility, theming)
 
@@ -20,7 +20,7 @@ pnpm --filter=@woocommerce/block-library test:js                      # Jest uni
 pnpm --filter=@woocommerce/block-library test:js -- path/to/test      # Specific test file
 pnpm --filter=@woocommerce/block-library test:watch                   # Jest watch mode
 pnpm --filter=@woocommerce/block-library test:update                  # Update snapshots
-pnpm --filter=@woocommerce/block-library test:e2e                     # Playwright E2E tests
+pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:blocks         # Playwright E2E tests (lives in the core e2e suite)
 
 # Lint (target specific files only)
 npx eslint --fix path/to/file.tsx                                      # Fix JS/TS file
@@ -28,8 +28,8 @@ pnpm --filter=@woocommerce/block-library lint:css                      # Styleli
 pnpm --filter=@woocommerce/block-library ts:check                     # TypeScript type checking
 
 # Environment
-pnpm --filter=@woocommerce/block-library env:start                    # Start wp-env + setup
-pnpm --filter=@woocommerce/block-library env:restart                  # Clean restart
+pnpm --filter=@woocommerce/block-library wp-env start                 # Start wp-env
+pnpm --filter=@woocommerce/block-library env:stop                     # Stop wp-env
 
 # Analysis
 pnpm --filter=@woocommerce/block-library knip                         # Find unused code (dead code detector)
@@ -139,7 +139,7 @@ For private stores:
 
 - Not intended for third-party extension
 - Removing/changing store state is NOT a breaking change
-- `assets/js/base/stores/woocommerce/` contains cart, product-data, products stores
+- `assets/js/base/stores/woocommerce/` contains cart, products, shopper-lists stores
 - Cart store uses mutation batching for performance
 
 ### IntegrationRegistry (Extension API)
@@ -179,9 +179,9 @@ Third-party extensions consume these as externals — changing the public API of
 
 ## Build System
 
-Webpack is configured with **11 separate configs** in `bin/webpack-configs.js`:
+Webpack is configured with **8 separate configs** in `bin/webpack-configs.js`:
 
-- Core, Main, Frontend, Extensions, Payments, Styling, Site Editor, Interactivity, Cart/Checkout Frontend, Dependency Detection
+- Core, Main, Front, Payments, Extensions, Site Editor, Styling, Cart/Checkout Frontend
 
 Webpack writes directly to `plugins/woocommerce/assets/client/blocks/` so PHP enqueues run against the final asset locations with no copy step. TypeScript uses **60+ path aliases** defined in `tsconfig.base.json`.
 
@@ -189,7 +189,7 @@ Webpack writes directly to `plugins/woocommerce/assets/client/blocks/` so PHP en
 
 ### Jest Unit Tests
 
-- Config: `tests/js/jest.config.json`
+- Config: `tests/js/jest.config.js`
 - Environment: `jest-fixed-jsdom`
 - Tests live in `test/` subdirectories alongside components
 - Path aliases mapped in jest config (mirrors tsconfig)
@@ -209,7 +209,7 @@ Webpack writes directly to `plugins/woocommerce/assets/client/blocks/` so PHP en
 
 ## Gotchas
 
-- **ESLint config** has custom WooCommerce rules and lodash import restrictions - use the local `.eslintrc.js`, not the monorepo root
+- **ESLint config** has custom WooCommerce rules and lodash import restrictions - use the local `eslint.config.mjs`, not the monorepo root
 - **`side-effects` in package.json** is extensive - many files cannot be tree-shaken (CSS, block registrations, filters)
 - **StoreApi lives outside Blocks** at `src/StoreApi/`, not `src/Blocks/StoreApi/`
 - **Two DI containers** exist: `src/Blocks/Registry/Container.php` (blocks-specific, legacy) and the main WooCommerce DI container in `src/`

--- a/plugins/woocommerce/src/Admin/Settings/AGENTS.md
+++ b/plugins/woocommerce/src/Admin/Settings/AGENTS.md
@@ -8,7 +8,7 @@ During a plugin update, a request can pair new files on disk with stale cached c
 
 Rules for this package and its call sites:
 
-- Code reachable from `includes/`, templates, or hook callbacks must call `SettingsUIRequestContext` (and the other classes here) either through methods that exist since WooCommerce 10.9, or inside a `class_exists` check plus `try/catch (\Throwable)` that falls back to legacy rendering. 10.9.x is the oldest release shipping these classes, so it is the version a stale class can be. `is_drill_down()` and `get_settings_page()` do not exist in 10.9; the rest of the context's surface does.
+- Code reachable from `includes/`, templates, or hook callbacks must call `SettingsUIRequestContext` (the `Internal\Admin\Settings` counterpart of the classes here — see `src/Internal/Admin/Settings/CLAUDE.md`) or the classes in this directory either through methods that exist since WooCommerce 10.9, or inside a `class_exists` check plus `try/catch (\Throwable)` that falls back to legacy rendering. 10.9.x is the oldest release shipping these classes, so it is the version a stale class can be. `is_drill_down()` and `get_settings_page()` do not exist in 10.9; the rest of the context's surface does.
 - Public and protected method signatures are additive only. Never remove or change one; deprecate and keep it working.
 - Never delete or rename a class file that has shipped in a release. A stale classmap entry pointing at a missing file fatals inside the autoloader, where no guard can catch it.
 - Never add a required method to an interface here. Stale implementers fail at class-link time, uncatchably. Add a concrete default to the `SettingsSection` base class instead, the way `SettingsSectionUIPageProviderInterface` was introduced.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/CLAUDE.md
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/CLAUDE.md
@@ -28,12 +28,25 @@
 ```text
 Settings/
 |-- PaymentsRestController.php                          # Main REST endpoint
+|-- PaymentsController.php                               # Settings UI wrapper
 |-- Payments.php                                        # Business logic
 |-- PaymentsProviders.php                               # Provider aggregation
 |-- Utils.php                                           # Utilities
-`-- PaymentsProviders/WooPayments/
-    `-- WooPaymentsRestController.php                   # WooPayments endpoints
+|-- LegacySettingsPageAdapter.php                        # Settings UI framework
+|-- RegisteredSettingsSectionAdapter.php                 # Settings UI framework
+|-- SettingsUIRequestContext.php                         # Settings UI framework
+|-- SettingsUISchema.php                                 # Settings UI framework
+|-- SettingsUIPageInterface.php                          # Settings UI framework
+|-- SettingsUIPages/                                     # Settings UI page adapters
+|-- Exceptions/                                          # ApiException, ApiArgumentException
+`-- PaymentsProviders/                                   # One file per gateway (Stripe, PayPal, ...)
+    `-- WooPayments/
+        |-- WooPaymentsRestController.php                # WooPayments endpoints
+        |-- WooPaymentsController.php
+        `-- WooPaymentsService.php
 ```
+
+Note: this directory holds two distinct things — the Payments REST API/business logic this doc focuses on, and the newer Settings UI framework classes (`PaymentsController.php`, `SettingsUI*`, `*Adapter.php`) that back the public wrappers in `src/Admin/Settings/`. See `src/Admin/Settings/AGENTS.md` for that layer.
 
 ## Critical Patterns
 
@@ -95,7 +108,7 @@ The `onboarding.state` field has an incomplete schema definition:
 ),
 ```
 
-**Actual implementation** (PaymentGateway.php:76-81):
+**Actual implementation** (PaymentsProviders/PaymentGateway.php:94-98):
 
 ```php
 'state' => array(
@@ -181,7 +194,7 @@ array(
 | File | Endpoint | Key Methods |
 | ------ | ---------- | ------------- |
 | PaymentsRestController.php | `/wc-admin/settings/payments/*` | `get_providers()`, `set_country()`, `update_providers_order()` |
-| PaymentsProviders/WooPayments/WooPaymentsRestController.php | `/wc-admin/settings/payments/providers/woopayments/*` | `get_onboarding_details()` |
+| PaymentsProviders/WooPayments/WooPaymentsRestController.php | `/wc-admin/settings/payments/woopayments/*` | `get_onboarding_details()` |
 | Payments.php | N/A (business logic) | `get_payment_providers()`, `get_payment_extension_suggestions()` |
 
 ## Linting
@@ -203,4 +216,4 @@ pnpm run lint:php:fix -- src/Internal/Admin/Settings/PaymentsRestController.php
 
 - JSON Schema Draft 04: <https://json-schema.org/draft-04/schema#>
 - WordPress REST API: <https://developer.wordpress.org/rest-api/>
-- Main plugin docs: `../../CLAUDE.md`
+- Main plugin docs: `../../../../../../AGENTS.md` (repo root)

--- a/plugins/woocommerce/tests/php/src/CLAUDE.md
+++ b/plugins/woocommerce/tests/php/src/CLAUDE.md
@@ -1,7 +1,7 @@
 # PHP Testing - Claude Code Documentation
 
 **Scope**: PHPUnit test patterns for WooCommerce plugin tests
-**Parent**: `plugins/woocommerce/CLAUDE.md`
+**Parent**: `AGENTS.md` (repo root)
 
 ## Quick Reference: Resilient Test Patterns
 
@@ -15,13 +15,13 @@
 
 Why: Full equality breaks when new keys are added.
 
-**Example**: `WooPaymentsServiceTest.php:510-511`
+**Real example** (`WooPaymentsServiceTest.php:510-511`, already using the resilient pattern):
 
 ```php
-// WRONG - Breaks if new keys added to messages array
+// Avoid - breaks if new keys are added to the messages array
 $this->assertSame( array( 'not_supported' => null ), $result['messages'] );
 
-// CORRECT - Tests only what matters
+// Prefer - tests only what matters
 $this->assertArrayHasKey( 'not_supported', $result['messages'] );
 $this->assertNull( $result['messages']['not_supported'] );
 ```
@@ -278,6 +278,6 @@ tests/php/src/
 
 ## Related Docs
 
-- `plugins/woocommerce/CLAUDE.md` - Test commands, linting, workflow
+- `AGENTS.md` (repo root) - Test commands, linting, workflow
 - `src/Internal/Admin/Settings/CLAUDE.md` - Settings backend patterns
 - PHPUnit: <https://phpunit.de/manual/9.6/en/index.html>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a cleanup of several stale file paths, renamed commands and dead cross-links that had accumulated as the codebase and docs site evolved.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

#### Type

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Documentation-only changes to AI agent instructions (`AGENTS.md`, `.ai/skills/`) and internal `CLAUDE.md` files. Nothing shipped to merchants.

</details>