### PR TITLE
Update the documentation for conditional functions

### DIFF
--- a/docs/theming/theme-development/conditional-tags.md
+++ b/docs/theming/theme-development/conditional-tags.md
@@ -12,7 +12,7 @@ The conditional tags of WooCommerce and WordPress can be used in your template f
 
 Because WooCommerce uses custom post types, you can also use many of WordPress' conditional tags. See [codex.wordpress.org/Conditional_Tags](https://codex.wordpress.org/Conditional_Tags) for a list of the tags included with WordPress.
 
-**Note**: You can only use conditional query tags after the `posts_selection` [action hook](https://codex.wordpress.org/Plugin_API/Action_Reference#Actions_Run_During_a_Typical_Request) in WordPress (the `wp` action hook is the first one through which you can use these conditionals). For themes, this means the conditional tag will never work properly if you are using it in the body of functions.php.
+**Note**: You can only use conditional query tags after the `posts_selection` [action hook](https://codex.wordpress.org/Plugin_API/Action_Reference#Actions_Run_During_a_Typical_Request) in WordPress (the `wp` action hook is the first one through which you can use these conditionals). For themes, this means the conditional tag will never work properly if you are using it in the body of functions.php. If a conditional tag is used before it's supposed to, it won't trigger any error or warning: it will simply return `false`, even if the condition it checks for would be met later in the request.
 
 ## Available conditional tags
 

--- a/plugins/woocommerce/changelog/update-docs-for-conditional-functions
+++ b/plugins/woocommerce/changelog/update-docs-for-conditional-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document that conditional functions simply return false when used before the main query is set up.

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -4,6 +4,11 @@
  *
  * Functions for determining the current query/page.
  *
+ * Note that these functions are only reliable once the main query has been set up,
+ * that is, on or after the "wp" action hook. If used before that, they won't trigger
+ * any error or warning: they will simply return false, even if the condition
+ * they check for would be met later in the request.
+ *
  * @package     WooCommerce\Functions
  * @version     2.3.0
  */

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -4,10 +4,10 @@
  *
  * Functions for determining the current query/page.
  *
- * Note that these functions are only reliable once the main query has been set up,
- * that is, on or after the "wp" action hook. If used before that, they won't trigger
- * any error or warning: they will simply return false, even if the condition
- * they check for would be met later in the request.
+ * Note that the query-dependent conditional functions are only reliable
+ * once the main query has been set up, that is, on or after the "wp" action hook.
+ * If used before that, they won't trigger any error or warning: they will simply
+ * return false, even if the condition they check for would be met later in the request.
  *
  * @package     WooCommerce\Functions
  * @version     2.3.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR documents the behavior of the WooCommerce conditional functions (`is_shop()`, `is_cart()`, `is_checkout()`, etc.) when they are used too early in the request lifecycle: they don't trigger any error or warning, they simply return `false`, even if the condition they check for would be met later in the request.

Two places are updated:

-   `docs/theming/theme-development/conditional-tags.md`: the existing note about conditional tags only working on or after the `wp` action hook is extended with the return-`false` behavior.
-   `plugins/woocommerce/includes/wc-conditional-functions.php`: the same note is added to the file header docblock (comment-only change, no behavior change).

This is an alternative to #53257, which proposed emitting `wc_doing_it_wrong()` when conditional functions are called before the `wp` action. That is in principle a sensible approach but it has a problem: the notices would fire during normal WooCommerce operation. For example, `MiniCart.php` calls `is_cart() || is_checkout()` in several places and renders via the block-renderer REST endpoint in the site editor, and `wc_doing_it_wrong()` calls `error_log()` unconditionally in REST/AJAX contexts (there is no debug gate), so every site editor session rendering the Mini Cart would write to the error log on production sites. Documenting the actual behavior avoids that while still giving developers the information they need.

Related: #53256.

### How to test the changes in this Pull Request:

Review the documentation changes for accuracy.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

Changelog entry created manually: `plugins/woocommerce/changelog/update-docs-for-conditional-functions` (significance: patch, type: dev).

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
