### PR TITLE
Stop the analytics tracking proxy from accepting client-supplied server props

### DIFF
--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -72,36 +72,37 @@ add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
 add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 ```
 
-The `POST /wp-json/woocommerce-analytics/v1/track` endpoint this enables is
-unauthenticated, so a site where the filter has never returned `true` never gets
-it. Once a site has used it the route stays registered and answers `403
-proxy_tracking_disabled` while the filter is `false`, rather than disappearing:
-pages cached while it was on still tell their visitors to post there, and a `404`
-loses those events with no signal anywhere.
+This registers the unauthenticated `POST /wp-json/woocommerce-analytics/v1/track`
+endpoint. Sites that have never enabled proxy tracking do not get it. Once
+enabled, the route stays registered and answers `403 proxy_tracking_disabled`
+while the filter is `false`, so events from pages still held in a cache fail
+visibly instead of disappearing into a `404`.
 
-Events arriving through it are treated as untrusted:
+Events arriving through it are untrusted:
 
-- Server-derived properties (store id, visitor id, IP, session, timezone and the
-  rest of `WC_Analytics_Tracking::get_reserved_property_names()`) are replaced
-  with the server's own values. `_lg`, `_dl` and `_dr` stay the client's, since
-  they describe the page the event happened on rather than the `/track` request.
+-   Server-derived properties are replaced with the server's own values. The set
+    is `WC_Analytics_Tracking::get_reserved_property_names()`, which includes
+    generic names like `url`, `device` and `timezone`. Rename event properties
+    that would collide. `_lg`, `_dl` and `_dr` stay the client's: they describe
+    the page, not the `/track` request.
+-   Input is bounded silently. Over-limit properties are dropped and the event
+    still records; events past the batch limit are not recorded at all.
 
-  The reserved set includes generic names such as `url`, `device`, `timezone`,
-  `is_guest` and `landing_page`. An event that sends one of those for its own
-  purposes has it silently replaced, so prefix or rename event-specific
-  properties that would collide.
-- Input is bounded, silently. A request carries at most 50 events; events past
-  that are **not recorded at all**. Within an event, at most 50 properties, 50
-  members per array value, 200 characters per value, 100 characters per name and
-  4096 encoded bytes of payload; anything past those is dropped and **the event
-  still records** without it. A finished pixel URL over 8KB is not fired.
+| Limit                     | Value |
+| ------------------------- | ----- |
+| Events per request        | 50    |
+| Properties per event      | 50    |
+| Members per array value   | 50    |
+| Characters per value      | 200   |
+| Characters per name       | 100   |
+| Encoded payload per event | 4096  |
+| Pixel URL bytes           | 8192  |
 
-The filter's resolved value is mirrored into the `woocommerce_analytics_proxy_tracking_enabled`
-option (`yes`/`no`) on `init`. The optional MU-plugin speed module reads that
-option, because it runs before plugins register their filters. The module serves
-requests only while the option is `yes`.
+The filter's value is mirrored into the `woocommerce_analytics_proxy_tracking_enabled`
+option, which the optional MU-plugin speed module reads because it runs before
+plugins register filters.
 
-The filter must resolve to the same value for every request on a site. A callback
+**The filter must resolve to the same value for every request on a site.** One
 that varies by cohort, percentage or geo makes cached pages disagree with what
 `/track` decides, and makes the speed module install and uninstall itself on
 alternate runs.

--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -72,6 +72,24 @@ add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
 add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 ```
 
+The `POST /wp-json/woocommerce-analytics/v1/track` endpoint this enables is
+unauthenticated, so it is registered only while the filter above returns `true`,
+and events arriving through it are treated as untrusted:
+
+- Server-derived properties (store id, visitor id, IP, session, timezone and the
+  rest of `WC_Analytics_Tracking::get_reserved_property_names()`) are replaced
+  with the server's own values. `_lg`, `_dl` and `_dr` stay the client's, since
+  they describe the page the event happened on rather than the `/track` request.
+- Input is bounded: 50 events per request, 50 properties per event, 50 members
+  per array value, 200 characters per value, 100 characters per name, and 4096
+  characters of client payload per event. Anything past a limit is dropped
+  silently, and the event still records.
+
+The filter's resolved value is mirrored into the `woocommerce_analytics_proxy_tracking_enabled`
+option (`yes`/`no`) on `init`. The optional MU-plugin speed module reads that
+option, because it runs before plugins register their filters. The module serves
+requests only while the option is `yes`.
+
 ## Privacy & Consent Management
 
 ### WP Consent API Integration

--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -73,13 +73,23 @@ add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__retu
 ```
 
 The `POST /wp-json/woocommerce-analytics/v1/track` endpoint this enables is
-unauthenticated, so it is registered only while the filter above returns `true`,
-and events arriving through it are treated as untrusted:
+unauthenticated, so a site where the filter has never returned `true` never gets
+it. Once a site has used it the route stays registered and answers `403
+proxy_tracking_disabled` while the filter is `false`, rather than disappearing:
+pages cached while it was on still tell their visitors to post there, and a `404`
+loses those events with no signal anywhere.
+
+Events arriving through it are treated as untrusted:
 
 - Server-derived properties (store id, visitor id, IP, session, timezone and the
   rest of `WC_Analytics_Tracking::get_reserved_property_names()`) are replaced
   with the server's own values. `_lg`, `_dl` and `_dr` stay the client's, since
   they describe the page the event happened on rather than the `/track` request.
+
+  The reserved set includes generic names such as `url`, `device`, `timezone`,
+  `is_guest` and `landing_page`. An event that sends one of those for its own
+  purposes has it silently replaced, so prefix or rename event-specific
+  properties that would collide.
 - Input is bounded, silently. A request carries at most 50 events; events past
   that are **not recorded at all**. Within an event, at most 50 properties, 50
   members per array value, 200 characters per value, 100 characters per name and

--- a/packages/php/woocommerce-analytics/README.md
+++ b/packages/php/woocommerce-analytics/README.md
@@ -80,15 +80,21 @@ and events arriving through it are treated as untrusted:
   rest of `WC_Analytics_Tracking::get_reserved_property_names()`) are replaced
   with the server's own values. `_lg`, `_dl` and `_dr` stay the client's, since
   they describe the page the event happened on rather than the `/track` request.
-- Input is bounded: 50 events per request, 50 properties per event, 50 members
-  per array value, 200 characters per value, 100 characters per name, and 4096
-  characters of client payload per event. Anything past a limit is dropped
-  silently, and the event still records.
+- Input is bounded, silently. A request carries at most 50 events; events past
+  that are **not recorded at all**. Within an event, at most 50 properties, 50
+  members per array value, 200 characters per value, 100 characters per name and
+  4096 encoded bytes of payload; anything past those is dropped and **the event
+  still records** without it. A finished pixel URL over 8KB is not fired.
 
 The filter's resolved value is mirrored into the `woocommerce_analytics_proxy_tracking_enabled`
 option (`yes`/`no`) on `init`. The optional MU-plugin speed module reads that
 option, because it runs before plugins register their filters. The module serves
 requests only while the option is `yes`.
+
+The filter must resolve to the same value for every request on a site. A callback
+that varies by cohort, percentage or geo makes cached pages disagree with what
+`/track` decides, and makes the speed module install and uninstall itself on
+alternate runs.
 
 ## Privacy & Consent Management
 

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, and only register it where proxy tracking is enabled.

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, bound the size of what it accepts, and only serve it where proxy tracking is enabled.
+Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, bound the size of what it accepts, and only serve it where proxy tracking is enabled. The `jetpack_woocommerce_analytics_event_props` filter gains a third `$is_client_supplied` argument.

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: security
 
-Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, bound the size of what it accepts, and only serve it where proxy tracking is enabled. The `jetpack_woocommerce_analytics_event_props` filter gains a third `$is_client_supplied` argument.
+Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, bound the size of what it accepts, and serve it only on sites that use proxy tracking. Adds `WC_Analytics_Tracking::record_client_event()`, the `MAX_CLIENT_*` bounds, and a third `$is_client_supplied` argument to the `jetpack_woocommerce_analytics_event_props` filter.

--- a/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
+++ b/packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, and only register it where proxy tracking is enabled.
+Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, bound the size of what it accepts, and only serve it where proxy tracking is enabled.

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -100,7 +100,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 				continue;
 			}
 
-			$result = WC_Analytics_Tracking::record_event( $event_name, $properties );
+			$result = WC_Analytics_Tracking::record_client_event( $event_name, $properties );
 
 			if ( is_wp_error( $result ) ) {
 				$results[ $index ] = array(

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -41,7 +41,10 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'track_events' ),
-					'permission_callback' => '__return_true', // no need to check permissions
+					// Unauthenticated by design: this receives front-end events. The route is
+					// only registered where proxy tracking is enabled, and track_events()
+					// records via record_client_event(), which strips server-owned properties.
+					'permission_callback' => '__return_true',
 					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
 			)
@@ -72,6 +75,13 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 		if ( ! is_array( $events ) || ( isset( $events['event_name'] ) ) ) {
 			// If $events is a single event (associative array), wrap it in an array.
 			$events = array( $events );
+		}
+
+		// Bound the batch: every event becomes an outbound pixel request, and this
+		// endpoint is unauthenticated. Dropping the tail is silent on purpose — see
+		// WC_Analytics_Tracking::sanitize_client_properties().
+		if ( count( $events ) > WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST ) {
+			$events = array_slice( $events, 0, WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST, true );
 		}
 
 		$results    = array();

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -101,7 +101,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			// Validate event name and properties.
 			$event_name = $event['event_name'] ?? null;
 			$properties = $event['properties'] ?? array();
-			if ( ! $event_name || ! is_array( $properties ) ) {
+			if ( ! $event_name || ! is_string( $event_name ) || ! is_array( $properties ) ) {
 				$results[ $index ] = array(
 					'success' => false,
 					'error'   => 'Missing event_name or invalid properties',

--- a/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/packages/php/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -41,9 +41,10 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'track_events' ),
-					// Unauthenticated by design: this receives front-end events. The route is
-					// only registered where proxy tracking is enabled, and track_events()
-					// records via record_client_event(), which strips server-owned properties.
+					// Unauthenticated by design: this receives front-end events. The route
+					// exists only on sites that have used proxy tracking, track_events()
+					// refuses while the feature is off, and it records via
+					// record_client_event(), which strips server-owned properties.
 					'permission_callback' => '__return_true',
 					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
@@ -58,6 +59,17 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function track_events( $request ) {
+		// Refused rather than unregistered: pages cached while the feature was on
+		// still tell their visitors to POST here, and a 404 loses those events with
+		// no signal anywhere. Matches the MU-plugin speed module's own refusal.
+		if ( ! Features::is_proxy_tracking_enabled() ) {
+			return new \WP_Error(
+				'proxy_tracking_disabled',
+				'Proxy tracking is not enabled on this site.',
+				array( 'status' => 403 )
+			);
+		}
+
 		// Check consent before processing any events
 		if ( ! Consent_Manager::has_analytics_consent() ) {
 			return new \WP_REST_Response(

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -531,7 +531,8 @@ class WC_Analytics_Tracking {
 			return false;
 		}
 
-		$method = strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared against a fixed string below; unsanitized on purpose to stay byte-for-byte in step with the MU-plugin template's read.
+		$method = strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) );
 		if ( 'POST' !== $method ) {
 			return false;
 		}

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -43,7 +43,7 @@ class WC_Analytics_Tracking {
 	 * it records the referrer of the request that fired the pixel, which on the
 	 * proxy path is the /track POST, and is not used for page attribution.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var string[]
 	 */
@@ -59,7 +59,7 @@ class WC_Analytics_Tracking {
 	 * downstream overwrite is the only thing standing between a client and the
 	 * visitor id.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var string[]
 	 */
@@ -72,7 +72,7 @@ class WC_Analytics_Tracking {
 	 * the unauthenticated endpoint into an amplifier. The client's own batch size
 	 * is 10 (see `api-client.ts`); the headroom is for retries coalescing.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -81,7 +81,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum number of properties a client may set on one event.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -95,7 +95,7 @@ class WC_Analytics_Tracking {
 	 * URL, which is rejected outright once it grows too long. The two are
 	 * independent — a change to one does not imply a change to the other.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -106,7 +106,7 @@ class WC_Analytics_Tracking {
 	 *
 	 * `Pixel_Builder` checks a name's characters but not its length.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -118,7 +118,7 @@ class WC_Analytics_Tracking {
 	 * `get_properties()` joins members into one string, which the per-value cap
 	 * never sees, so an array of short members is otherwise unbounded.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -135,7 +135,7 @@ class WC_Analytics_Tracking {
 	 * so counting characters here would under-count by 3x and let the budget pass
 	 * a payload that still blows past MAX_PIXEL_URL_LENGTH.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -149,7 +149,7 @@ class WC_Analytics_Tracking {
 	 * `jetpack_woocommerce_analytics_event_props` callback added after the
 	 * client-side caps ran.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var int
 	 */
@@ -162,7 +162,7 @@ class WC_Analytics_Tracking {
 	 * copy: it tests the request shape before loading the autoloader, so no
 	 * package class exists yet at that point. Change both together.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var string
 	 */
@@ -213,7 +213,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
 	 *
-	 * @since 0.17.1 Added the `$is_client_supplied` parameter.
+	 * @since 0.18.0 Added the `$is_client_supplied` parameter.
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
@@ -296,7 +296,7 @@ class WC_Analytics_Tracking {
 	 * method rather than a sanitizer callers must remember to invoke, so that a
 	 * future entry point choosing the wrong one is visible at the call site.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Client-supplied properties.
@@ -521,7 +521,7 @@ class WC_Analytics_Tracking {
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
-		 * @since 0.17.1 Added the `$is_client_supplied` parameter.
+		 * @since 0.18.0 Added the `$is_client_supplied` parameter.
 		 *
 		 * @param array  $all_props Array of event props to be filtered.
 		 * @param string $event_name Event name.
@@ -574,7 +574,7 @@ class WC_Analytics_Tracking {
 	 * Memoized: a batch of events would otherwise recompute the common properties
 	 * once per event.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @return string[] Reserved property names.
 	 */
@@ -607,7 +607,7 @@ class WC_Analytics_Tracking {
 	 * Names the filter invents are still the client's to win — see the filter's
 	 * docblock for the contract callbacks are expected to follow.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param array $event_properties Client-supplied properties. Any non-array value
 	 *                                is tolerated — the REST body is attacker-shaped —
@@ -639,7 +639,7 @@ class WC_Analytics_Tracking {
 	 * keep an ellipsis so they stay distinguishable downstream from a value that
 	 * genuinely ended at the limit, matching `Woo_Analytics_Trait::cap_page_string()`.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param array $event_properties Client-supplied properties.
 	 * @return array Sanitized properties.
@@ -701,7 +701,7 @@ class WC_Analytics_Tracking {
 	 * Without the type check an array name reaches `PREFIX . $event_name` and
 	 * writes a PHP warning to the log, unauthenticated.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param mixed $name Client-supplied name.
 	 * @return bool True when the name is a non-empty string within the length bound.
@@ -721,7 +721,7 @@ class WC_Analytics_Tracking {
 	 * running it through here, and an approximation that missed the JSON branch
 	 * charged nothing for those keys.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param mixed $value Property value.
 	 * @return mixed The scalar it serializes to; non-array values are returned as-is.
@@ -745,7 +745,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Bytes one value contributes to the pixel URL.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param mixed $value Already-capped client value.
 	 * @return int Byte count after `flatten_property_value()` and the encoding
@@ -758,7 +758,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Drop trailing members until an array value fits the remaining budget.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param array $members Already-capped members.
 	 * @param int   $budget Bytes still available for this value.
@@ -781,7 +781,7 @@ class WC_Analytics_Tracking {
 	 * unauthenticated caller write warnings into the error log is the actual
 	 * problem; the value itself is meaningless either way.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @param mixed $value Client-supplied value.
 	 * @return mixed Bounded value.
@@ -818,7 +818,7 @@ class WC_Analytics_Tracking {
 	 * Kept in step with `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in
 	 * the MU-plugin template, including the character restriction on the path.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @return bool True when the request shape matches the proxy endpoint.
 	 */

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -394,19 +394,33 @@ class WC_Analytics_Tracking {
 	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted client.
 	 * @return array
 	 */
-	public static function get_properties( $event_name, $event_properties, $is_client_supplied = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- consumed by a filter argument added in a follow-up change.
+	public static function get_properties( $event_name, $event_properties, $is_client_supplied = false ) {
 		$common_properties = self::get_common_properties();
 
 		/**
 		 * Allow defining custom event properties in WooCommerce Analytics.
 		 *
+		 * On the proxy path the incoming array contains client-controlled values:
+		 * a callback setting a server-authoritative property must assign
+		 * unconditionally rather than defer to what is already there, because a
+		 * client can supply that property name itself. `$is_client_supplied` says
+		 * when that applies.
+		 *
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
+		 * @since 0.16.8 Added the `$is_client_supplied` parameter.
 		 *
-		 * @param array $all_props Array of event props to be filtered.
+		 * @param array  $all_props Array of event props to be filtered.
+		 * @param string $event_name Event name.
+		 * @param bool   $is_client_supplied Whether the props came from an untrusted client.
 		 */
-		$properties = apply_filters( 'jetpack_woocommerce_analytics_event_props', array_merge( $common_properties, $event_properties ), $event_name );
+		$properties = apply_filters(
+			'jetpack_woocommerce_analytics_event_props',
+			array_merge( $common_properties, $event_properties ),
+			$event_name,
+			$is_client_supplied
+		);
 
 		$required_properties = $event_name
 			? array(

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -37,8 +37,7 @@ class WC_Analytics_Tracking {
 	 *
 	 * The server's own values for these describe the /track request itself — its
 	 * URL, its referrer, its Accept-Language header — not the page the event
-	 * happened on. The client's values are the correct ones, so they are excluded
-	 * from the reserved set.
+	 * happened on. The client's values are the correct ones.
 	 *
 	 * @since 0.16.8
 	 *
@@ -463,9 +462,7 @@ class WC_Analytics_Tracking {
 	 *
 	 * Derived from the properties the server actually computes rather than
 	 * restated as a literal, so a property added to `get_page_common_properties()`
-	 * or `get_server_details()` is protected without a second edit here. The
-	 * failure mode of a hand-maintained list — a new property silently losing its
-	 * protection — cannot occur.
+	 * or `get_server_details()` is protected without a second edit here.
 	 *
 	 * Memoized: a batch of events would otherwise recompute the common properties
 	 * once per event.

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -222,9 +222,9 @@ class WC_Analytics_Tracking {
 	 *                                   the rest are capped when true. Defaults to false
 	 *                                   for server-side callers.
 	 *
-	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA,
-	 *                       cookie-less context, or an unusable client event name);
-	 *                       WP_Error if pixel firing failed.
+	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA, or
+	 *                       cookie-less context); WP_Error for an unusable client
+	 *                       event name, or if the pixel could not be built or fired.
 	 */
 	public static function record_event( $event_name, $event_properties = array(), $is_client_supplied = false ) {
 		// Check consent before recording any event.
@@ -246,8 +246,12 @@ class WC_Analytics_Tracking {
 		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
 
 		if ( $is_client_supplied ) {
+			// An error rather than a silent skip: the caller sent a name that cannot
+			// be recorded, and reporting success for an event that produced no pixel
+			// is what makes the loss invisible. Telling a client about its own
+			// malformed input leaks nothing.
 			if ( ! self::is_valid_client_name( $event_name ) ) {
-				return true;
+				return new WP_Error( 'invalid_event_name', 'the event name is empty, too long, or not a string', 400 );
 			}
 
 			$event_properties = self::sanitize_client_properties( $event_properties );
@@ -550,26 +554,8 @@ class WC_Analytics_Tracking {
 
 		$all_properties = array_merge( $properties, $required_properties );
 
-		// Convert array values to a comma-separated string and URL-encode them to ensure compatibility with JavaScript's encodeURIComponent() for pixel URL transmission.
 		foreach ( $all_properties as $key => $value ) {
-			if ( ! is_array( $value ) ) {
-				continue;
-			}
-
-			if ( empty( $value ) ) {
-				$all_properties[ $key ] = '';
-				continue;
-			}
-
-			$is_indexed_array = array_keys( $value ) === range( 0, count( $value ) - 1 );
-			if ( $is_indexed_array ) {
-				$value_string           = implode( ',', $value );
-				$all_properties[ $key ] = rawurlencode( $value_string );
-				continue;
-			}
-
-			// Serialize non-indexed arrays to JSON strings.
-			$all_properties[ $key ] = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+			$all_properties[ $key ] = self::flatten_property_value( $value );
 		}
 
 		return $all_properties;
@@ -674,7 +660,7 @@ class WC_Analytics_Tracking {
 				continue;
 			}
 
-			$budget -= strlen( $key );
+			$was_array = is_array( $value ) && ! empty( $value );
 
 			// Arrays are flattened later by get_properties(); bound their members too.
 			if ( is_array( $value ) ) {
@@ -685,13 +671,19 @@ class WC_Analytics_Tracking {
 				// Trimmed to fit rather than dropped: losing a few categories is
 				// easier to notice than the whole property disappearing, and the
 				// member cap alone always exceeds the budget.
-				$value = self::fit_client_array( array_map( array( __CLASS__, 'cap_client_value' ), $value ), $budget );
+				$value = self::fit_client_array(
+					array_map( array( __CLASS__, 'cap_client_value' ), $value ),
+					$budget - strlen( $key )
+				);
 			} else {
 				$value = self::cap_client_value( $value );
 			}
 
-			$cost = self::measure_client_value( $value );
-			if ( array() === $value || $cost > $budget ) {
+			$cost = strlen( $key ) + self::measure_client_value( $value );
+
+			// The budget is only spent on properties that survive, or one oversized
+			// value would charge its key against everything after it.
+			if ( ( $was_array && array() === $value ) || $cost > $budget ) {
 				unset( $event_properties[ $key ] );
 				continue;
 			}
@@ -721,22 +713,46 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Bytes one value contributes to the pixel URL.
+	 * Reduce one property value to the string that goes into the pixel URL.
 	 *
-	 * Mirrors the two encoding steps a value goes through: `get_properties()`
-	 * encodes a joined array, then `http_build_query()` encodes every value again.
+	 * Array values are joined and encoded for compatibility with the client's
+	 * `encodeURIComponent()`; an associative array becomes JSON, which carries its
+	 * keys. The single definition matters: the payload budget measures a value by
+	 * running it through here, and an approximation that missed the JSON branch
+	 * charged nothing for those keys.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @param mixed $value Property value.
+	 * @return mixed The scalar it serializes to; non-array values are returned as-is.
+	 */
+	private static function flatten_property_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( empty( $value ) ) {
+			return '';
+		}
+
+		if ( array_keys( $value ) === range( 0, count( $value ) - 1 ) ) {
+			return rawurlencode( implode( ',', $value ) );
+		}
+
+		return wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * Bytes one value contributes to the pixel URL.
 	 *
 	 * @since 0.17.1
 	 *
 	 * @param mixed $value Already-capped client value.
-	 * @return int Byte count after encoding.
+	 * @return int Byte count after `flatten_property_value()` and the encoding
+	 *             `http_build_query()` applies on top of it.
 	 */
 	private static function measure_client_value( $value ) {
-		if ( is_array( $value ) ) {
-			$value = rawurlencode( implode( ',', array_map( 'strval', $value ) ) );
-		}
-
-		return strlen( rawurlencode( (string) $value ) );
+		return strlen( rawurlencode( (string) self::flatten_property_value( $value ) ) );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -130,11 +130,30 @@ class WC_Analytics_Tracking {
 	 * The other caps bound each axis separately and multiply: at their limits one
 	 * event still built a 512KB pixel URL. This bounds the product.
 	 *
+	 * Counted after percent-encoding, in bytes, unlike the per-value cap which
+	 * counts characters. A `%` or a CJK character costs three bytes in the URL,
+	 * so counting characters here would under-count by 3x and let the budget pass
+	 * a payload that still blows past MAX_PIXEL_URL_LENGTH.
+	 *
 	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
 	const MAX_CLIENT_PAYLOAD_LENGTH = 4096;
+
+	/**
+	 * Maximum length of a pixel URL this package will fire.
+	 *
+	 * The backstop for every other cap. It is the only bound that sees the final
+	 * URL, so it is also the only one covering properties a
+	 * `jetpack_woocommerce_analytics_event_props` callback added after the
+	 * client-side caps ran.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @var int
+	 */
+	const MAX_PIXEL_URL_LENGTH = 8192;
 
 	/**
 	 * Path suffix of the proxy tracking endpoint.
@@ -347,6 +366,10 @@ class WC_Analytics_Tracking {
 	private static function record_pixel_url( $pixel_url ) {
 		if ( empty( $pixel_url ) ) {
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
+		}
+
+		if ( strlen( $pixel_url ) > self::MAX_PIXEL_URL_LENGTH ) {
+			return new WP_Error( 'pixel_too_long', 'tracks pixel URL exceeds the maximum length', 400 );
 		}
 
 		// Check if batching is supported.
@@ -651,19 +674,24 @@ class WC_Analytics_Tracking {
 				continue;
 			}
 
+			$budget -= strlen( $key );
+
 			// Arrays are flattened later by get_properties(); bound their members too.
 			if ( is_array( $value ) ) {
 				if ( count( $value ) > self::MAX_CLIENT_ARRAY_MEMBERS ) {
 					$value = array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true );
 				}
 
-				$value = array_map( array( __CLASS__, 'cap_client_value' ), $value );
+				// Trimmed to fit rather than dropped: losing a few categories is
+				// easier to notice than the whole property disappearing, and the
+				// member cap alone always exceeds the budget.
+				$value = self::fit_client_array( array_map( array( __CLASS__, 'cap_client_value' ), $value ), $budget );
 			} else {
 				$value = self::cap_client_value( $value );
 			}
 
-			$cost = strlen( $key ) + self::measure_client_value( $value );
-			if ( $cost > $budget ) {
+			$cost = self::measure_client_value( $value );
+			if ( array() === $value || $cost > $budget ) {
 				unset( $event_properties[ $key ] );
 				continue;
 			}
@@ -693,24 +721,39 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
-	 * Length one value contributes to the pixel URL once flattened.
+	 * Bytes one value contributes to the pixel URL.
+	 *
+	 * Mirrors the two encoding steps a value goes through: `get_properties()`
+	 * encodes a joined array, then `http_build_query()` encodes every value again.
 	 *
 	 * @since 0.17.1
 	 *
 	 * @param mixed $value Already-capped client value.
-	 * @return int Character count, counting the separators an array is joined with.
+	 * @return int Byte count after encoding.
 	 */
 	private static function measure_client_value( $value ) {
-		if ( ! is_array( $value ) ) {
-			return strlen( (string) $value );
+		if ( is_array( $value ) ) {
+			$value = rawurlencode( implode( ',', array_map( 'strval', $value ) ) );
 		}
 
-		$length = count( $value );
-		foreach ( $value as $member ) {
-			$length += strlen( (string) $member );
+		return strlen( rawurlencode( (string) $value ) );
+	}
+
+	/**
+	 * Drop trailing members until an array value fits the remaining budget.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @param array $members Already-capped members.
+	 * @param int   $budget Bytes still available for this value.
+	 * @return array Members that fit; empty when even one does not.
+	 */
+	private static function fit_client_array( $members, $budget ) {
+		while ( ! empty( $members ) && self::measure_client_value( $members ) > $budget ) {
+			array_pop( $members );
 		}
 
-		return $length;
+		return $members;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -33,6 +33,33 @@ class WC_Analytics_Tracking {
 	const DAILY_SALT_OPTION = 'woocommerce_analytics_daily_salt';
 
 	/**
+	 * Property names a client is authoritative for on the proxy path.
+	 *
+	 * The server's own values for these describe the /track request itself — its
+	 * URL, its referrer, its Accept-Language header — not the page the event
+	 * happened on. The client's values are the correct ones, so they are excluded
+	 * from the reserved set.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var string[]
+	 */
+	const CLIENT_OVERRIDABLE_PROPERTIES = array( '_lg', '_dl', '_dr' );
+
+	/**
+	 * Identity and envelope property names a client may never set.
+	 *
+	 * These are also protected today by `$required_properties` merging last in
+	 * `get_properties()`. Listed explicitly so that merge ordering is not the only
+	 * thing standing between a client and the visitor id.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var string[]
+	 */
+	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', 'browser_type' );
+
+	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -66,6 +93,13 @@ class WC_Analytics_Tracking {
 	 * @var string|null
 	 */
 	private static $cached_visitor_id = null;
+
+	/**
+	 * Memoized reserved property names for the current request.
+	 *
+	 * @var string[]|null
+	 */
+	private static $reserved_property_names = null;
 
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
@@ -365,6 +399,68 @@ class WC_Analytics_Tracking {
 		}
 
 		return $all_properties;
+	}
+
+	/**
+	 * Get the property names a client may not set.
+	 *
+	 * Derived from the properties the server actually computes rather than
+	 * restated as a literal, so a property added to `get_page_common_properties()`
+	 * or `get_server_details()` is protected without a second edit here. The
+	 * failure mode of a hand-maintained list — a new property silently losing its
+	 * protection — cannot occur.
+	 *
+	 * Memoized: a batch of events would otherwise recompute the common properties
+	 * once per event.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @return string[] Reserved property names.
+	 */
+	public static function get_reserved_property_names() {
+		if ( null !== self::$reserved_property_names ) {
+			return self::$reserved_property_names;
+		}
+
+		$server_owned = array_diff(
+			array_keys( self::get_common_properties() ),
+			self::CLIENT_OVERRIDABLE_PROPERTIES
+		);
+
+		self::$reserved_property_names = array_values(
+			array_unique( array_merge( $server_owned, self::RESERVED_IDENTITY_PROPERTIES ) )
+		);
+
+		return self::$reserved_property_names;
+	}
+
+	/**
+	 * Remove server-owned properties from a client-supplied property array.
+	 *
+	 * Stripping is silent and the event still records. Rejecting the event would
+	 * turn the endpoint into an oracle for probing the reserved list, and
+	 * analytics should not fail loudly on a malformed client.
+	 *
+	 * Does not cover property names introduced by callbacks on
+	 * `jetpack_woocommerce_analytics_event_props`: those do not exist until after
+	 * the filter has run, by which point a client value of the same name has
+	 * already been merged. See the filter's docblock for the contract callbacks
+	 * are expected to follow.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @param array $event_properties Client-supplied properties.
+	 * @return array Properties with reserved names removed.
+	 */
+	public static function strip_reserved_properties( $event_properties ) {
+		if ( ! is_array( $event_properties ) || empty( $event_properties ) ) {
+			return array();
+		}
+
+		return array_diff_key(
+			$event_properties,
+			array_flip( self::get_reserved_property_names() )
+		);
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -106,11 +106,14 @@ class WC_Analytics_Tracking {
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
+	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted
+	 *                                   client. Reserved property names are stripped when
+	 *                                   true. Defaults to false for server-side callers.
 	 *
 	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA,
 	 *                       or cookie-less context); WP_Error if pixel firing failed.
 	 */
-	public static function record_event( $event_name, $event_properties = array() ) {
+	public static function record_event( $event_name, $event_properties = array(), $is_client_supplied = false ) {
 		// Check consent before recording any event.
 		if ( ! Consent_Manager::has_analytics_consent() ) {
 			return true; // Skip recording.
@@ -126,8 +129,12 @@ class WC_Analytics_Tracking {
 			return true;
 		}
 
+		if ( $is_client_supplied ) {
+			$event_properties = self::strip_reserved_properties( $event_properties );
+		}
+
 		$prefixed_event_name = self::PREFIX . $event_name;
-		$properties          = self::get_properties( $prefixed_event_name, $event_properties );
+		$properties          = self::get_properties( $prefixed_event_name, $event_properties, $is_client_supplied );
 
 		// Record Tracks event.
 		$tracks_error  = null;
@@ -155,6 +162,25 @@ class WC_Analytics_Tracking {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Record an event whose properties came from an untrusted client.
+	 *
+	 * The entry point for the tracking proxy: the REST controller and the
+	 * MU-plugin speed module both come through here. It exists as a distinct
+	 * method rather than a sanitizer callers must remember to invoke, so that a
+	 * future entry point choosing the wrong one is visible at the call site.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @param string $event_name The name of the event.
+	 * @param array  $event_properties Client-supplied properties.
+	 *
+	 * @return bool|WP_Error True on emit or deliberate skip; WP_Error if pixel firing failed.
+	 */
+	public static function record_client_event( $event_name, $event_properties = array() ) {
+		return self::record_event( $event_name, $event_properties, true );
 	}
 
 	/**
@@ -349,9 +375,10 @@ class WC_Analytics_Tracking {
 	 *
 	 * @param string $event_name Event name.
 	 * @param array  $event_properties Event specific properties.
+	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted client.
 	 * @return array
 	 */
-	public static function get_properties( $event_name, $event_properties ) {
+	public static function get_properties( $event_name, $event_properties, $is_client_supplied = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- consumed by a filter argument added in a follow-up change.
 		$common_properties = self::get_common_properties();
 
 		/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -60,6 +60,19 @@ class WC_Analytics_Tracking {
 	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', 'browser_type' );
 
 	/**
+	 * Path suffix of the proxy tracking endpoint.
+	 *
+	 * Duplicated in the MU-plugin speed module template, which cannot use this
+	 * copy: it tests the request shape before loading the autoloader, so no
+	 * package class exists yet at that point. Change both together.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var string
+	 */
+	const PROXY_REQUEST_PATH = 'woocommerce-analytics/v1/track';
+
+	/**
 	 * Event queue.
 	 *
 	 * @var array
@@ -128,6 +141,9 @@ class WC_Analytics_Tracking {
 		if ( empty( self::get_visitor_id() ) ) {
 			return true;
 		}
+
+		// The guard covers MU-plugin copies predating record_client_event(); see is_proxy_tracking_request().
+		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
 
 		if ( $is_client_supplied ) {
 			$event_properties = self::strip_reserved_properties( $event_properties );
@@ -488,6 +504,66 @@ class WC_Analytics_Tracking {
 			$event_properties,
 			array_flip( self::get_reserved_property_names() )
 		);
+	}
+
+	/**
+	 * Whether the current request is a POST to the proxy tracking endpoint.
+	 *
+	 * A safety net, not the boundary. The boundary is `record_client_event()`,
+	 * which does not depend on URL shape and so survives subdirectory installs,
+	 * rewrites and proxying. This exists only because MU-plugin copies installed
+	 * before `record_client_event()` existed call `record_event()` directly, and
+	 * rewriting an installed copy depends on a chain of preconditions — admin
+	 * traffic, an expired transient, a writable mu-plugins directory — that is
+	 * not guaranteed to hold.
+	 *
+	 * Remove once a package-version floor guarantees no such copy survives.
+	 *
+	 * Kept in step with `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in
+	 * the MU-plugin template, including the character restriction on the path.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @return bool True when the request shape matches the proxy endpoint.
+	 */
+	public static function is_proxy_tracking_request() {
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
+			return false;
+		}
+
+		$method = strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
+		if ( 'POST' !== $method ) {
+			return false;
+		}
+
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Parsed and character-restricted below; sanitizing first would mangle the path.
+		$raw_uri = wp_unslash( $_SERVER['REQUEST_URI'] );
+		if ( ! is_string( $raw_uri ) || '' === $raw_uri ) {
+			return false;
+		}
+
+		$path = wp_parse_url( $raw_uri, PHP_URL_PATH );
+		if ( ! is_string( $path ) ) {
+			return false;
+		}
+
+		// Reject anything outside expected URL path characters, matching the template.
+		if ( preg_match( '/[^A-Za-z0-9\-._~\/]/', $path ) ) {
+			return false;
+		}
+
+		$normalized_path = rtrim( $path, '/' );
+		$proxy_suffix    = '/' . ltrim( self::PROXY_REQUEST_PATH, '/' );
+
+		if ( strlen( $normalized_path ) < strlen( $proxy_suffix ) ) {
+			return false;
+		}
+
+		return substr( $normalized_path, -strlen( $proxy_suffix ) ) === $proxy_suffix;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -43,7 +43,7 @@ class WC_Analytics_Tracking {
 	 * it records the referrer of the request that fired the pixel, which on the
 	 * proxy path is the /track POST, and is not used for page attribution.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var string[]
 	 */
@@ -59,7 +59,7 @@ class WC_Analytics_Tracking {
 	 * downstream overwrite is the only thing standing between a client and the
 	 * visitor id.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var string[]
 	 */
@@ -72,7 +72,7 @@ class WC_Analytics_Tracking {
 	 * the unauthenticated endpoint into an amplifier. The client's own batch size
 	 * is 10 (see `api-client.ts`); the headroom is for retries coalescing.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
@@ -81,7 +81,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Maximum number of properties a client may set on one event.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
@@ -95,7 +95,7 @@ class WC_Analytics_Tracking {
 	 * URL, which is rejected outright once it grows too long. The two are
 	 * independent — a change to one does not imply a change to the other.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
@@ -106,7 +106,7 @@ class WC_Analytics_Tracking {
 	 *
 	 * `Pixel_Builder` checks a name's characters but not its length.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
@@ -118,11 +118,23 @@ class WC_Analytics_Tracking {
 	 * `get_properties()` joins members into one string, which the per-value cap
 	 * never sees, so an array of short members is otherwise unbounded.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var int
 	 */
 	const MAX_CLIENT_ARRAY_MEMBERS = 50;
+
+	/**
+	 * Maximum total length of one event's client-supplied properties.
+	 *
+	 * The other caps bound each axis separately and multiply: at their limits one
+	 * event still built a 512KB pixel URL. This bounds the product.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PAYLOAD_LENGTH = 4096;
 
 	/**
 	 * Path suffix of the proxy tracking endpoint.
@@ -131,7 +143,7 @@ class WC_Analytics_Tracking {
 	 * copy: it tests the request shape before loading the autoloader, so no
 	 * package class exists yet at that point. Change both together.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var string
 	 */
@@ -182,7 +194,7 @@ class WC_Analytics_Tracking {
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
 	 *
-	 * @since 0.16.8 Added the `$is_client_supplied` parameter.
+	 * @since 0.17.1 Added the `$is_client_supplied` parameter.
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
@@ -192,7 +204,8 @@ class WC_Analytics_Tracking {
 	 *                                   for server-side callers.
 	 *
 	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA,
-	 *                       or cookie-less context); WP_Error if pixel firing failed.
+	 *                       cookie-less context, or an unusable client event name);
+	 *                       WP_Error if pixel firing failed.
 	 */
 	public static function record_event( $event_name, $event_properties = array(), $is_client_supplied = false ) {
 		// Check consent before recording any event.
@@ -260,7 +273,7 @@ class WC_Analytics_Tracking {
 	 * method rather than a sanitizer callers must remember to invoke, so that a
 	 * future entry point choosing the wrong one is visible at the call site.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Client-supplied properties.
@@ -481,7 +494,7 @@ class WC_Analytics_Tracking {
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
-		 * @since 0.16.8 Added the `$is_client_supplied` parameter.
+		 * @since 0.17.1 Added the `$is_client_supplied` parameter.
 		 *
 		 * @param array  $all_props Array of event props to be filtered.
 		 * @param string $event_name Event name.
@@ -552,7 +565,7 @@ class WC_Analytics_Tracking {
 	 * Memoized: a batch of events would otherwise recompute the common properties
 	 * once per event.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @return string[] Reserved property names.
 	 */
@@ -585,7 +598,7 @@ class WC_Analytics_Tracking {
 	 * Names the filter invents are still the client's to win — see the filter's
 	 * docblock for the contract callbacks are expected to follow.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @param array $event_properties Client-supplied properties. Any non-array value
 	 *                                is tolerated — the REST body is attacker-shaped —
@@ -617,7 +630,7 @@ class WC_Analytics_Tracking {
 	 * keep an ellipsis so they stay distinguishable downstream from a value that
 	 * genuinely ended at the limit, matching `Woo_Analytics_Trait::cap_page_string()`.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @param array $event_properties Client-supplied properties.
 	 * @return array Sanitized properties.
@@ -628,6 +641,8 @@ class WC_Analytics_Tracking {
 		if ( count( $event_properties ) > self::MAX_CLIENT_PROPERTIES_PER_EVENT ) {
 			$event_properties = array_slice( $event_properties, 0, self::MAX_CLIENT_PROPERTIES_PER_EVENT, true );
 		}
+
+		$budget = self::MAX_CLIENT_PAYLOAD_LENGTH;
 
 		foreach ( $event_properties as $key => $value ) {
 			// Dropped, not truncated: two long names could truncate to the same key.
@@ -642,11 +657,19 @@ class WC_Analytics_Tracking {
 					$value = array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true );
 				}
 
-				$event_properties[ $key ] = array_map( array( __CLASS__, 'cap_client_value' ), $value );
+				$value = array_map( array( __CLASS__, 'cap_client_value' ), $value );
+			} else {
+				$value = self::cap_client_value( $value );
+			}
+
+			$cost = strlen( $key ) + self::measure_client_value( $value );
+			if ( $cost > $budget ) {
+				unset( $event_properties[ $key ] );
 				continue;
 			}
 
-			$event_properties[ $key ] = self::cap_client_value( $value );
+			$budget                  -= $cost;
+			$event_properties[ $key ] = $value;
 		}
 
 		return $event_properties;
@@ -658,7 +681,7 @@ class WC_Analytics_Tracking {
 	 * Without the type check an array name reaches `PREFIX . $event_name` and
 	 * writes a PHP warning to the log, unauthenticated.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @param mixed $name Client-supplied name.
 	 * @return bool True when the name is a non-empty string within the length bound.
@@ -670,6 +693,27 @@ class WC_Analytics_Tracking {
 	}
 
 	/**
+	 * Length one value contributes to the pixel URL once flattened.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @param mixed $value Already-capped client value.
+	 * @return int Character count, counting the separators an array is joined with.
+	 */
+	private static function measure_client_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return strlen( (string) $value );
+		}
+
+		$length = count( $value );
+		foreach ( $value as $member ) {
+			$length += strlen( (string) $member );
+		}
+
+		return $length;
+	}
+
+	/**
 	 * Bound one client-supplied value on its way to the pixel URL.
 	 *
 	 * Nested arrays are collapsed to an empty string rather than capped: the
@@ -678,7 +722,7 @@ class WC_Analytics_Tracking {
 	 * unauthenticated caller write warnings into the error log is the actual
 	 * problem; the value itself is meaningless either way.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @param mixed $value Client-supplied value.
 	 * @return mixed Bounded value.
@@ -715,7 +759,7 @@ class WC_Analytics_Tracking {
 	 * Kept in step with `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in
 	 * the MU-plugin template, including the character restriction on the path.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @return bool True when the request shape matches the proxy endpoint.
 	 */

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -39,6 +39,10 @@ class WC_Analytics_Tracking {
 	 * URL, its referrer, its Accept-Language header — not the page the event
 	 * happened on. The client's values are the correct ones.
 	 *
+	 * `_via_ref` stays server-owned despite coming from the same header as `_dr`:
+	 * it records the referrer of the request that fired the pixel, which on the
+	 * proxy path is the /track POST, and is not used for page attribution.
+	 *
 	 * @since 0.16.8
 	 *
 	 * @var string[]
@@ -48,15 +52,54 @@ class WC_Analytics_Tracking {
 	/**
 	 * Identity and envelope property names a client may never set.
 	 *
-	 * These are also protected today by `$required_properties` merging last in
-	 * `get_properties()`. Listed explicitly so that merge ordering is not the only
-	 * thing standing between a client and the visitor id.
+	 * Each is also protected today by something else: `_ui`, `_ut`, `_en` and
+	 * `_ts` by `$required_properties` merging last in `get_properties()`,
+	 * `browser_type` by `Pixel_Builder::validate_and_sanitize()` assigning it
+	 * unconditionally. Listed explicitly so that neither merge ordering nor a
+	 * downstream overwrite is the only thing standing between a client and the
+	 * visitor id.
 	 *
 	 * @since 0.16.8
 	 *
 	 * @var string[]
 	 */
-	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', 'browser_type' );
+	const RESERVED_IDENTITY_PROPERTIES = array( '_ui', '_ut', '_en', '_ts', 'browser_type' );
+
+	/**
+	 * Maximum number of events a single client request may record.
+	 *
+	 * Each event becomes an outbound pixel request, so an unbounded batch turns
+	 * the unauthenticated endpoint into an amplifier. The client's own batch size
+	 * is 10 (see `api-client.ts`); the headroom is for retries coalescing.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_EVENTS_PER_REQUEST = 50;
+
+	/**
+	 * Maximum number of properties a client may set on one event.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PROPERTIES_PER_EVENT = 50;
+
+	/**
+	 * Maximum length of a single client-supplied property value.
+	 *
+	 * Set for the same reason `Woo_Analytics_Trait::cap_page_string()` bounds
+	 * caller-influenced strings on the page-output path: values reach the pixel
+	 * URL, which is rejected outright once it grows too long. The two are
+	 * independent — a change to one does not imply a change to the other.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_PROPERTY_LENGTH = 200;
 
 	/**
 	 * Path suffix of the proxy tracking endpoint.
@@ -116,11 +159,14 @@ class WC_Analytics_Tracking {
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
 	 *
+	 * @since 0.16.8 Added the `$is_client_supplied` parameter.
+	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $event_properties Custom properties to send with the event.
 	 * @param bool   $is_client_supplied Whether $event_properties came from an untrusted
-	 *                                   client. Reserved property names are stripped when
-	 *                                   true. Defaults to false for server-side callers.
+	 *                                   client. Reserved property names are stripped and
+	 *                                   the rest are capped when true. Defaults to false
+	 *                                   for server-side callers.
 	 *
 	 * @return bool|WP_Error True on emit or deliberate skip (no consent, bot UA,
 	 *                       or cookie-less context); WP_Error if pixel firing failed.
@@ -145,7 +191,7 @@ class WC_Analytics_Tracking {
 		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
 
 		if ( $is_client_supplied ) {
-			$event_properties = self::strip_reserved_properties( $event_properties );
+			$event_properties = self::sanitize_client_properties( $event_properties );
 		}
 
 		$prefixed_event_name = self::PREFIX . $event_name;
@@ -421,6 +467,15 @@ class WC_Analytics_Tracking {
 			$is_client_supplied
 		);
 
+		if ( $is_client_supplied ) {
+			// A callback that defers to an existing value hands a reserved property
+			// back to the client, which supplied it. Re-assert the server's own.
+			$properties = array_merge(
+				$properties,
+				array_intersect_key( $common_properties, array_flip( self::get_reserved_property_names() ) )
+			);
+		}
+
 		$required_properties = $event_name
 			? array(
 				'_en' => $event_name,
@@ -460,9 +515,12 @@ class WC_Analytics_Tracking {
 	/**
 	 * Get the property names a client may not set.
 	 *
-	 * Derived from the properties the server actually computes rather than
-	 * restated as a literal, so a property added to `get_page_common_properties()`
-	 * or `get_server_details()` is protected without a second edit here.
+	 * Derived from `get_common_properties()` — everything `get_session_properties()`,
+	 * `get_page_common_properties()` and `get_server_details()` compute — rather
+	 * than restated as a literal, so a property added to any of the three is
+	 * protected with no edit to this method. The pinned list in
+	 * `WC_Analytics_Tracking_Reserved_Props_Test` still fails on the addition, on
+	 * purpose: protection is automatic, granting an exemption is not.
 	 *
 	 * Memoized: a batch of events would otherwise recompute the common properties
 	 * once per event.
@@ -495,16 +553,18 @@ class WC_Analytics_Tracking {
 	 * turn the endpoint into an oracle for probing the reserved list, and
 	 * analytics should not fail loudly on a malformed client.
 	 *
-	 * Does not cover property names introduced by callbacks on
-	 * `jetpack_woocommerce_analytics_event_props`: those do not exist until after
-	 * the filter has run, by which point a client value of the same name has
-	 * already been merged. See the filter's docblock for the contract callbacks
-	 * are expected to follow.
+	 * Reserved names a callback on `jetpack_woocommerce_analytics_event_props`
+	 * introduces are re-asserted after the filter runs; see `get_properties()`.
+	 * Names the filter invents are still the client's to win — see the filter's
+	 * docblock for the contract callbacks are expected to follow.
 	 *
 	 * @since 0.16.8
 	 *
-	 * @param array $event_properties Client-supplied properties.
-	 * @return array Properties with reserved names removed.
+	 * @param array $event_properties Client-supplied properties. Any non-array value
+	 *                                is tolerated — the REST body is attacker-shaped —
+	 *                                and yields an empty array.
+	 * @return array Properties with reserved names removed; empty array for empty or
+	 *               non-array input.
 	 */
 	public static function strip_reserved_properties( $event_properties ) {
 		if ( ! is_array( $event_properties ) || empty( $event_properties ) ) {
@@ -515,6 +575,74 @@ class WC_Analytics_Tracking {
 			$event_properties,
 			array_flip( self::get_reserved_property_names() )
 		);
+	}
+
+	/**
+	 * Strip and bound a client-supplied property array.
+	 *
+	 * The single place the untrusted-input rules are applied, so that the REST
+	 * controller, the MU-plugin speed module and the stale-template safety net
+	 * cannot drift apart on what "sanitized" means.
+	 *
+	 * Capping is silent and lossy for the same reason stripping is: an
+	 * unauthenticated endpoint that reports which values it rejected is an oracle,
+	 * and analytics should not fail loudly on a malformed client. Truncated values
+	 * keep an ellipsis so they stay distinguishable downstream from a value that
+	 * genuinely ended at the limit, matching `Woo_Analytics_Trait::cap_page_string()`.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @param array $event_properties Client-supplied properties.
+	 * @return array Sanitized properties.
+	 */
+	public static function sanitize_client_properties( $event_properties ) {
+		$event_properties = self::strip_reserved_properties( $event_properties );
+
+		if ( count( $event_properties ) > self::MAX_CLIENT_PROPERTIES_PER_EVENT ) {
+			$event_properties = array_slice( $event_properties, 0, self::MAX_CLIENT_PROPERTIES_PER_EVENT, true );
+		}
+
+		foreach ( $event_properties as $key => $value ) {
+			// Arrays are flattened later by get_properties(); bound their members too.
+			if ( is_array( $value ) ) {
+				$event_properties[ $key ] = array_map( array( __CLASS__, 'cap_client_value' ), $value );
+				continue;
+			}
+
+			$event_properties[ $key ] = self::cap_client_value( $value );
+		}
+
+		return $event_properties;
+	}
+
+	/**
+	 * Bound one client-supplied value on its way to the pixel URL.
+	 *
+	 * Nested arrays are collapsed to an empty string rather than capped: the
+	 * flattening in `get_properties()` calls `implode()` on array members, which
+	 * emits an "Array to string conversion" warning for a nested one. Letting an
+	 * unauthenticated caller write warnings into the error log is the actual
+	 * problem; the value itself is meaningless either way.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @param mixed $value Client-supplied value.
+	 * @return mixed Bounded value.
+	 */
+	private static function cap_client_value( $value ) {
+		if ( is_array( $value ) || is_object( $value ) ) {
+			return '';
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( mb_strlen( $value ) <= self::MAX_CLIENT_PROPERTY_LENGTH ) {
+			return $value;
+		}
+
+		return mb_substr( $value, 0, self::MAX_CLIENT_PROPERTY_LENGTH - 1 ) . '…';
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -102,6 +102,17 @@ class WC_Analytics_Tracking {
 	const MAX_CLIENT_PROPERTY_LENGTH = 200;
 
 	/**
+	 * Maximum length of a client-supplied event or property name.
+	 *
+	 * `Pixel_Builder` checks a name's characters but not its length.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_NAME_LENGTH = 100;
+
+	/**
 	 * Path suffix of the proxy tracking endpoint.
 	 *
 	 * Duplicated in the MU-plugin speed module template, which cannot use this
@@ -191,6 +202,10 @@ class WC_Analytics_Tracking {
 		$is_client_supplied = $is_client_supplied || self::is_proxy_tracking_request();
 
 		if ( $is_client_supplied ) {
+			if ( ! self::is_valid_client_name( $event_name ) ) {
+				return true;
+			}
+
 			$event_properties = self::sanitize_client_properties( $event_properties );
 		}
 
@@ -603,6 +618,12 @@ class WC_Analytics_Tracking {
 		}
 
 		foreach ( $event_properties as $key => $value ) {
+			// Dropped, not truncated: two long names could truncate to the same key.
+			if ( ! self::is_valid_client_name( $key ) || ! Pixel_Builder::prop_name_is_valid( $key ) ) {
+				unset( $event_properties[ $key ] );
+				continue;
+			}
+
 			// Arrays are flattened later by get_properties(); bound their members too.
 			if ( is_array( $value ) ) {
 				$event_properties[ $key ] = array_map( array( __CLASS__, 'cap_client_value' ), $value );
@@ -613,6 +634,23 @@ class WC_Analytics_Tracking {
 		}
 
 		return $event_properties;
+	}
+
+	/**
+	 * Whether a client-supplied event or property name is usable.
+	 *
+	 * Without the type check an array name reaches `PREFIX . $event_name` and
+	 * writes a PHP warning to the log, unauthenticated.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @param mixed $name Client-supplied name.
+	 * @return bool True when the name is a non-empty string within the length bound.
+	 */
+	private static function is_valid_client_name( $name ) {
+		return is_string( $name )
+			&& '' !== $name
+			&& mb_strlen( $name ) <= self::MAX_CLIENT_NAME_LENGTH;
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/packages/php/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -113,6 +113,18 @@ class WC_Analytics_Tracking {
 	const MAX_CLIENT_NAME_LENGTH = 100;
 
 	/**
+	 * Maximum number of members in a client-supplied array value.
+	 *
+	 * `get_properties()` joins members into one string, which the per-value cap
+	 * never sees, so an array of short members is otherwise unbounded.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var int
+	 */
+	const MAX_CLIENT_ARRAY_MEMBERS = 50;
+
+	/**
 	 * Path suffix of the proxy tracking endpoint.
 	 *
 	 * Duplicated in the MU-plugin speed module template, which cannot use this
@@ -626,6 +638,10 @@ class WC_Analytics_Tracking {
 
 			// Arrays are flattened later by get_properties(); bound their members too.
 			if ( is_array( $value ) ) {
+				if ( count( $value ) > self::MAX_CLIENT_ARRAY_MEMBERS ) {
+					$value = array_slice( $value, 0, self::MAX_CLIENT_ARRAY_MEMBERS, true );
+				}
+
 				$event_properties[ $key ] = array_map( array( __CLASS__, 'cap_client_value' ), $value );
 				continue;
 			}

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -272,7 +272,8 @@ trait Woo_Analytics_Trait {
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
-		 * @since 0.16.8 Added the `$event_name` and `$is_client_supplied` parameters.
+		 * @since 0.17.1 Added the `$is_client_supplied` parameter. This call site
+		 *               also began passing `$event_name`, which the hook already had.
 		 *
 		 * @param array  $properties Array of event props to be filtered.
 		 * @param string $event_name Event name. Empty string here: this call builds

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -269,12 +269,17 @@ trait Woo_Analytics_Trait {
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
+		 * @since 0.16.8 Added the `$event_name` and `$is_client_supplied` parameters.
 		 *
-		 * @param array $properties Array of event props to be filtered.
+		 * @param array  $properties Array of event props to be filtered.
+		 * @param string $event_name Event name.
+		 * @param bool   $is_client_supplied Whether the props came from an untrusted client.
 		 */
 		$properties = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
-			$common_properties
+			$common_properties,
+			null,
+			false
 		);
 
 		return $properties;
@@ -298,7 +303,9 @@ trait Woo_Analytics_Trait {
 		/** This filter is documented in src/class-woo-analytics-trait.php */
 		return apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
-			$common_properties
+			$common_properties,
+			null,
+			false
 		);
 	}
 

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -266,19 +266,23 @@ trait Woo_Analytics_Trait {
 		/**
 		 * Allow defining custom event properties in WooCommerce Analytics.
 		 *
+		 * See `WC_Analytics_Tracking::get_properties()` for the full contract
+		 * around `$is_client_supplied`.
+		 *
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
 		 * @since 0.16.8 Added the `$event_name` and `$is_client_supplied` parameters.
 		 *
 		 * @param array  $properties Array of event props to be filtered.
-		 * @param string $event_name Event name.
+		 * @param string $event_name Event name. Empty string here: this call builds
+		 *                           common properties, not properties for a specific event.
 		 * @param bool   $is_client_supplied Whether the props came from an untrusted client.
 		 */
 		$properties = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
 			$common_properties,
-			null,
+			'',
 			false
 		);
 
@@ -304,7 +308,7 @@ trait Woo_Analytics_Trait {
 		return apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
 			$common_properties,
-			null,
+			'',
 			false
 		);
 	}

--- a/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/packages/php/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -272,7 +272,7 @@ trait Woo_Analytics_Trait {
 		 * @module woocommerce-analytics
 		 *
 		 * @since 12.5
-		 * @since 0.17.1 Added the `$is_client_supplied` parameter. This call site
+		 * @since 0.18.0 Added the `$is_client_supplied` parameter. This call site
 		 *               also began passing `$event_name`, which the hook already had.
 		 *
 		 * @param array  $properties Array of event props to be filtered.

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -174,8 +174,17 @@ class Woocommerce_Analytics {
 
 	/**
 	 * Register REST API routes.
+	 *
+	 * The tracking proxy endpoint is unauthenticated by design — it exists to
+	 * receive front-end events — so it is only registered where proxy tracking is
+	 * actually in use. The check lives here rather than at the `add_action` site
+	 * because `rest_api_init` fires late enough for the filter to be registered.
 	 */
 	public static function register_rest_routes() {
+		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ) {
+			return;
+		}
+
 		$controller = new WC_Analytics_Tracking_Proxy();
 		$controller->register_routes();
 	}

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -387,6 +387,11 @@ class Woocommerce_Analytics {
 
 	/**
 	 * Maybe removes the proxy speed module. This should be invoked when the plugin is deactivated.
+	 *
+	 * Also drops the module's authorization. MU-plugins load whether or not the
+	 * plugin carrying this package is active, so an undeletable module file left
+	 * behind by a deactivation would keep answering on a stale `yes`. The sticky
+	 * option is left alone: pages cached while the feature was on outlive both.
 	 */
 	public static function maybe_remove_proxy_speed_module() {
 		if ( ! self::init_filesystem() ) {
@@ -408,6 +413,7 @@ class Woocommerce_Analytics {
 		}
 
 		delete_option( self::PROXY_SPEED_MODULE_VERSION_OPTION );
+		delete_option( self::PROXY_TRACKING_ENABLED_OPTION );
 		delete_transient( self::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT );
 	}
 

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -53,6 +53,24 @@ class Woocommerce_Analytics {
 	const PROXY_TRACKING_ENABLED_OPTION = 'woocommerce_analytics_proxy_tracking_enabled';
 
 	/**
+	 * Whether proxy tracking has ever been enabled on this site.
+	 *
+	 * Decides whether the REST route exists at all. Turning the feature off cannot
+	 * unregister it, because pages cached while it was on still tell their visitors
+	 * to POST events: a 404 loses every one of those silently, while the registered
+	 * route answers 403 with a reason. Sites that never turned it on never get the
+	 * endpoint.
+	 *
+	 * Sticky on purpose — it records that cached pages may exist, which staying off
+	 * for a while does not undo.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @var string
+	 */
+	const PROXY_TRACKING_EVER_ENABLED_OPTION = 'woocommerce_analytics_proxy_tracking_ever_enabled';
+
+	/**
 	 * Initializer.
 	 * Used to configure the WooCommerce Analytics package.
 	 *
@@ -193,12 +211,13 @@ class Woocommerce_Analytics {
 	 * Register REST API routes.
 	 *
 	 * The tracking proxy endpoint is unauthenticated by design — it exists to
-	 * receive front-end events — so it is only registered where proxy tracking is
-	 * actually in use. The check lives here rather than at the `add_action` site
-	 * because `rest_api_init` fires late enough for the filter to be registered.
+	 * receive front-end events — so a site that has never used proxy tracking never
+	 * gets it. Once a site has used it the route stays registered and refuses while
+	 * the feature is off, rather than disappearing; see
+	 * PROXY_TRACKING_EVER_ENABLED_OPTION and `WC_Analytics_Tracking_Proxy::track_events()`.
 	 */
 	public static function register_rest_routes() {
-		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ) {
+		if ( 'yes' !== get_option( self::PROXY_TRACKING_EVER_ENABLED_OPTION ) ) {
 			return;
 		}
 
@@ -215,6 +234,10 @@ class Woocommerce_Analytics {
 	 */
 	public static function sync_proxy_tracking_state() {
 		$enabled = \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ? 'yes' : 'no';
+
+		if ( 'yes' === $enabled && 'yes' !== get_option( self::PROXY_TRACKING_EVER_ENABLED_OPTION ) ) {
+			update_option( self::PROXY_TRACKING_EVER_ENABLED_OPTION, 'yes' );
+		}
 
 		if ( get_option( self::PROXY_TRACKING_ENABLED_OPTION ) === $enabled ) {
 			return;

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -39,6 +39,19 @@ class Woocommerce_Analytics {
 	const PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT = 'woocommerce_analytics_proxy_speed_module_version_check';
 
 	/**
+	 * Last resolved state of the proxy tracking feature.
+	 *
+	 * The speed module runs before plugins load, where the proxy tracking filter
+	 * reads false everywhere. Absent means enabled, so a site that has not
+	 * written it yet keeps working.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @var string
+	 */
+	const PROXY_TRACKING_ENABLED_OPTION = 'woocommerce_analytics_proxy_tracking_enabled';
+
+	/**
 	 * Initializer.
 	 * Used to configure the WooCommerce Analytics package.
 	 *
@@ -111,6 +124,9 @@ class Woocommerce_Analytics {
 		}
 
 		add_action( 'admin_init', array( __CLASS__, 'maybe_update_proxy_speed_module' ) );
+
+		// Late on `init`, so every plugin has registered its feature filters.
+		add_action( 'init', array( __CLASS__, 'sync_proxy_tracking_state' ), 20 );
 
 		// Tracking only Site pages.
 		if ( is_admin() || wp_doing_ajax() || wp_is_xml_request() || is_login() || is_feed() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
@@ -187,6 +203,23 @@ class Woocommerce_Analytics {
 
 		$controller = new WC_Analytics_Tracking_Proxy();
 		$controller->register_routes();
+	}
+
+	/**
+	 * Mirror the resolved proxy tracking state into PROXY_TRACKING_ENABLED_OPTION.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @return void
+	 */
+	public static function sync_proxy_tracking_state() {
+		$enabled = \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ? 'yes' : 'no';
+
+		if ( get_option( self::PROXY_TRACKING_ENABLED_OPTION ) === $enabled ) {
+			return;
+		}
+
+		update_option( self::PROXY_TRACKING_ENABLED_OPTION, $enabled );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -62,7 +62,9 @@ class Woocommerce_Analytics {
 	 * endpoint.
 	 *
 	 * Sticky on purpose — it records that cached pages may exist, which staying off
-	 * for a while does not undo.
+	 * for a while does not undo. `reset_proxy_tracking_state()` is the way to clear
+	 * it, for an uninstall routine or a site that wants the endpoint gone once the
+	 * caches holding those pages have expired.
 	 *
 	 * @since 0.17.1
 	 *
@@ -247,13 +249,29 @@ class Woocommerce_Analytics {
 	}
 
 	/**
+	 * Forget that proxy tracking was ever enabled, so the REST route stops being
+	 * registered.
+	 *
+	 * Separate from `maybe_remove_proxy_speed_module()`, which clears the module's
+	 * authorization but deliberately leaves this alone: removing the module does
+	 * not expire the cached pages this records.
+	 *
+	 * @since 0.17.1
+	 *
+	 * @return void
+	 */
+	public static function reset_proxy_tracking_state() {
+		delete_option( self::PROXY_TRACKING_EVER_ENABLED_OPTION );
+		delete_option( self::PROXY_TRACKING_ENABLED_OPTION );
+	}
+
+	/**
 	 * Maybe update proxy speed module.
 	 *
-	 * Turning proxy tracking off uninstalls the module as well as leaving the REST
-	 * route unregistered, so the two halves of "the endpoint is gone" agree. The
-	 * module itself also refuses requests while the feature is off, because this
-	 * runs on `admin_init` behind a day-long transient and cannot be relied on to
-	 * take effect promptly.
+	 * Turning proxy tracking off uninstalls the module, and the REST route starts
+	 * refusing, so both halves stop serving. The module refuses on its own too,
+	 * because this runs on `admin_init` behind a day-long transient and cannot be
+	 * relied on to take effect promptly.
 	 */
 	public static function maybe_update_proxy_speed_module() {
 		// Skip if we've already checked recently.

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,7 +22,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.16.8';
+	const PACKAGE_VERSION = '0.17.1';
 
 	/**
 	 * Proxy speed module version option.
@@ -42,10 +42,11 @@ class Woocommerce_Analytics {
 	 * Last resolved state of the proxy tracking feature.
 	 *
 	 * The speed module runs before plugins load, where the proxy tracking filter
-	 * reads false everywhere. Absent means enabled, so a site that has not
-	 * written it yet keeps working.
+	 * reads false everywhere. Only `yes` serves: the module is installed from a
+	 * request that already wrote this, and on multisite one network-wide module
+	 * file answers for sites that never enabled anything.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @var string
 	 */
@@ -208,7 +209,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Mirror the resolved proxy tracking state into PROXY_TRACKING_ENABLED_OPTION.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @return void
 	 */
@@ -260,7 +261,7 @@ class Woocommerce_Analytics {
 	 * turning proxy tracking off would leave an installed module answering
 	 * requests the REST route no longer serves.
 	 *
-	 * @since 0.16.8
+	 * @since 0.17.1
 	 *
 	 * @return bool
 	 */
@@ -276,6 +277,10 @@ class Woocommerce_Analytics {
 		if ( ! self::should_install_proxy_speed_module() ) {
 			return;
 		}
+
+		// The module fails closed on this option, so it must be written before the
+		// file exists, not merely on the next `init`.
+		self::sync_proxy_tracking_state();
 
 		if ( ! self::init_filesystem() ) {
 			if ( function_exists( 'wc_get_logger' ) ) {

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,7 +22,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.17.1';
+	const PACKAGE_VERSION = '0.18.0';
 
 	/**
 	 * Proxy speed module version option.
@@ -46,7 +46,7 @@ class Woocommerce_Analytics {
 	 * request that already wrote this, and on multisite one network-wide module
 	 * file answers for sites that never enabled anything.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var string
 	 */
@@ -66,7 +66,7 @@ class Woocommerce_Analytics {
 	 * it, for an uninstall routine or a site that wants the endpoint gone once the
 	 * caches holding those pages have expired.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @var string
 	 */
@@ -230,7 +230,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Mirror the resolved proxy tracking state into PROXY_TRACKING_ENABLED_OPTION.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @return void
 	 */
@@ -256,7 +256,7 @@ class Woocommerce_Analytics {
 	 * authorization but deliberately leaves this alone: removing the module does
 	 * not expire the cached pages this records.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @return void
 	 */
@@ -302,7 +302,7 @@ class Woocommerce_Analytics {
 	 * turning proxy tracking off would leave an installed module answering
 	 * requests the REST route no longer serves.
 	 *
-	 * @since 0.17.1
+	 * @since 0.18.0
 	 *
 	 * @return bool
 	 */

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,7 +22,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.16.3';
+	const PACKAGE_VERSION = '0.16.8';
 
 	/**
 	 * Proxy speed module version option.

--- a/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/packages/php/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -191,6 +191,12 @@ class Woocommerce_Analytics {
 
 	/**
 	 * Maybe update proxy speed module.
+	 *
+	 * Turning proxy tracking off uninstalls the module as well as leaving the REST
+	 * route unregistered, so the two halves of "the endpoint is gone" agree. The
+	 * module itself also refuses requests while the feature is off, because this
+	 * runs on `admin_init` behind a day-long transient and cannot be relied on to
+	 * take effect promptly.
 	 */
 	public static function maybe_update_proxy_speed_module() {
 		// Skip if we've already checked recently.
@@ -200,7 +206,7 @@ class Woocommerce_Analytics {
 
 		$version = get_option( self::PROXY_SPEED_MODULE_VERSION_OPTION, false );
 
-		if ( \Automattic\Woocommerce_Analytics\Features::is_proxy_speed_module_enabled() ) {
+		if ( self::should_install_proxy_speed_module() ) {
 			if ( $version !== self::PACKAGE_VERSION ) {
 				self::maybe_add_proxy_speed_module();
 			}
@@ -214,14 +220,34 @@ class Woocommerce_Analytics {
 	}
 
 	/**
+	 * Whether the proxy speed module belongs on this site.
+	 *
+	 * It is an accelerator for the tracking proxy, so it needs both its own
+	 * opt-in and the feature it accelerates. Without the second condition,
+	 * turning proxy tracking off would leave an installed module answering
+	 * requests the REST route no longer serves.
+	 *
+	 * @since 0.16.8
+	 *
+	 * @return bool
+	 */
+	private static function should_install_proxy_speed_module() {
+		return \Automattic\Woocommerce_Analytics\Features::is_proxy_speed_module_enabled()
+			&& \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled();
+	}
+
+	/**
 	 * Maybe add proxy speed module.
 	 */
 	public static function maybe_add_proxy_speed_module() {
-		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_speed_module_enabled() ) {
+		if ( ! self::should_install_proxy_speed_module() ) {
 			return;
 		}
 
 		if ( ! self::init_filesystem() ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->error( 'WooCommerce Analytics proxy speed module not installed: filesystem unavailable.', array( 'source' => 'woocommerce-analytics' ) );
+			}
 			return;
 		}
 
@@ -234,6 +260,9 @@ class Woocommerce_Analytics {
 
 		// If the mu-plugin directory doesn't exist, we can't copy the files.
 		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->error( 'WooCommerce Analytics proxy speed module not installed: mu-plugins directory could not be created.', array( 'source' => 'woocommerce-analytics' ) );
+			}
 			return;
 		}
 

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -162,10 +162,13 @@ class WooCommerceAnalyticsProxySpeed {
 		// Features::is_proxy_tracking_enabled() cannot be used here: no plugin has
 		// registered that filter this early, so it reads false everywhere.
 		if ( 'yes' !== get_option( \Automattic\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) ) {
+			// Same body the REST controller's WP_Error produces, so a client has one
+			// shape to recognise whichever path answered.
 			$this->send_json_response(
 				array(
-					'success' => false,
-					'error'   => 'Proxy tracking is not enabled on this site.',
+					'code'    => 'proxy_tracking_disabled',
+					'message' => 'Proxy tracking is not enabled on this site.',
+					'data'    => array( 'status' => 403 ),
 				),
 				403
 			);

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -161,7 +161,7 @@ class WooCommerceAnalyticsProxySpeed {
 	private function process_proxy_request() {
 		// Features::is_proxy_tracking_enabled() cannot be used here: no plugin has
 		// registered that filter this early, so it reads false everywhere.
-		if ( 'no' === get_option( \Automattic\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) ) {
+		if ( 'yes' !== get_option( \Automattic\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) ) {
 			$this->send_json_response(
 				array(
 					'success' => false,

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -159,6 +159,22 @@ class WooCommerceAnalyticsProxySpeed {
 	 * @return void
 	 */
 	private function process_proxy_request() {
+		// The REST route is only registered where proxy tracking is enabled, but this
+		// module runs at MU-plugin stage and never reaches rest_api_init, so without
+		// this check the endpoint would keep answering on sites that turned the
+		// feature off. The check lives here rather than in init() because it needs
+		// the autoloader, which init() loads only after is_proxy_request() matches.
+		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ) {
+			$this->send_json_response(
+				array(
+					'success' => false,
+					'error'   => 'Proxy tracking is not enabled on this site.',
+				),
+				403
+			);
+			return;
+		}
+
 		// Apply magic quotes to superglobals ($_GET, $_POST, $_COOKIE, $_REQUEST) for compatibility with the regular API flow.
 		if ( function_exists( 'wp_magic_quotes' ) ) {
 			wp_magic_quotes();
@@ -191,6 +207,14 @@ class WooCommerceAnalyticsProxySpeed {
 		// Normalize: wrap a single event object or unexpected scalar in an array.
 		if ( ! is_array( $events ) || isset( $events['event_name'] ) ) {
 			$events = array( $events );
+		}
+
+		// Same bound as the REST controller. The constant lives in the package rather
+		// than being restated here: unlike is_proxy_request(), this runs after the
+		// autoloader, so the class is available.
+		$max_events = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST;
+		if ( count( $events ) > $max_events ) {
+			$events = array_slice( $events, 0, $max_events, true );
 		}
 
 		$results    = array();

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -61,6 +61,10 @@ class WooCommerceAnalyticsProxySpeed {
 	/**
 	 * Check if current request is a proxy request.
 	 *
+	 * Duplicated as WC_Analytics_Tracking::is_proxy_tracking_request(). This copy
+	 * cannot delegate to that one: init() calls this before load_autoloader(), so
+	 * no package class exists yet. Change both together.
+	 *
 	 * @return bool
 	 */
 	private function is_proxy_request() {
@@ -214,7 +218,7 @@ class WooCommerceAnalyticsProxySpeed {
 				continue;
 			}
 
-			$result = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::record_event( $event_name, $properties );
+			$result = \Automattic\Woocommerce_Analytics\WC_Analytics_Tracking::record_client_event( $event_name, $properties );
 
 			if ( is_wp_error( $result ) ) {
 				$results[ $index ] = array(

--- a/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
+++ b/packages/php/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php
@@ -159,12 +159,9 @@ class WooCommerceAnalyticsProxySpeed {
 	 * @return void
 	 */
 	private function process_proxy_request() {
-		// The REST route is only registered where proxy tracking is enabled, but this
-		// module runs at MU-plugin stage and never reaches rest_api_init, so without
-		// this check the endpoint would keep answering on sites that turned the
-		// feature off. The check lives here rather than in init() because it needs
-		// the autoloader, which init() loads only after is_proxy_request() matches.
-		if ( ! \Automattic\Woocommerce_Analytics\Features::is_proxy_tracking_enabled() ) {
+		// Features::is_proxy_tracking_enabled() cannot be used here: no plugin has
+		// registered that filter this early, so it reads false everywhere.
+		if ( 'no' === get_option( \Automattic\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) ) {
 			$this->send_json_response(
 				array(
 					'success' => false,
@@ -233,7 +230,7 @@ class WooCommerceAnalyticsProxySpeed {
 			$event_name = $event['event_name'] ?? null;
 			$properties = $event['properties'] ?? array();
 
-			if ( ! $event_name || ! is_array( $properties ) ) {
+			if ( ! $event_name || ! is_string( $event_name ) || ! is_array( $properties ) ) {
 				$results[ $index ] = array(
 					'success' => false,
 					'error'   => 'Missing event_name or invalid properties',

--- a/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Universal_Test.php
@@ -148,6 +148,42 @@ class Universal_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Universal consumes Woo_Analytics_Trait, whose get_common_properties()
+	 * and get_page_common_properties() both fire
+	 * jetpack_woocommerce_analytics_event_props with three arguments. A
+	 * callback registered with accepted_args = 3 used to fatal with an
+	 * ArgumentCountError because both call sites passed only one argument;
+	 * this pins the fix and the exact values passed ('' for the event name,
+	 * since neither call builds properties for a specific event, and false
+	 * for is_client_supplied, since neither is on the proxy path).
+	 */
+	public function test_trait_filter_call_sites_pass_empty_event_name_and_false_client_flag(): void {
+		$seen     = array();
+		$callback = function ( $props, $event_name, $is_client_supplied ) use ( &$seen ) {
+			$seen[] = array( $event_name, $is_client_supplied );
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10, 3 );
+
+		try {
+			$universal = new Universal();
+			$universal->get_common_properties();
+			$universal->get_page_common_properties();
+		} finally {
+			remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
+		}
+
+		$this->assertSame(
+			array(
+				array( '', false ),
+				array( '', false ),
+			),
+			$seen,
+			'Both trait call sites must invoke the filter with an empty-string event name and a false client-supplied flag, without fataling.'
+		);
+	}
+
+	/**
 	 * Reset the WC_Analytics_Tracking::$pixel_batch_queue static so each
 	 * test starts from a known-empty state.
 	 */

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -41,6 +41,8 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	public function set_up(): void {
 		parent::set_up();
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
 		$GLOBALS['wp_rest_server'] = null;
 		$this->server_snapshot     = $_SERVER;
 		$this->reset_pixel_batch_queue();
@@ -54,6 +56,8 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	 */
 	public function tear_down(): void {
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
 		$GLOBALS['wp_rest_server'] = null;
 		$_SERVER                   = $this->server_snapshot;
 		unset( $_COOKIE['tk_ai'] );
@@ -133,6 +137,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	 */
 	public function test_route_is_registered_when_proxy_tracking_is_enabled(): void {
 		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
 
 		Woocommerce_Analytics::register_rest_routes();
 
@@ -169,6 +174,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		update_option( 'woocommerce_store_id', 'real-store-id' );
 
 		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
 		Woocommerce_Analytics::register_rest_routes();
 
 		$request = new \WP_REST_Request( 'POST', self::ROUTE );
@@ -199,18 +205,56 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 
 	/**
 	 * The route being absent from get_routes() is a white-box fact; what actually
-	 * has to hold is that a POST arriving anyway records nothing. Pinning the
-	 * behaviour means a future move to "register but reject in the callback" has
-	 * to be a deliberate decision rather than a silent one.
+	 * has to hold is that a POST arriving anyway records nothing.
 	 */
-	public function test_post_records_nothing_when_proxy_tracking_is_disabled(): void {
+	public function test_post_records_nothing_on_a_site_that_never_enabled_proxy_tracking(): void {
 		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
 
-		// No filter: proxy tracking is off by default.
+		// No filter and no sync: proxy tracking has never been on here.
 		Woocommerce_Analytics::register_rest_routes();
 
+		$response = rest_do_request( $this->build_track_request() );
+
+		$this->assertSame( 404, $response->get_status(), 'A site that never used proxy tracking must not expose the endpoint.' );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued when the route is gated off.' );
+	}
+
+	/**
+	 * Turning the feature off cannot unregister the route, because pages cached
+	 * while it was on still tell their visitors to POST here. A 404 loses every
+	 * one of those events with no signal anywhere; a 403 with a reason is
+	 * something the client and the server log can both act on.
+	 */
+	public function test_post_is_refused_with_a_reason_once_the_feature_is_turned_off(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		// On, then off — the sticky option records that cached pages may exist.
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		Woocommerce_Analytics::register_rest_routes();
+
+		$this->assertArrayHasKey( self::ROUTE, rest_get_server()->get_routes(), 'The route must survive the feature being turned off.' );
+
+		$response = rest_do_request( $this->build_track_request() );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'proxy_tracking_disabled', $response->get_data()['code'] ?? null );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'Refusing must not record.' );
+	}
+
+	/**
+	 * A single valid event, for the tests that only care about the response.
+	 *
+	 * @return \WP_REST_Request
+	 */
+	private function build_track_request(): \WP_REST_Request {
 		$request = new \WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
@@ -222,10 +266,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 			)
 		);
 
-		$response = rest_do_request( $request );
-
-		$this->assertSame( 404, $response->get_status(), 'A POST to /track must not be served where proxy tracking is off.' );
-		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued when the route is gated off.' );
+		return $request;
 	}
 
 	/**
@@ -241,6 +282,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		update_option( 'woocommerce_store_id', 'real-store-id' );
 
 		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
 		Woocommerce_Analytics::register_rest_routes();
 
 		$request = new \WP_REST_Request( 'POST', self::ROUTE );
@@ -283,6 +325,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
 
 		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
 		Woocommerce_Analytics::register_rest_routes();
 
 		$events = array();

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -42,7 +42,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		parent::set_up();
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 		$GLOBALS['wp_rest_server'] = null;
-		$this->server_snapshot    = $_SERVER;
+		$this->server_snapshot     = $_SERVER;
 		$this->reset_pixel_batch_queue();
 	}
 
@@ -55,7 +55,7 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	public function tear_down(): void {
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 		$GLOBALS['wp_rest_server'] = null;
-		$_SERVER                  = $this->server_snapshot;
+		$_SERVER                   = $this->server_snapshot;
 		unset( $_COOKIE['tk_ai'] );
 		$this->reset_pixel_batch_queue();
 		parent::tear_down();
@@ -75,8 +75,10 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Clear the queued pixel URLs and the cached visitor id, so one test's
-	 * cookie or event cannot leak into the next.
+	 * Clear the queued pixel URLs and every per-request memo, so one test's
+	 * cookie, IP or event cannot leak into the next. `cached_ip` in particular
+	 * survives the whole PHP process, so a test that never set REMOTE_ADDR would
+	 * otherwise pin '' for every test after it.
 	 */
 	private function reset_pixel_batch_queue(): void {
 		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
@@ -84,6 +86,14 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		$property = $reflection->getProperty( 'pixel_batch_queue' );
 		$property->setAccessible( true );
 		$property->setValue( null, array() );
+
+		$ip = $reflection->getProperty( 'cached_ip' );
+		$ip->setAccessible( true );
+		$ip->setValue( null, null );
+
+		$reserved = $reflection->getProperty( 'reserved_property_names' );
+		$reserved->setAccessible( true );
+		$reserved->setValue( null, null );
 
 		$visitor = $reflection->getProperty( 'cached_visitor_id' );
 		$visitor->setAccessible( true );
@@ -152,6 +162,12 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
 
+		// Seeded so the assertions below prove the server's value replaced the
+		// forged one. Unseeded, store_id is absent from the pixel entirely and
+		// _via_ip is '', so an assertNotSame() would pass on absence alone.
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
 		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 		Woocommerce_Analytics::register_rest_routes();
 
@@ -176,8 +192,117 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 
 		$props = $this->get_queued_pixel_props();
 
-		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null, 'store_id must not survive a forged value posted to /track.' );
-		$this->assertNotSame( '8.8.8.8', $props['_via_ip'] ?? null, '_via_ip must not survive a forged value posted to /track.' );
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'store_id must be the server value, not merely absent.' );
+		$this->assertSame( '203.0.113.7', $props['_via_ip'] ?? null, '_via_ip must be the server value, not merely absent.' );
 		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must still survive.' );
+	}
+
+	/**
+	 * The route being absent from get_routes() is a white-box fact; what actually
+	 * has to hold is that a POST arriving anyway records nothing. Pinning the
+	 * behaviour means a future move to "register but reject in the callback" has
+	 * to be a deliberate decision rather than a silent one.
+	 */
+	public function test_post_records_nothing_when_proxy_tracking_is_disabled(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		// No filter: proxy tracking is off by default.
+		Woocommerce_Analytics::register_rest_routes();
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'event_name' => 'add_to_cart',
+					'properties' => array( 'pi' => 42 ),
+				)
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 404, $response->get_status(), 'A POST to /track must not be served where proxy tracking is off.' );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued when the route is gated off.' );
+	}
+
+	/**
+	 * The batch loop is the controller's main path, and the memoized reserved
+	 * list is justified by batches specifically — so a later event in the same
+	 * request must still be stripped. Also covers the 207 partial-failure branch,
+	 * which nothing else exercises.
+	 */
+	public function test_batch_strips_every_event_and_reports_per_event_results(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					// No event_name: must fail on its own without aborting the batch.
+					array( 'properties' => array( 'pi' => 1 ) ),
+					array(
+						'event_name' => 'add_to_cart',
+						'properties' => array(
+							'store_id' => 'someone-elses-store',
+							'pi'       => 2,
+						),
+					),
+				)
+			)
+		);
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 207, $response->get_status() );
+		$this->assertFalse( $data['results'][0]['success'] );
+		$this->assertTrue( $data['results'][1]['success'] );
+
+		$props = $this->get_queued_pixel_props();
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'The memoized reserved list must still strip on a later event in the batch.' );
+		$this->assertSame( '2', $props['pi'] ?? null );
+	}
+
+	/**
+	 * Every event becomes an outbound pixel request, so an unauthenticated caller
+	 * must not be able to fan out an unbounded batch.
+	 */
+	public function test_batch_size_is_capped(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$events = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST + 10; $i++ ) {
+			$events[] = array(
+				'event_name' => 'add_to_cart',
+				'properties' => array( 'pi' => $i ),
+			);
+		}
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $events ) );
+
+		rest_do_request( $request );
+
+		$this->assertCount(
+			WC_Analytics_Tracking::MAX_CLIENT_EVENTS_PER_REQUEST,
+			$this->get_pixel_batch_queue(),
+			'The batch must be truncated to MAX_CLIENT_EVENTS_PER_REQUEST.'
+		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for the tracking proxy REST route.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use Automattic\Woocommerce_Analytics;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests that the proxy route only exists where proxy tracking is enabled.
+ */
+class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
+
+	/**
+	 * Route path as registered with the REST server.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/woocommerce-analytics/v1/track';
+
+	/**
+	 * Start each test with a clean REST server and no feature filters.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		$GLOBALS['wp_rest_server'] = null;
+	}
+
+	/**
+	 * Leave no REST server or filters behind.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+		$GLOBALS['wp_rest_server'] = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * The endpoint is unauthenticated by design, so it must not exist on the
+	 * sites that never opted into proxy tracking — which is every site, by
+	 * default.
+	 */
+	public function test_route_is_not_registered_when_proxy_tracking_is_disabled(): void {
+		Woocommerce_Analytics::register_rest_routes();
+
+		$this->assertArrayNotHasKey( self::ROUTE, rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * The endpoint still exists where the feature is on, otherwise the client
+	 * has nowhere to post.
+	 */
+	public function test_route_is_registered_when_proxy_tracking_is_enabled(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		Woocommerce_Analytics::register_rest_routes();
+
+		$this->assertArrayHasKey( self::ROUTE, rest_get_server()->get_routes() );
+	}
+}

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Proxy_Test.php
@@ -11,7 +11,9 @@ use Automattic\Woocommerce_Analytics;
 use WorDBless\BaseTestCase;
 
 /**
- * Tests that the proxy route only exists where proxy tracking is enabled.
+ * Tests that the proxy route only exists where proxy tracking is enabled, and
+ * that dispatching a request through it goes through the untrusted-client
+ * entry point rather than the trusted one.
  */
 class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 
@@ -23,21 +25,85 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 	const ROUTE = '/woocommerce-analytics/v1/track';
 
 	/**
+	 * Snapshot of $_SERVER taken in set_up(), restored in tear_down(). The
+	 * dispatch test below controls REQUEST_METHOD/REQUEST_URI to keep the
+	 * request-shape guard in WC_Analytics_Tracking::record_event() inactive,
+	 * so a passing test can only be explained by the REST controller's own
+	 * call to record_client_event().
+	 *
+	 * @var array
+	 */
+	private $server_snapshot = array();
+
+	/**
 	 * Start each test with a clean REST server and no feature filters.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 		$GLOBALS['wp_rest_server'] = null;
+		$this->server_snapshot    = $_SERVER;
+		$this->reset_pixel_batch_queue();
 	}
 
 	/**
-	 * Leave no REST server or filters behind.
+	 * Leave no REST server, filters, $_SERVER/$_COOKIE mutation, or queued
+	 * pixel behind. Runs unconditionally regardless of the test outcome, so a
+	 * failed assertion mid-test cannot leak the tk_ai cookie set by the
+	 * dispatch test into the next test.
 	 */
 	public function tear_down(): void {
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 		$GLOBALS['wp_rest_server'] = null;
+		$_SERVER                  = $this->server_snapshot;
+		unset( $_COOKIE['tk_ai'] );
+		$this->reset_pixel_batch_queue();
 		parent::tear_down();
+	}
+
+	/**
+	 * Read the queued pixel URLs via reflection, as
+	 * WC_Analytics_Tracking_Reserved_Props_Test does.
+	 *
+	 * @return array
+	 */
+	private function get_pixel_batch_queue(): array {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
+	/**
+	 * Clear the queued pixel URLs and the cached visitor id, so one test's
+	 * cookie or event cannot leak into the next.
+	 */
+	private function reset_pixel_batch_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+
+		$property = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+
+		$visitor = $reflection->getProperty( 'cached_visitor_id' );
+		$visitor->setAccessible( true );
+		$visitor->setValue( null, null );
+	}
+
+	/**
+	 * Parse the query string of the single queued pixel into an array.
+	 *
+	 * @return array
+	 */
+	private function get_queued_pixel_props(): array {
+		$queue = $this->get_pixel_batch_queue();
+		$this->assertCount( 1, $queue, 'Expected exactly one queued pixel.' );
+
+		$query = wp_parse_url( $queue[0], PHP_URL_QUERY );
+		$props = array();
+		parse_str( (string) $query, $props );
+
+		return $props;
 	}
 
 	/**
@@ -61,5 +127,57 @@ class WC_Analytics_Tracking_Proxy_Test extends BaseTestCase {
 		Woocommerce_Analytics::register_rest_routes();
 
 		$this->assertArrayHasKey( self::ROUTE, rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * The security boundary is WC_Analytics_Tracking::record_client_event(),
+	 * not the request-shape guard in record_event() — that guard is documented
+	 * as a removable net for stale MU-plugin copies. This test proves the
+	 * controller itself goes through record_client_event() by dispatching a
+	 * real WP_REST_Request through the REST server with $_SERVER deliberately
+	 * shaped so the guard does NOT match (REQUEST_URI is the genuine
+	 * `?rest_route=` form, whose parsed path is `/` — see
+	 * non_proxy_request_provider() in WC_Analytics_Tracking_Reserved_Props_Test).
+	 * On a plain-permalink site this is exactly what `rest_url()` produces, so
+	 * it is also the realistic shape, not a contrived one.
+	 *
+	 * If WC_Analytics_Tracking_Proxy::track_events() is ever changed to call
+	 * record_event() instead of record_client_event(), this is the only test
+	 * that fails: every other test in the suite drives record_client_event()
+	 * or record_event() directly rather than through a real REST dispatch, so
+	 * none of them would catch a silent revert on a plain-permalink site.
+	 */
+	public function test_track_events_strips_reserved_properties_through_the_rest_route(): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/?rest_route=/woocommerce-analytics/v1/track';
+
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::register_rest_routes();
+
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'event_name' => 'add_to_cart',
+					'properties' => array(
+						'store_id' => 'someone-elses-store',
+						'_via_ip'  => '8.8.8.8',
+						'pi'       => 42,
+					),
+				)
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null, 'store_id must not survive a forged value posted to /track.' );
+		$this->assertNotSame( '8.8.8.8', $props['_via_ip'] ?? null, '_via_ip must not survive a forged value posted to /track.' );
+		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must still survive.' );
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -400,4 +400,72 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
 	}
+
+	/**
+	 * A callback that assigns unconditionally beats a client value of the same
+	 * name. This is the pattern the filter docblock tells extensions to use.
+	 */
+	public function test_filter_callback_assigning_unconditionally_beats_the_client(): void {
+		$callback = function ( $props ) {
+			$props['partner_tier'] = 'gold';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'partner_tier' => 'forged' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'gold', $props['partner_tier'] );
+	}
+
+	/**
+	 * The known limitation, asserted so it is a recorded decision rather than an
+	 * assumption: a callback that defers to an existing value loses to the
+	 * client, because the reserved set cannot cover names the filter invents.
+	 * If this ever starts passing, the limitation has been closed and the spec
+	 * needs updating.
+	 */
+	public function test_filter_callback_deferring_to_an_existing_value_loses_to_the_client(): void {
+		$callback = function ( $props ) {
+			$props['partner_tier'] = isset( $props['partner_tier'] ) ? $props['partner_tier'] : 'gold';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'partner_tier' => 'forged' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'forged', $props['partner_tier'], 'Known limitation: see the spec.' );
+	}
+
+	/**
+	 * The third argument tells a callback whether the properties it is looking
+	 * at came from an untrusted client, which is the only way it can know to
+	 * assign unconditionally.
+	 */
+	public function test_filter_receives_the_client_supplied_flag(): void {
+		$seen     = array();
+		$callback = function ( $props, $event_name, $is_client_supplied ) use ( &$seen ) {
+			$seen[] = $is_client_supplied;
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10, 3 );
+
+		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_add_to_cart', array(), true );
+		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_add_to_cart', array(), false );
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
+
+		$this->assertSame( array( true, false ), $seen );
+	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -385,10 +385,18 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 * allowed set, matching the MU-plugin template's is_proxy_request(). This
 	 * is the one piece of the "kept in step with the template" claim that was
 	 * previously covered only by inspection, not by an assertion.
+	 *
+	 * The disallowed '%' sits mid-path, not at the end, on purpose: the path
+	 * still ends with the exact proxy suffix, so the suffix comparison alone
+	 * would accept this request. Only the character-restriction check can
+	 * reject it. A trailing disallowed character (e.g. a suffix of
+	 * "/track%20") would also break the suffix match by itself, so it would
+	 * return false regardless of whether the character check exists — that
+	 * shape cannot isolate the regex, and must not be used here.
 	 */
 	public function test_is_proxy_tracking_request_rejects_disallowed_characters(): void {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_SERVER['REQUEST_URI']    = '/wp-json/woocommerce-analytics/v1/track%20';
+		$_SERVER['REQUEST_URI']    = '/wp%20json/woocommerce-analytics/v1/track';
 
 		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
 	}

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -379,4 +379,17 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			'rest_route form'   => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
 		);
 	}
+
+	/**
+	 * The character restriction on the path must reject anything outside the
+	 * allowed set, matching the MU-plugin template's is_proxy_request(). This
+	 * is the one piece of the "kept in step with the template" claim that was
+	 * previously covered only by inspection, not by an assertion.
+	 */
+	public function test_is_proxy_tracking_request_rejects_disallowed_characters(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/woocommerce-analytics/v1/track%20';
+
+		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
+	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -679,6 +679,77 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The per-axis caps multiply: at their limits one event built a 512KB pixel
+	 * URL, so the product needs its own bound. Properties are dropped from the
+	 * tail once the budget is spent.
+	 */
+	public function test_client_payload_total_is_capped(): void {
+		$properties = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $i++ ) {
+			$properties[ 'p' . $i ] = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertNotEmpty( $sanitized, 'The budget drops the tail, it does not empty the event.' );
+
+		// The pixel URL is what the budget exists to bound, so assert on it rather
+		// than on the constant. 8KB is the practical ceiling for a GET.
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$props            = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThan( 8192, strlen( Pixel_Builder::build_tracks_url( $props ) ) );
+
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * A realistic event must pass through untouched, or the budget is capping
+	 * first-party analytics rather than an attacker's payload.
+	 */
+	public function test_a_realistic_client_payload_is_not_capped(): void {
+		$properties = array(
+			'pi'  => 731,
+			'pn'  => 'Some Reasonably Long Product Name With Words',
+			'pt'  => 'simple',
+			'pc'  => array( 'Clothing', 'Shirts', 'Sale' ),
+			'pp'  => 115.81,
+			'_lg' => 'en-GB',
+			'_dl' => 'https://example.com/product/some-reasonably-long-product-slug/?utm_source=x',
+			'_dr' => 'https://example.com/shop/page/3/',
+		);
+
+		$this->assertSame( $properties, WC_Analytics_Tracking::sanitize_client_properties( $properties ) );
+	}
+
+	/**
+	 * Every other bounds test calls `sanitize_client_properties()` directly, so
+	 * removing its call site in `record_event()` left the suite green while the
+	 * bounds silently stopped applying. This drives one through the real entry
+	 * point instead.
+	 */
+	public function test_record_client_event_actually_applies_the_bounds(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'pn'        => str_repeat( 'a', 500 ),
+				'Uppercase' => 'dropped by the name check',
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $props['pn'] ?? '' ) );
+		$this->assertArrayNotHasKey( 'Uppercase', $props );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
 	 * Non-string scalars are analytics payload, not text: capping them would
 	 * change their type on the way to the pixel.
 	 */

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -16,10 +16,25 @@ use WorDBless\BaseTestCase;
 class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 	/**
+	 * Snapshot of $_SERVER taken in set_up(), restored in tear_down().
+	 *
+	 * Several tests mutate REQUEST_METHOD/REQUEST_URI to exercise
+	 * is_proxy_tracking_request(). Restoring the full array — rather than
+	 * unset()-ing the specific keys a test touched — puts back whatever the
+	 * WordPress bootstrap actually populated (e.g. REQUEST_URI defaults to
+	 * '', not "absent"), and does so from tear_down() so a failed assertion
+	 * mid-test cannot skip cleanup and leak state into the next test.
+	 *
+	 * @var array
+	 */
+	private $server_snapshot = array();
+
+	/**
 	 * Clear the memoized reserved-name list before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
+		$this->server_snapshot = $_SERVER;
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
 	}
@@ -28,6 +43,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 * Clear the memoized reserved-name list after each test.
 	 */
 	public function tear_down(): void {
+		$_SERVER = $this->server_snapshot;
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
 		parent::tear_down();
@@ -288,7 +304,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null );
 
 		$this->reset_pixel_batch_queue();
-		unset( $_COOKIE['tk_ai'], $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
+		unset( $_COOKIE['tk_ai'] );
 	}
 
 	/**
@@ -317,7 +333,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
 
 		$this->reset_pixel_batch_queue();
-		unset( $_COOKIE['tk_ai'], $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
+		unset( $_COOKIE['tk_ai'] );
 	}
 
 	/**
@@ -347,8 +363,6 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$_SERVER['REQUEST_URI']    = $uri;
 
 		$this->assertTrue( WC_Analytics_Tracking::is_proxy_tracking_request(), $uri );
-
-		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -267,4 +267,102 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->reset_pixel_batch_queue();
 		unset( $_COOKIE['tk_ai'] );
 	}
+
+	/**
+	 * Simulates a stale MU-plugin copy: it calls record_event() with no flag,
+	 * during a POST to the track endpoint. The guard must strip anyway.
+	 */
+	public function test_record_event_strips_during_a_proxy_request(): void {
+		$_COOKIE['tk_ai']           = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD']  = 'POST';
+		$_SERVER['REQUEST_URI']     = '/wp-json/woocommerce-analytics/v1/track';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'someone-elses-store' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'], $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
+	}
+
+	/**
+	 * The over-stripping guard. If the path or method test is ever loosened,
+	 * this is what fails — trusted server-side callers must keep their
+	 * properties on every request that is not a proxy POST.
+	 *
+	 * @dataProvider non_proxy_request_provider
+	 *
+	 * @param string $method Request method.
+	 * @param string $uri    Request URI.
+	 */
+	public function test_record_event_does_not_strip_outside_a_proxy_request( string $method, string $uri ): void {
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$_SERVER['REQUEST_URI']    = $uri;
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'], $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
+	}
+
+	/**
+	 * Requests that must not trigger the guard.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function non_proxy_request_provider(): array {
+		return array(
+			'GET to the track path'      => array( 'GET', '/wp-json/woocommerce-analytics/v1/track' ),
+			'POST to the Store API'      => array( 'POST', '/wp-json/wc/store/v1/checkout' ),
+			'POST to a lookalike suffix' => array( 'POST', '/wp-json/other/woocommerce-analytics/v1/tracking' ),
+			'POST to the site root'      => array( 'POST', '/' ),
+		);
+	}
+
+	/**
+	 * Shapes that must still match, so the safety net is not defeated by a
+	 * query string, a trailing slash, or a subdirectory install.
+	 *
+	 * @dataProvider proxy_request_shape_provider
+	 *
+	 * @param string $uri Request URI.
+	 */
+	public function test_is_proxy_tracking_request_matches_real_world_shapes( string $uri ): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = $uri;
+
+		$this->assertTrue( WC_Analytics_Tracking::is_proxy_tracking_request(), $uri );
+
+		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
+	}
+
+	/**
+	 * URIs that must match.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function proxy_request_shape_provider(): array {
+		return array(
+			'plain'             => array( '/wp-json/woocommerce-analytics/v1/track' ),
+			'trailing slash'    => array( '/wp-json/woocommerce-analytics/v1/track/' ),
+			'query string'      => array( '/wp-json/woocommerce-analytics/v1/track?_wpnonce=abc123' ),
+			'subdirectory'      => array( '/shop/wp-json/woocommerce-analytics/v1/track' ),
+			'rest_route form'   => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
+		);
+	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -52,6 +52,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 */
 	public function tear_down(): void {
 		$_SERVER = $this->server_snapshot;
+		unset( $_COOKIE['tk_ai'] );
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
 		$this->reset_cached_ip();
@@ -72,9 +73,10 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 	/**
 	 * Pins the effective reserved set. This test exists to fail: adding a
-	 * property to get_page_common_properties() or get_server_details() must
-	 * force a deliberate decision about whether a client may set it, rather
-	 * than silently inheriting protection or silently missing out on it.
+	 * property to get_session_properties(), get_page_common_properties() or
+	 * get_server_details() must force a deliberate decision about whether a
+	 * client may set it, rather than silently inheriting protection or silently
+	 * missing out on it.
 	 */
 	public function test_reserved_property_names_match_the_documented_set(): void {
 		$expected = array(
@@ -102,6 +104,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			'_ui',
 			'_ut',
 			'_en',
+			'_ts',
 			'browser_type',
 		);
 
@@ -319,11 +322,17 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	/**
 	 * Simulates a stale MU-plugin copy: it calls record_event() with no flag,
 	 * during a POST to the track endpoint. The guard must strip anyway.
+	 *
+	 * `woocommerce_store_id` is seeded so the assertion proves the server's value
+	 * replaced the forged one. Without it the property is absent from the pixel
+	 * entirely — `get_option()` returns null and `http_build_query()` drops nulls
+	 * — and an assertNotSame() would pass on absence alone.
 	 */
 	public function test_record_event_strips_during_a_proxy_request(): void {
-		$_COOKIE['tk_ai']           = 'test-visitor-id-1234567890ab';
-		$_SERVER['REQUEST_METHOD']  = 'POST';
-		$_SERVER['REQUEST_URI']     = '/wp-json/woocommerce-analytics/v1/track';
+		$_COOKIE['tk_ai']          = 'test-visitor-id-1234567890ab';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI']    = '/wp-json/woocommerce-analytics/v1/track';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
 		$this->reset_pixel_batch_queue();
 
 		WC_Analytics_Tracking::record_event(
@@ -333,10 +342,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 		$props = $this->get_queued_pixel_props();
 
-		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null );
-
-		$this->reset_pixel_batch_queue();
-		unset( $_COOKIE['tk_ai'] );
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'The server value must replace the forged one, not merely be absent.' );
 	}
 
 	/**
@@ -515,5 +521,234 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
 
 		$this->assertSame( array( true, false ), $seen );
+	}
+
+	/**
+	 * A callback that defers to an existing value hands a *reserved* property
+	 * straight back to the client that supplied it. The strip runs before the
+	 * filter, so it cannot see this; get_properties() re-asserts the server's
+	 * values afterwards. Contrast with
+	 * test_filter_callback_deferring_to_an_existing_value_loses_to_the_client(),
+	 * which covers a name the filter invents — still the client's to win.
+	 */
+	public function test_filter_callback_cannot_hand_a_reserved_property_back_to_the_client(): void {
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		$callback = function ( $props ) {
+			$props['store_id'] = isset( $props['store_id'] ) ? $props['store_id'] : 'unused';
+			return $props;
+		};
+		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'store_id' => 'someone-elses-store' ),
+			true
+		);
+
+		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback );
+
+		$this->assertSame( 'real-store-id', $props['store_id'] );
+	}
+
+	/**
+	 * The trusted path must keep its escape hatch: a server-side caller can still
+	 * set a property that collides with a common one, and the post-filter
+	 * re-assertion must not take that away.
+	 */
+	public function test_reserved_properties_are_not_re_asserted_for_trusted_callers(): void {
+		update_option( 'woocommerce_store_id', 'real-store-id' );
+
+		$props = WC_Analytics_Tracking::get_properties(
+			'woocommerceanalytics_add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' ),
+			false
+		);
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] );
+	}
+
+	/**
+	 * `_ts` is in $required_properties and in RESERVED_IDENTITY_PROPERTIES, so a
+	 * client cannot forge the event timestamp at either layer.
+	 */
+	public function test_client_cannot_forge_the_event_timestamp(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_ts' => '1',
+				'pi'  => 42,
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertMatchesRegularExpression( '/^\d{13}$/', (string) ( $props['_ts'] ?? '' ), '_ts must be the server timestamp.' );
+	}
+
+	/**
+	 * The endpoint is unauthenticated and every property reaches the pixel URL,
+	 * which is rejected outright once it grows too long. Values are truncated
+	 * with an ellipsis so a capped value stays distinguishable from one that
+	 * genuinely ended at the limit.
+	 */
+	public function test_client_property_values_are_capped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'pn'    => str_repeat( 'a', 500 ),
+				'short' => 'kept',
+			)
+		);
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $sanitized['pn'] ) );
+		$this->assertStringEndsWith( '…', $sanitized['pn'] );
+		$this->assertSame( 'kept', $sanitized['short'], 'Values within the limit must be untouched.' );
+	}
+
+	/**
+	 * A client cannot widen its own footprint by sending hundreds of properties.
+	 */
+	public function test_client_property_count_is_capped(): void {
+		$properties = array();
+		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT + 25; $i++ ) {
+			$properties[ 'p' . $i ] = $i;
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertCount( WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT, $sanitized );
+	}
+
+	/**
+	 * get_properties() flattens array values with implode(), which emits an
+	 * "Array to string conversion" warning for a nested array. Letting an
+	 * unauthenticated caller write warnings into the error log is the problem
+	 * worth closing; the value itself is meaningless either way.
+	 */
+	public function test_nested_client_arrays_do_not_reach_the_flattening_step(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array( 'foo' => array( array( 1, 2 ), 'ok' ) )
+		);
+
+		$this->assertSame( array( '', 'ok' ), $sanitized['foo'] );
+	}
+
+	/**
+	 * Non-string scalars are analytics payload, not text: capping them would
+	 * change their type on the way to the pixel.
+	 */
+	public function test_client_scalar_values_keep_their_type(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'pi' => 42,
+				'ch' => true,
+			)
+		);
+
+		$this->assertSame( 42, $sanitized['pi'] );
+		$this->assertTrue( $sanitized['ch'] );
+	}
+
+	/**
+	 * The guard's defensive early returns, none of which a data provider typed
+	 * `string` can reach. WorDBless leaves REQUEST_METHOD absent and REQUEST_URI
+	 * empty, so without this the `! isset()` branches are never executed and
+	 * could be deleted with the suite still green.
+	 *
+	 * @dataProvider malformed_request_provider
+	 *
+	 * @param array $server Superglobal overrides; a null value means unset the key.
+	 */
+	public function test_is_proxy_tracking_request_is_false_for_malformed_requests( array $server ): void {
+		foreach ( $server as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+				continue;
+			}
+			$_SERVER[ $key ] = $value;
+		}
+
+		$this->assertFalse( WC_Analytics_Tracking::is_proxy_tracking_request() );
+	}
+
+	/**
+	 * Malformed request shapes that must not reach the suffix comparison.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function malformed_request_provider(): array {
+		$uri = '/wp-json/woocommerce-analytics/v1/track';
+
+		return array(
+			'no REQUEST_METHOD (WP-CLI, cron)' => array(
+				array(
+					'REQUEST_METHOD' => null,
+					'REQUEST_URI'    => $uri,
+				),
+			),
+			'no REQUEST_URI'                   => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => null,
+				),
+			),
+			'empty REQUEST_URI'                => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => '',
+				),
+			),
+			'non-string REQUEST_URI'           => array(
+				array(
+					'REQUEST_METHOD' => 'POST',
+					'REQUEST_URI'    => array( $uri ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * The two copies of the request-shape logic must not drift: the template's
+	 * copy is the first thing that decides whether a request is a proxy POST, it
+	 * runs before the autoloader so it cannot delegate, and nothing else in the
+	 * suite executes it. Asserting on the source text is crude, but it is the
+	 * only thing standing behind the "Change both together" comments.
+	 */
+	public function test_mu_plugin_template_stays_in_step_with_the_package(): void {
+		$template = file_get_contents(
+			dirname( __DIR__, 2 ) . '/src/mu-plugin/woocommerce-analytics-proxy-speed-module-template.php'
+		);
+
+		$this->assertSame(
+			1,
+			preg_match( "/const PROXY_REQUEST_PATH = '([^']+)';/", $template, $matches ),
+			'The template must declare PROXY_REQUEST_PATH.'
+		);
+		$this->assertSame( WC_Analytics_Tracking::PROXY_REQUEST_PATH, $matches[1] );
+
+		$this->assertStringContainsString(
+			'preg_match( \'/[^A-Za-z0-9\-._~\/]/\', $path )',
+			$template,
+			'The template must keep the same character restriction as is_proxy_tracking_request().'
+		);
+
+		$this->assertStringContainsString(
+			'::record_client_event(',
+			$template,
+			'The template must record through the untrusted-client entry point.'
+		);
+		$this->assertStringNotContainsString(
+			'::record_event(',
+			$template,
+			'The template must not call the trusted entry point.'
+		);
+
+		$this->assertStringContainsString(
+			'Features::is_proxy_tracking_enabled()',
+			$template,
+			'The template must refuse requests while proxy tracking is disabled; the REST gate cannot reach it.'
+		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -734,6 +734,95 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * An associative array serializes to JSON, which carries its keys, while an
+	 * indexed one is joined and drops them. Measuring both as a joined list
+	 * charged nothing for the keys, and 50 such properties built a 152KB URL.
+	 */
+	public function test_associative_array_keys_are_charged_to_the_budget(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+
+		$properties = array();
+		for ( $p = 0; $p < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $p++ ) {
+			$members = array();
+			for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS; $i++ ) {
+				$members[ str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) . $i ] = 'v';
+			}
+			$properties[ 'p' . $p ] = $members;
+		}
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+		$props     = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThanOrEqual(
+			WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH,
+			strlen( Pixel_Builder::build_tracks_url( $props ) )
+		);
+
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * One oversized value used to charge its key against the budget and then be
+	 * dropped anyway, so short properties after it were refused for space that
+	 * nothing occupied.
+	 */
+	public function test_a_dropped_property_does_not_spend_the_budget(): void {
+		// Long names on purpose: the leak is the key's own cost, so short keys hide
+		// it however many properties are dropped.
+		$properties = array();
+		for ( $i = 0; $i < 40; $i++ ) {
+			$name                = str_repeat( 'k', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH - 12 ) . $i;
+			$properties[ $name ] = str_repeat( 'y', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+		}
+		$properties['last'] = 'short';
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
+
+		$this->assertSame( 'short', $sanitized['last'] ?? null, 'A property that fits must not be refused for a dropped one.' );
+	}
+
+	/**
+	 * `cap_client_value()` counts characters, so a 250-character CJK value must
+	 * come back at 200 characters rather than being cut mid-sequence at 200 bytes.
+	 *
+	 * @dataProvider multibyte_value_provider
+	 *
+	 * @param string $character One multibyte character.
+	 */
+	public function test_value_cap_counts_characters_not_bytes( string $character ): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array( 'pn' => str_repeat( $character, 250 ) )
+		);
+
+		$this->assertSame( WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH, mb_strlen( $sanitized['pn'] ) );
+		$this->assertSame( $sanitized['pn'], mb_convert_encoding( $sanitized['pn'], 'UTF-8', 'UTF-8' ), 'The cut must not split a character.' );
+	}
+
+	/**
+	 * Multibyte characters whose byte length differs from their character length.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function multibyte_value_provider(): array {
+		return array(
+			'CJK'    => array( '漢' ),
+			'emoji'  => array( '😀' ),
+			'accent' => array( 'é' ),
+		);
+	}
+
+	/**
+	 * The bound is a limit, not an off-by-one rejection of the longest legal value.
+	 */
+	public function test_a_value_at_the_length_limit_is_untouched(): void {
+		$exact = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pn' => $exact ) );
+
+		$this->assertSame( $exact, $sanitized['pn'] );
+	}
+
+	/**
 	 * An array that hits the member cap always exceeded the budget, so the whole
 	 * property used to vanish. Losing a few categories is easier to notice.
 	 */
@@ -845,7 +934,8 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 		$result = WC_Analytics_Tracking::record_client_event( $event_name, array( 'pi' => 42 ) );
 
-		$this->assertTrue( $result, 'A malformed name is a skip, not an error the caller must handle.' );
+		$this->assertTrue( is_wp_error( $result ), 'Reporting success for an event that produced no pixel is what hides the loss.' );
+		$this->assertSame( 'invalid_event_name', $result->get_error_code() );
 		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued for an unusable event name.' );
 	}
 
@@ -1008,10 +1098,18 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 			'The template must not call the trusted entry point.'
 		);
 
+		// Nothing executes the template, so the direction of the comparison has to
+		// be asserted literally: inverting it serves exactly the requests it is
+		// there to refuse, and every other test stays green.
 		$this->assertStringContainsString(
-			'Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION',
+			"if ( 'yes' !== get_option( \\Automattic\\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) ) {",
 			$template,
-			'The template must refuse requests while proxy tracking is disabled; the REST gate cannot reach it.'
+			'The template must refuse unless the option says yes; the REST gate cannot reach it.'
+		);
+		$this->assertStringContainsString(
+			"'code'    => 'proxy_tracking_disabled',",
+			$template,
+			'Both paths must refuse with one body shape, or a client has two to recognise.'
 		);
 
 		$this->assertStringContainsString(

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for the reserved-property set that keeps client-supplied event
+ * properties from overriding the ones the server derives.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for WC_Analytics_Tracking reserved property handling.
+ */
+class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
+
+	/**
+	 * Clear the memoized reserved-name list before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->reset_reserved_property_names();
+	}
+
+	/**
+	 * Clear the memoized reserved-name list after each test.
+	 */
+	public function tear_down(): void {
+		$this->reset_reserved_property_names();
+		parent::tear_down();
+	}
+
+	/**
+	 * The memo persists for the life of the PHP process, so tests must clear it
+	 * or the first test's environment leaks into every later one.
+	 */
+	private function reset_reserved_property_names(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'reserved_property_names' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Pins the effective reserved set. This test exists to fail: adding a
+	 * property to get_page_common_properties() or get_server_details() must
+	 * force a deliberate decision about whether a client may set it, rather
+	 * than silently inheriting protection or silently missing out on it.
+	 */
+	public function test_reserved_property_names_match_the_documented_set(): void {
+		$expected = array(
+			// get_session_properties().
+			'session_id',
+			'landing_page',
+			'is_engaged',
+			// get_page_common_properties().
+			'ui',
+			'blog_id',
+			'store_id',
+			'url',
+			'woo_version',
+			'wp_version',
+			'store_admin',
+			'device',
+			'store_currency',
+			'timezone',
+			'is_guest',
+			// get_server_details(), minus CLIENT_OVERRIDABLE_PROPERTIES.
+			'_via_ua',
+			'_via_ip',
+			'_via_ref',
+			// Identity and envelope.
+			'_ui',
+			'_ut',
+			'_en',
+			'browser_type',
+		);
+
+		$actual = WC_Analytics_Tracking::get_reserved_property_names();
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * The three properties the client is authoritative for must not be
+	 * reserved: on the proxy path the server's values describe the /track
+	 * request, not the page the event happened on.
+	 */
+	public function test_client_overridable_properties_are_not_reserved(): void {
+		$reserved = WC_Analytics_Tracking::get_reserved_property_names();
+
+		$this->assertNotContains( '_lg', $reserved );
+		$this->assertNotContains( '_dl', $reserved );
+		$this->assertNotContains( '_dr', $reserved );
+	}
+
+	/**
+	 * The strip removes reserved names and leaves everything else — including
+	 * arbitrary event-specific properties — untouched.
+	 */
+	public function test_strip_removes_reserved_names_only(): void {
+		$stripped = WC_Analytics_Tracking::strip_reserved_properties(
+			array(
+				'_via_ip'     => '8.8.8.8',
+				'store_id'    => 'someone-elses-store',
+				'blog_id'     => 12345,
+				'session_id'  => 'forged-session',
+				'store_admin' => 1,
+				'is_guest'    => 0,
+				'_ui'         => 'forged-visitor',
+				'_lg'         => 'en-GB',
+				'_dl'         => 'https://example.com/product/thing',
+				'_dr'         => 'https://example.com/',
+				'pi'          => 42,
+				'pq'          => 2,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'_lg' => 'en-GB',
+				'_dl' => 'https://example.com/product/thing',
+				'_dr' => 'https://example.com/',
+				'pi'  => 42,
+				'pq'  => 2,
+			),
+			$stripped
+		);
+	}
+
+	/**
+	 * Defensive: the REST body is attacker-shaped, so a non-array or empty
+	 * value must not fatal.
+	 */
+	public function test_strip_handles_empty_and_non_array_input(): void {
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( array() ) );
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( 'not-an-array' ) );
+		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( null ) );
+	}
+}

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -510,17 +510,23 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	public function test_filter_receives_the_client_supplied_flag(): void {
 		$seen     = array();
 		$callback = function ( $props, $event_name, $is_client_supplied ) use ( &$seen ) {
-			$seen[] = $is_client_supplied;
+			$seen[] = array( $event_name, $is_client_supplied );
 			return $props;
 		};
 		add_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10, 3 );
 
 		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_add_to_cart', array(), true );
-		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_add_to_cart', array(), false );
+		WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', array(), false );
 
 		remove_filter( 'jetpack_woocommerce_analytics_event_props', $callback, 10 );
 
-		$this->assertSame( array( true, false ), $seen );
+		$this->assertSame(
+			array(
+				array( 'woocommerceanalytics_add_to_cart', true ),
+				array( 'woocommerceanalytics_product_view', false ),
+			),
+			$seen
+		);
 	}
 
 	/**
@@ -652,6 +658,90 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A JSON array survives the consumers' truthiness check and reaches
+	 * `PREFIX . $event_name`, where PHP writes a warning to the log on an
+	 * unauthenticated request. `failOnWarning` makes that warning fail the test.
+	 *
+	 * @dataProvider unusable_client_event_name_provider
+	 *
+	 * @param mixed $event_name Name a client could post.
+	 */
+	public function test_client_events_with_an_unusable_name_are_dropped( $event_name ): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$result = WC_Analytics_Tracking::record_client_event( $event_name, array( 'pi' => 42 ) );
+
+		$this->assertTrue( $result, 'A malformed name is a skip, not an error the caller must handle.' );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'No pixel may be queued for an unusable event name.' );
+	}
+
+	/**
+	 * Names a client could post that cannot become an `_en` value.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function unusable_client_event_name_provider(): array {
+		return array(
+			'array'      => array( array( 'product_view' ) ),
+			'nested map' => array( array( 'name' => 'product_view' ) ),
+			'empty'      => array( '' ),
+			'oversized'  => array( str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH + 1 ) ),
+		);
+	}
+
+	/**
+	 * A name at the limit is still recorded: the bound is a limit, not an
+	 * off-by-one rejection of the longest legal name.
+	 */
+	public function test_client_event_name_at_the_length_limit_is_recorded(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$name = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH );
+
+		WC_Analytics_Tracking::record_client_event( $name, array() );
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( WC_Analytics_Tracking::PREFIX . $name, $props['_en'] ?? null );
+	}
+
+	/**
+	 * Names are the one axis left unbounded once values and counts are capped.
+	 * The charset check is `Pixel_Builder`'s own, so this drops exactly what it
+	 * would reject — but rejecting there loses the whole event, not one property.
+	 */
+	public function test_unusable_client_property_names_are_dropped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_NAME_LENGTH + 1 ) => 'oversized',
+				'Uppercase' => 'bad charset',
+				'has space' => 'bad charset',
+				'pi'        => 42,
+				'_lg'       => 'en-GB',
+			)
+		);
+
+		$this->assertSame( array( 'pi' => 42, '_lg' => 'en-GB' ), $sanitized );
+	}
+
+	/**
+	 * A JSON object key that is all digits becomes an integer array key in PHP,
+	 * which `Pixel_Builder` would reject for the whole event.
+	 */
+	public function test_numeric_client_property_names_are_dropped(): void {
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties(
+			array(
+				'0'  => 'dropped',
+				'pi' => 42,
+			)
+		);
+
+		$this->assertSame( array( 'pi' => 42 ), $sanitized );
+	}
+
+	/**
 	 * The guard's defensive early returns, none of which a data provider typed
 	 * `string` can reach. WorDBless leaves REQUEST_METHOD absent and REQUEST_URI
 	 * empty, so without this the `! isset()` branches are never executed and
@@ -746,9 +836,15 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		);
 
 		$this->assertStringContainsString(
-			'Features::is_proxy_tracking_enabled()',
+			'Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION',
 			$template,
 			'The template must refuse requests while proxy tracking is disabled; the REST gate cannot reach it.'
+		);
+
+		$this->assertStringContainsString(
+			'MAX_CLIENT_EVENTS_PER_REQUEST',
+			$template,
+			'The template must cap the batch with the same constant as the REST controller.'
 		);
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -642,6 +642,43 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The per-value cap runs on each member, never on the string
+	 * `get_properties()` joins them into: 20,000 ten-character members produced a
+	 * 300KB pixel URL, which nothing downstream rejects.
+	 */
+	public function test_client_array_member_count_is_capped(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 25, 'abcdefghij' );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+
+		$this->assertCount( WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, $sanitized['pc'] );
+
+		$props = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertLessThan(
+			2000,
+			strlen( $props['pc'] ),
+			'The flattened value is what reaches the pixel URL, so the cap must survive flattening.'
+		);
+	}
+
+	/**
+	 * Slicing must not turn an indexed array into an associative one:
+	 * `get_properties()` picks `implode()` over `wp_json_encode()` on that test.
+	 */
+	public function test_capped_arrays_still_flatten_with_implode(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS + 5, 'a' );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+		$props     = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
+
+		$this->assertSame(
+			rawurlencode( implode( ',', array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, 'a' ) ) ),
+			$props['pc']
+		);
+	}
+
+	/**
 	 * Non-string scalars are analytics payload, not text: capping them would
 	 * change their type on the way to the pixel.
 	 */

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -37,15 +37,25 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->server_snapshot = $_SERVER;
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
+		$this->reset_cached_ip();
+		delete_transient( 'wc_analytics_blog_details' );
 	}
 
 	/**
 	 * Clear the memoized reserved-name list after each test.
+	 *
+	 * Runs unconditionally regardless of the test outcome, so a seeded
+	 * `woocommerce_store_id` option, the blog-details transient, or the cached
+	 * IP address set up for one test (to prove substitution rather than mere
+	 * absence, see test_record_client_event_drops_client_supplied_server_properties())
+	 * cannot leak into the next test even if an assertion fails first.
 	 */
 	public function tear_down(): void {
 		$_SERVER = $this->server_snapshot;
 		$this->reset_reserved_property_names();
 		$this->reset_pixel_batch_queue();
+		$this->reset_cached_ip();
+		delete_transient( 'wc_analytics_blog_details' );
 		parent::tear_down();
 	}
 
@@ -190,6 +200,18 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Clear the cached IP address, so a REMOTE_ADDR seeded for one test cannot
+	 * leak into the next: get_user_ip_address() memoizes its result for the
+	 * life of the PHP process.
+	 */
+	private function reset_cached_ip(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'cached_ip' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
 	 * Parse the query string of the single queued pixel into an array.
 	 *
 	 * @return array
@@ -208,9 +230,19 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	/**
 	 * A client that posts server-owned properties must not see them reach the
 	 * pixel. This is the core of WOOA7S-1803.
+	 *
+	 * Both `store_id` and `_via_ip` are seeded with a real server-derived value
+	 * before the call, so the assertions prove the server's value replaced the
+	 * client's forged one, not merely that the forged one is absent. Under
+	 * WorDBless, `get_option( 'woocommerce_store_id', null )` is null and
+	 * `http_build_query()` drops null values, so an assertNotSame() against an
+	 * unseeded environment would pass on absence alone and miss a stripped-but-
+	 * not-substituted bug.
 	 */
 	public function test_record_client_event_drops_client_supplied_server_properties(): void {
-		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$_COOKIE['tk_ai']       = 'test-visitor-id-1234567890ab';
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+		update_option( 'woocommerce_store_id', 'real-store-id' );
 		$this->reset_pixel_batch_queue();
 
 		WC_Analytics_Tracking::record_client_event(
@@ -225,8 +257,8 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 
 		$props = $this->get_queued_pixel_props();
 
-		$this->assertNotSame( '8.8.8.8', $props['_via_ip'] ?? null, '_via_ip must come from the server.' );
-		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null, 'store_id must come from the server.' );
+		$this->assertSame( '203.0.113.7', $props['_via_ip'] ?? null, '_via_ip must come from the server (REMOTE_ADDR), not the client.' );
+		$this->assertSame( 'real-store-id', $props['store_id'] ?? null, 'store_id must come from the server (woocommerce_store_id option), not the client.' );
 		$this->assertSame( 'test-visitor-id-1234567890ab', $props['_ui'] ?? null, '_ui must come from the tk_ai cookie.' );
 		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must survive.' );
 
@@ -339,14 +371,24 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	/**
 	 * Requests that must not trigger the guard.
 	 *
+	 * The `?rest_route=` case is load-bearing, not incidental: on a
+	 * plain-permalink site `rest_url()` produces exactly this shape, whose
+	 * parsed path is `/`, so the guard correctly does not match it — and
+	 * neither does `WooCommerceAnalyticsProxySpeed::is_proxy_request()` in the
+	 * MU-plugin template. The two copies agreeing here is what keeps a stale
+	 * template from intercepting a request this guard would not recognise. On
+	 * such sites `record_client_event()` — not this guard — is the only thing
+	 * stripping reserved properties.
+	 *
 	 * @return array<string, array{0: string, 1: string}>
 	 */
 	public function non_proxy_request_provider(): array {
 		return array(
-			'GET to the track path'      => array( 'GET', '/wp-json/woocommerce-analytics/v1/track' ),
-			'POST to the Store API'      => array( 'POST', '/wp-json/wc/store/v1/checkout' ),
-			'POST to a lookalike suffix' => array( 'POST', '/wp-json/other/woocommerce-analytics/v1/tracking' ),
-			'POST to the site root'      => array( 'POST', '/' ),
+			'GET to the track path'          => array( 'GET', '/wp-json/woocommerce-analytics/v1/track' ),
+			'POST to the Store API'          => array( 'POST', '/wp-json/wc/store/v1/checkout' ),
+			'POST to a lookalike suffix'     => array( 'POST', '/wp-json/other/woocommerce-analytics/v1/tracking' ),
+			'POST to the site root'          => array( 'POST', '/' ),
+			'POST with rest_route query var' => array( 'POST', '/?rest_route=/woocommerce-analytics/v1/track' ),
 		);
 	}
 
@@ -368,15 +410,21 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	/**
 	 * URIs that must match.
 	 *
+	 * Note what is deliberately absent: the genuine `?rest_route=` query-var
+	 * form (e.g. `/?rest_route=/woocommerce-analytics/v1/track`, what
+	 * `rest_url()` produces on a plain-permalink site) does NOT match this
+	 * guard — its parsed path is just `/`. That is covered as a non-matching
+	 * case in non_proxy_request_provider(), not here.
+	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public function proxy_request_shape_provider(): array {
 		return array(
-			'plain'             => array( '/wp-json/woocommerce-analytics/v1/track' ),
-			'trailing slash'    => array( '/wp-json/woocommerce-analytics/v1/track/' ),
-			'query string'      => array( '/wp-json/woocommerce-analytics/v1/track?_wpnonce=abc123' ),
-			'subdirectory'      => array( '/shop/wp-json/woocommerce-analytics/v1/track' ),
-			'rest_route form'   => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
+			'plain'                                    => array( '/wp-json/woocommerce-analytics/v1/track' ),
+			'trailing slash'                           => array( '/wp-json/woocommerce-analytics/v1/track/' ),
+			'query string'                             => array( '/wp-json/woocommerce-analytics/v1/track?_wpnonce=abc123' ),
+			'subdirectory'                             => array( '/shop/wp-json/woocommerce-analytics/v1/track' ),
+			'index.php-prefixed pretty-permalink form' => array( '/index.php/wp-json/woocommerce-analytics/v1/track' ),
 		);
 	}
 

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -21,6 +21,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	public function set_up(): void {
 		parent::set_up();
 		$this->reset_reserved_property_names();
+		$this->reset_pixel_batch_queue();
 	}
 
 	/**
@@ -28,6 +29,7 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 */
 	public function tear_down(): void {
 		$this->reset_reserved_property_names();
+		$this->reset_pixel_batch_queue();
 		parent::tear_down();
 	}
 
@@ -140,5 +142,129 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( array() ) );
 		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( 'not-an-array' ) );
 		$this->assertSame( array(), WC_Analytics_Tracking::strip_reserved_properties( null ) );
+	}
+
+	/**
+	 * Read the queued pixel URLs. record_event() queues rather than sends when
+	 * the Requests library supports request_multiple(), which it does here.
+	 *
+	 * @return array
+	 */
+	private function get_pixel_batch_queue(): array {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+		$property   = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
+	/**
+	 * Clear the queued pixel URLs and the cached visitor id, so one test's
+	 * cookie cannot leak into the next.
+	 */
+	private function reset_pixel_batch_queue(): void {
+		$reflection = new \ReflectionClass( WC_Analytics_Tracking::class );
+
+		$property = $reflection->getProperty( 'pixel_batch_queue' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+
+		$visitor = $reflection->getProperty( 'cached_visitor_id' );
+		$visitor->setAccessible( true );
+		$visitor->setValue( null, null );
+	}
+
+	/**
+	 * Parse the query string of the single queued pixel into an array.
+	 *
+	 * @return array
+	 */
+	private function get_queued_pixel_props(): array {
+		$queue = $this->get_pixel_batch_queue();
+		$this->assertCount( 1, $queue, 'Expected exactly one queued pixel.' );
+
+		$query = wp_parse_url( $queue[0], PHP_URL_QUERY );
+		$props = array();
+		parse_str( (string) $query, $props );
+
+		return $props;
+	}
+
+	/**
+	 * A client that posts server-owned properties must not see them reach the
+	 * pixel. This is the core of WOOA7S-1803.
+	 */
+	public function test_record_client_event_drops_client_supplied_server_properties(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_via_ip'  => '8.8.8.8',
+				'store_id' => 'someone-elses-store',
+				'_ui'      => 'forged-visitor',
+				'pi'       => 42,
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertNotSame( '8.8.8.8', $props['_via_ip'] ?? null, '_via_ip must come from the server.' );
+		$this->assertNotSame( 'someone-elses-store', $props['store_id'] ?? null, 'store_id must come from the server.' );
+		$this->assertSame( 'test-visitor-id-1234567890ab', $props['_ui'] ?? null, '_ui must come from the tk_ai cookie.' );
+		$this->assertSame( '42', $props['pi'] ?? null, 'Event-specific properties must survive.' );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * The three client-authoritative properties must survive to the pixel,
+	 * otherwise proxy-mode page attribution breaks: the server's values would
+	 * describe the /track request instead of the page.
+	 */
+	public function test_record_client_event_keeps_client_authoritative_properties(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_client_event(
+			'add_to_cart',
+			array(
+				'_lg' => 'en-GB',
+				'_dl' => 'https://example.com/product/thing',
+				'_dr' => 'https://example.com/',
+			)
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'en-GB', $props['_lg'] ?? null );
+		$this->assertSame( 'https://example.com/product/thing', $props['_dl'] ?? null );
+		$this->assertSame( 'https://example.com/', $props['_dr'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * The trusted path is unchanged: a server-side caller can still set a
+	 * property that collides with a common one. Universal and My_Account rely
+	 * on record_event() keeping these semantics.
+	 */
+	public function test_record_event_leaves_trusted_caller_properties_alone(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'store_id' => 'set-by-trusted-caller' )
+		);
+
+		$props = $this->get_queued_pixel_props();
+
+		$this->assertSame( 'set-by-trusted-caller', $props['store_id'] ?? null );
+
+		$this->reset_pixel_batch_queue();
+		unset( $_COOKIE['tk_ai'] );
 	}
 }

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Reserved_Props_Test.php
@@ -683,10 +683,10 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 	 * URL, so the product needs its own bound. Properties are dropped from the
 	 * tail once the budget is spent.
 	 */
-	public function test_client_payload_total_is_capped(): void {
+	public function test_client_payload_total_is_capped( string $character = 'a' ): void {
 		$properties = array();
 		for ( $i = 0; $i < WC_Analytics_Tracking::MAX_CLIENT_PROPERTIES_PER_EVENT; $i++ ) {
-			$properties[ 'p' . $i ] = str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
+			$properties[ 'p' . $i ] = str_repeat( $character, WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH );
 		}
 
 		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( $properties );
@@ -694,12 +694,77 @@ class WC_Analytics_Tracking_Reserved_Props_Test extends BaseTestCase {
 		$this->assertNotEmpty( $sanitized, 'The budget drops the tail, it does not empty the event.' );
 
 		// The pixel URL is what the budget exists to bound, so assert on it rather
-		// than on the constant. 8KB is the practical ceiling for a GET.
+		// than on the constant.
 		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
 		$props            = WC_Analytics_Tracking::get_properties( 'woocommerceanalytics_product_view', $sanitized, true );
 
-		$this->assertLessThan( 8192, strlen( Pixel_Builder::build_tracks_url( $props ) ) );
+		$this->assertLessThanOrEqual(
+			WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH,
+			strlen( Pixel_Builder::build_tracks_url( $props ) )
+		);
 
+		unset( $_COOKIE['tk_ai'] );
+	}
+
+	/**
+	 * An ASCII-only fixture hid this: the budget counted characters while the URL
+	 * carries percent-encoded bytes, so `%`, CJK and emoji each cost 3x what the
+	 * budget charged and the same payload built a 12KB URL.
+	 *
+	 * @dataProvider expensive_character_provider
+	 *
+	 * @param string $character One character whose encoded form is longer than itself.
+	 */
+	public function test_client_payload_budget_counts_encoded_bytes( string $character ): void {
+		$this->test_client_payload_total_is_capped( $character );
+	}
+
+	/**
+	 * Characters that cost more in the URL than they do in the payload.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function expensive_character_provider(): array {
+		return array(
+			'percent' => array( '%' ),
+			'CJK'     => array( '漢' ),
+			'emoji'   => array( '😀' ),
+			'space'   => array( ' ' ),
+		);
+	}
+
+	/**
+	 * An array that hits the member cap always exceeded the budget, so the whole
+	 * property used to vanish. Losing a few categories is easier to notice.
+	 */
+	public function test_oversized_arrays_lose_members_not_the_property(): void {
+		$members = array_fill( 0, WC_Analytics_Tracking::MAX_CLIENT_ARRAY_MEMBERS, str_repeat( 'a', WC_Analytics_Tracking::MAX_CLIENT_PROPERTY_LENGTH ) );
+
+		$sanitized = WC_Analytics_Tracking::sanitize_client_properties( array( 'pc' => $members ) );
+
+		$this->assertArrayHasKey( 'pc', $sanitized, 'The property must survive with fewer members.' );
+		$this->assertLessThan( count( $members ), count( $sanitized['pc'] ) );
+	}
+
+	/**
+	 * The last bound, and the only one that sees the final URL — so the only one
+	 * covering properties a filter callback added after the client caps ran.
+	 * Driven through the trusted path, where no client cap applies.
+	 */
+	public function test_oversized_pixel_urls_are_not_fired(): void {
+		$_COOKIE['tk_ai'] = 'test-visitor-id-1234567890ab';
+		$this->reset_pixel_batch_queue();
+
+		$result = WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			array( 'pn' => str_repeat( 'a', WC_Analytics_Tracking::MAX_PIXEL_URL_LENGTH * 2 ) )
+		);
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'pixel_too_long', $result->get_error_code() );
+		$this->assertSame( array(), $this->get_pixel_batch_queue(), 'Nothing may be queued.' );
+
+		$this->reset_pixel_batch_queue();
 		unset( $_COOKIE['tk_ai'] );
 	}
 

--- a/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/WC_Analytics_Tracking_Test.php
@@ -55,6 +55,10 @@ class WC_Analytics_Tracking_Test extends BaseTestCase {
 		$queue = $reflection->getProperty( 'pixel_batch_queue' );
 		$queue->setAccessible( true );
 		$queue->setValue( null, array() );
+
+		$reserved = $reflection->getProperty( 'reserved_property_names' );
+		$reserved->setAccessible( true );
+		$reserved->setValue( null, null );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -140,8 +140,10 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 	 * Test that update is skipped when version matches current package version.
 	 */
 	public function test_maybe_update_proxy_speed_module_skips_when_version_matches(): void {
-		// Enable the feature flag so the update path is checked.
+		// Enable both flags: the module is only installed where the feature it
+		// accelerates is also on.
 		add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 
 		// Set version to match current.
 		update_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION, Woocommerce_Analytics::PACKAGE_VERSION );
@@ -151,6 +153,49 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 
 		// Version should remain the same (no update needed).
 		$this->assertSame( Woocommerce_Analytics::PACKAGE_VERSION, get_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION ) );
+
+		remove_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
+		remove_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+	}
+
+	/**
+	 * Turning proxy tracking off must uninstall the speed module, not just leave
+	 * the REST route unregistered. Otherwise the module keeps intercepting POSTs
+	 * at MU-plugin stage on a site whose operator believes the endpoint is gone.
+	 */
+	public function test_maybe_update_proxy_speed_module_removes_when_proxy_tracking_disabled(): void {
+		// The module's own flag stays on; only proxy tracking is off.
+		add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
+
+		update_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION, Woocommerce_Analytics::PACKAGE_VERSION );
+
+		Woocommerce_Analytics::maybe_update_proxy_speed_module();
+
+		$this->assertFalse(
+			get_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION ),
+			'The speed module must be uninstalled when proxy tracking is disabled.'
+		);
+
+		remove_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
+	}
+
+	/**
+	 * The install path needs both flags, so that an operator cannot end up with a
+	 * module installed for a feature that is switched off.
+	 */
+	public function test_maybe_add_proxy_speed_module_requires_proxy_tracking_too(): void {
+		add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
+
+		if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+			define( 'WPMU_PLUGIN_DIR', $this->temp_mu_plugin_dir );
+		}
+
+		Woocommerce_Analytics::maybe_add_proxy_speed_module();
+
+		$this->assertFileDoesNotExist(
+			$this->temp_mu_plugin_dir . '/woocommerce-analytics-proxy-speed-module.php',
+			'No module may be written while proxy tracking is disabled.'
+		);
 
 		remove_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', '__return_true' );
 	}

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -42,6 +42,7 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		// Clean up any existing options/transients.
 		delete_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION );
 		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION );
 		delete_transient( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT );
 
 		// Remove any filters that might interfere.
@@ -61,6 +62,7 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		// Clean up options and transients.
 		delete_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION );
 		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION );
 		delete_transient( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT );
 		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 
@@ -268,6 +270,30 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		// No file should be created since version matches.
 		$mu_plugin_file = $this->temp_mu_plugin_dir . '/woocommerce-analytics-proxy-speed-module.php';
 		$this->assertFileDoesNotExist( $mu_plugin_file );
+	}
+
+	/**
+	 * MU-plugins load whether or not the plugin carrying this package is active,
+	 * so a module file that outlives a deactivation must not be left holding a
+	 * stale `yes`. The sticky option survives: cached pages outlive both.
+	 */
+	public function test_removing_the_module_drops_its_authorization(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		$this->assertSame( 'yes', get_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) );
+
+		Woocommerce_Analytics::maybe_remove_proxy_speed_module();
+
+		$this->assertFalse(
+			get_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ),
+			'The module reads this to decide whether to serve; it must not survive removal.'
+		);
+		$this->assertSame(
+			'yes',
+			get_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION ),
+			'The sticky option records that cached pages may exist, which removal does not undo.'
+		);
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -297,6 +297,20 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The sticky option has to be clearable, or a site that tried the feature once
+	 * carries the endpoint for good with no supported way back.
+	 */
+	public function test_reset_proxy_tracking_state_clears_both_options(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		Woocommerce_Analytics::reset_proxy_tracking_state();
+
+		$this->assertFalse( get_option( Woocommerce_Analytics::PROXY_TRACKING_EVER_ENABLED_OPTION ) );
+		$this->assertFalse( get_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) );
+	}
+
+	/**
 	 * Test that maybe_remove_proxy_speed_module cleans up options and transients.
 	 */
 	public function test_maybe_remove_proxy_speed_module_cleans_up(): void {

--- a/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
+++ b/packages/php/woocommerce-analytics/tests/php/Woocommerce_Analytics_Test.php
@@ -41,10 +41,12 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 
 		// Clean up any existing options/transients.
 		delete_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
 		delete_transient( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT );
 
 		// Remove any filters that might interfere.
 		remove_all_filters( 'woocommerce_analytics_auto_install_proxy_speed_module' );
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 	}
 
 	/**
@@ -58,7 +60,9 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 
 		// Clean up options and transients.
 		delete_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION );
+		delete_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION );
 		delete_transient( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT );
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
 
 		parent::tear_down();
 	}
@@ -280,6 +284,50 @@ class Woocommerce_Analytics_Test extends BaseTestCase {
 		// Options and transients should be deleted.
 		$this->assertFalse( get_option( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_OPTION ) );
 		$this->assertFalse( get_transient( Woocommerce_Analytics::PROXY_SPEED_MODULE_VERSION_CHECK_TRANSIENT ) );
+	}
+
+	/**
+	 * The speed module runs at MU-plugin stage, where no plugin has registered a
+	 * callback on the proxy tracking filter yet, so it cannot ask `Features` and
+	 * has to read a persisted answer instead.
+	 */
+	public function test_sync_proxy_tracking_state_records_the_resolved_value(): void {
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		$this->assertSame( 'yes', get_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ) );
+
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		$this->assertSame(
+			'no',
+			get_option( Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION ),
+			'Turning the feature off must be mirrored too, or the module never stops answering.'
+		);
+	}
+
+	/**
+	 * The mirror runs on every front-end and admin request, so it must not write
+	 * to the options table when nothing changed.
+	 */
+	public function test_sync_proxy_tracking_state_does_not_rewrite_an_unchanged_value(): void {
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		$writes = 0;
+		$spy    = function ( $value ) use ( &$writes ) {
+			++$writes;
+			return $value;
+		};
+		add_filter( 'pre_update_option_' . Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION, $spy );
+
+		Woocommerce_Analytics::sync_proxy_tracking_state();
+
+		remove_filter( 'pre_update_option_' . Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION, $spy );
+
+		$this->assertSame( 0, $writes );
 	}
 
 	/**

--- a/packages/php/woocommerce-analytics/tests/php/bootstrap.php
+++ b/packages/php/woocommerce-analytics/tests/php/bootstrap.php
@@ -17,3 +17,6 @@ require_once __DIR__ . '/mocks/class-wc-tracks.php';
 
 // Initialize WordPress test environment using WorDBless (database-less).
 \WorDBless\Load::load();
+
+// Depends on WP_REST_Controller, so it must come after WorDBless has loaded core.
+require_once __DIR__ . '/mocks/class-wc-rest-controller.php';

--- a/packages/php/woocommerce-analytics/tests/php/mocks/class-wc-rest-controller.php
+++ b/packages/php/woocommerce-analytics/tests/php/mocks/class-wc-rest-controller.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Minimal WC_REST_Controller stub.
+ *
+ * WooCommerce is not loaded under WorDBless, so the real controller base class
+ * is unavailable and anything extending it cannot be instantiated in tests. The
+ * package only relies on the WP_REST_Controller behaviour it inherits, so an
+ * empty subclass is enough.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+if ( ! class_exists( 'WC_REST_Controller' ) ) {
+	/**
+	 * Stub for WooCommerce's REST controller base class.
+	 */
+	class WC_REST_Controller extends WP_REST_Controller {} // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

**The problem**

`POST /wp-json/woocommerce-analytics/v1/track` is unauthenticated by design and registered on every site running the package. `get_properties()` merges caller-supplied properties **after** the server-derived ones, so a posted `_via_ip`, `session_id`, `blog_id`, `store_id`, `store_admin` or `is_guest` wins over the server's value.

Anyone can therefore write events into the Tracks / ClickHouse pipeline with attacker-chosen geo, session identity and store identifiers. This is a data-integrity problem for the analytics pipeline, not a site-compromise one.

**The fix**

-   Add `record_client_event()` as the untrusted entry point — it strips server-derived properties before calling `record_event()`. The proxy and the MU-plugin now call it instead.
-   Apply the same strip inside `record_event()` for any `POST` to `/track`, so stale MU-plugin templates are covered too.
-   Register the REST route only on sites that have used proxy tracking, and refuse requests with `403` while the feature is off — in the MU-plugin speed module too. The module runs before any plugin has registered a filter callback, so it reads a new `woocommerce_analytics_proxy_tracking_enabled` option the package keeps in step with the feature.
-   Bound what a client can send: 50 events per request, 50 properties per event, 50 members per array value, 200 characters per value, 100 characters per event or property name, 4096 encoded bytes of payload per event, and an 8KB ceiling on the finished pixel URL. Unusable names are dropped, not truncated.
-   Bump `PACKAGE_VERSION` `0.16.3` → `0.18.0` so installed MU-plugin speed modules get rewritten (see BC note below).

Closes WOOA7S-1803.

Not a regression from a specific PR — the endpoint has behaved this way since proxy tracking was introduced.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Not applicable — no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Start with step 1 — the package suite covers the whole change. Steps 2–6 are the manual pass over a real request path. Step 6 is the one that matters most: the MU-plugin speed module has **no execution coverage in the suite**, and this PR changes it twice.

The pinned reserved-name list, the stale-template safety net and the filter's new argument are deterministic logic with tests and need no manual step.

#### 1. Package suite

```bash
cd packages/php/woocommerce-analytics
composer install
XDEBUG_MODE=off ./vendor/bin/phpunit --colors=never
```

Expect `OK (163 tests, 311 assertions)`.

#### 2. Setup

This package doesn't run from the monorepo directly — it ships as the composer package `automattic/woocommerce-analytics`, vendored inside plugins. So it has to be deployed onto a site first. This PR is PHP-only, so unlike #67003 no client bundle rebuild is involved.

**A store** — local or Jurassic Ninja — with WooCommerce active, a plugin that vendors this package active, pretty permalinks and `WP_DEBUG_LOG` on. If a consent plugin is installed, allow statistics. With Jetpack as the host plugin it must also be **connected** to WordPress.com (`should_track_store()` returns early without a connection, so `rest_api_init` never runs).

**Find the copy the site actually loads, then deploy into that one.** Several active plugins can vendor this package, and the Jetpack autoloader resolves the **highest version** across all of them, so the copy that runs is often not the one you'd guess. Ask the site over HTTP rather than through `wp eval`: plugin directories are frequently symlinks, and CLI and web can resolve to different copies.

```php
<?php // wp-content/mu-plugins/00-wca-probe.php — delete when done.
add_action( 'init', function () {
	if ( ! isset( $_GET['wca_probe'] ) ) { return; }
	header( 'Content-Type: text/plain' );
	echo ( new ReflectionClass( '\Automattic\Woocommerce_Analytics' ) )->getFileName(), "\n";
	echo 'PACKAGE_VERSION=', \Automattic\Woocommerce_Analytics::PACKAGE_VERSION, "\n";
	exit;
}, 999 );
```

```bash
SITE=https://example.com
curl -s "$SITE/?wca_probe=1"

cd packages/php/woocommerce-analytics
rsync -a --delete src/ "<the path printed above>/../src/"

curl -s "$SITE/?wca_probe=1"   # PACKAGE_VERSION=0.18.0
```

No autoloader regeneration needed (methods and constants only, no new classes), and don't touch the vendored `build/`. Restart PHP-FPM if opcache holds files for long. Re-run the probe until it reports `0.18.0` — if it still reports an older version, another active plugin carries a higher-versioned copy and that is the one to deploy into.

**A harness** in `wp-content/mu-plugins/00-wca-proxy-test.php`:

```php
<?php
// Test harness for WOOA7S-1803. Delete when done.

// Drive both feature filters from options rather than a request flag: the
// MU-plugin path reads a persisted option, and priority 99 outranks plugins
// that force proxy tracking on at the default priority.
add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', function () {
	return 'yes' === get_option( 'wca_proxy_on' );
}, 99 );

add_filter( 'woocommerce_analytics_auto_install_proxy_speed_module', function () {
	return 'yes' === get_option( 'wca_module_on' );
}, 99 );

// Log the properties an event is recorded with. Proxy-path pixels are fired by PHP,
// so they never appear in the browser's Network tab.
add_filter(
	'jetpack_woocommerce_analytics_event_props',
	function ( $props, $event_name, $is_client_supplied ) {
		error_log( "WCA $event_name client=" . var_export( $is_client_supplied, true ) . ' ' . wp_json_encode( $props ) );
		return $props;
	},
	PHP_INT_MAX,
	3
);
```

> [!NOTE]
> On `trunk` that three-argument callback throws `ArgumentCountError`, because the trait's call sites pass only one argument — and it takes the analytics payload with it: page rendering stops at the error, so `wcAnalytics` never reaches the HTML. That latent bug is also fixed here.

```bash
TRACK="$SITE/wp-json/woocommerce-analytics/v1/track"
EVENT='[{"event_name":"product_view","properties":{"pi":42}}]'
tail -f wp-content/debug.log
```

> [!IMPORTANT]
> If the host plugin runs Jetpack's bot check, `curl/` is on its bot list and `record_event()` skips silently — every request returns `{"success":true}` and records nothing. Add `-A "$UA"` with a browser User-Agent if the `debug.log` line never appears.

#### 3. The endpoint exists only where proxy tracking has been used

Three states, in this order, starting on a site that has never enabled it.

```bash
wp option delete woocommerce_analytics_proxy_tracking_ever_enabled
wp option delete woocommerce_analytics_proxy_tracking_enabled
wp option update wca_proxy_on no

# a) Never enabled: no route, no namespace.
curl -s "$SITE/wp-json/woocommerce-analytics/v1" | jq '.routes | keys'
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"

# b) Enabled.
wp option update wca_proxy_on yes
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
wp option get woocommerce_analytics_proxy_tracking_ever_enabled   # yes

# c) Used, then turned off.
wp option update wca_proxy_on no
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
```

In (a) the whole namespace is gone: `wp-json/woocommerce-analytics/v1` returns `404` (`rest_no_route`) — `/track` was its only route — the root index at `wp-json/` no longer lists `woocommerce-analytics/v1`, and the `POST` is `404`. In (b): `200`, and a `WCA …` line in `debug.log`. In (c): `403` with `{"code":"proxy_tracking_disabled","message":"Proxy tracking is not enabled on this site.","data":{"status":403}}`, and no `WCA` line. On `trunk`, all three return `200`.

The sticky option is what separates (a) from (c). To rerun (a), delete it again.

> [!NOTE]
> The first `POST` after enabling already works — no warm-up page load needed. `sync_proxy_tracking_state()` runs on `init` priority 20 and `rest_api_init` runs after it, so the same request that sets the sticky option also gets the route.

> [!NOTE]
> Don't read a bare `200` as "the event was recorded". With proxy tracking off there is no IP-based visitor id, so `record_event()` skips silently unless the request carries a `tk_ai` cookie — on `trunk` the first `POST` returns `{"success":true}` while recording nothing. The `debug.log` line is the only proof either way.

#### 4. A real POST can't set server-owned properties

```bash
wp option update wca_proxy_on yes
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"product_view","properties":{
    "_via_ip":"8.8.8.8","store_id":"someone-elses-store","blog_id":424242,
    "session_id":"forged-session","store_admin":1,"is_guest":0,"ui":999,
    "_ui":"forged-visitor","device":"forged","timezone":"Antarctica/Troll",
    "_lg":"en-GB","_dl":"https://example.com/product/thing","_dr":"https://example.com/",
    "pi":42,"pq":2}}]'
```

In the logged properties, confirm:

- **Server values win** — `_via_ip` is the requesting IP (not `8.8.8.8`), `store_id`/`blog_id`/`timezone`/`device` are this store's own, `store_admin=0`, `is_guest=1`, `ui=0`, and no `forged-session` / `forged-visitor` anywhere. `client=true` on the line.
- **Client values pass through** — `_lg=en-GB`, `_dl=https://example.com/product/thing`, `_dr=https://example.com/`, `pi=42`, `pq=2`. Those three `_` props are the client's on purpose: the server's own describe the `/track` POST, not the page the event happened on.
- On `trunk`, the same request records every forged value.

The full reserved set is `WC_Analytics_Tracking::get_reserved_property_names()` — 22 names today, derived from `get_common_properties()` rather than restated.

#### 5. Bounds

The bounds exist to keep an unauthenticated request from producing an enormous outbound pixel URL, so check the URL, not just the response. Add to the harness:

```php
add_action( 'shutdown', function () {
	$p = new ReflectionProperty( '\Automattic\Woocommerce_Analytics\WC_Analytics_Tracking', 'pixel_batch_queue' );
	$p->setAccessible( true );
	foreach ( (array) $p->getValue() as $url ) {
		error_log( 'WCA-PIXEL ' . strlen( $url ) . ' ' . $url );
	}
}, 19 );
```

```bash
# 500-member array value → 50 members, tail dropped.
python3 -c "import json;print(json.dumps([{'event_name':'a','properties':{'cats':['c%d'%i for i in range(500)]}}]))" \
  | curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# 50 properties x 200 multi-byte characters — ~24KB of CJK, emoji and '%'.
python3 -c "import json;print(json.dumps([{'event_name':'b','properties':{'p%02d'%i:('測試%🎉'*60)[:200] for i in range(50)}}],ensure_ascii=False))" \
  | curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# 300-character property name dropped, the short one kept.
python3 -c "import json;print(json.dumps([{'event_name':'c','properties':{'x'*300:'dropped','ok':'kept'}}]))" \
  | curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# 100 events → 50 results, 50 pixels.
python3 -c "import json;print(json.dumps([{'event_name':'batch_%d'%i,'properties':{}} for i in range(100)]))" \
  | curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data @-

# Unusable event names → 207 multi-status, per-event errors, no PHP warning.
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' \
  --data '[{"event_name":"","properties":{}},{"event_name":123,"properties":{}},{"event_name":"xxx…300 chars…","properties":{}},{"event_name":"good","properties":{"ok":"1"}}]'
```

Every `WCA-PIXEL` line should stay well under `MAX_PIXEL_URL_LENGTH` (8192) — a baseline event is ~460 bytes and the 24KB multi-byte payload lands around 3.3KB, with only the properties that fit in the 4096-byte budget surviving. The last request returns `207` with `"the event name is empty, too long, or not a string"` for the third event and `"Missing event_name or invalid properties"` for the first two. Confirm `debug.log` has no `Array to string conversion` warnings throughout.

#### 6. The MU-plugin speed module

**This is the path with no automated coverage.** It bypasses the REST stack entirely, so route gating alone wouldn't have stopped it, and it runs before plugins load — a mistake here is a fatal on every proxy POST, not a failed assertion.

```bash
wp option update wca_proxy_on yes
wp option update wca_module_on yes
wp transient delete woocommerce_analytics_proxy_speed_module_version_check
# visit $SITE/wp-admin/ as an admin, which runs the admin_init installer
grep -m1 Version wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php   # Version: 0.18.0
```

`Version: 0.18.0` matters: `PACKAGE_VERSION` is the only trigger for rewriting an already-installed module, and it had drifted behind `composer.json`.

```bash
# a) Feature on → the module serves and says so.
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
# {"success":true,"results":[{"success":true}],"is_proxy_speed_module":true}

# b) Same forged payload as step 4, through the fast path.
#    debug.log shows client=true and the server's own values.

# c) Feature off. The module refuses on its own, before admin_init removes it.
wp option update wca_proxy_on no
curl -s -o /dev/null "$SITE/"                                  # one page load runs the init sync
wp option get woocommerce_analytics_proxy_tracking_enabled     # no
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"
ls wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php   # still there
```

(c) is the point of the change: `403` with the **same body the REST route returns**, while the module file is still installed and `admin_init` has not run. On `trunk` the module records the event. The `403` comes from the `woocommerce_analytics_proxy_tracking_enabled` option, not the filter — the module runs before plugins load, so it cannot call `Features::is_proxy_tracking_enabled()` itself. That is also why one normal page load is needed after flipping the flag.

```bash
# d) Fail-closed while the option is missing (what an upgrade looks like).
wp option update wca_proxy_on yes
wp option delete woocommerce_analytics_proxy_tracking_enabled
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"   # 403
curl -s -o /dev/null "$SITE/"
curl -s -X POST "$TRACK" -H 'Content-Type: application/json' --data "$EVENT"   # 200

# e) Removal drops the module's authorization, not the sticky flag.
wp option update wca_module_on no
wp transient delete woocommerce_analytics_proxy_speed_module_version_check
# visit $SITE/wp-admin/ again
ls wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php          # gone
wp option get woocommerce_analytics_proxy_speed_module_version                 # gone
wp option get woocommerce_analytics_proxy_tracking_ever_enabled                # yes
```

(e) matters because MU-plugins load whether or not the host plugin is active: a module file left behind by a failed delete must not keep answering on a stale `yes`.

#### 7. First-party events still work

Browse the shop with proxy tracking on and add a product to cart. Confirm events are still delivered (`POST /track` → `200`, `client=true` in the log) with correct page attribution — `_dl`/`_dr`/`_lg` reflect the page, not the `/track` request — and intact product properties (`pi`/`pn`/`pc`/`pp`/`pt`). Then set `wca_proxy_on` to `no` and confirm normal (non-proxy) tracking is unaffected: `client=false` lines, no `/track` requests.

Afterwards delete both harness files, reset the options, and reactivate anything you deactivated.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Full PHPUnit suite locally under WorDBless (PHP 8.1, PHPUnit 9.6.34): 163 tests, 311 assertions, all passing, no PHP warnings.
- `composer phpcs`: only the 5 pre-existing findings in `src/class-universal.php` (out of scope), nothing new.
- New tests: `WC_Analytics_Tracking_Reserved_Props_Test.php` (property stripping, reserved-set snapshot, stale-template guard), plus additions to `WC_Analytics_Tracking_Proxy_Test.php` (route gating) and `Universal_Test.php` (trait filter arity).
**Manual, on a local store** (WooCommerce 11.1.0-dev, WordPress 7.0, Jetpack 16.1-a.5 connected, `premium-analytics` active so ClickHouse and proxy tracking are both forced on, storefront over HTTPS via a tunnel, this branch's `src/` deployed into the vendored copy and confirmed loaded as `0.16.8` with 22 reserved names — the constant has since moved to `0.18.0`):

- **Reproduced first.** Against the shipped copy, a single `POST /track` wrote every forged value into the event: `_via_ip=8.8.8.8`, `store_id=someone-elses-store`, `blog_id=424242`, `session_id=forged-session`, `store_admin=1`, `is_guest=0`, `ui=999`, `device=forged`, `timezone=Antarctica/Troll`, `_ui=forged-visitor`.
- **Route gating.** With proxy tracking off, `wp-json/woocommerce-analytics/v1` itself returns `404` (`/track` was its only route), the root index no longer lists the namespace, and the `POST` is `404`. With it on: route listed, `200`, event recorded. (This was tested against the earlier revision, where the gate was the live filter rather than the sticky option; the `403` state below did not exist yet.)
- **Stripping.** The same forged payload now records the server's own values for all ten names, while `_lg`, `_dl`, `_dr`, `pi` and `pq` pass through unchanged.
- **Bounds.** 60 events in one request → 50 recorded; 65 client properties → the first 50 kept; a 1000-character value → 199 characters plus `…`; a 250-character CJK value → 200 characters, not a byte-wise cut; a value of exactly 200 characters untouched; a flat array preserved as `a,b`; a doubly-nested value emptied, with zero `Array to string conversion` warnings in the log.
- **Filter arity, worse than expected.** A callback registered with three arguments throws `ArgumentCountError` on the shipped copy *and takes the page payload with it* — rendering stops at the error, so `wcAnalytics` never reaches the HTML (0 occurrences, response body ends in the stack trace). On this branch the same callback runs cleanly and reports `client=true` on `/track`, `client=false` on page output.
- **First-party flow in a real browser.** Shop → product page → add to cart with proxy tracking on: `page_view` and `product_view` recorded through `record_client_event()` (`client=true`) with `_dl`/`_dr` pointing at the product page rather than the `/track` request, `_lg` from the browser, real `session_id`/`landing_page`/`is_engaged`, and product properties intact (`pi=731`, `pn`, `pc`, `pp=115.81`, `pt=simple`); `add_to_cart` still fires on the server path (`client=false`). No console errors, no PHP warnings.
- **Not done in this pass:** the MU-plugin speed module path. Covered in the second pass below.

**Second manual pass, on the final revision** (WooCommerce 11.2.0-dev, WordPress 7.0, `premium-analytics` as the host plugin, storefront over HTTPS via a tunnel, this branch's `src/` deployed into the vendored copy and confirmed loaded as `0.18.0` over HTTP). Everything below was re-run against the code as it stands, including the paths the first pass could not reach:

- **Route gating, all three states.** Never enabled → `404 rest_no_route`. Enabled → `200`, and the *first* POST after flipping the flag already works, since `init` priority 20 runs before `rest_api_init`. Enabled then turned off → `403 proxy_tracking_disabled`.
- **MU-plugin speed module, which the suite does not execute.** Installed through the real `admin_init` path at `Version: 0.18.0`; serves with `is_proxy_speed_module:true`; the new `\Automattic\Woocommerce_Analytics::PROXY_TRACKING_ENABLED_OPTION` reference resolves at MU-plugin stage with no fatal. With the feature off it returns `403` with a byte-identical body to the REST route while the file is still on disk and `admin_init` has not run. With the option deleted (what an upgrade looks like) it fails closed at `403`, and one normal page load restores `200`. `maybe_remove_proxy_speed_module()` deletes the file, the version option and the live authorization while leaving the sticky flag at `yes`.
- **Stripping on both paths.** The forged payload from step 4 records the server's own `blog_id`, `store_id`, `_via_ip`, `is_guest` and `_ui` through the REST route *and* through the fast path, with `is_client_supplied=true` at the filter and no forged value anywhere in the recorded properties.
- **Bounds, measured on the resulting pixel URL.** Baseline event 459 bytes. A 500-member array value → exactly 50 members, `c0`–`c49`. A 24.6KB request of CJK, emoji and `%` characters → a 3,321-byte URL with 2 client properties surviving the 4096-byte budget, against ~90KB if the budget counted characters. A 300-character property name dropped, the short one kept. 100 events → 50 results and 50 pixels. Unusable event names → `207` with per-event errors and no `Array to string conversion` warning in the log.

The earlier "not yet re-run manually" caveat on the review-round fixes no longer applies: the option-based module gate, the event-name validation, the array member cap and the payload budget are all covered above.

**Review round.** Three fixes went in after the manual pass above, covered by the suite but not by a second pass on a real store:

- The MU-plugin gate is now an option read instead of a filter call. The filter version could never have passed at MU-plugin stage, so the `403` half of the optional section above would have applied to every request, not just disabled sites.
- Unusable client event names are dropped. An array event name previously reached `PREFIX . $event_name` and wrote an `Array to string conversion` warning to the log from an unauthenticated request — the same class of problem the nested-array value handling already closes. `failOnWarning` is on for this suite, so the test fails on the warning alone.
- Unusable client property names are dropped.
- Array values are capped at 50 members. The per-value cap runs on each member, never on the string `get_properties()` joins them into, so one property of 20,000 ten-character members produced a 300KB pixel URL — `build_tracks_url()` returns it and `record_pixel_url()` only checks for empty, so nothing downstream rejects it.

A later round added the payload budget, the fail-closed module gate and the version correction, also suite-only:

- Mutation testing found the bounds were never pinned through `record_client_event()` — removing the `sanitize_client_properties()` call left the whole suite green, because `get_properties()` re-asserts reserved properties independently. There is now a test through the real entry point, and removing that call fails it.
- `MAX_CLIENT_PROPERTY_LENGTH`, `MAX_CLIENT_PAYLOAD_LENGTH` and `MAX_PIXEL_URL_LENGTH` are pinned by assertions on the resulting pixel URL rather than on the constants themselves. `MAX_CLIENT_EVENTS_PER_REQUEST`, `MAX_CLIENT_PROPERTIES_PER_EVENT` and `MAX_CLIENT_NAME_LENGTH` are still unpinned — raising them to 5000 keeps the suite green.
- The payload budget's first version counted characters, not encoded bytes, so the ceiling it was written to enforce was exceeded by 50% on a payload of `%` or CJK characters. The test that should have caught it asserted the ceiling but used an ASCII-only fixture. It now runs over percent, CJK, emoji and space, and reverting any of the three bounds fails the suite.

Verified locally: the package suite is green at 163 tests, `composer phpcs` still reports only the 5 pre-existing findings in `src/class-universal.php`.

**Known gaps, all filed rather than fixed here** — see the follow-up list at the end.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->

-   [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry has already been committed manually at `packages/php/woocommerce-analytics/changelog/wooa7s-1803-tracking-proxy-hardening` (significance: minor, type: security), so neither box above is checked. Minor rather than patch because the change adds public API: `record_client_event()`, the `MAX_CLIENT_*` and `MAX_PIXEL_URL_LENGTH` constants, `reset_proxy_tracking_state()`, and a third filter argument.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

(Type is `Security`, matching the 0.16.7 entry for WOOA7S-1800 part 1 — not listed as a checkbox option in this template's Type list. Entry is already committed as a file with `Type: security`.)

#### Message <!-- Add a changelog message here -->

Stop the tracking proxy endpoint from accepting client-supplied values for server-derived event properties, and only register it where proxy tracking is enabled.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

N/A — entry already committed as a file (see above).

</details>

### Release Communication

<!-- release-communication-section -->

Select if this PR needs a generated summary for release notes:

-   [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
-   [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

-   Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

-   Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>

---

### Backward compatibility

All signature changes are additive. The behavioural changes are what need review:

1. **The REST route exists only on sites that have used proxy tracking, and answers `403` once it is turned off.** `GET`/`POST /wp-json/woocommerce-analytics/v1/track` never resolve on a site where `Features::is_proxy_tracking_enabled()` has never been true — removing that public surface for the default case is the point of the change, and any third party posting to the endpoint there breaks.

    It does **not** disappear when a site that has used it turns it off. Unregistering there loses every event from pages already in a page cache or CDN, which still carry `proxy: true` and whose visitors keep posting: the client is a hard binary with no fallback ([analytics.ts:144](../blob/trunk/packages/php/woocommerce-analytics/src/client/analytics.ts)), and `flush()` prefers `sendBeacon`, which discards the HTTP response and clears its own queue on success — so a `404` is invisible in the browser as well as absent from the server log. The route instead stays registered and returns `403 proxy_tracking_disabled`, which is what the MU-plugin speed module already returns, so the two halves no longer answer differently for one condition.

    This does not by itself recover those events: `sendBeacon` cannot observe the `403` either. Handling it in the client is a follow-up. The `403` is what makes the failure visible in a server log and actionable by that future client change.

    **Operational note:** `woocommerce_analytics_experimental_proxy_tracking_enabled` must resolve to the same value for every request on a site. A callback that varies by cohort, percentage or geo produces cached pages whose `proxy` flag disagrees with what `/track` decides, and it already makes `maybe_update_proxy_speed_module()` install and uninstall the module on alternate runs.
2. **Reserved property names are silently overwritten on the proxy path.** A client sending `store_id`, `_via_ip`, `session_id`, `ui` or any other server-owned name now gets the server's value — no error, the event still records. `_lg`, `_dl` and `_dr` still come from the client. Full set: `WC_Analytics_Tracking::get_reserved_property_names()`. Callers needing one of those names for their own data must rename it.
3. **Client-supplied event and property names are validated.** A name that is not a non-empty string, or is longer than 100 characters, is rejected. An event with an unusable name returns an `invalid_event_name` `WP_Error`, which the REST controller reports for that event — reporting success for an event that produced no pixel is what would hide the loss. A property with an unusable name is dropped and the rest of the event still records. Property names are also checked against `Pixel_Builder::prop_name_is_valid()`, which previously rejected the whole event — dropping the one property is the more forgiving outcome. This only applies on the client path.
4. **`record_event()` and `get_properties()` gain an optional third `$is_client_supplied` argument** (defaults to `false`, existing callers unaffected). `record_event()` also strips reserved properties during any `POST` to `/track` even when called directly, to cover stale MU-plugin templates. No first-party call site runs in that request context, so it should be a no-op for our own traffic.
5. **`jetpack_woocommerce_analytics_event_props` gains a third argument** (`$is_client_supplied`, additive). This also fixes a latent bug: callbacks registered with `accepted_args >= 2` used to fatal with `ArgumentCountError`, because the trait's call sites passed only one argument. Verified locally — such a callback stops page rendering at the error, so no `wcAnalytics` payload reaches the HTML at all.

6. **New options: `woocommerce_analytics_proxy_tracking_enabled` and `woocommerce_analytics_proxy_tracking_ever_enabled`.** The second is sticky: set to `yes` the first time the feature resolves true, and it alone decides whether the REST route is registered. `Woocommerce_Analytics::reset_proxy_tracking_state()` clears both, for an uninstall routine or a site that wants the endpoint gone once the caches holding those pages have expired. `maybe_remove_proxy_speed_module()` clears only the live one, since removing the module does not expire those pages. It records that cached pages carrying `proxy: true` may exist, which the feature being off for a while does not undo.

    The first is the live mirror: Written on `init` (priority 20) with `yes`/`no`, mirroring `Features::is_proxy_tracking_enabled()` so the MU-plugin speed module can read it at a stage where the filter has no callbacks yet. Only written when the value changes, and written again when the module is installed so the file never exists without it. Site-scoped (`get_option`), matching the filter.

    Both refusals share one body — `{"code":"proxy_tracking_disabled","message":…,"data":{"status":403}}` — so a client has one shape to recognise whichever path answered.

    The module **fails closed**: only `yes` serves. Treating an absent option as enabled would have been a multisite hole, since one network-wide module file in `WPMU_PLUGIN_DIR` answers for every site while the option is per-site — a site that never enabled anything would have been served by a module its network sibling installed. The cost is a narrow window: a site whose very first request after updating is a proxy `POST` gets a `403` until any normal request runs `init`.
7. **Client payload is capped at 4096 encoded bytes per event, and any pixel URL over 8KB is not fired.** The per-axis caps multiply, so at their limits one event still built a 512KB pixel URL and one request 24.5MB of outbound traffic. Properties are dropped from the tail once the budget is spent, and an array loses trailing members rather than the whole property, since the member cap times the value cap always exceeds the budget. A realistic event (product id, name, categories, price, page URL and referrer) is well inside the budget and passes through untouched.

    The budget measures a value by running it through the same `flatten_property_value()` that `get_properties()` uses, rather than approximating it. The approximation had already been wrong twice: it counted characters where the URL carries percent-encoded bytes, and it measured every array as a joined list, so the keys of an associative array — which serializes to JSON and carries them — cost nothing. `record_pixel_url()` refuses anything over `MAX_PIXEL_URL_LENGTH` as the backstop, the only bound that sees the finished URL and so the only one covering properties a `jetpack_woocommerce_analytics_event_props` callback adds after the client caps have run. That backstop applies to first-party events too, and no first-party call site checks the return value, so an oversized server-side event is dropped without a signal.

    The budget is counted **after percent-encoding**, unlike the per-value cap which counts characters. The two units differ on purpose: a `%`, a CJK character or an emoji occupies one character but three bytes in the URL, and counting characters here let the same 50 x 200 payload build a 12KB URL. `record_pixel_url()` refuses anything over `MAX_PIXEL_URL_LENGTH` as the backstop — the only bound that sees the finished URL, and so the only one covering properties a `jetpack_woocommerce_analytics_event_props` callback adds after the client caps have run. That path returns a `pixel_too_long` `WP_Error`, which the REST controller reports per event.

**Not covered:** properties added by `jetpack_woocommerce_analytics_event_props` callbacks. The reserved set is derived before the filter runs, so names a callback introduces aren't in it. Extensions get the new third argument to detect client-supplied props instead.

**`PACKAGE_VERSION` had drifted** — pinned at `0.16.3` while `composer.json` was on `0.16.7`. It's the only trigger for rewriting an installed MU-plugin speed module, so sites on 0.16.4–0.16.7 have been running a frozen template. Now `0.18.0`, matching the `minor` changelog bump against the released `0.17.0`. The drift reappeared twice during this branch's life: once when a rebase moved `composer.json` forward and left the constant behind, and again when the changelog was raised from `patch` to `minor` without the constant following. Nothing enforces the two staying in sync, which needs its own issue.

**Deferred:** client-settable `ch` and rate limiting (WOOA7S-1806).

### Follow-ups this PR deliberately leaves alone

- **The route declares a `schema` but no `args`, so REST never validates the declared types.** `args` drives validation in WordPress; `schema` only shapes the `OPTIONS` response. It does not fit this payload, which is a bare JSON array of events rather than named parameters, so the type checks stay hand-rolled in `track_events()`. Worth a comment saying so, and worth revisiting if the payload shape ever changes.
- **A failed module deletion is recorded as a success.** `maybe_remove_proxy_speed_module()` logs the failure but still deletes the version option, and `maybe_update_proxy_speed_module()` keys the retry off that option, so the removal is never retried. Untouched by this PR — and less harmful now, since a module that survives deletion still refuses once the option flips to `no`.
- **`Woocommerce_Analytics_Test` cannot exercise the install paths.** `WPMU_PLUGIN_DIR` is a constant defined once, while each test builds a fresh `uniqid()` temp directory, so every later test asserts against a directory the code never writes to. `test_maybe_add_proxy_speed_module_requires_proxy_tracking_too()` passes even with `should_install_proxy_speed_module()` forced to `true`. Fixing it means reworking the fixture for ~10 pre-existing tests.
- **The MU-plugin template has no execution coverage.** `phpcs` parses it, so syntax is checked, but no test loads it: the `403` path, the batch cap and the event-name guard are verified only by string matching in `test_mu_plugin_template_stays_in_step_with_the_package()`.
- **`record_event()` returns `true` for five different outcomes** — no consent, bot UA, no visitor id, unusable client event name, and an actual emit. The REST controller reports `success` for all of them. Distinguishing them means changing a public signature.
- **First-party events are sanitized when they ride in a `/track` request.** `is_proxy_tracking_request()` is request-scoped, not caller-scoped, so a first-party `record_event()` during a proxy `POST` gets capped and stripped. Hard to reach in practice (the module exits before plugins load, and REST requests do not fire cart actions), and narrowing it would remove the stale-template safety net.
- **`strip_reserved_properties()`, `sanitize_client_properties()` and `is_proxy_tracking_request()` are public with no caller outside their own class.** The last is documented for removal once a package-version floor exists, so it should not be public API at all. Making the three private breaks 33 tests, which drive them directly — that is the same coupling that let the `sanitize_client_properties()` call site be deleted with the suite green, and untangling it is its own change.
- **The MU-plugin template still has no execution coverage.** `test_mu_plugin_template_stays_in_step_with_the_package()` now asserts the gate's comparison and error code literally, because inverting `'yes' !==` to `'yes' ===` served exactly the requests the gate exists to refuse while all 156 tests stayed green. String matching is a stopgap; loading the template in a test is the real fix.
- **A truncated batch does not say how many events were dropped.** Unlike a capped property, the count is something the client already knows, so reporting it is not an oracle.

Gating the MU-plugin path is no longer deferred. It was, for the reason above — `Features::*` are `apply_filters()` calls whose callbacks aren't registered at MU-plugin stage, so the module always read `false`. Persisting the resolved state into an option turned out small enough to do here, and without it the gate the earlier revision added would have 403'd every speed-module request. Only proxy tracking is mirrored; the other `Features::*` reads all happen after plugins load and don't need it.










