### PR TITLE
Improve Product Image srcset to prevent wide images from appearing blurry

### DIFF
--- a/plugins/woocommerce/changelog/fix-67103-product-image-updated-srcset
+++ b/plugins/woocommerce/changelog/fix-67103-product-image-updated-srcset
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve Product Image srcset to avoid very wide images to look blurry
+Improve Product Image srcset to prevent wide images from appearing blurry

--- a/plugins/woocommerce/changelog/fix-67103-product-image-updated-srcset
+++ b/plugins/woocommerce/changelog/fix-67103-product-image-updated-srcset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve Product Image srcset to avoid very wide images to look blurry

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -289,9 +289,11 @@ class ProductImage extends AbstractBlock {
 
 		add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );
 
-		$image_html = $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
-
-		remove_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10 );
+		try {
+			$image_html = $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
+		} finally {
+			remove_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10 );
+		}
 
 		return $image_html;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -261,7 +261,13 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
-			if ( ! $aspect_ratio ) {
+			if (
+				! $aspect_ratio
+				|| false === strpos( $aspect_ratio, '/' )
+				|| empty( $sources )
+				|| empty( $image_meta['width'] )
+				|| empty( $image_meta['height'] )
+			) {
 				return $sources;
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -262,17 +262,26 @@ class ProductImage extends AbstractBlock {
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
 			if (
-				! $aspect_ratio
-				|| false === strpos( $aspect_ratio, '/' )
-				|| empty( $sources )
-				|| empty( $image_meta['width'] )
-				|| empty( $image_meta['height'] )
+				empty( $sources ) ||
+				empty( $image_meta['width'] ) ||
+				empty( $image_meta['height'] )
 			) {
 				return $sources;
 			}
 
 			$aspect_ratio_parts = explode( '/', $aspect_ratio );
-			$block_aspect_ratio = (int) $aspect_ratio_parts[0] / (int) $aspect_ratio_parts[1];
+
+			if (
+				count( $aspect_ratio_parts ) !== 2 ||
+				! is_numeric( $aspect_ratio_parts[0] ) ||
+				! is_numeric( $aspect_ratio_parts[1] ) ||
+				$aspect_ratio_parts[0] <= 0 ||
+				$aspect_ratio_parts[1] <= 0
+			) {
+				return $sources;
+			}
+
+			$block_aspect_ratio = (float) $aspect_ratio_parts[0] / (float) $aspect_ratio_parts[1];
 
 			$image_aspect_ratio = $image_meta['width'] / $image_meta['height'];
 
@@ -287,12 +296,21 @@ class ProductImage extends AbstractBlock {
 			return $sources;
 		};
 
-		add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );
+		$maybe_adjust_srcset =
+			'cover' === $attributes['scale'] &&
+			$aspect_ratio &&
+			false !== strpos( $aspect_ratio, '/' );
+
+		if ( $maybe_adjust_srcset ) {
+			add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );
+		}
 
 		try {
 			$image_html = $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
 		} finally {
-			remove_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10 );
+			if ( $maybe_adjust_srcset ) {
+				remove_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10 );
+			}
 		}
 
 		return $image_html;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -276,14 +276,12 @@ class ProductImage extends AbstractBlock {
 				count( $aspect_ratio_parts ) !== 2 ||
 				! is_numeric( $aspect_ratio_parts[0] ) ||
 				! is_numeric( $aspect_ratio_parts[1] ) ||
-				$aspect_ratio_parts[0] <= 0 ||
 				$aspect_ratio_parts[1] <= 0
 			) {
 				return $sources;
 			}
 
-			$block_aspect_ratio = (float) $aspect_ratio_parts[0] / (float) $aspect_ratio_parts[1];
-
+			$block_aspect_ratio = $aspect_ratio_parts[0] / $aspect_ratio_parts[1];
 			$image_aspect_ratio = $image_meta['width'] / $image_meta['height'];
 
 			if ( $image_aspect_ratio > $block_aspect_ratio ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -268,10 +268,10 @@ class ProductImage extends AbstractBlock {
 			$aspect_ratio_parts = explode( '/', $aspect_ratio );
 			$block_aspect_ratio = (int) $aspect_ratio_parts[0] / (int) $aspect_ratio_parts[1];
 
-			$image_aspect_radio = $image_meta['width'] / $image_meta['height'];
+			$image_aspect_ratio = $image_meta['width'] / $image_meta['height'];
 
-			if ( $image_aspect_radio > $block_aspect_ratio ) {
-				$stretch_factor = $image_aspect_radio / $block_aspect_ratio;
+			if ( $image_aspect_ratio > $block_aspect_ratio ) {
+				$stretch_factor = $image_aspect_ratio / $block_aspect_ratio;
 
 				foreach ( $sources as $key => $source ) {
 					$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -262,6 +262,7 @@ class ProductImage extends AbstractBlock {
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
 			if (
+				! $aspect_ratio ||
 				empty( $sources ) ||
 				empty( $image_meta['width'] ) ||
 				empty( $image_meta['height'] )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -263,8 +263,12 @@ class ProductImage extends AbstractBlock {
 		add_filter(
 			'wp_calculate_image_srcset',
 			function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
+				if ( ! $aspect_ratio ) {
+					return $sources;
+				}
+
 				$aspect_ratio_parts = explode( '/', $aspect_ratio );
-				$block_aspect_ratio = $aspect_ratio_parts[0] / $aspect_ratio_parts[1];
+				$block_aspect_ratio = (int) $aspect_ratio_parts[0] / (int) $aspect_ratio_parts[1];
 
 				$image_aspect_radio = $image_meta['width'] / $image_meta['height'];
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -263,9 +263,13 @@ class ProductImage extends AbstractBlock {
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
 			if (
 				! is_string( $aspect_ratio ) ||
-				empty( $sources ) ||
-				empty( $image_meta['width'] ) ||
-				empty( $image_meta['height'] )
+				! is_array( $sources ) ||
+				! is_array( $image_meta ) ||
+				! isset( $image_meta['width'], $image_meta['height'] ) ||
+				! is_numeric( $image_meta['width'] ) ||
+				! is_numeric( $image_meta['height'] ) ||
+				$image_meta['width'] <= 0 ||
+				$image_meta['height'] <= 0
 			) {
 				return $sources;
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -260,33 +260,34 @@ class ProductImage extends AbstractBlock {
 			$attr['loading'] = $loading_attr;
 		}
 
-		add_filter(
-			'wp_calculate_image_srcset',
-			function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
-				if ( ! $aspect_ratio ) {
-					return $sources;
-				}
-
-				$aspect_ratio_parts = explode( '/', $aspect_ratio );
-				$block_aspect_ratio = (int) $aspect_ratio_parts[0] / (int) $aspect_ratio_parts[1];
-
-				$image_aspect_radio = $image_meta['width'] / $image_meta['height'];
-
-				if ( $image_aspect_radio > $block_aspect_ratio ) {
-					$stretch_factor = $image_aspect_radio / $block_aspect_ratio;
-
-					foreach ( $sources as $key => $source ) {
-						$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );
-					}
-				}
-
+		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
+			if ( ! $aspect_ratio ) {
 				return $sources;
-			},
-			10,
-			4
-		);
+			}
 
-		return $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
+			$aspect_ratio_parts = explode( '/', $aspect_ratio );
+			$block_aspect_ratio = (int) $aspect_ratio_parts[0] / (int) $aspect_ratio_parts[1];
+
+			$image_aspect_radio = $image_meta['width'] / $image_meta['height'];
+
+			if ( $image_aspect_radio > $block_aspect_ratio ) {
+				$stretch_factor = $image_aspect_radio / $block_aspect_ratio;
+
+				foreach ( $sources as $key => $source ) {
+					$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );
+				}
+			}
+
+			return $sources;
+		};
+
+		add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );
+
+		$image_html = $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
+
+		remove_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10 );
+
+		return $image_html;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -260,6 +260,28 @@ class ProductImage extends AbstractBlock {
 			$attr['loading'] = $loading_attr;
 		}
 
+		add_filter(
+			'wp_calculate_image_srcset',
+			function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
+				$aspect_ratio_parts = explode( '/', $aspect_ratio );
+				$block_aspect_ratio = $aspect_ratio_parts[0] / $aspect_ratio_parts[1];
+
+				$image_aspect_radio = $image_meta['width'] / $image_meta['height'];
+
+				if ( $image_aspect_radio > $block_aspect_ratio ) {
+					$stretch_factor = $image_aspect_radio / $block_aspect_ratio;
+
+					foreach ( $sources as $key => $source ) {
+						$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );
+					}
+				}
+
+				return $sources;
+			},
+			10,
+			4
+		);
+
 		return $provided_image_id_is_valid ? wp_get_attachment_image( $image_id, $image_size, false, $attr ) : $product->get_image( $image_size, $attr );
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -262,7 +262,7 @@ class ProductImage extends AbstractBlock {
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
 			if (
-				! $aspect_ratio ||
+				! is_string( $aspect_ratio ) ||
 				empty( $sources ) ||
 				empty( $image_meta['width'] ) ||
 				empty( $image_meta['height'] )
@@ -290,6 +290,9 @@ class ProductImage extends AbstractBlock {
 				$stretch_factor = $image_aspect_ratio / $block_aspect_ratio;
 
 				foreach ( $sources as $key => $source ) {
+					if ( ! is_array( $source ) || ! isset( $source['value'] ) || ! is_numeric( $source['value'] ) ) {
+						continue;
+					}
 					$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );
 				}
 			}
@@ -299,7 +302,7 @@ class ProductImage extends AbstractBlock {
 
 		$maybe_adjust_srcset =
 			'cover' === $attributes['scale'] &&
-			$aspect_ratio &&
+			is_string( $aspect_ratio ) &&
 			false !== strpos( $aspect_ratio, '/' );
 
 		if ( $maybe_adjust_srcset ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -280,6 +280,7 @@ class ProductImage extends AbstractBlock {
 				count( $aspect_ratio_parts ) !== 2 ||
 				! is_numeric( $aspect_ratio_parts[0] ) ||
 				! is_numeric( $aspect_ratio_parts[1] ) ||
+				$aspect_ratio_parts[0] <= 0 ||
 				$aspect_ratio_parts[1] <= 0
 			) {
 				return $sources;

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -376,8 +376,8 @@ class ProductImage extends \WP_UnitTestCase {
 		$default_markup  = $this->render_product_image_block( $data['product'], '{"imageSizing":"single"}' );
 		$portrait_markup = $this->render_product_image_block( $data['product'], '{"aspectRatio":"3/4"}' );
 
-		$this->assertStringContainsString( 'http://localhost:8186/wp-content/uploads/wide-image-1024x512.jpg 1024w', $default_markup );
-		$this->assertStringContainsString( 'http://localhost:8186/wp-content/uploads/wide-image-1024x512.jpg 384w', $portrait_markup );
+		$this->assertStringContainsString( 'wide-image-1024x512.jpg 1024w', $default_markup );
+		$this->assertStringContainsString( 'wide-image-1024x512.jpg 384w', $portrait_markup );
 
 		$data['product']->delete( true );
 		wp_delete_attachment( $data['image_id'], true );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -350,6 +350,51 @@ class ProductImage extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Should reduce srcset width descriptors for wide images in portrait aspect ratios.
+	 */
+	public function test_product_image_render_adjusts_srcset_for_portrait_aspect_ratio() {
+		$data = $this->create_product_with_image();
+
+		wp_update_attachment_metadata(
+			$data['image_id'],
+			array(
+				'width'  => 2000,
+				'height' => 1000,
+				'file'   => 'wide-image.jpg',
+				'sizes'  => array(
+					'large' => array(
+						'file'      => 'wide-image.jpg',
+						'width'     => 2000,
+						'height'    => 1000,
+						'mime-type' => 'image/jpeg',
+					),
+				),
+			)
+		);
+		update_post_meta( $data['image_id'], '_wp_attached_file', 'wide-image.jpg' );
+
+		$default_markup  = $this->render_product_image_block( $data['product'], '{"imageSizing":"single"}' );
+		$portrait_markup = $this->render_product_image_block( $data['product'], '{"aspectRatio":"3/4"}' );
+
+		preg_match( '/srcset="([^"]+)"/', $default_markup, $default_srcset );
+		preg_match( '/srcset="([^"]+)"/', $portrait_markup, $portrait_srcset );
+
+		$this->assertNotEmpty( $default_srcset[1] );
+		$this->assertNotEmpty( $portrait_srcset[1] );
+
+		preg_match_all( '/(\d+)w/', $default_srcset[1], $default_widths );
+		preg_match_all( '/(\d+)w/', $portrait_srcset[1], $portrait_widths );
+
+		$this->assertLessThan(
+			max( array_map( 'intval', $default_widths[1] ) ),
+			max( array_map( 'intval', $portrait_widths[1] ) )
+		);
+
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
 	 * Test that the ProductImage block handles invalid product IDs correctly.
 	 */
 	public function test_product_image_render_with_invalid_product() {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -363,9 +363,9 @@ class ProductImage extends \WP_UnitTestCase {
 				'file'   => 'wide-image.jpg',
 				'sizes'  => array(
 					'large' => array(
-						'file'      => 'wide-image.jpg',
-						'width'     => 2000,
-						'height'    => 1000,
+						'file'      => 'wide-image-1024x512.jpg',
+						'width'     => 1024,
+						'height'    => 512,
 						'mime-type' => 'image/jpeg',
 					),
 				),
@@ -376,19 +376,8 @@ class ProductImage extends \WP_UnitTestCase {
 		$default_markup  = $this->render_product_image_block( $data['product'], '{"imageSizing":"single"}' );
 		$portrait_markup = $this->render_product_image_block( $data['product'], '{"aspectRatio":"3/4"}' );
 
-		preg_match( '/srcset="([^"]+)"/', $default_markup, $default_srcset );
-		preg_match( '/srcset="([^"]+)"/', $portrait_markup, $portrait_srcset );
-
-		$this->assertNotEmpty( $default_srcset[1] );
-		$this->assertNotEmpty( $portrait_srcset[1] );
-
-		preg_match_all( '/(\d+)w/', $default_srcset[1], $default_widths );
-		preg_match_all( '/(\d+)w/', $portrait_srcset[1], $portrait_widths );
-
-		$this->assertLessThan(
-			max( array_map( 'intval', $default_widths[1] ) ),
-			max( array_map( 'intval', $portrait_widths[1] ) )
-		);
+		$this->assertStringContainsString( 'http://localhost:8186/wp-content/uploads/wide-image-1024x512.jpg 1024w', $default_markup );
+		$this->assertStringContainsString( 'http://localhost:8186/wp-content/uploads/wide-image-1024x512.jpg 384w', $portrait_markup );
 
 		$data['product']->delete( true );
 		wp_delete_attachment( $data['image_id'], true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #67103.

This PR makes the `srcset` of the Product Image block a bit smarter by taking into account the aspect ratio of the original image and the aspect ratio of the block. So if the image is more "landscape" than the block, we tweak the srcset to make sure we account for the image being stretched.

This PR is kind of a follow-up from https://github.com/woocommerce/woocommerce/pull/66191.

### How to test the changes in this Pull Request:

1. Add a product image that is twice as wide as its height. Like this one:

<img width="1774" height="887" alt="Image" src="https://github.com/user-attachments/assets/7a138fb5-0368-4d03-8dfa-9d441602cb0e" />

2. Edit the Product Catalog template and set the product image aspect ratio to Portrait or Tall.
3. In the frontend, verify the image of the product image you just added no longer looks blurry.

Before | After
--- | ---
<img width="1715" height="1192" alt="Image" src="https://github.com/user-attachments/assets/2895a9d6-a332-402e-8531-f05a10ef9e12" /> | <img width="1715" height="1192" alt="imatge" src="https://github.com/user-attachments/assets/fec409db-de43-4c2a-9f1d-219d250980af" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->