### PR TITLE
e2e tests: Fix swallowed REST API errors in the order emails spec

### DIFF
--- a/plugins/woocommerce/changelog/testops-256-order-emails-error-propagation
+++ b/plugins/woocommerce/changelog/testops-256-order-emails-error-propagation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Propagate REST API errors in the order emails e2e spec instead of swallowing them; test-only, no changes to shipped code.

--- a/plugins/woocommerce/tests/e2e/tests/email/order-emails.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/order-emails.spec.ts
@@ -17,19 +17,10 @@ import { setFeatureEmailImprovementsFlag } from './helpers/set-email-improvement
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
 	order: async ( { restApi }, use ) => {
-		let order;
-
-		await restApi
-			.post( `${ WC_API_PATH }/orders`, {
-				status: 'processing',
-				billing: { email: faker.internet.exampleEmail() },
-			} )
-			.then( ( response ) => {
-				order = response.data;
-			} )
-			.catch( ( error ) => {
-				console.error( error );
-			} );
+		const { data: order } = await restApi.post( `${ WC_API_PATH }/orders`, {
+			status: 'processing',
+			billing: { email: faker.internet.exampleEmail() },
+		} );
 
 		await use( order );
 
@@ -79,31 +70,19 @@ test.beforeEach( async ( { baseURL } ) => {
 			subject.replace( 'ORDER_ID', `${ order.id }` )
 		);
 
-		await restApi
-			.put( `${ WC_API_PATH }/orders/${ order.id }`, {
-				status,
-			} )
-			.catch( ( error ) => {
-				console.error( error );
-			} );
+		const { data: updatedOrder } = await restApi.put(
+			`${ WC_API_PATH }/orders/${ order.id }`,
+			{ status }
+		);
 
-		let orderStatus;
-		await restApi
-			.get( `${ WC_API_PATH }/orders/${ order.id }` )
-			.then( ( response ) => {
-				orderStatus = response.data.status;
-			} );
+		expect( updatedOrder.status ).toEqual( status );
 
-		await expect( orderStatus ).toEqual( status );
-
-		let emailRow;
-		await test.step( 'check the email exists', async () => {
-			emailRow = await expectEmail(
+		const emailRow = await test.step( 'check the email exists', () =>
+			expectEmail(
 				page,
 				role === 'customer' ? order.billing.email : admin.email,
 				subjectRegex
-			);
-		} );
+			) );
 
 		await test.step( 'check the email content', async () => {
 			await emailRow.getByRole( 'button', { name: 'View log' } ).click();


### PR DESCRIPTION
Fixes TESTOPS-256

### Changes proposed in this Pull Request:

`order-emails.spec.ts` wrapped its REST calls in `.catch()` handlers that only logged the error. Execution continued, so a failed request showed up as a missing-property error further down the test instead of the API failure that caused it. Await the calls directly: the API client is an axios instance with the default `validateStatus`, so a non-2xx response rejects and the real error reaches the report.

Two cleanups of the same shape came out of reviewing the file:

- The `GET` after the status `PUT` was redundant. `WC_REST_Orders_Controller::save_object()` re-reads the order after saving and returns it, so the `PUT` body is already authoritative.
- `emailRow` was assigned inside a `test.step` callback and used outside it. `test.step` returns its callback's value, so it is now a `const`.

### How to test the changes in this Pull Request:

1. Start the E2E environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:test:e2e:start`.
2. Run the spec and confirm all five tests pass: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e -- tests/email/order-emails.spec.ts`.
3. Break the order creation in the `order` fixture — change the path to `${ WC_API_PATH }/nope` — and re-run. The failure should name the REST error (`Request failed with status code 404`) at the fixture, not a missing property later in the test.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
