### PR TITLE
Fix Product short description editor breaking when its metabox moves

### DIFF
--- a/plugins/woocommerce/changelog/fix-32113-short-description-metabox-move
+++ b/plugins/woocommerce/changelog/fix-32113-short-description-metabox-move
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Product short description visual editor becoming blank and non-editable after moving its metabox.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1,4 +1,80 @@
-/*global woocommerce_admin_meta_boxes, _ */
+/*global woocommerce_admin_meta_boxes, _, module */
+
+/*
+ * Keep the "Product short description" editor alive when its metabox is moved.
+ * WordPress repositions postboxes by detaching and re-inserting the DOM node,
+ * which reloads the TinyMCE iframe and wipes its document. The iframe is only
+ * hidden in "Text" mode, so a move breaks that too, just invisibly until the
+ * user returns to the Visual tab.
+ */
+const shortDescriptionEditor = ( function () {
+	let tornDown = false;
+
+	return {
+		/**
+		 * Destroy the editor ahead of a metabox move.
+		 */
+		teardown: function () {
+			const editor = window.tinymce && window.tinymce.get( 'excerpt' );
+
+			if ( ! editor ) {
+				return;
+			}
+
+			// Ask the editor for its own element rather than looking the id up
+			// in the document: while a postbox is being dragged, core's sortable
+			// helper is a clone of it (see postbox.js), and that clone carries a
+			// second element with the same id.
+			const textarea = editor.getElement();
+
+			// Removing the editor is what flushes its content into the textarea:
+			// TinyMCE's remove() saves whenever the editor still has a body, and
+			// for a textarea that write is unconditional. In Visual mode that
+			// flush is what carries the content across the move.
+			//
+			// In Text mode the editor is only hidden, so it still has a body and
+			// that same flush overwrites what the user typed. This snapshot is
+			// the only thing protecting those edits, so do not drop it.
+			const isTextMode = editor.isHidden();
+			const textModeContent = isTextMode ? textarea.value : null;
+
+			window.tinymce.execCommand( 'mceRemoveEditor', false, 'excerpt' );
+
+			if ( isTextMode ) {
+				// Core builds a fresh instance when the user returns to the
+				// Visual tab, so nothing is re-initialized here.
+				textarea.value = textModeContent;
+				return;
+			}
+
+			// Core marks the textarea aria-hidden while the visual editor is up,
+			// and removing the editor makes it visible again.
+			textarea.removeAttribute( 'aria-hidden' );
+			tornDown = true;
+		},
+
+		/**
+		 * Rebuild the editor after a metabox move.
+		 */
+		restore: function () {
+			if ( ! tornDown ) {
+				return;
+			}
+
+			tornDown = false;
+
+			// Re-initialize from the editor's own settings, exactly as core's
+			// switchEditors() does. mceAddEditor would instead rebuild it from
+			// whichever editor initialized last on the page.
+			window.tinymce.init( window.tinyMCEPreInit.mceInit.excerpt );
+		},
+	};
+}() );
+
+if ( typeof module !== 'undefined' && module.exports ) {
+	module.exports = shortDescriptionEditor;
+}
+
 jQuery( function ( $ ) {
 	let isPageUnloading = false;
 
@@ -1635,4 +1711,45 @@ jQuery( function ( $ ) {
 			.insertAfter( addProductImagesLink )
 			.tipTip( tooltipData );
 	}
+
+	// Header order buttons (WP >= 5.5): core moves the box in a click handler
+	// bound directly on the button, so tear down in the capture phase (which
+	// runs first) and restore in a delegated bubble-phase handler (which runs
+	// after the move).
+	document.addEventListener(
+		'click',
+		function ( event ) {
+			const button =
+				event.target.closest &&
+				event.target.closest(
+					'#postexcerpt .handle-order-higher, #postexcerpt .handle-order-lower'
+				);
+
+			// Buttons on the first/last position are a no-op in core.
+			if ( button && 'true' !== button.getAttribute( 'aria-disabled' ) ) {
+				shortDescriptionEditor.teardown();
+			}
+		},
+		true
+	);
+
+	$( document ).on(
+		'click',
+		'#postexcerpt .handle-order-higher, #postexcerpt .handle-order-lower',
+		shortDescriptionEditor.restore
+	);
+
+	// Drag-and-drop sorting: jQuery UI sortable events bubble up from the
+	// .meta-box-sortables containers.
+	$( '#poststuff' )
+		.on( 'sortstart', function ( event, ui ) {
+			if ( ui.item.is( '#postexcerpt' ) ) {
+				shortDescriptionEditor.teardown();
+			}
+		} )
+		.on( 'sortstop', function ( event, ui ) {
+			if ( ui.item.is( '#postexcerpt' ) ) {
+				shortDescriptionEditor.restore();
+			}
+		} );
 } );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1,73 +1,114 @@
 /*global woocommerce_admin_meta_boxes, _, module */
 
-/*
- * Keep the "Product short description" editor alive when its metabox is moved.
- * WordPress repositions postboxes by detaching and re-inserting the DOM node,
- * which reloads the TinyMCE iframe and wipes its document. The iframe is only
- * hidden in "Text" mode, so a move breaks that too, just invisibly until the
- * user returns to the Visual tab.
- */
 const shortDescriptionEditor = ( function () {
-	let tornDown = false;
+	let wasTextMode = null;
+	let textModeRestorePending = false;
+
+	function teardown() {
+		const editor = window.tinymce && window.tinymce.get( 'excerpt' );
+
+		if ( ! editor ) {
+			return;
+		}
+
+		const textarea = editor.getElement();
+		wasTextMode = textModeRestorePending || editor.isHidden();
+		const textModeContent = wasTextMode ? textarea.value : null;
+
+		window.tinymce.execCommand( 'mceRemoveEditor', false, 'excerpt' );
+
+		if ( wasTextMode ) {
+			// The hidden editor contains stale content while Text mode is active.
+			textarea.value = textModeContent;
+		} else {
+			textarea.removeAttribute( 'aria-hidden' );
+		}
+	}
+
+	function restore() {
+		if ( null === wasTextMode ) {
+			return;
+		}
+
+		const restoreTextMode = wasTextMode;
+		wasTextMode = null;
+
+		if ( restoreTextMode ) {
+			textModeRestorePending = true;
+		}
+
+		const initializedEditors = window.tinymce.init(
+			window.tinyMCEPreInit.mceInit.excerpt
+		);
+
+		if ( ! restoreTextMode ) {
+			return initializedEditors;
+		}
+
+		return initializedEditors.then( function ( editors ) {
+			const editor = editors[ 0 ];
+
+			if ( ! editor || window.tinymce.get( 'excerpt' ) !== editor ) {
+				return editors;
+			}
+
+			const textarea = editor.getElement();
+			const content = textarea.value;
+
+			window.switchEditors.go( 'excerpt', 'html' );
+			textarea.value = content;
+			textModeRestorePending = false;
+
+			return editors;
+		} );
+	}
+
+	function bindPostboxEvents( $ ) {
+		const eventNamespace = '.shortDescriptionEditor';
+		const orderButtonSelector =
+			'#postexcerpt .handle-order-higher, #postexcerpt .handle-order-lower';
+		const $poststuff = $( '#poststuff' );
+		const handleOrderButtonClick = function ( event ) {
+			const button =
+				event.target.closest &&
+				event.target.closest( orderButtonSelector );
+
+			// Buttons on the first/last position are a no-op in core.
+			if ( button && 'true' !== button.getAttribute( 'aria-disabled' ) ) {
+				teardown();
+				window.setTimeout( restore );
+			}
+		};
+
+		document.addEventListener( 'click', handleOrderButtonClick, true );
+
+		// jQuery UI sortable events bubble up from the metabox containers.
+		$poststuff
+			.on( 'sortstart' + eventNamespace, function ( event, ui ) {
+				if ( ui.item.is( '#postexcerpt' ) ) {
+					teardown();
+				}
+			} )
+			.on( 'sortstop' + eventNamespace, function ( event, ui ) {
+				if ( ui.item.is( '#postexcerpt' ) ) {
+					restore();
+				}
+			} );
+
+		return function () {
+			document.removeEventListener(
+				'click',
+				handleOrderButtonClick,
+				true
+			);
+			$poststuff.off( eventNamespace );
+		};
+	}
 
 	return {
-		/**
-		 * Destroy the editor ahead of a metabox move.
-		 */
-		teardown: function () {
-			const editor = window.tinymce && window.tinymce.get( 'excerpt' );
-
-			if ( ! editor ) {
-				return;
-			}
-
-			// Ask the editor for its own element rather than looking the id up
-			// in the document: while a postbox is being dragged, core's sortable
-			// helper is a clone of it (see postbox.js), and that clone carries a
-			// second element with the same id.
-			const textarea = editor.getElement();
-
-			// Removing the editor is what flushes its content into the textarea:
-			// TinyMCE's remove() saves whenever the editor still has a body, and
-			// for a textarea that write is unconditional. In Visual mode that
-			// flush is what carries the content across the move.
-			//
-			// In Text mode the editor is only hidden, so it still has a body and
-			// that same flush overwrites what the user typed. This snapshot is
-			// the only thing protecting those edits, so do not drop it.
-			const isTextMode = editor.isHidden();
-			const textModeContent = isTextMode ? textarea.value : null;
-
-			window.tinymce.execCommand( 'mceRemoveEditor', false, 'excerpt' );
-
-			if ( isTextMode ) {
-				// Core builds a fresh instance when the user returns to the
-				// Visual tab, so nothing is re-initialized here.
-				textarea.value = textModeContent;
-				return;
-			}
-
-			// Core marks the textarea aria-hidden while the visual editor is up,
-			// and removing the editor makes it visible again.
-			textarea.removeAttribute( 'aria-hidden' );
-			tornDown = true;
-		},
-
-		/**
-		 * Rebuild the editor after a metabox move.
-		 */
-		restore: function () {
-			if ( ! tornDown ) {
-				return;
-			}
-
-			tornDown = false;
-
-			// Re-initialize from the editor's own settings, exactly as core's
-			// switchEditors() does. mceAddEditor would instead rebuild it from
-			// whichever editor initialized last on the page.
-			window.tinymce.init( window.tinyMCEPreInit.mceInit.excerpt );
-		},
+		teardown,
+		restore,
+		bindPostboxEvents,
 	};
 }() );
 
@@ -1712,44 +1753,5 @@ jQuery( function ( $ ) {
 			.tipTip( tooltipData );
 	}
 
-	// Header order buttons (WP >= 5.5): core moves the box in a click handler
-	// bound directly on the button, so tear down in the capture phase (which
-	// runs first) and restore in a delegated bubble-phase handler (which runs
-	// after the move).
-	document.addEventListener(
-		'click',
-		function ( event ) {
-			const button =
-				event.target.closest &&
-				event.target.closest(
-					'#postexcerpt .handle-order-higher, #postexcerpt .handle-order-lower'
-				);
-
-			// Buttons on the first/last position are a no-op in core.
-			if ( button && 'true' !== button.getAttribute( 'aria-disabled' ) ) {
-				shortDescriptionEditor.teardown();
-			}
-		},
-		true
-	);
-
-	$( document ).on(
-		'click',
-		'#postexcerpt .handle-order-higher, #postexcerpt .handle-order-lower',
-		shortDescriptionEditor.restore
-	);
-
-	// Drag-and-drop sorting: jQuery UI sortable events bubble up from the
-	// .meta-box-sortables containers.
-	$( '#poststuff' )
-		.on( 'sortstart', function ( event, ui ) {
-			if ( ui.item.is( '#postexcerpt' ) ) {
-				shortDescriptionEditor.teardown();
-			}
-		} )
-		.on( 'sortstop', function ( event, ui ) {
-			if ( ui.item.is( '#postexcerpt' ) ) {
-				shortDescriptionEditor.restore();
-			}
-		} );
+	shortDescriptionEditor.bindPostboxEvents( $ );
 } );

--- a/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-product.test.js
+++ b/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-product.test.js
@@ -1,251 +1,216 @@
-/**
- * Tests for keeping the Product short description editor alive across metabox moves.
- *
- * Moving a postbox detaches and re-inserts its DOM node, which reloads the
- * TinyMCE iframe and wipes the editor document. See
- * https://github.com/woocommerce/woocommerce/issues/32113.
- */
-
 global.jQuery = jest.fn();
 
 const {
-	teardown: teardownShortDescriptionEditor,
-	restore: restoreShortDescriptionEditor,
+	teardown,
+	restore,
+	bindPostboxEvents,
 } = require( '../meta-boxes-product' );
 
-/**
- * Install a TinyMCE stub that mimics the parts of the real API this code leans on.
- *
- * The important fidelity detail is that remove() flushes the editor's content
- * into the textarea unconditionally, because TinyMCE's Editor.remove() calls
- * save() whenever the editor still has a body, and for a textarea target that
- * write is not gated by the is_removing flag. That is what makes the Visual-mode
- * path work without an explicit save(), and what would clobber the user's typing
- * in Text mode if the snapshot/restore pair were removed.
- *
- * @param {Object}  options            Stub options.
- * @param {boolean} options.hidden     Whether the editor is in "Text" mode.
- * @param {string}  options.content    Content the editor would flush on removal.
- * @param {boolean} options.hasEditor  Whether an editor instance exists at all.
- * @return {Object} The installed tinymce stub.
- */
-function stubTinyMce( { hidden = false, content = '', hasEditor = true } = {} ) {
-	// TinyMCE caches the element it was bound to, so this deliberately captures
-	// the node now rather than looking the id up later.
-	const target = document.querySelector( '#postexcerpt #excerpt' );
-	let editor = hasEditor
-		? { isHidden: () => hidden, getElement: () => target }
-		: null;
+const $ = function ( target ) {
+	const element =
+		typeof target === 'string' ? document.querySelector( target ) : target;
+	const listeners = [];
 
-	const tinymce = {
+	return {
+		on: function ( namespacedEvent, handler ) {
+			const event = namespacedEvent.split( '.' )[ 0 ];
+			const listener = ( domEvent ) => handler( domEvent, domEvent.detail );
+
+			element.addEventListener( event, listener );
+			listeners.push( { event, listener } );
+			return this;
+		},
+		off: function () {
+			listeners.forEach( ( { event, listener } ) => {
+				element.removeEventListener( event, listener );
+			} );
+		},
+		is: function ( selector ) {
+			return element.matches( selector );
+		},
+	};
+};
+
+function renderEditor( value = '' ) {
+	document.body.innerHTML =
+		'<div id="poststuff"><div id="postexcerpt">' +
+		'<button class="handle-order-higher" aria-disabled="false">' +
+		'<span>Move</span></button>' +
+		'<textarea id="excerpt" aria-hidden="true"></textarea>' +
+		'</div></div>';
+
+	const textarea = document.querySelector( '#excerpt' );
+	textarea.value = value;
+	return textarea;
+}
+
+function installTinyMce( {
+	hidden = false,
+	savedContent = '',
+	deferInit = false,
+} = {} ) {
+	const textarea = document.querySelector( '#excerpt' );
+	const resolveInitializations = [];
+	const createEditor = ( isHidden ) => ( {
+		getElement: () => textarea,
+		isHidden: () => isHidden,
+		setHidden: ( value ) => ( isHidden = value ),
+	} );
+	let editor = createEditor( hidden );
+
+	window.tinymce = {
 		get: jest.fn( () => editor ),
-		init: jest.fn(),
-		execCommand: jest.fn( ( command ) => {
-			if ( 'mceRemoveEditor' === command ) {
-				if ( target ) {
-					target.value = content;
-				}
+		init: jest.fn( () => {
+			const initializedEditor = ( editor = createEditor( false ) );
 
-				editor = null;
+			if ( ! deferInit ) {
+				return Promise.resolve( [ editor ] );
 			}
+
+			return new Promise( ( resolve ) => {
+				resolveInitializations.push( () =>
+					resolve( [ initializedEditor ] )
+				);
+			} );
 		} ),
+		execCommand: jest.fn( () => {
+			textarea.value = savedContent;
+			editor = null;
+		} ),
+		resolveInit: ( index ) => resolveInitializations[ index ](),
 	};
 
-	window.tinymce = tinymce;
-
-	return tinymce;
-}
-
-/**
- * Add a copy of the postbox carrying a duplicate id, as core's sortable helper
- * does while a postbox is being dragged.
- *
- * @param {string} value Value to put in the duplicate textarea.
- * @return {HTMLElement} The inserted copy.
- */
-function insertDragHelperClone( value ) {
-	const postbox = document.querySelector( '#postexcerpt' );
-	const clone = postbox.cloneNode( true );
-
-	clone.removeAttribute( 'id' );
-
-	const cloned = clone.querySelector( 'textarea' );
-	cloned.value = value;
-	// The clone goes earlier in tree order, so a browser resolves the duplicate
-	// id to it rather than to the real textarea. jsdom keeps returning the
-	// original, so make getElementById behave the way a browser would; without
-	// this the tests would pass even when the code looks the id up itself.
-	postbox.parentElement.insertBefore( clone, postbox );
-	jest.spyOn( document, 'getElementById' ).mockImplementation( ( id ) =>
-		'excerpt' === id ? cloned : null
-	);
-
-	return clone;
-}
-
-/**
- * Render the markup wp_editor() produces for the short description box.
- *
- * @param {string} value Initial textarea value.
- */
-function renderEditorMarkup( value = '' ) {
-	document.body.innerHTML =
-		'<div id="sortables">' +
-		'<div id="postexcerpt">' +
-		'<textarea id="excerpt" aria-hidden="true"></textarea>' +
-		'</div>' +
-		'</div>';
-	document.querySelector( '#postexcerpt #excerpt' ).value = value;
+	return window.tinymce;
 }
 
 describe( 'Product short description editor across metabox moves', () => {
+	let unbindPostboxEvents;
+
 	beforeEach( () => {
-		// WordPress always prints these alongside a wp_editor() instance.
-		window.tinyMCEPreInit = { mceInit: { excerpt: { selector: '#excerpt' } } };
+		unbindPostboxEvents = null;
+		window.tinyMCEPreInit = {
+			mceInit: { excerpt: { selector: '#excerpt' } },
+		};
+		window.switchEditors = {
+			go: jest.fn( () => {
+				const editor = window.tinymce.get( 'excerpt' );
+				editor.getElement().value = '<p>normalized</p>';
+				editor.setHidden( true );
+			} ),
+		};
 	} );
 
-	afterEach( () => {
-		// Clear any torn-down state before removing the stubs, since the module
-		// keeps that flag between tests.
-		restoreShortDescriptionEditor();
+	afterEach( async () => {
+		if ( unbindPostboxEvents ) {
+			unbindPostboxEvents();
+		}
 
+		await restore();
+		jest.useRealTimers();
 		jest.restoreAllMocks();
 		delete window.tinymce;
 		delete window.tinyMCEPreInit;
+		delete window.switchEditors;
 		document.body.innerHTML = '';
 	} );
 
-	describe( 'Text mode', () => {
-		test( 'keeps what the user typed in the textarea', () => {
-			renderEditorMarkup( 'typed in the textarea' );
-			// The hidden editor still holds older content and would flush it.
-			stubTinyMce( { hidden: true, content: 'stale editor content' } );
-
-			teardownShortDescriptionEditor();
-
-			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
-				'typed in the textarea'
-			);
+	test( 'preserves Visual content and rebuilds from the excerpt settings', async () => {
+		const textarea = renderEditor();
+		const settings = window.tinyMCEPreInit.mceInit.excerpt;
+		const tinymce = installTinyMce( {
+			savedContent: '<p>written in the editor</p>',
 		} );
 
-		test( 'leaves re-initialization to core', () => {
-			renderEditorMarkup( 'typed in the textarea' );
-			const tinymce = stubTinyMce( { hidden: true, content: 'stale' } );
+		teardown();
+		expect( textarea.value ).toBe( '<p>written in the editor</p>' );
+		expect( textarea.hasAttribute( 'aria-hidden' ) ).toBe( false );
 
-			teardownShortDescriptionEditor();
-			restoreShortDescriptionEditor();
-
-			expect( tinymce.init ).not.toHaveBeenCalled();
-		} );
+		await restore();
+		expect( tinymce.init ).toHaveBeenCalledWith( settings );
 	} );
 
-	describe( 'Visual mode', () => {
-		test( 'carries the editor content into the textarea', () => {
-			renderEditorMarkup( '' );
-			stubTinyMce( { content: '<p>written in the editor</p>' } );
-
-			teardownShortDescriptionEditor();
-
-			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
-				'<p>written in the editor</p>'
-			);
+	test( 'preserves raw Text mode through rapid consecutive moves', async () => {
+		const content = '<custom-element>raw</custom-element>\n';
+		const textarea = renderEditor( content );
+		const originalSetup = jest.fn();
+		const settings = window.tinyMCEPreInit.mceInit.excerpt;
+		settings.setup = originalSetup;
+		const tinymce = installTinyMce( {
+			hidden: true,
+			savedContent: 'stale editor content',
+			deferInit: true,
 		} );
 
-		test( 'rebuilds the editor from its own stored settings', () => {
-			renderEditorMarkup( '' );
-			const tinymce = stubTinyMce( { content: 'content' } );
-			const excerptSettings = { selector: '#excerpt', toolbar1: 'bold' };
-			window.tinyMCEPreInit = {
-				mceInit: {
-					excerpt: excerptSettings,
-					// A later-initialized editor must not supply the settings.
-					content: { selector: '#content', toolbar1: 'italic' },
-				},
-			};
+		teardown();
+		expect( textarea.value ).toBe( content );
+		const firstRestore = restore();
+		teardown();
+		const secondRestore = restore();
 
-			teardownShortDescriptionEditor();
-			restoreShortDescriptionEditor();
+		tinymce.resolveInit( 0 );
+		await firstRestore;
+		expect( window.switchEditors.go ).not.toHaveBeenCalled();
+		expect( textarea.value ).toBe( content );
+		tinymce.resolveInit( 1 );
+		await secondRestore;
 
-			expect( tinymce.init ).toHaveBeenCalledWith( excerptSettings );
-		} );
-
-		test( 'stops hiding the textarea from assistive tech while it is visible', () => {
-			renderEditorMarkup( '' );
-			stubTinyMce( { content: 'content' } );
-
-			teardownShortDescriptionEditor();
-
-			expect(
-				document.querySelector( '#postexcerpt #excerpt' ).hasAttribute( 'aria-hidden' )
-			).toBe( false );
-		} );
+		expect( tinymce.get( 'excerpt' ).isHidden() ).toBe( true );
+		expect( window.switchEditors.go ).toHaveBeenCalledTimes( 1 );
+		expect( window.switchEditors.go ).toHaveBeenCalledWith(
+			'excerpt',
+			'html'
+		);
+		expect( textarea.value ).toBe( content );
+		expect( tinymce.init.mock.calls[ 0 ][ 0 ] ).toBe( settings );
+		expect( tinymce.init.mock.calls[ 1 ][ 0 ] ).toBe( settings );
+		expect( settings.setup ).toBe( originalSetup );
 	} );
 
-	// While a postbox is dragged, core's sortable helper is a clone of it that
-	// carries a second element with the same id, so looking the id up in the
-	// document resolves to the wrong node. The code has to ask the editor which
-	// element it owns instead.
-	describe( 'while a drag helper clone duplicates the id', () => {
-		test( 'takes the textarea from the editor rather than the document', () => {
-			renderEditorMarkup( 'typed in the textarea' );
-			stubTinyMce( { hidden: true, content: 'stale editor content' } );
-			const clone = insertDragHelperClone( 'clone value' );
-
-			teardownShortDescriptionEditor();
-
-			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
-				'typed in the textarea'
-			);
-			expect( clone.querySelector( 'textarea' ).value ).toBe(
-				'clone value'
-			);
+	test( 'uses the editor textarea when a drag helper duplicates its id', () => {
+		const textarea = renderEditor( 'real content' );
+		const tinymce = installTinyMce( {
+			hidden: true,
+			savedContent: 'stale editor content',
 		} );
+		const clone = document.querySelector( '#postexcerpt' ).cloneNode( true );
+		clone.removeAttribute( 'id' );
+		clone.querySelector( 'textarea' ).value = 'clone content';
+		document.body.prepend( clone );
 
-		test( 'leaves the clone untouched when clearing aria-hidden', () => {
-			renderEditorMarkup( '' );
-			stubTinyMce( { content: 'content' } );
-			const clone = insertDragHelperClone( '' );
+		teardown();
 
-			teardownShortDescriptionEditor();
-
-			expect(
-				document.querySelector( '#postexcerpt #excerpt' ).hasAttribute( 'aria-hidden' )
-			).toBe( false );
-			expect(
-				clone.querySelector( 'textarea' ).hasAttribute( 'aria-hidden' )
-			).toBe( true );
-		} );
+		expect( tinymce.execCommand ).toHaveBeenCalledWith(
+			'mceRemoveEditor',
+			false,
+			'excerpt'
+		);
+		expect( textarea.value ).toBe( 'real content' );
+		expect( clone.querySelector( 'textarea' ).value ).toBe( 'clone content' );
 	} );
 
-	describe( 'when there is nothing to tear down', () => {
-		test( 'does nothing without a TinyMCE instance', () => {
-			renderEditorMarkup( 'untouched' );
-			const tinymce = stubTinyMce( { hasEditor: false } );
+	test( 'restores through the order-button and sortable event paths', async () => {
+		jest.useFakeTimers();
+		renderEditor( 'content' );
+		const tinymce = installTinyMce();
+		unbindPostboxEvents = bindPostboxEvents( $ );
+		const button = document.querySelector( '.handle-order-higher' );
+		button.addEventListener( 'click', ( event ) => event.stopPropagation() );
 
-			expect( () => teardownShortDescriptionEditor() ).not.toThrow();
-			expect( tinymce.execCommand ).not.toHaveBeenCalled();
-			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
-				'untouched'
-			);
-		} );
+		button.querySelector( 'span' ).click();
 
-		test( 'does nothing when TinyMCE is unavailable', () => {
-			renderEditorMarkup( 'untouched' );
+		expect( tinymce.execCommand ).toHaveBeenCalledTimes( 1 );
+		jest.runOnlyPendingTimers();
+		await Promise.resolve();
+		expect( tinymce.init ).toHaveBeenCalledTimes( 1 );
 
-			expect( () => teardownShortDescriptionEditor() ).not.toThrow();
-			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
-				'untouched'
-			);
-		} );
+		const poststuff = document.querySelector( '#poststuff' );
+		const ui = { item: $( document.querySelector( '#postexcerpt' ) ) };
 
-		test( 'restore is a no-op when no teardown happened', () => {
-			renderEditorMarkup( '' );
-			const tinymce = stubTinyMce( { content: 'content' } );
+		poststuff.dispatchEvent( new CustomEvent( 'sortstart', { detail: ui } ) );
+		poststuff.dispatchEvent( new CustomEvent( 'sortstop', { detail: ui } ) );
+		await Promise.resolve();
 
-			restoreShortDescriptionEditor();
-
-			expect( tinymce.init ).not.toHaveBeenCalled();
-			expect( tinymce.execCommand ).not.toHaveBeenCalled();
-		} );
+		expect( tinymce.execCommand ).toHaveBeenCalledTimes( 2 );
+		expect( tinymce.init ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-product.test.js
+++ b/plugins/woocommerce/client/legacy/js/admin/test/meta-boxes-product.test.js
@@ -1,0 +1,251 @@
+/**
+ * Tests for keeping the Product short description editor alive across metabox moves.
+ *
+ * Moving a postbox detaches and re-inserts its DOM node, which reloads the
+ * TinyMCE iframe and wipes the editor document. See
+ * https://github.com/woocommerce/woocommerce/issues/32113.
+ */
+
+global.jQuery = jest.fn();
+
+const {
+	teardown: teardownShortDescriptionEditor,
+	restore: restoreShortDescriptionEditor,
+} = require( '../meta-boxes-product' );
+
+/**
+ * Install a TinyMCE stub that mimics the parts of the real API this code leans on.
+ *
+ * The important fidelity detail is that remove() flushes the editor's content
+ * into the textarea unconditionally, because TinyMCE's Editor.remove() calls
+ * save() whenever the editor still has a body, and for a textarea target that
+ * write is not gated by the is_removing flag. That is what makes the Visual-mode
+ * path work without an explicit save(), and what would clobber the user's typing
+ * in Text mode if the snapshot/restore pair were removed.
+ *
+ * @param {Object}  options            Stub options.
+ * @param {boolean} options.hidden     Whether the editor is in "Text" mode.
+ * @param {string}  options.content    Content the editor would flush on removal.
+ * @param {boolean} options.hasEditor  Whether an editor instance exists at all.
+ * @return {Object} The installed tinymce stub.
+ */
+function stubTinyMce( { hidden = false, content = '', hasEditor = true } = {} ) {
+	// TinyMCE caches the element it was bound to, so this deliberately captures
+	// the node now rather than looking the id up later.
+	const target = document.querySelector( '#postexcerpt #excerpt' );
+	let editor = hasEditor
+		? { isHidden: () => hidden, getElement: () => target }
+		: null;
+
+	const tinymce = {
+		get: jest.fn( () => editor ),
+		init: jest.fn(),
+		execCommand: jest.fn( ( command ) => {
+			if ( 'mceRemoveEditor' === command ) {
+				if ( target ) {
+					target.value = content;
+				}
+
+				editor = null;
+			}
+		} ),
+	};
+
+	window.tinymce = tinymce;
+
+	return tinymce;
+}
+
+/**
+ * Add a copy of the postbox carrying a duplicate id, as core's sortable helper
+ * does while a postbox is being dragged.
+ *
+ * @param {string} value Value to put in the duplicate textarea.
+ * @return {HTMLElement} The inserted copy.
+ */
+function insertDragHelperClone( value ) {
+	const postbox = document.querySelector( '#postexcerpt' );
+	const clone = postbox.cloneNode( true );
+
+	clone.removeAttribute( 'id' );
+
+	const cloned = clone.querySelector( 'textarea' );
+	cloned.value = value;
+	// The clone goes earlier in tree order, so a browser resolves the duplicate
+	// id to it rather than to the real textarea. jsdom keeps returning the
+	// original, so make getElementById behave the way a browser would; without
+	// this the tests would pass even when the code looks the id up itself.
+	postbox.parentElement.insertBefore( clone, postbox );
+	jest.spyOn( document, 'getElementById' ).mockImplementation( ( id ) =>
+		'excerpt' === id ? cloned : null
+	);
+
+	return clone;
+}
+
+/**
+ * Render the markup wp_editor() produces for the short description box.
+ *
+ * @param {string} value Initial textarea value.
+ */
+function renderEditorMarkup( value = '' ) {
+	document.body.innerHTML =
+		'<div id="sortables">' +
+		'<div id="postexcerpt">' +
+		'<textarea id="excerpt" aria-hidden="true"></textarea>' +
+		'</div>' +
+		'</div>';
+	document.querySelector( '#postexcerpt #excerpt' ).value = value;
+}
+
+describe( 'Product short description editor across metabox moves', () => {
+	beforeEach( () => {
+		// WordPress always prints these alongside a wp_editor() instance.
+		window.tinyMCEPreInit = { mceInit: { excerpt: { selector: '#excerpt' } } };
+	} );
+
+	afterEach( () => {
+		// Clear any torn-down state before removing the stubs, since the module
+		// keeps that flag between tests.
+		restoreShortDescriptionEditor();
+
+		jest.restoreAllMocks();
+		delete window.tinymce;
+		delete window.tinyMCEPreInit;
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'Text mode', () => {
+		test( 'keeps what the user typed in the textarea', () => {
+			renderEditorMarkup( 'typed in the textarea' );
+			// The hidden editor still holds older content and would flush it.
+			stubTinyMce( { hidden: true, content: 'stale editor content' } );
+
+			teardownShortDescriptionEditor();
+
+			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
+				'typed in the textarea'
+			);
+		} );
+
+		test( 'leaves re-initialization to core', () => {
+			renderEditorMarkup( 'typed in the textarea' );
+			const tinymce = stubTinyMce( { hidden: true, content: 'stale' } );
+
+			teardownShortDescriptionEditor();
+			restoreShortDescriptionEditor();
+
+			expect( tinymce.init ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Visual mode', () => {
+		test( 'carries the editor content into the textarea', () => {
+			renderEditorMarkup( '' );
+			stubTinyMce( { content: '<p>written in the editor</p>' } );
+
+			teardownShortDescriptionEditor();
+
+			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
+				'<p>written in the editor</p>'
+			);
+		} );
+
+		test( 'rebuilds the editor from its own stored settings', () => {
+			renderEditorMarkup( '' );
+			const tinymce = stubTinyMce( { content: 'content' } );
+			const excerptSettings = { selector: '#excerpt', toolbar1: 'bold' };
+			window.tinyMCEPreInit = {
+				mceInit: {
+					excerpt: excerptSettings,
+					// A later-initialized editor must not supply the settings.
+					content: { selector: '#content', toolbar1: 'italic' },
+				},
+			};
+
+			teardownShortDescriptionEditor();
+			restoreShortDescriptionEditor();
+
+			expect( tinymce.init ).toHaveBeenCalledWith( excerptSettings );
+		} );
+
+		test( 'stops hiding the textarea from assistive tech while it is visible', () => {
+			renderEditorMarkup( '' );
+			stubTinyMce( { content: 'content' } );
+
+			teardownShortDescriptionEditor();
+
+			expect(
+				document.querySelector( '#postexcerpt #excerpt' ).hasAttribute( 'aria-hidden' )
+			).toBe( false );
+		} );
+	} );
+
+	// While a postbox is dragged, core's sortable helper is a clone of it that
+	// carries a second element with the same id, so looking the id up in the
+	// document resolves to the wrong node. The code has to ask the editor which
+	// element it owns instead.
+	describe( 'while a drag helper clone duplicates the id', () => {
+		test( 'takes the textarea from the editor rather than the document', () => {
+			renderEditorMarkup( 'typed in the textarea' );
+			stubTinyMce( { hidden: true, content: 'stale editor content' } );
+			const clone = insertDragHelperClone( 'clone value' );
+
+			teardownShortDescriptionEditor();
+
+			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
+				'typed in the textarea'
+			);
+			expect( clone.querySelector( 'textarea' ).value ).toBe(
+				'clone value'
+			);
+		} );
+
+		test( 'leaves the clone untouched when clearing aria-hidden', () => {
+			renderEditorMarkup( '' );
+			stubTinyMce( { content: 'content' } );
+			const clone = insertDragHelperClone( '' );
+
+			teardownShortDescriptionEditor();
+
+			expect(
+				document.querySelector( '#postexcerpt #excerpt' ).hasAttribute( 'aria-hidden' )
+			).toBe( false );
+			expect(
+				clone.querySelector( 'textarea' ).hasAttribute( 'aria-hidden' )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'when there is nothing to tear down', () => {
+		test( 'does nothing without a TinyMCE instance', () => {
+			renderEditorMarkup( 'untouched' );
+			const tinymce = stubTinyMce( { hasEditor: false } );
+
+			expect( () => teardownShortDescriptionEditor() ).not.toThrow();
+			expect( tinymce.execCommand ).not.toHaveBeenCalled();
+			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
+				'untouched'
+			);
+		} );
+
+		test( 'does nothing when TinyMCE is unavailable', () => {
+			renderEditorMarkup( 'untouched' );
+
+			expect( () => teardownShortDescriptionEditor() ).not.toThrow();
+			expect( document.querySelector( '#postexcerpt #excerpt' ).value ).toBe(
+				'untouched'
+			);
+		} );
+
+		test( 'restore is a no-op when no teardown happened', () => {
+			renderEditorMarkup( '' );
+			const tinymce = stubTinyMce( { content: 'content' } );
+
+			restoreShortDescriptionEditor();
+
+			expect( tinymce.init ).not.toHaveBeenCalled();
+			expect( tinymce.execCommand ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Moving the "Product short description" metabox blanks its visual editor until reload: WordPress repositions postboxes by re-inserting the DOM node, and moving an `<iframe>` reloads it, destroying the TinyMCE document. This is the only `wp_editor()` in a movable metabox, so core never hits it.

The fix tears the editor down before the move and rebuilds it after, as core's Text widget and ACF do. Three non-obvious bits:

-   Header buttons need a capture-phase listener, since core binds its handler directly to the button. Drag uses `sortstart`/`sortstop`.
-   Text mode breaks too (the editor is only hidden), and `remove()` writes to the textarea unconditionally, so that path snapshots the textarea and restores it.
-   The element comes from `editor.getElement()`: core's drag helper is a clone keeping the same `id`, so two elements answer to `#excerpt` mid-drag.

**Backward compatibility:** no PHP, hooks, filters, or templates change; `woocommerce_product_short_description_editor_settings` still applies.

Closes #32113.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

On a classic (non-block) product edit screen:

1. Edit a product, type into **Product short description**, then drag the metabox to a new position by its header. The editor should keep your text and stay editable. On trunk it goes blank until you reload.
2. Repeat with the **Move up** / **Move down** buttons in the metabox header.
3. Switch to the **Text** tab, type, move the box again, then switch back to **Visual**. Your text should be there and editable.
4. Save and confirm the short description persisted.

<!-- End testing instructions -->

### Testing that has already taken place:

`wp-env` (WordPress latest, PHP 8.1), classic product editor, TinyMCE 4.9.11. Reproduced the bug on trunk first, then verified the fix on the rendered page across both move paths in Visual and Text mode. The drag case used real mouse events through jQuery UI's own handlers, which also confirmed the duplicate `id="excerpt"` condition that `getElement()` guards against.

10 new Jest tests, full legacy suite green (7 suites, 141 tests), ESLint clean. Each test was mutation-checked, so the suite is not passing vacuously.

Not tested: multisite, and browsers other than Chromium. The event wiring is not unit-covered because it lives in the jQuery ready closure, matching the convention in `meta-boxes-order.test.js`; it is covered by the manual passes instead.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
