### PR TITLE
Complete Settings UI WPDS token migration

### DIFF
--- a/plugins/woocommerce/changelog/wooprd-3608-settings-ui-wpds-tokens
+++ b/plugins/woocommerce/changelog/wooprd-3608-settings-ui-wpds-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Complete the WPDS token migration for the Settings UI shell while preserving compatibility-specific dimensions.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -261,7 +261,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		transition: box-shadow 0.1s linear;
 		width: 100%;
 
-		// Preserve the mobile Safari breakpoint; WPDS has no breakpoint tokens.
 		@media (min-width: 600px) {
 			font-size: var(--wpds-typography-font-size-md);
 		}
@@ -296,7 +295,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		z-index: 100000;
 	}
 
-	// Preserve the existing responsive cutoff; WPDS has no breakpoint tokens.
 	@media (max-width: 960px) {
 		#mainform {
 			padding: 0 var(--wpds-dimension-padding-2xl)

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -25,6 +25,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	#mainform {
+		// The shell uses a 48px gutter, which has no WPDS spacing token.
 		padding: 0 48px 48px;
 	}
 
@@ -39,6 +40,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		font-size: var(--wpds-typography-font-size-md);
 		height: auto;
 		line-height: var(--wpds-typography-line-height-sm);
+		// Offset the 48px form gutter; WPDS has no matching negative token.
 		margin: 0 -48px;
 
 		&:has(.wc-settings-ui-shell__navigation) .wc-settings-ui-shell__header {
@@ -48,11 +50,14 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 	.wc-settings-ui-shell__header {
 		background: var(--wpds-color-background-surface-neutral-strong);
-		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
-		padding: 24px 48px;
+		border-bottom: var(--wpds-border-width-xs) solid
+			var(--wpds-color-stroke-surface-neutral-weak);
+		// The horizontal 48px shell gutter has no WPDS spacing token.
+		padding: var(--wpds-dimension-padding-2xl) 48px;
 	}
 
 	.wc-settings-ui-shell__title {
+		// Preserve the shell title size; WPDS has no 16px font token.
 		font-size: 16px;
 		font-weight: var(--wpds-typography-font-weight-medium);
 		line-height: var(--wpds-typography-line-height-md);
@@ -60,7 +65,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	.wc-settings-ui-shell__header-row > .wc-settings-ui-shell__badge {
-		margin-inline-start: var(--wpds-dimension-gap-sm, 8px);
+		margin-inline-start: var(--wpds-dimension-gap-sm);
 	}
 
 	.wc-settings-ui-shell__header-actions {
@@ -75,6 +80,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	// Carries #mainform so the margins beat extension styles targeting bare
 	// `nav` elements inside the settings form (WooPayments ships one).
 	#mainform .wc-settings-ui-shell__breadcrumbs {
+		// Preserve the breadcrumb size; WPDS has no 16px font token.
 		font-size: 16px;
 		line-height: var(--wpds-typography-line-height-md);
 		margin: 0;
@@ -86,7 +92,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		&::after {
 			color: var(--wpds-color-foreground-content-neutral-weak);
 			content: "/";
-			margin: 0 var(--wpds-dimension-gap-sm, 8px);
+			margin: 0 var(--wpds-dimension-gap-sm);
 		}
 
 		a {
@@ -101,7 +107,8 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	.wc-settings-ui-shell__navigation {
-		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+		border-bottom: var(--wpds-border-width-xs) solid
+			var(--wpds-color-stroke-surface-neutral-weak);
 		margin: 0;
 		width: 100%;
 	}
@@ -112,6 +119,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		display: flex;
 		margin: 0 !important;
 		overflow-x: auto;
+		// The horizontal 48px shell gutter has no WPDS spacing token.
 		padding: 0 48px;
 		width: 100%;
 	}
@@ -122,6 +130,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		display: inline-flex;
 		font-size: var(--wpds-typography-font-size-md);
 		font-weight: var(--wpds-typography-font-weight-medium);
+		// Preserve the 48px tab height; WPDS has no matching size token.
 		height: 48px;
 		line-height: var(--wpds-typography-line-height-sm);
 		padding: 0 var(--wpds-dimension-padding-lg);
@@ -142,10 +151,11 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 			&::after {
 				background: var(--wpds-color-stroke-interactive-brand);
+				// Keep the pill shape; WPDS has no fully rounded radius token.
 				border-radius: 999px;
 				bottom: 0;
 				content: "";
-				height: 2px;
+				height: var(--wpds-border-width-sm);
 				left: 0;
 				position: absolute;
 				right: 0;
@@ -154,12 +164,14 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	.wc-settings-ui-shell__notice {
-		margin: 24px 48px 0;
+		// The horizontal 48px shell gutter has no WPDS spacing token.
+		margin: var(--wpds-dimension-gap-xl) 48px 0;
 	}
 
 	.wc-settings-ui {
 		box-sizing: border-box;
-		margin: 32px auto 48px;
+		// Preserve the 48px bottom spacing; WPDS has no matching gap token.
+		margin: var(--wpds-dimension-gap-2xl) auto 48px;
 		max-width: var(--wpds-dimension-surface-width-xl);
 	}
 
@@ -169,10 +181,10 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 	.wc-settings-ui__section-description {
 		color: var(--wpds-color-foreground-content-neutral-weak);
-		margin: 8px 0 0;
+		margin: var(--wpds-dimension-gap-sm) 0 0;
 
 		p {
-			margin: 0 0 8px;
+			margin: 0 0 var(--wpds-dimension-gap-sm);
 		}
 
 		p:last-child {
@@ -192,11 +204,11 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	.wc-settings-ui__info {
 		background: var(--wpds-color-background-surface-neutral-weak);
 		border-radius: var(--wpds-border-radius-md);
-		padding: 16px;
+		padding: var(--wpds-dimension-padding-lg);
 
 		strong {
 			display: block;
-			margin-bottom: 4px;
+			margin-bottom: var(--wpds-dimension-gap-xs);
 		}
 
 		p {
@@ -216,9 +228,9 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 		.components-base-control__help {
 			color: var(--wpds-color-foreground-content-neutral-weak);
-			font-size: 13px;
-			line-height: 20px;
-			margin-top: 8px;
+			font-size: var(--wpds-typography-font-size-md);
+			line-height: var(--wpds-typography-line-height-sm);
+			margin-top: var(--wpds-dimension-gap-sm);
 		}
 	}
 
@@ -228,11 +240,12 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 	// Owned input skin: deliberately not borrowing internal
 	// @wordpress/components classnames, which carry no compatibility
-	// guarantee. Values mirror the 40px TextControl input.
+	// guarantee. Values mirror the default-size TextControl input.
 	.wc-settings-ui__number-control-input {
 		appearance: textfield;
-		border: 1px solid #949494;
-		border-radius: 2px;
+		border: var(--wpds-border-width-xs) solid
+			var(--wpds-color-stroke-interactive-neutral);
+		border-radius: var(--wpds-border-radius-sm);
 		box-shadow: 0 0 0 transparent;
 		box-sizing: border-box;
 		font-family: inherit;
@@ -240,21 +253,24 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		font-size: 16px;
 		line-height: normal;
 		margin: 0;
-		min-height: 40px;
-		padding: 6px 12px;
-		// Keep typed values clear of the spin buttons.
+		min-height: var(--wpds-dimension-size-lg);
+		// WPDS has no token for the 6px vertical input padding.
+		padding: 6px var(--wpds-dimension-padding-md);
+		// WPDS has no padding token for the 64px spin-button clearance.
 		padding-right: 64px;
 		transition: box-shadow 0.1s linear;
 		width: 100%;
 
+		// Preserve the mobile Safari breakpoint; WPDS has no breakpoint tokens.
 		@media (min-width: 600px) {
-			font-size: 13px;
+			font-size: var(--wpds-typography-font-size-md);
 		}
 
 		&:focus {
-			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
-			outline: 2px solid transparent;
+			border-color: var(--wpds-color-stroke-focus);
+			// WPDS has no token for the 0.5px focus-ring expansion.
+			box-shadow: 0 0 0 0.5px var(--wpds-color-stroke-focus);
+			outline: var(--wpds-border-width-sm) solid transparent;
 		}
 
 		&::-webkit-inner-spin-button,
@@ -267,6 +283,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	.wc-settings-ui__number-control-spin-buttons {
 		display: flex;
 		position: absolute;
+		// WPDS has no spacing token for the 6px spinner inset.
 		right: 6px;
 		top: 50%;
 		transform: translateY(-50%);
@@ -279,33 +296,37 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		z-index: 100000;
 	}
 
+	// Preserve the existing responsive cutoff; WPDS has no breakpoint tokens.
 	@media (max-width: 960px) {
 		#mainform {
-			padding: 0 24px 32px;
+			padding: 0 var(--wpds-dimension-padding-2xl)
+				var(--wpds-dimension-padding-3xl);
 		}
 
 		.wc-settings-ui-shell {
-			margin-left: -24px;
-			margin-right: -24px;
+			margin-left: calc(var(--wpds-dimension-gap-xl) * -1);
+			margin-right: calc(var(--wpds-dimension-gap-xl) * -1);
 		}
 
 		.wc-settings-ui-shell__header {
-			padding-left: 24px;
-			padding-right: 24px;
+			padding-left: var(--wpds-dimension-padding-2xl);
+			padding-right: var(--wpds-dimension-padding-2xl);
 		}
 
 		.wc-settings-ui-shell__tabs {
-			padding-left: 24px;
-			padding-right: 24px;
+			padding-left: var(--wpds-dimension-padding-2xl);
+			padding-right: var(--wpds-dimension-padding-2xl);
 		}
 
 		.wc-settings-ui-shell__notice {
-			margin-left: 24px;
-			margin-right: 24px;
+			margin-left: var(--wpds-dimension-gap-xl);
+			margin-right: var(--wpds-dimension-gap-xl);
 		}
 
 		.wc-settings-ui {
-			margin: 48px 24px 32px;
+			// Preserve the 48px top spacing; WPDS has no matching gap token.
+			margin: 48px var(--wpds-dimension-gap-xl)
+				var(--wpds-dimension-gap-2xl);
 			max-width: none;
 		}
 
@@ -314,7 +335,7 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		}
 
 		.wc-settings-ui__section-actions {
-			margin-top: 16px;
+			margin-top: var(--wpds-dimension-gap-lg);
 		}
 	}
 }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -25,7 +25,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	#mainform {
-		// The shell uses a 48px gutter, which has no WPDS spacing token.
 		padding: 0 48px 48px;
 	}
 
@@ -40,7 +39,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		font-size: var(--wpds-typography-font-size-md);
 		height: auto;
 		line-height: var(--wpds-typography-line-height-sm);
-		// Offset the 48px form gutter; WPDS has no matching negative token.
 		margin: 0 -48px;
 
 		&:has(.wc-settings-ui-shell__navigation) .wc-settings-ui-shell__header {
@@ -52,12 +50,10 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		background: var(--wpds-color-background-surface-neutral-strong);
 		border-bottom: var(--wpds-border-width-xs) solid
 			var(--wpds-color-stroke-surface-neutral-weak);
-		// The horizontal 48px shell gutter has no WPDS spacing token.
 		padding: var(--wpds-dimension-padding-2xl) 48px;
 	}
 
 	.wc-settings-ui-shell__title {
-		// Preserve the shell title size; WPDS has no 16px font token.
 		font-size: 16px;
 		font-weight: var(--wpds-typography-font-weight-medium);
 		line-height: var(--wpds-typography-line-height-md);
@@ -80,7 +76,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	// Carries #mainform so the margins beat extension styles targeting bare
 	// `nav` elements inside the settings form (WooPayments ships one).
 	#mainform .wc-settings-ui-shell__breadcrumbs {
-		// Preserve the breadcrumb size; WPDS has no 16px font token.
 		font-size: 16px;
 		line-height: var(--wpds-typography-line-height-md);
 		margin: 0;
@@ -119,7 +114,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		display: flex;
 		margin: 0 !important;
 		overflow-x: auto;
-		// The horizontal 48px shell gutter has no WPDS spacing token.
 		padding: 0 48px;
 		width: 100%;
 	}
@@ -130,7 +124,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		display: inline-flex;
 		font-size: var(--wpds-typography-font-size-md);
 		font-weight: var(--wpds-typography-font-weight-medium);
-		// Preserve the 48px tab height; WPDS has no matching size token.
 		height: 48px;
 		line-height: var(--wpds-typography-line-height-sm);
 		padding: 0 var(--wpds-dimension-padding-lg);
@@ -151,7 +144,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 			&::after {
 				background: var(--wpds-color-stroke-interactive-brand);
-				// Keep the pill shape; WPDS has no fully rounded radius token.
 				border-radius: 999px;
 				bottom: 0;
 				content: "";
@@ -164,13 +156,11 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	.wc-settings-ui-shell__notice {
-		// The horizontal 48px shell gutter has no WPDS spacing token.
 		margin: var(--wpds-dimension-gap-xl) 48px 0;
 	}
 
 	.wc-settings-ui {
 		box-sizing: border-box;
-		// Preserve the 48px bottom spacing; WPDS has no matching gap token.
 		margin: var(--wpds-dimension-gap-2xl) auto 48px;
 		max-width: var(--wpds-dimension-surface-width-xl);
 	}
@@ -254,9 +244,8 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		line-height: normal;
 		margin: 0;
 		min-height: var(--wpds-dimension-size-lg);
-		// WPDS has no token for the 6px vertical input padding.
 		padding: 6px var(--wpds-dimension-padding-md);
-		// WPDS has no padding token for the 64px spin-button clearance.
+		// Keep typed values clear of the spin buttons.
 		padding-right: 64px;
 		transition: box-shadow 0.1s linear;
 		width: 100%;
@@ -267,7 +256,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 
 		&:focus {
 			border-color: var(--wpds-color-stroke-focus);
-			// WPDS has no token for the 0.5px focus-ring expansion.
 			box-shadow: 0 0 0 0.5px var(--wpds-color-stroke-focus);
 			outline: var(--wpds-border-width-sm) solid transparent;
 		}
@@ -282,7 +270,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	.wc-settings-ui__number-control-spin-buttons {
 		display: flex;
 		position: absolute;
-		// WPDS has no spacing token for the 6px spinner inset.
 		right: 6px;
 		top: 50%;
 		transform: translateY(-50%);
@@ -322,7 +309,6 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 		}
 
 		.wc-settings-ui {
-			// Preserve the 48px top spacing; WPDS has no matching gap token.
 			margin: 48px var(--wpds-dimension-gap-xl)
 				var(--wpds-dimension-gap-2xl);
 			max-width: none;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Settings UI shell now uses the WPDS design-token contract consistently instead of mixing tokens with raw supported values. Remaining raw values are retained only where the pinned `@wordpress/theme` token catalog has no property-appropriate WPDS token.

The number-control substitutions include three deliberate behavior changes:

- The focus ring uses the WPDS focus stroke instead of the active WordPress admin color. This aligns it with other WPDS controls and improves its contrast against white from 2.86:1 to 5.61:1 under the Sunrise admin color scheme.
- The neutral border adopts the WPDS stroke value (`#8d8d8d` instead of `#949494`), improving its contrast against white from 3.03:1 to 3.32:1.
- The corner radius follows the WPDS radius preset instead of remaining fixed at `2px`. It remains `2px` under the default `subtle` preset.

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Open **WooCommerce > Settings > Products > Inventory** and confirm the Settings UI shell has unchanged spacing at desktop widths and at widths up to `960px`.
2. Focus a number-control input and confirm its border and focus ring match the surrounding WPDS controls.
3. Switch the WordPress admin color scheme to **Sunrise**, reload the page, and confirm the number-control focus ring remains clearly visible.

<!-- End testing instructions -->

### Testing that has already taken place:

- Focused Stylelint passed without warnings or errors.
- The production admin bundle compiled successfully.
- Source audits found no raw hexadecimal colors or WPDS custom-property fallbacks; remaining raw values are limited to values without a suitable shipped token.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set the milestone to the first available milestone that is not in the past (unless otherwise specified).


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Post-Deploy Monitoring & Validation

- No additional log queries or dashboards are required because this is a source-only stylesheet migration with no data, API, or server-runtime changes.
- Within the first release validation window, the WooCommerce Settings UI release owner should open the Products and Inventory settings at desktop and responsive widths.
- Healthy signals are unchanged shell geometry, visible number-input focus treatment, and resolved WPDS custom properties.
- Shifted gutters, clipped controls, a missing focus ring, or unresolved custom-property values are failure signals. Revert this PR if any of those signals appear.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
