### PR TITLE
Harden Settings UI schema boundaries

### DIFF
--- a/docs/extensions/settings-and-config/registering-settings-ui-components.md
+++ b/docs/extensions/settings-and-config/registering-settings-ui-components.md
@@ -151,10 +151,25 @@ registerSettingsExtension( {
 		page: 'my_plugin',
 	},
 	typeRenderers: {
-		my_plugin_color: ColorField,
+		text: TextField,
 	},
 } );
 ```
+
+`typeRenderers` only overrides a canonical field type that WooCommerce already accepts. It does not register a new field type. PHP rejects unknown types before the Settings UI mounts.
+
+To migrate an extension-defined type, keep the field's storage shape on a canonical type and name the specialized component explicitly:
+
+```php
+array(
+	'id'        => 'my_plugin_color',
+	'title'     => __( 'Color', 'my-plugin' ),
+	'type'      => 'text',
+	'component' => 'my-plugin/color-field',
+)
+```
+
+Register `my-plugin/color-field` in `components`, or use `fieldOverrides` when the PHP field metadata cannot be changed yet.
 
 Resolution order is:
 
@@ -196,3 +211,9 @@ final class My_Plugin_Settings_UI_Page extends LegacySettingsPageAdapter {
 ```
 
 WooCommerce loads the settings UI package first, then your script, then mounts the settings app.
+
+## Failure and fallback behavior
+
+WooCommerce validates server-observable schema metadata and declared script handles before rendering the Settings UI mount. An invalid schema or a script handle that is not registered and enqueued renders the complete classic settings page in the same response.
+
+PHP cannot inspect the component registry in the browser. If a declared script executes but does not register the named component, or if the component throws while rendering, the Settings UI fails closed inside its page error boundary. It renders no editable fallback control and no Save action. The error notice offers a **Use classic settings** action that reloads the same page and section with `wc_settings_ui=classic` for that request. The action does not disable the feature flag, persist a preference, or reload automatically.

--- a/docs/extensions/settings-and-config/settings-ui.md
+++ b/docs/extensions/settings-and-config/settings-ui.md
@@ -256,6 +256,10 @@ final class My_Plugin_Settings_UI_Page extends LegacySettingsPageAdapter {
 
 The settings embed script depends on the settings UI package and these handles only for the opted-in page. Other settings pages do not load it.
 
+WooCommerce validates the schema and declared script handles on the server. If either is invalid, it renders the complete classic settings page in that response. Unknown field types are rejected here; `typeRenderers` can override a supported canonical type, but cannot introduce an extension-defined type.
+
+The component registry exists only in the browser, after PHP has selected the Settings UI mount. If a script loads without registering a field's named component, or a component throws during rendering, the page fails closed with no editable fallback and no Save action. The error notice provides a **Use classic settings** link that preserves the current page and section and adds `wc_settings_ui=classic`. This is a user-initiated, request-only reload: it does not change the feature flag or automatically reload the page.
+
 ## Save adapters
 
 The settings UI supports two save adapters:

--- a/packages/js/settings-ui/changelog/fix-wooprd-3593-missing-components
+++ b/packages/js/settings-ui/changelog/fix-wooprd-3593-missing-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fail closed when a declared settings component is not registered and offer a request-only classic settings reload.

--- a/packages/js/settings-ui/changelog/fix-wooprd-3594-settings-value-boundary
+++ b/packages/js/settings-ui/changelog/fix-wooprd-3594-settings-value-boundary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve original form values until a canonical Settings UI field is edited.

--- a/packages/js/settings-ui/package.json
+++ b/packages/js/settings-ui/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/admin-ui": "catalog:wp-bundled",
 		"@wordpress/a11y": "catalog:wp-min",
 		"@wordpress/components": "catalog:wp-min",
+		"@wordpress/date": "catalog:wp-min",
 		"@wordpress/element": "catalog:wp-min",
 		"@wordpress/i18n": "catalog:wp-min",
 		"@wordpress/ui": "catalog:wp-bundled"

--- a/packages/js/settings-ui/src/hidden-inputs.tsx
+++ b/packages/js/settings-ui/src/hidden-inputs.tsx
@@ -8,6 +8,7 @@ import { createElement, Fragment } from '@wordpress/element';
  */
 import { error } from './diagnostics';
 import type { SettingsUIField, SettingsValue } from './types';
+import { areSettingsValuesEqual, toStoreLocalDateTime } from './values';
 
 type HiddenInput = {
 	name: string;
@@ -19,9 +20,60 @@ const getFieldName = ( field: SettingsUIField ) => field.save?.name || field.id;
 const getArrayFieldName = ( name: string ) =>
 	name.endsWith( '[]' ) ? name : `${ name }[]`;
 
+const isSupportedFieldName = ( name: string, isArray: boolean ) => {
+	const baseName =
+		isArray && name.endsWith( '[]' ) ? name.slice( 0, -2 ) : name;
+
+	return /^[^\[\]]+(?:\[[^\[\]]+\])?$/.test( baseName );
+};
+
+const toRepeatedInputs = ( name: string, values: string[] ): HiddenInput[] =>
+	values.map( ( item ) => ( {
+		name: getArrayFieldName( name ),
+		value: item,
+	} ) );
+
+const serializeCanonicalValue = (
+	field: SettingsUIField,
+	name: string,
+	value: SettingsValue
+): HiddenInput[] => {
+	if ( field.type === 'checkbox' ) {
+		return [ { name, value: value === true ? 'yes' : 'no' } ];
+	}
+
+	if ( field.type === 'array' ) {
+		return toRepeatedInputs( name, Array.isArray( value ) ? value : [] );
+	}
+
+	let serializedValue = '';
+
+	if ( field.type === 'datetime-local' ) {
+		serializedValue = toStoreLocalDateTime( value );
+	} else if ( value !== null && typeof value !== 'undefined' ) {
+		serializedValue = String( value );
+	}
+
+	return [
+		{
+			name,
+			value: serializedValue,
+		},
+	];
+};
+
+const serializeOriginalFormValue = (
+	name: string,
+	value: string | string[]
+): HiddenInput[] =>
+	Array.isArray( value )
+		? toRepeatedInputs( name, value )
+		: [ { name, value } ];
+
 export const getHiddenInputs = (
 	field: SettingsUIField,
-	value: SettingsValue
+	value: SettingsValue,
+	initialCanonicalValue: SettingsValue = value
 ): HiddenInput[] => {
 	const adapter = field.save?.adapter || 'form_post';
 
@@ -36,51 +88,46 @@ export const getHiddenInputs = (
 
 	const name = getFieldName( field );
 
-	if ( field.type === 'checkbox' ) {
-		return [
-			{
-				name,
-				value:
-					value === true || value === 'yes' || value === '1'
-						? 'yes'
-						: 'no',
-			},
-		];
+	if ( ! isSupportedFieldName( name, field.type === 'array' ) ) {
+		error( `Form-post field name "${ name }" is not supported.`, {
+			field,
+		} );
+		return [];
 	}
 
-	if ( field.type === 'array' ) {
-		return ( Array.isArray( value ) ? value : [] ).map( ( item ) => ( {
-			name: getArrayFieldName( name ),
-			value: String( item ),
-		} ) );
-	}
-
-	return [
-		{
+	if (
+		field.save &&
+		Object.prototype.hasOwnProperty.call( field.save, 'initialValue' ) &&
+		areSettingsValuesEqual( value, initialCanonicalValue )
+	) {
+		return serializeOriginalFormValue(
 			name,
-			value:
-				value === null || typeof value === 'undefined'
-					? ''
-					: String( value ),
-		},
-	];
+			field.save.initialValue as string | string[]
+		);
+	}
+
+	return serializeCanonicalValue( field, name, value );
 };
 
 export const HiddenInputs = ( {
 	field,
 	value,
+	initialCanonicalValue,
 }: {
 	field: SettingsUIField;
 	value: SettingsValue;
+	initialCanonicalValue?: SettingsValue;
 } ) => (
 	<>
-		{ getHiddenInputs( field, value ).map( ( input, index ) => (
-			<input
-				key={ `${ input.name }-${ index }` }
-				type="hidden"
-				name={ input.name }
-				value={ input.value }
-			/>
-		) ) }
+		{ getHiddenInputs( field, value, initialCanonicalValue ).map(
+			( input, index ) => (
+				<input
+					key={ `${ input.name }-${ index }` }
+					type="hidden"
+					name={ input.name }
+					value={ input.value }
+				/>
+			)
+		) }
 	</>
 );

--- a/packages/js/settings-ui/src/hidden-inputs.tsx
+++ b/packages/js/settings-ui/src/hidden-inputs.tsx
@@ -6,7 +6,6 @@ import { createElement, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { error } from './diagnostics';
 import type { SettingsUIField, SettingsValue } from './types';
 import { areSettingsValuesEqual, toStoreLocalDateTime } from './values';
 
@@ -82,17 +81,13 @@ export const getHiddenInputs = (
 	}
 
 	if ( adapter !== 'form_post' ) {
-		error( `Save adapter "${ adapter }" is not supported.`, { field } );
-		return [];
+		throw new Error( `Save adapter "${ adapter }" is not supported.` );
 	}
 
 	const name = getFieldName( field );
 
 	if ( ! isSupportedFieldName( name, field.type === 'array' ) ) {
-		error( `Form-post field name "${ name }" is not supported.`, {
-			field,
-		} );
-		return [];
+		throw new Error( `Form-post field name "${ name }" is not supported.` );
 	}
 
 	if (

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -12,11 +12,15 @@ import { warn } from './diagnostics';
 import { sanitizeSettingsHtml } from './html';
 import { NumberSpinControl } from './number-spin-control';
 import type { SettingsFieldComponentProps, SettingsValue } from './types';
+import {
+	toCanonicalDateTime,
+	toCanonicalNumberValue,
+	toStoreLocalDateTime,
+} from './values';
 
 type TextInputType =
 	| 'text'
 	| 'password'
-	| 'datetime-local'
 	| 'date'
 	| 'time'
 	| 'email'
@@ -26,7 +30,6 @@ type TextInputType =
 const textInputTypes: TextInputType[] = [
 	'text',
 	'password',
-	'datetime-local',
 	'date',
 	'time',
 	'email',
@@ -59,20 +62,24 @@ const toStringCustomAttribute = (
 };
 
 const getNumberInputAttributes = (
-	customAttributes?: Record< string, string | number | boolean >
+	field: SettingsFieldComponentProps[ 'field' ]
 ) => {
+	const customAttributes = field.customAttributes;
 	const safeAttributes =
 		customAttributes && typeof customAttributes === 'object'
 			? customAttributes
 			: {};
-	const { disabled, placeholder, ...inputAttributes } = safeAttributes;
+	const { disabled, placeholder, ...customInputAttributes } = safeAttributes;
 	const placeholderAttribute =
 		typeof placeholder === 'boolean' ? undefined : placeholder;
 
 	return {
 		disabled: toPresenceBooleanCustomAttribute( disabled ),
 		placeholder: toStringCustomAttribute( placeholderAttribute ),
-		inputAttributes,
+		inputAttributes: {
+			...field.validation,
+			...customInputAttributes,
+		},
 	};
 };
 
@@ -192,8 +199,8 @@ export const NativeSettingsField = ( {
 		);
 	}
 
-	if ( field.type === 'number' ) {
-		const numberInput = getNumberInputAttributes( field.customAttributes );
+	if ( field.type === 'number' || field.type === 'integer' ) {
+		const numberInput = getNumberInputAttributes( field );
 
 		return (
 			<NumberSpinControl
@@ -203,8 +210,33 @@ export const NativeSettingsField = ( {
 				value={ toStringValue( value ) }
 				placeholder={ field.placeholder ?? numberInput.placeholder }
 				disabled={ field.disabled ?? numberInput.disabled }
-				onChange={ onChange }
+				onChange={ ( nextValue ) =>
+					onChange(
+						toCanonicalNumberValue(
+							nextValue,
+							field.type === 'integer'
+						)
+					)
+				}
 				inputAttributes={ numberInput.inputAttributes }
+			/>
+		);
+	}
+
+	if ( field.type === 'datetime-local' ) {
+		return (
+			<InputControl
+				className="wc-settings-ui__control"
+				type="datetime-local"
+				label={ field.label }
+				details={ getHelp( field.description ) }
+				value={ toStoreLocalDateTime( value ) }
+				placeholder={ field.placeholder }
+				disabled={ field.disabled }
+				onChange={ ( event ) =>
+					onChange( toCanonicalDateTime( event.target.value ) )
+				}
+				{ ...field.customAttributes }
 			/>
 		);
 	}

--- a/packages/js/settings-ui/src/registry.ts
+++ b/packages/js/settings-ui/src/registry.ts
@@ -183,15 +183,22 @@ export const resolveFieldComponent = (
 	context: SettingsFieldContext
 ): SettingsFieldComponent | undefined => {
 	const componentName = field.component;
-	const component = componentName
-		? findInMatchingRegistrations(
-				context,
-				( registration ) => registration.components?.[ componentName ]
-		  )
-		: undefined;
+	if ( componentName ) {
+		const component = findInMatchingRegistrations(
+			context,
+			( registration ) => registration.components?.[ componentName ]
+		);
+
+		if ( ! component ) {
+			throw new Error(
+				`Component "${ componentName }" is not registered.`
+			);
+		}
+
+		return component;
+	}
 
 	const resolvedComponent =
-		component ??
 		findInMatchingRegistrations(
 			context,
 			( registration ) => registration.fieldOverrides?.[ field.id ]
@@ -203,13 +210,6 @@ export const resolveFieldComponent = (
 
 	if ( resolvedComponent ) {
 		return resolvedComponent;
-	}
-
-	if ( field.component ) {
-		warn( `Component "${ field.component }" is not registered.`, {
-			field,
-			context,
-		} );
 	}
 
 	return undefined;

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -382,6 +382,12 @@ const getVisible = ( {
 const getAllFields = ( schema: SettingsUISchema ): SettingsUIField[] =>
 	Object.values( schema.groups ).flatMap( ( group ) => group.fields );
 
+const getClassicSettingsUrl = () => {
+	const url = new URL( window.location.href );
+	url.searchParams.set( 'wc_settings_ui', 'classic' );
+	return url.toString();
+};
+
 type ErrorBoundaryProps = {
 	children: ReactNode;
 };
@@ -413,10 +419,15 @@ export class SettingsUIErrorBoundary extends Component<
 				<Notice.Root intent="error">
 					<Notice.Description>
 						{ __(
-							'Something went wrong while rendering this settings page. Reload the page with the settings UI feature disabled to use the classic settings screen.',
+							'Something went wrong while rendering this settings page.',
 							'woocommerce'
 						) }
 					</Notice.Description>
+					<Notice.Actions>
+						<Notice.ActionLink href={ getClassicSettingsUrl() }>
+							{ __( 'Use classic settings', 'woocommerce' ) }
+						</Notice.ActionLink>
+					</Notice.Actions>
 				</Notice.Root>
 			);
 		}

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -49,6 +49,7 @@ import type {
 	SettingsValue,
 	SettingsValues,
 } from './types';
+import { areSettingsValuesEqual } from './values';
 
 type SaveNotice = {
 	status: 'success' | 'error';
@@ -77,19 +78,6 @@ const getInitialValues = ( schema: SettingsUISchema ): SettingsValues => {
 	return values;
 };
 
-const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
-	if ( Array.isArray( a ) || Array.isArray( b ) ) {
-		return (
-			Array.isArray( a ) &&
-			Array.isArray( b ) &&
-			a.length === b.length &&
-			a.every( ( value, index ) => value === b[ index ] )
-		);
-	}
-
-	return a === b;
-};
-
 const getChangedValues = (
 	values: SettingsValues,
 	initialValues: SettingsValues
@@ -97,7 +85,7 @@ const getChangedValues = (
 	const changedValues: Partial< SettingsValues > = {};
 
 	Object.keys( values ).forEach( ( key ) => {
-		if ( ! areValuesEqual( values[ key ], initialValues[ key ] ) ) {
+		if ( ! areSettingsValuesEqual( values[ key ], initialValues[ key ] ) ) {
 			changedValues[ key ] = values[ key ];
 		}
 	} );
@@ -331,7 +319,7 @@ const valueMatchesVisibilityRule = (
 		: [ expected ?? true ];
 
 	return expectedValues.some( ( expectedValue ) =>
-		areValuesEqual( value, expectedValue )
+		areSettingsValuesEqual( value, expectedValue )
 	);
 };
 
@@ -650,10 +638,14 @@ export const SettingsUIPage = ( {
 
 	const setValue = useCallback(
 		( fieldId: string, nextValue: SettingsValue ) => {
-			setValuesState( ( currentValues ) => ( {
-				...currentValues,
-				[ fieldId ]: nextValue,
-			} ) );
+			setValuesState( ( currentValues ) =>
+				areSettingsValuesEqual( currentValues[ fieldId ], nextValue )
+					? currentValues
+					: {
+							...currentValues,
+							[ fieldId ]: nextValue,
+					  }
+			);
 		},
 		[]
 	);
@@ -1013,6 +1005,7 @@ export const SettingsUIPage = ( {
 						<HiddenInputs
 							field={ field }
 							value={ values[ field.id ] }
+							initialCanonicalValue={ initialValues[ field.id ] }
 							key={ field.id }
 						/>
 					) ) }

--- a/packages/js/settings-ui/src/test/hidden-inputs.test.ts
+++ b/packages/js/settings-ui/src/test/hidden-inputs.test.ts
@@ -76,6 +76,20 @@ describe( 'getHiddenInputs', () => {
 		).toEqual( [] );
 	} );
 
+	it( 'fails closed for unsupported save adapters', () => {
+		expect( () =>
+			getHiddenInputs(
+				{
+					id: 'quantity',
+					label: 'Quantity',
+					type: 'number',
+					save: { adapter: 'custom', name: 'quantity' },
+				},
+				2
+			)
+		).toThrow( 'Save adapter "custom" is not supported.' );
+	} );
+
 	it( 'preserves the original form representation while the canonical value is unchanged', () => {
 		const field = formPostField( {
 			save: {
@@ -127,11 +141,7 @@ describe( 'getHiddenInputs', () => {
 		}
 	);
 
-	it( 'serializes flat and one-level nested names but not deeper names', () => {
-		const consoleError = jest
-			.spyOn( console, 'error' )
-			.mockImplementation( () => {} );
-
+	it( 'serializes flat and one-level nested names and fails closed for deeper names', () => {
 		expect(
 			getHiddenInputs(
 				formPostField( {
@@ -144,7 +154,7 @@ describe( 'getHiddenInputs', () => {
 				1
 			)
 		).toEqual( [ { name: 'settings[quantity]', value: '2' } ] );
-		expect(
+		expect( () =>
 			getHiddenInputs(
 				formPostField( {
 					save: {
@@ -155,14 +165,9 @@ describe( 'getHiddenInputs', () => {
 				2,
 				1
 			)
-		).toEqual( [] );
-		expect( consoleError ).toHaveBeenCalledWith(
-			expect.stringContaining(
-				'Form-post field name "settings[group][quantity]" is not supported.'
-			),
-			expect.any( Object )
+		).toThrow(
+			'Form-post field name "settings[group][quantity]" is not supported.'
 		);
-		consoleError.mockRestore();
 	} );
 
 	it( 'keeps array entries bracketed for one-level nested names', () => {

--- a/packages/js/settings-ui/src/test/hidden-inputs.test.ts
+++ b/packages/js/settings-ui/src/test/hidden-inputs.test.ts
@@ -2,6 +2,17 @@
  * Internal dependencies
  */
 import { getHiddenInputs } from '../hidden-inputs';
+import type { SettingsUIField, SettingsValue } from '../types';
+
+const formPostField = (
+	overrides: Partial< SettingsUIField > = {}
+): SettingsUIField => ( {
+	id: 'quantity',
+	label: 'Quantity',
+	type: 'number',
+	save: { adapter: 'form_post', name: 'quantity' },
+	...overrides,
+} );
 
 describe( 'getHiddenInputs', () => {
 	it( 'serializes checkbox values for legacy form posts', () => {
@@ -16,6 +27,22 @@ describe( 'getHiddenInputs', () => {
 				true
 			)
 		).toEqual( [ { name: 'enabled', value: 'yes' } ] );
+		expect(
+			getHiddenInputs(
+				{
+					id: 'enabled',
+					label: 'Enabled',
+					type: 'checkbox',
+					save: {
+						adapter: 'form_post',
+						name: 'enabled',
+						initialValue: 'yes',
+					},
+				},
+				false,
+				true
+			)
+		).toEqual( [ { name: 'enabled', value: 'no' } ] );
 	} );
 
 	it( 'serializes array values with bracketed field names', () => {
@@ -47,5 +74,160 @@ describe( 'getHiddenInputs', () => {
 				''
 			)
 		).toEqual( [] );
+	} );
+
+	it( 'preserves the original form representation while the canonical value is unchanged', () => {
+		const field = formPostField( {
+			save: {
+				adapter: 'form_post',
+				name: 'quantity',
+				initialValue: '02',
+			},
+		} );
+
+		expect( getHiddenInputs( field, 2, 2 ) ).toEqual( [
+			{ name: 'quantity', value: '02' },
+		] );
+		expect( getHiddenInputs( field, 3, 2 ) ).toEqual( [
+			{ name: 'quantity', value: '3' },
+		] );
+		expect( getHiddenInputs( field, null, 2 ) ).toEqual( [
+			{ name: 'quantity', value: '' },
+		] );
+	} );
+
+	it.each< [ SettingsValue, SettingsValue, boolean ] >( [
+		[ 0, 0, true ],
+		[ 0, '0', false ],
+		[ '', '', true ],
+		[ '', false, false ],
+		[ false, false, true ],
+		[ false, null, false ],
+		[ null, null, true ],
+		[ null, '', false ],
+		[ [], [], true ],
+		[ [], [ '' ], false ],
+	] )(
+		'distinguishes exact falsey values (%p and %p)',
+		( currentValue, initialValue, isUnchanged ) => {
+			const field = formPostField( {
+				save: {
+					adapter: 'form_post',
+					name: 'quantity',
+					initialValue: 'original',
+				},
+			} );
+			const [ input ] = getHiddenInputs(
+				field,
+				currentValue,
+				initialValue
+			);
+
+			expect( input?.value === 'original' ).toBe( isUnchanged );
+		}
+	);
+
+	it( 'serializes flat and one-level nested names but not deeper names', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					save: {
+						adapter: 'form_post',
+						name: 'settings[quantity]',
+					},
+				} ),
+				2,
+				1
+			)
+		).toEqual( [ { name: 'settings[quantity]', value: '2' } ] );
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					save: {
+						adapter: 'form_post',
+						name: 'settings[group][quantity]',
+					},
+				} ),
+				2,
+				1
+			)
+		).toEqual( [] );
+		expect( consoleError ).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'Form-post field name "settings[group][quantity]" is not supported.'
+			),
+			expect.any( Object )
+		);
+		consoleError.mockRestore();
+	} );
+
+	it( 'keeps array entries bracketed for one-level nested names', () => {
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					type: 'array',
+					save: {
+						adapter: 'form_post',
+						name: 'settings[methods]',
+						initialValue: [ 'card', 'link' ],
+					},
+				} ),
+				[ 'card', 'link' ],
+				[ 'card', 'link' ]
+			)
+		).toEqual( [
+			{ name: 'settings[methods][]', value: 'card' },
+			{ name: 'settings[methods][]', value: 'link' },
+		] );
+	} );
+
+	it( 'keeps disabled fields in the form-post entry list', () => {
+		expect(
+			getHiddenInputs( formPostField( { disabled: true } ), 2, 1 )
+		).toEqual( [ { name: 'quantity', value: '2' } ] );
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					visibility: { controller: 'enabled', value: true },
+				} ),
+				2,
+				1
+			)
+		).toEqual( [ { name: 'quantity', value: '2' } ] );
+	} );
+
+	it( 'serializes edited canonical datetimes back to store-local form', () => {
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					type: 'datetime-local',
+					save: {
+						adapter: 'form_post',
+						name: 'starts_at',
+						initialValue: '2026-01-01T12:00',
+					},
+				} ),
+				'2026-01-01T12:00:00Z',
+				'2026-01-01T12:00:00Z'
+			)
+		).toEqual( [ { name: 'starts_at', value: '2026-01-01T12:00' } ] );
+		expect(
+			getHiddenInputs(
+				formPostField( {
+					type: 'datetime-local',
+					save: {
+						adapter: 'form_post',
+						name: 'starts_at',
+						initialValue: '2026-01-01T12:00',
+					},
+				} ),
+				'2026-01-01T13:30:00Z',
+				'2026-01-01T12:00:00Z'
+			)
+		).toEqual( [ { name: 'starts_at', value: '2026-01-01T13:30:00' } ] );
 	} );
 } );

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -19,7 +19,7 @@ jest.mock( '@wordpress/admin-ui', () => ( {
 /**
  * Internal dependencies
  */
-import { SettingsUIPage } from '../settings-ui-page';
+import { SettingsUIErrorBoundary, SettingsUIPage } from '../settings-ui-page';
 import { __resetRegistry, registerSettingsExtension } from '../registry';
 import type { SettingsUISchema } from '../types';
 
@@ -197,6 +197,123 @@ describe( 'settings HTML rendering', () => {
 
 		act( () => root.unmount() );
 		container.remove();
+	} );
+
+	it( 'fails closed when an explicit component is not registered', () => {
+		const originalUrl = window.location.href;
+		window.history.replaceState(
+			{},
+			'',
+			'/wp-admin/admin.php?page=wc-settings&tab=products&section=advanced&preserved=yes#wc-settings'
+		);
+		const consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const schema: SettingsUISchema = {
+			id: 'products',
+			title: 'Products',
+			section: 'advanced',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'test_field',
+							label: 'Test field',
+							type: 'text',
+							component: 'test/missing-component',
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIErrorBoundary>
+				<SettingsUIPage schema={ schema } />
+			</SettingsUIErrorBoundary>
+		);
+
+		expect( container.textContent ).toContain(
+			'Something went wrong while rendering this settings page.'
+		);
+		expect( container.querySelector( 'input' ) ).toBeNull();
+		expect(
+			container.querySelector( '.woocommerce-save-button' )
+		).toBeNull();
+		const classicAction = Array.from(
+			container.querySelectorAll( 'a' )
+		).find(
+			( link ) => link.textContent?.trim() === 'Use classic settings'
+		);
+		expect( classicAction ).toBeDefined();
+		const classicUrl = new URL( classicAction?.href || '' );
+		expect( classicUrl.searchParams.getAll( 'wc_settings_ui' ) ).toEqual( [
+			'classic',
+		] );
+		expect( classicUrl.searchParams.get( 'page' ) ).toBe( 'wc-settings' );
+		expect( classicUrl.searchParams.get( 'tab' ) ).toBe( 'products' );
+		expect( classicUrl.searchParams.get( 'section' ) ).toBe( 'advanced' );
+		expect( classicUrl.searchParams.get( 'preserved' ) ).toBe( 'yes' );
+		expect( classicUrl.hash ).toBe( '#wc-settings' );
+
+		act( () => root.unmount() );
+		container.remove();
+		consoleErrorSpy.mockRestore();
+		window.history.replaceState( {}, '', originalUrl );
+	} );
+
+	it( 'contains errors thrown by registered field components', () => {
+		const ThrowingField = () => {
+			throw new Error( 'Test component failed.' );
+		};
+		registerSettingsExtension( {
+			scope: { page: 'test-page' },
+			components: {
+				'test/throwing-component': ThrowingField,
+			},
+		} );
+		const consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const schema: SettingsUISchema = {
+			id: 'test-page',
+			title: 'Test page',
+			section: 'default',
+			save: { adapter: 'form_post' },
+			groups: {
+				general: {
+					id: 'general',
+					fields: [
+						{
+							id: 'test_field',
+							label: 'Test field',
+							type: 'text',
+							component: 'test/throwing-component',
+						},
+					],
+				},
+			},
+		};
+
+		const { container, root } = renderElement(
+			<SettingsUIErrorBoundary>
+				<SettingsUIPage schema={ schema } />
+			</SettingsUIErrorBoundary>
+		);
+
+		expect( container.textContent ).toContain(
+			'Something went wrong while rendering this settings page.'
+		);
+		expect( container.querySelector( 'input' ) ).toBeNull();
+		expect(
+			container.querySelector( '.woocommerce-save-button' )
+		).toBeNull();
+
+		act( () => root.unmount() );
+		container.remove();
+		consoleErrorSpy.mockRestore();
 	} );
 
 	it( 'sanitizes native field descriptions before rendering', () => {

--- a/packages/js/settings-ui/src/test/html-rendering.test.tsx
+++ b/packages/js/settings-ui/src/test/html-rendering.test.tsx
@@ -99,8 +99,12 @@ const expectUnsafeMarkupRemoved = ( container: HTMLElement ) => {
 };
 
 describe( 'settings HTML rendering', () => {
+	const originalUrl = window.location.href;
+
 	afterEach( () => {
 		__resetRegistry();
+		jest.restoreAllMocks();
+		window.history.replaceState( {}, '', originalUrl );
 	} );
 
 	it( 'renders settings as centered sections and cards', () => {
@@ -200,15 +204,12 @@ describe( 'settings HTML rendering', () => {
 	} );
 
 	it( 'fails closed when an explicit component is not registered', () => {
-		const originalUrl = window.location.href;
 		window.history.replaceState(
 			{},
 			'',
 			'/wp-admin/admin.php?page=wc-settings&tab=products&section=advanced&preserved=yes#wc-settings'
 		);
-		const consoleErrorSpy = jest
-			.spyOn( console, 'error' )
-			.mockImplementation( () => undefined );
+		jest.spyOn( console, 'error' ).mockImplementation( () => undefined );
 		const schema: SettingsUISchema = {
 			id: 'products',
 			title: 'Products',
@@ -260,8 +261,6 @@ describe( 'settings HTML rendering', () => {
 
 		act( () => root.unmount() );
 		container.remove();
-		consoleErrorSpy.mockRestore();
-		window.history.replaceState( {}, '', originalUrl );
 	} );
 
 	it( 'contains errors thrown by registered field components', () => {
@@ -274,9 +273,7 @@ describe( 'settings HTML rendering', () => {
 				'test/throwing-component': ThrowingField,
 			},
 		} );
-		const consoleErrorSpy = jest
-			.spyOn( console, 'error' )
-			.mockImplementation( () => undefined );
+		jest.spyOn( console, 'error' ).mockImplementation( () => undefined );
 		const schema: SettingsUISchema = {
 			id: 'test-page',
 			title: 'Test page',
@@ -313,7 +310,6 @@ describe( 'settings HTML rendering', () => {
 
 		act( () => root.unmount() );
 		container.remove();
-		consoleErrorSpy.mockRestore();
 	} );
 
 	it( 'sanitizes native field descriptions before rendering', () => {

--- a/packages/js/settings-ui/src/test/native-fields.test.tsx
+++ b/packages/js/settings-ui/src/test/native-fields.test.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { speak } from '@wordpress/a11y';
-import { createElement } from '@wordpress/element';
+import {
+	getSettings as getDateSettings,
+	setSettings as setDateSettings,
+} from '@wordpress/date';
+import { createElement, useState } from '@wordpress/element';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
@@ -56,10 +60,12 @@ const makeProps = (
 
 describe( 'NativeSettingsField', () => {
 	let cleanup: ( () => void ) | null = null;
+	const originalDateSettings = getDateSettings();
 
 	afterEach( () => {
 		cleanup?.();
 		cleanup = null;
+		setDateSettings( originalDateSettings );
 	} );
 
 	const render = ( element: JSX.Element ) => {
@@ -79,6 +85,39 @@ describe( 'NativeSettingsField', () => {
 				new MouseEvent( 'click', { bubbles: true } )
 			);
 		} );
+	};
+
+	const changeInput = ( input: HTMLInputElement, value: string ) => {
+		const valueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			'value'
+		)?.set;
+
+		act( () => {
+			valueSetter?.call( input, value );
+			input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		} );
+	};
+
+	const renderStatefulField = (
+		field: SettingsUIField,
+		initialValue: SettingsValue,
+		onChange: jest.Mock
+	) => {
+		const StatefulField = () => {
+			const [ value, setValue ] = useState( initialValue );
+
+			return (
+				<NativeSettingsField
+					{ ...makeProps( field, value, ( nextValue ) => {
+						onChange( nextValue );
+						setValue( nextValue );
+					} ) }
+				/>
+			);
+		};
+
+		return render( <StatefulField /> );
 	};
 
 	const getSpinButton = ( container: HTMLElement, ariaLabel: string ) => {
@@ -110,7 +149,7 @@ describe( 'NativeSettingsField', () => {
 
 		it( 'renders a number input with custom spin buttons instead of native spinners', () => {
 			const container = render(
-				<NativeSettingsField { ...makeProps( numberField, '5' ) } />
+				<NativeSettingsField { ...makeProps( numberField, 5 ) } />
 			);
 
 			const input = container.querySelector( 'input[type="number"]' );
@@ -126,6 +165,26 @@ describe( 'NativeSettingsField', () => {
 			).toBeInstanceOf( HTMLButtonElement );
 		} );
 
+		it( 'uses canonical validation bounds when custom attributes omit them', () => {
+			const container = render(
+				<NativeSettingsField
+					{ ...makeProps(
+						{
+							...numberField,
+							validation: { min: 2, max: 8 },
+							customAttributes: { step: 0.5 },
+						},
+						5
+					) }
+				/>
+			);
+			const input = container.querySelector( 'input[type="number"]' );
+
+			expect( input ).toHaveAttribute( 'min', '2' );
+			expect( input ).toHaveAttribute( 'max', '8' );
+			expect( input ).toHaveAttribute( 'step', '0.5' );
+		} );
+
 		it( 'honors placeholder and disabled custom attributes for number inputs', () => {
 			const container = render(
 				<NativeSettingsField
@@ -138,7 +197,7 @@ describe( 'NativeSettingsField', () => {
 								placeholder: 'Only configurable in code',
 							},
 						},
-						''
+						null
 					) }
 				/>
 			);
@@ -175,7 +234,7 @@ describe( 'NativeSettingsField', () => {
 								disabled: 'false',
 							},
 						},
-						'5'
+						5
 					) }
 				/>
 			);
@@ -207,7 +266,7 @@ describe( 'NativeSettingsField', () => {
 								disabled: 'true',
 							},
 						},
-						'5'
+						5
 					) }
 				/>
 			);
@@ -231,7 +290,7 @@ describe( 'NativeSettingsField', () => {
 			const onChange = jest.fn();
 			const container = render(
 				<NativeSettingsField
-					{ ...makeProps( numberField, '5', onChange ) }
+					{ ...makeProps( numberField, 5, onChange ) }
 				/>
 			);
 
@@ -239,13 +298,13 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '6' );
+			expect( onChange ).toHaveBeenCalledWith( 6 );
 			expect( speak ).toHaveBeenCalledWith( '6' );
 		} );
 
 		it( 'disables the decrement button at the minimum value', () => {
 			const container = render(
-				<NativeSettingsField { ...makeProps( numberField, '0' ) } />
+				<NativeSettingsField { ...makeProps( numberField, 0 ) } />
 			);
 
 			expect(
@@ -268,7 +327,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, max: 10, step: 1 },
 						},
-						'10'
+						10
 					) }
 				/>
 			);
@@ -294,7 +353,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, step: 0 },
 						},
-						'5',
+						5,
 						onChange
 					) }
 				/>
@@ -304,7 +363,7 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '6' );
+			expect( onChange ).toHaveBeenCalledWith( 6 );
 		} );
 
 		it( 'clamps stepping to the maximum and avoids float precision drift', () => {
@@ -316,7 +375,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, max: 0.3, step: 0.2 },
 						},
-						'0.1',
+						0.1,
 						onChange
 					) }
 				/>
@@ -326,7 +385,7 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '0.3' );
+			expect( onChange ).toHaveBeenCalledWith( 0.3 );
 		} );
 
 		it( 'preserves current value precision when it exceeds step precision', () => {
@@ -338,7 +397,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, step: 0.1 },
 						},
-						'0.05',
+						0.05,
 						onChange
 					) }
 				/>
@@ -348,7 +407,7 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '0.15' );
+			expect( onChange ).toHaveBeenCalledWith( 0.15 );
 		} );
 
 		it( 'handles scientific-notation steps', () => {
@@ -360,7 +419,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, step: 1e-7 },
 						},
-						'0',
+						0,
 						onChange
 					) }
 				/>
@@ -370,7 +429,7 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '1e-7' );
+			expect( onChange ).toHaveBeenCalledWith( 1e-7 );
 		} );
 
 		it( 'does not exceed toFixed precision limits for tiny scientific-notation steps', () => {
@@ -382,7 +441,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 0, step: 1e-200 },
 						},
-						'0',
+						0,
 						onChange
 					) }
 				/>
@@ -393,7 +452,7 @@ describe( 'NativeSettingsField', () => {
 					getSpinButton( container, 'Increment Low stock threshold' )
 				)
 			).not.toThrow();
-			expect( onChange ).toHaveBeenCalledWith( '1e-200' );
+			expect( onChange ).toHaveBeenCalledWith( 1e-200 );
 		} );
 
 		it( 'steps onto the minimum from an empty value', () => {
@@ -405,7 +464,7 @@ describe( 'NativeSettingsField', () => {
 							...numberField,
 							customAttributes: { min: 2, step: 1 },
 						},
-						'',
+						null,
 						onChange
 					) }
 				/>
@@ -415,7 +474,127 @@ describe( 'NativeSettingsField', () => {
 				getSpinButton( container, 'Increment Low stock threshold' )
 			);
 
-			expect( onChange ).toHaveBeenCalledWith( '2' );
+			expect( onChange ).toHaveBeenCalledWith( 2 );
+		} );
+
+		it( 'keeps sequential number edits canonical', () => {
+			const onChange = jest.fn();
+			const container = renderStatefulField( numberField, 5, onChange );
+
+			clickButton(
+				getSpinButton( container, 'Increment Low stock threshold' )
+			);
+			clickButton(
+				getSpinButton( container, 'Increment Low stock threshold' )
+			);
+
+			expect( onChange.mock.calls.map( ( [ value ] ) => value ) ).toEqual(
+				[ 6, 7 ]
+			);
+		} );
+
+		it( 'emits null when a number is cleared', () => {
+			const onChange = jest.fn();
+			const container = renderStatefulField( numberField, 5, onChange );
+			const input = container.querySelector( 'input[type="number"]' );
+
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			changeInput( input as HTMLInputElement, '' );
+			expect( onChange ).toHaveBeenLastCalledWith( null );
+		} );
+
+		it( 'emits null for an unsafe integral number', () => {
+			const onChange = jest.fn();
+			const container = renderStatefulField( numberField, 5, onChange );
+			const input = container.querySelector( 'input[type="number"]' );
+
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			changeInput( input as HTMLInputElement, '9007199254740992' );
+			expect( onChange ).toHaveBeenLastCalledWith( null );
+		} );
+	} );
+
+	describe( 'integer fields', () => {
+		it( 'uses NumberSpinControl and emits safe integers rather than text', () => {
+			const onChange = jest.fn();
+			const container = renderStatefulField(
+				{
+					id: 'wc_test_integer',
+					label: 'Items per row',
+					type: 'integer',
+					customAttributes: { min: 1, step: 1 },
+				},
+				2,
+				onChange
+			);
+
+			expect(
+				container.querySelector( 'input[type="number"]' )
+			).toBeInstanceOf( HTMLInputElement );
+			expect(
+				container.querySelector( 'input[type="text"]' )
+			).toBeNull();
+			clickButton(
+				getSpinButton( container, 'Increment Items per row' )
+			);
+			expect( onChange ).toHaveBeenLastCalledWith( 3 );
+		} );
+
+		it( 'emits null for fractional or unsafe integer input', () => {
+			const onChange = jest.fn();
+			const container = renderStatefulField(
+				{
+					id: 'wc_test_integer',
+					label: 'Items per row',
+					type: 'integer',
+				},
+				2,
+				onChange
+			);
+			const input = container.querySelector( 'input[type="number"]' );
+
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			changeInput( input as HTMLInputElement, '2.5' );
+			changeInput( input as HTMLInputElement, '9007199254740992' );
+			expect( onChange.mock.calls.map( ( [ value ] ) => value ) ).toEqual(
+				[ null, null ]
+			);
+		} );
+	} );
+
+	describe( 'datetime-local fields', () => {
+		it( 'displays canonical ISO state as local wall time and emits ISO or null', () => {
+			setDateSettings( {
+				...originalDateSettings,
+				timezone: {
+					...originalDateSettings.timezone,
+					offset: '-5',
+					offsetFormatted: '-05:00',
+					string: 'America/New_York',
+				},
+			} );
+			const onChange = jest.fn();
+			const container = renderStatefulField(
+				{
+					id: 'wc_test_starts_at',
+					label: 'Starts at',
+					type: 'datetime-local',
+				},
+				'2026-01-01T17:30:00Z',
+				onChange
+			);
+			const input = container.querySelector(
+				'input[type="datetime-local"]'
+			);
+
+			expect( input ).toBeInstanceOf( HTMLInputElement );
+			expect( input ).toHaveValue( '2026-01-01T12:30' );
+			changeInput( input as HTMLInputElement, '2026-01-01T13:45:00' );
+			expect( onChange ).toHaveBeenLastCalledWith(
+				'2026-01-01T18:45:00Z'
+			);
+			changeInput( input as HTMLInputElement, '' );
+			expect( onChange ).toHaveBeenLastCalledWith( null );
 		} );
 	} );
 

--- a/packages/js/settings-ui/src/test/registry.test.ts
+++ b/packages/js/settings-ui/src/test/registry.test.ts
@@ -90,6 +90,33 @@ describe( 'settings extension registry', () => {
 		).toBe( fieldOverride );
 	} );
 
+	it( 'does not fall back when an explicit component is missing', () => {
+		const fieldOverride: SettingsFieldComponent = () => null;
+		const typeRenderer: SettingsFieldComponent = () => null;
+
+		registerSettingsExtension( {
+			scope: { page: 'registry-missing-component' },
+			fieldOverrides: {
+				field: fieldOverride,
+			},
+			typeRenderers: {
+				text: typeRenderer,
+			},
+		} );
+
+		expect( () =>
+			resolveFieldComponent(
+				{
+					id: 'field',
+					label: 'Field',
+					type: 'text',
+					component: 'test/missing-component',
+				},
+				{ page: 'registry-missing-component' }
+			)
+		).toThrow( 'Component "test/missing-component" is not registered.' );
+	} );
+
 	it( 'ignores malformed registration payloads', () => {
 		const warnSpy = jest
 			.spyOn( console, 'warn' )
@@ -101,7 +128,7 @@ describe( 'settings extension registry', () => {
 				components: [],
 			} as unknown as SettingsExtensionRegistration )
 		).not.toThrow();
-		expect(
+		expect( () =>
 			resolveFieldComponent(
 				{
 					id: 'field',
@@ -111,7 +138,7 @@ describe( 'settings extension registry', () => {
 				},
 				{ page: 'registry-invalid' }
 			)
-		).toBeUndefined();
+		).toThrow( 'Component "0" is not registered.' );
 		expect( warnSpy ).toHaveBeenCalledWith(
 			expect.stringContaining(
 				'Invalid settings extension registration payload.'
@@ -210,10 +237,7 @@ describe( 'settings extension registry', () => {
 				{ page: 'registry-section-scope', section: 'advanced' }
 			)
 		).toBeUndefined();
-		const warnSpy = jest
-			.spyOn( console, 'warn' )
-			.mockImplementation( jest.fn() );
-		expect(
+		expect( () =>
 			resolveFieldComponent(
 				{
 					id: 'field',
@@ -223,8 +247,7 @@ describe( 'settings extension registry', () => {
 				},
 				{ page: 'registry-section-scope', section: '' }
 			)
-		).toBeUndefined();
-		warnSpy.mockRestore();
+		).toThrow( 'Component "named-section" is not registered.' );
 		expect(
 			resolveFieldComponent(
 				{

--- a/packages/js/settings-ui/src/types.ts
+++ b/packages/js/settings-ui/src/types.ts
@@ -15,6 +15,7 @@ export type SettingsUISaveAdapter =
 export type SettingsUISaveSchema = {
 	adapter: SettingsUISaveAdapter;
 	name?: string;
+	initialValue?: string | string[];
 };
 
 export type SettingsUISaveStrategy =
@@ -39,6 +40,10 @@ export type SettingsUIField = {
 	placeholder?: string;
 	disabled?: boolean;
 	customAttributes?: Record< string, string | number | boolean >;
+	validation?: {
+		min?: number;
+		max?: number;
+	};
 	visibility?: SettingsUIVisibilityRule;
 	save?: SettingsUISaveSchema;
 };

--- a/packages/js/settings-ui/src/values.ts
+++ b/packages/js/settings-ui/src/values.ts
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { date, getDate } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import type { SettingsValue } from './types';
+
+const STORE_LOCAL_DATETIME_FORMAT = 'Y-m-d\\TH:i:s';
+
+export const areSettingsValuesEqual = (
+	left: SettingsValue,
+	right: SettingsValue
+) => {
+	if ( Array.isArray( left ) || Array.isArray( right ) ) {
+		return (
+			Array.isArray( left ) &&
+			Array.isArray( right ) &&
+			left.length === right.length &&
+			left.every( ( value, index ) => value === right[ index ] )
+		);
+	}
+
+	return left === right;
+};
+
+export const toCanonicalNumberValue = (
+	value: string,
+	integerOnly = false
+): number | null => {
+	if ( value.trim() === '' ) {
+		return null;
+	}
+
+	const numberValue = Number( value );
+
+	if ( ! Number.isFinite( numberValue ) ) {
+		return null;
+	}
+
+	if (
+		( Number.isInteger( numberValue ) &&
+			! Number.isSafeInteger( numberValue ) ) ||
+		( integerOnly && ! Number.isInteger( numberValue ) )
+	) {
+		return null;
+	}
+
+	return numberValue;
+};
+
+export const toStoreLocalDateTime = ( value: SettingsValue ) => {
+	if ( typeof value !== 'string' || value === '' ) {
+		return '';
+	}
+
+	return date( STORE_LOCAL_DATETIME_FORMAT, value );
+};
+
+export const toCanonicalDateTime = ( value: string ): string | null => {
+	if ( value === '' ) {
+		return null;
+	}
+
+	return getDate( value ).toISOString().replace( '.000Z', 'Z' );
+};

--- a/plugins/woocommerce/changelog/fix-wooprd-3593-settings-ui-components
+++ b/plugins/woocommerce/changelog/fix-wooprd-3593-settings-ui-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent missing Settings UI components from falling back to editable native controls.

--- a/plugins/woocommerce/changelog/fix-wooprd-3594-settings-value-boundary
+++ b/plugins/woocommerce/changelog/fix-wooprd-3594-settings-value-boundary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve classic settings values while canonicalizing typed Settings UI fields.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -413,37 +413,42 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			$section = is_string( $current_section ) ? $current_section : '';
 			$context = $this->get_settings_ui_request_context( $section );
 
-			if ( $context && $context->is_rendering_enabled() ) {
-				$settings_ui_page = $context->get_settings_ui_page();
-				assert( $settings_ui_page instanceof SettingsUIPageInterface );
+			try {
+				if ( $context && $context->is_rendering_enabled() ) {
+					$settings_ui_page = $context->get_settings_ui_page();
+					assert( $settings_ui_page instanceof SettingsUIPageInterface );
 
-				if ( $context->has_schema_failed() ) {
-					$this->log_settings_ui_fallback(
-						$settings_ui_page,
-						$section,
-						__( 'Settings UI schema generation failed.', 'woocommerce' )
-					);
-				} else {
-					$script_handles = $context->get_script_handles();
+					if ( $context->has_schema_failed() ) {
+						$schema_failure_reason = method_exists( $context, 'get_schema_failure_reason' )
+							? $context->get_schema_failure_reason()
+							: __( 'Settings UI schema generation failed.', 'woocommerce' );
 
-					if ( $context->has_script_handles_failed() ) {
-						$this->log_settings_ui_fallback( $settings_ui_page, $section, $context->get_script_handles_failure_reason() );
+						$this->log_settings_ui_fallback( $settings_ui_page, $section, $schema_failure_reason );
 					} else {
-						foreach ( $script_handles as $script_handle ) {
-							wp_enqueue_script( $script_handle );
+						$script_handles = $context->get_script_handles();
+
+						if ( $context->has_script_handles_failed() ) {
+							$this->log_settings_ui_fallback( $settings_ui_page, $section, $context->get_script_handles_failure_reason() );
+						} else {
+							foreach ( $script_handles as $script_handle ) {
+								wp_enqueue_script( $script_handle );
+							}
+
+							$GLOBALS['hide_save_button'] = true;
+
+							printf(
+								'<div id="%1$s" data-wc-settings-ui="1" data-wc-settings-page="%2$s" data-wc-settings-section="%3$s"></div>',
+								esc_attr( 'wc_settings_ui_' . sanitize_html_class( $this->id ) . '_' . sanitize_html_class( '' === $section ? 'default' : $section ) ),
+								esc_attr( $context->get_page_id() ),
+								esc_attr( $section )
+							);
+							return;
 						}
-
-						$GLOBALS['hide_save_button'] = true;
-
-						printf(
-							'<div id="%1$s" data-wc-settings-ui="1" data-wc-settings-page="%2$s" data-wc-settings-section="%3$s"></div>',
-							esc_attr( 'wc_settings_ui_' . sanitize_html_class( $this->id ) . '_' . sanitize_html_class( '' === $section ? 'default' : $section ) ),
-							esc_attr( $context->get_page_id() ),
-							esc_attr( $section )
-						);
-						return;
 					}
 				}
+			} catch ( \Throwable $e ) {
+				// A stale or unavailable Settings UI class must keep the classic renderer usable during updates.
+				$context = null;
 			}
 
 			// We can't use "get_settings_for_section" here

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -569,7 +569,7 @@ class SettingsUIRequestContext {
 
 		try {
 			$schema = $this->settings_ui_page->get_schema( $this->section );
-			$schema = SettingsUISchema::canonicalize_option_values( $schema );
+			$schema = SettingsUISchema::canonicalize_schema_values( $schema, $this->settings_ui_page instanceof LegacySettingsPageAdapter );
 			$schema = $this->apply_section_navigation( $schema );
 			$schema = $this->apply_shell_header_visibility( $schema );
 			$schema = $this->ensure_drill_down_breadcrumbs( $schema );

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUIRequestContext.php
@@ -35,6 +35,13 @@ class SettingsUIRequestContext {
 	private const DRILL_DOWN_TABS = array( 'checkout' );
 
 	/**
+	 * Query argument used to request classic settings for the current request.
+	 *
+	 * @var string
+	 */
+	private const CLASSIC_REQUEST_QUERY_ARG = 'wc_settings_ui';
+
+	/**
 	 * Context instances keyed by settings page object and section.
 	 *
 	 * @var array<string, SettingsUIRequestContext>
@@ -112,6 +119,13 @@ class SettingsUIRequestContext {
 	private bool $schema_failed = false;
 
 	/**
+	 * Developer-facing schema failure reason.
+	 *
+	 * @var string
+	 */
+	private string $schema_failure_reason = '';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param \WC_Settings_Page $settings_page Settings page.
@@ -120,7 +134,7 @@ class SettingsUIRequestContext {
 	private function __construct( \WC_Settings_Page $settings_page, string $section ) {
 		$this->settings_page    = $settings_page;
 		$this->section          = $section;
-		$this->settings_ui_page = self::resolve_settings_ui_page( $settings_page, $section );
+		$this->settings_ui_page = self::is_classic_request() ? null : self::resolve_settings_ui_page( $settings_page, $section );
 	}
 
 	/**
@@ -129,7 +143,7 @@ class SettingsUIRequestContext {
 	 * @return SettingsUIRequestContext|null
 	 */
 	public static function get_current(): ?SettingsUIRequestContext {
-		if ( ! PageController::is_settings_page() || ! Features::is_enabled( 'settings-ui' ) || ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( self::is_classic_request() || ! PageController::is_settings_page() || ! Features::is_enabled( 'settings-ui' ) || ! current_user_can( 'manage_woocommerce' ) ) {
 			return null;
 		}
 
@@ -342,6 +356,10 @@ class SettingsUIRequestContext {
 	 * @return array|null
 	 */
 	public function get_schema(): ?array {
+		if ( $this->has_script_handles_failed() ) {
+			return null;
+		}
+
 		if ( ! $this->schema_resolved ) {
 			$this->resolve_schema();
 		}
@@ -360,6 +378,40 @@ class SettingsUIRequestContext {
 		}
 
 		return $this->schema_failed;
+	}
+
+	/**
+	 * Get the schema failure reason.
+	 *
+	 * @return string
+	 *
+	 * @since 11.1.0
+	 */
+	public function get_schema_failure_reason(): string {
+		if ( ! $this->schema_resolved ) {
+			$this->resolve_schema();
+		}
+
+		return '' !== $this->schema_failure_reason
+			? $this->schema_failure_reason
+			: __( 'Settings UI schema could not be resolved.', 'woocommerce' );
+	}
+
+	/**
+	 * Whether the current request explicitly asks for classic settings.
+	 *
+	 * @return bool
+	 */
+	private static function is_classic_request(): bool {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only request override that changes rendering only.
+		if ( ! isset( $_GET[ self::CLASSIC_REQUEST_QUERY_ARG ] ) ) {
+			return false;
+		}
+
+		$rendering_mode = wp_unslash( $_GET[ self::CLASSIC_REQUEST_QUERY_ARG ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Type checked and sanitized below.
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return is_string( $rendering_mode ) && 'classic' === sanitize_key( $rendering_mode );
 	}
 
 	/**
@@ -443,20 +495,65 @@ class SettingsUIRequestContext {
 		}
 
 		try {
-			$this->script_handles = self::filter_script_handles( $this->settings_ui_page->get_script_handles( $this->section ) );
+			$this->script_handles = self::validate_and_enqueue_script_handles( $this->settings_ui_page->get_script_handles( $this->section ) );
 		} catch ( \Throwable $e ) {
 			$this->script_handles_failed = true;
 
 			self::log_resolution_failure( 'Settings UI script handles', $this->get_page_id(), $this->section, $e, __METHOD__ );
 
-			if ( $e instanceof \Exception ) {
-				$this->script_handles_failure_reason = sprintf(
-					/* translators: %s: exception message. */
-					__( 'Settings UI script handles could not be resolved: %s', 'woocommerce' ),
-					$e->getMessage()
+			$this->script_handles_failure_reason = sprintf(
+				/* translators: %s: failure reason. */
+				__( 'Settings UI script handles could not be resolved: %s', 'woocommerce' ),
+				self::sanitize_failure_reason( $e )
+			);
+		}
+	}
+
+	/**
+	 * Validate and enqueue extension script handles.
+	 *
+	 * @param array $script_handles Declared script handles.
+	 * @return string[] Validated script handles.
+	 * @throws \InvalidArgumentException When a handle is not a non-empty string.
+	 * @throws \RuntimeException When a handle is not registered or cannot be enqueued.
+	 */
+	private static function validate_and_enqueue_script_handles( array $script_handles ): array {
+		// Exception messages are cached diagnostics rather than HTML output. Dynamic
+		// handles are sanitized before the exception crosses this boundary.
+		// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		foreach ( $script_handles as $script_handle ) {
+			if ( ! is_string( $script_handle ) || '' === trim( $script_handle ) ) {
+				throw new \InvalidArgumentException( __( 'Settings UI script handles must be non-empty strings.', 'woocommerce' ) );
+			}
+
+			if ( ! wp_script_is( $script_handle, 'registered' ) ) {
+				throw new \RuntimeException(
+					sprintf(
+						/* translators: %s: script handle. */
+						__( 'Settings UI script handle "%s" is not registered.', 'woocommerce' ),
+						sanitize_text_field( $script_handle )
+					)
 				);
 			}
 		}
+
+		$script_handles = array_values( array_unique( $script_handles ) );
+		foreach ( $script_handles as $script_handle ) {
+			wp_enqueue_script( $script_handle );
+
+			if ( ! wp_script_is( $script_handle, 'enqueued' ) ) {
+				throw new \RuntimeException(
+					sprintf(
+						/* translators: %s: script handle. */
+						__( 'Settings UI script handle "%s" could not be enqueued.', 'woocommerce' ),
+						sanitize_text_field( $script_handle )
+					)
+				);
+			}
+		}
+		// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+		return $script_handles;
 	}
 
 	/**
@@ -471,16 +568,32 @@ class SettingsUIRequestContext {
 		}
 
 		try {
-			$schema       = $this->settings_ui_page->get_schema( $this->section );
-			$schema       = SettingsUISchema::canonicalize_option_values( $schema );
-			$schema       = $this->apply_section_navigation( $schema );
-			$schema       = $this->apply_shell_header_visibility( $schema );
-			$this->schema = $this->ensure_drill_down_breadcrumbs( $schema );
+			$schema = $this->settings_ui_page->get_schema( $this->section );
+			$schema = SettingsUISchema::canonicalize_option_values( $schema );
+			$schema = $this->apply_section_navigation( $schema );
+			$schema = $this->apply_shell_header_visibility( $schema );
+			$schema = $this->ensure_drill_down_breadcrumbs( $schema );
+
+			SettingsUISchema::assert_valid_schema( $schema );
+			$this->schema = $schema;
 		} catch ( \Throwable $e ) {
-			$this->schema_failed = true;
+			$this->schema_failed         = true;
+			$this->schema_failure_reason = self::sanitize_failure_reason( $e );
 
 			self::log_resolution_failure( 'Settings UI schema', $this->get_page_id(), $this->section, $e, __METHOD__ );
 		}
+	}
+
+	/**
+	 * Sanitize a failure reason before it reaches developer-facing output.
+	 *
+	 * @param \Throwable $e Resolution failure.
+	 * @return string
+	 */
+	private static function sanitize_failure_reason( \Throwable $e ): string {
+		$reason = sanitize_text_field( $e->getMessage() );
+
+		return '' !== $reason ? $reason : get_class( $e );
 	}
 
 	/**
@@ -582,22 +695,5 @@ class SettingsUIRequestContext {
 		);
 
 		return $schema;
-	}
-
-	/**
-	 * Filter extension-provided script handles to valid WordPress script handle strings.
-	 *
-	 * @param array $script_handles Raw script handles.
-	 * @return string[]
-	 */
-	private static function filter_script_handles( array $script_handles ): array {
-		return array_values(
-			array_filter(
-				$script_handles,
-				static function ( $script_handle ): bool {
-					return is_string( $script_handle ) && '' !== $script_handle;
-				}
-			)
-		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -26,6 +26,43 @@ class SettingsUISchema {
 	private const DEFAULT_GROUP_ID = 'default';
 
 	/**
+	 * Field types that the current Settings UI renderer handles explicitly.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_FIELD_TYPES = array(
+		'array',
+		'checkbox',
+		'date',
+		'datetime-local',
+		'email',
+		'info',
+		'number',
+		'password',
+		'radio',
+		'select',
+		'tel',
+		'text',
+		'textarea',
+		'time',
+		'url',
+	);
+
+	/**
+	 * Field types that require a choice list.
+	 *
+	 * @var string[]
+	 */
+	private const CHOICE_FIELD_TYPES = array( 'array', 'radio', 'select' );
+
+	/**
+	 * Custom attributes that describe a numeric range.
+	 *
+	 * @var string[]
+	 */
+	private const RANGE_ATTRIBUTES = array( 'min', 'max', 'step' );
+
+	/**
 	 * Build a schema from a legacy WC settings array.
 	 *
 	 * @since 10.9.0
@@ -136,6 +173,101 @@ class SettingsUISchema {
 			),
 			'groups'  => $groups,
 		);
+	}
+
+	// Exception messages are not HTML output. Dynamic values are sanitized once
+	// by invalid_schema() before the exception crosses the schema boundary.
+	// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+	/**
+	 * Assert that a schema is safe for the current Settings UI renderer.
+	 *
+	 * Compatibility normalization and request-owned shell defaults must run
+	 * before this assertion. An invalid schema throws before it can be cached or
+	 * emitted to JavaScript.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $schema Settings UI schema.
+	 * @throws \InvalidArgumentException When the schema is malformed or unsupported.
+	 */
+	public static function assert_valid_schema( array $schema ): void {
+		self::assert_non_empty_string( $schema['id'] ?? null, 'Schema id must be a non-empty string.' );
+
+		foreach ( array( 'title', 'section' ) as $property ) {
+			if ( array_key_exists( $property, $schema ) && ! is_string( $schema[ $property ] ) ) {
+				throw self::invalid_schema( sprintf( 'Schema %s must be a string.', $property ) );
+			}
+		}
+
+		if ( array_key_exists( 'section', $schema ) && '' === $schema['section'] ) {
+			throw self::invalid_schema( 'Schema section must be a non-empty string.' );
+		}
+
+		self::assert_page_save_strategy( $schema['save'] ?? null );
+		self::assert_shell( $schema['shell'] ?? null );
+
+		if ( ! isset( $schema['groups'] ) || ! is_array( $schema['groups'] ) ) {
+			throw self::invalid_schema( 'Schema groups must be a map.' );
+		}
+
+		$group_ids = array();
+		foreach ( $schema['groups'] as $group_key => $group ) {
+			if ( ! is_string( $group_key ) || '' === $group_key ) {
+				throw self::invalid_schema( 'Group map keys must be non-empty strings.' );
+			}
+
+			if ( ! is_array( $group ) ) {
+				throw self::invalid_schema( sprintf( 'Group "%s" must be an array.', $group_key ) );
+			}
+
+			self::assert_non_empty_string( $group['id'] ?? null, sprintf( 'Group "%s" id must be a non-empty string.', $group_key ) );
+			if ( $group_key !== $group['id'] ) {
+				throw self::invalid_schema( sprintf( 'Group map key "%s" must match group id "%s".', $group_key, $group['id'] ) );
+			}
+
+			$group_ids[] = $group['id'];
+		}
+
+		$field_ids        = array();
+		$visibility_rules = array();
+		foreach ( $schema['groups'] as $group ) {
+			$group_id = $group['id'];
+			self::assert_optional_strings( $group, array( 'title', 'description' ), sprintf( 'Group "%s"', $group_id ) );
+			self::assert_group_actions( $group['actions'] ?? null, $group_id );
+
+			if ( ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) || ! ArrayUtil::array_is_list( $group['fields'] ) ) {
+				throw self::invalid_schema( sprintf( 'Group "%s" fields must be a list.', $group_id ) );
+			}
+
+			foreach ( $group['fields'] as $field_index => $field ) {
+				if ( ! is_array( $field ) ) {
+					throw self::invalid_schema( sprintf( 'Group "%s" field %d must be an array.', $group_id, $field_index ) );
+				}
+
+				self::assert_non_empty_string( $field['id'] ?? null, sprintf( 'Group "%s" field %d id must be a non-empty string.', $group_id, $field_index ) );
+				$field_id = $field['id'];
+				if ( in_array( $field_id, $field_ids, true ) ) {
+					throw self::invalid_schema( sprintf( 'Field id "%s" is duplicated.', $field_id ) );
+				}
+				if ( in_array( $field_id, $group_ids, true ) ) {
+					throw self::invalid_schema( sprintf( 'Field id "%s" collides with a group id.', $field_id ) );
+				}
+
+				$field_ids[] = $field_id;
+				self::assert_field( $field );
+				if ( isset( $field['visibility'] ) ) {
+					$visibility_rules[ $field_id ] = $field['visibility'];
+				}
+			}
+		}
+
+		foreach ( $visibility_rules as $field_id => $visibility ) {
+			$controller = $visibility['controller'];
+			if ( ! in_array( $controller, $field_ids, true ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" visibility controller "%s" does not reference a field.', $field_id, $controller ) );
+			}
+		}
 	}
 
 	/**
@@ -368,9 +500,11 @@ class SettingsUISchema {
 			$field['options'] = $options;
 		}
 
-		if ( 'info' === $type && '' === $field['description'] && isset( $setting['text'] ) && is_scalar( $setting['text'] ) ) {
-			$field['description'] = wp_kses_post( (string) $setting['text'] );
-			$field['save']        = array( 'adapter' => 'none' );
+		if ( 'info' === $type ) {
+			if ( '' === $field['description'] && isset( $setting['text'] ) && is_scalar( $setting['text'] ) ) {
+				$field['description'] = wp_kses_post( (string) $setting['text'] );
+			}
+			$field['save'] = array( 'adapter' => 'none' );
 		}
 
 		return $field;
@@ -632,6 +766,476 @@ class SettingsUISchema {
 
 		return $actions;
 	}
+
+	// The assertion helpers deliberately propagate InvalidArgumentException to
+	// the public boundary method, whose contract documents that exception.
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.Missing
+
+	/**
+	 * Assert page-level save metadata.
+	 *
+	 * @param mixed $save Save metadata, or null when omitted.
+	 */
+	private static function assert_page_save_strategy( $save ): void {
+		if ( null === $save ) {
+			return;
+		}
+
+		if ( ! is_array( $save ) ) {
+			throw self::invalid_schema( 'Schema save strategy must be an array.' );
+		}
+
+		$adapter = $save['adapter'] ?? null;
+		if ( ! is_string( $adapter ) || ! in_array( $adapter, array( 'custom', 'form_post', 'none' ), true ) ) {
+			throw self::invalid_schema( 'Schema save adapter must be "custom", "form_post", or "none".' );
+		}
+
+		if ( 'custom' === $adapter ) {
+			self::assert_non_empty_string( $save['handler'] ?? null, 'Schema custom save strategy must define a non-empty handler.' );
+		} elseif ( array_key_exists( 'handler', $save ) ) {
+			throw self::invalid_schema( 'Schema save handler is only valid for the "custom" adapter.' );
+		}
+	}
+
+	/**
+	 * Assert shell metadata.
+	 *
+	 * @param mixed $shell Shell metadata, or null when omitted.
+	 */
+	private static function assert_shell( $shell ): void {
+		if ( null === $shell ) {
+			return;
+		}
+
+		if ( ! is_array( $shell ) ) {
+			throw self::invalid_schema( 'Schema shell must be an array.' );
+		}
+
+		self::assert_optional_strings( $shell, array( 'title', 'subtitle' ), 'Shell' );
+		if ( isset( $shell['header'] ) && ! in_array( $shell['header'], array( 'hidden', 'visible' ), true ) ) {
+			throw self::invalid_schema( 'Shell header must be "hidden" or "visible".' );
+		}
+
+		if ( array_key_exists( 'navigationComponent', $shell ) ) {
+			self::assert_non_empty_string( $shell['navigationComponent'], 'Shell navigationComponent must be a non-empty string.' );
+		}
+
+		foreach ( array( 'navigation', 'sectionNavigation' ) as $property ) {
+			if ( ! array_key_exists( $property, $shell ) ) {
+				continue;
+			}
+
+			self::assert_shell_navigation( $shell[ $property ], 'Shell ' . $property );
+		}
+
+		self::assert_shell_breadcrumbs( $shell['breadcrumbs'] ?? null );
+		self::assert_shell_badges( $shell['badges'] ?? null );
+	}
+
+	/**
+	 * Assert shell navigation items.
+	 *
+	 * @param mixed  $items Navigation items.
+	 * @param string $context Error message context.
+	 */
+	private static function assert_shell_navigation( $items, string $context ): void {
+		if ( ! is_array( $items ) || ! ArrayUtil::array_is_list( $items ) ) {
+			throw self::invalid_schema( $context . ' must be a list.' );
+		}
+
+		$ids = array();
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				throw self::invalid_schema( sprintf( '%s item %d must be an array.', $context, $index ) );
+			}
+
+			self::assert_non_empty_string( $item['id'] ?? null, sprintf( '%s item %d id must be a non-empty string.', $context, $index ) );
+			if ( in_array( $item['id'], $ids, true ) ) {
+				throw self::invalid_schema( sprintf( '%s item id "%s" is duplicated.', $context, $item['id'] ) );
+			}
+			$ids[] = $item['id'];
+
+			foreach ( array( 'label', 'href' ) as $property ) {
+				if ( ! isset( $item[ $property ] ) || ! is_string( $item[ $property ] ) ) {
+					throw self::invalid_schema( sprintf( '%s item %d %s must be a string.', $context, $index, $property ) );
+				}
+			}
+
+			if ( isset( $item['active'] ) && ! is_bool( $item['active'] ) ) {
+				throw self::invalid_schema( sprintf( '%s item %d active must be a boolean.', $context, $index ) );
+			}
+		}
+	}
+
+	/**
+	 * Assert shell breadcrumbs.
+	 *
+	 * @param mixed $breadcrumbs Breadcrumb metadata, or null when omitted.
+	 */
+	private static function assert_shell_breadcrumbs( $breadcrumbs ): void {
+		if ( null === $breadcrumbs ) {
+			return;
+		}
+
+		if ( ! is_array( $breadcrumbs ) || ! ArrayUtil::array_is_list( $breadcrumbs ) ) {
+			throw self::invalid_schema( 'Shell breadcrumbs must be a list.' );
+		}
+
+		foreach ( $breadcrumbs as $index => $breadcrumb ) {
+			if ( ! is_array( $breadcrumb ) || ! isset( $breadcrumb['label'] ) || ! is_string( $breadcrumb['label'] ) ) {
+				throw self::invalid_schema( sprintf( 'Shell breadcrumb %d label must be a string.', $index ) );
+			}
+
+			if ( isset( $breadcrumb['href'] ) && ! is_string( $breadcrumb['href'] ) ) {
+				throw self::invalid_schema( sprintf( 'Shell breadcrumb %d href must be a string.', $index ) );
+			}
+		}
+	}
+
+	/**
+	 * Assert shell badges.
+	 *
+	 * @param mixed $badges Badge metadata, or null when omitted.
+	 */
+	private static function assert_shell_badges( $badges ): void {
+		if ( null === $badges ) {
+			return;
+		}
+
+		if ( ! is_array( $badges ) || ! ArrayUtil::array_is_list( $badges ) ) {
+			throw self::invalid_schema( 'Shell badges must be a list.' );
+		}
+
+		foreach ( $badges as $index => $badge ) {
+			if ( ! is_array( $badge ) || ! isset( $badge['label'] ) || ! is_string( $badge['label'] ) ) {
+				throw self::invalid_schema( sprintf( 'Shell badge %d label must be a string.', $index ) );
+			}
+
+			if ( isset( $badge['intent'] ) && ! in_array( $badge['intent'], array( 'default', 'info', 'success', 'warning', 'error' ), true ) ) {
+				throw self::invalid_schema( sprintf( 'Shell badge %d intent "%s" is not supported.', $index, is_scalar( $badge['intent'] ) ? (string) $badge['intent'] : gettype( $badge['intent'] ) ) );
+			}
+		}
+	}
+
+	/**
+	 * Assert group header actions.
+	 *
+	 * @param mixed  $actions Group actions, or null when omitted.
+	 * @param string $group_id Group id.
+	 */
+	private static function assert_group_actions( $actions, string $group_id ): void {
+		if ( null === $actions ) {
+			return;
+		}
+
+		if ( ! is_array( $actions ) || ! ArrayUtil::array_is_list( $actions ) ) {
+			throw self::invalid_schema( sprintf( 'Group "%s" actions must be a list.', $group_id ) );
+		}
+
+		$ids = array();
+		foreach ( $actions as $index => $action ) {
+			if ( ! is_array( $action ) ) {
+				throw self::invalid_schema( sprintf( 'Group "%s" action %d must be an array.', $group_id, $index ) );
+			}
+
+			self::assert_non_empty_string( $action['id'] ?? null, sprintf( 'Group "%s" action %d id must be a non-empty string.', $group_id, $index ) );
+			if ( in_array( $action['id'], $ids, true ) ) {
+				throw self::invalid_schema( sprintf( 'Group "%s" action id "%s" is duplicated.', $group_id, $action['id'] ) );
+			}
+			$ids[] = $action['id'];
+
+			foreach ( array( 'label', 'href' ) as $property ) {
+				if ( ! isset( $action[ $property ] ) || ! is_string( $action[ $property ] ) ) {
+					throw self::invalid_schema( sprintf( 'Group "%s" action %d %s must be a string.', $group_id, $index, $property ) );
+				}
+			}
+
+			self::assert_optional_strings( $action, array( 'variant', 'target', 'rel' ), sprintf( 'Group "%s" action %d', $group_id, $index ) );
+		}
+	}
+
+	/**
+	 * Assert a field definition.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_field( array $field ): void {
+		$field_id = $field['id'];
+		if ( ! isset( $field['label'] ) || ! is_string( $field['label'] ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" label must be a string.', $field_id ) );
+		}
+
+		$type = $field['type'] ?? null;
+		if ( ! is_string( $type ) || ! in_array( $type, self::SUPPORTED_FIELD_TYPES, true ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" has unsupported type "%s".', $field_id, is_scalar( $type ) ? (string) $type : gettype( $type ) ) );
+		}
+
+		self::assert_optional_strings( $field, array( 'description', 'placeholder' ), sprintf( 'Field "%s"', $field_id ) );
+		if ( isset( $field['disabled'] ) && ! is_bool( $field['disabled'] ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" disabled must be a boolean.', $field_id ) );
+		}
+
+		if ( array_key_exists( 'component', $field ) ) {
+			self::assert_non_empty_string( $field['component'], sprintf( 'Field "%s" component must be a non-empty string.', $field_id ) );
+		}
+
+		self::assert_field_value( $field );
+		self::assert_field_options( $field );
+		self::assert_custom_attributes( $field );
+		self::assert_field_save( $field );
+		self::assert_visibility( $field );
+	}
+
+	/**
+	 * Assert a field value when supplied.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_field_value( array $field ): void {
+		if ( ! array_key_exists( 'value', $field ) ) {
+			return;
+		}
+
+		$value = $field['value'];
+		switch ( $field['type'] ) {
+			case 'array':
+				$valid = is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) );
+				break;
+			case 'checkbox':
+				$valid = is_bool( $value );
+				break;
+			case 'number':
+				$valid = self::is_finite_number( $value, true );
+				break;
+			default:
+				$valid = is_string( $value );
+				break;
+		}
+
+		if ( ! $valid ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" value is invalid for type "%s".', $field['id'], $field['type'] ) );
+		}
+	}
+
+	/**
+	 * Assert choice options.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_field_options( array $field ): void {
+		$field_id = $field['id'];
+		$options  = $field['options'] ?? null;
+		if ( in_array( $field['type'], self::CHOICE_FIELD_TYPES, true ) && ( ! is_array( $options ) || empty( $options ) || ! ArrayUtil::array_is_list( $options ) ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" of type "%s" must define a non-empty options list.', $field_id, $field['type'] ) );
+		}
+
+		if ( null === $options ) {
+			return;
+		}
+
+		if ( ! is_array( $options ) || ! ArrayUtil::array_is_list( $options ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" options must be a list.', $field_id ) );
+		}
+
+		foreach ( $options as $index => $option ) {
+			if ( ! is_array( $option ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" option %d must be an array.', $field_id, $index ) );
+			}
+
+			foreach ( array( 'label', 'value' ) as $property ) {
+				if ( ! isset( $option[ $property ] ) || ! is_string( $option[ $property ] ) ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" option %d %s must be a string.', $field_id, $index, $property ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Assert custom input attributes.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_custom_attributes( array $field ): void {
+		if ( ! array_key_exists( 'customAttributes', $field ) ) {
+			return;
+		}
+
+		if ( ! is_array( $field['customAttributes'] ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" customAttributes must be a map.', $field['id'] ) );
+		}
+
+		foreach ( $field['customAttributes'] as $attribute => $value ) {
+			if ( ! is_string( $attribute ) || '' === $attribute ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" custom attribute names must be non-empty strings.', $field['id'] ) );
+			}
+
+			if ( ! is_string( $value ) && ! is_int( $value ) && ! is_float( $value ) && ! is_bool( $value ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" has an invalid value.', $field['id'], $attribute ) );
+			}
+
+			if ( in_array( $attribute, self::RANGE_ATTRIBUTES, true ) ) {
+				if ( 'number' !== $field['type'] ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" may define "%s" only when its type is "number".', $field['id'], $attribute ) );
+				}
+
+				$allow_any = 'step' === $attribute;
+				if ( ! self::is_finite_number( $value, false ) && ! ( $allow_any && 'any' === $value ) ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" must be a finite number.', $field['id'], $attribute ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Assert field save metadata.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_field_save( array $field ): void {
+		$save = $field['save'] ?? null;
+		if ( null !== $save && ! is_array( $save ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" save metadata must be an array.', $field['id'] ) );
+		}
+
+		$adapter = is_array( $save ) ? ( $save['adapter'] ?? null ) : 'form_post';
+		if ( ! is_string( $adapter ) || ! in_array( $adapter, array( 'form_post', 'none' ), true ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" save adapter must be "form_post" or "none".', $field['id'] ) );
+		}
+
+		if ( is_array( $save ) && array_key_exists( 'name', $save ) ) {
+			self::assert_non_empty_string( $save['name'], sprintf( 'Field "%s" save name must be a non-empty string.', $field['id'] ) );
+		}
+
+		if ( 'info' === $field['type'] && 'none' !== $adapter ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" of type "info" must use the "none" save adapter.', $field['id'] ) );
+		}
+	}
+
+	/**
+	 * Assert field visibility metadata.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_visibility( array $field ): void {
+		if ( ! array_key_exists( 'visibility', $field ) ) {
+			return;
+		}
+
+		$visibility = $field['visibility'];
+		if ( ! is_array( $visibility ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" visibility must be an array.', $field['id'] ) );
+		}
+
+		self::assert_non_empty_string( $visibility['controller'] ?? null, sprintf( 'Field "%s" visibility controller must be a non-empty string.', $field['id'] ) );
+		if ( array_key_exists( 'value', $visibility ) && ! self::is_visibility_value( $visibility['value'] ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" visibility value is invalid.', $field['id'] ) );
+		}
+	}
+
+	/**
+	 * Whether a value is representable by the visibility rule contract.
+	 *
+	 * Visibility rules accept either one settings value or a list of settings
+	 * values. String lists are valid in both positions and are disambiguated by
+	 * the renderer at comparison time.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	private static function is_visibility_value( $value ): bool {
+		if ( self::is_settings_value( $value ) ) {
+			return true;
+		}
+
+		return is_array( $value )
+			&& ArrayUtil::array_is_list( $value )
+			&& count( $value ) === count( array_filter( $value, array( __CLASS__, 'is_settings_value' ) ) );
+	}
+
+	/**
+	 * Whether a value is representable by the Settings UI state contract.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	private static function is_settings_value( $value ): bool {
+		if ( null === $value || is_string( $value ) || is_bool( $value ) || is_int( $value ) ) {
+			return true;
+		}
+
+		if ( is_float( $value ) ) {
+			return is_finite( $value );
+		}
+
+		return is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) );
+	}
+
+	/**
+	 * Whether a value is a finite number accepted by the transitional renderer.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @param bool  $allow_empty_string Whether an empty input representation is valid.
+	 * @return bool
+	 */
+	private static function is_finite_number( $value, bool $allow_empty_string ): bool {
+		if ( is_int( $value ) ) {
+			return true;
+		}
+
+		if ( is_float( $value ) ) {
+			return is_finite( $value );
+		}
+
+		if ( ! is_string( $value ) ) {
+			return false;
+		}
+
+		if ( $allow_empty_string && '' === $value ) {
+			return true;
+		}
+
+		return is_numeric( $value ) && is_finite( (float) $value );
+	}
+
+	/**
+	 * Assert optional string properties.
+	 *
+	 * @param array    $value Candidate container.
+	 * @param string[] $properties Property names.
+	 * @param string   $context Error message context.
+	 */
+	private static function assert_optional_strings( array $value, array $properties, string $context ): void {
+		foreach ( $properties as $property ) {
+			if ( array_key_exists( $property, $value ) && ! is_string( $value[ $property ] ) ) {
+				throw self::invalid_schema( sprintf( '%s %s must be a string.', $context, $property ) );
+			}
+		}
+	}
+
+	/**
+	 * Assert a non-empty string.
+	 *
+	 * @param mixed  $value Candidate value.
+	 * @param string $message Exception message.
+	 */
+	private static function assert_non_empty_string( $value, string $message ): void {
+		if ( ! is_string( $value ) || '' === $value ) {
+			throw self::invalid_schema( $message );
+		}
+	}
+
+	/**
+	 * Build a safely escaped schema validation exception.
+	 *
+	 * @param string $message Developer-facing validation reason.
+	 * @return \InvalidArgumentException
+	 */
+	private static function invalid_schema( string $message ): \InvalidArgumentException {
+		return new \InvalidArgumentException( sanitize_text_field( $message ) );
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.Missing
+	// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
 	/**
 	 * Get the default group.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -37,6 +37,7 @@ class SettingsUISchema {
 		'datetime-local',
 		'email',
 		'info',
+		'integer',
 		'number',
 		'password',
 		'radio',
@@ -61,6 +62,13 @@ class SettingsUISchema {
 	 * @var string[]
 	 */
 	private const RANGE_ATTRIBUTES = array( 'min', 'max', 'step' );
+
+	/**
+	 * Largest integer JavaScript can represent exactly.
+	 *
+	 * @var string
+	 */
+	private const JAVASCRIPT_SAFE_INTEGER = '9007199254740991';
 
 	/**
 	 * Build a schema from a legacy WC settings array.
@@ -161,7 +169,7 @@ class SettingsUISchema {
 
 		$decoded_title = html_entity_decode( $title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 
-		return array(
+		$schema = array(
 			'id'      => $page_id,
 			'title'   => $decoded_title,
 			'section' => '' === $section ? self::DEFAULT_GROUP_ID : $section,
@@ -173,6 +181,8 @@ class SettingsUISchema {
 			),
 			'groups'  => $groups,
 		);
+
+		return self::canonicalize_schema_values( $schema, true );
 	}
 
 	// Exception messages are not HTML output. Dynamic values are sanitized once
@@ -286,11 +296,32 @@ class SettingsUISchema {
 	 * @return array Schema with scalar option values canonicalized to strings.
 	 */
 	public static function canonicalize_option_values( array $schema ): array {
+		$converted_fields = array();
+		$schema           = self::canonicalize_option_values_and_collect( $schema, $converted_fields );
+
+		self::emit_conversion_notice(
+			__METHOD__,
+			$converted_fields,
+			/* translators: %s: comma-separated field ids. */
+			__( 'A Settings UI schema provider supplied non-string option, field, or visibility values that WooCommerce converted for compatibility: %s. Update the provider to supply string values.', 'woocommerce' ),
+			'11.0.0'
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Canonicalize option values and collect affected field ids.
+	 *
+	 * @param array    $schema Settings UI schema.
+	 * @param string[] $converted_fields Affected field ids.
+	 * @return array Canonicalized schema.
+	 */
+	private static function canonicalize_option_values_and_collect( array $schema, array &$converted_fields ): array {
 		if ( ! isset( $schema['groups'] ) || ! is_array( $schema['groups'] ) ) {
 			return $schema;
 		}
 
-		$converted_fields = array();
 		$option_field_ids = array();
 
 		foreach ( $schema['groups'] as &$group ) {
@@ -308,8 +339,9 @@ class SettingsUISchema {
 					continue;
 				}
 
-				$option_field_ids[] = $field['id'];
-				$converted          = false;
+				$option_field_ids[ $field['id'] ] = true;
+
+				$converted = false;
 
 				foreach ( $field['options'] as &$option ) {
 					if (
@@ -378,19 +410,591 @@ class SettingsUISchema {
 		}
 		unset( $group );
 
-		if ( ! empty( $converted_fields ) ) {
-			wc_doing_it_wrong(
+		return $schema;
+	}
+
+	/**
+	 * Canonicalize typed field values and compatibility metadata.
+	 *
+	 * This additive entry point preserves canonicalize_option_values() for
+	 * existing callers while letting request resolution issue one aggregate
+	 * compatibility notice for the complete native-provider pass.
+	 *
+	 * @since 11.1.0
+	 *
+	 * @param array $schema Settings UI schema.
+	 * @param bool  $legacy_derived Whether the schema came from legacy settings definitions.
+	 * @return array Canonicalized schema.
+	 * @throws \InvalidArgumentException When a value cannot be converted without loss.
+	 */
+	public static function canonicalize_schema_values( array $schema, bool $legacy_derived = false ): array {
+		if ( ! isset( $schema['groups'] ) || ! is_array( $schema['groups'] ) ) {
+			return $schema;
+		}
+
+		$converted_fields = array();
+		$original_values  = array();
+
+		foreach ( $schema['groups'] as &$group ) {
+			if ( ! is_array( $group ) || ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) ) {
+				continue;
+			}
+
+			foreach ( $group['fields'] as &$field ) {
+				if ( ! is_array( $field ) || ! isset( $field['id'] ) || ! is_string( $field['id'] ) ) {
+					continue;
+				}
+
+				if ( array_key_exists( 'value', $field ) ) {
+					$original_values[ $field['id'] ] = $field['value'];
+				}
+			}
+			unset( $field );
+		}
+		unset( $group );
+
+		$schema = self::canonicalize_option_values_and_collect( $schema, $converted_fields );
+		foreach ( $schema['groups'] as &$group ) {
+			if ( ! is_array( $group ) || ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) ) {
+				continue;
+			}
+
+			foreach ( $group['fields'] as &$field ) {
+				if ( ! is_array( $field ) || ! isset( $field['id'] ) || ! is_string( $field['id'] ) ) {
+					continue;
+				}
+
+				self::canonicalize_field( $field, $converted_fields );
+			}
+			unset( $field );
+		}
+		unset( $group );
+
+		self::preserve_converted_form_values( $schema, $original_values );
+
+		if ( ! $legacy_derived ) {
+			self::emit_conversion_notice(
 				__METHOD__,
-				sprintf(
-					/* translators: %s: comma-separated field ids. */
-					esc_html__( 'A Settings UI schema provider supplied non-string option, field, or visibility values that WooCommerce converted for compatibility: %s. Update the provider to supply string values.', 'woocommerce' ),
-					esc_html( implode( ', ', array_unique( $converted_fields ) ) )
-				),
-				'11.0.0'
+				$converted_fields,
+				/* translators: %s: comma-separated field ids. */
+				__( 'A Settings UI schema provider supplied legacy field values or metadata that WooCommerce converted for compatibility: %s. Update the provider to supply canonical values.', 'woocommerce' ),
+				'11.1.0'
 			);
 		}
 
 		return $schema;
+	}
+
+	/**
+	 * Canonicalize one field in place.
+	 *
+	 * @param array    $field Field definition.
+	 * @param string[] $converted_fields Affected field ids.
+	 */
+	private static function canonicalize_field( array &$field, array &$converted_fields ): void {
+		$type = $field['type'] ?? null;
+		if ( ! is_string( $type ) ) {
+			return;
+		}
+
+		$original_type  = $type;
+		$original_value = $field['value'] ?? null;
+
+		$numeric_validation_converted = false;
+
+		if ( 'number' === $type && self::should_promote_to_integer( $field ) ) {
+			$type          = 'integer';
+			$field['type'] = $type;
+		}
+
+		if ( array_key_exists( 'value', $field ) ) {
+			switch ( $type ) {
+				case 'array':
+					$field['value'] = self::canonicalize_array_value( $field['value'], $field['id'] );
+					break;
+				case 'checkbox':
+					$field['value'] = self::canonicalize_checkbox_value( $field['value'], $field['id'] );
+					break;
+				case 'number':
+					$field['value'] = self::canonicalize_number( $field['value'], false, $field['id'], 'value' );
+					break;
+				case 'integer':
+					$field['value'] = self::canonicalize_number( $field['value'], true, $field['id'], 'value' );
+					break;
+				case 'datetime-local':
+					$field['value'] = self::canonicalize_datetime( $field['value'], $field['id'] );
+					break;
+			}
+		}
+
+		if ( in_array( $type, array( 'number', 'integer' ), true ) ) {
+			$numeric_validation_converted = self::canonicalize_numeric_validation( $field, 'integer' === $type );
+		}
+
+		if (
+			$original_type !== $field['type'] ||
+			( array_key_exists( 'value', $field ) && $original_value !== $field['value'] ) ||
+			$numeric_validation_converted
+		) {
+			$converted_fields[] = $field['id'];
+		}
+	}
+
+	/**
+	 * Whether a legacy number follows the HTML integer step contract.
+	 *
+	 * @param array $field Field definition.
+	 * @return bool
+	 */
+	private static function should_promote_to_integer( array $field ): bool {
+		$attributes = isset( $field['customAttributes'] ) && is_array( $field['customAttributes'] ) ? $field['customAttributes'] : array();
+		if ( ! array_key_exists( 'step', $attributes ) || '1' !== self::get_integral_decimal( $attributes['step'] ) ) {
+			return false;
+		}
+
+		$base = $attributes['min'] ?? ( $field['value'] ?? '' );
+		if ( is_string( $base ) && '' === trim( $base ) ) {
+			$base = 0;
+		}
+
+		return null !== self::get_integral_decimal( $base );
+	}
+
+	/**
+	 * Canonicalize an array value to a string list.
+	 *
+	 * @param mixed  $value Candidate value.
+	 * @param string $field_id Field id.
+	 * @return array
+	 * @throws \InvalidArgumentException When the value cannot become a string list.
+	 */
+	private static function canonicalize_array_value( $value, string $field_id ): array {
+		if ( is_string( $value ) ) {
+			return '' === $value ? array() : array( $value );
+		}
+
+		if ( ! is_array( $value ) || ! ArrayUtil::array_is_list( $value ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" value must be a string list.', $field_id ) );
+		}
+
+		$canonical = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" value must be a string list.', $field_id ) );
+			}
+			$canonical[] = is_string( $item ) ? $item : self::to_canonical_string( $item );
+		}
+
+		return $canonical;
+	}
+
+	/**
+	 * Canonicalize a checkbox value.
+	 *
+	 * @param mixed  $value Candidate value.
+	 * @param string $field_id Field id.
+	 * @return bool
+	 * @throws \InvalidArgumentException When the value is ambiguous.
+	 */
+	private static function canonicalize_checkbox_value( $value, string $field_id ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_int( $value ) && in_array( $value, array( 0, 1 ), true ) ) {
+			return 1 === $value;
+		}
+
+		if ( is_string( $value ) ) {
+			$normalized = strtolower( trim( $value ) );
+			if ( in_array( $normalized, array( '1', 'true', 'yes' ), true ) ) {
+				return true;
+			}
+			if ( in_array( $normalized, array( '', '0', 'false', 'no' ), true ) ) {
+				return false;
+			}
+		}
+
+		throw self::invalid_schema( sprintf( 'Field "%s" checkbox value is ambiguous.', $field_id ) );
+	}
+
+	/**
+	 * Canonicalize a number without first rounding integral strings.
+	 *
+	 * @param mixed  $value Candidate value.
+	 * @param bool   $integer_only Whether the result must be an integer.
+	 * @param string $field_id Field id.
+	 * @param string $property Value or bound name.
+	 * @return int|float|null
+	 * @throws \InvalidArgumentException When the number is invalid, unsafe, or lossy.
+	 */
+	private static function canonicalize_number( $value, bool $integer_only, string $field_id, string $property ) {
+		if ( null === $value || ( is_string( $value ) && '' === trim( $value ) ) ) {
+			return null;
+		}
+
+		if ( is_int( $value ) ) {
+			self::assert_safe_integer( (string) $value, $field_id, $property );
+			return $value;
+		}
+
+		if ( is_float( $value ) ) {
+			if ( ! is_finite( $value ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s must be a finite number.', $field_id, $property ) );
+			}
+
+			if ( floor( $value ) === $value ) {
+				$integral = sprintf( '%.0f', $value );
+				self::assert_safe_integer( $integral, $field_id, $property );
+				return $integer_only ? (int) $integral : $value;
+			}
+
+			if ( $integer_only ) {
+				throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s must be an integer.', $field_id, $property ) );
+			}
+
+			return $value;
+		}
+
+		$integral = self::get_integral_decimal( $value );
+		if ( null !== $integral ) {
+			self::assert_safe_integer( $integral, $field_id, $property );
+
+			return (int) $integral;
+		}
+
+		if ( $integer_only ) {
+			throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s must be an integer.', $field_id, $property ) );
+		}
+
+		if ( ! is_string( $value ) || ! self::is_decimal_number( trim( $value ) ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s must be a finite number.', $field_id, $property ) );
+		}
+
+		$number = (float) trim( $value );
+		if ( ! is_finite( $number ) || ( 0.0 === $number && ! self::decimal_string_is_zero( trim( $value ) ) ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s cannot be represented as a finite number without loss.', $field_id, $property ) );
+		}
+
+		return $number;
+	}
+
+	/**
+	 * Return the exact integral decimal represented by a numeric value.
+	 *
+	 * @param mixed $value Candidate numeric value.
+	 * @return string|null Normalized signed integer, or null when non-integral.
+	 */
+	private static function get_integral_decimal( $value ): ?string {
+		if ( is_int( $value ) ) {
+			return (string) $value;
+		}
+
+		if ( is_float( $value ) ) {
+			return is_finite( $value ) && floor( $value ) === $value ? sprintf( '%.0f', $value ) : null;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$value = trim( $value );
+		if ( ! preg_match( '/^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:[eE]([+-]?\d+))?$/', $value, $matches ) ) {
+			return null;
+		}
+
+		$whole    = $matches[2] ?? '';
+		$fraction = '' !== ( $matches[3] ?? '' ) ? $matches[3] : ( $matches[4] ?? '' );
+		$digits   = ltrim( $whole . $fraction, '0' );
+		$digits   = '' === $digits ? '0' : $digits;
+		$exponent = $matches[5] ?? '0';
+		$negative = '-' === ( $matches[1] ?? '' );
+		$scale    = strlen( $fraction );
+
+		if ( strlen( ltrim( $exponent, '+-' ) ) > 6 ) {
+			if ( '0' === $digits ) {
+				return '0';
+			}
+
+			return '-' === substr( $exponent, 0, 1 ) ? null : ( $negative ? '-' : '' ) . str_repeat( '9', 17 );
+		}
+
+		$decimal_places = $scale - (int) $exponent;
+		if ( 0 < $decimal_places ) {
+			if ( $decimal_places >= strlen( $digits ) ) {
+				return '0' === $digits ? '0' : null;
+			}
+
+			$trailing = substr( $digits, -$decimal_places );
+			if ( '' !== trim( $trailing, '0' ) ) {
+				return null;
+			}
+			$digits = substr( $digits, 0, -$decimal_places );
+		} elseif ( 0 > $decimal_places ) {
+			$zeros = -$decimal_places;
+			if ( 17 < strlen( $digits ) + $zeros ) {
+				$digits = str_repeat( '9', 17 );
+			} else {
+				$digits .= str_repeat( '0', $zeros );
+			}
+		}
+
+		$digits = ltrim( $digits, '0' );
+		if ( '' === $digits ) {
+			return '0';
+		}
+
+		return $negative ? '-' . $digits : $digits;
+	}
+
+	/**
+	 * Assert an exact integer fits both JavaScript and the current PHP runtime.
+	 *
+	 * @param string $integer Normalized signed integer.
+	 * @param string $field_id Field id.
+	 * @param string $property Value or bound name.
+	 * @throws \InvalidArgumentException When the integer is unsafe.
+	 */
+	private static function assert_safe_integer( string $integer, string $field_id, string $property ): void {
+		$absolute = ltrim( $integer, '-' );
+		if ( self::unsigned_decimal_is_greater( $absolute, self::JAVASCRIPT_SAFE_INTEGER ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s is outside the JavaScript safe integer range.', $field_id, $property ) );
+		}
+
+		$php_integer_limit = '-' === substr( $integer, 0, 1 ) ? ltrim( (string) PHP_INT_MIN, '-' ) : (string) PHP_INT_MAX;
+		if ( self::unsigned_decimal_is_greater( $absolute, $php_integer_limit ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s cannot be represented as an integer on this PHP platform.', $field_id, $property ) );
+		}
+	}
+
+	/**
+	 * Compare normalized unsigned decimal strings.
+	 *
+	 * @param string $left Left operand.
+	 * @param string $right Right operand.
+	 * @return bool
+	 */
+	private static function unsigned_decimal_is_greater( string $left, string $right ): bool {
+		$left  = ltrim( $left, '0' );
+		$right = ltrim( $right, '0' );
+		$left  = '' === $left ? '0' : $left;
+		$right = '' === $right ? '0' : $right;
+
+		return strlen( $left ) !== strlen( $right ) ? strlen( $left ) > strlen( $right ) : 0 < strcmp( $left, $right );
+	}
+
+	/**
+	 * Whether a string follows the HTML decimal-number grammar.
+	 *
+	 * @param string $value Candidate number.
+	 * @return bool
+	 */
+	private static function is_decimal_number( string $value ): bool {
+		return 1 === preg_match( '/^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/', $value );
+	}
+
+	/**
+	 * Whether a decimal numeric string represents zero.
+	 *
+	 * @param string $value Candidate number.
+	 * @return bool
+	 */
+	private static function decimal_string_is_zero( string $value ): bool {
+		$mantissa = preg_replace( '/[eE].*$/', '', $value );
+		return '' === trim( (string) $mantissa, '+-0.' );
+	}
+
+	/**
+	 * Canonicalize numeric validation and mirror it to legacy attributes.
+	 *
+	 * @param array $field Field definition.
+	 * @param bool  $integer_only Whether bounds must be integers.
+	 * @return bool Whether provider-supplied metadata required compatibility conversion.
+	 * @throws \InvalidArgumentException When bounds are invalid or disagree.
+	 */
+	private static function canonicalize_numeric_validation( array &$field, bool $integer_only ): bool {
+		$attributes = $field['customAttributes'] ?? array();
+		$validation = $field['validation'] ?? array();
+		$converted  = false;
+
+		if ( ! is_array( $attributes ) || ! is_array( $validation ) ) {
+			return false;
+		}
+
+		foreach ( array( 'min', 'max' ) as $bound ) {
+			$has_attribute  = array_key_exists( $bound, $attributes );
+			$has_validation = array_key_exists( $bound, $validation );
+			if ( ! $has_attribute && ! $has_validation ) {
+				continue;
+			}
+
+			$original_attribute  = $has_attribute ? $attributes[ $bound ] : null;
+			$original_validation = $has_validation ? $validation[ $bound ] : null;
+			$attribute_value     = $has_attribute ? self::canonicalize_number( $original_attribute, $integer_only, $field['id'], $bound ) : null;
+			$validation_value    = $has_validation ? self::canonicalize_number( $original_validation, $integer_only, $field['id'], $bound ) : null;
+
+			if ( $has_attribute && $has_validation && ! self::numeric_values_agree( $attribute_value, $validation_value ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%1$s" %2$s disagrees between customAttributes and validation.', $field['id'], $bound ) );
+			}
+
+			$canonical            = $has_validation ? $validation_value : $attribute_value;
+			$validation[ $bound ] = $canonical;
+			$attributes[ $bound ] = $canonical;
+			$converted            = $converted ||
+				( $has_attribute && ! $has_validation ) ||
+				( $has_attribute && $original_attribute !== $attribute_value ) ||
+				( $has_validation && $original_validation !== $validation_value );
+		}
+
+		if ( ! empty( $validation ) ) {
+			$field['validation'] = $validation;
+		}
+		if ( ! empty( $attributes ) ) {
+			$field['customAttributes'] = $attributes;
+		}
+
+		return $converted;
+	}
+
+	/**
+	 * Whether two numeric values describe the same number.
+	 *
+	 * @param mixed $left Left operand.
+	 * @param mixed $right Right operand.
+	 * @return bool
+	 */
+	private static function numeric_values_agree( $left, $right ): bool {
+		if ( ! is_numeric( $left ) || ! is_numeric( $right ) ) {
+			return false;
+		}
+
+		return (float) $left === (float) $right;
+	}
+
+	/**
+	 * Canonicalize a store-local or already-qualified datetime.
+	 *
+	 * @param mixed  $value Candidate value.
+	 * @param string $field_id Field id.
+	 * @return string|null
+	 * @throws \InvalidArgumentException When the datetime is malformed.
+	 */
+	private static function canonicalize_datetime( $value, string $field_id ): ?string {
+		if ( null === $value || ( is_string( $value ) && '' === trim( $value ) ) ) {
+			return null;
+		}
+
+		if ( ! is_string( $value ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" datetime value must be a string or null.', $field_id ) );
+		}
+
+		$value = trim( $value );
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?$/', $value ) ) {
+			$format   = 16 === strlen( $value ) ? '!Y-m-d\TH:i' : '!Y-m-d\TH:i:s';
+			$datetime = \DateTimeImmutable::createFromFormat( $format, $value, wp_timezone() );
+		} elseif ( preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:Z|[+-]\d{2}:\d{2})$/', $value ) ) {
+			$format   = preg_match( '/T\d{2}:\d{2}:/', $value ) ? '!Y-m-d\TH:i:sP' : '!Y-m-d\TH:iP';
+			$datetime = \DateTimeImmutable::createFromFormat( $format, $value );
+		} else {
+			throw self::invalid_schema( sprintf( 'Field "%s" datetime value is malformed.', $field_id ) );
+		}
+
+		$errors = \DateTimeImmutable::getLastErrors();
+		if ( false === $datetime || ( is_array( $errors ) && ( 0 < $errors['warning_count'] || 0 < $errors['error_count'] ) ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" datetime value is malformed.', $field_id ) );
+		}
+
+		return $datetime->format( 'Y-m-d\TH:i:sP' );
+	}
+
+	/**
+	 * Preserve valid pre-conversion form values for changed fields.
+	 *
+	 * @param array $schema Canonical schema.
+	 * @param array $original_values Original values keyed by field id.
+	 * @throws \InvalidArgumentException When a converted value has no safe form representation.
+	 */
+	private static function preserve_converted_form_values( array &$schema, array $original_values ): void {
+		$page_save_adapter = isset( $schema['save'] ) && is_array( $schema['save'] ) ? ( $schema['save']['adapter'] ?? 'form_post' ) : 'form_post';
+		if ( 'form_post' !== $page_save_adapter ) {
+			return;
+		}
+
+		foreach ( $schema['groups'] as &$group ) {
+			if ( ! is_array( $group ) || ! isset( $group['fields'] ) || ! is_array( $group['fields'] ) ) {
+				continue;
+			}
+
+			foreach ( $group['fields'] as &$field ) {
+				if ( ! is_array( $field ) || ! isset( $field['id'] ) || ! array_key_exists( $field['id'], $original_values ) ) {
+					continue;
+				}
+
+				$original = $original_values[ $field['id'] ];
+				if ( ( $field['value'] ?? null ) === $original || 'form_post' !== self::get_field_save_adapter( $field ) ) {
+					continue;
+				}
+
+				if ( isset( $field['save'] ) && is_array( $field['save'] ) && array_key_exists( 'initialValue', $field['save'] ) ) {
+					continue;
+				}
+
+				if ( ! self::is_form_value( $original ) ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" must define save.initialValue before its native form value can be converted.', $field['id'] ) );
+				}
+
+				if ( ! isset( $field['save'] ) || ! is_array( $field['save'] ) ) {
+					$field['save'] = array( 'adapter' => 'form_post' );
+				}
+				$field['save']['initialValue'] = $original;
+			}
+			unset( $field );
+		}
+		unset( $group );
+	}
+
+	/**
+	 * Get a field's effective save adapter.
+	 *
+	 * @param array $field Field definition.
+	 * @return string
+	 */
+	private static function get_field_save_adapter( array $field ): string {
+		return isset( $field['save'] ) && is_array( $field['save'] ) ? ( $field['save']['adapter'] ?? 'form_post' ) : 'form_post';
+	}
+
+	/**
+	 * Whether a value is a valid HTML form representation.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	private static function is_form_value( $value ): bool {
+		return is_string( $value ) || ( is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) ) );
+	}
+
+	/**
+	 * Emit one compatibility notice for all affected fields.
+	 *
+	 * @param string   $method Method name reported by the notice.
+	 * @param string[] $field_ids Affected field ids.
+	 * @param string   $message Translatable sprintf message.
+	 * @param string   $version Version when the notice was introduced.
+	 */
+	private static function emit_conversion_notice( string $method, array $field_ids, string $message, string $version ): void {
+		if ( empty( $field_ids ) ) {
+			return;
+		}
+
+		wc_doing_it_wrong(
+			$method,
+			sprintf(
+				/* translators: %s: comma-separated field ids. */
+				esc_html( $message ),
+				esc_html( implode( ', ', array_unique( $field_ids ) ) )
+			),
+			$version
+		);
 	}
 
 	/**
@@ -422,14 +1026,17 @@ class SettingsUISchema {
 	/**
 	 * Whether a visibility rule carries a value compared against an options field.
 	 *
-	 * @param mixed $rule Candidate visibility rule.
-	 * @param array $option_field_ids Ids of fields carrying an options array.
+	 * @param mixed               $rule Candidate visibility rule.
+	 * @param array<string, bool> $option_field_ids Ids of fields carrying an options array.
 	 * @return bool
 	 */
 	private static function is_canonicalizable_visibility_rule( $rule, array $option_field_ids ): bool {
+		$controller = is_array( $rule ) ? ( $rule['controller'] ?? null ) : null;
+
 		return is_array( $rule )
 			&& array_key_exists( 'value', $rule )
-			&& in_array( $rule['controller'] ?? null, $option_field_ids, true );
+			&& is_string( $controller )
+			&& isset( $option_field_ids[ $controller ] );
 	}
 
 	/**
@@ -471,14 +1078,23 @@ class SettingsUISchema {
 		}
 
 		$canonical_type = self::normalize_type( $type );
-		$field          = array(
+		$save           = self::get_save_schema( $setting, $default_save_adapter );
+		if ( 'info' === $type ) {
+			$save = array( 'adapter' => 'none' );
+		}
+		$raw_value = self::get_field_raw_value( $setting, $save );
+		$field     = array(
 			'id'          => $id,
 			'label'       => self::get_field_label( $setting, $id, $type ),
 			'type'        => $canonical_type,
 			'description' => self::get_field_description( $setting, $type ),
-			'value'       => self::get_field_value( $setting, $canonical_type ),
-			'save'        => self::get_save_schema( $setting, $default_save_adapter ),
+			'value'       => $raw_value,
+			'save'        => $save,
 		);
+
+		if ( 'form_post' === ( $save['adapter'] ?? null ) && ! array_key_exists( 'initialValue', $save ) && self::is_form_value( $raw_value ) ) {
+			$field['save']['initialValue'] = $raw_value;
+		}
 
 		foreach ( array( 'component', 'placeholder', 'disabled' ) as $key ) {
 			if ( array_key_exists( $key, $setting ) ) {
@@ -577,39 +1193,46 @@ class SettingsUISchema {
 	}
 
 	/**
-	 * Get a field value.
+	 * Get the raw value for a legacy field.
 	 *
-	 * @param array  $setting Legacy field definition.
-	 * @param string $type Canonical field type.
+	 * Option-backed values are read only for legacy form-post fields. The field
+	 * name is the persistence source of truth and supports the same flat or
+	 * one-level nested shape as the classic form.
+	 *
+	 * @param array $setting Legacy field definition.
+	 * @param array $save Field save metadata.
 	 * @return mixed
+	 * @throws \InvalidArgumentException When the effective field name is unsupported.
 	 */
-	private static function get_field_value( array $setting, string $type ) {
+	private static function get_field_raw_value( array $setting, array $save ) {
 		if ( array_key_exists( 'value', $setting ) ) {
-			return self::normalize_value( $setting['value'], $type );
+			return $setting['value'];
 		}
 
 		$default = $setting['default'] ?? '';
-		$value   = \WC_Admin_Settings::get_option( (string) $setting['id'], $default );
-
-		return self::normalize_value( $value, $type );
-	}
-
-	/**
-	 * Normalize a value for the canonical schema.
-	 *
-	 * @param mixed  $value Field value.
-	 * @param string $type Canonical type.
-	 * @return mixed
-	 */
-	private static function normalize_value( $value, string $type ) {
-		switch ( $type ) {
-			case 'array':
-				return is_array( $value ) ? array_values( $value ) : array();
-			case 'checkbox':
-				return function_exists( 'wc_string_to_bool' ) ? wc_string_to_bool( $value ) : (bool) $value;
-			default:
-				return $value;
+		if ( 'form_post' !== ( $save['adapter'] ?? null ) ) {
+			return $default;
 		}
+
+		$field_name = $save['name'] ?? $setting['id'] ?? '';
+		if ( ! is_string( $field_name ) || '' === $field_name ) {
+			throw self::invalid_schema( 'A legacy form-post field must define a non-empty field name.' );
+		}
+
+		if ( false === strpos( $field_name, '[' ) && false === strpos( $field_name, ']' ) ) {
+			return get_option( $field_name, $default );
+		}
+
+		if ( ! preg_match( '/^([^\[\]]+)\[([^\[\]]+)\]$/', $field_name, $matches ) ) {
+			throw self::invalid_schema( sprintf( 'Legacy form-post field "%s" may use only one bracketed setting name.', $field_name ) );
+		}
+
+		$option = get_option( $matches[1], array() );
+		if ( ! is_array( $option ) ) {
+			throw self::invalid_schema( sprintf( 'Legacy form-post field "%s" option value must be an array.', $field_name ) );
+		}
+
+		return array_key_exists( $matches[2], $option ) ? $option[ $matches[2] ] : $default;
 	}
 
 	/**
@@ -982,6 +1605,7 @@ class SettingsUISchema {
 		self::assert_field_value( $field );
 		self::assert_field_options( $field );
 		self::assert_custom_attributes( $field );
+		self::assert_field_validation( $field );
 		self::assert_field_save( $field );
 		self::assert_visibility( $field );
 	}
@@ -999,13 +1623,19 @@ class SettingsUISchema {
 		$value = $field['value'];
 		switch ( $field['type'] ) {
 			case 'array':
-				$valid = is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) );
+				$valid = is_array( $value ) && self::is_form_value( $value );
 				break;
 			case 'checkbox':
 				$valid = is_bool( $value );
 				break;
 			case 'number':
-				$valid = self::is_finite_number( $value, true );
+				$valid = self::is_canonical_number( $value );
+				break;
+			case 'integer':
+				$valid = null === $value || ( is_int( $value ) && self::is_canonical_number( $value ) );
+				break;
+			case 'datetime-local':
+				$valid = null === $value || ( is_string( $value ) && 1 === preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/', $value ) );
 				break;
 			default:
 				$valid = is_string( $value );
@@ -1074,14 +1704,46 @@ class SettingsUISchema {
 			}
 
 			if ( in_array( $attribute, self::RANGE_ATTRIBUTES, true ) ) {
-				if ( 'number' !== $field['type'] ) {
-					throw self::invalid_schema( sprintf( 'Field "%s" may define "%s" only when its type is "number".', $field['id'], $attribute ) );
+				if ( ! in_array( $field['type'], array( 'number', 'integer' ), true ) ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" may define "%s" only when its type is "number" or "integer".', $field['id'], $attribute ) );
 				}
 
 				$allow_any = 'step' === $attribute;
-				if ( ! self::is_finite_number( $value, false ) && ! ( $allow_any && 'any' === $value ) ) {
+				$valid     = $allow_any
+					? self::is_finite_number( $value, false ) || 'any' === $value
+					: self::is_canonical_number( $value );
+				if ( ! $valid ) {
 					throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" must be a finite number.', $field['id'], $attribute ) );
 				}
+
+				if ( 'integer' === $field['type'] && in_array( $attribute, array( 'min', 'max' ), true ) && ! is_int( $value ) ) {
+					throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" must be an integer.', $field['id'], $attribute ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Assert canonical field validation metadata.
+	 *
+	 * @param array $field Field definition.
+	 */
+	private static function assert_field_validation( array $field ): void {
+		if ( ! array_key_exists( 'validation', $field ) ) {
+			return;
+		}
+
+		if ( ! is_array( $field['validation'] ) || ! in_array( $field['type'], array( 'number', 'integer' ), true ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" validation is supported only for numeric fields.', $field['id'] ) );
+		}
+
+		foreach ( $field['validation'] as $rule => $value ) {
+			if ( ! in_array( $rule, array( 'min', 'max' ), true ) || null === $value || ! self::is_canonical_number( $value ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%1$s" validation rule "%2$s" must be a finite numeric bound.', $field['id'], is_scalar( $rule ) ? (string) $rule : gettype( $rule ) ) );
+			}
+
+			if ( 'integer' === $field['type'] && ! is_int( $value ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%1$s" validation rule "%2$s" must be an integer.', $field['id'], $rule ) );
 			}
 		}
 	}
@@ -1097,13 +1759,17 @@ class SettingsUISchema {
 			throw self::invalid_schema( sprintf( 'Field "%s" save metadata must be an array.', $field['id'] ) );
 		}
 
-		$adapter = is_array( $save ) ? ( $save['adapter'] ?? null ) : 'form_post';
+		$adapter = self::get_field_save_adapter( $field );
 		if ( ! is_string( $adapter ) || ! in_array( $adapter, array( 'form_post', 'none' ), true ) ) {
 			throw self::invalid_schema( sprintf( 'Field "%s" save adapter must be "form_post" or "none".', $field['id'] ) );
 		}
 
 		if ( is_array( $save ) && array_key_exists( 'name', $save ) ) {
 			self::assert_non_empty_string( $save['name'], sprintf( 'Field "%s" save name must be a non-empty string.', $field['id'] ) );
+		}
+
+		if ( is_array( $save ) && array_key_exists( 'initialValue', $save ) && ! self::is_form_value( $save['initialValue'] ) ) {
+			throw self::invalid_schema( sprintf( 'Field "%s" save.initialValue must be a string or string list.', $field['id'] ) );
 		}
 
 		if ( 'info' === $field['type'] && 'none' !== $adapter ) {
@@ -1167,7 +1833,7 @@ class SettingsUISchema {
 			return is_finite( $value );
 		}
 
-		return is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) );
+		return is_array( $value ) && self::is_form_value( $value );
 	}
 
 	/**
@@ -1195,6 +1861,28 @@ class SettingsUISchema {
 		}
 
 		return is_numeric( $value ) && is_finite( (float) $value );
+	}
+
+	/**
+	 * Whether a value satisfies the final JavaScript number contract.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	private static function is_canonical_number( $value ): bool {
+		if ( null === $value ) {
+			return true;
+		}
+
+		if ( is_int( $value ) ) {
+			return ! self::unsigned_decimal_is_greater( ltrim( (string) $value, '-' ), self::JAVASCRIPT_SAFE_INTEGER );
+		}
+
+		if ( ! is_float( $value ) || ! is_finite( $value ) ) {
+			return false;
+		}
+
+		return floor( $value ) !== $value || ! self::unsigned_decimal_is_greater( ltrim( sprintf( '%.0f', $value ), '-' ), self::JAVASCRIPT_SAFE_INTEGER );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/SettingsUISchema.php
@@ -98,8 +98,8 @@ class SettingsUISchema {
 
 			if ( 'title' === $type ) {
 				$visibility_controller = null;
-				if ( $current_group && $current_id ) {
-					$groups[ $current_id ] = $current_group;
+				if ( null !== $current_group && null !== $current_id ) {
+					self::add_group( $groups, $current_id, $current_group );
 				}
 
 				$current_id    = isset( $setting['id'] ) && is_scalar( $setting['id'] ) && '' !== (string) $setting['id']
@@ -119,8 +119,8 @@ class SettingsUISchema {
 
 			if ( 'sectionend' === $type ) {
 				$visibility_controller = null;
-				if ( $current_group && $current_id ) {
-					$groups[ $current_id ] = $current_group;
+				if ( null !== $current_group && null !== $current_id ) {
+					self::add_group( $groups, $current_id, $current_group );
 				}
 				$current_group = null;
 				$current_id    = null;
@@ -151,8 +151,8 @@ class SettingsUISchema {
 			}
 		}
 
-		if ( $current_group && $current_id ) {
-			$groups[ $current_id ] = $current_group;
+		if ( null !== $current_group && null !== $current_id ) {
+			self::add_group( $groups, $current_id, $current_group );
 		}
 
 		uasort(
@@ -464,7 +464,7 @@ class SettingsUISchema {
 					continue;
 				}
 
-				self::canonicalize_field( $field, $converted_fields );
+				self::canonicalize_field( $field, $converted_fields, $legacy_derived );
 			}
 			unset( $field );
 		}
@@ -490,8 +490,9 @@ class SettingsUISchema {
 	 *
 	 * @param array    $field Field definition.
 	 * @param string[] $converted_fields Affected field ids.
+	 * @param bool     $legacy_derived Whether the schema came from legacy settings definitions.
 	 */
-	private static function canonicalize_field( array &$field, array &$converted_fields ): void {
+	private static function canonicalize_field( array &$field, array &$converted_fields, bool $legacy_derived ): void {
 		$type = $field['type'] ?? null;
 		if ( ! is_string( $type ) ) {
 			return;
@@ -502,7 +503,7 @@ class SettingsUISchema {
 
 		$numeric_validation_converted = false;
 
-		if ( 'number' === $type && self::should_promote_to_integer( $field ) ) {
+		if ( $legacy_derived && 'number' === $type && self::should_promote_to_integer( $field ) ) {
 			$type          = 'integer';
 			$field['type'] = $type;
 		}
@@ -939,7 +940,7 @@ class SettingsUISchema {
 					continue;
 				}
 
-				if ( ! self::is_form_value( $original ) ) {
+				if ( ! self::is_form_value_for_field( $original, $field ) ) {
 					throw self::invalid_schema( sprintf( 'Field "%s" must define save.initialValue before its native form value can be converted.', $field['id'] ) );
 				}
 
@@ -971,6 +972,31 @@ class SettingsUISchema {
 	 */
 	private static function is_form_value( $value ): bool {
 		return is_string( $value ) || ( is_array( $value ) && ArrayUtil::array_is_list( $value ) && count( $value ) === count( array_filter( $value, 'is_string' ) ) );
+	}
+
+	/**
+	 * Whether a form value preserves the canonical field value through the
+	 * classic save pipeline.
+	 *
+	 * @param mixed $value Candidate form value.
+	 * @param array $field Canonical field definition.
+	 * @return bool
+	 */
+	private static function is_form_value_for_field( $value, array $field ): bool {
+		if ( ! self::is_form_value( $value ) ) {
+			return false;
+		}
+
+		if ( 'checkbox' !== ( $field['type'] ?? null ) ) {
+			return true;
+		}
+
+		if ( ! is_string( $value ) || ! is_bool( $field['value'] ?? null ) ) {
+			return false;
+		}
+
+		$checked = '1' === $value || 'yes' === $value;
+		return $checked === $field['value'];
 	}
 
 	/**
@@ -1716,6 +1742,13 @@ class SettingsUISchema {
 					throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" must be a finite number.', $field['id'], $attribute ) );
 				}
 
+				if ( 'integer' === $field['type'] && 'step' === $attribute ) {
+					$integer_step = self::get_integral_decimal( $value );
+					if ( null === $integer_step || '0' === $integer_step || '-' === substr( $integer_step, 0, 1 ) ) {
+						throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "step" must be a positive integer.', $field['id'] ) );
+					}
+				}
+
 				if ( 'integer' === $field['type'] && in_array( $attribute, array( 'min', 'max' ), true ) && ! is_int( $value ) ) {
 					throw self::invalid_schema( sprintf( 'Field "%s" custom attribute "%s" must be an integer.', $field['id'], $attribute ) );
 				}
@@ -1768,13 +1801,42 @@ class SettingsUISchema {
 			self::assert_non_empty_string( $save['name'], sprintf( 'Field "%s" save name must be a non-empty string.', $field['id'] ) );
 		}
 
-		if ( is_array( $save ) && array_key_exists( 'initialValue', $save ) && ! self::is_form_value( $save['initialValue'] ) ) {
-			throw self::invalid_schema( sprintf( 'Field "%s" save.initialValue must be a string or string list.', $field['id'] ) );
+		if ( 'form_post' === $adapter ) {
+			$name = is_array( $save ) && array_key_exists( 'name', $save ) ? $save['name'] : $field['id'];
+			if ( ! self::is_supported_form_post_name( $name, 'array' === $field['type'] ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" save name "%s" is not a supported form-post field name.', $field['id'], $name ) );
+			}
+		}
+
+		if ( is_array( $save ) && array_key_exists( 'initialValue', $save ) ) {
+			if ( ! self::is_form_value( $save['initialValue'] ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" save.initialValue must be a string or string list.', $field['id'] ) );
+			}
+
+			if ( ! self::is_form_value_for_field( $save['initialValue'], $field ) ) {
+				throw self::invalid_schema( sprintf( 'Field "%s" save.initialValue must preserve its canonical value through classic form-post semantics.', $field['id'] ) );
+			}
 		}
 
 		if ( 'info' === $field['type'] && 'none' !== $adapter ) {
 			throw self::invalid_schema( sprintf( 'Field "%s" of type "info" must use the "none" save adapter.', $field['id'] ) );
 		}
+	}
+
+	/**
+	 * Whether a field name can be serialized by the form-post adapter.
+	 *
+	 * @param mixed $name Candidate field name.
+	 * @param bool  $is_array Whether the field posts a string list.
+	 * @return bool
+	 */
+	private static function is_supported_form_post_name( $name, bool $is_array ): bool {
+		if ( ! is_string( $name ) || '' === $name ) {
+			return false;
+		}
+
+		$base_name = $is_array && '[]' === substr( $name, -2 ) ? substr( $name, 0, -2 ) : $name;
+		return 1 === preg_match( '/^[^\[\]]+(?:\[[^\[\]]+\])?$/', $base_name );
 	}
 
 	/**
@@ -1940,5 +2002,24 @@ class SettingsUISchema {
 			'order'       => $order,
 			'fields'      => array(),
 		);
+	}
+
+	/**
+	 * Add a legacy group without allowing a later group to overwrite it.
+	 *
+	 * @param array  $groups Groups keyed by id.
+	 * @param string $group_id Group id.
+	 * @param array  $group Group definition.
+	 * @throws \InvalidArgumentException When the group id is duplicated.
+	 */
+	private static function add_group( array &$groups, string $group_id, array $group ): void {
+		// Exception messages are sanitized by invalid_schema() before they cross the schema boundary.
+		// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		if ( array_key_exists( $group_id, $groups ) ) {
+			throw self::invalid_schema( sprintf( 'Group id "%s" is duplicated.', $group_id ) );
+		}
+		// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+		$groups[ $group_id ] = $group;
 	}
 }

--- a/plugins/woocommerce/tests/e2e/test-plugins/settings-ui-component-registration/settings-ui-component-registration.php
+++ b/plugins/woocommerce/tests/e2e/test-plugins/settings-ui-component-registration/settings-ui-component-registration.php
@@ -16,102 +16,13 @@ use Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Registers the Settings UI test fixture and represents its test sections.
+ * Registers the Settings UI test fixture.
  */
-final class WC_Settings_UI_Component_Registration_Test_Plugin extends SettingsSection {
+final class WC_Settings_UI_Component_Registration_Test_Plugin {
 
 	private const REGISTERED_HANDLE   = 'settings-ui-component-test-registered';
 	private const MISSING_HANDLE      = 'settings-ui-component-test-missing-registration';
 	private const UNREGISTERED_HANDLE = 'settings-ui-component-test-unregistered';
-
-	/**
-	 * Section id.
-	 *
-	 * @var string
-	 */
-	private string $section_id;
-
-	/**
-	 * Declared script handle.
-	 *
-	 * @var string
-	 */
-	private string $script_handle;
-
-	/**
-	 * Create a test section.
-	 *
-	 * @param string $section_id   Section id.
-	 * @param string $script_handle Declared script handle.
-	 */
-	public function __construct( string $section_id, string $script_handle ) {
-		$this->section_id    = $section_id;
-		$this->script_handle = $script_handle;
-	}
-
-	/**
-	 * Get the parent page id.
-	 *
-	 * @return string
-	 */
-	public function get_parent_page_id(): string {
-		return 'products';
-	}
-
-	/**
-	 * Get the section id.
-	 *
-	 * @return string
-	 */
-	public function get_id(): string {
-		return $this->section_id;
-	}
-
-	/**
-	 * Get the section label.
-	 *
-	 * @return string
-	 */
-	public function get_label(): string {
-		return 'Settings UI component test';
-	}
-
-	/**
-	 * Get the section settings.
-	 *
-	 * @param WC_Settings_Page $parent_page Parent settings page.
-	 * @return array
-	 */
-	public function get_settings( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by the settings section contract.
-		return array(
-			array(
-				'id'    => $this->section_id . '_group',
-				'title' => 'Settings UI component test',
-				'type'  => 'title',
-			),
-			array(
-				'component' => 'woocommerce/settings-ui-component-test',
-				'default'   => 'Initial value',
-				'id'        => $this->section_id . '_value',
-				'title'     => 'Component value',
-				'type'      => 'text',
-			),
-			array(
-				'id'   => $this->section_id . '_group',
-				'type' => 'sectionend',
-			),
-		);
-	}
-
-	/**
-	 * Get the declared script handles.
-	 *
-	 * @param WC_Settings_Page $parent_page Parent settings page.
-	 * @return string[]
-	 */
-	public function get_script_handles( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by the settings section contract.
-		return array( $this->script_handle );
-	}
 
 	/**
 	 * Register hooks.
@@ -131,8 +42,6 @@ final class WC_Settings_UI_Component_Registration_Test_Plugin extends SettingsSe
 		wp_add_inline_script(
 			self::REGISTERED_HANDLE,
 			<<<'JS'
-window.wcSettingsUIComponentTest = window.wcSettingsUIComponentTest || {};
-window.wcSettingsUIComponentTest.registeredScriptExecuted = true;
 window.wcSettingsUI.registerSettingsExtension( {
 	scope: { page: 'products', section: 'settings_ui_component_registered' },
 	components: {
@@ -152,12 +61,14 @@ window.wcSettingsUI.registerSettingsExtension( {
 } );
 JS
 		);
+		wp_enqueue_script( self::REGISTERED_HANDLE );
 
 		wp_register_script( self::MISSING_HANDLE, false, array( 'wc-settings-ui' ), '1.0.0', true );
 		wp_add_inline_script(
 			self::MISSING_HANDLE,
 			'window.wcSettingsUIComponentTest = window.wcSettingsUIComponentTest || {}; window.wcSettingsUIComponentTest.missingRegistrationScriptExecuted = true;'
 		);
+		wp_enqueue_script( self::MISSING_HANDLE );
 	}
 
 	/**
@@ -168,9 +79,109 @@ JS
 	 * @param SettingsSectionRegistry $registry Settings section registry.
 	 */
 	public static function register_sections( SettingsSectionRegistry $registry ): void {
-		$registry->register( new self( 'settings_ui_component_registered', self::REGISTERED_HANDLE ) );
-		$registry->register( new self( 'settings_ui_component_missing', self::MISSING_HANDLE ) );
-		$registry->register( new self( 'settings_ui_component_unregistered', self::UNREGISTERED_HANDLE ) );
+		$registry->register( self::create_section( 'settings_ui_component_registered', self::REGISTERED_HANDLE ) );
+		$registry->register( self::create_section( 'settings_ui_component_missing', self::MISSING_HANDLE ) );
+		$registry->register( self::create_section( 'settings_ui_component_unregistered', self::UNREGISTERED_HANDLE ) );
+	}
+
+	/**
+	 * Create a Settings UI test section after WooCommerce has loaded its settings classes.
+	 *
+	 * @param string $section_id   Section id.
+	 * @param string $script_handle Declared script handle.
+	 * @return SettingsSection
+	 */
+	private static function create_section( string $section_id, string $script_handle ): SettingsSection {
+		return new class( $section_id, $script_handle ) extends SettingsSection {
+			/**
+			 * Section id.
+			 *
+			 * @var string
+			 */
+			private string $section_id;
+
+			/**
+			 * Declared script handle.
+			 *
+			 * @var string
+			 */
+			private string $script_handle;
+
+			/**
+			 * Create a test section.
+			 *
+			 * @param string $section_id   Section id.
+			 * @param string $script_handle Declared script handle.
+			 */
+			public function __construct( string $section_id, string $script_handle ) {
+				$this->section_id    = $section_id;
+				$this->script_handle = $script_handle;
+			}
+
+			/**
+			 * Get the parent page id.
+			 *
+			 * @return string
+			 */
+			public function get_parent_page_id(): string {
+				return 'products';
+			}
+
+			/**
+			 * Get the section id.
+			 *
+			 * @return string
+			 */
+			public function get_id(): string {
+				return $this->section_id;
+			}
+
+			/**
+			 * Get the section label.
+			 *
+			 * @return string
+			 */
+			public function get_label(): string {
+				return 'Settings UI component test';
+			}
+
+			/**
+			 * Get the section settings.
+			 *
+			 * @param WC_Settings_Page $parent_page Parent settings page.
+			 * @return array
+			 */
+			public function get_settings( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by the settings section contract.
+				return array(
+					array(
+						'id'    => $this->section_id . '_group',
+						'title' => 'Settings UI component test',
+						'type'  => 'title',
+					),
+					array(
+						'component' => 'woocommerce/settings-ui-component-test',
+						'default'   => 'Initial value',
+						'id'        => $this->section_id . '_value',
+						'title'     => 'Component value',
+						'type'      => 'text',
+					),
+					array(
+						'id'   => $this->section_id . '_group',
+						'type' => 'sectionend',
+					),
+				);
+			}
+
+			/**
+			 * Get the declared script handles.
+			 *
+			 * @param WC_Settings_Page $parent_page Parent settings page.
+			 * @return string[]
+			 */
+			public function get_script_handles( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by the settings section contract.
+				return array( $this->script_handle );
+			}
+		};
 	}
 }
 

--- a/plugins/woocommerce/tests/e2e/test-plugins/settings-ui-component-registration/settings-ui-component-registration.php
+++ b/plugins/woocommerce/tests/e2e/test-plugins/settings-ui-component-registration/settings-ui-component-registration.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Settings UI Component Registration Test
+ * Description: Provides Settings UI component registration scenarios for end-to-end tests.
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ *
+ * @package woocommerce-settings-ui-component-registration-test
+ */
+
+declare( strict_types=1 );
+
+use Automattic\WooCommerce\Admin\Settings\SettingsSection;
+use Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the Settings UI test fixture and represents its test sections.
+ */
+final class WC_Settings_UI_Component_Registration_Test_Plugin extends SettingsSection {
+
+	private const REGISTERED_HANDLE   = 'settings-ui-component-test-registered';
+	private const MISSING_HANDLE      = 'settings-ui-component-test-missing-registration';
+	private const UNREGISTERED_HANDLE = 'settings-ui-component-test-unregistered';
+
+	/**
+	 * Section id.
+	 *
+	 * @var string
+	 */
+	private string $section_id;
+
+	/**
+	 * Declared script handle.
+	 *
+	 * @var string
+	 */
+	private string $script_handle;
+
+	/**
+	 * Create a test section.
+	 *
+	 * @param string $section_id   Section id.
+	 * @param string $script_handle Declared script handle.
+	 */
+	public function __construct( string $section_id, string $script_handle ) {
+		$this->section_id    = $section_id;
+		$this->script_handle = $script_handle;
+	}
+
+	/**
+	 * Get the parent page id.
+	 *
+	 * @return string
+	 */
+	public function get_parent_page_id(): string {
+		return 'products';
+	}
+
+	/**
+	 * Get the section id.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return $this->section_id;
+	}
+
+	/**
+	 * Get the section label.
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return 'Settings UI component test';
+	}
+
+	/**
+	 * Get the section settings.
+	 *
+	 * @param WC_Settings_Page $parent_page Parent settings page.
+	 * @return array
+	 */
+	public function get_settings( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by the settings section contract.
+		return array(
+			array(
+				'id'    => $this->section_id . '_group',
+				'title' => 'Settings UI component test',
+				'type'  => 'title',
+			),
+			array(
+				'component' => 'woocommerce/settings-ui-component-test',
+				'default'   => 'Initial value',
+				'id'        => $this->section_id . '_value',
+				'title'     => 'Component value',
+				'type'      => 'text',
+			),
+			array(
+				'id'   => $this->section_id . '_group',
+				'type' => 'sectionend',
+			),
+		);
+	}
+
+	/**
+	 * Get the declared script handles.
+	 *
+	 * @param WC_Settings_Page $parent_page Parent settings page.
+	 * @return string[]
+	 */
+	public function get_script_handles( WC_Settings_Page $parent_page ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by the settings section contract.
+		return array( $this->script_handle );
+	}
+
+	/**
+	 * Register hooks.
+	 */
+	public static function init(): void {
+		add_action( 'admin_init', array( self::class, 'register_scripts' ) );
+		add_action( 'woocommerce_settings_sections_registration', array( self::class, 'register_sections' ) );
+	}
+
+	/**
+	 * Register test scripts before Settings UI dependencies are resolved.
+	 *
+	 * @internal
+	 */
+	public static function register_scripts(): void {
+		wp_register_script( self::REGISTERED_HANDLE, false, array( 'wc-settings-ui', 'wp-element' ), '1.0.0', true );
+		wp_add_inline_script(
+			self::REGISTERED_HANDLE,
+			<<<'JS'
+window.wcSettingsUIComponentTest = window.wcSettingsUIComponentTest || {};
+window.wcSettingsUIComponentTest.registeredScriptExecuted = true;
+window.wcSettingsUI.registerSettingsExtension( {
+	scope: { page: 'products', section: 'settings_ui_component_registered' },
+	components: {
+		'woocommerce/settings-ui-component-test': function SettingsUIComponentTest( props ) {
+			return window.wp.element.createElement(
+				'label',
+				{ 'data-testid': 'settings-ui-registered-component' },
+				'Registered settings UI component',
+				window.wp.element.createElement( 'input', {
+					'aria-label': 'Registered component value',
+					onChange: function ( event ) { props.onChange( event.target.value ); },
+					value: typeof props.value === 'string' ? props.value : '',
+				} )
+			);
+		},
+	},
+} );
+JS
+		);
+
+		wp_register_script( self::MISSING_HANDLE, false, array( 'wc-settings-ui' ), '1.0.0', true );
+		wp_add_inline_script(
+			self::MISSING_HANDLE,
+			'window.wcSettingsUIComponentTest = window.wcSettingsUIComponentTest || {}; window.wcSettingsUIComponentTest.missingRegistrationScriptExecuted = true;'
+		);
+	}
+
+	/**
+	 * Register the test settings sections.
+	 *
+	 * @internal
+	 *
+	 * @param SettingsSectionRegistry $registry Settings section registry.
+	 */
+	public static function register_sections( SettingsSectionRegistry $registry ): void {
+		$registry->register( new self( 'settings_ui_component_registered', self::REGISTERED_HANDLE ) );
+		$registry->register( new self( 'settings_ui_component_missing', self::MISSING_HANDLE ) );
+		$registry->register( new self( 'settings_ui_component_unregistered', self::UNREGISTERED_HANDLE ) );
+	}
+}
+
+WC_Settings_UI_Component_Registration_Test_Plugin::init();

--- a/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
@@ -5,6 +5,7 @@ import { expect, test, tags, request } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { setFeatureFlag, resetFeatureFlags } from '../../utils/features';
 import { setOption } from '../../utils/options';
+import { wpCLI } from '../../utils/cli';
 
 const getBaseURL = ( baseURL: string | undefined ): string => {
 	if ( ! baseURL ) {
@@ -15,7 +16,15 @@ const getBaseURL = ( baseURL: string | undefined ): string => {
 };
 
 test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
+	test.describe.configure( { mode: 'serial' } );
 	test.use( { storageState: ADMIN_STATE_PATH } );
+
+	test.beforeAll( async () => {
+		await wpCLI(
+			'ln -sfn /var/www/html/wp-content/plugins/woocommerce/tests/e2e/test-plugins/settings-ui-component-registration /var/www/html/wp-content/plugins/settings-ui-component-registration'
+		);
+		await wpCLI( 'wp plugin activate settings-ui-component-registration' );
+	} );
 
 	test.beforeEach( async ( { baseURL } ) => {
 		const url = getBaseURL( baseURL );
@@ -29,6 +38,12 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 
 		await resetFeatureFlags( request, url );
 		await setOption( request, url, 'woocommerce_enable_reviews', 'yes' );
+		await wpCLI(
+			'wp plugin deactivate settings-ui-component-registration'
+		);
+		await wpCLI(
+			'unlink /var/www/html/wp-content/plugins/settings-ui-component-registration'
+		);
 	} );
 
 	test( 'does not mount the settings UI when the feature flag is disabled', async ( {
@@ -51,5 +66,126 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 		await expect(
 			page.locator( '#woocommerce_enable_reviews' )
 		).not.toBeChecked();
+	} );
+
+	test( 'loads a declared component registration before mounting settings', async ( {
+		baseURL,
+		page,
+	} ) => {
+		const url = getBaseURL( baseURL );
+		await setFeatureFlag( request, url, 'settings-ui', true );
+
+		await page.goto(
+			'wp-admin/admin.php?page=wc-settings&tab=products&section=settings_ui_component_registered'
+		);
+
+		await expect(
+			page.locator( '[data-wc-settings-ui="1"]' )
+		).toBeVisible();
+		await expect(
+			page.getByTestId( 'settings-ui-registered-component' )
+		).toContainText( 'Registered settings UI component' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						(
+							window as unknown as {
+								wcSettingsUIComponentTest?: {
+									registeredScriptExecuted?: boolean;
+								};
+							}
+						 ).wcSettingsUIComponentTest?.registeredScriptExecuted
+				)
+			)
+			.toBe( true );
+	} );
+
+	test( 'uses classic output when a declared script handle is not registered', async ( {
+		baseURL,
+		page,
+	} ) => {
+		const url = getBaseURL( baseURL );
+		await setFeatureFlag( request, url, 'settings-ui', true );
+
+		await page.goto(
+			'wp-admin/admin.php?page=wc-settings&tab=products&section=settings_ui_component_unregistered'
+		);
+
+		await expect(
+			page.locator( '#settings_ui_component_unregistered_value' )
+		).toBeVisible();
+		await expect( page.locator( '[data-wc-settings-ui]' ) ).toHaveCount(
+			0
+		);
+		await expect(
+			page.getByRole( 'button', { name: 'Save changes' } )
+		).toBeVisible();
+	} );
+
+	test( 'fails closed when an executed script omits its component registration', async ( {
+		baseURL,
+		page,
+	} ) => {
+		const url = getBaseURL( baseURL );
+		await setFeatureFlag( request, url, 'settings-ui', true );
+		const settingsUrl =
+			'wp-admin/admin.php?page=wc-settings&tab=products&section=settings_ui_component_missing&preserved=yes';
+
+		await page.goto( settingsUrl );
+
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						(
+							window as unknown as {
+								wcSettingsUIComponentTest?: {
+									missingRegistrationScriptExecuted?: boolean;
+								};
+							}
+						 ).wcSettingsUIComponentTest
+							?.missingRegistrationScriptExecuted
+				)
+			)
+			.toBe( true );
+		await expect( page.getByRole( 'textbox' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.woocommerce-save-button' ) ).toHaveCount(
+			0
+		);
+		const classicAction = page.getByRole( 'link', {
+			name: 'Use classic settings',
+		} );
+		await expect( classicAction ).toBeVisible();
+
+		const classicHref = await classicAction.getAttribute( 'href' );
+		expect( classicHref ).not.toBeNull();
+		const classicUrl = new URL( classicHref as string );
+		expect( classicUrl.searchParams.getAll( 'wc_settings_ui' ) ).toEqual( [
+			'classic',
+		] );
+		expect( classicUrl.searchParams.get( 'page' ) ).toBe( 'wc-settings' );
+		expect( classicUrl.searchParams.get( 'tab' ) ).toBe( 'products' );
+		expect( classicUrl.searchParams.get( 'section' ) ).toBe(
+			'settings_ui_component_missing'
+		);
+		expect( classicUrl.searchParams.get( 'preserved' ) ).toBe( 'yes' );
+
+		await classicAction.click();
+		await expect( page ).toHaveURL( /wc_settings_ui=classic/ );
+		await expect(
+			page.locator( '#settings_ui_component_missing_value' )
+		).toBeVisible();
+		await expect( page.locator( '[data-wc-settings-ui]' ) ).toHaveCount(
+			0
+		);
+		await expect(
+			page.getByRole( 'button', { name: 'Save changes' } )
+		).toBeVisible();
+
+		await page.goto( settingsUrl );
+		await expect(
+			page.getByRole( 'link', { name: 'Use classic settings' } )
+		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
@@ -16,7 +16,6 @@ const getBaseURL = ( baseURL: string | undefined ): string => {
 };
 
 test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
-	test.describe.configure( { mode: 'serial' } );
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
 	test.beforeAll( async () => {
@@ -85,20 +84,6 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 		await expect(
 			page.getByTestId( 'settings-ui-registered-component' )
 		).toContainText( 'Registered settings UI component' );
-		await expect
-			.poll( () =>
-				page.evaluate(
-					() =>
-						(
-							window as unknown as {
-								wcSettingsUIComponentTest?: {
-									registeredScriptExecuted?: boolean;
-								};
-							}
-						 ).wcSettingsUIComponentTest?.registeredScriptExecuted
-				)
-			)
-			.toBe( true );
 	} );
 
 	test( 'uses classic output when a declared script handle is not registered', async ( {
@@ -134,21 +119,6 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 
 		await page.goto( settingsUrl );
 
-		await expect
-			.poll( () =>
-				page.evaluate(
-					() =>
-						(
-							window as unknown as {
-								wcSettingsUIComponentTest?: {
-									missingRegistrationScriptExecuted?: boolean;
-								};
-							}
-						 ).wcSettingsUIComponentTest
-							?.missingRegistrationScriptExecuted
-				)
-			)
-			.toBe( true );
 		await expect( page.getByRole( 'textbox' ) ).toHaveCount( 0 );
 		await expect( page.locator( '.woocommerce-save-button' ) ).toHaveCount(
 			0
@@ -157,6 +127,19 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 			name: 'Use classic settings',
 		} );
 		await expect( classicAction ).toBeVisible();
+		expect(
+			await page.evaluate(
+				() =>
+					(
+						window as unknown as {
+							wcSettingsUIComponentTest?: {
+								missingRegistrationScriptExecuted?: boolean;
+							};
+						}
+					 ).wcSettingsUIComponentTest
+						?.missingRegistrationScriptExecuted
+			)
+		).toBe( true );
 
 		const classicHref = await classicAction.getAttribute( 'href' );
 		expect( classicHref ).not.toBeNull();

--- a/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/settings-ui-feature-flag.spec.ts
@@ -37,6 +37,14 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 
 		await resetFeatureFlags( request, url );
 		await setOption( request, url, 'woocommerce_enable_reviews', 'yes' );
+		await setOption( request, url, 'woocommerce_manage_stock', 'yes' );
+		await setOption( request, url, 'woocommerce_hold_stock_minutes', '60' );
+		await setOption(
+			request,
+			url,
+			'woocommerce_notify_low_stock_amount',
+			'2'
+		);
 		await wpCLI(
 			'wp plugin deactivate settings-ui-component-registration'
 		);
@@ -65,6 +73,59 @@ test.describe( 'Settings UI feature flag', { tag: tags.NOT_E2E }, () => {
 		await expect(
 			page.locator( '#woocommerce_enable_reviews' )
 		).not.toBeChecked();
+	} );
+
+	test( 'preserves an untouched inventory value when another setting is saved', async ( {
+		baseURL,
+		page,
+	} ) => {
+		const url = getBaseURL( baseURL );
+		await setFeatureFlag( request, url, 'settings-ui', true );
+		await setOption( request, url, 'woocommerce_manage_stock', 'yes' );
+		await setOption( request, url, 'woocommerce_hold_stock_minutes', '60' );
+		await setOption(
+			request,
+			url,
+			'woocommerce_notify_low_stock_amount',
+			'02'
+		);
+
+		await page.goto(
+			'wp-admin/admin.php?page=wc-settings&tab=products&section=inventory'
+		);
+
+		const editedHoldStock = page.getByRole( 'spinbutton', {
+			name: 'Hold stock (minutes)',
+		} );
+		const preservedLowStock = page.getByRole( 'spinbutton', {
+			name: 'Low stock threshold',
+		} );
+		const lowStockFormValue = page.locator(
+			'input[type="hidden"][name="woocommerce_notify_low_stock_amount"]'
+		);
+
+		await expect(
+			page.locator( '[data-wc-settings-ui="1"]' )
+		).toBeVisible();
+		await expect( preservedLowStock ).toHaveValue( '2' );
+		await expect( lowStockFormValue ).toHaveValue( '02' );
+		await editedHoldStock.fill( '61' );
+		await expect( lowStockFormValue ).toHaveValue( '02' );
+		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
+
+		await expect( page.locator( 'div.updated.inline' ) ).toContainText(
+			'Your settings have been saved.'
+		);
+		await expect( preservedLowStock ).toBeVisible();
+		await expect( preservedLowStock ).toHaveValue( '2' );
+		await expect( editedHoldStock ).toHaveValue( '61' );
+
+		const [ holdStockOption, lowStockOption ] = await Promise.all( [
+			wpCLI( 'wp option get woocommerce_hold_stock_minutes' ),
+			wpCLI( 'wp option get woocommerce_notify_low_stock_amount' ),
+		] );
+		expect( holdStockOption.stdout.trim() ).toBe( '61' );
+		expect( lowStockOption.stdout.trim() ).toBe( '02' );
 	} );
 
 	test( 'loads a declared component registration before mounting settings', async ( {

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
@@ -65,6 +65,10 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 		$this->original_current_section = $current_section ?? null;
 		$this->original_current_tab     = $current_tab ?? null;
 
+		foreach ( array( 'acme-native-settings-ui', 'acme-payments-settings-ui', 'direct-payments-settings-ui' ) as $script_handle ) {
+			wp_register_script( $script_handle, false, array(), '1.0.0', true );
+		}
+
 		SettingsSectionRegistry::get_instance()->unregister_all();
 		SettingsUIRequestContext::reset();
 	}
@@ -80,6 +84,10 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 		$current_tab     = $this->original_current_tab;
 
 		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		foreach ( array( 'acme-native-settings-ui', 'acme-payments-settings-ui', 'direct-payments-settings-ui' ) as $script_handle ) {
+			wp_dequeue_script( $script_handle );
+			wp_deregister_script( $script_handle );
+		}
 		SettingsSectionRegistry::get_instance()->unregister_all();
 		SettingsUIRequestContext::reset();
 

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
@@ -135,6 +135,7 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'form_post', $settings_ui_page->get_save_adapter( 'acme_payments' ) );
 
 		$schema = $settings_ui_page->get_schema( 'acme_payments' );
+		SettingsUISchema::assert_valid_schema( $schema );
 		$this->assertSame( 'Acme Payments', $schema['title'] );
 		$this->assertSame( 'Acme Payments', $schema['shell']['title'] );
 	}
@@ -158,6 +159,42 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'native_tab', $schema['section'] );
 		$this->assertArrayHasKey( 'native_group', $schema['groups'] );
 		$this->assertArrayNotHasKey( 'registered_acme_payments_setting', $schema['groups'] );
+	}
+
+	/**
+	 * @testdox A registered native page accepts transitional number and datetime values.
+	 */
+	public function test_registered_native_page_schema_accepts_transitional_number_and_datetime_values(): void {
+		$page = $this->get_parent_page();
+		SettingsSectionRegistry::get_instance()->register(
+			$this->get_registered_section_with_native_settings_ui_page(
+				null,
+				null,
+				null,
+				array(
+					array(
+						'id'    => 'acme_number',
+						'label' => 'Acme number',
+						'type'  => 'number',
+						'value' => '02',
+						'save'  => array( 'adapter' => 'form_post' ),
+					),
+					array(
+						'id'    => 'acme_datetime',
+						'label' => 'Acme datetime',
+						'type'  => 'datetime-local',
+						'value' => '2026-08-03T12:30',
+						'save'  => array( 'adapter' => 'form_post' ),
+					),
+				)
+			)
+		);
+
+		$settings_ui_page = SettingsUIRequestContext::for_settings_page( $page, 'acme_payments' )->get_settings_ui_page();
+		$this->assertInstanceOf( SettingsUIPageInterface::class, $settings_ui_page );
+		$schema = $settings_ui_page->get_schema( 'acme_payments' );
+
+		SettingsUISchema::assert_valid_schema( $schema );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Settings/SettingsSectionRegistryTest.php
@@ -170,9 +170,18 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A registered native page accepts transitional number and datetime values.
+	 * @testdox A registered native page converts transitional number and datetime values before validation.
 	 */
 	public function test_registered_native_page_schema_accepts_transitional_number_and_datetime_values(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+		$compatibility_notices = 0;
+		$notice_listener       = static function ( string $function_name ) use ( &$compatibility_notices ): void {
+			if ( SettingsUISchema::class . '::canonicalize_schema_values' === $function_name ) {
+				++$compatibility_notices;
+			}
+		};
+		add_action( 'doing_it_wrong_run', $notice_listener );
+
 		$page = $this->get_parent_page();
 		SettingsSectionRegistry::get_instance()->register(
 			$this->get_registered_section_with_native_settings_ui_page(
@@ -198,10 +207,19 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$settings_ui_page = SettingsUIRequestContext::for_settings_page( $page, 'acme_payments' )->get_settings_ui_page();
-		$this->assertInstanceOf( SettingsUIPageInterface::class, $settings_ui_page );
-		$schema = $settings_ui_page->get_schema( 'acme_payments' );
+		try {
+			$context = SettingsUIRequestContext::for_settings_page( $page, 'acme_payments' );
+			$schema  = $context->get_schema();
+		} finally {
+			remove_action( 'doing_it_wrong_run', $notice_listener );
+		}
 
+		$this->assertFalse( $context->has_schema_failed() );
+		$this->assertSame( 1, $compatibility_notices, 'All converted native fields should be reported in one compatibility notice.' );
+		$this->assertSame( 2, $schema['groups']['native_group']['fields'][0]['value'] );
+		$this->assertArrayNotHasKey( 'initialValue', $schema['groups']['native_group']['fields'][0]['save'] );
+		$this->assertSame( '2026-08-03T12:30:00+00:00', $schema['groups']['native_group']['fields'][1]['value'] );
+		$this->assertArrayNotHasKey( 'initialValue', $schema['groups']['native_group']['fields'][1]['save'] );
 		SettingsUISchema::assert_valid_schema( $schema );
 	}
 
@@ -209,7 +227,7 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 	 * @testdox Should canonicalize option values from a native Settings UI page provider.
 	 */
 	public function test_canonicalizes_option_values_from_native_settings_ui_page(): void {
-		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_option_values' );
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
 
 		$page = $this->get_parent_page();
 		SettingsSectionRegistry::get_instance()->register(
@@ -223,6 +241,10 @@ class SettingsSectionRegistryTest extends WC_Unit_Test_Case {
 						'label'   => 'Tier',
 						'type'    => 'select',
 						'value'   => 1,
+						'save'    => array(
+							'adapter'      => 'form_post',
+							'initialValue' => '1',
+						),
 						'options' => array(
 							array(
 								'label' => 'One',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
 
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Internal\Admin\Settings;
 use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIRequestContext;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
@@ -92,6 +93,11 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
 		remove_filter( 'woocommerce_admin_features', array( $this, 'disable_settings_ui_feature' ) );
+		wp_dequeue_script( 'settings-ui-counting-handle' );
+		wp_deregister_script( 'settings-ui-counting-handle' );
+		wp_dequeue_script( 'settings-ui-registered-handle' );
+		wp_deregister_script( 'settings-ui-registered-handle' );
+		delete_option( 'woocommerce_settings_ui_flag_test' );
 		SettingsUIRequestContext::reset();
 
 		parent::tearDown();
@@ -217,7 +223,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 		$this->assertSame( '10.9.0', $settings_page_notices[0]['version'] );
 		$this->assertStringContainsString( 'settings_ui_flag_test', $settings_page_notices[0]['message'] );
 		$this->assertStringContainsString( 'advanced', $settings_page_notices[0]['message'] );
-		$this->assertStringContainsString( 'Settings UI schema generation failed.', $settings_page_notices[0]['message'] );
+		$this->assertStringContainsString( 'Unable to build settings UI schema.', $settings_page_notices[0]['message'] );
 	}
 
 	/**
@@ -225,6 +231,7 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	 */
 	public function test_settings_ui_script_handles_are_resolved_once_per_context(): void {
 		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		wp_register_script( 'settings-ui-counting-handle', false, array(), '1.0.0', true );
 
 		global $current_section;
 		$current_section = '';
@@ -238,6 +245,184 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 		ob_get_clean();
 
 		$this->assertSame( 1, $this->get_script_handle_resolution_count( $page ), 'Script handles should be resolved once for a page and section context.' );
+	}
+
+	/**
+	 * @testdox Should render the complete classic page once with a precise diagnostic when schema validation fails.
+	 */
+	public function test_invalid_schema_uses_complete_classic_fallback_once_without_changing_the_option(): void {
+		global $current_section, $current_tab, $wpdb;
+
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+
+		update_option( 'woocommerce_settings_ui_flag_test', '02' );
+		$stored_before = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+
+		$notices = array();
+		$action  = static function ( $function_name, $message, $version ) use ( &$notices ): void {
+			$notices[] = array(
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			);
+		};
+		add_action( 'doing_it_wrong_run', $action, 10, 3 );
+
+		$current_section = '';
+		$current_tab     = 'settings_ui_flag_test';
+		$page            = $this->get_settings_ui_test_page_with_invalid_schema();
+		$context         = SettingsUIRequestContext::for_settings_page( $page, '' );
+
+		try {
+			$classes = $page->add_settings_ui_body_class( 'existing-class' );
+			$output  = $this->render_settings_view( $page );
+		} finally {
+			remove_action( 'doing_it_wrong_run', $action, 10 );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$stored_after          = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+		$settings_page_notices = $this->get_settings_page_output_notices( $notices );
+
+		$this->assertSame( 'existing-class', $classes, 'Classic body classes should remain unchanged.' );
+		$this->assertStringContainsString( 'name="woocommerce_settings_ui_flag_test"', $output );
+		$this->assertStringContainsString( 'class="woocommerce-save-button', $output );
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertTrue( empty( $GLOBALS['hide_save_button'] ), 'The classic Save button should remain visible.' );
+		$this->assertNull( $context->get_schema(), 'An invalid schema must not be available for the shared settings asset.' );
+		$this->assertTrue( $context->has_schema_failed() );
+		$this->assertSame( 1, $this->get_schema_resolution_count( $page ), 'Schema validation should run once per request context.' );
+		$this->assertCount( 1, $settings_page_notices, 'The fallback diagnostic should be emitted once.' );
+		$this->assertStringContainsString( 'woocommerce_settings_ui_flag_test', $settings_page_notices[0]['message'] );
+		$this->assertStringContainsString( 'unsupported type "future-control"', $settings_page_notices[0]['message'] );
+		$this->assertSame( $stored_before, $stored_after, 'Classic fallback must preserve the raw stored option representation.' );
+	}
+
+	/**
+	 * @testdox Should fall back to classic settings when a declared script handle is not registered.
+	 */
+	public function test_unregistered_script_handle_uses_classic_fallback_with_precise_reason(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+
+		$notices = array();
+		$action  = static function ( $function_name, $message, $version ) use ( &$notices ): void {
+			$notices[] = array(
+				'function_name' => $function_name,
+				'message'       => $message,
+				'version'       => $version,
+			);
+		};
+		add_action( 'doing_it_wrong_run', $action, 10, 3 );
+
+		global $current_section;
+		$current_section = '';
+		$page            = $this->get_settings_ui_test_page_with_script_handles( array( 'settings-ui-missing-handle' ) );
+
+		try {
+			ob_start();
+			$page->output();
+			$output = ob_get_clean();
+		} finally {
+			remove_action( 'doing_it_wrong_run', $action, 10 );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$settings_page_notices = $this->get_settings_page_output_notices( $notices );
+
+		$this->assertStringContainsString( 'name="woocommerce_settings_ui_flag_test"', $output );
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertTrue( empty( $GLOBALS['hide_save_button'] ), 'The classic Save button should remain visible.' );
+		$this->assertCount( 1, $settings_page_notices );
+		$this->assertStringContainsString( 'settings-ui-missing-handle', $settings_page_notices[0]['message'] );
+		$this->assertStringContainsString( 'not registered', $settings_page_notices[0]['message'] );
+	}
+
+	/**
+	 * @testdox Should reject a declared extension script handle that is not a string.
+	 */
+	public function test_non_string_script_handle_is_rejected_before_schema_emission(): void {
+		$page    = $this->get_settings_ui_test_page_with_script_handles( array( 42 ) );
+		$context = SettingsUIRequestContext::for_settings_page( $page, '' );
+
+		$this->assertTrue( $context->has_script_handles_failed() );
+		$this->assertNull( $context->get_schema() );
+		$this->assertStringContainsString( 'must be non-empty strings', $context->get_script_handles_failure_reason() );
+	}
+
+	/**
+	 * @testdox Should enqueue each registered extension script handle before rendering the Settings UI mount.
+	 */
+	public function test_registered_script_handle_is_enqueued_before_settings_ui_mount(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		wp_register_script( 'settings-ui-registered-handle', false, array(), '1.0.0', true );
+
+		global $current_section;
+		$current_section = '';
+		$page            = $this->get_settings_ui_test_page_with_script_handles( array( 'settings-ui-registered-handle' ) );
+
+		ob_start();
+		$page->output();
+		$output = ob_get_clean();
+
+		$this->assertTrue( wp_script_is( 'settings-ui-registered-handle', 'enqueued' ) );
+		$this->assertStringContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertTrue( $GLOBALS['hide_save_button'] );
+	}
+
+	/**
+	 * @testdox Should use classic settings only for a request carrying the namespaced override.
+	 */
+	public function test_classic_request_override_preserves_routing_without_changing_the_feature_flag(): void {
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+
+		global $current_section, $current_tab;
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only rendering override under test.
+		$current_section        = 'test_gateway';
+		$current_tab            = 'checkout';
+		$_GET['page']           = 'wc-settings';
+		$_GET['tab']            = 'checkout';
+		$_GET['section']        = 'test_gateway';
+		$_GET['wc_settings_ui'] = 'classic';
+		$expected_query         = $_GET;
+		$page                   = $this->get_settings_ui_test_page_for_drill_down();
+
+		$classes = $page->add_settings_ui_body_class( 'existing-class' );
+		ob_start();
+		$page->output();
+		$classic_output = ob_get_clean();
+
+		$this->assertSame( $expected_query, $_GET, 'The override must not alter page or section routing.' );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		$this->assertSame( 'existing-class', $classes );
+		$this->assertStringContainsString( 'name="woocommerce_settings_ui_drill_down_test"', $classic_output );
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $classic_output );
+		$this->assertTrue( empty( $GLOBALS['hide_save_button'] ), 'The classic Save button should remain visible.' );
+		$this->assertTrue( Features::is_enabled( 'settings-ui' ), 'The request override must not persistently disable the feature.' );
+
+		unset( $_GET['wc_settings_ui'] );
+		SettingsUIRequestContext::reset();
+		unset( $GLOBALS['hide_save_button'] );
+
+		ob_start();
+		$page->output();
+		$settings_ui_output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-wc-settings-ui="1"', $settings_ui_output );
+		$this->assertTrue( Features::is_enabled( 'settings-ui' ) );
 	}
 
 	/**
@@ -851,6 +1036,166 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Build a settings page whose Settings UI schema contains an unsupported field type.
+	 *
+	 * @return \WC_Settings_Page
+	 */
+	private function get_settings_ui_test_page_with_invalid_schema(): \WC_Settings_Page {
+		return new class() extends \WC_Settings_Page {
+			/**
+			 * Schema resolution count.
+			 *
+			 * @var int
+			 */
+			private int $schema_resolution_count = 0;
+
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id    = 'settings_ui_flag_test';
+				$this->label = 'Settings UI flag test';
+			}
+
+			/**
+			 * Get the settings UI page adapter.
+			 *
+			 * @return \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface|null
+			 */
+			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
+				return new class( $this ) extends \Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter {
+					/**
+					 * Build an invalid schema.
+					 *
+					 * @param string $section_id Section id.
+					 * @return array
+					 */
+					public function get_schema( string $section_id ): array {
+						$schema = parent::get_schema( $section_id );
+						$this->settings_page->increment_schema_resolution_count();
+						$schema['groups']['default']['fields'][0]['type'] = 'future-control';
+
+						return $schema;
+					}
+				};
+			}
+
+			/**
+			 * Increment the schema resolution count.
+			 */
+			public function increment_schema_resolution_count(): void {
+				++$this->schema_resolution_count;
+			}
+
+			/**
+			 * Get the schema resolution count.
+			 *
+			 * @return int
+			 */
+			public function get_schema_resolution_count(): int {
+				return $this->schema_resolution_count;
+			}
+
+			/**
+			 * Get settings for the default section.
+			 *
+			 * @return array
+			 */
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'id'    => 'woocommerce_settings_ui_flag_test',
+						'type'  => 'text',
+						'title' => 'Settings UI flag test',
+					),
+				);
+			}
+		};
+	}
+
+	/**
+	 * Build a settings page declaring extension script handles.
+	 *
+	 * @param array $script_handles Script handles.
+	 * @return \WC_Settings_Page
+	 */
+	private function get_settings_ui_test_page_with_script_handles( array $script_handles ): \WC_Settings_Page {
+		return new class( $script_handles ) extends \WC_Settings_Page {
+			/**
+			 * Extension script handles.
+			 *
+			 * @var array
+			 */
+			private array $script_handles;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array $script_handles Script handles.
+			 */
+			public function __construct( array $script_handles ) {
+				$this->id             = 'settings_ui_flag_test';
+				$this->label          = 'Settings UI flag test';
+				$this->script_handles = $script_handles;
+			}
+
+			/**
+			 * Get the settings UI page adapter.
+			 *
+			 * @return \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface|null
+			 */
+			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
+				return new class( $this, $this->script_handles ) extends \Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter {
+					/**
+					 * Extension script handles.
+					 *
+					 * @var array
+					 */
+					private array $script_handles;
+
+					/**
+					 * Constructor.
+					 *
+					 * @param \WC_Settings_Page $settings_page Settings page.
+					 * @param array             $script_handles Script handles.
+					 */
+					public function __construct( \WC_Settings_Page $settings_page, array $script_handles ) {
+						parent::__construct( $settings_page );
+						$this->script_handles = $script_handles;
+					}
+
+					/**
+					 * Get script handles.
+					 *
+					 * @param string $section_id Section id.
+					 * @return array
+					 */
+					public function get_script_handles( string $section_id ): array {
+						unset( $section_id );
+
+						return $this->script_handles;
+					}
+				};
+			}
+
+			/**
+			 * Get settings for the default section.
+			 *
+			 * @return array
+			 */
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'id'    => 'woocommerce_settings_ui_flag_test',
+						'type'  => 'text',
+						'title' => 'Settings UI flag test',
+					),
+				);
+			}
+		};
+	}
+
+	/**
 	 * Get the script handle resolution count for a counting test page.
 	 *
 	 * @param \WC_Settings_Page $page Settings page.
@@ -858,6 +1203,19 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	 */
 	private function get_script_handle_resolution_count( \WC_Settings_Page $page ): int {
 		$method = new \ReflectionMethod( $page, 'get_script_handle_resolution_count' );
+		$method->setAccessible( true );
+
+		return (int) $method->invoke( $page );
+	}
+
+	/**
+	 * Get the schema resolution count for a counting test page.
+	 *
+	 * @param \WC_Settings_Page $page Settings page.
+	 * @return int
+	 */
+	private function get_schema_resolution_count( \WC_Settings_Page $page ): int {
+		$method = new \ReflectionMethod( $page, 'get_schema_resolution_count' );
 		$method->setAccessible( true );
 
 		return (int) $method->invoke( $page );
@@ -989,5 +1347,27 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		return $method->invokeArgs( $target, $arguments );
+	}
+
+	/**
+	 * Render the complete classic settings view for a test page.
+	 *
+	 * @param \WC_Settings_Page $page Settings page.
+	 * @return string
+	 */
+	private function render_settings_view( \WC_Settings_Page $page ): string {
+		global $current_tab;
+
+		$tabs   = array( $current_tab => $page->get_label() );
+		$action = array( $page, 'output' );
+		add_action( 'woocommerce_settings_' . $current_tab, $action );
+
+		try {
+			ob_start();
+			include WC_ABSPATH . 'includes/admin/views/html-admin-settings.php';
+			return (string) ob_get_clean();
+		} finally {
+			remove_action( 'woocommerce_settings_' . $current_tab, $action );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -311,6 +311,59 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should render classic settings without saving when value canonicalization fails.
+	 */
+	public function test_invalid_value_canonicalization_uses_classic_fallback_without_saving(): void {
+		global $current_section, $current_tab, $wpdb;
+
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+
+		update_option( 'woocommerce_settings_ui_flag_test', '9007199254740992' );
+		$stored_before = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+
+		$current_section = '';
+		$current_tab     = 'settings_ui_flag_test';
+		$page            = $this->get_settings_ui_test_page_with_invalid_canonical_value();
+		$context         = SettingsUIRequestContext::for_settings_page( $page, '' );
+		$save_calls      = 0;
+		$save_listener   = static function ( $value ) use ( &$save_calls ) {
+			++$save_calls;
+			return $value;
+		};
+		add_filter( 'woocommerce_admin_settings_sanitize_option', $save_listener );
+
+		try {
+			$output = $this->render_settings_view( $page );
+		} finally {
+			remove_filter( 'woocommerce_admin_settings_sanitize_option', $save_listener );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$stored_after = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+
+		$this->assertNull( $context->get_schema() );
+		$this->assertTrue( $context->has_schema_failed() );
+		$this->assertStringContainsString( 'outside the JavaScript safe integer range', $context->get_schema_failure_reason() );
+		$this->assertStringContainsString( 'name="woocommerce_settings_ui_flag_test"', $output );
+		$this->assertStringContainsString( 'class="woocommerce-save-button', $output );
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertSame( 0, $save_calls, 'Rendering classic fallback must not invoke the settings save pipeline.' );
+		$this->assertSame( $stored_before, $stored_after );
+	}
+
+	/**
 	 * @testdox Should fall back to classic settings when a declared script handle is not registered.
 	 */
 	public function test_unregistered_script_handle_uses_classic_fallback_with_precise_reason(): void {
@@ -1107,6 +1160,48 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 						'id'    => 'woocommerce_settings_ui_flag_test',
 						'type'  => 'text',
 						'title' => 'Settings UI flag test',
+					),
+				);
+			}
+		};
+	}
+
+	/**
+	 * Build a settings page whose numeric value cannot cross the JavaScript boundary safely.
+	 *
+	 * @return \WC_Settings_Page
+	 */
+	private function get_settings_ui_test_page_with_invalid_canonical_value(): \WC_Settings_Page {
+		return new class() extends \WC_Settings_Page {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id    = 'settings_ui_flag_test';
+				$this->label = 'Settings UI flag test';
+			}
+
+			/**
+			 * Get the settings UI page adapter.
+			 *
+			 * @return \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface|null
+			 */
+			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
+				return new \Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter( $this );
+			}
+
+			/**
+			 * Get settings for the default section.
+			 *
+			 * @return array
+			 */
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'id'                => 'woocommerce_settings_ui_flag_test',
+						'type'              => 'number',
+						'title'             => 'Settings UI flag test',
+						'custom_attributes' => array( 'step' => 1 ),
 					),
 				);
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUIFeatureFlagTest.php
@@ -311,6 +311,51 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should use complete classic fallback when legacy group ids are duplicated.
+	 */
+	public function test_duplicate_legacy_group_ids_use_classic_fallback_without_changing_the_option(): void {
+		global $current_section, $current_tab, $wpdb;
+
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_settings_ui_feature' ) );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WC_Settings_Page::output' );
+
+		update_option( 'woocommerce_settings_ui_flag_test', 'yes' );
+		$stored_before = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+
+		$current_section = '';
+		$current_tab     = 'settings_ui_flag_test';
+		$page            = $this->get_settings_ui_test_page_with_duplicate_group_ids();
+		$context         = SettingsUIRequestContext::for_settings_page( $page, '' );
+
+		try {
+			$output = $this->render_settings_view( $page );
+		} finally {
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$stored_after = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				'woocommerce_settings_ui_flag_test'
+			)
+		);
+
+		$this->assertStringContainsString( 'name="woocommerce_settings_ui_flag_test"', $output );
+		$this->assertStringContainsString( 'class="woocommerce-save-button', $output );
+		$this->assertStringNotContainsString( 'data-wc-settings-ui="1"', $output );
+		$this->assertNull( $context->get_schema() );
+		$this->assertTrue( $context->has_schema_failed() );
+		$this->assertStringContainsString( 'Group id "main" is duplicated.', $context->get_schema_failure_reason() );
+		$this->assertSame( $stored_before, $stored_after );
+	}
+
+	/**
 	 * @testdox Should render classic settings without saving when value canonicalization fails.
 	 */
 	public function test_invalid_value_canonicalization_uses_classic_fallback_without_saving(): void {
@@ -1160,6 +1205,63 @@ class SettingsUIFeatureFlagTest extends WC_Unit_Test_Case {
 						'id'    => 'woocommerce_settings_ui_flag_test',
 						'type'  => 'text',
 						'title' => 'Settings UI flag test',
+					),
+				);
+			}
+		};
+	}
+
+	/**
+	 * Build a settings page whose legacy settings contain duplicate group ids.
+	 *
+	 * @return \WC_Settings_Page
+	 */
+	private function get_settings_ui_test_page_with_duplicate_group_ids(): \WC_Settings_Page {
+		return new class() extends \WC_Settings_Page {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->id    = 'settings_ui_flag_test';
+				$this->label = 'Settings UI flag test';
+			}
+
+			/**
+			 * Get the settings UI page adapter.
+			 *
+			 * @return \Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface|null
+			 */
+			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
+				return new \Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter( $this );
+			}
+
+			/**
+			 * Get settings for the default section.
+			 *
+			 * @return array
+			 */
+			protected function get_settings_for_default_section() {
+				return array(
+					array(
+						'id'    => 'main',
+						'type'  => 'title',
+						'title' => 'First group',
+					),
+					array(
+						'id'    => 'woocommerce_settings_ui_flag_test',
+						'type'  => 'checkbox',
+						'title' => 'Enabled',
+					),
+					array( 'type' => 'sectionend' ),
+					array(
+						'id'    => 'main',
+						'type'  => 'title',
+						'title' => 'Second group',
+					),
+					array(
+						'id'    => 'woocommerce_settings_ui_flag_test_label',
+						'type'  => 'text',
+						'title' => 'Label',
 					),
 				);
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -1260,6 +1260,205 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox It preserves an unchanged numeric form value through the classic save pipeline.
+	 */
+	public function test_schema_post_preserves_unchanged_numeric_form_value(): void {
+		$settings = $this->get_numeric_save_settings();
+		update_option( 'acme_quantity', '02' );
+
+		try {
+			$schema   = SettingsUISchema::from_legacy_settings( 'acme', '', 'Acme', $settings );
+			$post     = $this->get_schema_post_data( $schema );
+			$captured = $this->save_fields_and_capture( $settings, $post, 'acme_quantity' );
+
+			$this->assertSame( array( 'acme_quantity' => '02' ), $post );
+			$this->assertSame( '02', $captured['global']['raw'] );
+			$this->assertSame( '02', $captured['global']['sanitized'] );
+			$this->assertSame( '02', $captured['specific']['raw'] );
+			$this->assertSame( '02', $captured['specific']['sanitized'] );
+			$this->assertSame( '02', get_option( 'acme_quantity' ) );
+			$this->assertSame( '02', $this->get_raw_option_value( 'acme_quantity' ) );
+		} finally {
+			delete_option( 'acme_quantity' );
+		}
+	}
+
+	/**
+	 * @testdox It sends edited numeric state through the existing classic sanitizer.
+	 */
+	public function test_schema_post_saves_edited_numeric_value_canonically(): void {
+		$settings = $this->get_numeric_save_settings();
+		update_option( 'acme_quantity', '01' );
+
+		try {
+			$schema   = SettingsUISchema::from_legacy_settings( 'acme', '', 'Acme', $settings );
+			$post     = $this->get_schema_post_data( $schema, array( 'acme_quantity' => '2' ) );
+			$captured = $this->save_fields_and_capture( $settings, $post, 'acme_quantity' );
+
+			$this->assertSame( array( 'acme_quantity' => '2' ), $post );
+			$this->assertSame( '2', $captured['global']['raw'] );
+			$this->assertSame( '2', $captured['global']['sanitized'] );
+			$this->assertSame( '2', $captured['specific']['raw'] );
+			$this->assertSame( '2', $captured['specific']['sanitized'] );
+			$this->assertSame( '2', get_option( 'acme_quantity' ) );
+			$this->assertSame( '2', $this->get_raw_option_value( 'acme_quantity' ) );
+		} finally {
+			delete_option( 'acme_quantity' );
+		}
+	}
+
+	/**
+	 * @testdox It preserves classic POST shapes for nested, checkbox, array, and datetime fields.
+	 */
+	public function test_schema_post_matches_classic_shapes_for_typed_fields(): void {
+		$original_timezone = get_option( 'timezone_string' );
+		$settings          = array(
+			array(
+				'id'                => 'acme_quantity',
+				'field_name'        => 'acme_settings[quantity]',
+				'title'             => 'Quantity',
+				'type'              => 'number',
+				'custom_attributes' => array( 'step' => 1 ),
+			),
+			array(
+				'id'    => 'acme_enabled',
+				'title' => 'Enabled',
+				'type'  => 'checkbox',
+			),
+			array(
+				'id'      => 'acme_methods',
+				'title'   => 'Methods',
+				'type'    => 'multiselect',
+				'options' => array(
+					'card' => 'Card',
+					'link' => 'Link',
+				),
+			),
+			array(
+				'id'    => 'acme_start',
+				'title' => 'Starts',
+				'type'  => 'datetime-local',
+			),
+		);
+		$option_names      = array( 'acme_settings', 'acme_enabled', 'acme_methods', 'acme_start' );
+
+		update_option(
+			'acme_settings',
+			array(
+				'quantity' => '02',
+				'other'    => 'keep',
+			)
+		);
+		update_option( 'acme_enabled', 'yes' );
+		update_option( 'acme_methods', array( 'card' ) );
+		update_option( 'acme_start', '2026-08-03T12:30' );
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$captured = array();
+		$listener = static function ( $value, $option, $raw_value ) use ( &$captured ) {
+			$captured[ $option['id'] ] = $raw_value;
+			return $value;
+		};
+		add_filter( 'woocommerce_admin_settings_sanitize_option', $listener, 10, 3 );
+
+		try {
+			include_once WC_ABSPATH . 'includes/admin/class-wc-admin-settings.php';
+			$schema = SettingsUISchema::from_legacy_settings( 'acme', '', 'Acme', $settings );
+			$post   = $this->get_schema_post_data(
+				$schema,
+				array(
+					'acme_quantity' => '3',
+					'acme_enabled'  => 'no',
+					'acme_methods'  => array( 'card', 'link' ),
+					'acme_start'    => '2026-08-03T13:45:00',
+				)
+			);
+
+			$this->assertTrue( \WC_Admin_Settings::save_fields( $settings, $post ) );
+			$this->clear_option_caches( $option_names );
+
+			$this->assertSame(
+				array(
+					'acme_settings' => array( 'quantity' => '3' ),
+					'acme_enabled'  => 'no',
+					'acme_methods'  => array( 'card', 'link' ),
+					'acme_start'    => '2026-08-03T13:45:00',
+				),
+				$post
+			);
+			$this->assertSame( '3', $captured['acme_quantity'] );
+			$this->assertSame( 'no', $captured['acme_enabled'] );
+			$this->assertSame( array( 'card', 'link' ), $captured['acme_methods'] );
+			$this->assertSame( '2026-08-03T13:45:00', $captured['acme_start'] );
+			$this->assertSame(
+				array(
+					'quantity' => '3',
+					'other'    => 'keep',
+				),
+				get_option( 'acme_settings' )
+			);
+			$this->assertSame( 'no', get_option( 'acme_enabled' ) );
+			$this->assertSame( array( 'card', 'link' ), get_option( 'acme_methods' ) );
+			$this->assertSame( '2026-08-03T13:45:00', get_option( 'acme_start' ) );
+			$this->assertSame( maybe_serialize( get_option( 'acme_settings' ) ), $this->get_raw_option_value( 'acme_settings' ) );
+			$this->assertSame( maybe_serialize( get_option( 'acme_methods' ) ), $this->get_raw_option_value( 'acme_methods' ) );
+		} finally {
+			remove_filter( 'woocommerce_admin_settings_sanitize_option', $listener, 10 );
+			update_option( 'timezone_string', $original_timezone );
+			foreach ( $option_names as $option_name ) {
+				delete_option( $option_name );
+			}
+		}
+	}
+
+	/**
+	 * @testdox It preserves valid native form values and accepts explicit original representations.
+	 */
+	public function test_canonicalize_schema_values_preserves_native_form_representations(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+
+		$schema = SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_fields(
+				array(
+					array(
+						'id'    => 'acme_quantity',
+						'label' => 'Quantity',
+						'type'  => 'number',
+						'value' => '02',
+						'save'  => array(
+							'adapter' => 'form_post',
+							'name'    => 'acme_quantity',
+						),
+					),
+					array(
+						'id'      => 'acme_methods',
+						'label'   => 'Methods',
+						'type'    => 'array',
+						'value'   => array( 1 ),
+						'options' => array(
+							array(
+								'label' => 'One',
+								'value' => '1',
+							),
+						),
+						'save'    => array(
+							'adapter'      => 'form_post',
+							'name'         => 'acme_methods',
+							'initialValue' => array( 'legacy-one' ),
+						),
+					),
+				)
+			)
+		);
+
+		$fields = $schema['groups']['main']['fields'];
+		$this->assertSame( 2, $fields[0]['value'] );
+		$this->assertSame( '02', $fields[0]['save']['initialValue'] );
+		$this->assertSame( array( '1' ), $fields[1]['value'] );
+		$this->assertSame( array( 'legacy-one' ), $fields[1]['save']['initialValue'] );
+	}
+
+	/**
 	 * @testdox It accepts every field type supported by the current renderer.
 	 *
 	 * @dataProvider supported_field_types
@@ -1600,6 +1799,133 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 					'fields' => $fields,
 				),
 			),
+		);
+	}
+
+	/**
+	 * Get a legacy numeric field used by save-pipeline tests.
+	 *
+	 * @return array
+	 */
+	private function get_numeric_save_settings(): array {
+		return array(
+			array(
+				'id'                => 'acme_quantity',
+				'title'             => 'Quantity',
+				'type'              => 'number',
+				'custom_attributes' => array( 'step' => 1 ),
+			),
+		);
+	}
+
+	/**
+	 * Build classic POST data from schema fields and optional edited values.
+	 *
+	 * @param array $schema Settings UI schema.
+	 * @param array $edited_form_values Serialized values changed by the client, keyed by field id.
+	 * @return array
+	 */
+	private function get_schema_post_data( array $schema, array $edited_form_values = array() ): array {
+		$post = array();
+
+		foreach ( $schema['groups'] as $group ) {
+			foreach ( $group['fields'] as $field ) {
+				if ( 'form_post' !== ( $field['save']['adapter'] ?? null ) ) {
+					continue;
+				}
+
+				if ( array_key_exists( $field['id'], $edited_form_values ) ) {
+					$form_value = $edited_form_values[ $field['id'] ];
+				} elseif ( array_key_exists( 'initialValue', $field['save'] ) ) {
+					$form_value = $field['save']['initialValue'];
+				} else {
+					continue;
+				}
+
+				$name = $field['save']['name'] ?? $field['id'];
+				if ( preg_match( '/^([^\[\]]+)\[([^\[\]]+)\]$/', $name, $matches ) ) {
+					$post[ $matches[1] ][ $matches[2] ] = $form_value;
+				} else {
+					$post[ $name ] = $form_value;
+				}
+			}
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Save fields while capturing global and option-specific sanitizer inputs.
+	 *
+	 * @param array  $settings Legacy settings definitions.
+	 * @param array  $post Schema-derived POST data.
+	 * @param string $option_name Option name.
+	 * @return array
+	 */
+	private function save_fields_and_capture( array $settings, array $post, string $option_name ): array {
+		include_once WC_ABSPATH . 'includes/admin/class-wc-admin-settings.php';
+
+		$captured = array();
+		$global   = static function ( $value, $option, $raw_value ) use ( &$captured ) {
+			unset( $option );
+			$captured['global'] = array(
+				'raw'       => $raw_value,
+				'sanitized' => $value,
+			);
+			return $value;
+		};
+		$specific = static function ( $value, $option, $raw_value ) use ( &$captured ) {
+			unset( $option );
+			$captured['specific'] = array(
+				'raw'       => $raw_value,
+				'sanitized' => $value,
+			);
+			return $value;
+		};
+
+		add_filter( 'woocommerce_admin_settings_sanitize_option', $global, 10, 3 );
+		add_filter( 'woocommerce_admin_settings_sanitize_option_' . $option_name, $specific, 10, 3 );
+
+		try {
+			$this->assertTrue( \WC_Admin_Settings::save_fields( $settings, $post ) );
+		} finally {
+			remove_filter( 'woocommerce_admin_settings_sanitize_option', $global, 10 );
+			remove_filter( 'woocommerce_admin_settings_sanitize_option_' . $option_name, $specific, 10 );
+		}
+
+		$this->clear_option_caches( array( $option_name ) );
+
+		return $captured;
+	}
+
+	/**
+	 * Clear option caches before persistence assertions.
+	 *
+	 * @param string[] $option_names Option names.
+	 */
+	private function clear_option_caches( array $option_names ): void {
+		foreach ( $option_names as $option_name ) {
+			wp_cache_delete( $option_name, 'options' );
+		}
+
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
+	}
+
+	/**
+	 * Read an option's raw database representation.
+	 *
+	 * @param string $option_name Option name.
+	 * @return string|null
+	 */
+	private function get_raw_option_value( string $option_name ): ?string {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				$option_name
+			)
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -290,6 +290,30 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox It keeps info fields non-saving when their description comes from desc.
+	 */
+	public function test_from_legacy_settings_marks_info_fields_with_descriptions_as_non_saving(): void {
+		$schema = SettingsUISchema::from_legacy_settings(
+			'test',
+			'',
+			'Test settings',
+			array(
+				array(
+					'id'   => 'woocommerce_test_info',
+					'type' => 'info',
+					'desc' => 'Read-only information.',
+				),
+			)
+		);
+
+		$field = $schema['groups']['default']['fields'][0];
+
+		$this->assertSame( 'Read-only information.', $field['description'] );
+		$this->assertSame( array( 'adapter' => 'none' ), $field['save'] );
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
 	 * @testdox It preserves both legacy descriptions and string desc_tip values.
 	 */
 	public function test_from_legacy_settings_preserves_desc_and_string_desc_tip(): void {
@@ -708,6 +732,320 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( $schema, SettingsUISchema::canonicalize_option_values( $schema ), 'Associative value arrays should pass through unreindexed for the provider to fix.' );
+	}
+
+	/**
+	 * @testdox It accepts every field type supported by the current renderer.
+	 *
+	 * @dataProvider supported_field_types
+	 *
+	 * @param string $type Field type.
+	 * @param mixed  $value Field value.
+	 */
+	public function test_assert_valid_schema_accepts_supported_field_types( string $type, $value ): void {
+		$field = array(
+			'id'    => 'acme_' . str_replace( '-', '_', $type ),
+			'label' => 'Acme field',
+			'type'  => $type,
+			'value' => $value,
+			'save'  => array( 'adapter' => 'form_post' ),
+		);
+
+		if ( in_array( $type, array( 'array', 'radio', 'select' ), true ) ) {
+			$field['options'] = array(
+				array(
+					'label' => 'Option A',
+					'value' => 'a',
+				),
+			);
+		}
+
+		if ( 'info' === $type ) {
+			unset( $field['value'] );
+			$field['save'] = array( 'adapter' => 'none' );
+		}
+
+		SettingsUISchema::assert_valid_schema( $this->get_native_schema_with_field( $field ) );
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Supported field type fixtures.
+	 *
+	 * @return array<string, array{string, mixed}>
+	 */
+	public static function supported_field_types(): array {
+		return array(
+			'array'          => array( 'array', array( 'a' ) ),
+			'checkbox'       => array( 'checkbox', true ),
+			'date'           => array( 'date', '2026-08-03' ),
+			'datetime-local' => array( 'datetime-local', '2026-08-03T12:30' ),
+			'email'          => array( 'email', 'merchant@example.com' ),
+			'info'           => array( 'info', null ),
+			'number'         => array( 'number', '02' ),
+			'password'       => array( 'password', 'secret' ),
+			'radio'          => array( 'radio', 'a' ),
+			'select'         => array( 'select', 'a' ),
+			'tel'            => array( 'tel', '+1 555 555 5555' ),
+			'text'           => array( 'text', 'Acme' ),
+			'textarea'       => array( 'textarea', 'Acme description' ),
+			'time'           => array( 'time', '12:30' ),
+			'url'            => array( 'url', 'https://example.com' ),
+		);
+	}
+
+	/**
+	 * @testdox It normalizes every legacy field type alias before validation.
+	 *
+	 * @dataProvider legacy_field_type_aliases
+	 *
+	 * @param string $legacy_type Legacy field type.
+	 * @param string $canonical_type Canonical field type.
+	 */
+	public function test_from_legacy_settings_normalizes_aliases_before_validation( string $legacy_type, string $canonical_type ): void {
+		$schema = SettingsUISchema::from_legacy_settings(
+			'acme',
+			'',
+			'Acme',
+			array(
+				array(
+					'id'      => 'acme_field',
+					'label'   => 'Acme field',
+					'type'    => $legacy_type,
+					'value'   => 'a',
+					'options' => array( 'a' => 'Option A' ),
+				),
+			)
+		);
+
+		$this->assertSame( $canonical_type, $schema['groups']['default']['fields'][0]['type'] );
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * Legacy field type aliases.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public static function legacy_field_type_aliases(): array {
+		return array(
+			'multiselect'            => array( 'multiselect', 'array' ),
+			'multi_select_countries' => array( 'multi_select_countries', 'array' ),
+			'single_select_country'  => array( 'single_select_country', 'select' ),
+			'single_select_page'     => array( 'single_select_page', 'select' ),
+		);
+	}
+
+	/**
+	 * @testdox It rejects malformed schemas with a precise boundary reason.
+	 *
+	 * @dataProvider invalid_schemas
+	 *
+	 * @param array  $schema Invalid schema.
+	 * @param string $reason Expected exception message.
+	 */
+	public function test_assert_valid_schema_rejects_malformed_schemas( array $schema, string $reason ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( $reason );
+
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * Invalid schema fixtures.
+	 *
+	 * @return array<string, array{array, string}>
+	 */
+	public static function invalid_schemas(): array {
+		$valid = self::get_valid_schema_for_validation();
+
+		$unknown_type                                        = $valid;
+		$unknown_type['groups']['main']['fields'][0]['type'] = 'custom';
+		$duplicate_id                                        = $valid;
+		$duplicate_id['groups']['main']['fields'][]          = $duplicate_id['groups']['main']['fields'][0];
+		$group_field_collision                               = $valid;
+		$group_field_collision['groups']['main']['fields'][0]['id'] = 'main';
+		$empty_schema_id                                        = $valid;
+		$empty_schema_id['id']                                  = '';
+		$malformed_group                                        = $valid;
+		$malformed_group['groups']['main']['fields']            = 'invalid';
+		$missing_options                                        = $valid;
+		$missing_options['groups']['main']['fields'][0]['type'] = 'select';
+		$invalid_option = $missing_options;
+		$invalid_option['groups']['main']['fields'][0]['options'] = array(
+			array(
+				'label' => 'One',
+				'value' => 1,
+			),
+		);
+		$invalid_component                                        = $valid;
+		$invalid_component['groups']['main']['fields'][0]['component'] = '';
+		$invalid_field_save                                        = $valid;
+		$invalid_field_save['groups']['main']['fields'][0]['save'] = array( 'adapter' => 'custom' );
+		$invalid_visibility                                        = $valid;
+		$invalid_visibility['groups']['main']['fields'][0]['visibility'] = array( 'controller' => 'missing' );
+		$invalid_bound = $valid;
+		$invalid_bound['groups']['main']['fields'][0]['customAttributes'] = array( 'min' => 1 );
+		$invalid_info                                        = $valid;
+		$invalid_info['groups']['main']['fields'][0]['type'] = 'info';
+		$invalid_shell                                       = $valid;
+		$invalid_shell['shell']['navigation']                = array(
+			array(
+				'id'    => 'general',
+				'label' => 'General',
+			),
+		);
+		$invalid_breadcrumb                                  = $valid;
+		$invalid_breadcrumb['shell']['breadcrumbs']          = array( array( 'label' => 1 ) );
+		$invalid_badge                                       = $valid;
+		$invalid_badge['shell']['badges']                    = array(
+			array(
+				'label'  => 'Beta',
+				'intent' => 'purple',
+			),
+		);
+		$invalid_action                                      = $valid;
+		$invalid_action['groups']['main']['actions']         = array(
+			array(
+				'id'    => '',
+				'label' => 'Docs',
+				'href'  => 'https://example.com',
+			),
+		);
+		$invalid_page_save                                   = $valid;
+		$invalid_page_save['save']                           = array( 'adapter' => 'custom' );
+		$invalid_navigation_component                        = $valid;
+		$invalid_navigation_component['shell']['navigationComponent'] = '';
+		$invalid_group_map                    = $valid;
+		$invalid_group_map['groups']['other'] = $invalid_group_map['groups']['main'];
+		unset( $invalid_group_map['groups']['main'] );
+
+		return array(
+			'unknown field type'          => array( $unknown_type, 'Field "acme_field" has unsupported type "custom".' ),
+			'duplicate field id'          => array( $duplicate_id, 'Field id "acme_field" is duplicated.' ),
+			'group and field collision'   => array( $group_field_collision, 'Field id "main" collides with a group id.' ),
+			'empty schema id'             => array( $empty_schema_id, 'Schema id must be a non-empty string.' ),
+			'malformed group fields'      => array( $malformed_group, 'Group "main" fields must be a list.' ),
+			'missing choice options'      => array( $missing_options, 'Field "acme_field" of type "select" must define a non-empty options list.' ),
+			'non-string option value'     => array( $invalid_option, 'Field "acme_field" option 0 value must be a string.' ),
+			'empty component name'        => array( $invalid_component, 'Field "acme_field" component must be a non-empty string.' ),
+			'unsupported field save'      => array( $invalid_field_save, 'Field "acme_field" save adapter must be "form_post" or "none".' ),
+			'missing visibility control'  => array( $invalid_visibility, 'Field "acme_field" visibility controller "missing" does not reference a field.' ),
+			'bound on text field'         => array( $invalid_bound, 'Field "acme_field" may define "min" only when its type is "number".' ),
+			'saving info field'           => array( $invalid_info, 'Field "acme_field" of type "info" must use the "none" save adapter.' ),
+			'malformed shell navigation'  => array( $invalid_shell, 'Shell navigation item 0 href must be a string.' ),
+			'malformed breadcrumb'        => array( $invalid_breadcrumb, 'Shell breadcrumb 0 label must be a string.' ),
+			'invalid badge intent'        => array( $invalid_badge, 'Shell badge 0 intent "purple" is not supported.' ),
+			'empty group action id'       => array( $invalid_action, 'Group "main" action 0 id must be a non-empty string.' ),
+			'custom save without handler' => array( $invalid_page_save, 'Schema custom save strategy must define a non-empty handler.' ),
+			'empty navigation component'  => array( $invalid_navigation_component, 'Shell navigationComponent must be a non-empty string.' ),
+			'group map id mismatch'       => array( $invalid_group_map, 'Group map key "other" must match group id "main".' ),
+		);
+	}
+
+	/**
+	 * @testdox It accepts valid optional shell, field, visibility, action, and save metadata.
+	 */
+	public function test_assert_valid_schema_accepts_optional_metadata(): void {
+		$schema                              = self::get_valid_schema_for_validation();
+		$schema['save']                      = array(
+			'adapter' => 'custom',
+			'handler' => 'acme/save',
+		);
+		$schema['shell']                     = array(
+			'header'              => 'visible',
+			'title'               => 'Acme settings',
+			'subtitle'            => 'Configure Acme.',
+			'breadcrumbs'         => array(
+				array(
+					'label' => 'Settings',
+					'href'  => 'https://example.com/settings',
+				),
+			),
+			'badges'              => array(
+				array(
+					'label'  => 'Beta',
+					'intent' => 'info',
+				),
+			),
+			'navigation'          => array(
+				array(
+					'id'     => 'general',
+					'label'  => 'General',
+					'href'   => 'https://example.com/general',
+					'active' => true,
+				),
+			),
+			'sectionNavigation'   => array(),
+			'navigationComponent' => 'acme/navigation',
+		);
+		$schema['groups']['main']['actions'] = array(
+			array(
+				'id'      => 'docs',
+				'label'   => 'Documentation',
+				'href'    => 'https://example.com/docs',
+				'variant' => 'link',
+				'target'  => '_blank',
+				'rel'     => 'noopener',
+			),
+		);
+		$schema['groups']['main']['fields'][0]['component']  = 'acme/text';
+		$schema['groups']['main']['fields'][0]['visibility'] = array(
+			'controller' => 'acme_enabled',
+			'value'      => array( true, false ),
+		);
+		$schema['groups']['main']['fields'][]                = array(
+			'id'    => 'acme_enabled',
+			'label' => 'Enabled',
+			'type'  => 'checkbox',
+			'value' => true,
+			'save'  => array(
+				'adapter' => 'form_post',
+				'name'    => 'acme_enabled',
+			),
+		);
+
+		SettingsUISchema::assert_valid_schema( $schema );
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Build a valid schema for validation tests.
+	 *
+	 * @return array
+	 */
+	private static function get_valid_schema_for_validation(): array {
+		return array(
+			'id'      => 'acme',
+			'title'   => 'Acme',
+			'section' => 'general',
+			'save'    => array( 'adapter' => 'form_post' ),
+			'shell'   => array(
+				'header' => 'hidden',
+				'title'  => 'Acme',
+			),
+			'groups'  => array(
+				'main' => array(
+					'id'          => 'main',
+					'title'       => 'Main',
+					'description' => 'Main settings.',
+					'actions'     => array(),
+					'fields'      => array(
+						array(
+							'id'          => 'acme_field',
+							'label'       => 'Acme field',
+							'type'        => 'text',
+							'description' => 'A text field.',
+							'value'       => 'Acme',
+							'save'        => array(
+								'adapter' => 'form_post',
+								'name'    => 'acme_field',
+							),
+						),
+					),
+				),
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -287,7 +287,8 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		$field = $schema['groups']['default']['fields'][0];
 
 		$this->assertSame( 'Read-only <strong>information</strong>alert("x").', $field['description'] );
-		$this->assertSame( array( 'adapter' => 'none' ), $field['save'] );
+		$this->assertArrayHasKey( 'adapter', $field['save'] );
+		$this->assertSame( 'none', $field['save']['adapter'] );
 	}
 
 	/**
@@ -310,8 +311,62 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		$field = $schema['groups']['default']['fields'][0];
 
 		$this->assertSame( 'Read-only information.', $field['description'] );
-		$this->assertSame( array( 'adapter' => 'none' ), $field['save'] );
+		$this->assertArrayHasKey( 'adapter', $field['save'] );
+		$this->assertSame( 'none', $field['save']['adapter'] );
 		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * @testdox It rejects duplicate legacy group ids before either group can be overwritten.
+	 *
+	 * @dataProvider duplicate_legacy_group_ids
+	 *
+	 * @param string $group_id Duplicate group id.
+	 */
+	public function test_from_legacy_settings_rejects_duplicate_group_ids( string $group_id ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( sprintf( 'Group id "%s" is duplicated.', $group_id ) );
+
+		SettingsUISchema::from_legacy_settings(
+			'acme',
+			'',
+			'Acme',
+			array(
+				array(
+					'id'    => $group_id,
+					'type'  => 'title',
+					'title' => 'First',
+				),
+				array(
+					'id'    => 'acme_enabled',
+					'type'  => 'checkbox',
+					'title' => 'Enabled',
+				),
+				array( 'type' => 'sectionend' ),
+				array(
+					'id'    => $group_id,
+					'type'  => 'title',
+					'title' => 'Second',
+				),
+				array(
+					'id'    => 'acme_label',
+					'type'  => 'text',
+					'title' => 'Label',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Duplicate legacy group id fixtures.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function duplicate_legacy_group_ids(): array {
+		return array(
+			'normal id'      => array( 'main' ),
+			'zero-string id' => array( '0' ),
+		);
 	}
 
 	/**
@@ -884,8 +939,6 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	 * @param string $expected_type Expected canonical type.
 	 */
 	public function test_canonicalize_schema_values_infers_integer_from_step_base( array $field, string $expected_type ): void {
-		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
-
 		$field += array(
 			'id'    => 'acme_number',
 			'label' => 'Number',
@@ -893,7 +946,7 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 			'save'  => array( 'adapter' => 'custom' ),
 		);
 
-		$schema = SettingsUISchema::canonicalize_schema_values( $this->get_native_schema_with_field( $field ) );
+		$schema = SettingsUISchema::canonicalize_schema_values( $this->get_native_schema_with_field( $field ), true );
 
 		$this->assertSame( $expected_type, $schema['groups']['main']['fields'][0]['type'] );
 	}
@@ -1164,11 +1217,12 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		$schema = $this->get_native_schema_with_fields(
 			array(
 				array(
-					'id'    => 'acme_number',
-					'label' => 'Number',
-					'type'  => 'number',
-					'value' => 1.5,
-					'save'  => array( 'adapter' => 'custom' ),
+					'id'               => 'acme_number',
+					'label'            => 'Number',
+					'type'             => 'number',
+					'value'            => 2,
+					'customAttributes' => array( 'step' => 1 ),
+					'save'             => array( 'adapter' => 'custom' ),
 				),
 				array(
 					'id'    => 'acme_integer',
@@ -1188,6 +1242,29 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( $schema, SettingsUISchema::canonicalize_schema_values( $schema ) );
+	}
+
+	/**
+	 * @testdox It requires checkbox form representations to match the classic sanitizer meaning.
+	 */
+	public function test_canonicalize_schema_values_rejects_incompatible_checkbox_form_value(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'must define save.initialValue' );
+
+		SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_field(
+				array(
+					'id'    => 'acme_enabled',
+					'label' => 'Enabled',
+					'type'  => 'checkbox',
+					'value' => 'true',
+					'save'  => array(
+						'adapter' => 'form_post',
+						'name'    => 'acme_enabled',
+					),
+				)
+			)
+		);
 	}
 
 	/**
@@ -1305,6 +1382,96 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 		} finally {
 			delete_option( 'acme_quantity' );
 		}
+	}
+
+	/**
+	 * @testdox It preserves a native checkbox through the classic save pipeline with a compatible original value.
+	 */
+	public function test_schema_post_preserves_native_checkbox_form_value(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+
+		$settings = array(
+			array(
+				'id'    => 'acme_enabled',
+				'title' => 'Enabled',
+				'type'  => 'checkbox',
+			),
+		);
+		update_option( 'acme_enabled', 'yes' );
+
+		try {
+			$schema = SettingsUISchema::canonicalize_schema_values(
+				$this->get_native_schema_with_field(
+					array(
+						'id'    => 'acme_enabled',
+						'label' => 'Enabled',
+						'type'  => 'checkbox',
+						'value' => 'true',
+						'save'  => array(
+							'adapter'      => 'form_post',
+							'name'         => 'acme_enabled',
+							'initialValue' => 'yes',
+						),
+					)
+				)
+			);
+			SettingsUISchema::assert_valid_schema( $schema );
+			$post     = $this->get_schema_post_data( $schema );
+			$captured = $this->save_fields_and_capture( $settings, $post, 'acme_enabled' );
+
+			$this->assertSame( array( 'acme_enabled' => 'yes' ), $post );
+			$this->assertSame( 'yes', $captured['global']['raw'] );
+			$this->assertSame( 'yes', $captured['specific']['sanitized'] );
+			$this->assertSame( 'yes', get_option( 'acme_enabled' ) );
+			$this->assertSame( 'yes', $this->get_raw_option_value( 'acme_enabled' ) );
+		} finally {
+			delete_option( 'acme_enabled' );
+		}
+	}
+
+	/**
+	 * @testdox It rejects form-post names that the hidden-input serializer cannot represent.
+	 */
+	public function test_assert_valid_schema_rejects_unsupported_form_post_names(): void {
+		$schema = self::get_valid_schema_for_validation();
+		$schema['groups']['main']['fields'][0]['save']['name'] = 'settings[group][quantity]';
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'is not a supported form-post field name' );
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * @testdox It rejects integer steps that cannot preserve integer values.
+	 *
+	 * @dataProvider invalid_integer_steps
+	 *
+	 * @param int|float|string $step Invalid integer step.
+	 */
+	public function test_assert_valid_schema_rejects_invalid_integer_steps( $step ): void {
+		$schema                    = self::get_valid_schema_for_validation();
+		$field                     = &$schema['groups']['main']['fields'][0];
+		$field['type']             = 'integer';
+		$field['value']            = 2;
+		$field['customAttributes'] = array( 'step' => $step );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'custom attribute "step" must be a positive integer' );
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * Invalid integer step fixtures.
+	 *
+	 * @return array<string, array{int|float|string}>
+	 */
+	public static function invalid_integer_steps(): array {
+		return array(
+			'fractional' => array( 0.5 ),
+			'zero'       => array( 0 ),
+			'negative'   => array( -1 ),
+			'any'        => array( 'any' ),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/SettingsUISchemaTest.php
@@ -259,8 +259,9 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 
 		$this->assertSame(
 			array(
-				'adapter' => 'form_post',
-				'name'    => 'woocommerce_test[nested]',
+				'adapter'      => 'form_post',
+				'name'         => 'woocommerce_test[nested]',
+				'initialValue' => '',
 			),
 			$schema['groups']['default']['fields'][0]['save']
 		);
@@ -735,6 +736,530 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox It canonicalizes legacy values, numeric bounds, and original form representations atomically.
+	 */
+	public function test_from_legacy_settings_canonicalizes_typed_values_and_preserves_form_values(): void {
+		$schema = SettingsUISchema::from_legacy_settings(
+			'acme',
+			'',
+			'Acme',
+			array(
+				array(
+					'id'                => 'acme_quantity',
+					'label'             => 'Quantity',
+					'type'              => 'number',
+					'value'             => '02',
+					'custom_attributes' => array(
+						'min'  => '0',
+						'max'  => '10',
+						'step' => '1',
+					),
+				),
+			)
+		);
+
+		$field = $schema['groups']['default']['fields'][0];
+
+		$this->assertSame( 'integer', $field['type'] );
+		$this->assertSame( 2, $field['value'] );
+		$this->assertSame(
+			array(
+				'min' => 0,
+				'max' => 10,
+			),
+			$field['validation']
+		);
+		$this->assertSame( '02', $field['save']['initialValue'] );
+		SettingsUISchema::assert_valid_schema( $schema );
+	}
+
+	/**
+	 * @testdox It canonicalizes native numeric values without rounding unsafe integers first.
+	 *
+	 * @dataProvider canonical_numeric_values
+	 *
+	 * @param mixed          $raw Raw schema value.
+	 * @param string         $type Field type.
+	 * @param int|float|null $expected Expected canonical value.
+	 */
+	public function test_canonicalize_schema_values_handles_numeric_boundaries( $raw, string $type, $expected ): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+
+		$schema = $this->get_native_schema_with_field(
+			array(
+				'id'    => 'acme_number',
+				'label' => 'Number',
+				'type'  => $type,
+				'value' => $raw,
+				'save'  => array( 'adapter' => 'custom' ),
+			)
+		);
+
+		$canonical = SettingsUISchema::canonicalize_schema_values( $schema );
+
+		$this->assertSame( $expected, $canonical['groups']['main']['fields'][0]['value'] );
+	}
+
+	/**
+	 * Canonical numeric value fixtures.
+	 *
+	 * @return array<string, array{mixed, string, int|float|null}>
+	 */
+	public static function canonical_numeric_values(): array {
+		return array(
+			'empty number'         => array( '', 'number', null ),
+			'whitespace number'    => array( '  ', 'number', null ),
+			'zero number'          => array( '0', 'number', 0 ),
+			'decimal number'       => array( '1.25', 'number', 1.25 ),
+			'exponent number'      => array( '1e3', 'number', 1000 ),
+			'safe integer maximum' => array( '9007199254740991', 'integer', 9007199254740991 ),
+			'safe integer minimum' => array( '-9007199254740991', 'integer', -9007199254740991 ),
+		);
+	}
+
+	/**
+	 * @testdox It rejects integral numeric values outside JavaScript's safe range before conversion.
+	 *
+	 * @dataProvider unsafe_integral_values
+	 *
+	 * @param string $value Unsafe integral value.
+	 */
+	public function test_canonicalize_schema_values_rejects_unsafe_integral_values( string $value ): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'outside the JavaScript safe integer range' );
+
+		SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_field(
+				array(
+					'id'    => 'acme_integer',
+					'label' => 'Integer',
+					'type'  => 'integer',
+					'value' => $value,
+					'save'  => array( 'adapter' => 'custom' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Unsafe integral value fixtures.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function unsafe_integral_values(): array {
+		return array(
+			'above maximum' => array( '9007199254740992' ),
+			'below minimum' => array( '-9007199254740992' ),
+			'exponent'      => array( '9.007199254740992e15' ),
+		);
+	}
+
+	/**
+	 * @testdox It rejects unsafe integral bounds before converting them to floats.
+	 */
+	public function test_canonicalize_schema_values_rejects_unsafe_integral_bounds(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'max is outside the JavaScript safe integer range' );
+
+		SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_field(
+				array(
+					'id'               => 'acme_number',
+					'label'            => 'Number',
+					'type'             => 'number',
+					'value'            => 2,
+					'customAttributes' => array( 'max' => '9007199254740992' ),
+					'save'             => array( 'adapter' => 'custom' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox It promotes step-one numbers only when the selected step base is integral.
+	 *
+	 * @dataProvider integer_inference_values
+	 *
+	 * @param array  $field Field definition.
+	 * @param string $expected_type Expected canonical type.
+	 */
+	public function test_canonicalize_schema_values_infers_integer_from_step_base( array $field, string $expected_type ): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+
+		$field += array(
+			'id'    => 'acme_number',
+			'label' => 'Number',
+			'type'  => 'number',
+			'save'  => array( 'adapter' => 'custom' ),
+		);
+
+		$schema = SettingsUISchema::canonicalize_schema_values( $this->get_native_schema_with_field( $field ) );
+
+		$this->assertSame( $expected_type, $schema['groups']['main']['fields'][0]['type'] );
+	}
+
+	/**
+	 * Integer inference fixtures.
+	 *
+	 * @return array<string, array{array, string}>
+	 */
+	public static function integer_inference_values(): array {
+		return array(
+			'min takes precedence'       => array(
+				array(
+					'value'            => '2',
+					'customAttributes' => array(
+						'step' => '1',
+						'min'  => '0.5',
+					),
+				),
+				'number',
+			),
+			'integral current value'     => array(
+				array(
+					'value'            => '2',
+					'customAttributes' => array( 'step' => 1 ),
+				),
+				'integer',
+			),
+			'empty uses zero step base'  => array(
+				array(
+					'value'            => '',
+					'customAttributes' => array( 'step' => 1 ),
+				),
+				'integer',
+			),
+			'non-unit step stays number' => array(
+				array(
+					'value'            => '2',
+					'customAttributes' => array( 'step' => '0.5' ),
+				),
+				'number',
+			),
+			'near-one step stays number' => array(
+				array(
+					'value'            => '2',
+					'customAttributes' => array( 'step' => '1.0000000000000000001' ),
+				),
+				'number',
+			),
+		);
+	}
+
+	/**
+	 * @testdox It does not require form representation metadata for a page-level custom save strategy.
+	 */
+	public function test_canonicalize_schema_values_skips_initial_value_for_custom_page_save(): void {
+		$this->setExpectedIncorrectUsage( SettingsUISchema::class . '::canonicalize_schema_values' );
+
+		$schema         = $this->get_native_schema_with_field(
+			array(
+				'id'      => 'acme_choices',
+				'label'   => 'Choices',
+				'type'    => 'array',
+				'value'   => array( 1 ),
+				'options' => array(
+					array(
+						'label' => 'One',
+						'value' => '1',
+					),
+				),
+			)
+		);
+		$schema['save'] = array(
+			'adapter' => 'custom',
+			'handler' => 'acme/save',
+		);
+
+		$canonical = SettingsUISchema::canonicalize_schema_values( $schema );
+		$field     = $canonical['groups']['main']['fields'][0];
+
+		$this->assertSame( array( '1' ), $field['value'] );
+		$this->assertArrayNotHasKey( 'save', $field );
+		SettingsUISchema::assert_valid_schema( $canonical );
+	}
+
+	/**
+	 * @testdox It converts store-local datetimes to timezone-qualified ISO values while preserving form precision.
+	 */
+	public function test_from_legacy_settings_canonicalizes_local_datetime(): void {
+		$original_timezone = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'America/New_York' );
+
+		try {
+			$schema = SettingsUISchema::from_legacy_settings(
+				'acme',
+				'',
+				'Acme',
+				array(
+					array(
+						'id'    => 'acme_start',
+						'label' => 'Starts',
+						'type'  => 'datetime-local',
+						'value' => '2026-11-01T01:30',
+					),
+				)
+			);
+		} finally {
+			update_option( 'timezone_string', $original_timezone );
+		}
+
+		$field = $schema['groups']['default']['fields'][0];
+		$this->assertSame( '2026-11-01T01:30:00-04:00', $field['value'], 'PHP deterministically chooses the first occurrence of New York\'s repeated hour.' );
+		$this->assertSame( '2026-11-01T01:30', $field['save']['initialValue'] );
+	}
+
+	/**
+	 * @testdox It reads one-level legacy form names and captures the exact nested member.
+	 */
+	public function test_from_legacy_settings_reads_nested_form_option_once(): void {
+		update_option(
+			'acme_settings',
+			array(
+				'quantity' => '02',
+				'other'    => 'keep',
+			)
+		);
+
+		try {
+			$schema = SettingsUISchema::from_legacy_settings(
+				'acme',
+				'',
+				'Acme',
+				array(
+					array(
+						'id'                => 'acme_quantity',
+						'field_name'        => 'acme_settings[quantity]',
+						'label'             => 'Quantity',
+						'type'              => 'number',
+						'custom_attributes' => array( 'step' => 1 ),
+					),
+				)
+			);
+		} finally {
+			delete_option( 'acme_settings' );
+		}
+
+		$field = $schema['groups']['default']['fields'][0];
+		$this->assertSame( 2, $field['value'] );
+		$this->assertSame( '02', $field['save']['initialValue'] );
+	}
+
+	/**
+	 * @testdox It rejects deeper legacy form names rather than guessing an option path.
+	 */
+	public function test_from_legacy_settings_rejects_deep_form_option_names(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'one bracketed setting name' );
+
+		SettingsUISchema::from_legacy_settings(
+			'acme',
+			'',
+			'Acme',
+			array(
+				array(
+					'id'         => 'acme_quantity',
+					'field_name' => 'acme_settings[group][quantity]',
+					'label'      => 'Quantity',
+					'type'       => 'number',
+				),
+			)
+		);
+	}
+
+	/**
+	 * @testdox It requires an explicit original form value when native compatibility conversion cannot preserve one.
+	 */
+	public function test_canonicalize_schema_values_rejects_ambiguous_native_form_value(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'must define save.initialValue' );
+
+		SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_field(
+				array(
+					'id'      => 'acme_choices',
+					'label'   => 'Choices',
+					'type'    => 'array',
+					'value'   => array( 1 ),
+					'options' => array(
+						array(
+							'label' => 'One',
+							'value' => '1',
+						),
+					),
+					'save'    => array( 'adapter' => 'form_post' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox It rejects conflicting legacy and canonical numeric bounds.
+	 */
+	public function test_canonicalize_schema_values_rejects_conflicting_bounds(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'min disagrees between customAttributes and validation' );
+
+		SettingsUISchema::canonicalize_schema_values(
+			$this->get_native_schema_with_field(
+				array(
+					'id'               => 'acme_number',
+					'label'            => 'Number',
+					'type'             => 'number',
+					'value'            => 2,
+					'customAttributes' => array( 'min' => '1' ),
+					'validation'       => array( 'min' => 2 ),
+					'save'             => array( 'adapter' => 'custom' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox It accepts PHP's warning-free DST gap shift and rejects malformed local dates.
+	 */
+	public function test_canonicalize_schema_values_handles_dst_gap_and_invalid_dates(): void {
+		$original_timezone = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'America/New_York' );
+
+		try {
+			$schema = SettingsUISchema::canonicalize_schema_values(
+				$this->get_native_schema_with_field(
+					array(
+						'id'    => 'acme_start',
+						'label' => 'Starts',
+						'type'  => 'datetime-local',
+						'value' => '2026-03-08T02:30',
+						'save'  => array( 'adapter' => 'custom' ),
+					)
+				),
+				true
+			);
+
+			$this->assertSame( '2026-03-08T03:30:00-04:00', $schema['groups']['main']['fields'][0]['value'] );
+
+			$this->expectException( \InvalidArgumentException::class );
+			$this->expectExceptionMessage( 'datetime value is malformed' );
+			SettingsUISchema::canonicalize_schema_values(
+				$this->get_native_schema_with_field(
+					array(
+						'id'    => 'acme_start',
+						'label' => 'Starts',
+						'type'  => 'datetime-local',
+						'value' => '2026-02-30T12:00',
+						'save'  => array( 'adapter' => 'custom' ),
+					)
+				),
+				true
+			);
+		} finally {
+			update_option( 'timezone_string', $original_timezone );
+		}
+	}
+
+	/**
+	 * @testdox It leaves fully canonical native typed values unchanged without a compatibility notice.
+	 */
+	public function test_canonicalize_schema_values_leaves_canonical_native_values_unchanged(): void {
+		$schema = $this->get_native_schema_with_fields(
+			array(
+				array(
+					'id'    => 'acme_number',
+					'label' => 'Number',
+					'type'  => 'number',
+					'value' => 1.5,
+					'save'  => array( 'adapter' => 'custom' ),
+				),
+				array(
+					'id'    => 'acme_integer',
+					'label' => 'Integer',
+					'type'  => 'integer',
+					'value' => 2,
+					'save'  => array( 'adapter' => 'custom' ),
+				),
+				array(
+					'id'    => 'acme_start',
+					'label' => 'Starts',
+					'type'  => 'datetime-local',
+					'value' => '2026-08-03T12:30:00+00:00',
+					'save'  => array( 'adapter' => 'custom' ),
+				),
+			)
+		);
+
+		$this->assertSame( $schema, SettingsUISchema::canonicalize_schema_values( $schema ) );
+	}
+
+	/**
+	 * @testdox It mirrors canonical native validation without reporting a compatibility conversion.
+	 */
+	public function test_canonicalize_schema_values_silently_mirrors_canonical_validation(): void {
+		$schema = $this->get_native_schema_with_field(
+			array(
+				'id'         => 'acme_number',
+				'label'      => 'Number',
+				'type'       => 'number',
+				'value'      => 1.5,
+				'validation' => array(
+					'min' => 0.5,
+					'max' => 2.5,
+				),
+				'save'       => array( 'adapter' => 'custom' ),
+			)
+		);
+
+		$canonical = SettingsUISchema::canonicalize_schema_values( $schema );
+		$field     = $canonical['groups']['main']['fields'][0];
+
+		$this->assertSame( $field['validation'], $field['customAttributes'] );
+	}
+
+	/**
+	 * @testdox It does not read option-backed values for non-saving legacy fields.
+	 */
+	public function test_from_legacy_settings_does_not_read_options_for_non_saving_fields(): void {
+		$option_reads = 0;
+		$listener     = static function ( $fallback_value ) use ( &$option_reads ) {
+			++$option_reads;
+			return $fallback_value;
+		};
+		add_filter( 'default_option_acme_external', $listener );
+
+		try {
+			SettingsUISchema::from_legacy_settings(
+				'acme',
+				'',
+				'Acme',
+				array(
+					array(
+						'id'        => 'acme_external',
+						'label'     => 'External',
+						'type'      => 'text',
+						'is_option' => false,
+					),
+				)
+			);
+			SettingsUISchema::from_legacy_settings(
+				'acme',
+				'',
+				'Acme',
+				array(
+					array(
+						'id'    => 'acme_external',
+						'label' => 'External',
+						'type'  => 'text',
+					),
+				),
+				'custom'
+			);
+		} finally {
+			remove_filter( 'default_option_acme_external', $listener );
+		}
+
+		$this->assertSame( 0, $option_reads );
+	}
+
+	/**
 	 * @testdox It accepts every field type supported by the current renderer.
 	 *
 	 * @dataProvider supported_field_types
@@ -779,10 +1304,11 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 			'array'          => array( 'array', array( 'a' ) ),
 			'checkbox'       => array( 'checkbox', true ),
 			'date'           => array( 'date', '2026-08-03' ),
-			'datetime-local' => array( 'datetime-local', '2026-08-03T12:30' ),
+			'datetime-local' => array( 'datetime-local', '2026-08-03T12:30:00+00:00' ),
 			'email'          => array( 'email', 'merchant@example.com' ),
 			'info'           => array( 'info', null ),
-			'number'         => array( 'number', '02' ),
+			'integer'        => array( 'integer', 2 ),
+			'number'         => array( 'number', 2 ),
 			'password'       => array( 'password', 'secret' ),
 			'radio'          => array( 'radio', 'a' ),
 			'select'         => array( 'select', 'a' ),
@@ -931,7 +1457,7 @@ class SettingsUISchemaTest extends WC_Unit_Test_Case {
 			'empty component name'        => array( $invalid_component, 'Field "acme_field" component must be a non-empty string.' ),
 			'unsupported field save'      => array( $invalid_field_save, 'Field "acme_field" save adapter must be "form_post" or "none".' ),
 			'missing visibility control'  => array( $invalid_visibility, 'Field "acme_field" visibility controller "missing" does not reference a field.' ),
-			'bound on text field'         => array( $invalid_bound, 'Field "acme_field" may define "min" only when its type is "number".' ),
+			'bound on text field'         => array( $invalid_bound, 'Field "acme_field" may define "min" only when its type is "number" or "integer".' ),
 			'saving info field'           => array( $invalid_info, 'Field "acme_field" of type "info" must use the "none" save adapter.' ),
 			'malformed shell navigation'  => array( $invalid_shell, 'Shell navigation item 0 href must be a string.' ),
 			'malformed breadcrumb'        => array( $invalid_breadcrumb, 'Shell breadcrumb 0 label must be a string.' ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2442,6 +2442,9 @@ importers:
       '@wordpress/components':
         specifier: catalog:wp-min
         version: 30.6.5(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date':
+        specifier: catalog:wp-min
+        version: 5.33.1
       '@wordpress/element':
         specifier: catalog:wp-min
         version: 6.33.1


### PR DESCRIPTION
NOT READY FOR REVIEW

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Invalid or partially registered Settings UI schemas could render controls the server did not authorize, hide the classic Save action, or change values while crossing the classic persistence boundary. Settings schemas are now validated and canonicalized before reaching the client, server-side failures return to the classic renderer, and missing client components or save adapters fail closed without a Save action. Original form values remain authoritative until a setting is edited, so existing option names, sanitizers, hooks, and the classic save endpoint continue to govern persistence.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #64387.

#### Backward compatibility

No public or interface signatures, hooks, option names, or persistence endpoints are removed or renamed. Legacy settings definitions remain supported, while native providers with invalid or unsupported renderer metadata now fall back to classic settings; the experimental custom-type contract no longer accepts unknown types solely because JavaScript registered them. Multisite was not exercised separately; the change continues to use the existing site-scoped settings path and introduces no new topology or install-layout assumptions.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not included. The automated browser spec exercises the classic fallback, missing-component failure state, and successful Products inventory save round trip.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter 'SettingsUISchemaTest|SettingsUIFeatureFlagTest'` and confirm the focused schema and fallback suite passes.
2. From the repository root, run `pnpm --filter=@woocommerce/settings-ui test:js` and confirm the value serialization, native field, registry, and page-boundary tests pass.
3. Start the E2E environment, then from `plugins/woocommerce` run `pnpm test:e2e:default --project=core-serial tests/settings/settings-ui-feature-flag.spec.ts`. Confirm invalid server schemas use classic settings, missing runtime components show the safe error state without Save, and an inventory value survives a separate settings edit.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHP unit suite: 133 tests, 325 assertions passed in the WooCommerce `wp-env` test container.
- Settings UI Jest suite: 68 tests passed.
- Settings UI production build: all 10 entry points built.
- Settings UI lint and type checks: 0 errors; 63 pre-existing warnings remain.
- PHP coding standards: changed-file lint and full branch-diff lint passed without errors or warnings.
- Targeted Playwright spec: 7 tests passed and 1 installation setup test was skipped, against a fresh local `wp-env` site.
- `git diff --check` and PHP syntax checks passed.
- Structured review covered correctness, project conventions, tests, maintainability, performance, API contracts, and reliability; all actionable findings were resolved and independently revalidated.
- PHPStan could not reach code analysis in this checkout: host PHP 7.4 cannot parse the current vendor stubs, while the PHP container does not mount the configured `woocommerce-analytics/src` path. No baseline changes were made.

#### Post-deploy monitoring and validation

- During the release candidate and first 24 hours after release, the WooCommerce Settings maintainers or release lead should check WooCommerce logs with source `settings-ui` for `Settings UI schema could not be resolved` and developer logs for `fell back to the legacy settings renderer`.
- Healthy behavior is no fallback from built-in settings pages, no increase in settings-page JavaScript failures, and unchanged saved values after editing an unrelated field. Fallbacks from invalid third-party schemas are expected and should name the rejected contract.
- Treat any built-in-page fallback, value rewrite/loss, or runtime error that removes both the Settings UI and usable classic path as a release blocker. Disable the `settings-ui` feature, use the request-only classic rendering override for diagnosis, and roll back the affected build while investigating.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually for both `@woocommerce/plugin-woocommerce` and `@woocommerce/settings-ui`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
