### PR TITLE
Add compatibility stubs for two removed REST controllers to prevent 10.9.x to 11.0 upgrade fatals

### DIFF
--- a/plugins/woocommerce/changelog/fix-layout-templates-upgrade-stub
+++ b/plugins/woocommerce/changelog/fix-layout-templates-upgrade-stub
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add a no-op WC_REST_Layout_Templates_Controller stub so an in-place update from 10.9.x does not fatal when the 10.9 controller list instantiates a class whose file has already been swapped away.
+Add no-op WC_REST_Layout_Templates_Controller and WC_REST_Products_Catalog_Controller stubs so an in-place update from 10.9.x does not fatal when the 10.9 controller list instantiates a class whose file has already been swapped away.

--- a/plugins/woocommerce/changelog/fix-layout-templates-upgrade-stub
+++ b/plugins/woocommerce/changelog/fix-layout-templates-upgrade-stub
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a no-op WC_REST_Layout_Templates_Controller stub so an in-place update from 10.9.x does not fatal when the 10.9 controller list instantiates a class whose file has already been swapped away.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * REST API Layout Templates controller (compatibility stub).
+ *
+ * @package WooCommerce\RestApi
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Layout Templates controller class.
+ *
+ * The real controller was removed in 11.0 with the deprecated product block editor. This empty
+ * stub stays so an in-memory 10.9 controller list, still naming this class while the files are
+ * swapped to 11.0 during an update, can instantiate it instead of fataling on the deleted file.
+ * It registers nothing.
+ *
+ * @deprecated 11.0.0
+ */
+class WC_REST_Layout_Templates_Controller {
+
+	/**
+	 * Register routes. Intentionally a no-op.
+	 */
+	public function register_routes() {}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\RestApi
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -22,5 +24,5 @@ class WC_REST_Layout_Templates_Controller {
 	/**
 	 * Register routes. Intentionally a no-op.
 	 */
-	public function register_routes() {}
+	public function register_routes(): void {}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\RestApi
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,5 +28,5 @@ class WC_REST_Products_Catalog_Controller {
 	/**
 	 * Register routes. Intentionally a no-op.
 	 */
-	public function register_routes() {}
+	public function register_routes(): void {}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-catalog-controller.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * REST API Products Catalog controller (compatibility stub).
+ *
+ * @package WooCommerce\RestApi
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Products Catalog controller class.
+ *
+ * The real controller was removed in 11.0. This empty stub stays so an in-memory 10.9 controller
+ * list, still naming this class while the files are swapped to 11.0 during an update, can
+ * instantiate it instead of fataling on the deleted file. It registers nothing.
+ *
+ * 10.9 only added this entry when the `products-catalog-api` feature was enabled, which is off by
+ * default — but the flag is flippable at runtime (WooCommerce Beta Tester, or any plugin filtering
+ * `woocommerce_admin_get_feature_config`), and the feature config is resolved from the pre-swap
+ * code, so trunk dropping the flag does not close the path.
+ *
+ * @deprecated 11.0.0
+ */
+class WC_REST_Products_Catalog_Controller {
+
+	/**
+	 * Register routes. Intentionally a no-op.
+	 */
+	public function register_routes() {}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Restores two removed REST controllers as no-op compatibility stubs so an in-place update from 10.9.x to 11.0 doesn't fatal on the update screen.

- `WC_REST_Layout_Templates_Controller` — reproduced live, see below
- `WC_REST_Products_Catalog_Controller` — same mechanism, found by a follow-up sweep, feature-gated

The real controller was deleted in PR 65500 when the deprecated product block editor was removed. 10.9.4 still ships it and registers it unconditionally in `includes/rest-api/Server.php`. During an in-place update WordPress swaps the files while 10.9's code is still resident, `admin-footer.php` triggers the wc-admin shared-settings REST preload, `rest_api_init` fires, and `Server::register_rest_routes()` instantiates a class whose file has already gone. The bundled jetpack-autoloader hard-`require`s the missing path and the request dies.

Nothing in 11.0 registers or uses this class. The stub exists solely so a 10.9 controller list surviving in memory across the file swap has something to instantiate. It registers no routes and deliberately extends nothing, keeping the swap-time surface as small as possible.

Same shape as the fix in PR 66081 / PR 66214 for `Admin\API\Settings`, which was the identical failure mode one release earlier.

### The second stub

A sweep of every PHP file 10.9.4 ships that trunk does not — 37 files, 23 class definitions — turned up one more class on the same path. `WC_REST_Products_Catalog_Controller` is registered in the same `get_v3_controllers()` array at `Server.php:222-223`, behind a feature gate:

```php
if ( Features::is_enabled( 'products-catalog-api' ) ) {
	$controllers['products-catalog'] = 'WC_REST_Products_Catalog_Controller';
}
```

`products-catalog-api` is `false` in the shipped `core.json`, so it's off on a stock install. Two reasons it still warrants a stub:

1. **Trunk dropping the flag doesn't help.** `wc_admin_get_feature_config()` is a plain function loaded pre-swap and pinned in PHP's function table for the rest of the request, so the post-swap call still returns 10.9's array.
2. **The flag is flippable at runtime.** WooCommerce Beta Tester filters `woocommerce_admin_get_feature_config` from the `wc_admin_helper_feature_values` option, as does any plugin hooking `woocommerce_admin_features`. And `development.json` has it `true`.

The exposed population is small but poorly chosen: Beta Tester users are disproportionately the people who install an RC over 10.9.x. The stub costs one file.

I have **not** reproduced this second one live — I verified the registration, the deletion, and the gate statically, and identified the configurations that open it. Given a stub is nearly free and a second upgrade fatal in the same RC is not, adding it seemed clearly right rather than reasoning my way to "probably fine."

Fixes #67135.

Bug introduced in PR #65500.

### Screenshots or screen recordings:

Not applicable — no UI change. The observable difference is the absence of a critical-error notice on the update screen.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a clean WordPress install, install WooCommerce **10.9.4** and activate it.
2. Set `WP_DEBUG` and `WP_DEBUG_LOG` to `true`, and `WP_DEBUG_DISPLAY` to `false`.
3. Update in place to a build of this branch through **`/wp-admin/update.php`** — the admin web path specifically. WP-CLI does not exercise the affected code path and will pass either way.
4. Confirm the update screen completes normally with no "There has been a critical error on this website" notice.
5. Confirm `wp-content/debug.log` contains no `PHP Fatal error: Uncaught Error: Failed opening required ... class-wc-rest-layout-templates-controller.php`.
6. Confirm WooCommerce is active afterwards and reports the new version.
7. Sanity check that `/wp-json/wc/v3/layout-templates` is absent on 11.0, as expected — the stub registers nothing.

<!-- End testing instructions -->

### Testing that has already taken place:

Reproduced the original fatal on a disposable Jurassic Ninja site: WordPress 7.0.2, PHP 8.4.23, `FS_METHOD=direct`, no `DISALLOW_FILE_MODS`. Installed WooCommerce 10.9.4, confirmed the controller file and its `Server.php` registration were present on disk, then drove an in-place update to the 11.0.0-rc.2 release zip over `/wp-admin/update.php`.

Result: HTTP 200 with a half-rendered update page ending in the critical-error notice, and this in `debug.log`:

```
PHP Fatal error:  Uncaught Error: Failed opening required
'.../includes/rest-api/Controllers/Version3/class-wc-rest-layout-templates-controller.php'
in .../vendor/jetpack-autoloader/class-php-autoloader.php:102
#1 woocommerce/src/Proxies/LegacyProxy.php(53): method_exists('WC_REST_Layout_...', 'instance')
#2 woocommerce/includes/rest-api/Server.php(64): LegacyProxy->get_instance_of('WC_REST_Layout_...')
#9 [internal function]: rest_preload_api_request(Array, '/jetpack/v4/con...')
#20 wp-admin/update.php(76): require_once('.../admin-footer.php')
```

An `error_log()` probe on `rest_api_init` captured the split state directly: `wc_ver=10.9.4` resident in memory, `controller_file_exists=no` on disk.

Reproduced 3 out of 3 times, and confirmed **not** Jetpack-dependent — it fatals with Jetpack active, deactivated, and deleted entirely. With Jetpack absent, WooCommerce's own bundled jetpack-autoloader throws. The same upgrade over WP-CLI produced zero fatals, as expected.

Not yet re-tested against a build of this branch; that's step 3 above and is the thing a reviewer should confirm.

### Milestone

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Milestone set manually to 11.0.0 — this needs to ride the 11.0 release, not the next one.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry added manually: `plugins/woocommerce/changelog/fix-layout-templates-upgrade-stub`.

### A note for whoever touches this area next

The sweep surfaced a tripwire worth recording. `src/LayoutTemplates/LayoutTemplateRegistry.php` on trunk is a no-op compatibility shim, and it is load-bearing. 10.9's `ProductBlockEditor\Init` registers a `rest_api_init` callback that calls `LayoutTemplateRegistry::register()` with `SimpleProductTemplate::class` — and because `Features::load_features` runs at `init` priority 4 while `WC::load_rest_api` runs at priority 10, that callback fires *before* `Server::register_rest_routes()`. If the shim's `register()` ever regains a `class_exists()` or `is_subclass_of()` call, or if the shim is garbage-collected as dead code, stores with the new product editor enabled will fatal one step earlier than the bug this PR fixes — and these stubs won't save them.
