### PR TITLE
[Backport to release/11.0] Test-only Blocks e2e performance fixes (reduce shard runtime under the PR 20-minute cap)

### DIFF
--- a/plugins/woocommerce/changelog/perf-e2e-combined-db-restore
+++ b/plugins/woocommerce/changelog/perf-e2e-combined-db-restore
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Reduce Blocks E2E per-test database restoration overhead by running reset and snapshot import in one wp-env container invocation.

--- a/plugins/woocommerce/changelog/perf-e2e-combined-db-restore
+++ b/plugins/woocommerce/changelog/perf-e2e-combined-db-restore
@@ -1,4 +1,3 @@
 Significance: patch
 Type: performance
-
-Reduce Blocks E2E per-test database restoration overhead by running reset and snapshot import in one wp-env container invocation.
+Comment: Backport of test-only e2e perf change; entry suppressed for 11.0.0 notes (CI/test zone, no shipped code).

--- a/plugins/woocommerce/changelog/perf-e2e-direct-container-db-restore
+++ b/plugins/woocommerce/changelog/perf-e2e-direct-container-db-restore
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Resolve the Blocks E2E CLI container once per worker so per-test database restores can bypass repeated npm and wp-env startup.

--- a/plugins/woocommerce/changelog/perf-e2e-direct-container-db-restore
+++ b/plugins/woocommerce/changelog/perf-e2e-direct-container-db-restore
@@ -1,4 +1,3 @@
 Significance: patch
 Type: performance
-
-Resolve the Blocks E2E CLI container once per worker so per-test database restores can bypass repeated npm and wp-env startup.
+Comment: Backport of test-only e2e perf change; entry suppressed for 11.0.0 notes (CI/test zone, no shipped code).

--- a/plugins/woocommerce/changelog/testops-234-remove-redundant-blocks-e2e-tests
+++ b/plugins/woocommerce/changelog/testops-234-remove-redundant-blocks-e2e-tests
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Remove 4 redundant blocks E2E tests already covered by unit/component/PHPUnit tests.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -64,7 +64,7 @@
 		"test:e2e:core-parallel": "pnpm test:e2e:default --project=core-parallel",
 		"test:e2e:default": "pnpm test:e2e:install && pnpm test:e2e:with-env default",
 		"test:e2e:install": "pnpm playwright install chromium",
-		"test:e2e:blocks": "pnpm playwright test --config=tests/e2e/playwright.config.ts --project=blocks-chromium",
+		"test:e2e:blocks": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/e2e/utils/blocks/*.test.mjs && pnpm playwright test --config=tests/e2e/playwright.config.ts --project=blocks-chromium",
 		"test:e2e:blocks:performance": "pnpm playwright test --config=tests/e2e/playwright.performance.config.ts --project=blocks-performance",
 		"test:e2e:email-update-propagation:pr": "pnpm test:e2e:default --project=core-serial --project=core-parallel --grep @pr tests/email-editor/update-propagation",
 		"test:e2e:email-update-propagation:nightly": "pnpm test:e2e:default --project=core-serial --project=core-parallel tests/email-editor/update-propagation",

--- a/plugins/woocommerce/tests/e2e/tests/blocks/breadcrumbs/breadcrumbs.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/breadcrumbs/breadcrumbs.block_theme.spec.ts
@@ -9,23 +9,6 @@ const blockData = {
 };
 
 test.describe( `${ blockData.slug } Block`, () => {
-	test( "block can't be inserted in Post Editor", async ( {
-		admin,
-		editor,
-	} ) => {
-		await admin.createNewPost();
-
-		try {
-			await editor.insertBlock( { name: blockData.slug } );
-		} catch ( _error ) {
-			// noop
-		}
-
-		await expect(
-			await editor.getBlockByName( blockData.slug )
-		).toBeHidden();
-	} );
-
 	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/cart-store/mutation-batcher.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/cart-store/mutation-batcher.block_theme.spec.ts
@@ -25,38 +25,6 @@ test.describe( 'Mutation Batcher', () => {
 		await frontendUtils.goToShop();
 	} );
 
-	test( 'synchronous calls are batched into a single request', async ( {
-		page,
-	} ) => {
-		const batchRequests: number[] = [];
-
-		await page.route( '**/wc/store/v1/batch**', async ( route ) => {
-			const body = route.request().postDataJSON();
-			batchRequests.push( body?.requests?.length || 0 );
-			await route.continue();
-		} );
-
-		await page.evaluate( async () => {
-			const { store } = await import( '@wordpress/interactivity' );
-			const unlockKey =
-				'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
-
-			await import( '@woocommerce/stores/woocommerce/cart' );
-			const { actions } = store( 'woocommerce', {}, { lock: unlockKey } );
-
-			// Three calls with no await between them — same microtick.
-			const p1 = actions.addCartItem( { id: 15, quantityToAdd: 1 } );
-			const p2 = actions.addCartItem( { id: 16, quantityToAdd: 1 } );
-			const p3 = actions.addCartItem( { id: 17, quantityToAdd: 1 } );
-
-			await Promise.all( [ p1, p2, p3 ] );
-		} );
-
-		// All 3 operations should have been sent in a single batch request.
-		expect( batchRequests ).toHaveLength( 1 );
-		expect( batchRequests[ 0 ] ).toBe( 3 );
-	} );
-
 	test( 'awaited calls produce separate batch requests', async ( {
 		page,
 	} ) => {
@@ -220,60 +188,5 @@ test.describe( 'Mutation Batcher', () => {
 		// After the delayed failure response, the batcher rolls back
 		// to the snapshot taken before any optimistic mutations.
 		await expect( button ).toHaveText( '1 in cart' );
-	} );
-
-	test( 'partial failure in a batch does not prevent successful operations', async ( {
-		page,
-	} ) => {
-		const batchRequests: number[] = [];
-
-		await page.route( '**/wc/store/v1/batch**', async ( route ) => {
-			const body = route.request().postDataJSON();
-			batchRequests.push( body?.requests?.length || 0 );
-			await route.continue();
-		} );
-
-		const result = await page.evaluate( async () => {
-			const { store } = await import( '@wordpress/interactivity' );
-			const unlockKey =
-				'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
-
-			await import( '@woocommerce/stores/woocommerce/cart' );
-			const { actions, state } = store(
-				'woocommerce',
-				{},
-				{ lock: unlockKey }
-			);
-
-			// Refresh to get clean state.
-			await actions.refreshCartItems();
-
-			// Mix valid and invalid product IDs — all in one microtick.
-			const p1 = actions.addCartItem( { id: 15, quantityToAdd: 1 } );
-			const p2 = actions.addCartItem( { id: 999999, quantityToAdd: 1 } ); // Invalid
-			const p3 = actions.addCartItem( { id: 16, quantityToAdd: 1 } );
-
-			// addCartItem catches errors internally so all promises resolve.
-			await Promise.allSettled( [ p1, p2, p3 ] );
-
-			const cartProductIds = state.cart.items.map(
-				( item: { id: number } ) => item.id
-			);
-
-			return {
-				has15: cartProductIds.includes( 15 ),
-				has999999: cartProductIds.includes( 999999 ),
-				has16: cartProductIds.includes( 16 ),
-			};
-		} );
-
-		// Valid products should be in cart, invalid should not.
-		expect( result.has15 ).toBe( true );
-		expect( result.has999999 ).toBe( false );
-		expect( result.has16 ).toBe( true );
-
-		// Should still have been sent as a single batch.
-		expect( batchRequests ).toHaveLength( 1 );
-		expect( batchRequests[ 0 ] ).toBe( 3 );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -293,29 +293,6 @@ test.describe( 'Shopper → Local pickup', () => {
 	} );
 } );
 
-test.describe( 'Shopper → Payment Methods', () => {
-	test( 'User can change payment methods', async ( {
-		frontendUtils,
-		page,
-	} ) => {
-		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
-		await frontendUtils.goToCheckout();
-
-		await page
-			.getByRole( 'radio', { name: 'Direct bank transfer' } )
-			.click();
-		await expect(
-			page.getByRole( 'radio', { name: 'Direct bank transfer' } )
-		).toBeChecked();
-
-		await page.getByRole( 'radio', { name: 'Cash on delivery' } ).click();
-		await expect(
-			page.getByRole( 'radio', { name: 'Cash on delivery' } )
-		).toBeChecked();
-	} );
-} );
-
 test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 	const billingTestData = {
 		firstname: 'John',

--- a/plugins/woocommerce/tests/e2e/utils/blocks/test.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/test.ts
@@ -19,6 +19,11 @@ import {
 } from '@woocommerce/e2e-utils';
 
 /**
+ * Internal dependencies
+ */
+import { restoreBlocksDatabase } from './wp-cli';
+
+/**
  * Set of console logging types observed to protect against unexpected yet
  * handled (i.e. not catastrophic) errors or warnings. Each key corresponds
  * to the Playwright ConsoleMessage type, its value the corresponding function
@@ -159,9 +164,8 @@ const test = base.extend<
 			);
 		}
 
-		await wpCLI( `db reset --yes` );
 		// Reset the database to the initial state via snapshot import.
-		await wpCLI( `db import ${ DB_EXPORT_FILE }` );
+		await restoreBlocksDatabase( DB_EXPORT_FILE );
 	},
 	pageUtils: async ( { page }, use ) => {
 		await use( new PageUtils( { page } ) );

--- a/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.test.mjs
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+/**
+ * Internal dependencies
+ */
+import { createBlocksDatabaseRestorer } from './wp-cli.ts';
+
+const CLI_CONTAINER_ID = '0123456789ab';
+
+test( 'reuses the discovered CLI container across database restores', async () => {
+	const calls = [];
+	const runCommand = async ( executable, args ) => {
+		calls.push( [ executable, args ] );
+
+		if ( executable === 'npm' ) {
+			return {
+				stdout: `npm output\n${ CLI_CONTAINER_ID }\n`,
+				stderr: '',
+			};
+		}
+
+		return { stdout: '', stderr: '' };
+	};
+	const restoreDatabase = createBlocksDatabaseRestorer( runCommand );
+
+	await restoreDatabase( '/tmp/first snapshot.sql' );
+	await restoreDatabase( '/tmp/second.sql' );
+
+	assert.deepEqual( calls, [
+		[
+			'npm',
+			[ 'run', 'wp-env:e2e', 'run', 'cli', '--', 'printenv', 'HOSTNAME' ],
+		],
+		[
+			'docker',
+			[
+				'exec',
+				'--workdir',
+				'/var/www/html',
+				CLI_CONTAINER_ID,
+				'sh',
+				'-c',
+				'wp db reset --yes && wp db import "$1"',
+				'restore-blocks-database',
+				'/tmp/first snapshot.sql',
+			],
+		],
+		[
+			'docker',
+			[
+				'exec',
+				'--workdir',
+				'/var/www/html',
+				CLI_CONTAINER_ID,
+				'sh',
+				'-c',
+				'wp db reset --yes && wp db import "$1"',
+				'restore-blocks-database',
+				'/tmp/second.sql',
+			],
+		],
+	] );
+} );
+
+test( 'fails before restoring when CLI container discovery is malformed', async () => {
+	const calls = [];
+	const runCommand = async ( executable, args ) => {
+		calls.push( [ executable, args ] );
+		return { stdout: 'npm output without a container ID\n', stderr: '' };
+	};
+	const restoreDatabase = createBlocksDatabaseRestorer( runCommand );
+
+	await assert.rejects(
+		restoreDatabase( '/tmp/snapshot.sql' ),
+		/Failed to determine the Blocks E2E CLI container ID/
+	);
+	assert.equal( calls.length, 1 );
+} );
+
+test( 'retries CLI container discovery after a failed attempt', async () => {
+	const calls = [];
+	const runCommand = async ( executable, args ) => {
+		calls.push( [ executable, args ] );
+
+		if ( executable === 'npm' ) {
+			if ( calls.length === 1 ) {
+				throw new Error( 'transient wp-env failure' );
+			}
+
+			return {
+				stdout: `npm output\n${ CLI_CONTAINER_ID }\n`,
+				stderr: '',
+			};
+		}
+
+		return { stdout: '', stderr: '' };
+	};
+	const restoreDatabase = createBlocksDatabaseRestorer( runCommand );
+
+	await assert.rejects(
+		restoreDatabase( '/tmp/snapshot.sql' ),
+		/transient wp-env failure/
+	);
+
+	await restoreDatabase( '/tmp/snapshot.sql' );
+
+	assert.deepEqual(
+		calls.map( ( [ executable ] ) => executable ),
+		[ 'npm', 'npm', 'docker' ]
+	);
+} );

--- a/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.ts
@@ -7,6 +7,20 @@ import { exec, execFile } from 'child_process';
 const execPromisified = promisify( exec );
 const execFilePromisified = promisify( execFile );
 
+type CommandResult = {
+	stdout: string;
+	stderr: string;
+};
+
+type RunCommand = (
+	executable: string,
+	args: string[]
+) => Promise< CommandResult >;
+
+async function runCommand( executable: string, args: string[] ) {
+	return await execFilePromisified( executable, args );
+}
+
 /**
  * Runs a WP-CLI command inside the tests-cli container.
  */
@@ -17,22 +31,73 @@ export async function wpCLI( command: string ) {
 }
 
 /**
- * Resets the Blocks E2E database and imports its snapshot in one CLI-container
- * invocation.
+ * Creates a database restore function that resolves the Blocks E2E CLI
+ * container once and reuses it for subsequent restores.
+ */
+export function createBlocksDatabaseRestorer( execute: RunCommand ) {
+	let cliContainerIdPromise: Promise< string > | undefined;
+
+	const getCliContainerId = async () => {
+		if ( ! cliContainerIdPromise ) {
+			cliContainerIdPromise = execute( 'npm', [
+				'run',
+				'wp-env:e2e',
+				'run',
+				'cli',
+				'--',
+				'printenv',
+				'HOSTNAME',
+			] ).then( ( { stdout, stderr } ) => {
+				// Match a 12 to 64 character hex string (Docker container ID) on its own line,
+				// optionally followed by a carriage return.
+				const cliContainerId = stdout.match(
+					/^(?<containerId>[a-f0-9]{12,64})\r?$/m
+				)?.groups?.containerId;
+
+				if ( ! cliContainerId ) {
+					throw new Error(
+						`Failed to determine the Blocks E2E CLI container ID: ${ stdout } ${ stderr }`
+					);
+				}
+
+				return cliContainerId;
+			} );
+
+			// Drop failed discoveries from the cache so the next restore
+			// retries instead of reusing the rejection forever.
+			cliContainerIdPromise.catch( () => {
+				cliContainerIdPromise = undefined;
+			} );
+		}
+
+		return await cliContainerIdPromise;
+	};
+
+	return async ( databaseFile: string ) => {
+		const cliContainerId = await getCliContainerId();
+
+		return await execute( 'docker', [
+			'exec',
+			'--workdir',
+			'/var/www/html',
+			cliContainerId,
+			'sh',
+			'-c',
+			'wp db reset --yes && wp db import "$1"',
+			'restore-blocks-database',
+			databaseFile,
+		] );
+	};
+}
+
+const restoreDatabase = createBlocksDatabaseRestorer( runCommand );
+
+/**
+ * Resets the Blocks E2E database and imports its snapshot through the existing
+ * CLI container.
  */
 export async function restoreBlocksDatabase( databaseFile: string ) {
-	return await execFilePromisified( 'npm', [
-		'run',
-		'wp-env:e2e',
-		'run',
-		'cli',
-		'--',
-		'sh',
-		'-c',
-		'wp db reset --yes && wp db import "$1"',
-		'restore-blocks-database',
-		databaseFile,
-	] );
+	return await restoreDatabase( databaseFile );
 }
 
 /**

--- a/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/wp-cli.ts
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { promisify } from 'util';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 
 const execPromisified = promisify( exec );
+const execFilePromisified = promisify( execFile );
 
 /**
  * Runs a WP-CLI command inside the tests-cli container.
@@ -13,6 +14,25 @@ export async function wpCLI( command: string ) {
 	return await execPromisified(
 		'npm run wp-env run tests-cli -- wp ' + command
 	);
+}
+
+/**
+ * Resets the Blocks E2E database and imports its snapshot in one CLI-container
+ * invocation.
+ */
+export async function restoreBlocksDatabase( databaseFile: string ) {
+	return await execFilePromisified( 'npm', [
+		'run',
+		'wp-env:e2e',
+		'run',
+		'cli',
+		'--',
+		'sh',
+		'-c',
+		'wp db reset --yes && wp db import "$1"',
+		'restore-blocks-database',
+		databaseFile,
+	] );
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

Manual backport of three **test-only** trunk PRs to `release/11.0`, cherry-picked with `-x`:

- #66671 — [e2e] Reduce Blocks E2E database restore overhead
- #66699 — [e2e] Bypass repeated wp-env startup during Blocks restores
- #66731 — e2e tests: Remove 4 redundant blocks E2E tests covered lower in the pyramid

**Why:** Blocks e2e shards on `release/11.0` PR CI have repeatedly hit the 20-minute per-step cap on cherry-pick/backport PRs (#67094, #67107, #67118, #67138 — multiple re-run attempts each during the 11.0.0 RC cycle). Trunk received these shard-runtime reductions after the branch cut; the branch never did. Backporting restores headroom so release-critical backport PRs stop timing out on degraded runner days.

**Zero shipped code:** all changed files live under `plugins/woocommerce/tests/e2e/` plus one `package.json` script line; test files are excluded from the release zip.

**Changelog:** the two body-style changefiles from the source PRs are converted to `Comment:`-header form in the final commit, so no test-infrastructure entries surface in the 11.0.0 stable changelog.

**Deliberately NOT included** (conflict with e2e infra not present on the branch; value marginal): #66859 (requires the `.wp-env.e2e.json` restructure the branch lacks) and #65555 (shared build artifact; diverged ci.yml + generated `dist/index.js`).

This PR is opened as a **draft** first to empirically confirm the Blocks e2e shards pass under the 20-minute PR cap with these changes applied.

### How to test the changes in this Pull Request

1. Confirm all Blocks e2e shard jobs on this PR complete under the 20-minute test-step cap.
2. Compare shard test-step durations against the `release/11.0` push run on `5ded8f4863` (4.8–15 min baseline).