### PR TITLE
[Payments NOX] Add GoCardless to UK/GB

### DIFF
--- a/plugins/woocommerce/changelog/add-gocardless-uk-gb
+++ b/plugins/woocommerce/changelog/add-gocardless-uk-gb
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add GoCardless as a recommended payment partner extension for GB (UK) merchants.

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php
@@ -264,6 +264,7 @@ class PaymentsExtensionSuggestions {
 					),
 				),
 			),
+			self::GOCARDLESS,
 			self::PAYPAL_WALLET,
 			self::AMAZON_PAY,
 			self::AFFIRM          => array(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
@@ -128,7 +128,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 		$country_suggestions_count = array(
 			'CA' => 10,
 			'US' => 11,
-			'GB' => 14,
+			'GB' => 15,
 			'AT' => 13,
 			'BE' => 11,
 			'BG' => 7,
@@ -439,7 +439,7 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 		$country_suggestions_count = array(
 			'CA' => 10,
 			'US' => 11,
-			'GB' => 14,
+			'GB' => 15,
 			'AT' => 13,
 			'BE' => 11,
 			'BG' => 7,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Suggestions/PaymentsExtensionSuggestionsTest.php
@@ -694,6 +694,26 @@ class PaymentsExtensionSuggestionsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that GoCardless is placed immediately after Klarna Checkout in the GB suggestions order.
+	 *
+	 * The order of entries in PaymentsExtensionSuggestions::$country_extensions determines the
+	 * suggestions' display priority, so this guards against accidental reordering.
+	 */
+	public function test_get_country_extensions_gb_gocardless_order() {
+		// Act.
+		$extensions = $this->sut->get_country_extensions( 'GB' );
+		$ids        = array_column( $extensions, 'id' );
+
+		// Assert.
+		$this->assertCount( 15, $ids );
+		$klarna_checkout_index = array_search( PaymentsExtensionSuggestions::KLARNA_CHECKOUT, $ids, true );
+		$gocardless_index      = array_search( PaymentsExtensionSuggestions::GOCARDLESS, $ids, true );
+		$this->assertNotFalse( $klarna_checkout_index, 'Klarna Checkout should be in the GB suggestions.' );
+		$this->assertNotFalse( $gocardless_index, 'GoCardless should be in the GB suggestions.' );
+		$this->assertSame( $klarna_checkout_index + 1, $gocardless_index, 'GoCardless should immediately follow Klarna Checkout in the GB suggestions.' );
+	}
+
+	/**
 	 * Test getting payment extension suggestions by country with per-country config that uses merges.
 	 */
 	public function test_get_country_extensions_with_per_country_merges() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

GoCardless is already a fully registered payment partner suggestion in the Payments settings/onboarding ("NOX") system, but it was missing from the GB (UK) country list — an earlier placement pass missed it. This adds GoCardless to the GB country list, per the Payment Partnerships Onboarding Placement Tracking spreadsheet, so GB merchants see it as a recommended payment option alongside the other partners already listed for that market.

Closes WOOPRD-3638

### How to test the changes in this Pull Request:

1. On `trunk`, set your store's base country to United Kingdom (GB) and open WooCommerce → Settings → Payments (or the onboarding payments task). Confirm GoCardless is **not** in the list of recommended payment partner extensions.
2. Check out this branch and repeat step 1. Confirm GoCardless now appears in the list of recommended payment providers, positioned after Klarna Checkout.
3. Run `pnpm test:php:env -- --filter PaymentsExtensionSuggestionsTest` from `plugins/woocommerce` and confirm all tests pass.

### Testing that has already taken place:

-   `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` — clean
-   `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` — clean
-   `composer exec -- phpstan analyse src/Internal/Admin/Suggestions/PaymentsExtensionSuggestions.php --memory-limit=2G` — no errors
-   Full `PaymentsExtensionSuggestionsTest` suite (505 tests, 1271 assertions) passes via `pnpm test:php:env`
-   Independent Codex CLI review of the branch diff: no critical/important/suggestion findings. Confirmed the array position affects suggestion priority sort order (correct as placed), no other registry needed syncing, and no i18n/whitelist impact.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>