### PR TITLE
Fix long product name overflow in the order Add products modal

### DIFF
--- a/plugins/woocommerce/changelog/67114-fix-modal-select2-padding-wp70
+++ b/plugins/woocommerce/changelog/67114-fix-modal-select2-padding-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Add products modal select2 icon padding being overridden by the WP 7.0+ admin styles, so long product names no longer run under the clear/chevron icons.

--- a/plugins/woocommerce/changelog/67114-fix-modal-select2-padding-wp70
+++ b/plugins/woocommerce/changelog/67114-fix-modal-select2-padding-wp70
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the Add products modal select2 icon padding being overridden by the WP 7.0+ admin styles, so long product names no longer run under the clear/chevron icons.
+Fix long product names in the Add products modal running under the clear/chevron icons on WP 7.0+ and stretching the table past the modal edge.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8047,6 +8047,16 @@ table.bar_chart {
 		min-height: 180px
 	}
 
+	// Fixed layout so a long nowrap select2 selection truncates inside the Product
+	// column instead of stretching it and pushing Quantity past the modal edge.
+	&.wc-backbone-modal-add-products table.widefat {
+		table-layout: fixed;
+
+		th:last-child {
+			width: 100px;
+		}
+	}
+
 	.select2-container {
 		width: 100% !important;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8069,8 +8069,10 @@ table.bar_chart {
 			padding-right: 40px;
 		}
 
+		// Pull the clear (x) into the 40px padding zone so it sits beside the chevron
+		// rather than at the text edge.
 		.select2-selection__clear {
-			margin-right: 18px;
+			margin-right: -10px;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8051,8 +8051,10 @@ table.bar_chart {
 		width: 100% !important;
 	}
 
-	// Reserve room for the clear (x) and chevron icons; .select2-container keeps this rule above the later global 24px padding.
-	.select2-container .select2-selection--single {
+	// Reserve room for the clear (x) and chevron icons; .wc-backbone-modal-content lifts specificity
+	// to 0,5,0 so the later, equal-specificity WP 7.0 reset (`.wc-wp-version-gte-70 ... padding: 0 12px`)
+	// no longer wins the right padding.
+	.wc-backbone-modal-content .select2-container .select2-selection--single {
 		.select2-selection__rendered {
 			padding-right: 40px;
 		}

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -417,7 +417,7 @@ if ( wc_tax_enabled() ) {
 <?php endif; ?>
 
 <script type="text/template" id="tmpl-wc-modal-add-products">
-	<div class="wc-backbone-modal">
+	<div class="wc-backbone-modal wc-backbone-modal-add-products">
 		<div class="wc-backbone-modal-content">
 			<section class="wc-backbone-modal-main" role="main">
 				<header class="wc-backbone-modal-header">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- @TODO(Jana): rewrite -->

- Follow-up to #66381: the icon padding fix there never took effect on WP 7.0+ because an equal-specificity rule later in the stylesheet cancels it; the modal rule now outranks it.
- Long product names also stretched the modal table past its edge; the Add products table now uses fixed column layout.
- The clear (x) icon now sits next to the chevron instead of at the text edge.
- RTL output verified (`admin-rtl.css` flips the padding/margin correctly). The 40px padding intentionally applies to enhanced selects in all backbone modals, not just Add products.

Closes #67114.

Bug introduced in PR #66381.

### Screenshots or screen recordings:


### AFTER:
Desktop
<img width="910" height="480" alt="Screenshot 2026-07-31 at 12 24 20" src="https://github.com/user-attachments/assets/4e082988-c3dc-4ed7-a28d-0f25fc0b53a0" />

Mobile
<img width="384" height="788" alt="Screenshot 2026-07-31 at 12 26 50" src="https://github.com/user-attachments/assets/8f86d0e2-e96c-47b0-a568-13bb62b97c06" />




### How to test the changes in this Pull Request:

1. On WP 7.0+, create a product with a very long name (80+ characters).
2. Go to Orders → Add order → Add item(s) → Add product(s) and select that product.
3. The name truncates before the clear (x) and chevron icons, and the Quantity column stays inside the modal (no horizontal scrollbar).
4. Check a short product name and a narrow viewport still render correctly.

<details>
<summary>Milestone</summary>

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

</details>

<details>
<summary>Changelog entry</summary>

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

</details>

<details>
<summary>Release Communication</summary>

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

</details>