### PR TITLE
Fix excluded IDs leaking into product search results

### DIFF
--- a/plugins/woocommerce/changelog/67293-exclude-ids-in-product-search
+++ b/plugins/woocommerce/changelog/67293-exclude-ids-in-product-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Excluded product IDs no longer leak back into product search results through matching variations of a variable product or through numeric search terms, so already selected variable products stay hidden in enhanced product search multi-selects.

--- a/plugins/woocommerce/changelog/67293-exclude-ids-in-product-search
+++ b/plugins/woocommerce/changelog/67293-exclude-ids-in-product-search
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Excluded product IDs no longer leak back into product search results through matching variations of a variable product or through numeric search terms, so already selected variable products stay hidden in enhanced product search multi-selects.
+Excluded product IDs no longer leak back into product search results through matching variations of a variable product or through numeric search terms.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2074,8 +2074,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$search_where .= ' AND posts.ID IN(' . implode( ',', array_map( 'absint', $include ) ) . ') ';
 		}
 
-		if ( ! empty( $exclude ) && is_array( $exclude ) ) {
-			$search_where .= ' AND posts.ID NOT IN(' . implode( ',', array_map( 'absint', $exclude ) ) . ') ';
+		$exclude_ids = ! empty( $exclude ) && is_array( $exclude ) ? array_map( 'absint', $exclude ) : array();
+
+		if ( $exclude_ids ) {
+			$search_where .= ' AND posts.ID NOT IN(' . implode( ',', $exclude_ids ) . ') ';
 		}
 
 		if ( 'virtual' === $type ) {
@@ -2092,10 +2094,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$limit_query = $wpdb->prepare( ' LIMIT %d ', $limit );
 		}
 
+		// A matching variation contributes its parent ID, so excluded parents are discarded here
+		// rather than reintroduced alongside the variation.
+		$parent_id_select = 'posts.post_parent as parent_id';
+
+		if ( $exclude_ids ) {
+			$parent_id_select = 'CASE WHEN posts.post_parent IN(' . implode( ',', $exclude_ids ) . ') THEN NULL ELSE posts.post_parent END as parent_id';
+		}
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		$search_results = $wpdb->get_results(
 			// phpcs:disable
-			"SELECT DISTINCT posts.ID as product_id, posts.post_parent as parent_id FROM {$wpdb->posts} posts
+			"SELECT DISTINCT posts.ID as product_id, {$parent_id_select} FROM {$wpdb->posts} posts
 			 LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
 			 $join_query
 			WHERE posts.post_type IN ('" . implode( "','", $post_types ) . "')
@@ -2114,13 +2124,21 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$post_id   = absint( $term );
 			$post_type = get_post_type( $post_id );
 
-			if ( 'product_variation' === $post_type && $include_variations ) {
-				$product_ids[] = $post_id;
-			} elseif ( 'product' === $post_type ) {
-				$product_ids[] = $post_id;
+			// A numeric term bypasses the query above, so the exclusion is applied to both the
+			// searched ID and its parent before either is appended.
+			if ( ! in_array( $post_id, $exclude_ids, true ) ) {
+				if ( 'product_variation' === $post_type && $include_variations ) {
+					$product_ids[] = $post_id;
+				} elseif ( 'product' === $post_type ) {
+					$product_ids[] = $post_id;
+				}
 			}
 
-			$product_ids[] = wp_get_post_parent_id( $post_id );
+			$parent_id = absint( wp_get_post_parent_id( $post_id ) );
+
+			if ( ! in_array( $parent_id, $exclude_ids, true ) ) {
+				$product_ids[] = $parent_id;
+			}
 		}
 
 		return wp_parse_id_list( $product_ids );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2074,7 +2074,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$search_where .= ' AND posts.ID IN(' . implode( ',', array_map( 'absint', $include ) ) . ') ';
 		}
 
-		$exclude_ids = ! empty( $exclude ) && is_array( $exclude ) ? array_map( 'absint', $exclude ) : array();
+		$exclude_ids = ! empty( $exclude ) && is_array( $exclude ) ? array_filter( array_map( 'absint', $exclude ) ) : array();
 
 		if ( $exclude_ids ) {
 			$search_where .= ' AND posts.ID NOT IN(' . implode( ',', $exclude_ids ) . ') ';

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -270,6 +270,33 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A numeric term appends both the searched ID and its parent, so the parent needs its own
+	 * exclusion check. Searching a variation by ID is the case that exercises it, since a
+	 * top-level product has no parent to re-add.
+	 *
+	 * @testdox Excluded parents should not be re-added when the search term is a variation's numeric ID.
+	 */
+	public function test_search_products_excludes_parent_for_numeric_variation_term() {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Numeric parent widget' );
+		$parent->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		$results = $data_store->search_products( (string) $variation->get_id(), '', true, true );
+		$this->assertContains( $variation->get_id(), $results );
+		$this->assertContains( $parent->get_id(), $results, 'A numeric variation term should surface its parent' );
+
+		$results = $data_store->search_products( (string) $variation->get_id(), '', true, true, null, null, array( $parent->get_id() ) );
+		$this->assertNotContains( $parent->get_id(), $results, 'An excluded parent must not be re-added by a numeric variation term' );
+		$this->assertContains( $variation->get_id(), $results, 'Excluding the parent must not drop the searched variation' );
+	}
+
+	/**
 	 * Ensure product rating counts are calculated correctly.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -230,7 +230,7 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_search_products_excludes_variable_products_with_matching_variations() {
 		$parent = new WC_Product_Variable();
-		$parent->set_name( 'Excludable variable widget' );
+		$parent->set_name( 'Excludable variable product' );
 		$parent->save();
 
 		$variation = new WC_Product_Variation();

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -297,6 +297,36 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * absint() maps any non-numeric exclude value to 0, and 0 is the post_parent every top-level
+	 * product carries. Zeros are filtered out of the exclusion list so that such input stays the
+	 * no-op it has always been, rather than matching every top-level row.
+	 *
+	 * @testdox Exclude values that normalise to zero should leave search results untouched.
+	 */
+	public function test_search_products_ignores_zero_exclude_values() {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Zero exclude widget' );
+		$product->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		$baseline = $data_store->search_products( 'Zero exclude', '', true, true );
+		$this->assertContains( $product->get_id(), $baseline );
+
+		$zero_like = array(
+			'integer zero'      => 0,
+			'string zero'       => '0',
+			'non-numeric value' => 'abc',
+			'empty string'      => '',
+		);
+
+		foreach ( $zero_like as $label => $value ) {
+			$results = $data_store->search_products( 'Zero exclude', '', true, true, null, null, array( $value ) );
+			$this->assertEqualSets( $baseline, $results, "An exclude list holding a {$label} must not change the results" );
+		}
+	}
+
+	/**
 	 * Ensure product rating counts are calculated correctly.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -245,6 +245,7 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$results = $data_store->search_products( 'Excludable variable', '', true, true, null, null, array( $parent->get_id() ) );
 		$this->assertNotContains( $parent->get_id(), $results, 'An excluded parent must not be re-added through its matching variations' );
+		$this->assertContains( $variation->get_id(), $results, 'Excluding a parent must not exclude its variations' );
 
 		$results = $data_store->search_products( 'Excludable variable', '', true, true, null, null, array( $variation->get_id() ) );
 		$this->assertNotContains( $variation->get_id(), $results, 'An excluded variation must not be returned' );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -226,6 +226,49 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Excluded variable products should not be re-added to search results by their matching variations.
+	 */
+	public function test_search_products_excludes_variable_products_with_matching_variations() {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Excludable variable widget' );
+		$parent->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		$results = $data_store->search_products( 'Excludable variable', '', true, true );
+		$this->assertContains( $parent->get_id(), $results );
+		$this->assertContains( $variation->get_id(), $results );
+
+		$results = $data_store->search_products( 'Excludable variable', '', true, true, null, null, array( $parent->get_id() ) );
+		$this->assertNotContains( $parent->get_id(), $results, 'An excluded parent must not be re-added through its matching variations' );
+
+		$results = $data_store->search_products( 'Excludable variable', '', true, true, null, null, array( $variation->get_id() ) );
+		$this->assertNotContains( $variation->get_id(), $results, 'An excluded variation must not be returned' );
+		$this->assertContains( $parent->get_id(), $results, 'Excluding a variation must not exclude its parent' );
+	}
+
+	/**
+	 * @testdox Excluded products should not be re-added to search results when the search term is their numeric ID.
+	 */
+	public function test_search_products_excludes_numeric_term_matches() {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Numeric term widget' );
+		$product->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		$results = $data_store->search_products( (string) $product->get_id(), '', false, true );
+		$this->assertContains( $product->get_id(), $results );
+
+		$results = $data_store->search_products( (string) $product->get_id(), '', false, true, null, null, array( $product->get_id() ) );
+		$this->assertNotContains( $product->get_id(), $results, 'An excluded product must not be re-added by the numeric term match' );
+	}
+
+	/**
 	 * Ensure product rating counts are calculated correctly.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -228,7 +228,7 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Excluded variable products should not be re-added to search results by their matching variations.
 	 */
-	public function test_search_products_excludes_variable_products_with_matching_variations() {
+	public function test_search_products_excludes_variable_products_with_matching_variations(): void {
 		$parent = new WC_Product_Variable();
 		$parent->set_name( 'Excludable variable product' );
 		$parent->save();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Product searches re-added excluded IDs after the SQL exclusion had already removed them: a matching variation contributed its parent through the `parent_id` column, and a numeric search term appended the searched ID and its parent unconditionally. Already selected variable products therefore came back in the Linked Products search, where clicking one silently removed it from the selection.

Excluded parents are now discarded in the SELECT, and the exclusion is applied inside the numeric-term branch, so nothing excluded reaches the result list. Adds regression coverage for parent, variation, and numeric-ID behavior.

Rebased onto #67420, which fixes the OR-group precedence in the same query. That fix is what lets the exclusion live entirely in SQL here.

Scope: the numeric-term branch now enforces `exclude`, but it still bypasses the `include` allowlist, the status filter, and the product type filter, as it always has. Those are pre-existing and left alone here.

Zero-valued `exclude` entries are filtered out during normalization. `absint()` maps any non-numeric value to `0`, which was inert against `posts.ID NOT IN(0)` but would have matched every top-level row through `posts.post_parent IN(0)`.

Backward compatibility: No public signature, hook, or filter changes. The existing `$exclude` argument is now honored consistently. Custom results returned by `woocommerce_product_pre_search_products` remain unchanged.

This does not change the `exclude` AJAX request format introduced by #67063.

Addresses #67293.

Bug introduced in PR #67063.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Edit a product and open the **Linked Products** section.
2. Select a variable product as an upsell or cross-sell.
3. Search for the selected variable product by name and confirm it does not appear in the results.
4. Search using the selected product's numeric ID and confirm it does not appear.
5. Remove the product from the selection and repeat the searches. Confirm the expected parent and variation results appear.
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Data_Store_CPT_Test`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- PHPUnit in wp-env using PHP 8.1.34: 26 tests and 74 assertions passed. Both halves were mutation-checked: disabling the SELECT guard fails the variation test, disabling the numeric guards fails the numeric test.
- Browser verification confirmed that an excluded variable parent stays out of search results while its variation remains independently selectable.
- PHPStan completed without errors.
- Modified-file and full-branch PHP lint checks passed.
- An adversarial change-risk review found no public-contract, persistence, execution-context, or rollback concerns. It did surface that `WC_AJAX::json_search_downloadable_products_and_variations()` never passes its exclude list to `search_products()`, so the order screen's "Grant access" field is not covered. That predates this change and is deliberately left alone.
- Multisite was not tested. This change does not introduce site-scoped state or install-layout assumptions.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>



