### PR TITLE
Fix flaky Mini-Cart variation attributes e2e test

### DIFF
--- a/plugins/woocommerce/changelog/fix-mini-cart-variation-e2e-race
+++ b/plugins/woocommerce/changelog/fix-mini-cart-variation-e2e-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky Mini-Cart variation-attributes e2e test by waiting for the Add to cart button to be enabled.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart.block_theme.spec.ts
@@ -1029,7 +1029,10 @@ test.describe( `${ blockData.name } Block (variation attributes)`, () => {
 		await expect( page.locator( 'input.variation_id' ) ).toHaveValue(
 			/^[1-9][0-9]*$/
 		);
-		const addToCartButton = page.locator( '.single_add_to_cart_button' );
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+			exact: true,
+		} );
 		await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 		await addToCartButton.click();
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart.block_theme.spec.ts
@@ -1021,12 +1021,17 @@ test.describe( `${ blockData.name } Block (variation attributes)`, () => {
 		// no-op (the disabled state is class-based, which Playwright's
 		// actionability checks ignore). Wait for the variation to be registered
 		// (a positive, non-zero variation id) before clicking.
+		// That is necessary but not sufficient: the script sets `variation_id`
+		// synchronously and only drops the `disabled` class ~300ms later, from a
+		// setTimeout, so wait for the button to be enabled as well. Clicking in
+		// that window hits the guard that raises a window.alert Playwright
+		// silently dismisses, and the form never submits.
 		await expect( page.locator( 'input.variation_id' ) ).toHaveValue(
 			/^[1-9][0-9]*$/
 		);
-		await page
-			.getByRole( 'button', { name: 'Add to cart', exact: true } )
-			.click();
+		const addToCartButton = page.locator( '.single_add_to_cart_button' );
+		await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
+		await addToCartButton.click();
 
 		// Wait for a definitive "added to cart" confirmation before navigating
 		// to the shop. The single-product Add to cart is a form submission; if


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR attempts to stabilize an E2E test for Mini-Cart Block (variation attributes). 

`Mini-Cart Block (variation attributes) > should decode entities in variation attributes rendered via data-wp-text` fails on its first attempt in **18 of 21** sampled trunk CI runs. 

On #67146 it failed 5 attempts in a row.

The test is waiting on the hidden `variation_id` input becoming non-zero before clicking Add to cart. `add-to-cart-variation.js` sets that synchronously but only drops the button's `disabled` class ~300ms later, from a `setTimeout`. 
Clicking inside that window hits the guard at `add-to-cart-variation.js:192`, which calls `preventDefault()` and raises a `window.alert` that Playwright silently auto-dismisses — so the form never submits and the test times out waiting for the "added to your cart" notice. This PR adds an additional check on the button losing its `disabled` class.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The race cannot be reproduced on a typical dev machine — the 300ms timer fires before the old gate even resolves, so the test passes 3/3 unchanged. I was able to reproduce it with CPU throttling.

<!-- End testing instructions -->

### Testing that has already taken place:

Local blocks e2e environment (wp-env, Twenty Twenty-Four child block theme, `blocks-chromium`), `--retries=0`, each iteration a separate Playwright invocation so the `blocks setup` DB snapshot import makes every run a clean first attempt:

| Scenario | Result |
| --- | --- |
| Unchanged test, unthrottled | 3/3 pass (race not reproducible locally) |
| Old gating, 4x CPU throttle | **0/3 pass** — fails on the `role="alert"` notice, identical signature to CI |
| This PR's gating, 4x CPU throttle | 3/3 pass |
| This PR's gating, unthrottled | 3/3 pass |

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)