### PR TITLE
[3/3][Email Editor] Re-add listing Preview for emails without a saved post

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-6171-listing-preview-postless-emails
+++ b/plugins/woocommerce/changelog/wooplug-6171-listing-preview-postless-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Email editor: re-add the listing Preview action for emails without a saved post, rendering the current file template.

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-listview.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-listview.test.tsx
@@ -75,6 +75,8 @@ const emailType: EmailType = {
 	email_key: 'wc_email_new_order',
 	email_class_name: 'WC_Email_New_Order',
 	post_id: '123',
+	file_template_preview_url:
+		'https://example.test/wp-admin/?preview_woo_block_email=true&email_id=new_order&_wpnonce=abc',
 	recipients: {
 		to: 'admin@example.com',
 		cc: '',
@@ -182,8 +184,8 @@ describe( 'ListView', () => {
 		expect( getAction( 'recreate-email-post' ) ).toBeUndefined();
 	} );
 
-	describe( 'preview action eligibility', () => {
-		it( 'is eligible only for published posts', () => {
+	describe( 'preview action', () => {
+		it( 'is eligible for published posts and for rows with a file-template preview URL', () => {
 			render( <ListView emailTypes={ [ emailType ] } /> );
 			const isEligible = getAction( 'preview' )?.isEligible;
 
@@ -192,13 +194,78 @@ describe( 'ListView', () => {
 			).toBe( true );
 			expect(
 				isEligible?.( { ...emailType, postStatus: 'draft' } )
-			).toBe( false );
-			expect(
-				isEligible?.( { ...emailType, postStatus: 'auto-draft' } )
-			).toBe( false );
+			).toBe( true );
 			expect(
 				isEligible?.( { ...emailType, post_id: '', postStatus: null } )
+			).toBe( true );
+			// Emails not registered for the block editor have no preview URL
+			// and no published post — no preview.
+			expect(
+				isEligible?.( {
+					...emailType,
+					post_id: '',
+					postStatus: null,
+					file_template_preview_url: null,
+				} )
 			).toBe( false );
+			// A published row needs a resolved permalink; without one (and
+			// without a file-template URL) there is nothing to open.
+			expect(
+				isEligible?.( {
+					...emailType,
+					postStatus: 'publish',
+					link: 'https://example.test/?woo_email=new-order',
+					file_template_preview_url: null,
+				} )
+			).toBe( true );
+			expect(
+				isEligible?.( {
+					...emailType,
+					postStatus: 'publish',
+					link: '',
+					file_template_preview_url: null,
+				} )
+			).toBe( false );
+			expect(
+				isEligible?.( {
+					...emailType,
+					postStatus: 'draft',
+					file_template_preview_url: null,
+				} )
+			).toBe( false );
+		} );
+
+		it( 'opens the permalink for published posts and the file-template preview otherwise', () => {
+			const windowOpenSpy = jest
+				.spyOn( window, 'open' )
+				.mockImplementation( () => null );
+			render( <ListView emailTypes={ [ emailType ] } /> );
+			const callback = getAction( 'preview' )?.callback;
+
+			callback?.( [
+				{
+					...emailType,
+					postStatus: 'publish',
+					link: 'https://example.test/?woo_email=new-order',
+				},
+			] );
+			expect( windowOpenSpy ).toHaveBeenLastCalledWith(
+				'https://example.test/?woo_email=new-order'
+			);
+
+			// An unpublished draft is not what customers receive — preview the
+			// file template instead.
+			callback?.( [ { ...emailType, postStatus: 'draft' } ] );
+			expect( windowOpenSpy ).toHaveBeenLastCalledWith(
+				emailType.file_template_preview_url
+			);
+
+			callback?.( [ { ...emailType, post_id: '', postStatus: null } ] );
+			expect( windowOpenSpy ).toHaveBeenLastCalledWith(
+				emailType.file_template_preview_url
+			);
+
+			windowOpenSpy.mockRestore();
 		} );
 	} );
 

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-slotfill.test.tsx
@@ -80,6 +80,7 @@ jest.mock( '@woocommerce/settings', () => ( {
 const baseEmail: EmailType = {
 	id: 'new-order',
 	post_id: '123',
+	file_template_preview_url: null,
 	title: 'New order',
 	description: '',
 	enabled: true,

--- a/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-update-cell.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/__tests__/settings-email-listing-update-cell.test.tsx
@@ -47,6 +47,7 @@ const baseEmail: EmailType = {
 	templateVersion: null,
 	currentVersion: null,
 	wasBackfilled: false,
+	file_template_preview_url: null,
 };
 
 describe( '<UpdatesCell>', () => {

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -229,15 +229,27 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				label: __( 'Preview', 'woocommerce' ),
 				icon: <Icon icon={ external } />,
 				supportsBulk: false,
+				// A published post previews through its permalink (the saved
+				// content customers receive). Any other state — no post, or an
+				// unpublished draft — previews the file template via the admin
+				// preview page, matching what customers receive until the
+				// email is saved.
 				callback: ( items: EmailType[] ) => {
-					window.open( items[ 0 ].link );
+					const email = items[ 0 ];
+					const isPublished =
+						!! email.post_id && email.postStatus === 'publish';
+					const previewUrl = isPublished
+						? email.link
+						: email.file_template_preview_url;
+					if ( previewUrl ) {
+						window.open( previewUrl );
+					}
 				},
-				// The permalink only renders saved content, so previewing is
-				// limited to published posts (unpublished drafts are not what
-				// customers receive; emails without a post render from the
-				// file template and have no permalink).
 				isEligible: ( item: EmailType ) =>
-					!! item.post_id && item.postStatus === 'publish',
+					( !! item.post_id &&
+						item.postStatus === 'publish' &&
+						!! item.link ) ||
+					!! item.file_template_preview_url,
 				isPrimary: true,
 			},
 			{

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -45,6 +45,8 @@ export type EmailType = {
 	email_key: string;
 	email_class_name: string;
 	post_id: string;
+	/** Null for emails not registered for the block editor. */
+	file_template_preview_url: string | null;
 	recipients: Recipients;
 	enabled: boolean;
 	manual: boolean;

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-update-cell.story.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-update-cell.story.tsx
@@ -18,6 +18,7 @@ const baseEmail: EmailType = {
 	templateVersion: null,
 	currentVersion: null,
 	wasBackfilled: false,
+	file_template_preview_url: null,
 };
 
 export const CoreUpdatedCustomized = () => (

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\Email\EmailFont;
 use Automattic\WooCommerce\Internal\Email\EmailStyleSync;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
@@ -595,10 +596,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			'https://wordpress.org/plugins/wp-mail-logging/',
 			'https://woocommerce.com/document/email-faq'
 		);
-		$email_post_manager   = WCTransactionalEmailPostsManager::get_instance();
-		$emails               = WC()->mailer()->get_emails();
-		$email_types          = array();
-		$post_id_for_template = null;
+		$email_post_manager     = WCTransactionalEmailPostsManager::get_instance();
+		$emails                 = WC()->mailer()->get_emails();
+		$email_types            = array();
+		$post_id_for_template   = null;
+		$block_editor_email_ids = WCTransactionalEmails::get_transactional_emails();
 		foreach ( $emails as $email_key => $email ) {
 			$post_id     = $email_post_manager->get_email_template_post_id( $email->id );
 			$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( $email->id );
@@ -619,20 +621,25 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			$template_version = $post_id ? (string) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, true ) : '';
 			$was_backfilled   = $post_id ? (bool) get_post_meta( $post_id, WCEmailTemplateDivergenceDetector::BACKFILLED_META_KEY, true ) : false;
 
+			$file_template_preview_url = in_array( $email->id, $block_editor_email_ids, true )
+				? wp_nonce_url( admin_url( '?preview_woo_block_email=true&email_id=' . $email->id ), 'preview-woo-block-email' )
+				: null;
+
 			$email_types[] = array(
-				'title'            => $email->get_title(),
-				'description'      => $email->get_description(),
-				'id'               => $email->id,
-				'email_key'        => strtolower( $email_key ),
-				'email_class_name' => get_class( $email ),
-				'post_id'          => $post_id,
-				'enabled'          => $email->is_enabled(),
-				'manual'           => $email->is_manual(),
-				'current_version'  => '' !== $current_version ? $current_version : null,
-				'template_status'  => '' !== $template_status ? $template_status : null,
-				'template_version' => '' !== $template_version ? $template_version : null,
-				'was_backfilled'   => $was_backfilled,
-				'recipients'       => array(
+				'title'                     => $email->get_title(),
+				'description'               => $email->get_description(),
+				'id'                        => $email->id,
+				'email_key'                 => strtolower( $email_key ),
+				'email_class_name'          => get_class( $email ),
+				'post_id'                   => $post_id,
+				'file_template_preview_url' => $file_template_preview_url,
+				'enabled'                   => $email->is_enabled(),
+				'manual'                    => $email->is_manual(),
+				'current_version'           => '' !== $current_version ? $current_version : null,
+				'template_status'           => '' !== $template_status ? $template_status : null,
+				'template_version'          => '' !== $template_version ? $template_version : null,
+				'was_backfilled'            => $was_backfilled,
+				'recipients'                => array(
 					'to'  => $email->is_customer_email() ? __( 'Customers', 'woocommerce' ) : $email->get_recipient(),
 					'cc'  => $email->get_cc_recipient(),
 					'bcc' => $email->get_bcc_recipient(),

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -167,6 +167,8 @@ class Integration {
 		// Priority 10 runs before the package's post-based handler (11).
 		add_filter( 'woocommerce_email_editor_send_preview_email', array( $this, 'send_preview_email_for_email_type' ), 10, 1 );
 		add_filter( 'woocommerce_email_editor_send_preview_email_without_post_permission', array( $this, 'authorize_postless_send_preview' ), 10, 2 );
+		// Listing Preview page for emails rendering from the file template.
+		add_action( 'admin_init', array( $this, 'render_block_email_preview_page' ) );
 		add_action( 'rest_api_init', array( $this->email_api_controller, 'register_routes' ) );
 		add_action( 'transition_post_status', array( $this, 'save_email_mapping_on_publish' ), 10, 3 );
 		// Priority 11 ensures the email editor's `init` bootstrap (default priority 10)
@@ -477,6 +479,25 @@ class Integration {
 			throw new \InvalidArgumentException( 'Invalid email address' );
 		}
 
+		$preview = $this->render_preview_html_for_email_type( $email_type );
+
+		$send_preview = Email_Editor_Container::container()->get( Send_Preview_Email::class );
+
+		return $send_preview->send_email( $recipient, $preview['subject'], $preview['html'] );
+	}
+
+	/**
+	 * Render the file-template preview of an email type — the content customers
+	 * receive while the email has no published post — with the preview order
+	 * context applied and personalization tags resolved.
+	 *
+	 * Shared by the postless send-test handler and the listing Preview page.
+	 *
+	 * @param string $email_type The email type identifier (e.g. `customer_processing_order`).
+	 * @return array{subject: string, html: string} The preview subject and full HTML document.
+	 * @throws \InvalidArgumentException When the email type is invalid or has no template content.
+	 */
+	public function render_preview_html_for_email_type( string $email_type ): array {
 		$email = WCTransactionalEmailPostsManager::get_instance()->get_email_by_id( $email_type );
 		if ( ! $email instanceof \WC_Email || ! in_array( $email_type, WCTransactionalEmails::get_transactional_emails(), true ) ) {
 			throw new \InvalidArgumentException( 'Unknown email type' );
@@ -515,7 +536,43 @@ class Integration {
 			$this->sending_preview_for_email_type = '';
 		}
 
-		return $send_preview->send_email( $recipient, $subject, $html );
+		return array(
+			'subject' => $subject,
+			'html'    => $html,
+		);
+	}
+
+	/**
+	 * Render the listing Preview page for an email without a published post.
+	 *
+	 * Mirrors the `preview_woocommerce_mail` admin page pattern: a nonce-gated
+	 * query-param handler that echoes the full preview HTML document. Used by
+	 * the settings listing's Preview action for emails whose rendering source
+	 * is the file template (no post, or an unpublished draft).
+	 */
+	public function render_block_email_preview_page(): void {
+		if ( ! isset( $_GET['preview_woo_block_email'] ) ) {
+			return;
+		}
+
+		// Verifies the `_wpnonce` query arg that `wp_nonce_url()` appended to
+		// the listing payload's preview URL; dies when missing or invalid.
+		check_admin_referer( 'preview-woo-block-email' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to preview emails.', 'woocommerce' ) );
+		}
+
+		$email_type = isset( $_GET['email_id'] ) ? sanitize_text_field( wp_unslash( $_GET['email_id'] ) ) : '';
+
+		try {
+			$preview = $this->render_preview_html_for_email_type( $email_type );
+		} catch ( \InvalidArgumentException $e ) {
+			wp_die( esc_html__( 'This email cannot be previewed.', 'woocommerce' ) );
+		}
+
+		echo $preview['html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Full HTML document produced by the email renderer; escaping would break it.
+		exit;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/e2e/tests/email/settings-email-listing.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/settings-email-listing.spec.ts
@@ -118,4 +118,32 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		// Add 1 to account for header row
 		await expect( rows ).toHaveCount( 2 );
 	} );
+
+	test( 'Preview action renders the file template for emails without a saved post', async ( {
+		page,
+		baseURL,
+	} ) => {
+		await setBlockEmailEditorFeatureFlag( baseURL, 'yes' );
+
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+		const listViewLocator = page.locator(
+			'.woocommerce-email-listing-listview'
+		);
+		await expect( listViewLocator ).toBeVisible();
+
+		// A row no other spec creates a post for, so it renders from the file
+		// template and the Preview action must use the admin preview page.
+		const row = listViewLocator.locator( 'tr', {
+			hasText: 'Order on hold',
+		} );
+		const popupPromise = page.waitForEvent( 'popup' );
+		await row.getByRole( 'button', { name: 'Preview' } ).click();
+		const popup = await popupPromise;
+
+		await expect( popup ).toHaveURL( /preview_woo_block_email/ );
+		// The wooemailtemplate chrome proves the block pipeline rendered it.
+		await expect( popup.locator( 'body' ) ).toContainText(
+			'All Rights Reserved'
+		);
+	} );
 } );

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
@@ -353,6 +353,76 @@ class IntegrationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Preview HTML for an email type renders the file template with the preview context applied.
+	 */
+	public function test_render_preview_html_for_email_type_returns_full_document(): void {
+		$this->bootstrap_email_editor();
+		$this->skip_if_unsupported_environment();
+
+		$preview = $this->sut->render_preview_html_for_email_type( 'customer_processing_order' );
+
+		$this->assertNotSame( '', $preview['subject'] );
+		$this->assertStringContainsString( 'is now being processed', $preview['html'], 'The preview must contain the file template content' );
+		$this->assertStringContainsString( 'All Rights Reserved', $preview['html'], 'The preview must be rendered through the email template chrome' );
+		$this->assertStringNotContainsString( 'WOO_CONTENT', $preview['html'], 'The Woo content placeholder must be replaced with preview content' );
+	}
+
+	/**
+	 * @testdox Preview HTML rendering throws for an unregistered email type.
+	 */
+	public function test_render_preview_html_for_unknown_email_type_throws(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->sut->render_preview_html_for_email_type( 'this_type_is_not_registered' );
+	}
+
+	/**
+	 * @testdox The preview page dies on a missing or invalid nonce.
+	 */
+	public function test_preview_page_requires_valid_nonce(): void {
+		$_GET['preview_woo_block_email'] = 'true';
+		$_GET['email_id']                = 'customer_processing_order';
+
+		$this->expectException( \WPDieException::class );
+
+		$this->sut->render_block_email_preview_page();
+	}
+
+	/**
+	 * @testdox The preview page dies for users without manage_woocommerce.
+	 */
+	public function test_preview_page_requires_manage_woocommerce(): void {
+		$subscriber_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$_GET['preview_woo_block_email'] = 'true';
+		$_GET['email_id']                = 'customer_processing_order';
+		$_REQUEST['_wpnonce']            = wp_create_nonce( 'preview-woo-block-email' );
+
+		$this->expectException( \WPDieException::class );
+		$this->expectExceptionMessage( 'permission' );
+
+		$this->sut->render_block_email_preview_page();
+	}
+
+	/**
+	 * @testdox The preview page dies for an unregistered email type.
+	 */
+	public function test_preview_page_dies_for_unknown_email_type(): void {
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$_GET['preview_woo_block_email'] = 'true';
+		$_GET['email_id']                = 'this_type_is_not_registered';
+		$_REQUEST['_wpnonce']            = wp_create_nonce( 'preview-woo-block-email' );
+
+		$this->expectException( \WPDieException::class );
+		$this->expectExceptionMessage( 'cannot be previewed' );
+
+		$this->sut->render_block_email_preview_page();
+	}
+
+	/**
 	 * Initialize the email editor package so block templates resolve during rendering.
 	 */
 	private function bootstrap_email_editor(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

> **Stacked on #67025** — the base branch is that PR's branch, so this PR's diff is just the one preview commit. It will be rebased onto trunk after #67025 merges.

#67025 left the listing **Preview** action hidden for emails without a published post: the action opens the post permalink, and only published posts render. This PR re-adds Preview for those rows.

- We reused the code for sending postless preview emails from #67025.
- A nonce-gated admin preview page (`?preview_woo_block_email=true&email_id=…`, mirroring the existing `preview_woocommerce_mail` pattern) echoes that HTML. It requires `manage_woocommerce` and a block-editor-registered email type. The legacy `preview_woocommerce_mail` page was not reused because it renders via `get_content_html()` — the classic PHP templates — which is not what block emails send.
- The listing payload carries a per-row nonce'd `block_preview_url` (null for emails not registered for the block editor), and the Preview action shows for **any row with either a published post or a preview URL**: published posts keep the permalink preview (the saved content), everything else — no post, or an unpublished draft — previews the file template. That is always "what customers receive", consistent with how Send test email behaves.

No BC impact: purely additive (new query-param handler, new payload field, widened action eligibility).

Closes #62914.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block email editor feature on a site with no `woo_email` posts (`wp post list --post_type=woo_email`).
2. Go to WooCommerce → Settings → Emails. Every core email row now shows the **Preview** action; clicking it opens a new tab rendering the file template with dummy order content and resolved personalization tags.
3. Open an email in the editor (creates a draft), edit the content, and close **without saving**. The row's Preview still shows the file template — matching what customers receive.
4. Click **Save** in the editor (publishes). The row's Preview now opens the post permalink with your customized content.
5. Verify a third-party email not registered for the block editor shows no Preview action.
6. Auth: opening the preview URL without a valid nonce or as a user without `manage_woocommerce` dies with an error; unauthenticated requests redirect to login.

<!-- End testing instructions -->

### Testing that has already taken place:

- PHP: 17 IntegrationTest tests green, incl. new coverage for the shared render helper (template copy + chrome + no placeholder leak, unknown type throws) and the page handler's nonce/capability/invalid-type failure paths (`WPDieException`).
- JS: 50 settings-email tests green, incl. the new preview eligibility/callback matrix (published → permalink; draft and postless → preview URL; no URL → hidden).
- New e2e test in `settings-email-listing.spec.ts` (postless row → Preview opens a popup rendering the template chrome) — verified green against a provisioned e2e environment.
- phpcs + PHPStan clean; screenshots captured from the live environment.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

> Changelog entry is committed in the PR (`plugins/woocommerce/changelog/wooplug-6171-listing-preview-postless-emails`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
