### PR TITLE
Prevent crashes from invalid version cache values

### DIFF
--- a/plugins/woocommerce/changelog/woo6-44-codex-review-cache-miss-returning-null-can-crash
+++ b/plugins/woocommerce/changelog/woo6-44-codex-review-cache-miss-returning-null-can-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent invalid object cache values from crashing the version string generator.

--- a/plugins/woocommerce/changelog/woo6-44-version-cache-cleanup-hardening
+++ b/plugins/woocommerce/changelog/woo6-44-version-cache-cleanup-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Log and stop redundantly deleting invalid version string cache entries, and correctly detect misses from object cache drop-ins that report them as null.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -60892,12 +60892,6 @@ parameters:
 			path: src/Internal/CLI/Migrator/Runner.php
 
 		-
-			message: '#^Cannot call method call_function\(\) on Automattic\\WooCommerce\\Proxies\\LegacyProxy\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Internal/Caches/VersionStringGenerator.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Internal\\Caches\\VersionStringGenerator\:\:init\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -82,17 +82,18 @@ class VersionStringGenerator {
 		$this->validate_input( $id );
 
 		$cache_key = $this->get_cache_key( $id );
-		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		$found     = false;
+		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
-		if ( false === $version ) {
-			if ( ! $generate ) {
-				return null;
+		if ( ! is_string( $version ) ) {
+			if ( false !== $version || true === $found ) {
+				wp_cache_delete( $cache_key, self::CACHE_GROUP );
 			}
-			$version = $this->generate_version( $id );
-		} else {
-			// Refresh the cache lifetime.
-			$this->store_version( $id, $version );
+			return $generate ? $this->generate_version( $id ) : null;
 		}
+
+		// Refresh the cache lifetime.
+		$this->store_version( $id, $version );
 		return $version;
 	}
 

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -71,6 +71,11 @@ class VersionStringGenerator {
 	 * If no valid version exists and $generate is true, a new version will be created.
 	 * If no valid version exists and $generate is false, null will be returned.
 	 *
+	 * Cached values that aren't non-empty strings are treated as invalid and are never
+	 * returned. When $generate is true they are overwritten by the newly generated
+	 * version; when $generate is false they are deleted, which means a call with
+	 * $generate set to false can write to the cache.
+	 *
 	 * @param string $id       The ID to get the version string for.
 	 * @param bool   $generate Whether to generate a new version if one doesn't exist. Default true.
 	 * @return string|null Version string, or null if not found and $generate is false.
@@ -86,10 +91,17 @@ class VersionStringGenerator {
 		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( ! is_string( $version ) || '' === $version ) {
+			if ( $generate ) {
+				// The new version is written to the same cache key, replacing the invalid
+				// value, so deleting it first would only add a redundant round-trip.
+				return $this->generate_version( $id );
+			}
+
 			if ( $this->cache_entry_exists( $version, $found ) ) {
 				wp_cache_delete( $cache_key, self::CACHE_GROUP );
 			}
-			return $generate ? $this->generate_version( $id ) : null;
+
+			return null;
 		}
 
 		// Refresh the cache lifetime.

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -32,9 +32,9 @@ class VersionStringGenerator {
 	/**
 	 * Legacy proxy instance.
 	 *
-	 * @var LegacyProxy|null
+	 * @var LegacyProxy
 	 */
-	private ?LegacyProxy $legacy_proxy = null;
+	private LegacyProxy $legacy_proxy;
 
 	/**
 	 * Initialize the class dependencies.
@@ -91,13 +91,19 @@ class VersionStringGenerator {
 		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( ! is_string( $version ) || '' === $version ) {
+			$entry_exists = $this->cache_entry_exists( $version, $found );
+
+			if ( $entry_exists ) {
+				$this->log_invalid_cached_value( $id, $version );
+			}
+
 			if ( $generate ) {
 				// The new version is written to the same cache key, replacing the invalid
 				// value, so deleting it first would only add a redundant round-trip.
 				return $this->generate_version( $id );
 			}
 
-			if ( $this->cache_entry_exists( $version, $found ) ) {
+			if ( $entry_exists ) {
 				wp_cache_delete( $cache_key, self::CACHE_GROUP );
 			}
 
@@ -185,6 +191,27 @@ class VersionStringGenerator {
 	 */
 	private function cache_entry_exists( $value, $found ): bool {
 		return (bool) $found || ( false !== $value && null !== $value );
+	}
+
+	/**
+	 * Log a value found in the version string cache that isn't a usable version string.
+	 *
+	 * This should never happen with a well-behaved object cache, so surface it for
+	 * diagnosis rather than silently self-healing.
+	 *
+	 * @param string $id    The ID the invalid value was cached for.
+	 * @param mixed  $value The invalid cached value.
+	 * @return void
+	 */
+	private function log_invalid_cached_value( string $id, $value ): void {
+		$this->legacy_proxy->call_function( 'wc_get_logger' )->warning(
+			sprintf(
+				'Discarded an invalid version string cache entry for ID "%1$s" (got %2$s); the version will be regenerated.',
+				$id,
+				gettype( $value )
+			),
+			array( 'source' => 'version-string-generator' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -68,8 +68,8 @@ class VersionStringGenerator {
 	/**
 	 * Get the current version string for an ID.
 	 *
-	 * If no version exists and $generate is true, a new version will be created.
-	 * If no version exists and $generate is false, null will be returned.
+	 * If no valid version exists and $generate is true, a new version will be created.
+	 * If no valid version exists and $generate is false, null will be returned.
 	 *
 	 * @param string $id       The ID to get the version string for.
 	 * @param bool   $generate Whether to generate a new version if one doesn't exist. Default true.
@@ -85,7 +85,7 @@ class VersionStringGenerator {
 		$found     = false;
 		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
-		if ( ! is_string( $version ) ) {
+		if ( ! is_string( $version ) || '' === $version ) {
 			if ( false !== $version || true === $found ) {
 				wp_cache_delete( $cache_key, self::CACHE_GROUP );
 			}

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -86,7 +86,7 @@ class VersionStringGenerator {
 		$version   = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( ! is_string( $version ) || '' === $version ) {
-			if ( false !== $version || true === $found ) {
+			if ( $this->cache_entry_exists( $version, $found ) ) {
 				wp_cache_delete( $cache_key, self::CACHE_GROUP );
 			}
 			return $generate ? $this->generate_version( $id ) : null;
@@ -144,16 +144,35 @@ class VersionStringGenerator {
 
 		// Some object cache implementations may return non-boolean values.
 		// Verify the store by reading the value back.
-		$stored_value = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		$found        = false;
+		$stored_value = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 		if ( $stored_value === $version ) {
 			return true;
 		}
 
 		// The stored value doesn't match; clean up and report failure.
-		if ( false !== $stored_value ) {
+		if ( $this->cache_entry_exists( $stored_value, $found ) ) {
 			wp_cache_delete( $cache_key, self::CACHE_GROUP );
 		}
 		return false;
+	}
+
+	/**
+	 * Tell whether a value read from the cache is evidence that an entry is stored.
+	 *
+	 * Object cache drop-ins replace wp_cache_get() wholesale, so neither the returned
+	 * value nor the found flag is trustworthy on its own: some drop-ins never populate
+	 * $found, and some signal a miss with null rather than false. The value is therefore
+	 * the primary evidence, with $found as a tie-breaker that tells a stored false apart
+	 * from a genuine miss. $found is checked loosely because a drop-in may report it as a
+	 * truthy non-boolean.
+	 *
+	 * @param mixed $value The value returned by wp_cache_get().
+	 * @param mixed $found The found flag as populated by wp_cache_get(), if it populates it at all.
+	 * @return bool True if an entry appears to be stored, false if this looks like a miss.
+	 */
+	private function cache_entry_exists( $value, $found ): bool {
+		return (bool) $found || ( false !== $value && null !== $value );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
+++ b/plugins/woocommerce/src/Internal/Caches/VersionStringGenerator.php
@@ -94,7 +94,7 @@ class VersionStringGenerator {
 			$entry_exists = $this->cache_entry_exists( $version, $found );
 
 			if ( $entry_exists ) {
-				$this->log_invalid_cached_value( $id, $version );
+				$this->log_invalid_cached_value( $id, $version, $generate );
 			}
 
 			if ( $generate ) {
@@ -199,16 +199,18 @@ class VersionStringGenerator {
 	 * This should never happen with a well-behaved object cache, so surface it for
 	 * diagnosis rather than silently self-healing.
 	 *
-	 * @param string $id    The ID the invalid value was cached for.
-	 * @param mixed  $value The invalid cached value.
+	 * @param string $id           The ID the invalid value was cached for.
+	 * @param mixed  $value        The invalid cached value.
+	 * @param bool   $regenerating Whether a replacement version is being generated.
 	 * @return void
 	 */
-	private function log_invalid_cached_value( string $id, $value ): void {
+	private function log_invalid_cached_value( string $id, $value, bool $regenerating ): void {
 		$this->legacy_proxy->call_function( 'wc_get_logger' )->warning(
 			sprintf(
-				'Discarded an invalid version string cache entry for ID "%1$s" (got %2$s); the version will be regenerated.',
+				'Discarded an invalid version string cache entry for ID "%1$s" (got %2$s); %3$s.',
 				$id,
-				gettype( $value )
+				gettype( $value ),
+				$regenerating ? 'the version will be regenerated' : 'the entry will be deleted'
 			),
 			array( 'source' => 'version-string-generator' )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -20,6 +20,13 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	private $sut;
 
 	/**
+	 * The real object cache, saved while a mock is installed in its place.
+	 *
+	 * @var \WP_Object_Cache|null
+	 */
+	private $original_object_cache = null;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
@@ -34,6 +41,7 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	 * Runs after each test.
 	 */
 	public function tearDown(): void {
+		$this->restore_object_cache();
 		remove_all_filters( 'woocommerce_version_string_generator_ttl' );
 		$this->sut = null;
 		parent::tearDown();
@@ -48,6 +56,50 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 		$reflection = new \ReflectionClass( $this->sut );
 		$constant   = $reflection->getConstant( 'CACHE_GROUP' );
 		return $constant;
+	}
+
+	/**
+	 * Get the cache key the SUT uses for an ID.
+	 *
+	 * @param string $id The ID to get the cache key for.
+	 * @return string
+	 */
+	private function get_version_cache_key( string $id ): string {
+		return 'wc_version_string_' . md5( $id );
+	}
+
+	/**
+	 * Install a mock object cache in place of the real one.
+	 *
+	 * The real cache is restored in tearDown, so tests don't need to unwind it themselves.
+	 *
+	 * @return \WP_Object_Cache|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function install_mock_object_cache() {
+		global $wp_object_cache;
+
+		$mock = $this->createMock( \WP_Object_Cache::class );
+
+		$this->original_object_cache = $wp_object_cache;
+		$wp_object_cache             = $mock; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $mock;
+	}
+
+	/**
+	 * Restore the real object cache, if a mock was installed in its place.
+	 *
+	 * @return void
+	 */
+	private function restore_object_cache(): void {
+		global $wp_object_cache;
+
+		if ( null === $this->original_object_cache ) {
+			return;
+		}
+
+		$wp_object_cache             = $this->original_object_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$this->original_object_cache = null;
 	}
 
 	/**
@@ -122,91 +174,105 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	 * @testdox get_version does not delete on a genuine cache miss.
 	 */
 	public function test_get_version_does_not_delete_on_genuine_cache_miss(): void {
-		global $wp_object_cache;
-		$original_cache = $wp_object_cache;
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturnCallback(
+				static function ( $key, $group, $force, &$found ) {
+					$found = false;
+					return false;
+				}
+			);
+		$mock_cache->expects( $this->never() )->method( 'delete' );
 
-		try {
-			$mock_cache = $this->createMock( \WP_Object_Cache::class );
-			$mock_cache
-				->expects( $this->once() )
-				->method( 'get' )
-				->willReturnCallback(
-					static function ( $key, $group, $force, &$found ) {
-						$found = false;
-						return false;
-					}
-				);
-			$mock_cache->expects( $this->never() )->method( 'delete' );
-			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$version = $this->sut->get_version( 'genuine-cache-miss', false );
 
-			$version = $this->sut->get_version( 'genuine-cache-miss', false );
+		$this->assertNull( $version, 'A genuine cache miss should return null when generation is disabled' );
+	}
 
-			$this->assertNull( $version, 'A genuine cache miss should return null when generation is disabled' );
-		} finally {
-			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
+	/**
+	 * @testdox get_version does not delete when the cache signals a miss with null instead of false.
+	 */
+	public function test_get_version_does_not_delete_on_null_cache_miss(): void {
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( null );
+		$mock_cache->expects( $this->never() )->method( 'delete' );
+
+		$version = $this->sut->get_version( 'null-cache-miss', false );
+
+		$this->assertNull( $version, 'A null miss should be treated as a miss, not as a stored invalid value' );
+	}
+
+	/**
+	 * @testdox get_version deletes a stored false when the cache reports found as a truthy non-boolean.
+	 */
+	public function test_get_version_deletes_stored_false_when_found_flag_is_truthy(): void {
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturnCallback(
+				static function ( $key, $group, $force, &$found ) {
+					$found = 1;
+					return false;
+				}
+			);
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->get_version_cache_key( 'stored-false-truthy-found' ), $this->get_cache_group() )
+			->willReturn( true );
+
+		$version = $this->sut->get_version( 'stored-false-truthy-found', false );
+
+		$this->assertNull( $version, 'A stored false should be treated as an invalid cached value' );
 	}
 
 	/**
 	 * @testdox get_version accepts a cached string when the cache does not set the found flag.
 	 */
 	public function test_get_version_accepts_cached_string_without_found_flag(): void {
-		global $wp_object_cache;
-		$original_cache = $wp_object_cache;
-		$cache_group    = $this->get_cache_group();
-		$cache_key      = 'wc_version_string_' . md5( 'cached-string-without-found' );
 		$cached_version = 'cached-version';
 
-		try {
-			$mock_cache = $this->createMock( \WP_Object_Cache::class );
-			$mock_cache
-				->expects( $this->once() )
-				->method( 'get' )
-				->willReturn( $cached_version );
-			$mock_cache
-				->expects( $this->once() )
-				->method( 'set' )
-				->with( $cache_key, $cached_version, $cache_group, DAY_IN_SECONDS )
-				->willReturn( true );
-			$mock_cache->expects( $this->never() )->method( 'delete' );
-			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( $cached_version );
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'set' )
+			->with( $this->get_version_cache_key( 'cached-string-without-found' ), $cached_version, $this->get_cache_group(), DAY_IN_SECONDS )
+			->willReturn( true );
+		$mock_cache->expects( $this->never() )->method( 'delete' );
 
-			$version = $this->sut->get_version( 'cached-string-without-found' );
+		$version = $this->sut->get_version( 'cached-string-without-found' );
 
-			$this->assertSame( $cached_version, $version, 'A valid cached string should not depend on the found flag' );
-		} finally {
-			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
+		$this->assertSame( $cached_version, $version, 'A valid cached string should not depend on the found flag' );
 	}
 
 	/**
 	 * @testdox get_version deletes an invalid non-false value when the cache does not set the found flag.
 	 */
 	public function test_get_version_deletes_invalid_non_false_value_without_found_flag(): void {
-		global $wp_object_cache;
-		$original_cache = $wp_object_cache;
-		$cache_group    = $this->get_cache_group();
-		$cache_key      = 'wc_version_string_' . md5( 'invalid-value-without-found' );
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( true );
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->get_version_cache_key( 'invalid-value-without-found' ), $this->get_cache_group() )
+			->willReturn( true );
 
-		try {
-			$mock_cache = $this->createMock( \WP_Object_Cache::class );
-			$mock_cache
-				->expects( $this->once() )
-				->method( 'get' )
-				->willReturn( true );
-			$mock_cache
-				->expects( $this->once() )
-				->method( 'delete' )
-				->with( $cache_key, $cache_group )
-				->willReturn( true );
-			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$version = $this->sut->get_version( 'invalid-value-without-found', false );
 
-			$version = $this->sut->get_version( 'invalid-value-without-found', false );
-
-			$this->assertNull( $version, 'An invalid cached value should be treated as a miss' );
-		} finally {
-			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
+		$this->assertNull( $version, 'An invalid cached value should be treated as a miss' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -134,6 +134,60 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Invalid values that can be returned by an object cache.
+	 *
+	 * @return array<string, array{mixed}>
+	 */
+	public static function invalid_cached_version_values(): array {
+		return array(
+			'boolean false' => array( false ),
+			'null'          => array( null ),
+			'array'         => array( array( 'unexpected' ) ),
+			'integer'       => array( 42 ),
+		);
+	}
+
+	/**
+	 * @testdox get_version replaces invalid cached values when generation is enabled.
+	 * @dataProvider invalid_cached_version_values
+	 *
+	 * @param mixed $invalid_value Invalid cached value.
+	 */
+	public function test_get_version_replaces_invalid_cached_value_when_generation_enabled( $invalid_value ): void {
+		$cache_key = 'wc_version_string_' . md5( 'invalid-cached-version' );
+		wp_cache_set( $cache_key, $invalid_value, $this->get_cache_group() );
+
+		$version = $this->sut->get_version( 'invalid-cached-version' );
+
+		$this->assertIsString( $version, 'A new version string should be generated' );
+		$this->assertTrue( wp_is_uuid( (string) $version, 4 ), 'The generated version should be a UUID' );
+		$this->assertSame(
+			$version,
+			wp_cache_get( $cache_key, $this->get_cache_group() ),
+			'The invalid cached value should be replaced'
+		);
+	}
+
+	/**
+	 * @testdox get_version deletes invalid cached values when generation is disabled.
+	 * @dataProvider invalid_cached_version_values
+	 *
+	 * @param mixed $invalid_value Invalid cached value.
+	 */
+	public function test_get_version_deletes_invalid_cached_value_when_generation_disabled( $invalid_value ): void {
+		$cache_key = 'wc_version_string_' . md5( 'invalid-cached-version' );
+		wp_cache_set( $cache_key, $invalid_value, $this->get_cache_group() );
+
+		$version = $this->sut->get_version( 'invalid-cached-version', false );
+
+		$this->assertNull( $version, 'Generation-disabled cache misses should return null' );
+
+		$found = null;
+		wp_cache_get( $cache_key, $this->get_cache_group(), false, $found );
+		$this->assertFalse( $found, 'The invalid cached value should be deleted' );
+	}
+
+	/**
 	 * @testdox generate_version sets a new version for a not yet versioned ID.
 	 */
 	public function test_generate_version_creates_new() {

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Internal\Caches;
 
 use Automattic\WooCommerce\Internal\Caches\VersionStringGenerator;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 use WC_Unit_Test_Case;
 
 /**
  * Tests for VersionStringGenerator.
  */
 class VersionStringGeneratorTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
 
 	/**
 	 * The System Under Test.
@@ -294,6 +297,34 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 		$version = $this->sut->get_version( 'invalid-value-regenerated' );
 
 		$this->assertTrue( wp_is_uuid( (string) $version, 4 ), 'A new version should be generated over the invalid value' );
+	}
+
+	/**
+	 * @testdox get_version logs a warning when it discards an invalid cached value.
+	 */
+	public function test_get_version_logs_when_discarding_invalid_cached_value(): void {
+		$cache_key = $this->get_version_cache_key( 'logged-invalid-value' );
+		wp_cache_set( $cache_key, 42, $this->get_cache_group() );
+
+		$this->sut->get_version( 'logged-invalid-value' );
+
+		$this->assertLogged(
+			'warning',
+			'Discarded an invalid version string cache entry for ID "logged-invalid-value" (got integer)',
+			array( 'source' => 'version-string-generator' )
+		);
+	}
+
+	/**
+	 * @testdox get_version does not log on a genuine cache miss.
+	 */
+	public function test_get_version_does_not_log_on_genuine_cache_miss(): void {
+		$this->sut->get_version( 'unlogged-cache-miss' );
+
+		$this->assertEmpty(
+			$this->captured_logs,
+			'A genuine cache miss is the common path and should never be logged'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -119,6 +119,67 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_version does not delete on a genuine cache miss.
+	 */
+	public function test_get_version_does_not_delete_on_genuine_cache_miss(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+
+		try {
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache
+				->expects( $this->once() )
+				->method( 'get' )
+				->willReturnCallback(
+					static function ( $key, $group, $force, &$found ) {
+						$found = false;
+						return false;
+					}
+				);
+			$mock_cache->expects( $this->never() )->method( 'delete' );
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			$version = $this->sut->get_version( 'genuine-cache-miss', false );
+
+			$this->assertNull( $version, 'A genuine cache miss should return null when generation is disabled' );
+		} finally {
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
+	 * @testdox get_version accepts a cached string when the cache does not set the found flag.
+	 */
+	public function test_get_version_accepts_cached_string_without_found_flag(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+		$cache_group    = $this->get_cache_group();
+		$cache_key      = 'wc_version_string_' . md5( 'cached-string-without-found' );
+		$cached_version = 'cached-version';
+
+		try {
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache
+				->expects( $this->once() )
+				->method( 'get' )
+				->willReturn( $cached_version );
+			$mock_cache
+				->expects( $this->once() )
+				->method( 'set' )
+				->with( $cache_key, $cached_version, $cache_group, DAY_IN_SECONDS )
+				->willReturn( true );
+			$mock_cache->expects( $this->never() )->method( 'delete' );
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			$version = $this->sut->get_version( 'cached-string-without-found' );
+
+			$this->assertSame( $cached_version, $version, 'A valid cached string should not depend on the found flag' );
+		} finally {
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
 	 * @testdox get_version generates version by default when it doesn't exist.
 	 */
 	public function test_get_version_generates_by_default() {
@@ -141,6 +202,7 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	public static function invalid_cached_version_values(): array {
 		return array(
 			'boolean false' => array( false ),
+			'empty string'  => array( '' ),
 			'null'          => array( null ),
 			'array'         => array( array( 'unexpected' ) ),
 			'integer'       => array( 42 ),

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -180,6 +180,36 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_version deletes an invalid non-false value when the cache does not set the found flag.
+	 */
+	public function test_get_version_deletes_invalid_non_false_value_without_found_flag(): void {
+		global $wp_object_cache;
+		$original_cache = $wp_object_cache;
+		$cache_group    = $this->get_cache_group();
+		$cache_key      = 'wc_version_string_' . md5( 'invalid-value-without-found' );
+
+		try {
+			$mock_cache = $this->createMock( \WP_Object_Cache::class );
+			$mock_cache
+				->expects( $this->once() )
+				->method( 'get' )
+				->willReturn( true );
+			$mock_cache
+				->expects( $this->once() )
+				->method( 'delete' )
+				->with( $cache_key, $cache_group )
+				->willReturn( true );
+			$wp_object_cache = $mock_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+			$version = $this->sut->get_version( 'invalid-value-without-found', false );
+
+			$this->assertNull( $version, 'An invalid cached value should be treated as a miss' );
+		} finally {
+			$wp_object_cache = $original_cache; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+	}
+
+	/**
 	 * @testdox get_version generates version by default when it doesn't exist.
 	 */
 	public function test_get_version_generates_by_default() {

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -310,7 +310,24 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 
 		$this->assertLogged(
 			'warning',
-			'Discarded an invalid version string cache entry for ID "logged-invalid-value" (got integer)',
+			'Discarded an invalid version string cache entry for ID "logged-invalid-value" (got integer); the version will be regenerated.',
+			array( 'source' => 'version-string-generator' )
+		);
+	}
+
+	/**
+	 * @testdox get_version logs the deletion outcome when generation is disabled.
+	 */
+	public function test_get_version_logs_deletion_outcome_when_generation_disabled(): void {
+		$cache_key = $this->get_version_cache_key( 'logged-invalid-value-no-generate' );
+		wp_cache_set( $cache_key, 42, $this->get_cache_group() );
+
+		$this->sut->get_version( 'logged-invalid-value-no-generate', false );
+
+		// Nothing is regenerated on this path, so the message must not claim it is.
+		$this->assertLogged(
+			'warning',
+			'Discarded an invalid version string cache entry for ID "logged-invalid-value-no-generate" (got integer); the entry will be deleted.',
 			array( 'source' => 'version-string-generator' )
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/VersionStringGeneratorTest.php
@@ -276,6 +276,27 @@ class VersionStringGeneratorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_version replaces an invalid cached value without a separate delete when generating.
+	 */
+	public function test_get_version_does_not_delete_when_generating_a_replacement(): void {
+		$mock_cache = $this->install_mock_object_cache();
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( array( 'unexpected' ) );
+		$mock_cache
+			->expects( $this->once() )
+			->method( 'set' )
+			->with( $this->get_version_cache_key( 'invalid-value-regenerated' ), $this->anything(), $this->get_cache_group(), DAY_IN_SECONDS )
+			->willReturn( true );
+		$mock_cache->expects( $this->never() )->method( 'delete' );
+
+		$version = $this->sut->get_version( 'invalid-value-regenerated' );
+
+		$this->assertTrue( wp_is_uuid( (string) $version, 4 ), 'A new version should be generated over the invalid value' );
+	}
+
+	/**
 	 * @testdox get_version generates version by default when it doesn't exist.
 	 */
 	public function test_get_version_generates_by_default() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #63259.

`VersionStringGenerator::get_version()` treated every cache value other than boolean `false` as a valid version string. A malformed value such as `null` could therefore cross into the string-typed `store_version()` method and trigger a `TypeError` under `declare(strict_types=1)`. An empty string was the one invalid value that passed the type check: it was returned as-is, and `RestApiCache::generate_version_strings_hash()` filters with `if ( $version )`, so that entity silently dropped out of the tracked hash and its invalidation stayed inert until the response TTL expired.

This change validates cached values at the read boundary, replaces or removes invalid entries, and follows the existing generation contract.

**How an invalid entry is recognised.** Both the returned value and the `$found` output come from a pluggable `object-cache.php` drop-in, which replaces `wp_cache_get()` wholesale, so neither reliably matches WP core's convention. The decision lives in one place, `cache_entry_exists()`, which treats the value as the primary evidence, counts `null` alongside `false` as miss-like, and checks `$found` loosely as a tie-breaker for a stored `false`. `store_version()` asked the same question with its own predicate and now shares the helper. Valid non-empty strings are still accepted from backends that never populate `$found`.

**Cleanup only where it is needed.** When generation is enabled the replacement is written to the same cache key, so an explicit delete would remove a value the following `wp_cache_set()` overwrites anyway. `get_version()` is called once per tracked entity from the REST API cache trait, and this cache is only active with an external object cache configured, so the redundant delete cost one wasted round-trip per item against a remote backend on every cold read. The delete is now reserved for the `$generate = false` path, where nothing else will overwrite the invalid value.

**Diagnosability.** Discarding an invalid entry now logs a warning naming the ID and the type of the unexpected value, so a backend corrupting these entries at scale leaves a trace rather than presenting as generic cache thrash. This matches the logging the HPOS order and meta cache reads gained in #66131. The log is gated on `cache_entry_exists()`, so a genuine cache miss — by far the most common way through that branch — never logs.

### Backward compatibility

`get_version()` is `public` and shipped in 10.4.0. No signatures, hooks, cache keys or groups, or REST response shapes change, and no in-tree caller is affected: all three call sites in `RestApiCache` use the default `$generate = true` and none depends on invalid return values. Two behaviours do change for any out-of-tree consumer:

- **A read can now write.** `get_version( $id, false )` was previously guaranteed read-only. It can now issue a `wp_cache_delete()` when the cached value is invalid. Callers relying on strict read-only semantics for that argument should be aware of it; the method docblock now documents the side effect.
- **An empty string is no longer returned.** It is treated as an invalid entry and replaced or removed. Other invalid types (`null`, integers, arrays, booleans) were never returned before either — they threw a `TypeError` — so only the empty-string case changes what a caller can receive.

Extensions that directly store invalid sentinels in WooCommerce's internal version-string cache will observe cleanup and UUID regeneration, or `null` when generation is disabled. Valid non-empty strings remain supported.

The `LegacyProxy` property is now typed non-nullable, which is required to reach `wc_get_logger()` through it. The DI container always calls `init()`, and `can_use()` already dereferenced the property unguarded, so this introduces no new failure mode. It also resolves a baselined PHPStan error, so that entry was removed rather than allowed to grow.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From the repository root, run:

   ```sh
   cd plugins/woocommerce
   pnpm test:php:env -- --filter VersionStringGeneratorTest
   ```

2. Confirm the test class passes (38 tests, 85 assertions).
3. Confirm the invalid-cache-value cases cover boolean `false`, an empty string, `null`, an array, and an integer with generation both enabled and disabled.
4. Confirm the drop-in compatibility cases prove that a genuine cache miss is not deleted, that a miss signalled with `null` is not deleted either, that a stored `false` is deleted when the backend reports `$found` as a truthy non-boolean, that a valid cached string is accepted when the backend does not populate `$found`, and that an invalid non-false value is deleted without relying on `$found`.
5. Confirm `test_get_version_does_not_delete_when_generating_a_replacement` proves no delete is issued when a new version is generated over an invalid entry.
6. Confirm the logging cases prove a warning naming the ID and value type is emitted for a discarded entry, and that a genuine cache miss emits nothing.
7. Confirm the REST cache consumers still pass:

   ```sh
   pnpm test:php:env -- --filter 'VersionStringGenerator|RestApiCache'
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Docker `wp-env`, PHP 8.1.34: generator, REST cache, and product/order/tax invalidator suites passed with 190 tests and 777 assertions.
- Changed-file PHP lint passed.
- Full branch lint passed.
- PHPStan passed for `VersionStringGenerator.php`.
- `git diff --check` passed.
- Mutation testing covered 100% of the changed source file and killed all mutations in the changed `get_version()` logic. Four surviving mutations are in unchanged methods.
- Reviewed compatibility with object-cache backends that ignore `$found`, return invalid values, or return non-boolean write/delete results.

After the review follow-ups in this branch:

- `VersionStringGeneratorTest` passes with 38 tests and 85 assertions, up from 33 and 77.
- `VersionStringGenerator|RestApiCache` passes with 122 tests and 605 assertions, confirming the consumers are unaffected.
- Each of the four new behavioural tests was run against the pre-change source and confirmed to fail there, so they are genuine regression tests rather than restatements of the new code.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.
- `composer exec -- phpstan analyse src/Internal/Caches/VersionStringGenerator.php` reported no errors, and the PHPStan baseline shrank by one entry.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g., for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually. Two entries: one for the original crash fix, one for the cleanup and diagnosability follow-ups.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
