### PR TITLE
e2e tests: Normalize IS_MULTISITE env var handling

### DIFF
--- a/plugins/woocommerce/changelog/testops-257-normalize-is-multisite
+++ b/plugins/woocommerce/changelog/testops-257-normalize-is-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: normalize the IS_MULTISITE env var to '1'/unset so multisite skips behave consistently regardless of how the system status endpoint reports wp_multisite.

--- a/plugins/woocommerce/tests/e2e/fixtures/site.setup.ts
+++ b/plugins/woocommerce/tests/e2e/fixtures/site.setup.ts
@@ -91,12 +91,23 @@ setup( 'setup site', async ( { baseURL, restApi } ) => {
 		const response = await restApi.get( `${ WC_API_PATH }/system_status` );
 		const { environment } = response.data;
 
-		if ( environment.wp_multisite === false ) {
-			delete process.env.IS_MULTISITE;
+		// `wp_multisite` is a boolean (`is_multisite()`, schema `type: boolean`),
+		// but the response is untyped here and these suites also run against
+		// remote hosts on arbitrary WooCommerce versions, where a filter on
+		// `woocommerce_rest_prepare_system_status` could return a stringy value.
+		// Comparing the stringified value resolves either form. IS_MULTISITE is
+		// presence-based: '1' on multisite, unset otherwise — never '0'.
+		const rawMultisite = String( environment.wp_multisite ).toLowerCase();
+		const isMultisite = rawMultisite === 'true' || rawMultisite === '1';
+
+		if ( isMultisite ) {
+			process.env.IS_MULTISITE = '1';
 		} else {
-			process.env.IS_MULTISITE = environment.wp_multisite;
-			console.log( `IS_MULTISITE: ${ process.env.IS_MULTISITE }` );
+			delete process.env.IS_MULTISITE;
 		}
+		console.log(
+			`IS_MULTISITE: ${ process.env.IS_MULTISITE ?? '(unset)' }`
+		);
 	} );
 
 	await setup.step( 'general settings', async () => {

--- a/plugins/woocommerce/tests/e2e/tests/api-tests/customers/customers-crud.test.ts
+++ b/plugins/woocommerce/tests/e2e/tests/api-tests/customers/customers-crud.test.ts
@@ -344,7 +344,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 	test.describe( 'Delete a customer', () => {
 		test( 'can permanently delete an customer', async ( { request } ) => {
 			test.skip(
-				process.env.IS_MULTISITE === 'true',
+				!! process.env.IS_MULTISITE,
 				'Skip tests on deleting a customer on multisites until bug #384 in private repo is resolved.'
 			);
 
@@ -518,7 +518,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 
 		test( 'can batch delete customers', async ( { request } ) => {
 			test.skip(
-				process.env.IS_MULTISITE === 'true',
+				!! process.env.IS_MULTISITE,
 				'Skip tests on deleting a customer on multisites until bug #384 in private repo is resolved.'
 			);
 

--- a/plugins/woocommerce/tests/e2e/tests/email/account-emails.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/email/account-emails.spec.ts
@@ -35,7 +35,7 @@ test.beforeEach( async ( { baseURL } ) => {
 } );
 
 test.skip(
-	process.env.IS_MULTISITE,
+	!! process.env.IS_MULTISITE,
 	'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55082'
 );
 

--- a/plugins/woocommerce/tests/e2e/tests/onboarding/onboarding-wizard.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/onboarding/onboarding-wizard.spec.ts
@@ -45,7 +45,7 @@ test.describe(
 			page,
 		} ) => {
 			test.skip(
-				process.env.IS_MULTISITE,
+				!! process.env.IS_MULTISITE,
 				'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55066'
 			);
 			await page.goto(
@@ -206,7 +206,7 @@ test.describe(
 			page,
 		} ) => {
 			test.skip(
-				process.env.IS_MULTISITE,
+				!! process.env.IS_MULTISITE,
 				'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55066'
 			);
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e/tests/user/users-create.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/user/users-create.spec.ts
@@ -40,7 +40,7 @@ const test = baseTest.extend( {
 for ( const userData of users ) {
 	test( `can create a new ${ userData.role }`, async ( { page, user } ) => {
 		test.skip(
-			process.env.IS_MULTISITE,
+			!! process.env.IS_MULTISITE,
 			'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55082'
 		);
 		await page.goto( `wp-admin/user-new.php` );

--- a/plugins/woocommerce/tests/e2e/tests/user/users-manage.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/user/users-manage.spec.ts
@@ -304,7 +304,7 @@ test( `can update customer data`, async ( { page, customer } ) => {
 
 test( `can update shop manager data`, async ( { page, manager } ) => {
 	test.skip(
-		process.env.IS_MULTISITE,
+		!! process.env.IS_MULTISITE,
 		'Test not working on a multisite setup'
 	);
 	await page.goto( `wp-admin/user-edit.php?user_id=${ manager.id }` );
@@ -337,7 +337,7 @@ test( `can update shop manager data`, async ( { page, manager } ) => {
 
 test( `can delete a customer`, async ( { page, customer } ) => {
 	test.skip(
-		process.env.IS_MULTISITE,
+		!! process.env.IS_MULTISITE,
 		'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55082'
 	);
 	expect( await userDeletionTest( page, customer.username ) ).toBeTruthy();
@@ -345,7 +345,7 @@ test( `can delete a customer`, async ( { page, customer } ) => {
 
 test( `can delete a shop manager`, async ( { page, manager } ) => {
 	test.skip(
-		process.env.IS_MULTISITE,
+		!! process.env.IS_MULTISITE,
 		'Test not working on a multisite setup, see https://github.com/woocommerce/woocommerce/issues/55082'
 	);
 	expect( await userDeletionTest( page, manager.username ) ).toBeTruthy();


### PR DESCRIPTION
Fixes TESTOPS-257

### Changes proposed in this Pull Request:

The `site setup` fixture treated `wp_multisite` as non-multisite only when it was strictly `false`. Anything else — including the strings `"0"` and `"false"` — went straight into `IS_MULTISITE`, and the consumers then disagreed about what it meant. Seven call sites checked truthiness, where a non-empty string reads as multisite. Two checked `=== 'true'`, which never matched, because the endpoint returns a boolean.

`IS_MULTISITE` is now `'1'` on multisite and unset otherwise, never `'0'`, and all nine consumers check truthiness. Unrecognized values fall through to unset, so the affected tests run instead of silently skipping.

This changes behaviour in one place: the two `customers-crud` API tests never skipped on multisite, and now do — which is what their skip reason always intended.

### How to test the changes in this Pull Request:

On a single-site environment:

1. Run a spec that depends on the `site setup` project, e.g. `pnpm test:e2e-pw --project=api -g "can permanently delete an customer"`.
2. The setup log prints `IS_MULTISITE: (unset)`.
3. The customer-deletion tests run.

On a multisite environment:

1. Run the same command.
2. The setup log prints `IS_MULTISITE: 1`.
3. The customer-deletion tests skip, along with the existing multisite skips in `users-create`, `users-manage`, `account-emails`, and `onboarding-wizard`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
