### PR TITLE
Fix Blueprint screen fatal when a WordPress.org API filter throws

### DIFF
--- a/plugins/woocommerce/changelog/67121-fix-blueprint-themes-api-fatal
+++ b/plugins/woocommerce/changelog/67121-fix-blueprint-themes-api-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the Blueprint settings screen from fataling when a third-party filter throws while WooCommerce requests plugin or theme metadata from WordPress.org.

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -279,34 +279,40 @@ class Init {
 			$all_plugins[ $key ]['slug'] = $slug;
 		}
 
-		$api_response = $this->wp_plugins_api(
-			'plugin_information',
-			array(
-				'fields' => array(
-					'short_description' => false,
-					'sections'          => false,
-					'description'       => false,
-					'tested'            => false,
-					'requires'          => false,
-					'rating'            => false,
-					'ratings'           => false,
-					'downloaded'        => false,
-					'downloadlink'      => false,
-					'last_updated'      => false,
-					'added'             => false,
-					'tags'              => false,
-					'compatibility'     => false,
-					'homepage'          => false,
-					'versions'          => false,
-					'donate_link'       => false,
-					'reviews'           => false,
-					'banners'           => false,
-					'icons'             => false,
-					'active_installs'   => false,
-				),
-				'slugs'  => $plugin_slugs,
-			)
-		);
+		try {
+			$api_response = $this->wp_plugins_api(
+				'plugin_information',
+				array(
+					'fields' => array(
+						'short_description' => false,
+						'sections'          => false,
+						'description'       => false,
+						'tested'            => false,
+						'requires'          => false,
+						'rating'            => false,
+						'ratings'           => false,
+						'downloaded'        => false,
+						'downloadlink'      => false,
+						'last_updated'      => false,
+						'added'             => false,
+						'tags'              => false,
+						'compatibility'     => false,
+						'homepage'          => false,
+						'versions'          => false,
+						'donate_link'       => false,
+						'reviews'           => false,
+						'banners'           => false,
+						'icons'             => false,
+						'active_installs'   => false,
+					),
+					'slugs'  => $plugin_slugs,
+				)
+			);
+		} catch ( \Throwable $e ) {
+			// A third party filtering the plugins API result can throw. Don't let that take down the admin screen.
+			$this->log_api_failure( 'plugins_api', $e );
+			return $all_plugins;
+		}
 
 		// If API fails, return all plugins.
 		if ( is_wp_error( $api_response ) ) {
@@ -349,28 +355,34 @@ class Init {
 			}
 		}
 
-		$api_response = $this->wp_themes_api(
-			'theme_information',
-			array(
-				'fields' => array(
-					'downloadlink'    => true,
-					'sections'        => false,
-					'description'     => false,
-					'rating'          => false,
-					'ratings'         => false,
-					'downloaded'      => false,
-					'last_updated'    => false,
-					'tags'            => false,
-					'homepage'        => false,
-					'screenshots'     => false,
-					'screenshot_url'  => false,
-					'parent'          => false,
-					'versions'        => false,
-					'extended_author' => false,
-				),
-				'slugs'  => $theme_slugs,
-			)
-		);
+		try {
+			$api_response = $this->wp_themes_api(
+				'theme_information',
+				array(
+					'fields' => array(
+						'downloadlink'    => true,
+						'sections'        => false,
+						'description'     => false,
+						'rating'          => false,
+						'ratings'         => false,
+						'downloaded'      => false,
+						'last_updated'    => false,
+						'tags'            => false,
+						'homepage'        => false,
+						'screenshots'     => false,
+						'screenshot_url'  => false,
+						'parent'          => false,
+						'versions'        => false,
+						'extended_author' => false,
+					),
+					'slugs'  => $theme_slugs,
+				)
+			);
+		} catch ( \Throwable $e ) {
+			// A third party filtering the themes API result can throw. Don't let that take down the admin screen.
+			$this->log_api_failure( 'themes_api', $e );
+			return $all_themes;
+		}
 
 		// If the API fails, return all installed themes.
 		if ( is_wp_error( $api_response ) ) {
@@ -387,5 +399,26 @@ class Init {
 
 		set_transient( self::INSTALLED_WP_ORG_THEMES_TRANSIENT, $wp_org_themes );
 		return $wp_org_themes;
+	}
+
+	/**
+	 * Log a WordPress.org API request that threw.
+	 *
+	 * @param string     $api The API that was called, for example "themes_api".
+	 * @param \Throwable $e   The thrown error.
+	 *
+	 * @return void
+	 */
+	private function log_api_failure( string $api, \Throwable $e ) {
+		wc_get_logger()->error(
+			sprintf(
+				'Blueprint: %1$s() threw "%2$s" in %3$s:%4$d. Falling back to the installed list.',
+				$api,
+				$e->getMessage(),
+				$e->getFile(),
+				$e->getLine()
+			),
+			array( 'source' => 'blueprint' )
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
@@ -133,7 +133,7 @@ class InitTest extends MockeryTestCase {
 	 * A third party filtering plugins_api can throw. The export group should still list the installed plugins.
 	 */
 	public function test_get_plugins_for_export_group_falls_back_when_plugins_api_throws() {
-		delete_transient( 'woocommerce_blueprint_installed_wp_org_plugins' );
+		delete_transient( $this->init::INSTALLED_WP_ORG_PLUGINS_TRANSIENT );
 
 		$mock_plugins = array(
 			'plugin-1/plugin.php' => array( 'Name' => 'Plugin One' ),
@@ -147,14 +147,14 @@ class InitTest extends MockeryTestCase {
 		$result = $this->init->get_plugins_for_export_group();
 
 		$this->assertSame( array( 'plugin-1/plugin.php', 'plugin-2/plugin.php' ), wp_list_pluck( $result, 'id' ) );
-		$this->assertFalse( get_transient( 'woocommerce_blueprint_installed_wp_org_plugins' ) );
+		$this->assertFalse( get_transient( $this->init::INSTALLED_WP_ORG_PLUGINS_TRANSIENT ) );
 	}
 
 	/**
 	 * A third party filtering themes_api can throw. The export group should still list the installed themes.
 	 */
 	public function test_get_themes_for_export_group_falls_back_when_themes_api_throws() {
-		delete_transient( 'woocommerce_blueprint_installed_wp_org_themes' );
+		delete_transient( $this->init::INSTALLED_WP_ORG_THEMES_TRANSIENT );
 
 		$mock_theme_1      = $this->createThemeStub( 'theme-one', 'Theme One' );
 		$mock_theme_2      = $this->createThemeStub( 'custom-theme', 'Custom Theme' );
@@ -172,7 +172,7 @@ class InitTest extends MockeryTestCase {
 		$result = $this->init->get_themes_for_export_group();
 
 		$this->assertSame( array( 'theme-one', 'custom-theme' ), wp_list_pluck( $result, 'id' ) );
-		$this->assertFalse( get_transient( 'woocommerce_blueprint_installed_wp_org_themes' ) );
+		$this->assertFalse( get_transient( $this->init::INSTALLED_WP_ORG_THEMES_TRANSIENT ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
@@ -130,6 +130,52 @@ class InitTest extends MockeryTestCase {
 	}
 
 	/**
+	 * A third party filtering plugins_api can throw. The export group should still list the installed plugins.
+	 */
+	public function test_get_plugins_for_export_group_falls_back_when_plugins_api_throws() {
+		delete_transient( 'woocommerce_blueprint_installed_wp_org_plugins' );
+
+		$mock_plugins = array(
+			'plugin-1/plugin.php' => array( 'Name' => 'Plugin One' ),
+			'plugin-2/plugin.php' => array( 'Name' => 'Plugin Two' ),
+		);
+
+		$this->init->shouldReceive( 'wp_get_plugins' )->andReturn( $mock_plugins );
+		$this->init->shouldReceive( 'wp_get_option' )->andReturn( array( 'plugin-1/plugin.php' ) );
+		$this->init->shouldReceive( 'wp_plugins_api' )->once()->andThrow( new \TypeError( 'Argument #1 ($slug) must be of type string, null given' ) );
+
+		$result = $this->init->get_plugins_for_export_group();
+
+		$this->assertSame( array( 'plugin-1/plugin.php', 'plugin-2/plugin.php' ), wp_list_pluck( $result, 'id' ) );
+		$this->assertFalse( get_transient( 'woocommerce_blueprint_installed_wp_org_plugins' ) );
+	}
+
+	/**
+	 * A third party filtering themes_api can throw. The export group should still list the installed themes.
+	 */
+	public function test_get_themes_for_export_group_falls_back_when_themes_api_throws() {
+		delete_transient( 'woocommerce_blueprint_installed_wp_org_themes' );
+
+		$mock_theme_1      = $this->createThemeStub( 'theme-one', 'Theme One' );
+		$mock_theme_2      = $this->createThemeStub( 'custom-theme', 'Custom Theme' );
+		$mock_active_theme = $this->createThemeStub( 'theme-one', 'Theme One' );
+
+		$this->init->shouldReceive( 'wp_get_themes' )->andReturn(
+			array(
+				'theme-one'    => $mock_theme_1,
+				'custom-theme' => $mock_theme_2,
+			)
+		);
+		$this->init->shouldReceive( 'wp_get_theme' )->andReturn( $mock_active_theme );
+		$this->init->shouldReceive( 'wp_themes_api' )->once()->andThrow( new \TypeError( 'Argument #1 ($slug) must be of type string, null given' ) );
+
+		$result = $this->init->get_themes_for_export_group();
+
+		$this->assertSame( array( 'theme-one', 'custom-theme' ), wp_list_pluck( $result, 'id' ) );
+		$this->assertFalse( get_transient( 'woocommerce_blueprint_installed_wp_org_themes' ) );
+	}
+
+	/**
 	 * Test the get_step_groups_for_js method.
 	 */
 	public function test_get_step_groups_for_js() {


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Blueprint asks [WordPress.org](<http://WordPress.org>) for metadata about every installed plugin and theme, and only handled `WP_Error` from those calls. Any third party filtering `plugins_api_result` or `themes_api_result` that throws therefore takes down the whole settings screen — on [WordPress.com](<http://WordPress.com>), `wpcomsh` throws a `TypeError` because it expects a singular `slug` argument that Blueprint's bulk request does not send.

* Catch `Throwable` around both API calls and fall back to the installed list, matching the existing `WP_Error` behaviour.
* Log the failure through `wc_get_logger()` so the integration problem stays visible.

The failure is not cached, so the screen recovers on its own once the throwing integration is fixed. This hardens WooCommerce only — it does not remove the need for `wpcomsh` to leave the result unchanged when `slug` is absent.

Closes woocommerce/woocommerce#67121, closes woocommerce/woocommerce#67121.

(For Bug Fixes) Bug introduced in PR [#57888](<https://github.com/woocommerce/woocommerce/issues/57888>).

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Enable Blueprint under **WooCommerce > Settings > Advanced > Features**.
2. Add a mu-plugin that makes the themes API throw, mimicking the [WordPress.com](<http://WordPress.com>) integration:

   ```php
   add_filter( 'themes_api_result', function ( $res, $action, $args ) {
       if ( 'theme_information' === $action ) {
           throw new TypeError( 'Argument #1 ($slug) must be of type string, null given' );
       }
       return $res;
   }, 1, 3 );
   ```
3. Run `wp transient delete woocommerce_blueprint_installed_wp_org_themes`.
4. Open **WooCommerce > Settings > Advanced > Blueprint**. On `trunk` the screen fatals during footer processing; with this branch it loads, lists the installed themes, and records the error in **WooCommerce > Status > Logs** under `blueprint`.
5. Remove the mu-plugin, delete the transient again, and reload — the theme list is filtered to [WordPress.org](<http://WordPress.org>) themes as before.

### Testing that has already taken place:

* Two unit tests added, one per API path. Both fail on `trunk` with the reported `TypeError` and pass here. `--filter InitTest`: 19 tests, 54 assertions, green.
* Reproduced end to end in `wp-env` (WordPress 7.0.2, PHP 8.4, storefront) against the real [WordPress.com](<http://WordPress.com>) callback body: the Blueprint screen returns 500 without this change and 200 with it, with no PHP fatal and the fallback logged.
* Checked the happy path with no throwing filter: both the plugin and theme transients are still populated normally.
* `lint:php:changes` and PHPStan are clean on the changed source file.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>