### PR TITLE
e2e tests: Await webhook cleanup in webhooks.spec.ts

### DIFF
--- a/plugins/woocommerce/changelog/testops-255-await-webhooks-cleanup
+++ b/plugins/woocommerce/changelog/testops-255-await-webhooks-cleanup
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Await the webhook cleanup request in the E2E webhooks spec so afterAll cannot finish before the deletions complete. Test-only change, no production impact.

--- a/plugins/woocommerce/tests/e2e/tests/settings/webhooks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/webhooks.spec.ts
@@ -13,13 +13,16 @@ test.describe( 'Manage webhooks', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
 	test.afterAll( async ( { restApi } ) => {
-		await restApi.get( `${ WC_API_PATH }/webhooks` ).then( ( response ) => {
-			const ids = response.data.map( ( webhook ) => webhook.id );
+		const response = await restApi.get( `${ WC_API_PATH }/webhooks`, {
+			per_page: 100,
+		} );
+		const ids = response.data.map( ( webhook ) => webhook.id );
 
-			restApi.post( `${ WC_API_PATH }/webhooks/batch`, {
+		if ( ids.length ) {
+			await restApi.post( `${ WC_API_PATH }/webhooks/batch`, {
 				delete: ids,
 			} );
-		} );
+		}
 	} );
 
 	const WEBHOOKS_SCREEN_URI =


### PR DESCRIPTION
Fixes TESTOPS-255

### Changes proposed in this Pull Request:

The `afterAll` hook in `webhooks.spec.ts` fired the batch-delete inside a `.then()` without awaiting it. The hook could therefore resolve before the deletions landed, leaking webhooks into whatever ran next. It also hid failures: a rejected `post` surfaced as a stray unhandled rejection rather than a failed hook.

The cleanup is now awaited. The preceding GET also asks for `per_page=100`, because the REST default of 10 left the rest of an aborted run's webhooks in place. 100 is both the endpoint maximum and the batch endpoint's item limit, so the two calls stay in lockstep.

### How to test the changes in this Pull Request:

1. Create a few webhooks in **WooCommerce → Settings → Advanced → Webhooks** so the store starts dirty.
2. Run the spec: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e -- tests/settings/webhooks.spec.ts`
3. Confirm it passes.
4. Reload the Webhooks screen. It should be empty. On `trunk`, webhooks can survive the run.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
