### PR TITLE
Revert the legacy script shim loading strategy change (#64431)

### DIFF
--- a/plugins/woocommerce/changelog/revert-64431-legacy-shim-loading-strategy
+++ b/plugins/woocommerce/changelog/revert-64431-legacy-shim-loading-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert the legacy script shim loading strategy change (#64431) that broke script ordering on the classic cart and checkout.

--- a/plugins/woocommerce/changelog/revert-64431-legacy-shim-loading-strategy
+++ b/plugins/woocommerce/changelog/revert-64431-legacy-shim-loading-strategy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Revert the legacy script shim loading strategy change (#64431) that broke script ordering on the classic cart and checkout.
+Revert the legacy script blocking change (#64431) that broke the classic cart and checkout on sites loading a second jQuery instance.

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -139,11 +139,11 @@ class WC_Frontend_Scripts {
 	 * Register a script for use.
 	 *
 	 * @uses   wp_register_script()
-	 * @param  string                                          $handle    Name of the script. Should be unique.
-	 * @param  string                                          $path      Full URL of the script, or path of the script relative to the WordPress root directory.
-	 * @param  string[]                                        $deps      An array of registered script handles this script depends on.
-	 * @param  string                                          $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'strategy' => 'defer' ).
+	 * @param  string   $handle    Name of the script. Should be unique.
+	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
+	 * @param  string[] $deps      An array of registered script handles this script depends on.
+	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param  boolean  $in_footer Whether to enqueue the script before </body> instead of in the <head>. Default 'false'.
 	 */
 	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
 		self::$registered_scripts[] = $handle;
@@ -154,11 +154,11 @@ class WC_Frontend_Scripts {
 	 * Register and enqueue a script for use.
 	 *
 	 * @uses   wp_enqueue_script()
-	 * @param  string                                          $handle    Name of the script. Should be unique.
-	 * @param  string                                          $path      Full URL of the script, or path of the script relative to the WordPress root directory.
-	 * @param  string[]                                        $deps      An array of registered script handles this script depends on.
-	 * @param  string                                          $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  bool|array{strategy?: string, in_footer?: bool} $in_footer Whether to enqueue the script before </body> (boolean), or an array of arguments such as 'strategy' and 'in_footer'. Default array( 'strategy' => 'defer' ).
+	 * @param  string   $handle    Name of the script. Should be unique.
+	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
+	 * @param  string[] $deps      An array of registered script handles this script depends on.
+	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param  boolean  $in_footer Whether to enqueue the script before </body> instead of in the <head>. Default 'false'.
 	 */
 	private static function enqueue_script( $handle, $path = '', $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
 		if ( ! in_array( $handle, self::$registered_scripts, true ) && $path ) {
@@ -414,25 +414,10 @@ class WC_Frontend_Scripts {
 		$register_scripts = self::get_scripts();
 
 		foreach ( $register_scripts as $name => $props ) {
-			$is_legacy_handle = isset( $props['legacy_handle'] );
+			self::register_script( $name, $props['src'], $props['deps'], $props['version'] );
 
-			/*
-			 * Scripts with legacy alias handles must use a blocking strategy.
-			 * WordPress (since 6.3) silently discards loading strategies on alias
-			 * scripts (registered with src=false). If the real script uses defer
-			 * but the alias cannot inherit it, the strategy mismatch breaks
-			 * dependency resolution for third-party code that depends on the
-			 * legacy handle (e.g. payment gateways using 'jquery-payment').
-			 *
-			 * Using blocking for both the real script and its alias ensures
-			 * consistent execution order through the dependency chain.
-			 */
-			$in_footer = $is_legacy_handle ? true : array( 'strategy' => 'defer' );
-
-			self::register_script( $name, $props['src'], $props['deps'], $props['version'], $in_footer );
-
-			if ( $is_legacy_handle ) {
-				self::register_script( $props['legacy_handle'], false, array( $name ), $props['version'], $in_footer );
+			if ( isset( $props['legacy_handle'] ) ) {
+				self::register_script( $props['legacy_handle'], false, array( $name ), $props['version'], true );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -143,7 +143,7 @@ class WC_Frontend_Scripts {
 	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
 	 * @param  string[] $deps      An array of registered script handles this script depends on.
 	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  boolean  $in_footer Whether to enqueue the script before </body> instead of in the <head>. Default 'false'.
+	 * @param  boolean|array $in_footer Whether to enqueue the script before </body>, or an array of loading strategy arguments as accepted by wp_register_script(). Default 'defer' strategy.
 	 */
 	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
 		self::$registered_scripts[] = $handle;
@@ -158,7 +158,7 @@ class WC_Frontend_Scripts {
 	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
 	 * @param  string[] $deps      An array of registered script handles this script depends on.
 	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
-	 * @param  boolean  $in_footer Whether to enqueue the script before </body> instead of in the <head>. Default 'false'.
+	 * @param  boolean|array $in_footer Whether to enqueue the script before </body>, or an array of loading strategy arguments as accepted by wp_enqueue_script(). Default 'defer' strategy.
 	 */
 	private static function enqueue_script( $handle, $path = '', $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
 		if ( ! in_array( $handle, self::$registered_scripts, true ) && $path ) {

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -139,10 +139,10 @@ class WC_Frontend_Scripts {
 	 * Register a script for use.
 	 *
 	 * @uses   wp_register_script()
-	 * @param  string   $handle    Name of the script. Should be unique.
-	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
-	 * @param  string[] $deps      An array of registered script handles this script depends on.
-	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param  string        $handle    Name of the script. Should be unique.
+	 * @param  string        $path      Full URL of the script, or path of the script relative to the WordPress root directory.
+	 * @param  string[]      $deps      An array of registered script handles this script depends on.
+	 * @param  string        $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
 	 * @param  boolean|array $in_footer Whether to enqueue the script before </body>, or an array of loading strategy arguments as accepted by wp_register_script(). Default 'defer' strategy.
 	 */
 	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
@@ -154,10 +154,10 @@ class WC_Frontend_Scripts {
 	 * Register and enqueue a script for use.
 	 *
 	 * @uses   wp_enqueue_script()
-	 * @param  string   $handle    Name of the script. Should be unique.
-	 * @param  string   $path      Full URL of the script, or path of the script relative to the WordPress root directory.
-	 * @param  string[] $deps      An array of registered script handles this script depends on.
-	 * @param  string   $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
+	 * @param  string        $handle    Name of the script. Should be unique.
+	 * @param  string        $path      Full URL of the script, or path of the script relative to the WordPress root directory.
+	 * @param  string[]      $deps      An array of registered script handles this script depends on.
+	 * @param  string        $version   String specifying script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If version is set to false, a version number is automatically added equal to current installed WordPress version. If set to null, no version is added.
 	 * @param  boolean|array $in_footer Whether to enqueue the script before </body>, or an array of loading strategy arguments as accepted by wp_enqueue_script(). Default 'defer' strategy.
 	 */
 	private static function enqueue_script( $handle, $path = '', $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -11935,6 +11935,18 @@ parameters:
 			path: includes/class-wc-form-handler.php
 
 		-
+			message: '#^Default value of the parameter \#5 \$in_footer \(array\<string, string\>\) of method WC_Frontend_Scripts\:\:enqueue_script\(\) is incompatible with type bool\.$#'
+			identifier: parameter.defaultValue
+			count: 1
+			path: includes/class-wc-frontend-scripts.php
+
+		-
+			message: '#^Default value of the parameter \#5 \$in_footer \(array\<string, string\>\) of method WC_Frontend_Scripts\:\:register_script\(\) is incompatible with type bool\.$#'
+			identifier: parameter.defaultValue
+			count: 1
+			path: includes/class-wc-frontend-scripts.php
+
+		-
 			message: '#^Method WC_Frontend_Scripts\:\:enqueue_block_assets\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -11935,18 +11935,6 @@ parameters:
 			path: includes/class-wc-form-handler.php
 
 		-
-			message: '#^Default value of the parameter \#5 \$in_footer \(array\<string, string\>\) of method WC_Frontend_Scripts\:\:enqueue_script\(\) is incompatible with type bool\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: includes/class-wc-frontend-scripts.php
-
-		-
-			message: '#^Default value of the parameter \#5 \$in_footer \(array\<string, string\>\) of method WC_Frontend_Scripts\:\:register_script\(\) is incompatible with type bool\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: includes/class-wc-frontend-scripts.php
-
-		-
 			message: '#^Method WC_Frontend_Scripts\:\:enqueue_block_assets\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/tests/php/includes/class-wc-frontend-scripts-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-frontend-scripts-test.php
@@ -232,38 +232,4 @@ class WC_Frontend_Scripts_Test extends WC_Unit_Test_Case {
 		$this->assertNotContains( 'cod', $data['gateways_with_custom_place_order_button'] );
 		$this->assertNotContains( 'cheque', $data['gateways_with_custom_place_order_button'] );
 	}
-
-	/**
-	 * Test that scripts with legacy handles and their aliases use blocking strategy.
-	 *
-	 * WordPress (since 6.3) discards loading strategies on alias scripts
-	 * (src=false). To avoid strategy mismatches, both the real script and
-	 * its legacy alias must be registered as blocking (in_footer=true).
-	 */
-	public function test_legacy_handle_scripts_use_blocking_strategy(): void {
-		$reflection = new ReflectionClass( 'WC_Frontend_Scripts' );
-		$method     = $reflection->getMethod( 'register_scripts' );
-		$method->setAccessible( true );
-		$method->invoke( null );
-
-		$get_scripts_method = $reflection->getMethod( 'get_scripts' );
-		$get_scripts_method->setAccessible( true );
-		$scripts = $get_scripts_method->invoke( null );
-
-		foreach ( $scripts as $name => $props ) {
-			if ( ! isset( $props['legacy_handle'] ) ) {
-				continue;
-			}
-
-			$legacy_handle = $props['legacy_handle'];
-
-			// Real script must be blocking (no defer strategy).
-			$real_strategy = wp_scripts()->get_data( $name, 'strategy' );
-			$this->assertFalse( $real_strategy, "Real handle '{$name}' should not have a loading strategy (blocking)." );
-
-			// Alias script must also be blocking.
-			$legacy_strategy = wp_scripts()->get_data( $legacy_handle, 'strategy' );
-			$this->assertFalse( $legacy_strategy, "Legacy handle '{$legacy_handle}' should not have a loading strategy (blocking)." );
-		}
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Reverts [woocommerce/woocommerce#64431](<https://github.com/woocommerce/woocommerce/issues/64431>) which changed how scripts and aliases got loaded that broke Checkout when an aliased script is loaded. Sadly I couldn't reproduce the bug that was fixed in [woocommerce/woocommerce#64431](<https://github.com/woocommerce/woocommerce/issues/64431>) but I took this as higher priority.

Note: not a 100% pure revert — CI forbids re-adding entries to the PHPStan baseline, so the `$in_footer` docblocks were fixed to `boolean|array` instead of restoring their two baseline entries.

Closes woocommerce/woocommerce#67159.

(For Bug Fixes) Bug introduced in PR [woocommerce/woocommerce#64431](<https://github.com/woocommerce/woocommerce/issues/64431>).

### How to test the changes in this Pull Request:

1. With classic cart/checkout shortcodes, add a product to the cart.
2. Print a second jQuery copy in `wp_footer` at priority 21 (snippet in woocommerce/woocommerce#67159).
3. Cart: update quantity/remove item — no console errors, Ajax fires.
4. Verify the `wc-*` scripts load with `defer` again.

### Milestone

- [ ] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>