### PR TITLE
Fix date_paid order filter ignoring the site timezone

### DIFF
--- a/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
+++ b/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the date_paid/date_completed day filter on the legacy orders list table respect the site timezone, so the listed orders match the requested local day.

--- a/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
+++ b/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Make the date_paid/date_completed day filter on the orders list table respect the site timezone, and fall back to month filtering when the day value cannot be parsed.
+Make the date_paid/date_completed day filter on the orders list table respect the site timezone, so the listed orders match the requested local day.

--- a/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
+++ b/plugins/woocommerce/changelog/fix-39462-date-paid-filter-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the date_paid/date_completed day filter on the orders list table respect the site timezone, and fall back to month filtering when the day value cannot be parsed.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -714,15 +714,20 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			$date_type  = wc_clean( wp_unslash( $_GET['order_date_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$date_query = wc_clean( wp_unslash( $_GET['m'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// date_paid and date_completed are stored in postmeta, so we need to do a meta query.
-			if ( 'date_paid' === $date_type || 'date_completed' === $date_type ) {
-				$date_start = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 00:00:00" );
-				$date_end   = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 23:59:59" );
+			if ( is_string( $date_query ) && ( 'date_paid' === $date_type || 'date_completed' === $date_type ) ) {
+				// The postmeta values are UTC timestamps, while the requested day is in the site's timezone.
+				$date_start = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 00:00:00", wp_timezone() );
 
 				unset( $wp->query_vars['m'] );
 
-				if ( $date_start && $date_end ) {
+				if ( $date_start ) {
+					// Use the next local midnight so the range follows DST-shortened or extended days.
+					// 'tomorrow' resets to midnight; '+1 day' can retain a normalized 01:00 start.
+					// Midnight rollbacks before 2022 may still leave the first repeated hour uncovered.
+					$date_end = ( clone $date_start )->modify( 'tomorrow' );
+
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() - 1 ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 					$wp->query_vars['meta_compare'] = 'BETWEEN';
 				}
 			}

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -721,11 +721,9 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				unset( $wp->query_vars['m'] );
 
 				if ( $date_start ) {
-					// Derive the upper bound from the next local midnight rather than parsing 23:59:59, so the
-					// range follows the real length of the day across a DST transition. '+1 day' is not
-					// equivalent: it carries over the start time, which is not midnight on days where DST
-					// begins at 00:00. The range is still an hour short on the rare dates where a zone moved
-					// its clocks back onto midnight itself, leaving 00:00 ambiguous (last seen in 2021).
+					// Use the next local midnight so the range follows DST-shortened or extended days.
+					// 'tomorrow' resets to midnight; '+1 day' can retain a normalized 01:00 start.
+					// Midnight rollbacks before 2022 may still leave the first repeated hour uncovered.
 					$date_end = ( clone $date_start )->modify( 'tomorrow' );
 
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -717,13 +717,16 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			if ( 'date_paid' === $date_type || 'date_completed' === $date_type ) {
 				// The postmeta values are UTC timestamps, while the requested day is in the site's timezone.
 				$date_start = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 00:00:00", wp_timezone() );
-				$date_end   = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 23:59:59", wp_timezone() );
 
-				if ( $date_start && $date_end ) {
-					unset( $wp->query_vars['m'] );
+				unset( $wp->query_vars['m'] );
+
+				if ( $date_start ) {
+					// Derive the upper bound from the start of the next local day rather than parsing 23:59:59,
+					// so the range still covers the full day where DST ends at midnight and the day lasts 25 hours.
+					$date_end = ( clone $date_start )->modify( '+1 day' );
 
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() - 1 ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 					$wp->query_vars['meta_compare'] = 'BETWEEN';
 				}
 			}

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -715,12 +715,13 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			$date_query = wc_clean( wp_unslash( $_GET['m'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// date_paid and date_completed are stored in postmeta, so we need to do a meta query.
 			if ( 'date_paid' === $date_type || 'date_completed' === $date_type ) {
-				$date_start = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 00:00:00" );
-				$date_end   = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 23:59:59" );
-
-				unset( $wp->query_vars['m'] );
+				// The postmeta values are UTC timestamps, while the requested day is in the site's timezone.
+				$date_start = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 00:00:00", wp_timezone() );
+				$date_end   = \DateTime::createFromFormat( 'Ymd H:i:s', "$date_query 23:59:59", wp_timezone() );
 
 				if ( $date_start && $date_end ) {
+					unset( $wp->query_vars['m'] );
+
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 					$wp->query_vars['meta_compare'] = 'BETWEEN';

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -722,8 +722,10 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 				if ( $date_start ) {
 					// Derive the upper bound from the start of the next local day rather than parsing 23:59:59,
-					// so the range still covers the full day where DST ends at midnight and the day lasts 25 hours.
-					$date_end = ( clone $date_start )->modify( '+1 day' );
+					// so the range covers the whole day whatever its length around a DST transition. 'tomorrow'
+					// resolves to the next local midnight; '+1 day' would instead carry over the start time,
+					// which is not midnight on days where DST begins at 00:00.
+					$date_end = ( clone $date_start )->modify( 'tomorrow' );
 
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() - 1 ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -721,10 +721,11 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				unset( $wp->query_vars['m'] );
 
 				if ( $date_start ) {
-					// Derive the upper bound from the start of the next local day rather than parsing 23:59:59,
-					// so the range covers the whole day whatever its length around a DST transition. 'tomorrow'
-					// resolves to the next local midnight; '+1 day' would instead carry over the start time,
-					// which is not midnight on days where DST begins at 00:00.
+					// Derive the upper bound from the next local midnight rather than parsing 23:59:59, so the
+					// range follows the real length of the day across a DST transition. '+1 day' is not
+					// equivalent: it carries over the start time, which is not midnight on days where DST
+					// begins at 00:00. The range is still an hour short on the rare dates where a zone moved
+					// its clocks back onto midnight itself, leaving 00:00 ambiguous (last seen in 2021).
 					$date_end = ( clone $date_start )->modify( 'tomorrow' );
 
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -727,6 +727,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 					$date_end = ( clone $date_start )->modify( 'tomorrow' );
 
 					$wp->query_vars['meta_key']     = "_$date_type"; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					$wp->query_vars['meta_type']    = 'NUMERIC';
 					$wp->query_vars['meta_value']   = array( strval( $date_start->getTimestamp() ), strval( $date_end->getTimestamp() - 1 ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 					$wp->query_vars['meta_compare'] = 'BETWEEN';
 				}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -4711,12 +4711,6 @@ parameters:
 			path: includes/admin/list-tables/class-wc-admin-list-table-orders.php
 
 		-
-			message: '#^Part \$date_query \(array\|string\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 2
-			path: includes/admin/list-tables/class-wc-admin-list-table-orders.php
-
-		-
 			message: '#^Property WC_Admin_List_Table\:\:\$object \(object\|null\) does not accept WC_Order\|WC_Order_Refund\|false\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -4713,7 +4713,7 @@ parameters:
 		-
 			message: '#^Part \$date_query \(array\|string\) of encapsed string cannot be cast to string\.$#'
 			identifier: encapsedStringPart.nonString
-			count: 2
+			count: 1
 			path: includes/admin/list-tables/class-wc-admin-list-table-orders.php
 
 		-

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -273,6 +273,185 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Creates a paid order with date_paid set from a local-time string.
+	 *
+	 * @param string $local_datetime Local date/time string, e.g. '2023-07-20 21:00:00'.
+	 * @return WC_Order
+	 */
+	private function create_order_paid_at( string $local_datetime ): WC_Order {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( $local_datetime, wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Runs an order list table date query.
+	 *
+	 * @param string $date_type Order date field to filter.
+	 * @param string $date      Date in Ymd format.
+	 * @return int[] Matching order IDs.
+	 */
+	private function query_order_ids_with_date_filter( string $date_type, string $date ): array {
+		$_GET['order_date_type'] = $date_type;
+		$_GET['m']               = $date;
+		$GLOBALS['pagenow']      = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		new WC_Admin_List_Table_Orders();
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'shop_order',
+				'post_status' => 'all',
+				'fields'      => 'ids',
+				'm'           => $date,
+			)
+		);
+
+		$results = $query->get_posts();
+
+		unset( $_GET['order_date_type'], $_GET['m'], $GLOBALS['pagenow'] );
+
+		return $results;
+	}
+
+	/**
+	 * @testdox Should interpret the date_paid day filter in the store timezone, not UTC.
+	 */
+	public function test_date_paid_filter_uses_store_timezone(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$morning_order      = $this->create_order_paid_at( '2023-07-20 09:00:00' );
+		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
+		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
+
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20230720' );
+
+		$this->assertContains( $morning_order->get_id(), $results, 'Order paid in the morning (store time) should be listed for its local day.' );
+		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (store time) should be listed for its local day even though it falls on the next day in UTC.' );
+		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order paid the previous local day should not be listed even though it falls on the filtered day in UTC.' );
+
+		update_option( 'timezone_string', '' );
+		foreach ( array( $morning_order, $evening_order, $previous_day_order ) as $order ) {
+			wp_delete_post( $order->get_id(), true );
+		}
+	}
+
+	/**
+	 * @testdox Should respect a manual UTC offset (empty timezone_string) when filtering by date_paid.
+	 */
+	public function test_date_paid_filter_uses_store_timezone_with_manual_utc_offset(): void {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
+		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
+
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20230720' );
+
+		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (offset local time) should be listed for its local day.' );
+		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order paid the previous local day should not be listed.' );
+
+		update_option( 'gmt_offset', 0 );
+		foreach ( array( $evening_order, $previous_day_order ) as $order ) {
+			wp_delete_post( $order->get_id(), true );
+		}
+	}
+
+	/**
+	 * @testdox Should filter date_completed day ranges in the store timezone as well.
+	 */
+	public function test_date_completed_filter_uses_store_timezone(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_completed( ( new DateTime( '2023-07-20 21:00:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$previous_day_order = WC_Helper_Order::create_order();
+		$previous_day_order->set_status( 'completed' );
+		$previous_day_order->set_date_completed( ( new DateTime( '2023-07-19 21:00:00', wp_timezone() ) )->getTimestamp() );
+		$previous_day_order->save();
+
+		$results = $this->query_order_ids_with_date_filter( 'date_completed', '20230720' );
+
+		$this->assertContains( $order->get_id(), $results, 'Order completed late evening (store time) should be listed for its local day.' );
+		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order completed the previous local day should not be listed even though it falls on the filtered day in UTC.' );
+
+		update_option( 'timezone_string', '' );
+		foreach ( array( $order, $previous_day_order ) as $created_order ) {
+			wp_delete_post( $created_order->get_id(), true );
+		}
+	}
+
+	/**
+	 * @testdox Should cover the whole local day when DST ends at midnight and the day lasts 25 hours.
+	 */
+	public function test_date_paid_filter_covers_dst_extended_day(): void {
+		// Chile ends DST at midnight, so 2022-04-02 lasts 25 hours and repeats its 23:00 hour.
+		update_option( 'timezone_string', 'America/Santiago' );
+
+		$next_midnight = ( new DateTime( '2022-04-02 00:00:00', wp_timezone() ) )->modify( '+1 day' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( $next_midnight->getTimestamp() - 1800 );
+		$order->save();
+
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20220402' );
+
+		$this->assertContains( $order->get_id(), $results, 'An order paid during the repeated final hour of a 25-hour local day should still be listed for that day.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * @testdox Should not spill into the next day when DST starts at midnight and the day has no 00:00.
+	 */
+	public function test_date_paid_filter_does_not_overlap_dst_shortened_day(): void {
+		// Chile starts DST at midnight, so 2022-09-11 has no 00:00 hour and begins at 01:00.
+		update_option( 'timezone_string', 'America/Santiago' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( '2022-09-12 00:30:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$previous_day_results = $this->query_order_ids_with_date_filter( 'date_paid', '20220911' );
+		$own_day_results      = $this->query_order_ids_with_date_filter( 'date_paid', '20220912' );
+
+		$this->assertNotContains( $order->get_id(), $previous_day_results, 'An order paid after midnight the following day should not also be listed under the previous day.' );
+		$this->assertContains( $order->get_id(), $own_day_results, 'The order should be listed under the day it was actually paid.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * @testdox Should treat the next local midnight as the exclusive end of the day.
+	 */
+	public function test_date_paid_filter_excludes_the_next_midnight_instant(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( '2026-07-21 00:00:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$filtered_day_results = $this->query_order_ids_with_date_filter( 'date_paid', '20260720' );
+		$own_day_results      = $this->query_order_ids_with_date_filter( 'date_paid', '20260721' );
+
+		$this->assertNotContains( $order->get_id(), $filtered_day_results, 'An order paid exactly at midnight belongs to the day starting then, not the one ending then.' );
+		$this->assertContains( $order->get_id(), $own_day_results, 'An order paid exactly at midnight should be listed under the day that starts at that instant.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
 	 * Test that the search without post_type in query does not trigger warnings.
 	 * This is a regression test for https://github.com/woocommerce/woocommerce/pull/55353.
 	 */
@@ -306,5 +485,48 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 
 		// Cleanup.
 		unset( $GLOBALS['pagenow'] );
+	}
+
+	/**
+	 * @testdox Should not warn or drop orders when the m parameter is not a string.
+	 */
+	public function test_date_filter_with_non_string_m_does_not_trigger_warning(): void {
+		$order = $this->create_order_paid_at( '2023-07-20 21:00:00' );
+
+		$_GET['order_date_type'] = 'date_paid';
+		$_GET['m']               = array( '20230720' );
+		$GLOBALS['pagenow']      = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		new WC_Admin_List_Table_Orders();
+
+		$errors = array();
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+			function ( $errno, $errstr ) use ( &$errors ) {
+				$errors[] = "[$errno] $errstr";
+
+				return true;
+			}
+		);
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'shop_order',
+				'post_status'    => 'all',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'm'              => array( '20230720' ),
+			)
+		);
+
+		$results = $query->get_posts();
+
+		restore_error_handler();
+
+		$this->assertSame( array(), $errors, 'An array "m" parameter should not raise an "Array to string conversion" warning.' );
+		$this->assertEmpty( $query->query_vars['meta_key'], 'An unusable "m" parameter should not build a date meta query.' );
+		$this->assertContains( $order->get_id(), $results, 'An unusable "m" parameter should leave the list unfiltered rather than silently dropping orders.' );
+
+		unset( $_GET['order_date_type'], $_GET['m'], $GLOBALS['pagenow'] );
+		wp_delete_post( $order->get_id(), true );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -467,15 +467,17 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 			}
 		);
 
-		// Do not set post_type in the query.
-		new WP_Query(
-			array(
-				'post_status' => 'all',
-				'fields'      => 'ids',
-			)
-		);
-
-		restore_error_handler();
+		try {
+			// Do not set post_type in the query.
+			new WP_Query(
+				array(
+					'post_status' => 'all',
+					'fields'      => 'ids',
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
 
 		// Check no warnings were triggered.
 		$this->assertEmpty(
@@ -508,19 +510,21 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 			}
 		);
 
-		$query = new WP_Query(
-			array(
-				'post_type'      => 'shop_order',
-				'post_status'    => 'all',
-				'fields'         => 'ids',
-				'posts_per_page' => -1,
-				'm'              => array( '20230720' ),
-			)
-		);
+		try {
+			$query = new WP_Query(
+				array(
+					'post_type'      => 'shop_order',
+					'post_status'    => 'all',
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+					'm'              => array( '20230720' ),
+				)
+			);
 
-		$results = $query->get_posts();
-
-		restore_error_handler();
+			$results = $query->get_posts();
+		} finally {
+			restore_error_handler();
+		}
 
 		$this->assertSame( array(), $errors, 'An array "m" parameter should not raise an "Array to string conversion" warning.' );
 		$this->assertEmpty( $query->query_vars['meta_key'], 'An unusable "m" parameter should not build a date meta query.' );

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -435,14 +435,21 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$order->set_date_paid( ( new DateTime( '2022-09-12 00:30:00', wp_timezone() ) )->getTimestamp() );
 		$order->save();
 
-		$results = $this->query_order_ids_with_date_filter(
+		$previous_day_results = $this->query_order_ids_with_date_filter(
 			array(
 				'order_date_type' => 'date_paid',
 				'm'               => '20220911',
 			)
 		);
+		$own_day_results      = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20220912',
+			)
+		);
 
-		$this->assertNotContains( $order->get_id(), $results, 'An order paid after midnight the following day should not also be listed under the previous day.' );
+		$this->assertNotContains( $order->get_id(), $previous_day_results, 'An order paid after midnight the following day should not also be listed under the previous day.' );
+		$this->assertContains( $order->get_id(), $own_day_results, 'The order should be listed under the day it was actually paid.' );
 
 		update_option( 'timezone_string', '' );
 		wp_delete_post( $order->get_id(), true );

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -379,6 +379,28 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should compare paid and completed timestamps numerically.
+	 */
+	public function test_date_filters_compare_timestamps_numerically(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$timestamp = ( new DateTime( '2001-09-08 21:00:00', wp_timezone() ) )->getTimestamp();
+		$order     = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( $timestamp );
+		$order->set_date_completed( $timestamp );
+		$order->save();
+
+		foreach ( array( 'date_paid', 'date_completed' ) as $date_type ) {
+			$results = $this->query_order_ids_with_date_filter( $date_type, '20010908' );
+			$this->assertContains( $order->get_id(), $results, "{$date_type} should match across the Unix timestamp digit boundary." );
+		}
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
 	 * @testdox Should cover the whole local day when DST ends at midnight and the day lasts 25 hours.
 	 */
 	public function test_date_paid_filter_covers_dst_extended_day(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -456,6 +456,37 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should treat the next local midnight as the exclusive end of the day.
+	 */
+	public function test_date_paid_filter_excludes_the_next_midnight_instant(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( '2026-07-21 00:00:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$filtered_day_results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20260720',
+			)
+		);
+		$own_day_results      = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20260721',
+			)
+		);
+
+		$this->assertNotContains( $order->get_id(), $filtered_day_results, 'An order paid exactly at midnight belongs to the day starting then, not the one ending then.' );
+		$this->assertContains( $order->get_id(), $own_day_results, 'An order paid exactly at midnight should be listed under the day that starts at that instant.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
 	 * Test that the search without post_type in query does not trigger warnings.
 	 * This is a regression test for https://github.com/woocommerce/woocommerce/pull/55353.
 	 */

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -288,16 +288,16 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Runs the order list table query as if the given $_GET params were set on edit.php.
+	 * Runs an order list table date query.
 	 *
-	 * @param array $get_params Params to expose via $_GET (order_date_type, m).
+	 * @param string $date_type Order date field to filter.
+	 * @param string $date      Date in Ymd format.
 	 * @return int[] Matching order IDs.
 	 */
-	private function query_order_ids_with_date_filter( array $get_params ): array {
-		foreach ( $get_params as $key => $value ) {
-			$_GET[ $key ] = $value;
-		}
-		$GLOBALS['pagenow'] = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	private function query_order_ids_with_date_filter( string $date_type, string $date ): array {
+		$_GET['order_date_type'] = $date_type;
+		$_GET['m']               = $date;
+		$GLOBALS['pagenow']      = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		new WC_Admin_List_Table_Orders();
 		$query = new WP_Query(
@@ -305,16 +305,13 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 				'post_type'   => 'shop_order',
 				'post_status' => 'all',
 				'fields'      => 'ids',
-				'm'           => $get_params['m'] ?? '',
+				'm'           => $date,
 			)
 		);
 
 		$results = $query->get_posts();
 
-		foreach ( array_keys( $get_params ) as $key ) {
-			unset( $_GET[ $key ] );
-		}
-		unset( $GLOBALS['pagenow'] );
+		unset( $_GET['order_date_type'], $_GET['m'], $GLOBALS['pagenow'] );
 
 		return $results;
 	}
@@ -329,12 +326,7 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
 		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
 
-		$results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20230720',
-			)
-		);
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20230720' );
 
 		$this->assertContains( $morning_order->get_id(), $results, 'Order paid in the morning (store time) should be listed for its local day.' );
 		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (store time) should be listed for its local day even though it falls on the next day in UTC.' );
@@ -356,12 +348,7 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
 		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
 
-		$results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20230720',
-			)
-		);
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20230720' );
 
 		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (offset local time) should be listed for its local day.' );
 		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order paid the previous local day should not be listed.' );
@@ -383,12 +370,7 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$order->set_date_completed( ( new DateTime( '2023-07-20 21:00:00', wp_timezone() ) )->getTimestamp() );
 		$order->save();
 
-		$results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_completed',
-				'm'               => '20230720',
-			)
-		);
+		$results = $this->query_order_ids_with_date_filter( 'date_completed', '20230720' );
 
 		$this->assertContains( $order->get_id(), $results, 'Order completed late evening (store time) should be listed for its local day.' );
 
@@ -410,12 +392,7 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$order->set_date_paid( $next_midnight->getTimestamp() - 1800 );
 		$order->save();
 
-		$results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20220402',
-			)
-		);
+		$results = $this->query_order_ids_with_date_filter( 'date_paid', '20220402' );
 
 		$this->assertContains( $order->get_id(), $results, 'An order paid during the repeated final hour of a 25-hour local day should still be listed for that day.' );
 
@@ -435,18 +412,8 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$order->set_date_paid( ( new DateTime( '2022-09-12 00:30:00', wp_timezone() ) )->getTimestamp() );
 		$order->save();
 
-		$previous_day_results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20220911',
-			)
-		);
-		$own_day_results      = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20220912',
-			)
-		);
+		$previous_day_results = $this->query_order_ids_with_date_filter( 'date_paid', '20220911' );
+		$own_day_results      = $this->query_order_ids_with_date_filter( 'date_paid', '20220912' );
 
 		$this->assertNotContains( $order->get_id(), $previous_day_results, 'An order paid after midnight the following day should not also be listed under the previous day.' );
 		$this->assertContains( $order->get_id(), $own_day_results, 'The order should be listed under the day it was actually paid.' );
@@ -466,18 +433,8 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 		$order->set_date_paid( ( new DateTime( '2026-07-21 00:00:00', wp_timezone() ) )->getTimestamp() );
 		$order->save();
 
-		$filtered_day_results = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20260720',
-			)
-		);
-		$own_day_results      = $this->query_order_ids_with_date_filter(
-			array(
-				'order_date_type' => 'date_paid',
-				'm'               => '20260721',
-			)
-		);
+		$filtered_day_results = $this->query_order_ids_with_date_filter( 'date_paid', '20260720' );
+		$own_day_results      = $this->query_order_ids_with_date_filter( 'date_paid', '20260721' );
 
 		$this->assertNotContains( $order->get_id(), $filtered_day_results, 'An order paid exactly at midnight belongs to the day starting then, not the one ending then.' );
 		$this->assertContains( $order->get_id(), $own_day_results, 'An order paid exactly at midnight should be listed under the day that starts at that instant.' );

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -273,6 +273,151 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Creates a paid order with date_paid set from a local-time string.
+	 *
+	 * @param string $local_datetime Local date/time string, e.g. '2023-07-20 21:00:00'.
+	 * @return WC_Order
+	 */
+	private function create_order_paid_at( string $local_datetime ): WC_Order {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( $local_datetime, wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Runs the order list table query as if the given $_GET params were set on edit.php.
+	 *
+	 * @param array $get_params Params to expose via $_GET (order_date_type, m).
+	 * @return int[] Matching order IDs.
+	 */
+	private function query_order_ids_with_date_filter( array $get_params ): array {
+		foreach ( $get_params as $key => $value ) {
+			$_GET[ $key ] = $value;
+		}
+		$GLOBALS['pagenow'] = 'edit.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		new WC_Admin_List_Table_Orders();
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'shop_order',
+				'post_status' => 'all',
+				'fields'      => 'ids',
+				'm'           => $get_params['m'] ?? '',
+			)
+		);
+
+		$results = $query->get_posts();
+
+		foreach ( array_keys( $get_params ) as $key ) {
+			unset( $_GET[ $key ] );
+		}
+		unset( $GLOBALS['pagenow'] );
+
+		return $results;
+	}
+
+	/**
+	 * @testdox Should interpret the date_paid day filter in the store timezone, not UTC.
+	 */
+	public function test_date_paid_filter_uses_store_timezone(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$morning_order      = $this->create_order_paid_at( '2023-07-20 09:00:00' );
+		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
+		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
+
+		$results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20230720',
+			)
+		);
+
+		$this->assertContains( $morning_order->get_id(), $results, 'Order paid in the morning (store time) should be listed for its local day.' );
+		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (store time) should be listed for its local day even though it falls on the next day in UTC.' );
+		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order paid the previous local day should not be listed even though it falls on the filtered day in UTC.' );
+
+		update_option( 'timezone_string', '' );
+		foreach ( array( $morning_order, $evening_order, $previous_day_order ) as $order ) {
+			wp_delete_post( $order->get_id(), true );
+		}
+	}
+
+	/**
+	 * @testdox Should respect a manual UTC offset (empty timezone_string) when filtering by date_paid.
+	 */
+	public function test_date_paid_filter_uses_store_timezone_with_manual_utc_offset(): void {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$evening_order      = $this->create_order_paid_at( '2023-07-20 21:00:00' );
+		$previous_day_order = $this->create_order_paid_at( '2023-07-19 21:00:00' );
+
+		$results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20230720',
+			)
+		);
+
+		$this->assertContains( $evening_order->get_id(), $results, 'Order paid late evening (offset local time) should be listed for its local day.' );
+		$this->assertNotContains( $previous_day_order->get_id(), $results, 'Order paid the previous local day should not be listed.' );
+
+		update_option( 'gmt_offset', 0 );
+		foreach ( array( $evening_order, $previous_day_order ) as $order ) {
+			wp_delete_post( $order->get_id(), true );
+		}
+	}
+
+	/**
+	 * @testdox Should filter date_completed day ranges in the store timezone as well.
+	 */
+	public function test_date_completed_filter_uses_store_timezone(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_completed( ( new DateTime( '2023-07-20 21:00:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_completed',
+				'm'               => '20230720',
+			)
+		);
+
+		$this->assertContains( $order->get_id(), $results, 'Order completed late evening (store time) should be listed for its local day.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * @testdox Should fall back to native month filtering when the day value cannot be parsed, instead of dropping the date filter.
+	 */
+	public function test_date_paid_filter_falls_back_to_native_month_filter_for_malformed_day(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( time() );
+		$order->save();
+
+		$results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '202307',
+			)
+		);
+
+		$this->assertNotContains( $order->get_id(), $results, 'An order created now should not be listed when filtering for July 2023, even if the day-precision value cannot be parsed.' );
+
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
 	 * Test that the search without post_type in query does not trigger warnings.
 	 * This is a regression test for https://github.com/woocommerce/woocommerce/pull/55353.
 	 */

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -424,6 +424,31 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not spill into the next day when DST starts at midnight and the day has no 00:00.
+	 */
+	public function test_date_paid_filter_does_not_overlap_dst_shortened_day(): void {
+		// Chile starts DST at midnight, so 2022-09-11 has no 00:00 hour and begins at 01:00.
+		update_option( 'timezone_string', 'America/Santiago' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'completed' );
+		$order->set_date_paid( ( new DateTime( '2022-09-12 00:30:00', wp_timezone() ) )->getTimestamp() );
+		$order->save();
+
+		$results = $this->query_order_ids_with_date_filter(
+			array(
+				'order_date_type' => 'date_paid',
+				'm'               => '20220911',
+			)
+		);
+
+		$this->assertNotContains( $order->get_id(), $results, 'An order paid after midnight the following day should not also be listed under the previous day.' );
+
+		update_option( 'timezone_string', '' );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
 	 * Test that the search without post_type in query does not trigger warnings.
 	 * This is a regression test for https://github.com/woocommerce/woocommerce/pull/55353.
 	 */

--- a/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/list-tables/class-wc-admin-list-table-orders-test.php
@@ -397,23 +397,29 @@ class WC_Admin_List_Table_Orders_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fall back to native month filtering when the day value cannot be parsed, instead of dropping the date filter.
+	 * @testdox Should cover the whole local day when DST ends at midnight and the day lasts 25 hours.
 	 */
-	public function test_date_paid_filter_falls_back_to_native_month_filter_for_malformed_day(): void {
+	public function test_date_paid_filter_covers_dst_extended_day(): void {
+		// Chile ends DST at midnight, so 2022-04-02 lasts 25 hours and repeats its 23:00 hour.
+		update_option( 'timezone_string', 'America/Santiago' );
+
+		$next_midnight = ( new DateTime( '2022-04-02 00:00:00', wp_timezone() ) )->modify( '+1 day' );
+
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'completed' );
-		$order->set_date_paid( time() );
+		$order->set_date_paid( $next_midnight->getTimestamp() - 1800 );
 		$order->save();
 
 		$results = $this->query_order_ids_with_date_filter(
 			array(
 				'order_date_type' => 'date_paid',
-				'm'               => '202307',
+				'm'               => '20220402',
 			)
 		);
 
-		$this->assertNotContains( $order->get_id(), $results, 'An order created now should not be listed when filtering for July 2023, even if the day-precision value cannot be parsed.' );
+		$this->assertContains( $order->get_id(), $results, 'An order paid during the repeated final hour of a 25-hour local day should still be listed for that day.' );
 
+		update_option( 'timezone_string', '' );
 		wp_delete_post( $order->get_id(), true );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Analytics > Revenue orders link filters by `order_date_type=date_paid&m=YYYYMMDD`, but those day bounds were built without a timezone, so they anchored on UTC midnight while `_date_paid` holds UTC timestamps for a day the merchant expressed in store time. On a UTC-4 store, asking for July 25 returned orders paid from 8pm on July 24. Both bounds now derive from a `wp_timezone()`-aware `DateTime`, the upper one from the next local midnight rather than a parsed `23:59:59`, which resolves to the first occurrence and so cuts a 25-hour day short.

Two deliberate choices: `wp_timezone()` over `new DateTimeZone( get_option( 'timezone_string' ) )`, which throws on manual-offset stores, and `modify( 'tomorrow' )` over `modify( '+1 day' )`, which carries the start time over and would break Africa/Cairo yearly.

No database changes, but the `parse_query` `meta_value` bounds shift by the store's UTC offset, so anything on `parse_query`, `pre_get_posts` or `posts_clauses` reads different numbers for the same URL. Same key, same shape, same `BETWEEN`; on UTC stores the bounds are byte-identical to 11.0.1. Legacy screen only. HPOS got this filter in #67625 (closing #41318) and resolves the day locally too, so the two agree except on DST days, where it ends at `+ DAY_IN_SECONDS` rather than the next local midnight. `wc_get_orders()` and REST still bucket by UTC day; untouched here.

Closes #39462.

(For Bug Fixes) Bug introduced in PR #38428.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Keep HPOS disabled, this is the legacy orders screen.

1. Set Settings > General > Timezone to `New York`.
2. Create completed orders paid at 9am and 9pm local on the same day:
   ```
   wp eval 'foreach ( array( "09:00:00", "21:00:00" ) as $time ) { $o = wc_create_order(); $o->set_status( "completed" ); $o->set_date_paid( ( new DateTime( "2026-07-20 $time", wp_timezone() ) )->getTimestamp() ); $o->save(); echo $o->get_id() . PHP_EOL; }'
   ```
3. Open `/wp-admin/edit.php?post_type=shop_order&order_date_type=date_paid&m=20260720`. Both orders list. On trunk the 9pm one is missing and appears under `m=20260721` instead.
4. DST: set the timezone to `Santiago` and create an order paid `2022-04-02 23:30` local. `m=20220402` lists it and `m=20220403` does not. On trunk it appears under `m=20220403` instead.
5. Set the timezone to `UTC` and confirm results are unchanged from trunk.

`pnpm --filter='@woocommerce/plugin-woocommerce' test:php:env -- --filter WC_Admin_List_Table_Orders_Test`

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Verified in wp-env (WP 7.0.2, PHP 8.1, legacy order storage) on the rendered Orders screen, not only through WP-CLI.

Seven tests, each failing when the change it guards is reverted: five against trunk's UTC bounds, one on `modify( '+1 day' )`, one on dropping the `- 1`.

The bounds were also compared against an oracle that finds a local day's first instant by binary search instead of `DateTime::modify()`, across every timezone at every DST transition. Over 120,672 zone and date pairs this change beats trunk in 113,917, matches it in 6,755, and is worse in none.

Known limitation, noted in the code: where a zone moved its clocks back onto midnight, 00:00 is ambiguous and the range is still an hour short. Every such transition in the current tz database is from 2021 or earlier.

Not covered: multisite, and `_date_paid` values that aren't ten digits (pre-2001-09-09, negatives, millisecond-scale), which a string compare misorders. No WooCommerce order can hold one, so `meta_type = NUMERIC` was left out rather than change the SQL for nothing.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>




