### PR TITLE
Restore defer for legacy alias scripts and print them in the footer

### DIFF
--- a/plugins/woocommerce/changelog/fix-67159-legacy-script-blocking-regression
+++ b/plugins/woocommerce/changelog/fix-67159-legacy-script-blocking-regression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Print frontend scripts in the footer with the defer strategy instead of forcing legacy alias handles to be blocking, fixing classic cart and checkout on sites that load a second jQuery instance.

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -143,9 +143,12 @@ class WC_Frontend_Scripts {
 	 * @param  string                                          $path      Full URL of the script, or path of the script relative to the WordPress root directory.
 	 * @param  string[]                                        $deps      An array of registered script handles this script depends on.
 	 * @param  string                                          $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'strategy' => 'defer' ).
+	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'in_footer' => true, 'strategy' => 'defer' ).
 	 */
-	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
+	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array(
+		'in_footer' => true,
+		'strategy'  => 'defer',
+	) ) {
 		self::$registered_scripts[] = $handle;
 		wp_register_script( $handle, $path, $deps, $version, $in_footer );
 	}
@@ -158,9 +161,12 @@ class WC_Frontend_Scripts {
 	 * @param  string                                          $path      Full URL of the script, or path of the script relative to the WordPress root directory.
 	 * @param  string[]                                        $deps      An array of registered script handles this script depends on.
 	 * @param  string                                          $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'strategy' => 'defer' ).
+	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'in_footer' => true, 'strategy' => 'defer' ).
 	 */
-	private static function enqueue_script( $handle, $path = '', $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
+	private static function enqueue_script( $handle, $path = '', $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array(
+		'in_footer' => true,
+		'strategy'  => 'defer',
+	) ) {
 		if ( ! in_array( $handle, self::$registered_scripts, true ) && $path ) {
 			self::register_script( $handle, $path, $deps, $version, $in_footer );
 		}
@@ -414,25 +420,12 @@ class WC_Frontend_Scripts {
 		$register_scripts = self::get_scripts();
 
 		foreach ( $register_scripts as $name => $props ) {
-			$is_legacy_handle = isset( $props['legacy_handle'] );
+			self::register_script( $name, $props['src'], $props['deps'], $props['version'] );
 
-			/*
-			 * Scripts with legacy alias handles must use a blocking strategy.
-			 * WordPress (since 6.3) silently discards loading strategies on alias
-			 * scripts (registered with src=false). If the real script uses defer
-			 * but the alias cannot inherit it, the strategy mismatch breaks
-			 * dependency resolution for third-party code that depends on the
-			 * legacy handle (e.g. payment gateways using 'jquery-payment').
-			 *
-			 * Using blocking for both the real script and its alias ensures
-			 * consistent execution order through the dependency chain.
-			 */
-			$in_footer = $is_legacy_handle ? true : array( 'strategy' => 'defer' );
-
-			self::register_script( $name, $props['src'], $props['deps'], $props['version'], $in_footer );
-
-			if ( $is_legacy_handle ) {
-				self::register_script( $props['legacy_handle'], false, array( $name ), $props['version'], $in_footer );
+			// Alias scripts (src=false) can't carry a strategy, and WordPress exempts them
+			// from the "no strategy means blocking" rule, so the real script stays deferred.
+			if ( isset( $props['legacy_handle'] ) ) {
+				self::register_script( $props['legacy_handle'], false, array( $name ), $props['version'], array( 'in_footer' => true ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-frontend-scripts-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-frontend-scripts-test.php
@@ -234,36 +234,71 @@ class WC_Frontend_Scripts_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that scripts with legacy handles and their aliases use blocking strategy.
+	 * Invoke WC_Frontend_Scripts::register_scripts() and return the script definitions.
 	 *
-	 * WordPress (since 6.3) discards loading strategies on alias scripts
-	 * (src=false). To avoid strategy mismatches, both the real script and
-	 * its legacy alias must be registered as blocking (in_footer=true).
+	 * @return array
 	 */
-	public function test_legacy_handle_scripts_use_blocking_strategy(): void {
+	private function register_frontend_scripts(): array {
 		$reflection = new ReflectionClass( 'WC_Frontend_Scripts' );
-		$method     = $reflection->getMethod( 'register_scripts' );
-		$method->setAccessible( true );
-		$method->invoke( null );
 
-		$get_scripts_method = $reflection->getMethod( 'get_scripts' );
-		$get_scripts_method->setAccessible( true );
-		$scripts = $get_scripts_method->invoke( null );
+		$register = $reflection->getMethod( 'register_scripts' );
+		$register->setAccessible( true );
+		$register->invoke( null );
+
+		$get_scripts = $reflection->getMethod( 'get_scripts' );
+		$get_scripts->setAccessible( true );
+
+		return $get_scripts->invoke( null );
+	}
+
+	/**
+	 * Test that scripts with legacy alias handles stay deferred and footer-printed.
+	 */
+	public function test_legacy_handle_scripts_keep_defer_strategy(): void {
+		$scripts = $this->register_frontend_scripts();
 
 		foreach ( $scripts as $name => $props ) {
 			if ( ! isset( $props['legacy_handle'] ) ) {
 				continue;
 			}
 
-			$legacy_handle = $props['legacy_handle'];
-
-			// Real script must be blocking (no defer strategy).
-			$real_strategy = wp_scripts()->get_data( $name, 'strategy' );
-			$this->assertFalse( $real_strategy, "Real handle '{$name}' should not have a loading strategy (blocking)." );
-
-			// Alias script must also be blocking.
-			$legacy_strategy = wp_scripts()->get_data( $legacy_handle, 'strategy' );
-			$this->assertFalse( $legacy_strategy, "Legacy handle '{$legacy_handle}' should not have a loading strategy (blocking)." );
+			$this->assertSame( 'defer', wp_scripts()->get_data( $name, 'strategy' ), "Real handle '{$name}' should keep the defer loading strategy." );
+			$this->assertSame( 1, wp_scripts()->get_data( $name, 'group' ), "Real handle '{$name}' should be printed in the footer." );
 		}
+	}
+
+	/**
+	 * Test that a blocking script registered against a legacy alias after the head
+	 * is printed still executes after the handle it depends on.
+	 */
+	public function test_late_blocking_dependent_downgrades_legacy_handle(): void {
+		$this->register_frontend_scripts();
+		wp_enqueue_script( 'wc-cart' );
+
+		ob_start();
+		wp_scripts()->do_head_items();
+		ob_end_clean();
+
+		// A gateway enqueues its blocking script only once the head has been printed.
+		wp_register_script( 'test-gateway-form', 'https://example.com/gateway.js', array( 'jquery-payment' ), '1', array( 'in_footer' => true ) );
+		wp_enqueue_script( 'test-gateway-form' );
+
+		ob_start();
+		wp_scripts()->do_footer_items();
+		$footer = ob_get_clean();
+
+		$payment_position = strpos( $footer, 'id="wc-jquery-payment-js"' );
+		$gateway_position = strpos( $footer, 'id="test-gateway-form-js"' );
+
+		$this->assertNotFalse( $payment_position, 'wc-jquery-payment should be printed in the footer.' );
+		$this->assertNotFalse( $gateway_position, 'The gateway script should be printed in the footer.' );
+		$this->assertLessThan( $gateway_position, $payment_position, 'wc-jquery-payment should be printed before the gateway script that depends on it.' );
+
+		preg_match( '#<script([^>]*)id="wc-jquery-payment-js"#', $footer, $matches );
+		$this->assertStringNotContainsString( ' defer', $matches[1], 'wc-jquery-payment should be downgraded to blocking when a blocking script depends on its legacy alias.' );
+
+		// Only the affected handle is downgraded; the rest of the chain stays deferred.
+		preg_match( '#<script([^>]*)id="wc-cart-js"#', $footer, $cart_matches );
+		$this->assertStringContainsString( ' defer', $cart_matches[1], 'wc-cart should remain deferred.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* WooCommerce 11.0 forced scripts with legacy alias handles to be blocking ([#64431](<https://github.com/woocommerce/woocommerce/issues/64431>)), breaking classic cart/checkout on sites that load a second jQuery instance.
* Restore the defer strategy for those scripts.
* Print all frontend scripts in the footer, so blocking dependents enqueued late (e.g. payment gateway scripts) still downgrade them correctly.

Closes woocommerce/woocommerce#67159.

Bug introduced in PR [#64431](<https://github.com/woocommerce/woocommerce/issues/64431>).

### How to test the changes in this Pull Request:

1. With classic cart/checkout shortcodes, add a product to the cart.
2. Print a second jQuery copy in `wp_footer` at priority 21 (snippet in woocommerce/woocommerce#67159).
3. Cart: update quantity/remove item — no console errors, Ajax fires.
4. Checkout: payment fields initialize, no BlockUI errors.
5. Verify `wc-*` scripts print in the footer with `defer`.

<details><summary>Milestone</summary>

### Milestone

- [ ] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged. Alternatively (e.g. for point releases), manually assign the appropriate milestone.

</details>

<details><summary>Changelog entry</summary>

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

+++ Changelog Entry Details

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

+++

+++ Changelog Entry Comment

#### Comment

Created manually.

+++

</details>

<details><summary>Release Communication</summary>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

</details>