### PR TITLE
Give woocommercebot PRs a larger e2e timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,10 @@ jobs:
           path: '${{ runner.temp }}/last-run-info'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && 20 ) || ( matrix.testType == 'unit:php' && 20 ) ) ) || 360 }}
+        # `woocommercebot` PRs run on the `WooCommerce Release Checks` group (see `runs-on` above),
+        # which is slower than `ubuntu-latest`: the longest blocks e2e shard takes ~13 min hosted
+        # but overruns 20 there, so those PRs get a larger e2e budget.
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && ( github.event.pull_request.user.login == 'woocommercebot' && 30 || 20 ) ) || ( matrix.testType == 'unit:php' && 20 ) ) ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }} # required by Metrics tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,8 +331,7 @@ jobs:
 
       - name: 'Run tests (${{ matrix.testType }})'
         # `woocommercebot` PRs run on the `WooCommerce Release Checks` group (see `runs-on` above),
-        # which is slower than `ubuntu-latest`: the longest blocks e2e shard takes ~13 min hosted
-        # but overruns 20 there, so those PRs get a larger e2e budget.
+        # which is slower than `ubuntu-latest`, so they need a larger e2e budget than other PRs.
         timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && ( github.event.pull_request.user.login == 'woocommercebot' && 30 || 20 ) ) || ( matrix.testType == 'unit:php' && 20 ) ) ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Blocks e2e shard 10/10 times out on every package-release PR (e.g. #67146). No test fails — the step is killed at 20 minutes with 51 of 55 tests done.

`woocommercebot` PRs run on the `WooCommerce Release Checks` group (#65833), which is ~1.45× slower than `ubuntu-latest`. Same shard, same tests:

| `Run tests (e2e)`, shard 10/10 | duration |
| --- | --- |
| `ubuntu-latest` | 13 min ✅ |
| release-checks | 20 min ⏱ timeout |

The 20-minute PR cap (#57151, Apr 2025) predates that routing by 14 months and was sized for `ubuntu-latest`.

Gives `woocommercebot` PRs 30 minutes for `e2e`. Human PRs, `unit:php`, and trunk pushes are unchanged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

`.github/**` is excluded from `needs-code-validation`, so this PR runs no test jobs — green here proves nothing.

1. After merge, re-run CI on #67146 and confirm Blocks e2e 10/10 completes.
2. On any non-bot PR, confirm e2e is still capped at 20 minutes.

<!-- End testing instructions -->

### Testing that has already taken place:

- Expression evaluated against all 8 context combinations (bot/human × `e2e`/`unit:php`/other × `pull_request`/`push`/`workflow_call`); only bot + `e2e` + `pull_request` changes value.
- Workflow YAML parses, expression intact.
- Timings above from runs `30554897959` (bot PR), `30592792018` (trunk), `30607250331` (human PR).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI configuration only; nothing shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)