### PR TITLE
[docs] Fix the Hydration::get_rest_api_response_data() $path docblock type

### DIFF
--- a/plugins/woocommerce/changelog/fix-hydration-path-docblock
+++ b/plugins/woocommerce/changelog/fix-hydration-path-docblock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct the Hydration::get_rest_api_response_data() $path docblock type from array to string and drop the now-resolved PHPStan baseline entries.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53728,18 +53728,6 @@ parameters:
 			path: src/Blocks/Domain/Services/Hydration.php
 
 		-
-			message: '#^Default value of the parameter \#1 \$path \(string\) of method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Hydration\:\:get_rest_api_response_data\(\) is incompatible with type array\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
-
-		-
-			message: '#^Invalid array key type array\.$#'
-			identifier: offsetAccess.invalidOffset
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Hydration\:\:cache_store_notices\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -53769,23 +53757,6 @@ parameters:
 			count: 1
 			path: src/Blocks/Domain/Services/Hydration.php
 
-		-
-			message: '#^Parameter \#1 \$haystack of function str_starts_with expects string\|null, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
-
-		-
-			message: '#^Parameter \#1 \$path of method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Hydration\:\:match_route_to_handler\(\) expects string, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
-
-		-
-			message: '#^Parameter \#2 \$path of function rest_preload_api_request expects string, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
 
 		-
 			message: '#^Parameter \#2 \$path of method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Hydration\:\:get_response_from_controller\(\) expects string, array given\.$#'

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -53757,13 +53757,6 @@ parameters:
 			count: 1
 			path: src/Blocks/Domain/Services/Hydration.php
 
-
-		-
-			message: '#^Parameter \#2 \$path of method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Hydration\:\:get_response_from_controller\(\) expects string, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/Hydration.php
-
 		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\Notices\:\:init\(\) has no return type specified\.$#'
 			identifier: missingType.return

--- a/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/Hydration.php
@@ -41,7 +41,7 @@ class Hydration {
 	 * Hydrates the asset data registry with data from the API. Disables notices and nonces so requests contain valid
 	 * data that is not polluted by the current session.
 	 *
-	 * @param array $path API paths to hydrate e.g. '/wc/store/v1/cart'.
+	 * @param string $path API path to hydrate e.g. '/wc/store/v1/cart'.
 	 * @return array Response data.
 	 */
 	public function get_rest_api_response_data( $path = '' ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `get_rest_api_response_data()` docblock has declared `$path` as `array` since the method was introduced (woocommerce-blocks#10373, commit 3cfcdd0646), but the body has always required a string: `$path` is used as an array key, passed to `str_starts_with()`, and forwarded as the string `$path` parameter of `rest_preload_api_request()`. The stray `array` likely leaked from WP core's `rest_preload_api_request()`, whose `$path` can be a `[ path, method ]` array — a form that has never worked through this wrapper and, since the `str_starts_with()` allow-list guard (#44080, re-landed in #45134), raises a `TypeError` on the method's first line under PHP 8.

This PR corrects the annotation to `string` (and the description to singular) and removes the five PHPStan baseline entries that were anchored to the bogus `array` type, per the shrink-only baseline policy.

**Backward-compatibility impact:** none. This is a documentation-only change to a public method — no signature, runtime, or hook change. All six in-tree call sites pass strings, both public wrappers in `AssetDataRegistry` already document `@param string $path`, and an array argument has fataled at the guard for years, so no functioning external caller can be relying on the `array` annotation.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run `composer exec -- phpstan analyse src/Blocks/Domain/Services/Hydration.php --memory-limit=2G` and confirm it reports no errors (including no unmatched ignored-error entries).
2. Run `grep -c 'get_rest_api_response_data\|match_route_to_handler.*expects string\|rest_preload_api_request expects string' phpstan-baseline.neon` and confirm the removed entries are gone.
3. Confirm the CI PHPStan Analysis and Lint jobs pass — there is no runtime behavior to test.

### Testing that has already taken place:

- PHPStan (project config with baseline) on `src/Blocks/Domain/Services/Hydration.php` and all in-tree caller files (`AssetDataRegistry.php`, `BlocksSharedState.php`, `ProductsStore.php`): no errors, no unmatched baseline entries.
- PHPCS via `lint:php:changes`: clean.
- History audit: the annotation was wrong at introduction and never changed; the array form never functioned through this wrapper; no other baseline entries are entangled with this fix.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>