### PR TITLE
Add withdrawal window warning for merchants

### DIFF
--- a/plugins/woocommerce/changelog/add-withdraw-order-window-warning
+++ b/plugins/woocommerce/changelog/add-withdraw-order-window-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add merchant warning for order withdrawal requests outside the 14-day window.

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -39,7 +39,8 @@ final class OrderWithdrawalFormProcessor {
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const ORDER_WITHDRAWAL_REQUESTED_VALUE    = 'yes';
 	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
-	private const WITHDRAWAL_WINDOW_IN_SECONDS        = 14 * DAY_IN_SECONDS;
+	private const WITHDRAWAL_WINDOW_IN_DAYS           = 14;
+	private const WITHDRAWAL_WINDOW_IN_SECONDS        = self::WITHDRAWAL_WINDOW_IN_DAYS * DAY_IN_SECONDS;
 	private const RATE_LIMIT_IP_PREFIX                = 'order_withdrawal_ip_';
 	private const RATE_LIMIT_EMAIL_PREFIX             = 'order_withdrawal_email_';
 	private const RATE_LIMIT_DELAY                    = MINUTE_IN_SECONDS / 2;
@@ -568,7 +569,11 @@ final class OrderWithdrawalFormProcessor {
 	 * Get the warning shown to merchants when a request is outside the valid window.
 	 */
 	private function get_withdrawal_window_warning_message(): string {
-		return __( 'This order is older than 14 days. Order withdrawal requests are only valid within 14 days of the order date.', 'woocommerce' );
+		return sprintf(
+			__( 'This order is older than %1$d days. Only orders within %2$d days of delivery are eligible for withdrawal.', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
+			self::WITHDRAWAL_WINDOW_IN_DAYS,
+			self::WITHDRAWAL_WINDOW_IN_DAYS
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -570,7 +570,8 @@ final class OrderWithdrawalFormProcessor {
 	 */
 	private function get_withdrawal_window_warning_message(): string {
 		return sprintf(
-			__( 'This order is older than %1$d days. Only orders within %2$d days of delivery are eligible for withdrawal.', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
+			/* translators: 1: number of days since the order was placed. 2: length of the withdrawal window in days. */
+			__( 'This order is older than %1$d days. Only orders within %2$d days of delivery are eligible for withdrawal.', 'woocommerce' ),
 			self::WITHDRAWAL_WINDOW_IN_DAYS,
 			self::WITHDRAWAL_WINDOW_IN_DAYS
 		);

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -483,6 +483,16 @@ final class OrderWithdrawalFormProcessor {
 	 */
 	private function add_order_withdrawal_inbox_note( WC_Order $matched_order ): void {
 		try {
+			$content = sprintf(
+				/* translators: %s: order number. */
+				__( 'A customer submitted an order withdrawal request for order #%s. Review the matched order to confirm the request details.', 'woocommerce' ),
+				$matched_order->get_order_number()
+			);
+
+			if ( $this->is_order_outside_withdrawal_window( $matched_order ) ) {
+				$content .= ' ' . $this->get_withdrawal_window_warning_message();
+			}
+
 			$note = new Note();
 			$note->set_title(
 				sprintf(
@@ -491,13 +501,7 @@ final class OrderWithdrawalFormProcessor {
 					$matched_order->get_order_number()
 				)
 			);
-			$note->set_content(
-				sprintf(
-				/* translators: %s: order number. */
-					__( 'A customer submitted an order withdrawal request for order #%s. Review the matched order to confirm the request details.', 'woocommerce' ),
-					$matched_order->get_order_number()
-				)
-			);
+			$note->set_content( $content );
 			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 			$note->set_name( self::INBOX_NOTE_NAME_PREFIX . $matched_order->get_id() );
 			$note->set_source( 'woocommerce-admin' );
@@ -532,15 +536,15 @@ final class OrderWithdrawalFormProcessor {
 			return;
 		}
 
-		if ( $matched_order instanceof WC_Order ) {
-			if ( $this->is_order_outside_withdrawal_window( $matched_order ) ) {
-				$content .= ' ' . $this->get_withdrawal_window_warning_message();
-			}
-		} else {
-			$content .= ' ' . __( 'WooCommerce could not match this request to an order automatically.', 'woocommerce' );
+		if ( 0 >= $order_id ) {
+			return;
 		}
 
-		return $content;
+		try {
+			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . $order_id );
+		} catch ( Throwable $e ) {
+			$this->log_inbox_note_error( $e, $order_id );
+		}
 	}
 
 	/**
@@ -568,26 +572,6 @@ final class OrderWithdrawalFormProcessor {
 			self::WITHDRAWAL_WINDOW_IN_DAYS,
 			self::WITHDRAWAL_WINDOW_IN_DAYS
 		);
-	}
-
-	/**
-	 * Get a unique name for the merchant inbox notification.
-	 *
-	 * @param array<string,string> $data          Form data.
-	 * @param WC_Order|null        $matched_order Matched order, if found.
-	 */
-	private function get_inbox_note_name( array $data, ?WC_Order $matched_order ): string {
-		if ( $matched_order instanceof WC_Order ) {
-			return self::INBOX_NOTE_NAME_PREFIX . 'order-' . $matched_order->get_id();
-		if ( 0 >= $order_id ) {
-			return;
-		}
-
-		try {
-			Notes::delete_notes_with_name( self::INBOX_NOTE_NAME_PREFIX . $order_id );
-		} catch ( Throwable $e ) {
-			$this->log_inbox_note_error( $e, $order_id );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -539,12 +539,12 @@ final class OrderWithdrawalFormProcessor {
 			);
 		}
 
-		if ( ! $matched_order instanceof WC_Order ) {
+		if ( $matched_order instanceof WC_Order ) {
+			if ( $this->is_order_outside_withdrawal_window( $matched_order ) ) {
+				$content .= ' ' . $this->get_withdrawal_window_warning_message();
+			}
+		} else {
 			$content .= ' ' . __( 'WooCommerce could not match this request to an order automatically.', 'woocommerce' );
-		}
-
-		if ( $matched_order instanceof WC_Order && $this->is_order_outside_withdrawal_window( $matched_order ) ) {
-			$content .= ' ' . $this->get_withdrawal_window_warning_message();
 		}
 
 		return $content;

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -39,6 +39,7 @@ final class OrderWithdrawalFormProcessor {
 	private const ORDER_WITHDRAWAL_REQUESTED_META_KEY = '_order_withdrawal_requested';
 	private const ORDER_WITHDRAWAL_REQUESTED_VALUE    = 'yes';
 	private const INBOX_NOTE_NAME_PREFIX              = 'wc-order-withdrawal-requested-';
+	private const WITHDRAWAL_WINDOW_IN_SECONDS        = 14 * DAY_IN_SECONDS;
 	private const RATE_LIMIT_IP_PREFIX                = 'order_withdrawal_ip_';
 	private const RATE_LIMIT_EMAIL_PREFIX             = 'order_withdrawal_email_';
 	private const RATE_LIMIT_DELAY                    = MINUTE_IN_SECONDS / 2;
@@ -541,7 +542,33 @@ final class OrderWithdrawalFormProcessor {
 			$content .= ' ' . __( 'WooCommerce could not match this request to an order automatically.', 'woocommerce' );
 		}
 
+		if ( $matched_order instanceof WC_Order && $this->is_order_outside_withdrawal_window( $matched_order ) ) {
+			$content .= ' ' . $this->get_withdrawal_window_warning_message();
+		}
+
 		return $content;
+	}
+
+	/**
+	 * Whether the matched order is outside the valid withdrawal request window.
+	 *
+	 * @param WC_Order $order Matched order.
+	 */
+	private function is_order_outside_withdrawal_window( WC_Order $order ): bool {
+		$date_created = $order->get_date_created( 'edit' );
+
+		if ( ! $date_created ) {
+			return false;
+		}
+
+		return ( time() - self::WITHDRAWAL_WINDOW_IN_SECONDS ) > $date_created->getTimestamp();
+	}
+
+	/**
+	 * Get the warning shown to merchants when a request is outside the valid window.
+	 */
+	private function get_withdrawal_window_warning_message(): string {
+		return __( 'This order is older than 14 days. Order withdrawal requests are only valid within 14 days of the order date.', 'woocommerce' );
 	}
 
 	/**
@@ -668,6 +695,10 @@ final class OrderWithdrawalFormProcessor {
 
 		if ( $matched_order instanceof WC_Order ) {
 			$order_url = $matched_order->get_edit_order_url();
+
+			if ( $this->is_order_outside_withdrawal_window( $matched_order ) ) {
+				$body .= '<p>' . esc_html( $this->get_withdrawal_window_warning_message() ) . '</p>';
+			}
 
 			$body .= sprintf(
 				'<p>%s</p>',

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -501,7 +501,6 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * @testdox Should warn merchants only when the matched order is older than fourteen days.
 	 * @testWith [15, true]
 	 *           [13, false]
@@ -551,10 +550,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should add a merchant inbox notification without an order action when no order matches.
-=======
 	 * @testdox Should skip the merchant inbox notification when no order matches.
->>>>>>> add-withdraw-order-note
 	 */
 	public function test_process_current_request_skips_inbox_note_when_order_does_not_match(): void {
 		$order   = $this->create_order_for_form_data(

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -501,7 +501,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		$order->save();
 
 		$capture         = $this->capture_wp_mail();
-		$warning_message = 'This order is older than 14 days. Order withdrawal requests are only valid within 14 days of the order date.';
+		$warning_message = 'This order is older than 14 days. Only orders within 14 days of delivery are eligible for withdrawal.';
 
 		try {
 			$this->prepare_post_request(

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -531,6 +531,42 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should not warn merchants when the matched order is within fourteen days.
+	 */
+	public function test_process_current_request_does_not_warn_merchants_for_order_newer_than_fourteen_days(): void {
+		$order = $this->create_order_for_form_data();
+		$order->set_date_created( time() - ( 13 * DAY_IN_SECONDS ) );
+		$order->save();
+
+		$capture         = $this->capture_wp_mail();
+		$warning_message = 'This order is older than 14 days. Only orders within 14 days of delivery are eligible for withdrawal.';
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$state    = $this->sut->process_current_request();
+			$note_ids = $this->get_created_inbox_note_ids();
+
+			$this->assertSame( 'confirmation', $state->screen, 'Matched confirm submissions should reach the confirmation screen.' );
+			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
+
+			$note = Notes::get_note( $note_ids[0] );
+
+			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
+			$this->assertStringNotContainsString( $warning_message, $note->get_content(), 'The inbox notification should not warn when the order is inside the withdrawal window.' );
+
+			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
+
+			$this->assertStringNotContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should not warn when the order is inside the withdrawal window.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
 	 * @testdox Should add a merchant inbox notification without an order action when no order matches.
 	 */
 	public function test_process_current_request_adds_inbox_note_without_order_action_when_order_does_not_match(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -493,6 +493,44 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should warn merchants when the matched order is older than fourteen days.
+	 */
+	public function test_process_current_request_warns_merchants_for_order_older_than_fourteen_days(): void {
+		$order = $this->create_order_for_form_data();
+		$order->set_date_created( time() - ( 15 * DAY_IN_SECONDS ) );
+		$order->save();
+
+		$capture         = $this->capture_wp_mail();
+		$warning_message = 'This order is older than 14 days. Order withdrawal requests are only valid within 14 days of the order date.';
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$state    = $this->sut->process_current_request();
+			$note_ids = $this->get_created_inbox_note_ids();
+
+			$this->assertSame( 'confirmation', $state->screen, 'Matched confirm submissions should reach the confirmation screen.' );
+			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
+
+			$note = Notes::get_note( $note_ids[0] );
+
+			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
+			$this->assertStringContainsString( $warning_message, $note->get_content(), 'The inbox notification should warn when the order is outside the withdrawal window.' );
+
+			$customer_email = $this->get_captured_mail_to( 'jane@example.test', $capture['captures'] );
+			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
+
+			$this->assertStringContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should warn when the order is outside the withdrawal window.' );
+			$this->assertStringNotContainsString( $warning_message, (string) $customer_email['message'], 'The customer email should not include the merchant withdrawal window warning.' );
+		} finally {
+			$capture['remove']();
+		}
+	}
+
+	/**
 	 * @testdox Should add a merchant inbox notification without an order action when no order matches.
 	 */
 	public function test_process_current_request_adds_inbox_note_without_order_action_when_order_does_not_match(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -493,11 +493,16 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should warn merchants when the matched order is older than fourteen days.
+	 * @testdox Should warn merchants only when the matched order is older than fourteen days.
+	 * @testWith [15, true]
+	 *           [13, false]
+	 *
+	 * @param int  $order_age_days     Order age in days.
+	 * @param bool $is_warning_expected Whether the warning should be included for merchants.
 	 */
-	public function test_process_current_request_warns_merchants_for_order_older_than_fourteen_days(): void {
+	public function test_process_current_request_warns_merchants_only_for_orders_older_than_fourteen_days( int $order_age_days, bool $is_warning_expected ): void {
 		$order = $this->create_order_for_form_data();
-		$order->set_date_created( time() - ( 15 * DAY_IN_SECONDS ) );
+		$order->set_date_created( time() - ( $order_age_days * DAY_IN_SECONDS ) );
 		$order->save();
 
 		$capture         = $this->capture_wp_mail();
@@ -518,49 +523,19 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$note = Notes::get_note( $note_ids[0] );
 
 			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
-			$this->assertStringContainsString( $warning_message, $note->get_content(), 'The inbox notification should warn when the order is outside the withdrawal window.' );
 
 			$customer_email = $this->get_captured_mail_to( 'jane@example.test', $capture['captures'] );
 			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
 
-			$this->assertStringContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should warn when the order is outside the withdrawal window.' );
+			if ( $is_warning_expected ) {
+				$this->assertStringContainsString( $warning_message, $note->get_content(), 'The inbox notification should warn when the order is outside the withdrawal window.' );
+				$this->assertStringContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should warn when the order is outside the withdrawal window.' );
+			} else {
+				$this->assertStringNotContainsString( $warning_message, $note->get_content(), 'The inbox notification should not warn when the order is inside the withdrawal window.' );
+				$this->assertStringNotContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should not warn when the order is inside the withdrawal window.' );
+			}
+
 			$this->assertStringNotContainsString( $warning_message, (string) $customer_email['message'], 'The customer email should not include the merchant withdrawal window warning.' );
-		} finally {
-			$capture['remove']();
-		}
-	}
-
-	/**
-	 * @testdox Should not warn merchants when the matched order is within fourteen days.
-	 */
-	public function test_process_current_request_does_not_warn_merchants_for_order_newer_than_fourteen_days(): void {
-		$order = $this->create_order_for_form_data();
-		$order->set_date_created( time() - ( 13 * DAY_IN_SECONDS ) );
-		$order->save();
-
-		$capture         = $this->capture_wp_mail();
-		$warning_message = 'This order is older than 14 days. Only orders within 14 days of delivery are eligible for withdrawal.';
-
-		try {
-			$this->prepare_post_request(
-				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
-				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
-			);
-
-			$state    = $this->sut->process_current_request();
-			$note_ids = $this->get_created_inbox_note_ids();
-
-			$this->assertSame( 'confirmation', $state->screen, 'Matched confirm submissions should reach the confirmation screen.' );
-			$this->assertCount( 1, $note_ids, 'A matched submission should create one merchant inbox notification.' );
-
-			$note = Notes::get_note( $note_ids[0] );
-
-			$this->assertInstanceOf( Note::class, $note, 'The merchant inbox notification should be readable.' );
-			$this->assertStringNotContainsString( $warning_message, $note->get_content(), 'The inbox notification should not warn when the order is inside the withdrawal window.' );
-
-			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
-
-			$this->assertStringNotContainsString( $warning_message, (string) $merchant_email['message'], 'The merchant email should not warn when the order is inside the withdrawal window.' );
 		} finally {
 			$capture['remove']();
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This is a stacked follow-up to #67155 and targets `add-withdraw-order-note` until that branch is merged. It warns merchants when a matched order withdrawal request is outside the 14-day withdrawal window. The warning is added to the WooCommerce inbox note and merchant email only; the customer acknowledgement email remains unchanged.

Closes [WOOPRD-3619](https://linear.app/a8c/issue/WOOPRD-3619/query-matching-order-by-order-window)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and make sure the Order withdrawal feature is enabled under WooCommerce > Settings > Advanced > Features.
2. Place a test order and note the billing first name, last name, email, and order number.
3. Edit the order date so the order is older than 14 days.
4. Go to My Account > Withdraw from contract (`/my-account/withdraw-order/`), submit the form with the order's billing details and order number, and confirm the request.
5. Go to WooCommerce > Home and verify the inbox note includes: "This order is older than 14 days. Order withdrawal requests are only valid within 14 days of the order date."
6. Verify the merchant notification email includes the same warning.
7. Verify the customer acknowledgement email does not include the warning.
8. Repeat with an order less than 14 days old and verify the warning is not shown in the inbox note or merchant email.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit (`pnpm test:php:env -- --filter OrderWithdrawalTest`): 19 tests, 120 assertions, all passing.
- PHPCS clean on the changed files.
- PHPStan reports no errors for `src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php`.
- Environment: local wp-env (Docker), PHP 8.1, single site.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
