### PR TITLE
[dev] Fix reviews row test for the WP 7.1 check-column markup

### DIFF
--- a/plugins/woocommerce/changelog/fix-reviews-list-table-check-column-test
+++ b/plugins/woocommerce/changelog/fix-reviews-list-table-check-column-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Accept the WordPress 7.1 list table check-column markup in the reviews list table row test.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -75,8 +75,10 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 				$this->assertStringContainsString( 'data-colname="' . $column_name . '"', $row_output );
 			} else {
 				// WordPress 7.1 changed the list table check column cell from <th> to <td>.
+				// Accept either element; the backreference requires the closing tag to
+				// match the captured opening tag.
 				$this->assertMatchesRegularExpression(
-					'~<(th|td)[^>]*\bclass="check-column"></\1>~',
+					'~<(?<cell_tag>th|td)[^>]*\bclass="check-column"></\k<cell_tag>>~',
 					$row_output,
 					'The row should contain an empty check-column cell.'
 				);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -74,7 +74,12 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 			if ( 'cb' !== $column_id ) {
 				$this->assertStringContainsString( 'data-colname="' . $column_name . '"', $row_output );
 			} else {
-				$this->assertStringContainsString( '<th scope="row" class="check-column"></th>', $row_output );
+				// WordPress 7.1 changed the list table check column cell from <th> to <td>.
+				$this->assertMatchesRegularExpression(
+					'~<(th|td)[^>]*\bclass="check-column"></\1>~',
+					$row_output,
+					'The row should contain an empty check-column cell.'
+				);
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

WordPress 7.1-beta4 changed the `WP_List_Table` check-column cell from `<th scope="row" class="check-column">` to `<td class="check-column">`, which makes `ReviewsListTableTest::test_single_row` fail on the optional **WP: pre-release** CI job — the test asserts the `<th>` markup literally. WooCommerce still supports WordPress versions that render the `<th>` variant, so the assertion now matches the empty check-column cell through a regular expression accepting either tag, with a backreference so mismatched opening and closing tags still fail.

Test-only change; the `ReviewsListTable` runtime behavior is untouched (it inherits the cell rendering from WordPress core).

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter 'ReviewsListTableTest::test_single_row'`.
   - [ ] Confirm the test passes (one test, nine assertions) on the default (stable) WordPress version, which renders the `<th>` markup.
2. Optionally, point `wp-env` at a WordPress 7.1 pre-release (`"core": "WordPress/WordPress#master"` in the test environment config) and re-run the command from step 1.
   - [ ] Confirm the test passes against the new `<td>` markup.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The focused test passes in the local `wp-env` environment on PHP 8.1 with the stable WordPress (`<th>` markup): one test, nine assertions.
- The new regular expression was verified directly against the exact `<td class="check-column"></td>` markup captured from the failing WP 7.1-beta4 CI run, against the pre-7.1 `<th scope="row" class="check-column"></th>` markup, and against a mismatched `<th ...></td>` pair (correctly rejected).
- Recent `trunk` runs of the same CI job pinned WP 7.1-beta3 and passed; the failure appears only on runs resolving the pre-release to 7.1-beta4, confirming the upstream markup change as the cause.
- Branch-diff PHPCS lint passed; the remaining findings reported for the file are pre-existing and outside the changed lines.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-reviews-list-table-check-column-test`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>