### PR TITLE
Fix review selector controls shown by default

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -171,7 +171,7 @@ const ReviewsByCategoryEditor = ( {
 		);
 	};
 
-	if ( ! categoryIds || editMode ) {
+	if ( ! categoryIds || categoryIds.length === 0 || editMode ) {
 		return renderEditMode();
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -47,31 +47,6 @@ const ReviewsByCategoryEditor = ( {
 		return (
 			<InspectorControls key="inspector">
 				<ToolsPanel
-					label={ __( 'Category', 'woocommerce' ) }
-					resetAll={ () => setAttributes( { categoryIds: [] } ) }
-				>
-					<ToolsPanelItem
-						hasValue={ () =>
-							( attributes.categoryIds || [] ).length > 0
-						}
-						label={ __( 'Category', 'woocommerce' ) }
-						onDeselect={ () =>
-							setAttributes( { categoryIds: [] } )
-						}
-						isShownByDefault
-					>
-						<ProductCategoryControl
-							selected={ attributes.categoryIds }
-							onChange={ ( value = [] ) => {
-								const ids = value.map( ( { id } ) => id );
-								setAttributes( { categoryIds: ids } );
-							} }
-							isCompact={ true }
-							showReviewCount={ true }
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-				<ToolsPanel
 					label={ __( 'Content', 'woocommerce' ) }
 					resetAll={ () =>
 						setAttributes( {
@@ -123,6 +98,31 @@ const ReviewsByCategoryEditor = ( {
 					}
 				>
 					{ getSharedReviewListControls( attributes, setAttributes ) }
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Category', 'woocommerce' ) }
+					resetAll={ () => setAttributes( { categoryIds: [] } ) }
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							( attributes.categoryIds || [] ).length > 0
+						}
+						label={ __( 'Category', 'woocommerce' ) }
+						onDeselect={ () =>
+							setAttributes( { categoryIds: [] } )
+						}
+						isShownByDefault
+					>
+						<ProductCategoryControl
+							selected={ attributes.categoryIds }
+							onChange={ ( value = [] ) => {
+								const ids = value.map( ( { id } ) => id );
+								setAttributes( { categoryIds: ids } );
+							} }
+							isCompact={ true }
+							showReviewCount={ true }
+						/>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -77,31 +77,6 @@ const ReviewsByProductEditor = ( {
 		return (
 			<InspectorControls key="inspector">
 				<ToolsPanel
-					label={ __( 'Product', 'woocommerce' ) }
-					resetAll={ () => setAttributes( { productId: 0 } ) }
-				>
-					<ToolsPanelItem
-						hasValue={ () => !! attributes.productId }
-						label={ __( 'Product', 'woocommerce' ) }
-						onDeselect={ () => setAttributes( { productId: 0 } ) }
-						isShownByDefault
-					>
-						<ProductControl
-							selected={
-								attributes.productId
-									? [ attributes.productId ]
-									: []
-							}
-							onChange={ ( value = [] ) => {
-								const id = value[ 0 ] ? value[ 0 ].id : 0;
-								setAttributes( { productId: id } );
-							} }
-							renderItem={ renderProductControlItem }
-							isCompact={ true }
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-				<ToolsPanel
 					label={ __( 'Content', 'woocommerce' ) }
 					resetAll={ () =>
 						setAttributes( {
@@ -132,6 +107,31 @@ const ReviewsByProductEditor = ( {
 					}
 				>
 					{ getSharedReviewListControls( attributes, setAttributes ) }
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Product', 'woocommerce' ) }
+					resetAll={ () => setAttributes( { productId: 0 } ) }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.productId }
+						label={ __( 'Product', 'woocommerce' ) }
+						onDeselect={ () => setAttributes( { productId: 0 } ) }
+						isShownByDefault
+					>
+						<ProductControl
+							selected={
+								attributes.productId
+									? [ attributes.productId ]
+									: []
+							}
+							onChange={ ( value = [] ) => {
+								const id = value[ 0 ] ? value[ 0 ].id : 0;
+								setAttributes( { productId: id } );
+							} }
+							renderItem={ renderProductControlItem }
+							isCompact={ true }
+						/>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR moves the Product and Category Settings at the bottom of the Block Settings. 

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #65799.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->







| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/f5636572-888a-4409-aafd-03400d8f0c99" /> | <video src="https://github.com/user-attachments/assets/b53816d1-ba0d-45f0-9399-cedf52ddf25a" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create or edit a post or page, add the **Reviews by Product** block, select a product, and click **Done**.
2. Select the block and open the Block settings sidebar. Verify that the Product selector at the bottom of the block settings.
3. Repeat steps 1–4 with the **Reviews by Category** block and its Category selector.
4. Reload the editor and verify that both selectors are hidden by default while their block selections remain intact.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Targeted ESLint completed successfully for both changed files, with two pre-existing `@wordpress/icons` import warnings.
- `pnpm --filter=@woocommerce/block-library ts:check` remains blocked by existing project-wide type errors unrelated to these changes.
- Manual browser testing was not run because the local wp-env site was not running.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
