### PR TITLE
Add aria-label to Product Gallery Thumbnails

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-thumbnails-aria-label
+++ b/plugins/woocommerce/changelog/fix-product-gallery-thumbnails-aria-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add aria-label to Product Gallery Thumbnails

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -86,6 +86,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 				data-wp-init--init-resize-observer="callbacks.initResizeObserver"
 				data-wp-init--hide-ghost-overflow="callbacks.hideGhostOverflow"
 				data-wp-on--scroll="actions.onScroll"
+				aria-label="<?php esc_attr_e( 'Thumbnails', 'woocommerce' ); ?>"
 				role="listbox">
 				<?php foreach ( $product_gallery_media as $index => $media ) : ?>
 					<?php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -86,7 +86,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 				data-wp-init--init-resize-observer="callbacks.initResizeObserver"
 				data-wp-init--hide-ghost-overflow="callbacks.hideGhostOverflow"
 				data-wp-on--scroll="actions.onScroll"
-				aria-label="<?php esc_attr_e( 'Thumbnails', 'woocommerce' ); ?>"
+				aria-label="<?php esc_attr_e( 'Image thumbnails', 'woocommerce' ); ?>"
 				role="listbox">
 				<?php foreach ( $product_gallery_media as $index => $media ) : ?>
 					<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

According to https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name, any element with `role="listbox"` needs a label.

(For Bug Fixes) Bug introduced in PR #58505.

### How to test the changes in this Pull Request:

1. Add the Product Gallery block to the Single Product template.
2. In the frontend, verify the thumbnails wrapper has an aria-label.
3. Optionally, test with an online store, submit it to https://pagespeed.web.dev/ and verify there is no warning about this.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->