### PR TITLE
[tests] Fix unit tests that skip their parent setup or teardown

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-teardown-missing-parent-call
+++ b/plugins/woocommerce/changelog/fix-test-teardown-missing-parent-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Call the parent teardown from unit test classes that override it, so the per-test database transaction is rolled back and test data no longer leaks between tests.

--- a/plugins/woocommerce/changelog/fix-test-teardown-missing-parent-call
+++ b/plugins/woocommerce/changelog/fix-test-teardown-missing-parent-call
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Call the parent teardown from unit test classes that override it, so the per-test database transaction is rolled back and test data no longer leaks between tests.
+Call the parent setup and teardown from unit test classes that override them, so the per-test database transaction is opened and rolled back and test data no longer leaks between tests.

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -17,6 +17,8 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 *
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/wc-admin-functions.php';
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/notes/class-wc-notes-run-db-update.php';
 
@@ -26,6 +28,8 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 * Clean up before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		if ( ! WC()->is_wc_admin_active() ) {
 			$this->markTestSkipped( 'WC Admin is not active on WP versions < 5.3' );
 			return;

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -18,6 +18,8 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 	 *
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -16,6 +16,8 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-report-sales-by-date.php';
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-tests-customer-download.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-tests-customer-download.php
@@ -38,6 +38,8 @@ class WC_Tests_Customer_Download extends WC_Unit_Test_Case {
 	 * Tests set up.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->customer_id    = 1;
 		$this->customer_email = 'test@example.com';
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
@@ -18,6 +18,8 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 
 		WC()->session->set( 'wc_notices', null );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -24,6 +24,8 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	 * Set current local timezone.
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		self::$local_tz = new DateTimeZone( wc_timezone_string() );
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
@@ -17,6 +17,8 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_IsWooExpressRuleProcessor extend
 	 * Set Up Before Class.
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		/**
 		 * Fake function wc_calypso_bridge_is_woo_express_plan so that we can test the processor.
 		 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -37,6 +37,8 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	 */
 	public static function tearDownAfterClass(): void {
 		remove_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
+
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -23,6 +23,11 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	 * Don't cache report data during these tests.
 	 */
 	public static function setUpBeforeClass(): void {
+		// Must come first: the parent reconnects `$wpdb`, which discards anything this
+		// method has written but not committed. The matching `parent::tearDownAfterClass()`
+		// goes last, so the two are deliberately not symmetrical.
+		parent::setUpBeforeClass();
+
 		add_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
 
 		$db_version = strstr( WC()->version, '-', true );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-assets.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-assets.php
@@ -17,6 +17,8 @@ class WC_Admin_Tests_WCAdminAssets extends WP_UnitTestCase {
 	 * Setup
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		add_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20, 1 );
 	}
 
@@ -25,6 +27,8 @@ class WC_Admin_Tests_WCAdminAssets extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20 );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
+++ b/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
@@ -26,6 +26,8 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 	 * Make WP_Install::$db_updates readable and capture the original value.
 	 */
 	public function set_up() {
+		parent::set_up();
+
 		$this->db_updates_property = new ReflectionProperty( WC_Install::class, 'db_updates' );
 		$this->db_updates_property->setAccessible( true );
 		$this->db_updates_original_value = $this->db_updates_property->getValue();
@@ -37,6 +39,8 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 	public function tear_down() {
 		$this->db_updates_property->setValue( $this->db_updates_original_value );
 		$this->db_updates_property->setAccessible( false );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -86,8 +90,6 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 	 * Mock WP_CLI and related functionality.
 	 */
 	private function mock_wp_cli() {
-		parent::set_up();
-
 		$this->register_legacy_proxy_static_mocks(
 			array(
 				WP_CLI::class => array(

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -10,6 +10,8 @@ class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
 	 * Runs before any test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
 		$this->sut = new class() extends WC_REST_Terms_Controller {
 			public function get_taxonomy( $request ) {

--- a/plugins/woocommerce/tests/php/src/Admin/API/MarketingRecommendationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/MarketingRecommendationsTest.php
@@ -118,6 +118,8 @@ class MarketingRecommendationsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		remove_filter( 'pre_http_request', $this->response_mock_ref );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Marketing/MarketingChannelsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Marketing/MarketingChannelsTest.php
@@ -15,6 +15,8 @@ class MarketingChannelsTest extends WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		remove_all_filters( 'woocommerce_marketing_channels' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
@@ -29,6 +29,8 @@ class BlockHooksTests extends WP_UnitTestCase {
 	 * Initiate the mock object.
 	 */
 	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
 		delete_option( self::$option_name );
 		self::$block_instance = new BlockHooksTestBlock();
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
@@ -44,6 +44,8 @@ class Checkout extends \WP_UnitTestCase {
 	 * @throws \Exception If the API class is not registered with container.
 	 */
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->asset_api            = Package::container()->get( API::class );
 		$this->registry             = new AssetDataRegistryMock( $this->asset_api );
 		$this->integration_registry = new IntegrationRegistry();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductQuery.php
@@ -51,6 +51,8 @@ class ProductQuery extends \WP_UnitTestCase {
 	 * Initiate the mock object.
 	 */
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->block_instance = new ProductQueryMock();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Bootstrap/MainFile.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Bootstrap/MainFile.php
@@ -28,6 +28,8 @@ class MainFile extends WP_UnitTestCase {
 	 * Ensure that container is reset between tests.
 	 */
 	protected function setUp(): void {
+		parent::setUp();
+
 		// reset container.
 		$this->container = Package::container( true );
 	}
@@ -60,5 +62,7 @@ class MainFile extends WP_UnitTestCase {
 	 */
 	protected function tearDown(): void {
 		Package::init();
+
+		parent::tearDown();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsFrontendTest.php
@@ -62,6 +62,8 @@ class CheckoutFieldsFrontendTest extends TestCase {
 			__internal_woocommerce_blocks_deregister_checkout_field( $field_id );
 		}
 		$this->registered_fields = [];
+
+		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/TestValidateSchema.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/TestValidateSchema.php
@@ -22,6 +22,8 @@ class TestValidateSchema extends \WP_UnitTestCase {
 	 * Setup schema.
 	 */
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->validate = new ValidateSchema(
 			[
 				'properties' => [

--- a/plugins/woocommerce/tests/php/src/Blocks/Registry/Container.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Registry/Container.php
@@ -19,6 +19,8 @@ class Container extends TestCase {
 	private $container;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->container = new ContainerTest;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
@@ -13,6 +13,8 @@ class ControllerTests extends \WP_Test_REST_TestCase {
 	 * Setup Rest API server.
 	 */
 	protected function setUp(): void {
+		parent::setUp();
+
 		/** @var \WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();

--- a/plugins/woocommerce/tests/php/src/Caching/CacheExceptionTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/CacheExceptionTest.php
@@ -21,6 +21,8 @@ class CacheExceptionTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		// phpcs:disable Squiz.Commenting
 		$this->thrower = new class() extends ObjectCache {
 			public function get_object_type(): string {

--- a/plugins/woocommerce/tests/php/src/Caching/ObjectCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/ObjectCacheTest.php
@@ -23,6 +23,7 @@ class ObjectCacheTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
 
 		// phpcs:disable Squiz.Commenting
 

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/RuntimeContainerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/RuntimeContainerTest.php
@@ -42,6 +42,8 @@ class RuntimeContainerTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->sut = new RuntimeContainer(
 			array( 'Foo\Bar' => $this )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/TestingContainerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/TestingContainerTest.php
@@ -28,6 +28,8 @@ class TestingContainerTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$base_container = new RuntimeContainer(
 			array( 'Foo\Bar' => $this )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/McStatsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/McStatsTest.php
@@ -14,6 +14,8 @@ class McStatsTest extends \WC_Unit_Test_Case {
 	 * Set up. Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->sut = wc_get_container()->get( McStats::class );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
@@ -105,6 +105,9 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 
 	/**
 	 * Runs before each test.
+	 *
+	 * `parent::setUp()` is reached through `set_up_test_case()`, which exists so subclasses
+	 * can control where the per-test transaction starts relative to fixture creation.
 	 */
 	public function setUp(): void {
 		$this->set_up_test_case();

--- a/plugins/woocommerce/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
@@ -24,6 +24,8 @@ class ClassThatDependsOnLegacyCodeTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$container = wc_get_container();
 
 		$this->sut = $container->get( ClassThatDependsOnLegacyCode::class );

--- a/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
@@ -23,6 +23,8 @@ class DynamicDecoratorTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->sut = new DynamicDecorator( new ClassWithReplaceableMembers() );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -25,6 +25,8 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->sut = new LegacyProxy();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
@@ -24,6 +24,8 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->sut = new MockableLegacyProxy();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

A test class that overrides a lifecycle method and forgets `parent::` silently opts out of test isolation. This adds the missing calls across the whole PHPUnit surface — every `setUp` / `tearDown` / `setUpBeforeClass` / `tearDownAfterClass` override, camelCase and WordPress snake_case, in the `wc-phpunit-legacy`, `wc-phpunit-main` and `wc-phpunit-graphql` suites. Of 1,128 overrides, 35 did not chain; those 35 calls are added across 31 test classes.

**Why it matters.** On a WordPress test case, overriding camelCase `setUp` bypasses the entire `set_up()` chain rather than just the immediate parent — the PHPUnit Polyfills bridge is what dispatches `set_up()`, so `WC_Unit_Test_Case`, `WP_HTTP_TestCase` and `WP_UnitTestCase_Base` all drop out at once.

The per-test transaction is the expensive loss. `set_up()` issues `SET autocommit = 0; START TRANSACTION`, and `wpdb::db_connect()` builds a fresh connection for every class, so a class that skips setup runs its whole lifetime at `autocommit = 1`: every write commits immediately and the `ROLLBACK` in `tear_down()` is a no-op. Several of these classes do call `parent::tearDown()`, rolling back a transaction they never opened. Leaked rows in most tables get swept by `_delete_all_data()` at class teardown, but that function never touches `wp_options`, so a leaked option is permanent for the life of the test database.

Skipping setup also loses `$this->factory`, `_backup_hooks()`, the `$_GET`/`$_POST`/`$_REQUEST` reset and object-cache flush, the deprecation catcher, the `pre_http_request` blocker that keeps unit tests off the network, `CodeHacker::reset_hacks()`, the `LegacyProxy` reset, and — at class level — `WC_Install::create_terms()`, the only thing that restores WooCommerce's default `product_type`, `product_visibility` and `Uncategorized` terms after the previous class deleted them.

**Placement.** Parent calls go first in setup hooks and last in teardown. In `setUpBeforeClass` this is load-bearing rather than stylistic: the parent reconnects `$wpdb`, and MySQL discards the replaced connection's uncommitted work, so any write the method makes has to come after the parent call. `WC_Admin_Tests_Reports_Orders_Stats` is the one class where that applies — it writes two options in `setUpBeforeClass` — and it carries an inline comment explaining why its setup and teardown hooks are deliberately not symmetrical.

**`WC_CLI_Update_Command_Test`** also drops a `parent::set_up()` call from `mock_wp_cli()`, a helper invoked inside the test body. Calling it there opened a transaction mid-test with no matching rollback, which the next test's `START TRANSACTION` then implicitly committed. The class now chains normally from `set_up()` and `tear_down()` instead.

**`AbstractProductFiltersTest` is unchanged apart from a docblock.** It reaches `parent::setUp()` through `set_up_test_case()`, an extension point that lets its four subclasses control where the transaction starts relative to fixture creation. The docblock records that, since the indirection makes the chain easy to misread as missing.

Follow-up to #67154, where the same problem was found in `WooPaymentsTest`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

This is a test-only change. What matters is that no test regresses and that data stops leaking, so the verification is a before/after comparison of the full suite.

1. From `plugins/woocommerce` on `trunk`, run the full suite and record the result line:
    ```
    pnpm test:php:env
    ```
    Expect `Tests: 13309, Assertions: 48790, Failures: 5, Skipped: 57`.
2. Check out this branch and run it again. Expect the same test, assertion and skip counts, and **four** failures rather than five.
3. Compare the failure lists. `WC_Tests_Notes_Run_Db_Update::test_db_update_note_to_thanks_note` is present on `trunk` and absent here; the other four are unchanged. That test passes in isolation on both branches — in the full run it was failing on cross-class state that the missing `parent::setUp()` let through.
4. To watch a leak directly, temporarily append a probe to `tests/php/src/Admin/API/MarketingRecommendationsTest.php`, whose `setUp()` creates one administrator per test:
    ```php
    public function test_zz_probe() {
        $admins = get_users( array( 'role' => 'administrator', 'fields' => 'ID' ) );
        fwrite( STDERR, "\nadmins=" . count( $admins ) . "\n" );
        $this->assertTrue( true );
    }
    ```
    Run `pnpm test:php:env -- --filter MarketingRecommendationsTest` and note `admins=2`. Remove the `parent::tearDown()` call from that class, re-run, and the count rises to `admins=5` — the administrators from each earlier test are still there. Restore the call and delete the probe.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Full PHP suite in `wp-env`, on the branch point and on this branch:

| | Tests | Assertions | Failures | Skipped |
| --- | --- | --- | --- | --- |
| Branch point (matches pristine `trunk`) | 13309 | 48790 | 5 | 57 |
| This branch | 13309 | 48790 | 4 | 57 |

Test count, assertion count and the skipped list are unchanged. The failure list is the baseline list minus `WC_Tests_Notes_Run_Db_Update::test_db_update_note_to_thanks_note`; no test that previously passed now fails. The result is reproduced across two runs.

The remaining four failures (`WC_Tests_Notes_Run_Db_Update::test_soft_deleted_note_reappears_on_new_update`, `WC_Install_Test::test_db_auto_updates`, `VariationGallery\PackageTest` x2) are pre-existing on `trunk`. The first fails identically in a targeted run and a full run, on both branches, so it is order-independent and unaffected here.

Run in isolation, the 31 affected classes plus the four `AbstractProductFiltersTest` subclasses give `262 tests, 994 assertions, 1 failure, 2 skipped` both with and without the changes — same failure, same skips.

The `MarketingRecommendationsTest` probe above reports 5 administrators across 4 tests without the parent call and 2 with it.

`lint:php:changes` and `lint:changes:branch` both pass.

Mutation-tested the two classes where restoring the transaction changes what a test can see. Replacing the body of `WC_Customer_Download::set_order_id()` with a constant fails `WC_Tests_Customer_Download` (1 error, 1 failure). Forcing `$needs_db_update = false` in `WC_Notes_Run_Db_Update::show_reminder()` fails three of the five tests in `WC_Tests_Notes_Run_Db_Update`, including `test_db_update_note_to_thanks_note` — the one that goes from failing to passing on this branch. That test still detects behaviour changes in the code it covers, so it is fixed rather than blinded. Its first assertion is `assertEquals( 0, count( self::get_db_update_notes() ) )`, which is exactly the precondition that notes leaked by earlier tests were breaking.

Two coverage gaps surfaced during this work and are **not** addressed here, since they are test-correctness bugs rather than leaks. In both `BlockHooksTests` and `WC_Admin_Tests_Reports_Orders_Stats`, a filter is added in `setUpBeforeClass` — after `_backup_hooks()` has taken its once-per-process snapshot — so `_restore_hooks()` wipes it after the first test. In `BlockHooksTests` that leaves two `assertNotContains` tests passing vacuously, asserting the absence of a hook that no longer exists. Both warrant their own PRs.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — `plugins/woocommerce/changelog/fix-test-teardown-missing-parent-call` (patch/dev) is already committed in the branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

