### PR TITLE
Add merchant inbox notification for order withdrawal requests

### DIFF
--- a/plugins/woocommerce/changelog/add-withdraw-order-note
+++ b/plugins/woocommerce/changelog/add-withdraw-order-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds an inbox note when a customer submits a withdraw order request

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalController.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalController.php
@@ -58,6 +58,8 @@ final class OrderWithdrawalController implements RegisterHooksInterface {
 		add_filter( 'woocommerce_endpoint_' . self::ENDPOINT_KEY . '_title', array( $this, 'get_endpoint_title' ), 10, 1 );
 		add_filter( 'woocommerce_settings_pages', array( $this, 'add_endpoint_setting' ), 10, 1 );
 		add_action( 'woocommerce_account_' . self::ENDPOINT_KEY . '_endpoint', array( $this, 'render_view' ) );
+		add_action( 'woocommerce_before_delete_order', array( $this->form_processor, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
+		add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this->form_processor, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalController.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalController.php
@@ -59,6 +59,7 @@ final class OrderWithdrawalController implements RegisterHooksInterface {
 		add_filter( 'woocommerce_settings_pages', array( $this, 'add_endpoint_setting' ), 10, 1 );
 		add_action( 'woocommerce_account_' . self::ENDPOINT_KEY . '_endpoint', array( $this, 'render_view' ) );
 		add_action( 'woocommerce_before_delete_order', array( $this->form_processor, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
+		add_action( 'before_delete_post', array( $this->form_processor, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this->form_processor, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
 	}
 

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -462,19 +462,10 @@ final class OrderWithdrawalFormProcessor {
 	 */
 	private function add_order_withdrawal_note( WC_Order $order, array $data ): void {
 		$note = sprintf(
-			/* translators: 1: customer name, 2: customer email address. */
-			__( 'Order withdrawal requested by %1$s (%2$s).', 'woocommerce' ),
-			$this->get_customer_name( $data ),
-			$data[ self::FIELD_EMAIL ]
+			/* translators: %s: withdrawal type label. */
+			__( 'Order withdrawal requested. Withdrawal type: %s.', 'woocommerce' ),
+			$this->get_withdrawal_type_label( $data[ self::FIELD_WITHDRAWAL_TYPE ] )
 		);
-
-		if ( self::WITHDRAWAL_TYPE_SPECIFIC === $data[ self::FIELD_WITHDRAWAL_TYPE ] ) {
-			$note .= "\n\n" . sprintf(
-				/* translators: %s: items the customer listed for partial withdrawal. */
-				__( 'Items requested for withdrawal: %s', 'woocommerce' ),
-				$data[ self::FIELD_ADDITIONAL_DETAILS ]
-			);
-		}
 
 		try {
 			if ( ! $order->add_order_note( $note, 0, false, array( 'note_group' => OrderNoteGroup::ORDER_UPDATE ) ) ) {

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\OrderWithdrawal;
 
+use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 use Throwable;
 use WC_Geolocation;
@@ -37,6 +38,7 @@ final class OrderWithdrawalFormProcessor {
 	private const LOGGER_SOURCE                       = 'order-withdrawal';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const ORDER_WITHDRAWAL_REQUESTED_VALUE    = 'yes';
+	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
 	private const RATE_LIMIT_IP_PREFIX                = 'order_withdrawal_ip_';
 	private const RATE_LIMIT_EMAIL_PREFIX             = 'order_withdrawal_email_';
 	private const RATE_LIMIT_DELAY                    = MINUTE_IN_SECONDS / 2;
@@ -288,6 +290,8 @@ final class OrderWithdrawalFormProcessor {
 			return false;
 		}
 
+		$this->add_order_withdrawal_inbox_note( $data, $matched_order );
+
 		if ( $matched_order ) {
 			$this->mark_order_withdrawal_requested( $matched_order );
 		}
@@ -479,6 +483,82 @@ final class OrderWithdrawalFormProcessor {
 		} catch ( Throwable $e ) {
 			$this->log_order_note_error( $order, $e );
 		}
+	}
+
+	/**
+	 * Add a withdrawal request notification to the merchant's WooCommerce inbox.
+	 *
+	 * @param array<string,string> $data          Form data.
+	 * @param WC_Order|null        $matched_order Matched order, if found.
+	 */
+	private function add_order_withdrawal_inbox_note( array $data, ?WC_Order $matched_order ): void {
+		try {
+			$note = new Note();
+			$note->set_title( __( 'Withdraw Order Request', 'woocommerce' ) );
+			$note->set_content( $this->get_inbox_note_content( $data, $matched_order ) );
+			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_name( $this->get_inbox_note_name( $data, $matched_order ) );
+			$note->set_source( 'woocommerce-admin' );
+
+			if ( $matched_order instanceof WC_Order ) {
+				$order_url = $matched_order->get_edit_order_url();
+
+				if ( '' !== $order_url ) {
+					$note->add_action( 'view-order', __( 'View order', 'woocommerce' ), $order_url );
+				}
+			}
+
+			$note->save();
+		} catch ( Throwable $e ) {
+			$this->log_inbox_note_error( $e );
+		}
+	}
+
+	/**
+	 * Get the content for the merchant inbox notification.
+	 *
+	 * @param array<string,string> $data          Form data.
+	 * @param WC_Order|null        $matched_order Matched order, if found.
+	 */
+	private function get_inbox_note_content( array $data, ?WC_Order $matched_order ): string {
+		$content = sprintf(
+			/* translators: 1: customer name, 2: customer email address, 3: order number submitted by the customer. */
+			__( 'Order withdrawal requested by %1$s (%2$s) for order %3$s.', 'woocommerce' ),
+			$this->get_customer_name( $data ),
+			$data[ self::FIELD_EMAIL ],
+			$data[ self::FIELD_ORDER_NUMBER ]
+		);
+
+		if ( self::WITHDRAWAL_TYPE_SPECIFIC === $data[ self::FIELD_WITHDRAWAL_TYPE ] ) {
+			$content .= ' ' . sprintf(
+				/* translators: %s: items the customer listed for partial withdrawal. */
+				__( 'Items requested for withdrawal: %s', 'woocommerce' ),
+				$data[ self::FIELD_ADDITIONAL_DETAILS ]
+			);
+		}
+
+		if ( ! $matched_order instanceof WC_Order ) {
+			$content .= ' ' . __( 'WooCommerce could not match this request to an order automatically.', 'woocommerce' );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Get a unique name for the merchant inbox notification.
+	 *
+	 * @param array<string,string> $data          Form data.
+	 * @param WC_Order|null        $matched_order Matched order, if found.
+	 */
+	private function get_inbox_note_name( array $data, ?WC_Order $matched_order ): string {
+		if ( $matched_order instanceof WC_Order ) {
+			return self::INBOX_NOTE_NAME_PREFIX . 'order-' . $matched_order->get_id();
+		}
+
+		return self::INBOX_NOTE_NAME_PREFIX . 'unmatched-' . hash(
+			'sha256',
+			strtolower( trim( $data[ self::FIELD_EMAIL ] ) ) . '|' . $data[ self::FIELD_ORDER_NUMBER ] . '|' . microtime()
+		);
 	}
 
 	/**
@@ -716,6 +796,18 @@ final class OrderWithdrawalFormProcessor {
 
 		wc_get_logger()->warning(
 			sprintf( 'Order withdrawal email failed: %s', $message ),
+			array( 'source' => self::LOGGER_SOURCE )
+		);
+	}
+
+	/**
+	 * Log an inbox note failure without failing the submission.
+	 *
+	 * @param Throwable $e Inbox note error.
+	 */
+	private function log_inbox_note_error( Throwable $e ): void {
+		wc_get_logger()->warning(
+			sprintf( 'Order withdrawal inbox note could not be created. Error: %s', $e->getMessage() ),
 			array( 'source' => self::LOGGER_SOURCE )
 		);
 	}

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -507,7 +507,7 @@ final class OrderWithdrawalFormProcessor {
 
 			$note->save();
 		} catch ( Throwable $e ) {
-			$this->log_inbox_note_error( $e );
+			$this->log_inbox_note_error( $e, $matched_order->get_id() );
 		}
 	}
 
@@ -532,7 +532,7 @@ final class OrderWithdrawalFormProcessor {
 		try {
 			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id );
 		} catch ( Throwable $e ) {
-			$this->log_inbox_note_error( $e );
+			$this->log_inbox_note_error( $e, $order_id );
 		}
 	}
 
@@ -778,11 +778,12 @@ final class OrderWithdrawalFormProcessor {
 	/**
 	 * Log an inbox note failure without failing the submission.
 	 *
-	 * @param Throwable $e Inbox note error.
+	 * @param Throwable $e        Inbox note error.
+	 * @param int       $order_id Order ID.
 	 */
-	private function log_inbox_note_error( Throwable $e ): void {
+	private function log_inbox_note_error( Throwable $e, int $order_id ): void {
 		wc_get_logger()->warning(
-			sprintf( 'Order withdrawal inbox note could not be created. Error: %s', $e->getMessage() ),
+			sprintf( 'Order withdrawal inbox note could not be processed for order %1$d. Error: %2$s', $order_id, $e->getMessage() ),
 			array( 'source' => self::LOGGER_SOURCE )
 		);
 	}

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\OrderWithdrawal;
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 use Throwable;
 use WC_Geolocation;
 use WC_Order;
@@ -39,7 +40,7 @@ final class OrderWithdrawalFormProcessor {
 	private const LOGGER_SOURCE                       = 'order-withdrawal';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const ORDER_WITHDRAWAL_REQUESTED_VALUE    = 'yes';
-	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
+	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-order-';
 	private const RATE_LIMIT_IP_PREFIX                = 'order_withdrawal_ip_';
 	private const RATE_LIMIT_EMAIL_PREFIX             = 'order_withdrawal_email_';
 	private const RATE_LIMIT_DELAY                    = MINUTE_IN_SECONDS / 2;
@@ -484,19 +485,19 @@ final class OrderWithdrawalFormProcessor {
 			$note->set_title(
 				sprintf(
 					/* translators: %s: order number. */
-					__( 'Withdraw order request for #%s', 'woocommerce' ),
+					__( 'Order withdrawal request for #%s', 'woocommerce' ),
 					$matched_order->get_order_number()
 				)
 			);
 			$note->set_content(
 				sprintf(
 				/* translators: %s: order number. */
-					__( 'A customer submitted a withdrawal request for order %s. Review the matched order to confirm the request details.', 'woocommerce' ),
+					__( 'A customer submitted an order withdrawal request for order #%s. Review the matched order to confirm the request details.', 'woocommerce' ),
 					$matched_order->get_order_number()
 				)
 			);
 			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-			$note->set_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $matched_order->get_id() );
+			$note->set_name( self::INBOX_NOTE_NAME_PREFIX . $matched_order->get_id() );
 			$note->set_source( 'woocommerce-admin' );
 
 			$order_url = $matched_order->get_edit_order_url();
@@ -520,6 +521,10 @@ final class OrderWithdrawalFormProcessor {
 		if ( $order instanceof WC_Order ) {
 			$order_id = $order->get_id();
 		} elseif ( is_int( $order ) ) {
+			if ( ! OrderUtil::is_order( $order ) ) {
+				return;
+			}
+
 			$order_id = $order;
 		} else {
 			return;
@@ -530,7 +535,7 @@ final class OrderWithdrawalFormProcessor {
 		}
 
 		try {
-			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id );
+			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . $order_id );
 		} catch ( Throwable $e ) {
 			$this->log_inbox_note_error( $e, $order_id );
 		}

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -481,7 +481,13 @@ final class OrderWithdrawalFormProcessor {
 	private function add_order_withdrawal_inbox_note( WC_Order $matched_order ): void {
 		try {
 			$note = new Note();
-			$note->set_title( __( 'Withdraw Order Request', 'woocommerce' ) );
+			$note->set_title(
+				sprintf(
+					/* translators: %s: order number. */
+					__( 'Withdraw order request for #%s', 'woocommerce' ),
+					$matched_order->get_order_number()
+				)
+			);
 			$note->set_content(
 				sprintf(
 				/* translators: %s: order number. */

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\OrderWithdrawal;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 use Throwable;
 use WC_Geolocation;
@@ -281,6 +282,7 @@ final class OrderWithdrawalFormProcessor {
 			}
 
 			$this->add_order_withdrawal_note( $matched_order, $data );
+			$this->add_order_withdrawal_inbox_note( $matched_order );
 		}
 
 		if ( ! $this->send_order_withdrawal_emails( $data, $matched_order ) ) {
@@ -289,8 +291,6 @@ final class OrderWithdrawalFormProcessor {
 
 			return false;
 		}
-
-		$this->add_order_withdrawal_inbox_note( $data, $matched_order );
 
 		if ( $matched_order ) {
 			$this->mark_order_withdrawal_requested( $matched_order );
@@ -488,24 +488,31 @@ final class OrderWithdrawalFormProcessor {
 	/**
 	 * Add a withdrawal request notification to the merchant's WooCommerce inbox.
 	 *
-	 * @param array<string,string> $data          Form data.
-	 * @param WC_Order|null        $matched_order Matched order, if found.
+	 * @param WC_Order $matched_order Matched order.
 	 */
-	private function add_order_withdrawal_inbox_note( array $data, ?WC_Order $matched_order ): void {
+	private function add_order_withdrawal_inbox_note( WC_Order $matched_order ): void {
+		if ( $this->has_order_withdrawal_request( $matched_order ) ) {
+			return;
+		}
+
 		try {
 			$note = new Note();
 			$note->set_title( __( 'Withdraw Order Request', 'woocommerce' ) );
-			$note->set_content( $this->get_inbox_note_content( $data, $matched_order ) );
+			$note->set_content(
+				sprintf(
+				/* translators: %s: order number. */
+					__( 'A customer submitted a withdrawal request for order %s. Review the matched order to confirm the request details.', 'woocommerce' ),
+					$matched_order->get_order_number()
+				)
+			);
 			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-			$note->set_name( $this->get_inbox_note_name( $data, $matched_order ) );
+			$note->set_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $matched_order->get_id() );
 			$note->set_source( 'woocommerce-admin' );
 
-			if ( $matched_order instanceof WC_Order ) {
-				$order_url = $matched_order->get_edit_order_url();
+			$order_url = $matched_order->get_edit_order_url();
 
-				if ( '' !== $order_url ) {
-					$note->add_action( 'view-order', __( 'View order', 'woocommerce' ), $order_url );
-				}
+			if ( '' !== $order_url ) {
+				$note->add_action( 'view-order', __( 'View order', 'woocommerce' ), $order_url );
 			}
 
 			$note->save();
@@ -515,50 +522,22 @@ final class OrderWithdrawalFormProcessor {
 	}
 
 	/**
-	 * Get the content for the merchant inbox notification.
+	 * Delete the withdrawal request inbox notification associated with an order.
 	 *
-	 * @param array<string,string> $data          Form data.
-	 * @param WC_Order|null        $matched_order Matched order, if found.
+	 * @param int|WC_Order $order Order ID or order object.
 	 */
-	private function get_inbox_note_content( array $data, ?WC_Order $matched_order ): string {
-		$content = sprintf(
-			/* translators: 1: customer name, 2: customer email address, 3: order number submitted by the customer. */
-			__( 'Order withdrawal requested by %1$s (%2$s) for order %3$s.', 'woocommerce' ),
-			$this->get_customer_name( $data ),
-			$data[ self::FIELD_EMAIL ],
-			$data[ self::FIELD_ORDER_NUMBER ]
-		);
+	public function delete_order_withdrawal_inbox_note_for_order( $order ): void {
+		$order_id = $order instanceof WC_Order ? $order->get_id() : absint( $order );
 
-		if ( self::WITHDRAWAL_TYPE_SPECIFIC === $data[ self::FIELD_WITHDRAWAL_TYPE ] ) {
-			$content .= ' ' . sprintf(
-				/* translators: %s: items the customer listed for partial withdrawal. */
-				__( 'Items requested for withdrawal: %s', 'woocommerce' ),
-				$data[ self::FIELD_ADDITIONAL_DETAILS ]
-			);
+		if ( 0 === $order_id ) {
+			return;
 		}
 
-		if ( ! $matched_order instanceof WC_Order ) {
-			$content .= ' ' . __( 'WooCommerce could not match this request to an order automatically.', 'woocommerce' );
+		try {
+			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id );
+		} catch ( Throwable $e ) {
+			$this->log_inbox_note_error( $e );
 		}
-
-		return $content;
-	}
-
-	/**
-	 * Get a unique name for the merchant inbox notification.
-	 *
-	 * @param array<string,string> $data          Form data.
-	 * @param WC_Order|null        $matched_order Matched order, if found.
-	 */
-	private function get_inbox_note_name( array $data, ?WC_Order $matched_order ): string {
-		if ( $matched_order instanceof WC_Order ) {
-			return self::INBOX_NOTE_NAME_PREFIX . 'order-' . $matched_order->get_id();
-		}
-
-		return self::INBOX_NOTE_NAME_PREFIX . 'unmatched-' . hash(
-			'sha256',
-			strtolower( trim( $data[ self::FIELD_EMAIL ] ) ) . '|' . $data[ self::FIELD_ORDER_NUMBER ] . '|' . microtime()
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -517,9 +517,15 @@ final class OrderWithdrawalFormProcessor {
 	 * @param int|WC_Order $order Order ID or order object.
 	 */
 	public function delete_order_withdrawal_inbox_note_for_order( $order ): void {
-		$order_id = $order instanceof WC_Order ? $order->get_id() : absint( $order );
+		if ( $order instanceof WC_Order ) {
+			$order_id = $order->get_id();
+		} elseif ( is_int( $order ) ) {
+			$order_id = $order;
+		} else {
+			return;
+		}
 
-		if ( 0 === $order_id ) {
+		if ( 0 >= $order_id ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -269,20 +269,15 @@ final class OrderWithdrawalFormProcessor {
 
 		$matched_order = $this->get_matching_order( $data );
 
-		if ( $matched_order ) {
-			if ( $this->has_order_withdrawal_request( $matched_order ) ) {
-				wc_add_notice(
-					__( 'A withdrawal request has already been submitted for this order. Please contact us if you need help or want to make changes.', 'woocommerce' ),
-					'error'
-				);
+		if ( $matched_order && $this->has_order_withdrawal_request( $matched_order ) ) {
+			wc_add_notice(
+				__( 'A withdrawal request has already been submitted for this order. Please contact us if you need help or want to make changes.', 'woocommerce' ),
+				'error'
+			);
 
-				$this->apply_rate_limits( $rate_limit_ids, -1 );
+			$this->apply_rate_limits( $rate_limit_ids, -1 );
 
-				return false;
-			}
-
-			$this->add_order_withdrawal_note( $matched_order, $data );
-			$this->add_order_withdrawal_inbox_note( $matched_order );
+			return false;
 		}
 
 		if ( ! $this->send_order_withdrawal_emails( $data, $matched_order ) ) {
@@ -294,6 +289,8 @@ final class OrderWithdrawalFormProcessor {
 
 		if ( $matched_order ) {
 			$this->mark_order_withdrawal_requested( $matched_order );
+			$this->add_order_withdrawal_note( $matched_order, $data );
+			$this->add_order_withdrawal_inbox_note( $matched_order );
 		}
 
 		return true;
@@ -482,10 +479,6 @@ final class OrderWithdrawalFormProcessor {
 	 * @param WC_Order $matched_order Matched order.
 	 */
 	private function add_order_withdrawal_inbox_note( WC_Order $matched_order ): void {
-		if ( $this->has_order_withdrawal_request( $matched_order ) ) {
-			return;
-		}
-
 		try {
 			$note = new Note();
 			$note->set_title( __( 'Withdraw Order Request', 'woocommerce' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -159,8 +159,8 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		$this->restore_option( self::FLUSH_QUEUE_OPTION, $this->original_flush_queue_option );
 		wc_clear_notices();
 		$this->clear_order_withdrawal_rate_limits();
-		$this->delete_created_orders();
 		$this->delete_created_inbox_notes();
+		$this->delete_created_orders();
 		WC()->session = $this->original_session;
 
 		parent::tearDown();
@@ -947,28 +947,31 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	 * @return int[]
 	 */
 	private function get_created_inbox_note_ids(): array {
-		global $wpdb;
+		$note_ids = array();
 
-		$note_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE name LIKE %s",
-				$wpdb->esc_like( self::INBOX_NOTE_NAME_PREFIX ) . '%'
-			)
-		);
+		foreach ( $this->created_order_ids as $order_id ) {
+			$note = Notes::get_note_by_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id );
 
-		return array_map( 'intval', (array) $note_ids );
+			if ( $note instanceof Note ) {
+				$note_ids[] = $note->get_id();
+			}
+		}
+
+		return array_map( 'intval', $note_ids );
 	}
 
 	/**
 	 * Delete inbox notes created during a test.
 	 */
 	private function delete_created_inbox_notes(): void {
-		foreach ( $this->get_created_inbox_note_ids() as $note_id ) {
-			$note = Notes::get_note( $note_id );
+		$note_names = array();
 
-			if ( $note instanceof Note ) {
-				$note->delete();
-			}
+		foreach ( $this->created_order_ids as $order_id ) {
+			$note_names[] = self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id;
+		}
+
+		if ( ! empty( $note_names ) ) {
+			Notes::delete_notes_with_name( $note_names );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -482,7 +482,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_INFORMATIONAL, $note->get_type(), 'The inbox notification should be informational.' );
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_UNACTIONED, $note->get_status(), 'The inbox notification should start unactioned.' );
-			$this->assertSame( 'Withdraw Order Request', $note->get_title(), 'The inbox notification should have the expected title.' );
+			$this->assertSame( sprintf( 'Withdraw order request for #%s', $order->get_order_number() ), $note->get_title(), 'The inbox notification should have the expected title.' );
 			$this->assertStringContainsString( (string) $order->get_order_number(), $note->get_content(), 'The inbox notification should include the order number.' );
 			$this->assertStringContainsString( 'Review the matched order to confirm the request details.', $note->get_content(), 'The inbox notification should direct merchants to the matched order.' );
 			$this->assertStringNotContainsString( 'Jane Doe', $note->get_content(), 'The inbox notification should not include the customer name.' );

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -478,9 +478,11 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_INFORMATIONAL, $note->get_type(), 'The inbox notification should be informational.' );
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_UNACTIONED, $note->get_status(), 'The inbox notification should start unactioned.' );
 			$this->assertSame( 'Withdraw Order Request', $note->get_title(), 'The inbox notification should have the expected title.' );
-			$this->assertStringContainsString( 'Jane Doe', $note->get_content(), 'The inbox notification should include the customer name.' );
-			$this->assertStringContainsString( 'jane@example.test', $note->get_content(), 'The inbox notification should include the customer email address.' );
-			$this->assertStringContainsString( 'Items requested for withdrawal: Line item 1', $note->get_content(), 'The inbox notification should include the withdrawal details.' );
+			$this->assertStringContainsString( (string) $order->get_order_number(), $note->get_content(), 'The inbox notification should include the order number.' );
+			$this->assertStringContainsString( 'Review the matched order to confirm the request details.', $note->get_content(), 'The inbox notification should direct merchants to the matched order.' );
+			$this->assertStringNotContainsString( 'Jane Doe', $note->get_content(), 'The inbox notification should not include the customer name.' );
+			$this->assertStringNotContainsString( 'jane@example.test', $note->get_content(), 'The inbox notification should not include the customer email address.' );
+			$this->assertStringNotContainsString( 'Line item 1', $note->get_content(), 'The inbox notification should not include free-form withdrawal details.' );
 
 			$actions = $note->get_actions();
 
@@ -493,9 +495,9 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add a merchant inbox notification without an order action when no order matches.
+	 * @testdox Should not add a merchant inbox notification when no order matches.
 	 */
-	public function test_process_current_request_adds_inbox_note_without_order_action_when_order_does_not_match(): void {
+	public function test_process_current_request_does_not_add_inbox_note_when_order_does_not_match(): void {
 		$order   = $this->create_order_for_form_data(
 			array(
 				OrderWithdrawalFormProcessor::FIELD_EMAIL => 'different@example.test',
@@ -514,15 +516,37 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$note_ids = $this->get_created_inbox_note_ids();
 
 			$this->assertSame( 'confirmation', $state->screen, 'Unmatched confirm submissions should still reach the confirmation screen.' );
-			$this->assertCount( 1, $note_ids, 'An unmatched submission should create one merchant inbox notification.' );
-
-			$note = Notes::get_note( $note_ids[0] );
-
-			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
-			$this->assertStringContainsString( 'jane@example.test', $note->get_content(), 'The inbox notification should include the customer email address.' );
-			$this->assertStringContainsString( 'could not match this request to an order automatically', $note->get_content(), 'The inbox notification should explain that no order was matched.' );
-			$this->assertCount( 0, $note->get_actions(), 'An unmatched submission should not add a view order action.' );
+			$this->assertCount( 0, $note_ids, 'An unmatched submission should not create a merchant inbox notification.' );
 		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should delete a matched merchant inbox notification when its order is deleted.
+	 */
+	public function test_delete_order_withdrawal_inbox_note_for_order_deletes_matched_inbox_note(): void {
+		$order   = $this->create_order_for_form_data();
+		$capture = $this->capture_wp_mail();
+		add_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$this->sut->process_current_request();
+
+			$note_ids = $this->get_created_inbox_note_ids();
+
+			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
+
+			$order->delete( true );
+
+			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Deleting the order should remove the associated merchant inbox notification.' );
+		} finally {
+			remove_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
 			$capture['remove']();
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -495,9 +495,9 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not add a merchant inbox notification when no order matches.
+	 * @testdox Should skip the merchant inbox notification when no order matches.
 	 */
-	public function test_process_current_request_does_not_add_inbox_note_when_order_does_not_match(): void {
+	public function test_process_current_request_skips_inbox_note_when_order_does_not_match(): void {
 		$order   = $this->create_order_for_form_data(
 			array(
 				OrderWithdrawalFormProcessor::FIELD_EMAIL => 'different@example.test',

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -584,12 +584,13 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	 * @testdox Should keep the user on review with an error notice when notification emails fail.
 	 */
 	public function test_process_current_request_surfaces_error_when_emails_fail(): void {
+		$order   = $this->create_order_for_form_data();
 		$capture = $this->capture_wp_mail( false );
 
 		try {
 			$this->prepare_post_request(
 				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
-				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999999' )
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
 			);
 
 			$state         = $this->sut->process_current_request();
@@ -599,12 +600,18 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertCount( 2, $capture['captures'], 'The processor should attempt both notification emails before surfacing the failure.' );
 			$this->assertNotEmpty( $error_notices, 'Email failures should add an error notice.' );
 			$this->assertStringContainsString( 'We could not submit your withdrawal request.', $error_notices[0]['notice'], 'The error notice should tell the user the submission did not complete.' );
+			$this->assertFalse( $this->order_has_note_containing( $order, 'Order withdrawal requested' ), 'Email failures should not add a retryable request to the order notes.' );
+			$this->assertNotSame(
+				'yes',
+				$order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ),
+				'Email failures should not mark the matched order as having a withdrawal request.'
+			);
 			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Email failures should not create merchant inbox notifications.' );
 
 			wc_clear_notices();
 			$this->prepare_post_request(
 				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
-				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => '999999999' )
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
 			);
 
 			$second_state         = $this->sut->process_current_request();

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -24,7 +24,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	private const FLUSH_QUEUE_OPTION                  = 'woocommerce_queue_flush_rewrite_rules';
 	private const MISSING_OPTION_MARK                 = '__woocommerce_order_withdrawal_missing_option__';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
-	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
+	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-order-';
 	private const RATE_LIMIT_PREFIX                   = 'order_withdrawal_';
 	private const ORDER_NOTE_WITHDRAWAL_REQUESTED     = 'Order withdrawal requested. Withdrawal type: Specific items only.';
 
@@ -482,7 +482,8 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_INFORMATIONAL, $note->get_type(), 'The inbox notification should be informational.' );
 			$this->assertSame( Note::E_WC_ADMIN_NOTE_UNACTIONED, $note->get_status(), 'The inbox notification should start unactioned.' );
-			$this->assertSame( sprintf( 'Withdraw order request for #%s', $order->get_order_number() ), $note->get_title(), 'The inbox notification should have the expected title.' );
+			$this->assertSame( sprintf( 'Order withdrawal request for #%s', $order->get_order_number() ), $note->get_title(), 'The inbox notification should have the expected title.' );
+			$this->assertStringContainsString( sprintf( 'order #%s', $order->get_order_number() ), $note->get_content(), 'The inbox notification should consistently prefix the order number.' );
 			$this->assertStringContainsString( (string) $order->get_order_number(), $note->get_content(), 'The inbox notification should include the order number.' );
 			$this->assertStringContainsString( 'Review the matched order to confirm the request details.', $note->get_content(), 'The inbox notification should direct merchants to the matched order.' );
 			$this->assertStringNotContainsString( 'Jane Doe', $note->get_content(), 'The inbox notification should not include the customer name.' );
@@ -533,7 +534,6 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	public function test_delete_order_withdrawal_inbox_note_for_order_deletes_matched_inbox_note(): void {
 		$order   = $this->create_order_for_form_data();
 		$capture = $this->capture_wp_mail();
-		add_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10, 1 );
 
 		try {
 			$this->prepare_post_request(
@@ -547,12 +547,44 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 
 			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
 
-			$order->delete( true );
+			$this->sut->delete_order_withdrawal_inbox_note_for_order( $order );
 
-			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Deleting the order should remove the associated merchant inbox notification.' );
+			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Cleaning up the order should remove the associated merchant inbox notification.' );
 		} finally {
-			remove_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
 			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should not delete a merchant inbox notification for a non-order post ID.
+	 */
+	public function test_delete_order_withdrawal_inbox_note_for_order_ignores_non_order_post_ids(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Not an order',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$this->assertIsInt( $post_id, 'The test post should be created.' );
+
+		$note_name = self::INBOX_NOTE_NAME_PREFIX . $post_id;
+		$note      = new Note();
+		$note->set_title( 'Order withdrawal request for non-order post' );
+		$note->set_content( 'This note should not be deleted.' );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( $note_name );
+		$note->set_source( 'woocommerce-admin' );
+		$note->save();
+
+		try {
+			$this->sut->delete_order_withdrawal_inbox_note_for_order( $post_id );
+
+			$this->assertInstanceOf( Note::class, Notes::get_note_by_name( $note_name ), 'Non-order post deletion should not delete matching inbox notes.' );
+		} finally {
+			Notes::delete_notes_with_name( $note_name );
+			wp_delete_post( $post_id, true );
 		}
 	}
 
@@ -950,7 +982,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		$note_ids = array();
 
 		foreach ( $this->created_order_ids as $order_id ) {
-			$note = Notes::get_note_by_name( self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id );
+			$note = Notes::get_note_by_name( self::INBOX_NOTE_NAME_PREFIX . $order_id );
 
 			if ( $note instanceof Note ) {
 				$note_ids[] = $note->get_id();
@@ -967,7 +999,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		$note_names = array();
 
 		foreach ( $this->created_order_ids as $order_id ) {
-			$note_names[] = self::INBOX_NOTE_NAME_PREFIX . 'order-' . $order_id;
+			$note_names[] = self::INBOX_NOTE_NAME_PREFIX . $order_id;
 		}
 
 		if ( ! empty( $note_names ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -3,6 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\OrderWithdrawal;
 
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormProcessor;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormState;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormView;
@@ -20,6 +22,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	private const FLUSH_QUEUE_OPTION                  = 'woocommerce_queue_flush_rewrite_rules';
 	private const MISSING_OPTION_MARK                 = '__woocommerce_order_withdrawal_missing_option__';
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
+	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
 	private const RATE_LIMIT_PREFIX                   = 'order_withdrawal_';
 
 	/**
@@ -154,6 +157,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		wc_clear_notices();
 		$this->clear_order_withdrawal_rate_limits();
 		$this->delete_created_orders();
+		$this->delete_created_inbox_notes();
 		WC()->session = $this->original_session;
 
 		parent::tearDown();
@@ -365,6 +369,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertStringContainsString( 'already been submitted for this order', $error_notices[0]['notice'], 'The notice should explain that the order already has a withdrawal request.' );
 			$this->assertCount( 0, $capture['captures'], 'Duplicate matched submissions should not send notification emails.' );
 			$this->assertFalse( $this->order_has_note_containing( $order, 'Order withdrawal requested' ), 'Duplicate matched submissions should not add another order note.' );
+			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Duplicate matched submissions should not create merchant inbox notifications.' );
 
 			wc_clear_notices();
 			$this->prepare_post_request(
@@ -449,6 +454,80 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should add a merchant inbox notification with a view order action when a confirmed submission matches an order.
+	 */
+	public function test_process_current_request_adds_inbox_note_with_order_action_for_exact_order_match(): void {
+		$order   = $this->create_order_for_form_data();
+		$capture = $this->capture_wp_mail();
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$state    = $this->sut->process_current_request();
+			$note_ids = $this->get_created_inbox_note_ids();
+
+			$this->assertSame( 'confirmation', $state->screen, 'Matched confirm submissions should reach the confirmation screen.' );
+			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
+
+			$note = Notes::get_note( $note_ids[0] );
+
+			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
+			$this->assertSame( Note::E_WC_ADMIN_NOTE_INFORMATIONAL, $note->get_type(), 'The inbox notification should be informational.' );
+			$this->assertSame( Note::E_WC_ADMIN_NOTE_UNACTIONED, $note->get_status(), 'The inbox notification should start unactioned.' );
+			$this->assertSame( 'Withdraw Order Request', $note->get_title(), 'The inbox notification should have the expected title.' );
+			$this->assertStringContainsString( 'Jane Doe', $note->get_content(), 'The inbox notification should include the customer name.' );
+			$this->assertStringContainsString( 'jane@example.test', $note->get_content(), 'The inbox notification should include the customer email address.' );
+			$this->assertStringContainsString( 'Items requested for withdrawal: Line item 1', $note->get_content(), 'The inbox notification should include the withdrawal details.' );
+
+			$actions = $note->get_actions();
+
+			$this->assertCount( 1, $actions, 'The inbox notification should have one action.' );
+			$this->assertSame( 'view-order', $actions[0]->name, 'The inbox notification action should be the view order action.' );
+			$this->assertSame( $order->get_edit_order_url(), $actions[0]->query, 'The inbox notification action should link to the matched order.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should add a merchant inbox notification without an order action when no order matches.
+	 */
+	public function test_process_current_request_adds_inbox_note_without_order_action_when_order_does_not_match(): void {
+		$order   = $this->create_order_for_form_data(
+			array(
+				OrderWithdrawalFormProcessor::FIELD_EMAIL => 'different@example.test',
+				OrderWithdrawalFormProcessor::FIELD_EMAIL_CONFIRMATION => 'different@example.test',
+			)
+		);
+		$capture = $this->capture_wp_mail();
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$state    = $this->sut->process_current_request();
+			$note_ids = $this->get_created_inbox_note_ids();
+
+			$this->assertSame( 'confirmation', $state->screen, 'Unmatched confirm submissions should still reach the confirmation screen.' );
+			$this->assertCount( 1, $note_ids, 'An unmatched submission should create one merchant inbox notification.' );
+
+			$note = Notes::get_note( $note_ids[0] );
+
+			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
+			$this->assertStringContainsString( 'jane@example.test', $note->get_content(), 'The inbox notification should include the customer email address.' );
+			$this->assertStringContainsString( 'could not match this request to an order automatically', $note->get_content(), 'The inbox notification should explain that no order was matched.' );
+			$this->assertCount( 0, $note->get_actions(), 'An unmatched submission should not add a view order action.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
 	 * @testdox Should keep the user on review with an error notice when notification emails fail.
 	 */
 	public function test_process_current_request_surfaces_error_when_emails_fail(): void {
@@ -467,6 +546,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertCount( 2, $capture['captures'], 'The processor should attempt both notification emails before surfacing the failure.' );
 			$this->assertNotEmpty( $error_notices, 'Email failures should add an error notice.' );
 			$this->assertStringContainsString( 'We could not submit your withdrawal request.', $error_notices[0]['notice'], 'The error notice should tell the user the submission did not complete.' );
+			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Email failures should not create merchant inbox notifications.' );
 
 			wc_clear_notices();
 			$this->prepare_post_request(
@@ -795,6 +875,37 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 
 		$this->assertInstanceOf( WC_Order::class, $updated_order, 'The order should still exist.' );
 		$this->assertSame( 'yes', $updated_order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ), 'The matched order should be flagged as having a withdrawal request.' );
+	}
+
+	/**
+	 * Get the IDs of order withdrawal inbox notes created during a test.
+	 *
+	 * @return int[]
+	 */
+	private function get_created_inbox_note_ids(): array {
+		global $wpdb;
+
+		$note_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE name LIKE %s",
+				$wpdb->esc_like( self::INBOX_NOTE_NAME_PREFIX ) . '%'
+			)
+		);
+
+		return array_map( 'intval', (array) $note_ids );
+	}
+
+	/**
+	 * Delete inbox notes created during a test.
+	 */
+	private function delete_created_inbox_notes(): void {
+		foreach ( $this->get_created_inbox_note_ids() as $note_id ) {
+			$note = Notes::get_note( $note_id );
+
+			if ( $note instanceof Note ) {
+				$note->delete();
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -26,6 +26,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
 	private const RATE_LIMIT_PREFIX                   = 'order_withdrawal_';
+	private const ORDER_NOTE_WITHDRAWAL_REQUESTED     = 'Order withdrawal requested. Withdrawal type: Specific items only.';
 
 	/**
 	 * The System Under Test.
@@ -228,8 +229,10 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
 			$this->assertStringContainsString( str_replace( '&', '&amp;', $order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should link to the matched order.' );
 			$this->assertStringContainsString( 'View matched order', (string) $merchant_email['message'], 'The merchant email should include clear link text for the matched order.' );
-			$this->assertTrue( $this->order_has_note_containing( $order, 'Order withdrawal requested by Jane Doe (jane@example.test).' ), 'The matched order should receive a withdrawal note.' );
-			$this->assertTrue( $this->order_has_note_containing( $order, 'Items requested for withdrawal: Line item 1' ), 'Specific-item details should be included in the order note.' );
+			$this->assertTrue( $this->order_has_note_containing( $order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The matched order should receive a withdrawal note.' );
+			$this->assertFalse( $this->order_has_note_containing( $order, 'Jane Doe' ), 'The order note should not include the customer name.' );
+			$this->assertFalse( $this->order_has_note_containing( $order, 'jane@example.test' ), 'The order note should not include the customer email address.' );
+			$this->assertFalse( $this->order_has_note_containing( $order, 'Line item 1' ), 'The order note should not include free-form withdrawal details.' );
 			$this->assert_order_withdrawal_requested( $order );
 		} finally {
 			$capture['remove']();
@@ -263,7 +266,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 
 			$this->assertSame( 'confirmation', $state->screen, 'Custom order number submissions should reach the confirmation screen.' );
 			$this->assertCount( 2, $capture['captures'], 'The customer and merchant emails should both be sent.' );
-			$this->assertTrue( $this->order_has_note_containing( $order, 'Order withdrawal requested by Jane Doe (jane@example.test).' ), 'The custom-number matched order should receive a withdrawal note.' );
+			$this->assertTrue( $this->order_has_note_containing( $order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The custom-number matched order should receive a withdrawal note.' );
 			$this->assert_order_withdrawal_requested( $order );
 		} finally {
 			remove_filter( 'woocommerce_order_number', $filter, 10 );
@@ -292,7 +295,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertCount( 2, $capture['captures'], 'The customer and merchant emails should both be sent.' );
 			$this->assertStringContainsString( str_replace( '&', '&amp;', $target_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should link to the intended order.' );
 			$this->assertStringNotContainsString( str_replace( '&', '&amp;', $wrong_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should not link to the wrong order.' );
-			$this->assertTrue( $this->order_has_note_containing( $target_order, 'Order withdrawal requested by Jane Doe (jane@example.test).' ), 'The intended order should receive a withdrawal note.' );
+			$this->assertTrue( $this->order_has_note_containing( $target_order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The intended order should receive a withdrawal note.' );
 			$this->assertFalse( $this->order_has_note_containing( $wrong_order, 'Order withdrawal requested' ), 'The wrong order should not receive a withdrawal note.' );
 			$this->assert_order_withdrawal_requested( $target_order );
 		} finally {
@@ -339,7 +342,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertCount( 2, $capture['captures'], 'The customer and merchant emails should both be sent.' );
 			$this->assertStringContainsString( str_replace( '&', '&amp;', $target_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should link to the intended order.' );
 			$this->assertStringNotContainsString( str_replace( '&', '&amp;', $different_name_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should not link to the order with a different billing name.' );
-			$this->assertTrue( $this->order_has_note_containing( $target_order, 'Order withdrawal requested by Jane Doe (jane@example.test).' ), 'The intended order should receive a withdrawal note.' );
+			$this->assertTrue( $this->order_has_note_containing( $target_order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The intended order should receive a withdrawal note.' );
 			$this->assertFalse( $this->order_has_note_containing( $different_name_order, 'Order withdrawal requested' ), 'The order with a different billing name should not receive a withdrawal note.' );
 			$this->assert_order_withdrawal_requested( $target_order );
 		} finally {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -601,9 +601,13 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertNotEmpty( $error_notices, 'Email failures should add an error notice.' );
 			$this->assertStringContainsString( 'We could not submit your withdrawal request.', $error_notices[0]['notice'], 'The error notice should tell the user the submission did not complete.' );
 			$this->assertFalse( $this->order_has_note_containing( $order, 'Order withdrawal requested' ), 'Email failures should not add a retryable request to the order notes.' );
+
+			$updated_order = wc_get_order( $order->get_id() );
+
+			$this->assertInstanceOf( WC_Order::class, $updated_order, 'The matched order should still exist.' );
 			$this->assertNotSame(
 				'yes',
-				$order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ),
+				$updated_order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ),
 				'Email failures should not mark the matched order as having a withdrawal request.'
 			);
 			$this->assertCount( 0, $this->get_created_inbox_note_ids(), 'Email failures should not create merchant inbox notifications.' );

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Tests\Internal\OrderWithdrawal;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalController;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormProcessor;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormState;
 use Automattic\WooCommerce\Internal\OrderWithdrawal\OrderWithdrawalFormView;
@@ -548,6 +550,30 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		} finally {
 			remove_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
 			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should register cleanup hooks for HPOS and legacy order deletion.
+	 */
+	public function test_controller_registers_order_deletion_cleanup_hooks(): void {
+		$controller = new OrderWithdrawalController();
+		$controller->init( $this->sut, new OrderWithdrawalFormView() );
+
+		try {
+			$controller->register();
+
+			$this->assertNotFalse( has_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ) ) );
+			$this->assertNotFalse( has_action( 'before_delete_post', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ) ) );
+		} finally {
+			remove_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $controller, 'maybe_flush_rewrite_rules' ), 10 );
+			remove_filter( 'woocommerce_get_query_vars', array( $controller, 'add_query_var' ), 10 );
+			remove_filter( 'woocommerce_endpoint_order-withdrawal_title', array( $controller, 'get_endpoint_title' ), 10 );
+			remove_filter( 'woocommerce_settings_pages', array( $controller, 'add_endpoint_setting' ), 10 );
+			remove_action( 'woocommerce_account_order-withdrawal_endpoint', array( $controller, 'render_view' ), 10 );
+			remove_action( 'woocommerce_before_delete_order', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
+			remove_action( 'before_delete_post', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
+			remove_action( 'woocommerce_privacy_remove_order_personal_data', array( $this->sut, 'delete_order_withdrawal_inbox_note_for_order' ), 10 );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When a customer submits a withdraw order request we notify the merchant via email and create an order note (if the details match an order). This PR introduces another notification (if the order details match an order) by creating a WooCommerce inbox notification which intentionally omits any personally identifiable information.

Closes [WOOPRD-3625](https://linear.app/a8c/issue/WOOPRD-3625/show-merchant-notification-prompting-form-enablement)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the Order withdrawal feature under WooCommerce > Settings > Advanced > Features.
2. Place a test order and note the billing first name, last name, email, and order number.
3. Go to `/my-account/withdraw-order/`, submit the form with the order's billing details and order number, and confirm the request.
4. Go to WooCommerce > Home and verify the inbox shows a "Withdraw Order Request" notification with the order details and a "View order" button that opens the matched order.
5. Submit another request with an order number and details that do not match any order. Verify a inbox notification does not appear.
6. Resubmit the first request and verify it is rejected as a duplicate and no second inbox notification is created.
7. Submit another successful withdraw order request, but **do not** click "View order" in the inbox notification. Now, in the order move it to trash, and then delete it permanently. Ensure the inbox notification gets deleted when you delete the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit (`pnpm test:php:env -- --filter OrderWithdrawalTest`): 18 tests, 114 assertions, all passing. New tests cover inbox note creation for matched orders (including the "View order" action), note creation without an action for unmatched requests, and that no note is created for duplicate submissions or when notification emails fail.
- PHPCS clean on the changed files; PHPStan reports no errors.
- Environment: local wp-env (Docker), PHP 8.1, single site.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a merchant inbox notification when a customer submits an order withdrawal request.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
