### PR TITLE
Fix changelogger corrupting hand-edited breaking-change markers

### DIFF
--- a/tools/changelogger/class-formatter.php
+++ b/tools/changelogger/class-formatter.php
@@ -27,8 +27,8 @@ class Formatter extends KeepAChangelogParser {
 	use PluginTrait;
 
 	/**
-	 * Marker appended after the significance of a major change. Written by format() and stripped by
-	 * parse(), so both sides must share this definition for a changelog to survive a round trip.
+	 * Marker appended after the significance of a major change. format() is its only source: it is
+	 * emitted from the significance on every write, and parse() discards whatever marker it reads.
 	 *
 	 * @var string
 	 */
@@ -193,9 +193,14 @@ class Formatter extends KeepAChangelogParser {
 					if ( 0 === strpos( $row, $this->bullet ) ) {
 						$row = substr( $row, strlen( $this->bullet ) );
 					}
-					// Drop the marker that format() appends after a major significance, otherwise it lands in the
+					// Drop any bracketed decoration following the significance, otherwise it lands in the
 					// significance segment below and the entry is re-emitted with no significance at all.
-					$row = preg_replace( '/^(major)\s*' . preg_quote( self::BREAKING_CHANGE_MARKER, '/' ) . '/i', '$1', $row );
+					// format() derives the breaking-change marker from the significance rather than preserving
+					// it, so matching brackets loosely instead of that exact marker keeps a hand-edited
+					// changelog parseable when its emphasis or spacing differs.
+					if ( ! $is_subentry ) {
+						$row = preg_replace( '/^(patch|minor|major)\s*\[[^\]]*\]/i', '$1', $row );
+					}
 
 					// Limit the split so that content containing " - " is not truncated at its own separator.
 					$row_segments = explode( ' - ', $row, 2 );

--- a/tools/changelogger/class-formatter.php
+++ b/tools/changelogger/class-formatter.php
@@ -27,8 +27,10 @@ class Formatter extends KeepAChangelogParser {
 	use PluginTrait;
 
 	/**
-	 * Marker appended after the significance of a major change. format() is its only source: it is
-	 * emitted from the significance on every write, and parse() discards whatever marker it reads.
+	 * Marker appended after the significance of a major change. format() regenerates it from the
+	 * significance on every write, so it is never read back: parse() discards whatever bracketed
+	 * decoration sits in that slot, including hand-written variants of the marker. Subentry rows are
+	 * exempt, since their text is content verbatim.
 	 *
 	 * @var string
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

#67059 taught `parse()` to strip the breaking-change marker that `format()` writes, so that a `Major` entry survives a release rewrite. It got the canonical shape right but left two gaps, both of which only bite a **hand-edited** changelog:

-   **The strip runs on every row, before the subentry branch.** A row under a `###` subheading keeps its whole text as `content`, so a marker the author typed deliberately is silently removed. Reachable through `Legacy_Core_Formatter`, whose `entry_pattern` matches `###`. Gating on `! $is_subentry` mirrors `format()`, which emits the marker only for non-subentries.
-   **It matched one byte-exact string.** A marker written `[**BREAKING CHANGE**]` or `[ __BREAKING CHANGE__ ]` fell into the significance segment, so the entry was re-emitted with **no significance** and the five-space indent that fails markdownlint `MD007` — the release-blocking symptom #67059 set out to fix. Since `format()` derives the marker from the significance on every write rather than preserving what it read, `parse()` can match the brackets loosely instead of pinning one spelling.

The looser match is deliberately kept out of `$subheading`, so grouping and entry order are unchanged; only significance extraction is affected.

Closes #67099.

(For Bug Fixes) Bug introduced in PR #67059 — the subentry strip is new in that PR. The exact-string matching is a narrower statement: before #67059 there was no marker handling at all, so **every** marker shape broke, including the canonical one. This PR closes the remainder.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

**The output of every step below is already recorded in the next section, so re-running this is optional.**

The tool is only exercised by a release rewrite, so the meaningful test is `parse()` → `format()`. The harness needs `jetpack-changelogger`, which isn't vendored at the repo root but is a dev dependency of the PHP packages.

1. Install the dependency once (skip if `packages/php/blueprint/vendor` already exists):

    ```sh
    cd packages/php/blueprint && composer install && cd -
    ```

2. Save the script from the collapsed block below as `/tmp/verify-changelogger.php`.
3. Run it on this branch, then with `trunk`'s formatter swapped in, and diff:

    ```sh
    php /tmp/verify-changelogger.php "$PWD" > /tmp/after.txt
    git checkout trunk -- tools/changelogger/class-formatter.php
    php /tmp/verify-changelogger.php "$PWD" > /tmp/before.txt
    git checkout HEAD -- tools/changelogger/class-formatter.php   # restore the branch version
    diff /tmp/before.txt /tmp/after.txt
    ```

4. Expected: sections **A** and **B** differ exactly as tabulated below; section **C** is identical, i.e. no real changelog moves.

<details>
<summary><code>verify-changelogger.php</code></summary>

```php
<?php
/**
 * Round-trip verification for tools/changelogger.
 *
 * Usage: php verify-changelogger.php /path/to/woocommerce
 */

$repo = realpath( $argv[1] ?? getcwd() );
if ( ! $repo || ! is_dir( "$repo/tools/changelogger" ) ) {
	fwrite( STDERR, "Not a WooCommerce monorepo checkout: {$argv[1]}\n" );
	exit( 1 );
}

// jetpack-changelogger is not vendored at the repo root; use whichever php package has it installed.
$autoload = null;
foreach ( glob( "$repo/packages/php/*/vendor/autoload.php" ) as $candidate ) {
	if ( is_dir( dirname( $candidate ) . '/automattic/jetpack-changelogger' ) ) {
		$autoload = $candidate;
		break;
	}
}
if ( ! $autoload ) {
	fwrite( STDERR, "jetpack-changelogger not found. Run: (cd $repo/packages/php/blueprint && composer install)\n" );
	exit( 1 );
}
require $autoload;

require_once "$repo/tools/changelogger/class-formatter.php";
require_once "$repo/tools/changelogger/class-package-formatter.php";
require_once "$repo/tools/changelogger/class-legacy-core-formatter.php";
require_once "$repo/tools/changelogger/class-php-package-formatter.php";
require_once "$repo/tools/changelogger/class-plugin-formatter.php";

$ns = 'Automattic\\WooCommerce\\MonorepoTools\\Changelogger\\';

$bullets = function ( $text ) {
	preg_match_all( '/^[-*]\s.*$/m', $text, $m );
	return $m[0] ? implode( ' | ', array_map( 'rtrim', $m[0] ) ) : '(row dropped)';
};

echo "================================================================================\n";
echo " A. Non-subentry rows - Package_Formatter (all 12 real markers live on this path)\n";
echo "================================================================================\n";

chdir( "$repo/packages/js/email-editor" ); // release links are derived from cwd
$pkg_cls = $ns . 'Package_Formatter';
$pkg     = new $pkg_cls();

$rows = array(
	'canonical (what format writes)' => '-   Major [ **BREAKING CHANGE** ] - Removed the foo filter.',
	'no inner bracket spaces'        => '-   Major [**BREAKING CHANGE**] - Removed the foo filter.',
	'underscore emphasis'            => '-   Major [ __BREAKING CHANGE__ ] - Removed the foo filter.',
	'no emphasis at all'             => '-   Major [ BREAKING CHANGE ] - Removed the foo filter.',
	'lowercase significance'         => '-   major [ **BREAKING CHANGE** ] - Removed the foo filter.',
	'sentence case in marker'        => '-   Major [ **Breaking change** ] - Removed the foo filter.',
	'extra surrounding spaces'       => '-   Major  [ **BREAKING CHANGE** ]  - Removed the foo filter.',
	'marker moved into the text'     => '-   Major - [ **BREAKING CHANGE** ] Removed the foo filter.',
	'no marker, major significance'  => '-   Major - Removed the foo filter.',
	'minor significance'             => '-   Minor - Added a thing.',
	'patch significance'             => '-   Patch - Fixed a thing.',
	'content contains " - "'         => '-   Major [ **BREAKING CHANGE** ] - Remove foo - and bar too.',
	'trailing PR reference'          => '-   Major [ **BREAKING CHANGE** ] - Removed the foo filter. [#12345]',
	'non-marker bracket'             => '-   Minor [#12345] - Added a thing.',
	'no significance preamble'       => '-   Removed the foo filter.',
);

foreach ( $rows as $label => $row ) {
	$in     = "## [1.2.0](https://example.com) - 2026-01-01 \n\n$row\n";
	$out    = @$pkg->format( $pkg->parse( $in ) );
	$result = $bullets( $out );
	$status = ( rtrim( $row ) === $result ) ? 'stable ' : 'changed';
	printf( "[%s] %s\n         in:  %s\n         out: %s\n", $status, $label, $row, $result );
}

echo "\n================================================================================\n";
echo " B. Subentry rows - Legacy_Core_Formatter (the only path where \$is_subentry is true)\n";
echo "================================================================================\n";

$legacy_cls = $ns . 'Legacy_Core_Formatter';
$legacy     = new $legacy_cls();

$sub_rows = array(
	'marker in subentry content' => '* Major [ **BREAKING CHANGE** ] - Removed the foo filter.',
	'other bracket in subentry'  => '* Patch [ see #123 ] - Fixed a thing.',
	'plain subentry row'         => '* Fix - Something else.',
);

foreach ( $sub_rows as $label => $row ) {
	$in  = "### 1.2.0 2026-01-01 \n\n$row\n";
	$out = @$legacy->format( $legacy->parse( $in ) );
	printf( "%-28s in:  %s\n%-28s out: %s\n", $label, $row, '', $bullets( $out ) );
}

echo "\n================================================================================\n";
echo " C. Every changelogger-managed changelog, via its configured formatter\n";
echo "================================================================================\n";

$map = array(
	'class-package-formatter.php'     => 'Package_Formatter',
	'class-legacy-core-formatter.php' => 'Legacy_Core_Formatter',
	'class-php-package-formatter.php' => 'Php_Package_Formatter',
	'class-plugin-formatter.php'      => 'Plugin_Formatter',
);

$globs   = array( 'packages/*/*/composer.json', 'plugins/*/composer.json', 'plugins/woocommerce/*/composer.json', 'plugins/woocommerce/packages/*/composer.json' );
$targets = array();
foreach ( $globs as $g ) {
	foreach ( glob( "$repo/$g" ) as $cj ) {
		$conf = json_decode( (string) file_get_contents( $cj ), true );
		$cl   = $conf['extra']['changelogger'] ?? null;
		if ( ! $cl ) {
			continue;
		}
		$fmt = $cl['formatter'] ?? null;
		$fmt = is_array( $fmt ) ? ( $fmt['filename'] ?? null ) : $fmt;
		if ( ! $fmt ) {
			continue;
		}
		$targets[ dirname( $cj ) ] = array( basename( $fmt ), $cl['changelog'] ?? 'CHANGELOG.md' );
	}
}
ksort( $targets );

$checked = 0;
foreach ( $targets as $dir => list( $fmtfile, $clfile ) ) {
	$path = "$dir/$clfile";
	if ( ! is_file( $path ) || ! isset( $map[ $fmtfile ] ) ) {
		continue;
	}
	$rel = ltrim( str_replace( $repo, '', $dir ), '/' );
	chdir( $dir );
	$cls = $ns . $map[ $fmtfile ];
	try {
		$f   = new $cls();
		$out = @$f->format( $f->parse( (string) file_get_contents( $path ) ) );
	} catch ( \Throwable $e ) {
		printf( "%-52s PARSE/FORMAT ERROR: %s\n", $rel, $e->getMessage() );
		continue;
	}
	++$checked;
	printf( "%-52s %s  (%d bytes)\n", $rel, substr( sha1( $out ), 0, 16 ), strlen( $out ) );
}
echo "\nchangelogs fingerprinted: $checked\n";
```

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Ran the harness above on PHP 8.4 against the vendored `jetpack-changelogger` 3.3.0, on this branch and with `trunk`'s `class-formatter.php` swapped in. Raw output for both runs is attached at the bottom.

#### A. Non-subentry rows (`Package_Formatter`) — where all 12 real markers live

| Input row | `trunk` | This branch |
| --- | --- | --- |
| `Major [ **BREAKING CHANGE** ] - text` | round-trips | round-trips |
| `Major [**BREAKING CHANGE**] - text` | ❌ `-    - text` | ✅ canonical |
| `Major [ __BREAKING CHANGE__ ] - text` | ❌ `-    - text` | ✅ canonical |
| `Major [ BREAKING CHANGE ] - text` | ❌ `-    - text` | ✅ canonical |
| `major [ **BREAKING CHANGE** ] - text` | normalised to canonical | same |
| `Major [ **Breaking change** ] - text` | normalised to canonical | same |
| `Major  [ **BREAKING CHANGE** ]  - text` | normalised to canonical | same |
| `Major - [ **BREAKING CHANGE** ] text` | marker duplicated | same (unchanged) |
| `Major - text` (no marker) | marker added back | same |
| `Minor - text`, `Patch - text` | round-trip | round-trip |
| `Major [ … ] - Remove foo - and bar too.` | round-trips | round-trips |
| `Major [ … ] - text [#12345]` | round-trips | round-trips |
| `Minor [#12345] - text` | ❌ `-    - text` | ⚠️ `- Minor - text` |
| `Removed the foo filter.` (no significance) | ❌ row dropped | ❌ row dropped |

Two rows deserve calling out rather than hiding:

-   **`Minor [#12345] - text`** is still lossy on this branch — the bracket is discarded, because the strip matches any bracketed decoration and cannot tell a marker from a PR reference. It is strictly better than `trunk`, which loses the significance *and* emits the malformed indent, but it is not a full fix. Making it exact would mean re-pinning the marker spelling, which is the fragility this PR removes.
-   **`Removed the foo filter.`** (no `Significance - ` preamble) is dropped by both. That's a **separate pre-existing bug**, not addressed here: `content` parses empty and `format()` skips it at the `'' !== $text` guard. It currently affects 3 real entries — `packages/js/create-woo-extension/CHANGELOG.md:23` and `packages/js/data/CHANGELOG.md:260,276`. Out of scope, worth its own issue.

#### B. Subentry rows (`Legacy_Core_Formatter`) — the path this ticket reported

| Input row | `trunk` | This branch |
| --- | --- | --- |
| `* Major [ **BREAKING CHANGE** ] - text` | ❌ `* Update - Major - text` | ✅ `* Update - Major [ **BREAKING CHANGE** ] - text` |
| `* Patch [ see #123 ] - text` | round-trips | round-trips |
| `* Fix - text` | round-trips | round-trips |

The `* Update -` prefix is `Legacy_Core_Formatter`'s own pre-existing subheading mapping (its `getSubheadingTypeMapping()` falls back to `update`), identical on both sides and unrelated to this change.



### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal release tooling under `tools/changelogger/`; nothing here ships to merchants. Matches the precedent of previous changelogger-only changes (#33645, #33800, #35642, #67059), none of which carried changelog entries.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
