### PR TITLE
Correct the Review Order changelog note about the Shop page setting

### DIFF
--- a/plugins/woocommerce/changelog/fix-35361-scope-review-order-page-creation
+++ b/plugins/woocommerce/changelog/fix-35361-scope-review-order-page-creation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep the Review Order page from restoring an intentionally empty Shop page setting. If your Shop page setting was cleared by this bug, clear it once more after updating.
+Keep the Review Order page from restoring an intentionally empty Shop page setting. If this bug restored your intentionally cleared Shop page setting, clear it once more after updating.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The changelog entry shipped with #66959 tells merchants: "If your Shop page setting was cleared by this bug, clear it once more after updating." The conditional clause is inverted — the bug never cleared the option. `wc_create_page()` only ever writes a page ID into `woocommerce_shop_page_id`, so the bug *restored* an intentionally cleared setting. This PR corrects the sentence to "If this bug restored your intentionally cleared Shop page setting, clear it once more after updating."

Wording issue surfaced in the analysis of #67120.

Bug introduced in PR #66959.

### How to test the changes in this Pull Request:

1. Open `plugins/woocommerce/changelog/fix-35361-scope-review-order-page-creation`.
2. Confirm the entry reads "If this bug restored your intentionally cleared Shop page setting, clear it once more after updating."
3. From `plugins/woocommerce`, run `composer exec -- changelogger validate` and confirm it passes.

### Testing that has already taken place:

- WooCommerce changelog validation passes locally.
- Text-only change to an existing changelog entry; no code paths affected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR only corrects the wording of an existing unreleased changelog entry; a separate entry would be noise.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

---
🤖 Generated with [Claude Code](https://claude.ai/code)
