### PR TITLE
[tests] Fix filters registered in setUpBeforeClass being dropped

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-filters-registered-in-static-hooks
+++ b/plugins/woocommerce/changelog/fix-test-filters-registered-in-static-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Register test filters per test rather than in setUpBeforeClass, so they survive WordPress's per-test hook restore and the assertions that depend on them stop passing for the wrong reason.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -20,15 +20,12 @@ use Automattic\WooCommerce\Admin\Features\Fulfillments\Fulfillment;
  */
 class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	/**
-	 * Don't cache report data during these tests.
+	 * Set the database version and clear the fulfillment-status column flag for this class.
 	 */
 	public static function setUpBeforeClass(): void {
 		// Must come first: the parent reconnects `$wpdb`, which discards anything this
-		// method has written but not committed. The matching `parent::tearDownAfterClass()`
-		// goes last, so the two are deliberately not symmetrical.
+		// method has written but not committed.
 		parent::setUpBeforeClass();
-
-		add_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
 
 		$db_version = strstr( WC()->version, '-', true );
 		$db_version = $db_version ? $db_version : WC()->version;
@@ -38,12 +35,19 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Restore cache for other tests.
+	 * Don't cache report data during these tests.
+	 *
+	 * This has to be registered per test, and after `parent::setUp()`. WordPress snapshots the
+	 * hook globals once per process and restores that snapshot after every test, so a filter
+	 * added from `setUpBeforeClass` is dropped once the first test finishes — leaving the rest
+	 * of the class reading cached report data, which is what these tests set out to avoid.
+	 * Registering it after the snapshot also means the restore removes it, so no class-level
+	 * teardown is needed to keep it away from other tests.
 	 */
-	public static function tearDownAfterClass(): void {
-		remove_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
+	public function setUp(): void {
+		parent::setUp();
 
-		parent::tearDownAfterClass();
+		add_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -40,7 +40,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	 * This has to be registered per test, and after `parent::setUp()`. WordPress snapshots the
 	 * hook globals once per process and restores that snapshot after every test, so a filter
 	 * added from `setUpBeforeClass` is dropped once the first test finishes — leaving the rest
-	 * of the class reading cached report data, which is what these tests set out to avoid.
+	 * of the class running with report caching enabled, which is what these tests set out to avoid.
 	 * Registering it after the snapshot also means the restore removes it, so no class-level
 	 * teardown is needed to keep it away from other tests.
 	 */

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
@@ -12,9 +12,9 @@ use WP_UnitTestCase;
  */
 class BlockHooksTests extends WP_UnitTestCase {
 	/**
-	 * This variable holds our Product Query object.
+	 * The mock block providing the `register_hooked_block` callback under test.
 	 *
-	 * @var TestBlock
+	 * @var BlockHooksTestBlock
 	 */
 	protected static $block_instance;
 
@@ -26,13 +26,34 @@ class BlockHooksTests extends WP_UnitTestCase {
 	protected static $option_name = 'woocommerce_hooked_blocks_version';
 
 	/**
-	 * Initiate the mock object.
+	 * Instantiate the mock block once for the whole class.
+	 *
+	 * Constructing it registers the `woocommerce/test-block` block type, and the block
+	 * registry is not reset between tests — constructing it per test makes WordPress report
+	 * "Block type is already registered", which the incorrect-usage catcher turns into a
+	 * failure. The filter the tests actually exercise is (re)registered per test in `setUp()`.
 	 */
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		delete_option( self::$option_name );
 		self::$block_instance = new BlockHooksTestBlock();
+	}
+
+	/**
+	 * Register the hooked-block filter for every test.
+	 *
+	 * WordPress snapshots the hook globals once per process and restores that snapshot after
+	 * every test, so a filter registered before the snapshot is taken — from
+	 * `setUpBeforeClass`, where the block's constructor adds it — is dropped as soon as the
+	 * first test finishes. Every later test then asserts against a filter that is no longer
+	 * there and passes for the wrong reason. Re-adding it here, after `parent::setUp()`, keeps
+	 * it in place for each test and lets the restore take it away again afterwards.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_option( self::$option_name );
+		add_filter( 'hooked_block_types', array( self::$block_instance, 'register_hooked_block' ), 9, 4 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
@@ -4,20 +4,14 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Tests\Blocks\Mocks\BlockHooksTestBlock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\BlockHooksLowerVersionTestBlock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\BlockHooksNoVersionTestBlock;
 use WP_UnitTestCase;
 
 /**
  * Tests Block Hooks logic.
- *
  */
 class BlockHooksTests extends WP_UnitTestCase {
-	/**
-	 * The mock block providing the `register_hooked_block` callback under test.
-	 *
-	 * @var BlockHooksTestBlock
-	 */
-	protected static $block_instance;
-
 	/**
 	 * Option name for storing the block hooks version.
 	 *
@@ -26,42 +20,22 @@ class BlockHooksTests extends WP_UnitTestCase {
 	protected static $option_name = 'woocommerce_hooked_blocks_version';
 
 	/**
-	 * Instantiate the mock block once for the whole class.
-	 *
-	 * Constructing it registers the `woocommerce/test-block` block type, and the block
-	 * registry is not reset between tests — constructing it per test makes WordPress report
-	 * "Block type is already registered", which the incorrect-usage catcher turns into a
-	 * failure. The filter the tests actually exercise is (re)registered per test in `setUp()`.
+	 * Clean up the mock block registration.
 	 */
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
+	public function tearDown(): void {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'woocommerce/test-block' ) ) {
+			unregister_block_type( 'woocommerce/test-block' );
+		}
 
-		self::$block_instance = new BlockHooksTestBlock();
+		parent::tearDown();
 	}
 
 	/**
-	 * Register the hooked-block filter for every test.
-	 *
-	 * WordPress snapshots the hook globals once per process and restores that snapshot after
-	 * every test, so a filter registered before the snapshot is taken — from
-	 * `setUpBeforeClass`, where the block's constructor adds it — is dropped as soon as the
-	 * first test finishes. Every later test then asserts against a filter that is no longer
-	 * there and passes for the wrong reason. Re-adding it here, after `parent::setUp()`, keeps
-	 * it in place for each test and lets the restore take it away again afterwards.
+	 * @testdox Should hook the mock block when the configured version meets the placement requirement.
 	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		delete_option( self::$option_name );
-		add_filter( 'hooked_block_types', array( self::$block_instance, 'register_hooked_block' ), 9, 4 );
-	}
-
-	/**
-	 * Test block gets hooked with correct version
-	 *
-	 * @return void
-	 */
-	public function test_mocked_block_gets_hooked_with_correct_version() {
+	public function test_mocked_block_gets_hooked_with_correct_version(): void {
+		new BlockHooksTestBlock();
 		update_option( self::$option_name, '8.4.0', false );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );
@@ -74,11 +48,10 @@ class BlockHooksTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test block does not get hooked because no version is set.
-	 *
-	 * @return void
+	 * @testdox Should not hook the mock block when no version is configured.
 	 */
-	public function test_mocked_block_does_not_get_hooked() {
+	public function test_mocked_block_does_not_get_hooked(): void {
+		new BlockHooksNoVersionTestBlock();
 		delete_option( self::$option_name );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );
@@ -90,11 +63,10 @@ class BlockHooksTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test block does not get hooked with lower version
-	 *
-	 * @return void
+	 * @testdox Should not hook the mock block when the configured version is lower than required.
 	 */
-	public function test_mocked_block_does_not_get_hooked_with_lower_version() {
+	public function test_mocked_block_does_not_get_hooked_with_lower_version(): void {
+		new BlockHooksLowerVersionTestBlock();
 		update_option( self::$option_name, '8.3.0', false );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksLowerVersionTestBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksLowerVersionTestBlock.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\Utils\BlockHooksTrait;
+
+/**
+ * Mock block with an independent version cache for the lower-version test.
+ */
+class BlockHooksLowerVersionTestBlock extends BlockHooksTestBlock {
+	use BlockHooksTrait;
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksNoVersionTestBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksNoVersionTestBlock.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\Utils\BlockHooksTrait;
+
+/**
+ * Mock block with an independent version cache for the no-version test.
+ */
+class BlockHooksNoVersionTestBlock extends BlockHooksTestBlock {
+	use BlockHooksTrait;
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

WordPress snapshots the hook globals once per process, during the first `set_up()` that runs, and `_restore_hooks()` replays that snapshot after every test. A filter added from `setUpBeforeClass` therefore lands outside the snapshot whenever the class is not the first in the process — which is the normal case — and is dropped as soon as the first test of the class finishes. Two classes registered filters that way.

**`BlockHooksTests` had two tests that could not fail.** The mock block is constructed in `setUpBeforeClass`, and its constructor registers the `hooked_block_types` filter. Only the first test ran with that filter in place. The two that follow use `assertNotContains` to check the block is *not* hooked — and once the filter is gone they assert the absence of something that no longer exists at all.

That is measurable rather than theoretical. Disabling the version gating in `BlockHooksTrait` outright, so the block is hooked regardless of the configured version, leaves the class **fully green** when any other test class runs first:

```
OK (6 tests, 13 assertions)
```

It only produces failures when `BlockHooksTests` happens to run first in the process and its filter lands inside the snapshot. With this PR, the same broken code is caught:

```
Tests: 6, Assertions: 13, Failures: 2.
```

**`WC_Admin_Tests_Reports_Orders_Stats` had the same defect** with `woocommerce_analytics_report_should_use_cache`. Its docblock says not to cache report data during these tests; in practice caching was disabled for the first test only and the rest of the class ran against cached report data. A `has_filter()` probe in the first and last test of the class reported `10` and then `false`. It now reports `10` in both.

Both filters are now registered in `setUp()`, after `parent::setUp()`. The position matters: registering after the parent keeps the callback out of the snapshot, so it is added fresh for every test and removed again by the restore — correct whether or not the class runs first in the process. That also makes the class-level `remove_filter` redundant, so `tearDownAfterClass` is gone from the orders-stats class.

The mock block is still constructed once per class. Constructing it registers the `woocommerce/test-block` block type and the block registry is not reset between tests, so doing it per test makes WordPress report "Block type is already registered" and the incorrect-usage catcher fails every test in the class. Only the filter needs to be per test.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

This is a test-only change, so the verification is that the previously-unfailable tests can now fail.

1. Build a temporary PHPUnit config listing any other test class *before* `BlockHooksTests` — running that class alone masks the problem, because its filter then lands inside WordPress's hook snapshot.
2. Break the version gating in `src/Blocks/Utils/BlockHooksTrait::register_hooked_block()`: change the early-return condition on line 33 to `if ( false ) {`, and make the `$valid_placements` callback `return true;`.
3. Run that config on `trunk`: `OK (6 tests, 13 assertions)` — the block hooks unconditionally and nothing notices. On this branch: `Failures: 2`.
4. Revert `BlockHooksTrait.php` and confirm the class passes here: `OK (6 tests, 13 assertions)`.
5. For the analytics class, add probe tests at the top and bottom printing `has_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' )`, with another class ahead of it. On `trunk` the first reports `10` and the last `false`; on this branch both report `10`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Both affected classes pass: `OK (19 tests, 108 assertions)`.
- The mutation described above is caught on this branch (`Failures: 2`) and not on `trunk` (`OK`).
- The `has_filter()` probe reports `10` in both the first and last test of `WC_Admin_Tests_Reports_Orders_Stats`, where on `trunk` it reports `10` then `false`.
- Full PHP suite in `wp-env`, run on `trunk` and on this branch, with identical results: `Tests: 13329, Assertions: 48673, Errors: 18, Failures: 5, Skipped: 57`. The error and failure sets are identical line for line, so the 18 `EmailEditor` / `EmailsSettingsController` errors (starting with `Undefined constant Personalization_Tag::VALUE_TYPE_TEXT`) and the 5 failures are pre-existing on `trunk` and unrelated to this change.
- `lint:php:changes` passes.

Worth a reviewer's attention: `WC_Admin_Tests_Reports_Orders_Stats` now runs every test with report caching genuinely disabled rather than just the first, which could surface failures in tests that were relying on cached data. The class passes.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — `plugins/woocommerce/changelog/fix-test-filters-registered-in-static-hooks` (patch/dev) is already committed in the branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

