### PR TITLE
Fix order list compatibility with WordPress 7.1

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-list-wordpress-71-compatibility
+++ b/plugins/woocommerce/changelog/fix-order-list-wordpress-71-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order list checkbox interactions and responsive layout with WordPress 7.1.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3223,7 +3223,7 @@ body.woocommerce_page_wc-orders {
 			border-top: 1px solid #f5f5f5;
 		}
 
-		tbody tr:hover:not(.status-trash):not(.no-link) td {
+		tbody tr:hover:not(.status-trash):not(.no-link) > :not(.check-column) {
 			cursor: pointer;
 		}
 
@@ -3554,7 +3554,7 @@ body.woocommerce_page_wc-orders {
 			width: 100%;
 		}
 
-		td.column-order_number {
+		.column-order_number {
 			.toggle-row {
 				height: 20px;
 			}
@@ -3574,7 +3574,7 @@ body.woocommerce_page_wc-orders {
 		}
 
 		tr:not(.is-expanded) {
-			td.column-order_number {
+			.column-order_number {
 				vertical-align: top;
 
 				a.order-view {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
@@ -12,7 +12,8 @@ jQuery( function( $ ) {
 		$( document )
 			.on(
 				'click',
-				'.post-type-shop_order .wp-list-table tbody td, .woocommerce_page_wc-orders .wp-list-table.orders tbody td',
+				// WordPress 7.1 renders primary order cells as th instead of td.
+				'.post-type-shop_order .wp-list-table tbody td, .woocommerce_page_wc-orders .wp-list-table.orders tbody :is(td, th)',
 				this.onRowClick
 			)
 			.on( 'click', '.order-preview:not(.disabled)', this.onPreview );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-orders.js
@@ -9,11 +9,17 @@ jQuery( function( $ ) {
 	 * WCOrdersTable class.
 	 */
 	var WCOrdersTable = function() {
+
+		const SELECTORS = [
+			// WordPress 7.1 renders primary order cells as th instead of td.
+			".post-type-shop_order .wp-list-table tbody :is(td.check-column, th.check-column)",
+			".woocommerce_page_wc-orders .wp-list-table.orders tbody :is(td.check-column, th.check-column)"
+		]
+
 		$( document )
 			.on(
 				'click',
-				// WordPress 7.1 renders primary order cells as th instead of td.
-				'.post-type-shop_order .wp-list-table tbody td, .woocommerce_page_wc-orders .wp-list-table.orders tbody :is(td, th)',
+				SELECTORS.join( ', ' ),
 				this.onRowClick
 			)
 			.on( 'click', '.order-preview:not(.disabled)', this.onPreview );

--- a/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/order/order-list-hidden-columns-small-screen.spec.ts
@@ -45,13 +45,11 @@ test.describe(
 			await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
 			const dateCopy = page
-				.locator(
-					'td.column-order_number .order_date.small-screen-only'
-				)
+				.locator( '.column-order_number .order_date.small-screen-only' )
 				.first();
 			const statusCopy = page
 				.locator(
-					'td.column-order_number .order_status.small-screen-only'
+					'.column-order_number .order_status.small-screen-only'
 				)
 				.first();
 

--- a/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
@@ -330,6 +330,7 @@ test.describe( 'Product Reviews', () => {
 			).toBeTruthy();
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
 
+			// WordPress 7.1 renders primary list-table cells as row headers.
 			await expect(
 				reviewRow.getByRole( 'cell', { name: review.review } ).or(
 					reviewRow.getByRole( 'rowheader', {
@@ -354,6 +355,7 @@ test.describe( 'Product Reviews', () => {
 
 			await page.click( 'a[href*="comment_status=trash"]' );
 
+			// WordPress 7.1 renders primary list-table cells as row headers.
 			await expect(
 				reviewRow.getByRole( 'cell', { name: review.review } ).or(
 					reviewRow.getByRole( 'rowheader', {

--- a/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
@@ -196,7 +196,11 @@ test.describe( 'Product Reviews', () => {
 			const reviewRow = page.locator( `#comment-${ review.id }` );
 
 			await expect(
-				reviewRow.getByRole( 'cell', { name: updatedReview } )
+				reviewRow.getByRole( 'cell', { name: updatedReview } ).or(
+					reviewRow.getByRole( 'rowheader', {
+						name: updatedReview,
+					} )
+				)
 			).toBeVisible();
 			await expect(
 				reviewRow.getByLabel( `${ updatedRating } out of 5` )
@@ -326,7 +330,11 @@ test.describe( 'Product Reviews', () => {
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
 
 			await expect(
-				reviewRow.getByRole( 'cell', { name: review.review } )
+				reviewRow.getByRole( 'cell', { name: review.review } ).or(
+					reviewRow.getByRole( 'rowheader', {
+						name: review.review,
+					} )
+				)
 			).toBeVisible();
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
@@ -346,7 +354,11 @@ test.describe( 'Product Reviews', () => {
 			await page.click( 'a[href*="comment_status=trash"]' );
 
 			await expect(
-				reviewRow.getByRole( 'cell', { name: review.review } )
+				reviewRow.getByRole( 'cell', { name: review.review } ).or(
+					reviewRow.getByRole( 'rowheader', {
+						name: review.review,
+					} )
+				)
 			).toBeVisible();
 
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-reviews.spec.ts
@@ -195,6 +195,7 @@ test.describe( 'Product Reviews', () => {
 
 			const reviewRow = page.locator( `#comment-${ review.id }` );
 
+			// WordPress 7.1 renders primary list-table cells as row headers.
 			await expect(
 				reviewRow.getByRole( 'cell', { name: updatedReview } ).or(
 					reviewRow.getByRole( 'rowheader', {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

WordPress 7.1 renders primary list-table cells as `th` instead of `td`, which breaks WooCommerce order-row click handling and responsive styling. This updates order-list selectors to support both cell elements while excluding checkbox cells from pointer behavior, and makes product-review end-to-end assertions accept accessible row headers.

The upstream markup change was introduced in [WordPress changeset 62838](https://core.trac.wordpress.org/changeset/62838).


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Install and activate WordPress 7.1 with this WooCommerce build.
2. Go to **WooCommerce > Orders**.
3. Hover over and click an order checkbox. Confirm the checkbox does not show the row-link pointer cursor and clicking it only selects the order.
4. Hover over and click order data cells, including the order-number cell. Confirm they show the pointer cursor and open the order.
5. Click on the 'eye' icon.
6. Ensure that the preview is loaded.
7. Narrow the viewport until the order list uses its responsive layout. Confirm the order number and row toggle remain aligned and usable.
8. Install and active WordPress 7.0.
9. Test 2-7.
10. Ensure that everything works as expected.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
