### PR TITLE
Improve Product Image srcset to prevent wide images from appearing blurry in square blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-67301
+++ b/plugins/woocommerce/changelog/fix-67301
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve Product Image srcset to prevent wide images from appearing blurry in square blocks

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -300,7 +300,8 @@ class ProductImage extends AbstractBlock {
 					if ( ! is_array( $source ) || ! isset( $source['value'] ) || ! is_numeric( $source['value'] ) ) {
 						continue;
 					}
-					$sources[ $key ]['value'] = (int) round( $source['value'] / $stretch_factor );
+					$sources[ $key ]['value'] = max( 1, (int) round( $source['value'] / $stretch_factor ) );
+
 				}
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -260,13 +260,14 @@ class ProductImage extends AbstractBlock {
 			$attr['loading'] = $loading_attr;
 		}
 
-		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
-			if ( '1' === $aspect_ratio ) {
-				$aspect_ratio = '1/1';
-			}
+		$srcset_aspect_ratio = $aspect_ratio;
+		if ( is_string( $srcset_aspect_ratio ) && is_numeric( $srcset_aspect_ratio ) ) {
+			$srcset_aspect_ratio .= '/1';
+		}
+
+		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $srcset_aspect_ratio ) {
 			if (
-				! is_string( $aspect_ratio ) ||
-				false === strpos( $aspect_ratio, '/' ) ||
+				! is_string( $srcset_aspect_ratio ) ||
 				! is_array( $sources ) ||
 				! is_array( $image_meta ) ||
 				! isset( $image_meta['width'], $image_meta['height'] ) ||
@@ -278,7 +279,7 @@ class ProductImage extends AbstractBlock {
 				return $sources;
 			}
 
-			$aspect_ratio_parts = explode( '/', $aspect_ratio );
+			$aspect_ratio_parts = explode( '/', $srcset_aspect_ratio );
 
 			if (
 				count( $aspect_ratio_parts ) !== 2 ||
@@ -309,7 +310,8 @@ class ProductImage extends AbstractBlock {
 
 		$maybe_adjust_srcset =
 			'cover' === $attributes['scale'] &&
-			is_string( $aspect_ratio );
+			is_string( $srcset_aspect_ratio ) &&
+			false !== strpos( $srcset_aspect_ratio, '/' );
 
 		if ( $maybe_adjust_srcset ) {
 			add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -301,7 +301,6 @@ class ProductImage extends AbstractBlock {
 						continue;
 					}
 					$sources[ $key ]['value'] = max( 1, (int) round( $source['value'] / $stretch_factor ) );
-
 				}
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -261,8 +261,8 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$srcset_aspect_ratio = $aspect_ratio;
-		if ( is_string( $srcset_aspect_ratio ) && is_numeric( $srcset_aspect_ratio ) ) {
-			$srcset_aspect_ratio .= '/1';
+		if ( is_numeric( $srcset_aspect_ratio ) ) {
+			$srcset_aspect_ratio = (string) $srcset_aspect_ratio . '/1';
 		}
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $srcset_aspect_ratio ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -261,8 +261,12 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$adjust_srcset = function ( $sources, $size_array, $image_src, $image_meta ) use ( $aspect_ratio ) {
+			if ( '1' === $aspect_ratio ) {
+				$aspect_ratio = '1/1';
+			}
 			if (
 				! is_string( $aspect_ratio ) ||
+				false === strpos( $aspect_ratio, '/' ) ||
 				! is_array( $sources ) ||
 				! is_array( $image_meta ) ||
 				! isset( $image_meta['width'], $image_meta['height'] ) ||
@@ -305,8 +309,7 @@ class ProductImage extends AbstractBlock {
 
 		$maybe_adjust_srcset =
 			'cover' === $attributes['scale'] &&
-			is_string( $aspect_ratio ) &&
-			false !== strpos( $aspect_ratio, '/' );
+			is_string( $aspect_ratio );
 
 		if ( $maybe_adjust_srcset ) {
 			add_filter( 'wp_calculate_image_srcset', $adjust_srcset, 10, 4 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/67301.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/67105.

https://github.com/woocommerce/woocommerce/pull/67105 didn't consider the case of the "Square" aspect ratio. This PR fixes that.

### How to test the changes in this Pull Request:

1. Add a product image that is twice as wide as its height. Like this one:

<img width="1774" height="887" alt="Image" src="https://github.com/user-attachments/assets/7a138fb5-0368-4d03-8dfa-9d441602cb0e" />

2. Edit the Product Catalog template and set the product image aspect ratio to Square.
3. In the frontend, verify the image of the product image you just added no longer looks blurry.

Before | After
--- | ---
<img width="1532" height="885" alt="imatge" src="https://github.com/user-attachments/assets/89725307-c644-49b2-af06-9a66d09d386a" /> | <img width="1532" height="885" alt="imatge" src="https://github.com/user-attachments/assets/3240ab61-4871-4291-ae63-7aa70641f0af" />