### PR TITLE
[docs] Correct the NoticeHandler::convert_notices_to_wp_errors docblock

### DIFF
--- a/plugins/woocommerce/changelog/fix-notice-handler-docblock
+++ b/plugins/woocommerce/changelog/fix-notice-handler-docblock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct the NoticeHandler::convert_notices_to_wp_errors() docblock, which claimed it discards notices when it does not.

--- a/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
@@ -44,7 +44,10 @@ class NoticeHandler {
 	 * For example, cart validation processes may add error notices to prevent checkout.
 	 * Since we're not rendering notices at all, we need to catch them and group them in a single WP_Error instance.
 	 *
-	 * This method will discard notices once complete.
+	 * Unlike `convert_notices_to_exceptions()`, this leaves the notice queue untouched. Callers
+	 * that need the notices cleared are expected to manage the queue themselves — see
+	 * `CartController::validate_cart_items()`, which snapshots it beforehand and restores it
+	 * afterwards so that notices raised by `woocommerce_check_cart_items` do not survive.
 	 *
 	 * @param string $error_code Error code for the thrown exceptions.
 	 *

--- a/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
@@ -46,7 +46,7 @@ class NoticeHandler {
 	 *
 	 * Unlike `convert_notices_to_exceptions()`, this leaves the notice queue untouched. Callers
 	 * that need the notices cleared are expected to manage the queue themselves — see
-	 * `CartController::validate_cart_items()`, which snapshots it beforehand and restores it
+	 * `CartController::validate_cart()`, which snapshots it beforehand and restores it
 	 * afterwards so that notices raised by `woocommerce_check_cart_items` do not survive.
 	 *
 	 * @param string $error_code Error code for the thrown exceptions.

--- a/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
@@ -44,10 +44,8 @@ class NoticeHandler {
 	 * For example, cart validation processes may add error notices to prevent checkout.
 	 * Since we're not rendering notices at all, we need to catch them and group them in a single WP_Error instance.
 	 *
-	 * Unlike `convert_notices_to_exceptions()`, this leaves the notice queue untouched. Callers
-	 * that need the notices cleared are expected to manage the queue themselves — see
-	 * `CartController::validate_cart()`, which snapshots it beforehand and restores it
-	 * afterwards so that notices raised by `woocommerce_check_cart_items` do not survive.
+	 * Unlike `convert_notices_to_exceptions()`, this does not clear the notice queue. Callers
+	 * that need it cleared are responsible for doing so.
 	 *
 	 * @param string $error_code Error code for the thrown exceptions.
 	 *

--- a/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/NoticeHandler.php
@@ -47,7 +47,7 @@ class NoticeHandler {
 	 * Unlike `convert_notices_to_exceptions()`, this does not clear the notice queue. Callers
 	 * that need it cleared are responsible for doing so.
 	 *
-	 * @param string $error_code Error code for the thrown exceptions.
+	 * @param string $error_code Error code for each notice added to the WP_Error object.
 	 *
 	 * @return \WP_Error The WP_Error object containing all error notices.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`NoticeHandler::convert_notices_to_wp_errors()` documented itself as *"This method will discard notices once complete."* It never calls `wc_clear_notices()` on any path. The sibling `convert_notices_to_exceptions()` carries the same sentence and does honour it, which makes the claim easy to believe.

Corrects the comment, not the code. The only in-tree caller, `CartController::validate_cart()`, snapshots `wc_notices` before `do_action( 'woocommerce_check_cart_items' )` and restores it afterwards (lines 511, 527, 530), so clearing inside the method would be redundant there — and it is a `public static` on a Store API utility, so changing the behaviour is BC exposure for extension callers with no in-tree benefit.

New wording:

```
Unlike `convert_notices_to_exceptions()`, this does not clear the notice queue. Callers
that need it cleared are responsible for doing so.
```

It deliberately names nothing outside this class. An earlier draft referenced the caller and the hook; the caller's name went stale in review before this had even merged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

Comment-only change; nothing to exercise at runtime.

1. Confirm `convert_notices_to_wp_errors()` has no `wc_clear_notices()` call on any path, and that `convert_notices_to_exceptions()` does.
2. Confirm `CartController::validate_cart()` snapshots and restores `wc_notices` around the call (lines 511, 527, 530).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Docblock only; no executable code changed.
- `lint:php:changes` passes; `phpstan analyse src/StoreApi/Utilities/NoticeHandler.php` reports `[OK] No errors`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually — `plugins/woocommerce/changelog/fix-notice-handler-docblock` (patch/dev) is already committed in the branch.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
