### PR TITLE
[tests] Fix three test hygiene defects found while sweeping lifecycle methods

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-hygiene-followups
+++ b/plugins/woocommerce/changelog/fix-test-hygiene-followups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Guard the fake WC Calypso Bridge functions declared in tests, collect the LegacyProxy get_global test that was never running, and reset the REST server global the Store API controller tests replace.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
@@ -19,11 +19,16 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_IsWooExpressRuleProcessor extend
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		/**
-		 * Fake function wc_calypso_bridge_is_woo_express_plan so that we can test the processor.
-		 */
-		function wc_calypso_bridge_is_woo_express_plan() {
-			return apply_filters( 'test_wc_calypso_bridge_is_woo_express_plan', true ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		// Declaring a function is irreversible and process-wide, so guard it: without this a
+		// second declaration is a fatal error, whether it comes from this class running twice
+		// in a process or from the real WC Calypso Bridge plugin being loaded alongside it.
+		if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_plan' ) ) {
+			/**
+			 * Fake function wc_calypso_bridge_is_woo_express_plan so that we can test the processor.
+			 */
+			function wc_calypso_bridge_is_woo_express_plan() {
+				return apply_filters( 'test_wc_calypso_bridge_is_woo_express_plan', true ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			}
 		}
 	}
 
@@ -97,9 +102,13 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_IsWooExpressRuleProcessor extend
 	 * @group fast
 	 */
 	public function test_is_trial_plan() {
-		/** Fake function wc_calypso_bridge_is_woo_express_trial_plan. */
-		function wc_calypso_bridge_is_woo_express_trial_plan() {
-			return true;
+		// Guarded because this one sits in a test method: adding a data provider here would
+		// run it more than once and the redeclaration would be fatal.
+		if ( ! function_exists( 'wc_calypso_bridge_is_woo_express_trial_plan' ) ) {
+			/** Fake function wc_calypso_bridge_is_woo_express_trial_plan. */
+			function wc_calypso_bridge_is_woo_express_trial_plan() {
+				return true;
+			}
 		}
 
 		$processor = new IsWooExpressRuleProcessor();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
@@ -100,6 +100,9 @@ class Totals extends \WP_UnitTestCase {
 	 * tearDown.
 	 */
 	public function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
 		parent::tearDown();
 		remove_filter( 'woocommerce_set_cookie_enabled', array( $this, 'filter_woocommerce_set_cookie_enabled' ) );
 		WC()->cart->empty_cart();

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/ControllerTests.php
@@ -22,6 +22,21 @@ class ControllerTests extends \WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Discard the Spy_REST_Server this class installed.
+	 *
+	 * `$wp_rest_server` is not one of the globals WordPress resets between tests, so without
+	 * this the spy stays in place for every test that runs afterwards in the same process,
+	 * and `rest_get_server()` keeps handing it out. Nulling it lets the next caller build a
+	 * fresh server.
+	 */
+	protected function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Test v1 route registration.
 	 */
 	public function test_v1_routes() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
@@ -34,6 +34,16 @@ class RateLimitsTests extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Discard the REST server installed for the test.
+	 */
+	protected function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests that Rate limiting headers are sent and set correctly when Rate Limiting
 	 * main functionality is enabled.
 	 *

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/RateLimitsTests.php
@@ -36,7 +36,7 @@ class RateLimitsTests extends WP_Test_REST_TestCase {
 	/**
 	 * Discard the REST server installed for the test.
 	 */
-	protected function tearDown(): void {
+	public function tearDown(): void {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 

--- a/plugins/woocommerce/tests/php/src/Caching/ObjectCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/ObjectCacheTest.php
@@ -137,10 +137,34 @@ class ObjectCacheTest extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'set' returns false if the cache engine's caching method fails.
 	 */
-	public function try_set_when_cache_engine_fails() {
-		$this->cache_engine->caching_succeeds = false;
+	public function test_try_set_when_cache_engine_fails() {
+		$cache_engine = $this->createMock( CacheEngine::class );
+		$cache_engine->method( 'cache_object' )->willReturn( false );
 
-		$result = $this->sut->set( array( 'foo' ), 'the_id' );
+		add_filter(
+			'wc_object_cache_get_engine',
+			function () use ( $cache_engine ) {
+				return $cache_engine;
+			}
+		);
+
+		// phpcs:disable Squiz.Commenting
+		$sut = new class() extends ObjectCache {
+			public function get_object_type(): string {
+				return 'the_type';
+			}
+
+			protected function get_object_id( $value ) {
+				return null;
+			}
+
+			protected function validate( $value ): ?array {
+				return null;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$result = $sut->set( array( 'foo' ), 'the_id' );
 		$this->assertFalse( $result );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -110,7 +110,7 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox 'get_global' can be used to get the value of a global.
 	 */
-	public function get_global_can_be_used_to_get_the_value_of_a_global() {
+	public function test_get_global_can_be_used_to_get_the_value_of_a_global() {
 		global $wpdb;
 
 		$result = $this->sut->get_global( 'wpdb' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Three unrelated test hygiene defects surfaced by the lifecycle sweep in #67177. Each is a separate commit.

**Unguarded global function declarations** (`WC_Admin_Tests_RemoteSpecs_RuleProcessors_IsWooExpressRuleProcessor`). The class declares two stand-ins for functions the WC Calypso Bridge plugin provides. Declaring a function is irreversible and process-wide, and neither was guarded, so a redeclaration is fatal rather than untidy. `wc_calypso_bridge_is_woo_express_trial_plan` is declared *inside* `test_is_trial_plan` — adding a data provider to that test, an ordinary thing to do, would run the declaration twice and kill the process. Both are now behind `function_exists()`.

**A test that has never run** (`LegacyProxyTest`). `get_global_can_be_used_to_get_the_value_of_a_global` has no `test_` prefix and no `@test` annotation, so PHPUnit has never collected it. The `@testdox` line it carries is only a display label.

Nothing suggests that was deliberate. It arrived in #33140, the same change that introduced `LegacyProxy::get_global()`, and has not been touched since. All eight other tests in the file are prefixed, and the same commit added three correctly prefixed tests to `MockableLegacyProxyTest` — including the mockable counterpart of this exact test. A test that is never collected produces no output whatsoever, which is why it sat unnoticed for three and a half years. The upshot is that `LegacyProxy::get_global()` has had no direct coverage since it was added; only the mockable subclass was exercised. It passes once collected.

**A leaked REST server** (`ControllerTests`). `setUp()` replaces the `$wp_rest_server` global with a `Spy_REST_Server` and the class had no teardown. `$wp_rest_server` is not among the globals WordPress resets between tests, so the spy stayed in place for the rest of the process and `rest_get_server()` kept handing it out to every later test. It is now nulled in `tearDown()`, letting the next caller build a fresh server.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, confirm the previously-uncollected test now runs and passes:
    ```
    pnpm test:php:env -- --filter LegacyProxyTest
    ```
    Expect `OK (26 tests, 45 assertions)`. On the base branch it is 25 tests — the difference is `test_get_global_can_be_used_to_get_the_value_of_a_global`.
2. Confirm the other two classes still pass:
    ```
    pnpm test:php:env -- --filter 'IsWooExpressRuleProcessor'
    pnpm test:php:env -- --filter 'StoreApi\\ControllerTests'
    ```
3. To see the redeclaration fatal this guards against, temporarily add a data provider to `test_is_trial_plan` so it runs twice, and run the class on the base branch — the second run fatals on `Cannot redeclare wc_calypso_bridge_is_woo_express_trial_plan()`. On this branch it passes. Remove the data provider afterwards.
4. Run the full suite (`pnpm test:php:env`) and confirm the result matches the base branch apart from the one added test — see below.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Full PHP suite in `wp-env`, on the branch base and on this branch: the counts differ by exactly the one test this PR collects and its single assertion, and the failure set is identical.
- The three affected classes pass in isolation.
- `lint:php:changes` passes.

`--filter 'ControllerTests'` also matches `CartControllerTests` and `OrderControllerTests`, which show 5 failures. Those are pre-existing and order-dependent — identical on the base branch with the same filter, and absent from every full-suite run.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — `plugins/woocommerce/changelog/fix-test-hygiene-followups` (patch/dev) is already committed in the branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>


