### PR TITLE
Update session cookies hashing

### DIFF
--- a/plugins/woocommerce/changelog/switch-from-wp-fast-hash-to-hash
+++ b/plugins/woocommerce/changelog/switch-from-wp-fast-hash-to-hash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update session cookies hashing

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -320,12 +320,24 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Verify a hash produced by self::hash().
 	 *
+	 * Hashes produced by the previous `wp_fast_hash()` implementation are still accepted so that guest sessions
+	 * created before this change are not invalidated. That fallback can be removed once those cookies have expired.
+	 *
 	 * @param string $message Message to verify.
 	 * @param string $hash Hash to verify.
 	 * @return bool Whether the hash is valid.
 	 */
 	private function verify_hash( string $message, string $hash ) {
-		return hash_equals( $this->hash( $message ), $hash );
+		if ( hash_equals( $this->hash( $message ), $hash ) ) {
+			return true;
+		}
+
+		// `wp_fast_hash()` prefixes its output with `$generic$`, so only those cookies take the legacy path.
+		if ( function_exists( 'wp_verify_fast_hash' ) && str_starts_with( $hash, '$generic$' ) ) {
+			return wp_verify_fast_hash( $message, $hash );
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -321,7 +321,7 @@ class WC_Session_Handler extends WC_Session {
 	 * Verify a hash produced by self::hash().
 	 *
 	 * Hashes produced by the previous `wp_fast_hash()` implementation are still accepted so that guest sessions
-	 * created before this change are not invalidated. That fallback can be removed once those cookies have expired.
+	 * created before this change are not invalidated. That fallback can be removed in 11.1.0 forward after those cookies have expired.
 	 *
 	 * @param string $message Message to verify.
 	 * @param string $hash Hash to verify.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -308,34 +308,24 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Hash a value using wp_fast_hash (from WP 6.8 onwards).
-	 *
-	 * This method can be removed when the minimum version supported is 6.8.
+	 * Hash a value for the session cookie integrity tag.
 	 *
 	 * @param string $message Value to hash.
 	 * @return string Hashed value.
 	 */
 	private function hash( string $message ) {
-		if ( function_exists( 'wp_fast_hash' ) ) {
-			return wp_fast_hash( $message );
-		}
 		return hash_hmac( 'md5', $message, wp_hash( $message ) );
 	}
 
 	/**
-	 * Verify a hash using wp_verify_fast_hash (from WP 6.8 onwards).
-	 *
-	 * This method can be removed when the minimum version supported is 6.8.
+	 * Verify a hash produced by self::hash().
 	 *
 	 * @param string $message Message to verify.
 	 * @param string $hash Hash to verify.
 	 * @return bool Whether the hash is valid.
 	 */
 	private function verify_hash( string $message, string $hash ) {
-		if ( function_exists( 'wp_verify_fast_hash' ) ) {
-			return wp_verify_fast_hash( $message, $hash );
-		}
-		return hash_equals( hash_hmac( 'md5', $message, wp_hash( $message ) ), $hash );
+		return hash_equals( $this->hash( $message ), $hash );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
@@ -41,6 +41,8 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		$features            = $features_controller->get_features( true );
 		$features_controller->change_feature_enable( self::DESTROY_EMPTY_SESSION_FEATURE, ! empty( $features[ self::DESTROY_EMPTY_SESSION_FEATURE ]['enabled_by_default'] ) );
 
+		unset( $_COOKIE[ $this->get_session_cookie_name() ] );
+
 		parent::tearDown();
 	}
 
@@ -513,6 +515,90 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 
 		// Verify the DB and cache cleanup results.
 		$this->assertSame( array( array( 'customer' ) ), $wpdb->get_results( $wpdb->prepare( "SELECT session_key FROM %i WHERE session_key IN ('guest', 'customer')", "{$wpdb->prefix}woocommerce_sessions" ), ARRAY_N ) );
+	}
+
+	/**
+	 * @testdox Test that get_session_cookie accepts a cookie hashed with the current implementation.
+	 */
+	public function test_get_session_cookie_accepts_current_hash(): void {
+		$this->set_session_cookie( $this->build_session_cookie_value( 'cust_1', 'current' ) );
+
+		$cookie = $this->handler->get_session_cookie();
+
+		$this->assertNotFalse( $cookie, 'Cookie hashed with the current implementation should be accepted.' );
+		$this->assertSame( 'cust_1', $cookie[0] );
+	}
+
+	/**
+	 * @testdox Test that get_session_cookie still accepts a cookie hashed with the legacy wp_fast_hash implementation.
+	 */
+	public function test_get_session_cookie_accepts_legacy_fast_hash(): void {
+		if ( ! function_exists( 'wp_fast_hash' ) ) {
+			$this->markTestSkipped( 'wp_fast_hash() requires WordPress 6.8 or newer.' );
+		}
+
+		$this->set_session_cookie( $this->build_session_cookie_value( 'cust_1', 'legacy' ) );
+
+		$cookie = $this->handler->get_session_cookie();
+
+		$this->assertNotFalse( $cookie, 'Cookie hashed with wp_fast_hash() should still be accepted so existing guest sessions survive.' );
+		$this->assertSame( 'cust_1', $cookie[0] );
+	}
+
+	/**
+	 * @testdox Test that get_session_cookie rejects a cookie with a tampered hash.
+	 */
+	public function test_get_session_cookie_rejects_tampered_hash(): void {
+		$this->set_session_cookie( $this->build_session_cookie_value( 'cust_1', 'current' ) . 'tampered' );
+
+		$this->assertFalse( $this->handler->get_session_cookie() );
+	}
+
+	/**
+	 * @testdox Test that get_session_cookie rejects a cookie whose customer ID no longer matches the hash.
+	 */
+	public function test_get_session_cookie_rejects_tampered_customer_id(): void {
+		$cookie_value = $this->build_session_cookie_value( 'cust_1', 'current' );
+		$this->set_session_cookie( str_replace( 'cust_1', 'cust_2', $cookie_value ) );
+
+		$this->assertFalse( $this->handler->get_session_cookie() );
+	}
+
+	/**
+	 * Helper function to build a session cookie value for the handler under test.
+	 *
+	 * @param string $customer_id Customer ID to embed in the cookie.
+	 * @param string $hash_type   Either 'current' for the wp_hash() based tag, or 'legacy' for a wp_fast_hash() tag.
+	 * @return string
+	 */
+	protected function build_session_cookie_value( string $customer_id, string $hash_type ): string {
+		$session_expiration = time() + DAY_IN_SECONDS;
+		$session_expiring   = $session_expiration - HOUR_IN_SECONDS;
+		$message            = $customer_id . '|' . $session_expiration;
+		$cookie_hash        = 'legacy' === $hash_type ? wp_fast_hash( $message ) : hash_hmac( 'md5', $message, wp_hash( $message ) );
+
+		return implode( '|', array( $customer_id, $session_expiration, $session_expiring, $cookie_hash ) );
+	}
+
+	/**
+	 * Helper function to set the session cookie as if it were passed by the browser.
+	 *
+	 * @param string $cookie_value Raw cookie value.
+	 */
+	protected function set_session_cookie( string $cookie_value ) {
+		$_COOKIE[ $this->get_session_cookie_name() ] = $cookie_value;
+	}
+
+	/**
+	 * Helper function to read the cookie name used by the handler under test.
+	 *
+	 * @return string
+	 */
+	protected function get_session_cookie_name(): string {
+		$cookie_property = ( new ReflectionClass( $this->handler ) )->getProperty( '_cookie' );
+		$cookie_property->setAccessible( true );
+
+		return (string) $cookie_property->getValue( $this->handler );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes how session cookie hash is computed, away from wp_fast_hash to a regular hash, this is because wp_fast_hash is not meant for this task (low entropy, predictable values like user IDs, and is not salted).

### Backward compatibility

Session cookies are a public contract with the browser, so cookies issued before this change must keep working. `verify_hash()` accepts the new `wp_hash()`-based HMAC tag first, and falls back to `wp_verify_fast_hash()` when that does not match. Without the fallback, every existing guest cookie would fail verification on deploy and those carts would be dropped.

The fallback is gated on the hash starting with `$generic$` (the prefix `wp_fast_hash()` adds), so new-format cookies never take that path — otherwise `wp_verify_fast_hash()` would treat the 32-char HMAC as a phpass hash and load `class-phpass.php` on every request. Logged-in users are unaffected either way, since their session is loaded from user meta. The fallback can be removed once the legacy cookies have aged out.



(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58140

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**New sessions**

1. Add a product to cart.
2. Close the tab.
3. Open it again, ensure items still in cart.

**Upgrade path (existing cookies keep working)**

1. On `trunk`, as a guest, add a product to cart. This issues a `wp_fast_hash()`-based session cookie.
2. Switch to this branch without clearing cookies.
3. Reload the store — the cart should still contain the product, and `wp_woocommerce_session_*` should be unchanged until it hits its refresh window.
<!-- End testing instructions -->

### Testing that has already taken place:

Added unit tests in `WC_Tests_Session_Handler` covering the current tag, the legacy `wp_fast_hash()` tag, a tampered hash, and a tampered customer ID. Verified locally against WP 7.0.2 / PHP 8.1 that all four pass, and confirmed the legacy test fails when the fallback is removed.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

