### PR TITLE
Fix fatal error validating checkout fields outside the billing and shipping fieldsets

### DIFF
--- a/plugins/woocommerce/changelog/fix-67083-checkout-fieldset-country-fatal
+++ b/plugins/woocommerce/changelog/fix-67083-checkout-fieldset-country-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error on the shortcode checkout when a phone or postcode validated field is registered outside the billing and shipping fieldsets.

--- a/plugins/woocommerce/changelog/fix-67083-checkout-fieldset-country-fatal
+++ b/plugins/woocommerce/changelog/fix-67083-checkout-fieldset-country-fatal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix a fatal error on the shortcode checkout when a phone or postcode validated field is registered outside the billing and shipping fieldsets.
+Fix a fatal error on the shortcode checkout when a phone, postcode, or state validated field is registered outside the billing and shipping fieldsets.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -862,9 +862,9 @@ class WC_Checkout {
 	 * Get the country to validate a fieldset's fields against.
 	 *
 	 * Uses the posted country when the fieldset has one. Only 'billing' and 'shipping' have a customer
-	 * country to fall back on, so every other fieldset, including those registered through the
-	 * 'woocommerce_checkout_fields' filter, is validated without country specific rules instead of
-	 * fataling on an undefined method.
+	 * country to fall back on, and only once the customer object is set up, so every other fieldset,
+	 * including those registered through the 'woocommerce_checkout_fields' filter, is validated without
+	 * country specific rules instead of fataling on an undefined method.
 	 *
 	 * @param  string $fieldset_key Fieldset key.
 	 * @param  array  $data         An array of posted data.
@@ -873,6 +873,10 @@ class WC_Checkout {
 	private function get_fieldset_country( $fieldset_key, $data ) {
 		if ( isset( $data[ $fieldset_key . '_country' ] ) ) {
 			return $data[ $fieldset_key . '_country' ];
+		}
+
+		if ( ! WC()->customer instanceof WC_Customer ) {
+			return '';
 		}
 
 		switch ( $fieldset_key ) {

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -861,11 +861,10 @@ class WC_Checkout {
 	/**
 	 * Get the country to validate a fieldset's fields against.
 	 *
-	 * The country is taken from the posted data when the fieldset has a country field, and falls back to the
-	 * matching customer getter otherwise. Only some fieldsets have one: 'billing' and 'shipping' do, while
-	 * 'order', 'account', and most fieldsets registered through the 'woocommerce_checkout_fields' filter do
-	 * not. When there is no getter an empty string is returned and the fields are validated without country
-	 * specific rules, instead of fataling on an undefined method.
+	 * Uses the posted country when the fieldset has one. Only 'billing' and 'shipping' have a customer
+	 * country to fall back on, so every other fieldset, including those registered through the
+	 * 'woocommerce_checkout_fields' filter, is validated without country specific rules instead of
+	 * fataling on an undefined method.
 	 *
 	 * @param  string $fieldset_key Fieldset key.
 	 * @param  array  $data         An array of posted data.
@@ -876,9 +875,14 @@ class WC_Checkout {
 			return $data[ $fieldset_key . '_country' ];
 		}
 
-		$getter = "get_{$fieldset_key}_country";
-
-		return is_callable( array( WC()->customer, $getter ) ) ? WC()->customer->$getter() : '';
+		switch ( $fieldset_key ) {
+			case 'shipping':
+				return WC()->customer->get_shipping_country();
+			case 'billing':
+				return WC()->customer->get_billing_country();
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -861,10 +861,11 @@ class WC_Checkout {
 	/**
 	 * Get the country to validate a fieldset's fields against.
 	 *
-	 * The country is taken from the posted data when the fieldset has a country field, and from the customer
-	 * object otherwise. Fieldsets other than 'billing' and 'shipping' (namely 'order', 'account', and any
-	 * fieldset registered via the 'woocommerce_checkout_fields' filter) have no matching customer getter, in
-	 * which case an empty string is returned and the fields are validated without country specific rules.
+	 * The country is taken from the posted data when the fieldset has a country field, and falls back to the
+	 * matching customer getter otherwise. Only some fieldsets have one: 'billing' and 'shipping' do, while
+	 * 'order', 'account', and most fieldsets registered through the 'woocommerce_checkout_fields' filter do
+	 * not. When there is no getter an empty string is returned and the fields are validated without country
+	 * specific rules, instead of fataling on an undefined method.
 	 *
 	 * @param  string $fieldset_key Fieldset key.
 	 * @param  array  $data         An array of posted data.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -859,6 +859,28 @@ class WC_Checkout {
 	}
 
 	/**
+	 * Get the country to validate a fieldset's fields against.
+	 *
+	 * The country is taken from the posted data when the fieldset has a country field, and from the customer
+	 * object otherwise. Fieldsets other than 'billing' and 'shipping' (namely 'order', 'account', and any
+	 * fieldset registered via the 'woocommerce_checkout_fields' filter) have no matching customer getter, in
+	 * which case an empty string is returned and the fields are validated without country specific rules.
+	 *
+	 * @param  string $fieldset_key Fieldset key.
+	 * @param  array  $data         An array of posted data.
+	 * @return string Country code, or an empty string when it can't be determined.
+	 */
+	private function get_fieldset_country( $fieldset_key, $data ) {
+		if ( isset( $data[ $fieldset_key . '_country' ] ) ) {
+			return $data[ $fieldset_key . '_country' ];
+		}
+
+		$getter = "get_{$fieldset_key}_country";
+
+		return is_callable( array( WC()->customer, $getter ) ) ? WC()->customer->$getter() : '';
+	}
+
+	/**
 	 * Validates the posted checkout data based on field properties.
 	 *
 	 * @since  3.0.0
@@ -899,7 +921,7 @@ class WC_Checkout {
 				}
 
 				if ( in_array( 'postcode', $format, true ) ) {
-					$country      = isset( $data[ $fieldset_key . '_country' ] ) ? $data[ $fieldset_key . '_country' ] : WC()->customer->{"get_{$fieldset_key}_country"}();
+					$country      = $this->get_fieldset_country( $fieldset_key, $data );
 					$data[ $key ] = wc_format_postcode( $data[ $key ], $country );
 
 					if ( $validate_fieldset && '' !== $data[ $key ] && ! WC_Validation::is_postcode( $data[ $key ], $country ) ) {
@@ -917,7 +939,7 @@ class WC_Checkout {
 				}
 
 				if ( in_array( 'phone', $format, true ) ) {
-					$country = $data[ $fieldset_key . '_country' ] ?? WC()->customer->{"get_{$fieldset_key}_country"}();
+					$country = $this->get_fieldset_country( $fieldset_key, $data );
 					// This is a safe sanitize to prevent copy-paste issues with invisible chars. Won't ensure validation.
 					$data[ $key ] = wc_remove_non_displayable_chars( $data[ $key ] );
 
@@ -939,7 +961,7 @@ class WC_Checkout {
 				}
 
 				if ( '' !== $data[ $key ] && in_array( 'state', $format, true ) ) {
-					$country      = isset( $data[ $fieldset_key . '_country' ] ) ? $data[ $fieldset_key . '_country' ] : WC()->customer->{"get_{$fieldset_key}_country"}();
+					$country      = $this->get_fieldset_country( $fieldset_key, $data );
 					$valid_states = WC()->countries->get_states( $country );
 
 					if ( ! empty( $valid_states ) && is_array( $valid_states ) && count( $valid_states ) > 0 ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -348,6 +348,38 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'validate_posted_data' ignores customer getters that only match a fieldset key by accident.
+	 *
+	 * 'WC_Customer::get_default_country()' is public, so looking the getter up from the fieldset key made a
+	 * fieldset named 'default' validate against the store's base country and emit a deprecation notice.
+	 * 'ABCDE' passes the country agnostic postcode check but fails the store's base country rules.
+	 */
+	public function test_validate_posted_data_ignores_incidentally_matching_customer_getters() {
+		$this->register_extra_checkout_field(
+			'default',
+			'default_postcode',
+			array(
+				'label'    => 'Default postcode',
+				'validate' => array( 'postcode' ),
+			)
+		);
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'default_postcode'          => 'ABCDE',
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEmpty(
+			$errors->get_error_message( 'default_postcode_validation' ),
+			"Only billing and shipping have a country, so the 'default' fieldset must not resolve to one."
+		);
+	}
+
+	/**
 	 * @testdox 'validate_posted_data' prefers the posted country over the one stored on the customer.
 	 */
 	public function test_validate_posted_data_prefers_the_posted_country() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -18,9 +18,9 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	private $sut;
 
 	/**
-	 * @var callable|null Callback registering an extra checkout field, removed on tear down.
+	 * @var callable[] Callbacks registering extra checkout fields, all removed on tear down.
 	 */
-	private $extra_field_filter = null;
+	private $extra_field_filters = array();
 
 	/**
 	 * Runs before each test.
@@ -52,10 +52,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
 		delete_option( 'woocommerce_calc_taxes' );
 
-		if ( null !== $this->extra_field_filter ) {
-			remove_filter( 'woocommerce_checkout_fields', $this->extra_field_filter );
-			$this->extra_field_filter = null;
+		foreach ( $this->extra_field_filters as $extra_field_filter ) {
+			remove_filter( 'woocommerce_checkout_fields', $extra_field_filter );
 		}
+
+		$this->extra_field_filters = array();
 
 		parent::tearDown();
 	}
@@ -63,18 +64,22 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Register an extra checkout field in an arbitrary fieldset, the way checkout field editor plugins do.
 	 *
+	 * Can be called more than once per test: each callback is tracked and removed on tear down.
+	 *
 	 * @param string $fieldset_key Fieldset the field belongs to.
 	 * @param string $key          Field key.
 	 * @param array  $field        Field definition.
 	 */
 	private function register_extra_checkout_field( $fieldset_key, $key, $field ) {
-		$this->extra_field_filter = function ( $fields ) use ( $fieldset_key, $key, $field ) {
+		$extra_field_filter = function ( $fields ) use ( $fieldset_key, $key, $field ) {
 			$fields[ $fieldset_key ][ $key ] = $field;
 
 			return $fields;
 		};
 
-		add_filter( 'woocommerce_checkout_fields', $this->extra_field_filter );
+		$this->extra_field_filters[] = $extra_field_filter;
+
+		add_filter( 'woocommerce_checkout_fields', $extra_field_filter );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -283,8 +283,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'validate_posted_data' validates a postcode field in a fieldset without a country, without country specific rules.
 	 *
+	 * 'ABCDE' is deliberately valid only without a country: it passes the country agnostic check but fails the
+	 * store's own base country rules, so this fails if the fieldset ever resolves to a real country.
+	 *
 	 * @testWith ["INVALID!", true]
-	 *           ["12345", false]
+	 *           ["ABCDE", false]
 	 *
 	 * @param string $postcode     The posted postcode.
 	 * @param bool   $expect_error True to expect a validation error for the postcode field.
@@ -337,6 +340,34 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->sut->validate_posted_data( $data, $errors );
 
 		$this->assertEmpty( $errors->get_error_message( 'order_state_validation' ) );
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' prefers the posted country over the one stored on the customer.
+	 */
+	public function test_validate_posted_data_prefers_the_posted_country() {
+		$original_billing_country = WC()->customer->get_billing_country();
+
+		WC()->customer->set_billing_country( 'GB' );
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'billing_country'           => 'US',
+			'billing_postcode'          => '12345',
+		);
+
+		$errors = new WP_Error();
+
+		try {
+			$this->sut->validate_posted_data( $data, $errors );
+		} finally {
+			WC()->customer->set_billing_country( $original_billing_country );
+		}
+
+		$this->assertEmpty(
+			$errors->get_error_message( 'billing_postcode_validation' ),
+			"'12345' is a valid US postcode, so the posted country must win over the customer's GB country."
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -18,6 +18,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	private $sut;
 
 	/**
+	 * @var callable|null Callback registering an extra checkout field, removed on tear down.
+	 */
+	private $extra_field_filter = null;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
@@ -47,7 +52,29 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_checkout_registration_enabled', '__return_true' );
 		delete_option( 'woocommerce_calc_taxes' );
 
+		if ( null !== $this->extra_field_filter ) {
+			remove_filter( 'woocommerce_checkout_fields', $this->extra_field_filter );
+			$this->extra_field_filter = null;
+		}
+
 		parent::tearDown();
+	}
+
+	/**
+	 * Register an extra checkout field in an arbitrary fieldset, the way checkout field editor plugins do.
+	 *
+	 * @param string $fieldset_key Fieldset the field belongs to.
+	 * @param string $key          Field key.
+	 * @param array  $field        Field definition.
+	 */
+	private function register_extra_checkout_field( $fieldset_key, $key, $field ) {
+		$this->extra_field_filter = function ( $fields ) use ( $fieldset_key, $key, $field ) {
+			$fields[ $fieldset_key ][ $key ] = $field;
+
+			return $fields;
+		};
+
+		add_filter( 'woocommerce_checkout_fields', $this->extra_field_filter );
 	}
 
 	/**
@@ -181,6 +208,179 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEmpty( $errors->get_error_message( 'billing_country_validation' ) );
 		$this->assertEmpty( $errors->get_error_message( 'shipping_country_validation' ) );
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' reports a required field error, and doesn't throw, for an empty phone field in a fieldset without a country.
+	 *
+	 * @testWith ["order"]
+	 *           ["custom"]
+	 *
+	 * @param string $fieldset_key The fieldset the phone field belongs to.
+	 */
+	public function test_validate_posted_data_does_not_throw_for_empty_phone_field_without_a_country( $fieldset_key ) {
+		$this->register_extra_checkout_field(
+			$fieldset_key,
+			'extra_phone',
+			array(
+				'label'    => 'Phone number',
+				'validate' => array( 'phone' ),
+				'required' => true,
+			)
+		);
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'extra_phone'               => '',
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEquals(
+			'<strong>Phone number</strong> is a required field.',
+			$errors->get_error_message( 'extra_phone_required' ),
+			'An empty required phone field should be reported as missing, not blow up while resolving the country.'
+		);
+		$this->assertEmpty( $errors->get_error_message( 'extra_phone_validation' ) );
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' validates a phone field in a fieldset without a country, without country specific rules.
+	 *
+	 * @testWith ["not a phone number", true]
+	 *           ["+34 600 000 000", false]
+	 *
+	 * @param string $phone        The posted phone number.
+	 * @param bool   $expect_error True to expect a validation error for the phone field.
+	 */
+	public function test_validate_posted_data_validates_phone_field_in_order_fieldset( $phone, $expect_error ) {
+		$this->register_extra_checkout_field(
+			'order',
+			'order_phone',
+			array(
+				'label'    => 'Phone number',
+				'validate' => array( 'phone' ),
+			)
+		);
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'order_phone'               => $phone,
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEquals(
+			$expect_error ? '<strong>Phone number</strong> is not a valid phone number.' : '',
+			$errors->get_error_message( 'order_phone_validation' )
+		);
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' validates a postcode field in a fieldset without a country, without country specific rules.
+	 *
+	 * @testWith ["INVALID!", true]
+	 *           ["12345", false]
+	 *
+	 * @param string $postcode     The posted postcode.
+	 * @param bool   $expect_error True to expect a validation error for the postcode field.
+	 */
+	public function test_validate_posted_data_validates_postcode_field_in_order_fieldset( $postcode, $expect_error ) {
+		$this->register_extra_checkout_field(
+			'order',
+			'order_postcode',
+			array(
+				'label'    => 'Delivery postcode',
+				'validate' => array( 'postcode' ),
+			)
+		);
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'order_postcode'            => $postcode,
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEquals(
+			$expect_error ? '<strong>Delivery postcode</strong> is not a valid postcode / ZIP.' : '',
+			$errors->get_error_message( 'order_postcode_validation' )
+		);
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' skips state validation, and doesn't throw, for a state field in a fieldset without a country.
+	 */
+	public function test_validate_posted_data_does_not_throw_for_state_field_in_order_fieldset() {
+		$this->register_extra_checkout_field(
+			'order',
+			'order_state',
+			array(
+				'label'    => 'Delivery state',
+				'validate' => array( 'state' ),
+			)
+		);
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'order_state'               => 'Not a real state',
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEmpty( $errors->get_error_message( 'order_state_validation' ) );
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' still falls back to the customer country for billing and shipping fields.
+	 *
+	 * @testWith ["billing", "GB", true]
+	 *           ["billing", "US", false]
+	 *           ["shipping", "GB", true]
+	 *           ["shipping", "US", false]
+	 *
+	 * @param string $fieldset_key     The fieldset holding the postcode field.
+	 * @param string $customer_country The country stored on the customer object.
+	 * @param bool   $expect_error     True to expect a validation error for the postcode field.
+	 */
+	public function test_validate_posted_data_falls_back_to_the_customer_country( $fieldset_key, $customer_country, $expect_error ) {
+		add_filter( 'woocommerce_cart_needs_shipping_address', '__return_true' );
+
+		$original_billing_country  = WC()->customer->get_billing_country();
+		$original_shipping_country = WC()->customer->get_shipping_country();
+
+		WC()->customer->set_billing_country( $customer_country );
+		WC()->customer->set_shipping_country( $customer_country );
+
+		// The country is deliberately not posted, so it has to be resolved from the customer object.
+		$data = array(
+			'ship_to_different_address' => true,
+			$fieldset_key . '_postcode' => '12345',
+		);
+
+		$errors = new WP_Error();
+
+		try {
+			$this->sut->validate_posted_data( $data, $errors );
+		} finally {
+			WC()->customer->set_billing_country( $original_billing_country );
+			WC()->customer->set_shipping_country( $original_shipping_country );
+			remove_filter( 'woocommerce_cart_needs_shipping_address', '__return_true' );
+		}
+
+		$this->assertEquals(
+			$expect_error,
+			! empty( $errors->get_error_message( $fieldset_key . '_postcode_validation' ) ),
+			"'12345' should " . ( $expect_error ? 'not ' : '' ) . "be accepted as a {$customer_country} postcode."
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -380,6 +380,37 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'validate_posted_data' doesn't throw when the customer object isn't set up yet.
+	 *
+	 * 'WC()->customer' is null until 'WC_Woocommerce::initialize_cart()' runs, and 'validate_posted_data'
+	 * has to survive that. 'ABCDE' passes the country agnostic postcode check but fails the store's base
+	 * country rules, so this also pins that no country is assumed when the customer can't supply one.
+	 */
+	public function test_validate_posted_data_does_not_throw_without_a_customer_object() {
+		$original_customer = WC()->customer;
+
+		WC()->customer = null;
+
+		$data = array(
+			'ship_to_different_address' => false,
+			'billing_postcode'          => 'ABCDE',
+		);
+
+		$errors = new WP_Error();
+
+		try {
+			$this->sut->validate_posted_data( $data, $errors );
+		} finally {
+			WC()->customer = $original_customer;
+		}
+
+		$this->assertEmpty(
+			$errors->get_error_message( 'billing_postcode_validation' ),
+			'Without a customer object there is no country to validate against.'
+		);
+	}
+
+	/**
 	 * @testdox 'validate_posted_data' prefers the posted country over the one stored on the customer.
 	 */
 	public function test_validate_posted_data_prefers_the_posted_country() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

`WC_Checkout::validate_posted_data()` built the validation country out of the fieldset key:

```php
WC()->customer->{"get_{$fieldset_key}_country"}()
```

- `WC_Customer` only defines `get_billing_country()` and `get_shipping_country()`, so a validated field in `account`, `order`, or any plugin fieldset hit an undefined method and threw a PHP `Error`.
- `process_checkout()` catches `Exception`, not `Error`, so the request died with a 500 and no order was created.
- All three call sites now read the country from one `private` helper that switches on the fieldset key, mirroring the `switch ( $fieldset_key )` already in this method.
- `is_phone()`, `is_postcode()`, and `wc_format_postcode()` all accept an empty country, so affected fields validate without country rules instead of fataling. Billing and shipping behave as before.

Fixed all three sites, not just phone:

- Phone (line 920) is new in 11.0 and reads the country before the empty-value check, so it fatals on every submission once a phone field sits in the `order` fieldset. Checkout field editor plugins offer that as a checkbox.
- Postcode (line 902) has the same bug and has shipped since at least 10.9, just rarer in practice.
- State (line 942) shares the assumption. A test here confirms it fatals.
- Reverting #65817 would fix one of the three.

Two things came out of review, both now covered by tests:

- Resolving the getter from the fieldset key matched more than billing and shipping. `WC_Customer::get_default_country()` is public, so a fieldset keyed `default` validated against the store's base country and emitted a deprecation notice. The explicit switch removes that. `WC()->customer` is instantiated directly in `class-woocommerce.php` with no filter to swap the class, so no plugin can add a getter the lookup would have found.
- `WC()->customer` is null until `initialize_cart()` runs. An earlier `is_callable()` version of the helper covered that by accident, the switch did not. It is now guarded with an explicit `instanceof` check, matching `initialize_cart()`.

Bug introduced in PR #65817 (phone site). Postcode and state predate it.

Backward compatibility: the helper is `private`, no signature or hook changes. Two behaviour changes, both on paths that already fataled or misbehaved. A fieldset that fataled now returns validation errors, and a fieldset keyed `default` now validates without a country rather than against the store's base country.

### How to test the changes in this Pull Request

1. Add a phone-validated field to the `order` fieldset:

   ```php
   add_filter( 'woocommerce_checkout_fields', function ( $fields ) {
       $fields['order']['order_phone'] = array(
           'label'    => 'Phone Number',
           'type'     => 'tel',
           'validate' => array( 'phone' ),
       );
       return $fields;
   } );
   ```

2. Add a product, open the shortcode checkout, press Place Order with the form empty.
3. Trunk fatals with `Call to undefined method WC_Customer::get_order_country()` and creates no order. This branch returns the normal required-field errors.
4. Enter `not a phone` and check you get "is not a valid phone number".
5. Repeat with `array( 'postcode' )` and `array( 'state' )`. Both fataled before.
6. Repeat with the fieldset key changed from `order` to `default` and a postcode field. Trunk validates it against the store's base country and logs a deprecation notice for `WC_Customer::get_default_country`. This branch validates it without a country.
7. Confirm an invalid billing postcode is still rejected.

### Testing that has already taken place

`WC_Checkout_Test` had no coverage of fieldsets outside billing and shipping, which is how this got through. Added tests for:

- Empty required phone in `order` and in a plugin-registered fieldset.
- Invalid and valid phone and postcode values in `order`.
- A `state` field in `order`.
- A fieldset keyed `default`, which used to resolve `WC_Customer::get_default_country()`.
- `validate_posted_data()` with `WC()->customer` set to null.
- Billing and shipping still reading the country off `WC_Customer` when it is not posted (`12345` rejected as GB, accepted as US).

Restore the trunk version of the file and 9 of the 31 tests break: 8 error out at `:902`, `:920`, and `:942`, and the `default` fieldset one fails on the wrong country. With the fix, `OK (31 tests, 101 assertions)`. Checkout, validation, countries, and customer suites together: `OK (66 tests, 179 assertions)`. phpcs-changed and PHPStan clean, baseline unchanged.

### Changelog entry

`plugins/woocommerce/changelog/fix-67083-checkout-fieldset-country-fatal`, significance `patch`, type `fix`.

### Milestone

11.0.0, so the cherry-pick bot targets `release/11.0`. 11.0.0-rc.2 is cut today. Same flow as #67058 to #67094.

Fixes #67083

