### PR TITLE
Fix widget editor block initialization errors

### DIFF
--- a/plugins/woocommerce/changelog/fix-47831-widget-editor-wp-editor-dependency
+++ b/plugins/woocommerce/changelog/fix-47831-widget-editor-wp-editor-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent block initialization errors in the classic widget editor.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -44,12 +44,19 @@ function ProductTypeSwitcher() {
 
 export default function ProductTypeSelectorPlugin() {
 	const { slug, type } = useSelect( ( select ) => {
-		const { slug: currentPostSlug, type: currentPostType } = select(
-			'core/editor'
-		).getCurrentPost< {
-			slug: string;
-			type: string;
-		} >();
+		const editorStore = select( 'core/editor' );
+		if ( ! editorStore ) {
+			return {
+				slug: '',
+				type: '',
+			};
+		}
+
+		const { slug: currentPostSlug, type: currentPostType } =
+			editorStore.getCurrentPost< {
+				slug: string;
+				type: string;
+			} >();
 
 		return {
 			slug: currentPostSlug,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -45,6 +45,7 @@ function ProductTypeSwitcher() {
 export default function ProductTypeSelectorPlugin() {
 	const { slug, type } = useSelect( ( select ) => {
 		const editorStore = select( 'core/editor' );
+		// The widget editor does not load wp-editor, so the core/editor store may be unavailable.
 		if ( ! editorStore ) {
 			return {
 				slug: '',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -237,8 +237,9 @@ abstract class AbstractBlock {
 			)
 		);
 
-		// WordPress reports incorrect usage when wp-editor is loaded alongside the block-based widget editor,
-		// as it conflicts with the wp-edit-widgets and wp-customize-widgets scripts.
+		// For performance, the unified block library combines all block editor assets, so its dependencies include
+		// wp-editor even though blocks available in the widget editor do not use it. WordPress treats loading
+		// wp-editor alongside the block-based widget editor as incorrect usage, so remove it only on this screen.
 		if ( 'wc-block-library' === $handle && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && 'widgets' === $screen->base ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -230,14 +230,22 @@ abstract class AbstractBlock {
 			return;
 		}
 
-		$wp_scripts->registered[ $handle ]->deps = array_values(
-			array_unique(
-				array_merge(
-					$wp_scripts->registered[ $handle ]->deps,
-					$dependencies
-				)
+		$script_dependencies = array_unique(
+			array_merge(
+				$wp_scripts->registered[ $handle ]->deps,
+				$dependencies
 			)
 		);
+
+		// Loading wp-editor in the widget editor causes block initialization errors.
+		if ( 'wc-block-library' === $handle && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			if ( $screen && 'widgets' === $screen->base ) {
+				$script_dependencies = array_diff( $script_dependencies, array( 'wp-editor' ) );
+			}
+		}
+
+		$wp_scripts->registered[ $handle ]->deps = array_values( $script_dependencies );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -237,7 +237,8 @@ abstract class AbstractBlock {
 			)
 		);
 
-		// WordPress explicitly disallows loading wp-editor alongside the block-based widget editor.
+		// WordPress reports incorrect usage when wp-editor is loaded alongside the block-based widget editor,
+		// as it conflicts with the wp-edit-widgets and wp-customize-widgets scripts.
 		if ( 'wc-block-library' === $handle && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && 'widgets' === $screen->base ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -237,7 +237,7 @@ abstract class AbstractBlock {
 			)
 		);
 
-		// Loading wp-editor in the widget editor causes block initialization errors.
+		// WordPress explicitly disallows loading wp-editor alongside the block-based widget editor.
 		if ( 'wc-block-library' === $handle && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && 'widgets' === $screen->base ) {

--- a/plugins/woocommerce/tests/e2e/tests/blocks/widget-area/widget-area.classic_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/widget-area/widget-area.classic_theme.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { test, expect, CLASSIC_THEME_SLUG } from '@woocommerce/e2e-utils';
+
+test.describe( 'Merchant → Widget area', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
+	} );
+
+	test( 'does not render an error notice', async ( { admin, page } ) => {
+		await admin.visitWidgetEditor();
+
+		// Verify the wp-editor script wasn't loaded.
+		// See: https://github.com/woocommerce/woocommerce/issues/47831
+		await expect( page.locator( '#wp-editor-js' ) ).toHaveCount( 0 );
+
+		// Verify that no error notice is rendered in the widget editor.
+		await expect(
+			page.locator( '.components-notice.is-error' )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/admin/index.ts
@@ -35,10 +35,6 @@ export class Admin extends CoreAdmin {
 			.getByRole( 'dialog', { name: 'Welcome to block Widgets' } )
 			.getByRole( 'button', { name: 'Close' } );
 
-		// Verify the wp-editor script wasn't loaded.
-		// See: https://github.com/woocommerce/woocommerce/issues/47831
-		await expect( this.page.locator( '#wp-editor-js' ) ).toHaveCount( 0 );
-
 		// The welcome guide only shows when it hasn't been dismissed before, so
 		// wait for it briefly and close it only when it actually appears.
 		const guideAppeared = await closeWelcomeGuide


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The unified editor bundle can make `wc-block-library` load `wp-editor` on the classic widget screen, causing block initialization errors. 

Remove the dependency from `wc-block-library` on the widget screen, handle the missing `core/editor` store in the Add to Cart with Options plugin, and add an end-to-end test for the flow.

Related to #47831.

Bug introduced in PR #66200.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

No visual change. The widget editor now loads without an error notice.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Visit  `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Enable `Unified block editor assets`.
3. Activate a classic theme, such as Storefront.
4. Go to **Appearance > Widgets**.
5. Verify the widget editor loads without an error notice.
6. Verify `wp-editor` is not loaded by checking that the page has no script with the `wp-editor-js` ID.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
