### PR TITLE
e2e tests: Fix lost-response race in analytics and variable product specs

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics-overview-e2e-waitforresponse-race
+++ b/plugins/woocommerce/changelog/fix-analytics-overview-e2e-waitforresponse-race
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Fix lost-response race in the Analytics Overview and variable product E2E tests by registering waitForResponse before the click that triggers the save.

--- a/plugins/woocommerce/tests/e2e/tests/analytics/analytics-overview.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/analytics/analytics-overview.spec.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { test, expect } from '@playwright/test';
-import type { Page, Locator } from '@playwright/test';
+import type {
+	Page,
+	Locator,
+	Response as PlaywrightResponse,
+} from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -29,6 +33,22 @@ const headers = {
 	Authorization: `Basic ${ base64String }`,
 	cookie: '',
 };
+
+// Call this before the click that triggers the save, and await the returned
+// promise after it — registering the listener after the click can miss a
+// response that already arrived.
+const waitForUserPrefsSave = () =>
+	page.waitForResponse(
+		( res ) =>
+			res.url().includes( `/users/${ userId }` ) &&
+			res.request().method() !== 'GET'
+	);
+
+const expectSaved = ( response: PlaywrightResponse ) =>
+	expect(
+		response.ok(),
+		`${ response.status() } ${ response.url() }`
+	).toBeTruthy();
 
 const hidePerformanceSection = async () => {
 	const response =
@@ -212,12 +232,9 @@ test.describe(
 
 					await test.step( `Move first section down`, async () => {
 						await buttons_ellipsis.first().click();
+						const savePromise = waitForUserPrefsSave();
 						await menuitem_moveDown.click();
-						await page.waitForResponse(
-							( response ) =>
-								response.url().includes( '/users' ) &&
-								response.ok()
-						);
+						expectSaved( await savePromise );
 					} );
 
 					await test.step( `Expect the second section to become first, and first becomes second.`, async () => {
@@ -241,12 +258,9 @@ test.describe(
 
 					await test.step( `Move second section up`, async () => {
 						await buttons_ellipsis.nth( 1 ).click();
+						const savePromise = waitForUserPrefsSave();
 						await menuitem_moveUp.click();
-						await page.waitForResponse(
-							( response ) =>
-								response.url().includes( '/users' ) &&
-								response.ok()
-						);
+						expectSaved( await savePromise );
 					} );
 
 					await test.step( `Expect second section becomes first section, first becomes second`, async () => {
@@ -268,13 +282,11 @@ test.describe(
 						name: 'Choose which analytics to display and the section name',
 					} )
 					.click();
+				const savePromise = waitForUserPrefsSave();
 				await page
 					.getByRole( 'menuitem', { name: 'Remove section' } )
 					.click();
-				await page.waitForResponse(
-					( response ) =>
-						response.url().includes( '/users' ) && response.ok()
-				);
+				expectSaved( await savePromise );
 			} );
 
 			await test.step( `Expect the Performance section to be hidden`, async () => {
@@ -284,16 +296,14 @@ test.describe(
 		} );
 
 		test( 'should allow a user to add a section back in', async () => {
-			await hidePerformanceSection( page );
+			await hidePerformanceSection();
 			await page.reload();
 
 			await test.step( `Add the Performance section back in.`, async () => {
 				await page.getByTitle( 'Add more sections' ).click();
+				const savePromise = waitForUserPrefsSave();
 				await page.getByTitle( 'Add Performance section' ).click();
-				await page.waitForResponse(
-					( response ) =>
-						response.url().includes( '/users' ) && response.ok()
-				);
+				expectSaved( await savePromise );
 			} );
 
 			await test.step( `Expect the Performance section to be added back.`, async () => {

--- a/plugins/woocommerce/tests/e2e/tests/product/create-variable-product.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/create-variable-product.spec.ts
@@ -66,6 +66,16 @@ test.describe( 'Add variable product', { tag: tags.GUTENBERG }, () => {
 			} );
 
 		if ( tourWasDisplayed ) {
+			// Start listening before the click — the save can complete before
+			// the click call returns, and a listener registered afterwards
+			// would never see it.
+			const savePromise = page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/users/' ) &&
+					response.request().method() !== 'GET' &&
+					response.ok()
+			);
+
 			await test.step( 'Tour was displayed, so dismiss it.', async () => {
 				await page
 					.getByRole( 'button', { name: 'Close Tour' } )
@@ -73,11 +83,7 @@ test.describe( 'Add variable product', { tag: tags.GUTENBERG }, () => {
 			} );
 
 			await test.step( "Wait for the tour's dismissal to be saved", async () => {
-				await page.waitForResponse(
-					( response ) =>
-						response.url().includes( '/users/' ) &&
-						response.status() === 200
-				);
+				await savePromise;
 			} );
 		}
 


### PR DESCRIPTION
Fixes TESTOPS-254

### Changes proposed in this Pull Request:

Five `page.waitForResponse()` calls were registered after the click that triggers the request. The user-preferences store updates optimistically, so the save can finish before `click()` returns. The listener then never sees the response, and the test waits the full 30 seconds and fails. These waits were added to fix flaky tests. In the wrong order they became a source of flakiness.

Each call now creates the promise before the click and awaits it after, as the [Playwright docs describe](https://playwright.dev/docs/api/class-page#page-wait-for-response).

The predicates were also too loose. `url().includes( '/users' )` matched the `GET /wp/v2/users/me` that core-data sends on page load. Registering the listener earlier widens the window for that GET to satisfy the wait, which trades a late race for an early one. Both predicates now require a non-GET method, and the analytics predicate pins the URL to the current user.

### How to test the changes in this Pull Request:

Both specs run in the `core-parallel` project.

1. Start the e2e environment on this branch.
2. Run `pnpm --filter='@woocommerce/plugin-woocommerce' test:e2e:core-parallel tests/analytics/analytics-overview.spec.ts`. All five tests pass.
3. Run `pnpm --filter='@woocommerce/plugin-woocommerce' test:e2e:core-parallel tests/product/create-variable-product.spec.ts`. It passes.
4. To see the race the old code was exposed to, check out `trunk`, add `await page.waitForTimeout( 2000 );` directly after `menuitem_moveDown.click()` in `analytics-overview.spec.ts`, and run the analytics spec. "should allow a user to move a section down" fails with `Timeout 30000ms exceeded while waiting for event "response"`, because the save lands during the pause and no listener exists yet. The same edit on this branch passes.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
