### PR TITLE
Fix product permalink radio always reverting to Custom base

### DIFF
--- a/plugins/woocommerce/changelog/67323-fix-product-permalink-radio-checked-state
+++ b/plugins/woocommerce/changelog/67323-fix-product-permalink-radio-checked-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product permalink settings radio buttons reverting to "Custom base" after saving Default, Shop base, or Shop base with category.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -210,12 +210,20 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['tag_base']       = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_tag_slug'] ) );
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) );
 
-			// Generate product base.
-			$product_base = isset( $_POST['product_permalink'] ) ? wc_clean( wp_unslash( $_POST['product_permalink'] ) ) : '';
+			/*
+			 * Generate product base. Both fields post a scalar; anything else is coerced to the
+			 * empty string, which the Default branch below resolves. Unguarded, an array reaches
+			 * trim() and wc_sanitize_permalink(), which both expect a string.
+			 */
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
+			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
+			$product_base        = sanitize_text_field( (string) $posted_product_base );
 
 			if ( 'custom' === $product_base ) {
-				if ( isset( $_POST['product_permalink_structure'] ) ) {
-					$product_base = preg_replace( '#/+#', '/', '/' . str_replace( '#', '', trim( wp_unslash( $_POST['product_permalink_structure'] ) ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce is verified; permalink tokens require domain-specific cleaning.
+				if ( isset( $_POST['product_permalink_structure'] ) && is_scalar( $_POST['product_permalink_structure'] ) ) {
+					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
+					$posted_structure = trim( (string) wp_unslash( $_POST['product_permalink_structure'] ) );
+					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
 					$product_base = '/';
 				}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -180,7 +180,7 @@ class WC_Admin_Permalink_Settings {
 					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( false === $selected_structure ); ?> />
 						<?php esc_html_e( 'Custom base', 'woocommerce' ); ?></label></th>
 					<td>
-						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code"> <span class="description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
+						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code" aria-label="<?php esc_attr_e( 'Custom base', 'woocommerce' ); ?>" aria-describedby="woocommerce_permalink_structure_description"> <span class="description" id="woocommerce_permalink_structure_description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
 					</td>
 				</tr>
 			</tbody>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -135,32 +135,47 @@ class WC_Admin_Permalink_Settings {
 			2 => wc_sanitize_permalink( $structures[2] ),
 		);
 
+		$stored_product_base       = $this->permalinks['product_base'];
 		$default_product_structure = trailingslashit( '/' . ltrim( $default_product_base, '/' ) );
 
-		if ( $default_product_base === $this->permalinks['product_base'] ) {
-			$product_permalink_structure = $default_product_structure;
-		} else {
-			$product_permalink_structure = $this->permalinks['product_base'] ? trailingslashit( $this->permalinks['product_base'] ) : '';
+		// The index of the predefined structure the stored base corresponds to, or false for a custom one.
+		$selected_structure = array_search( $stored_product_base, $structures_for_comparison, true );
+
+		/*
+		 * The Custom base field is the next tab stop after the radio group, and focusing it selects
+		 * Custom base. Saving from there posts the field's prefilled value through the custom
+		 * branch, which always prepends a slash, so Default comes back as `/product` where the
+		 * Default radio stores a bare `product`. Both describe the same structure -- WordPress
+		 * strips leading slashes when it builds the rewrite rules -- so report the choice the
+		 * merchant made rather than a Custom base they never typed. Saving Default again rewrites
+		 * the stored value to its bare form.
+		 */
+		if ( false === $selected_structure && untrailingslashit( $default_product_structure ) === $stored_product_base ) {
+			$selected_structure = 0;
 		}
+
+		$product_permalink_structure = 0 === $selected_structure
+			? $default_product_structure
+			: ( $stored_product_base ? trailingslashit( $stored_product_base ) : '' );
 		?>
 		<table class="form-table wc-permalink-structure">
 			<tbody>
 				<tr>
-					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" data-permalink-structure="<?php echo esc_attr( $default_product_structure ); ?>" class="wctog" <?php checked( $structures_for_comparison[0], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
+					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" data-permalink-structure="<?php echo esc_attr( $default_product_structure ); ?>" class="wctog" <?php checked( 0 === $selected_structure ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
 					<td><code class="default-example"><?php echo esc_html( home_url() ); ?>/?product=sample-product</code> <code class="non-default-example"><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $default_product_base ); ?>/sample-product/</code></td>
 				</tr>
 				<?php if ( $shop_page_id ) : ?>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( $structures_for_comparison[1], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( 1 === $selected_structure ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/sample-product/</code></td>
 					</tr>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( $structures_for_comparison[2], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( 2 === $selected_structure ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/product-category/sample-product/</code></td>
 					</tr>
 				<?php endif; ?>
 				<tr>
-					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( in_array( $this->permalinks['product_base'], $structures_for_comparison, true ), false ); ?> />
+					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( false === $selected_structure ); ?> />
 						<?php esc_html_e( 'Custom base', 'woocommerce' ); ?></label></th>
 					<td>
 						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code"> <span class="description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -274,7 +274,11 @@ class WC_Admin_Permalink_Settings {
 					}
 				});
 				jQuery('.permalink-structure input:checked').trigger( 'change' );
-				jQuery('#woocommerce_permalink_structure').on( 'focus', function(){
+				// Selecting Custom base takes a click or a typed character, the pair core binds to
+				// its own structure field. Focus alone must not: the radios share one tab stop, so
+				// tabbing forward lands here, and flipping on focus would move the checked radio
+				// off the structure the store actually uses.
+				jQuery('#woocommerce_permalink_structure').on( 'click input', function(){
 					jQuery('#woocommerce_custom_selection').trigger( 'click' );
 				} );
 			} );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -94,6 +94,72 @@ class WC_Admin_Permalink_Settings {
 	}
 
 	/**
+	 * Resolve the Shop page URI that serves as the Shop base, or the default slug.
+	 *
+	 * Shared by the render and the save paths so both describe the same base.
+	 *
+	 * @param int $shop_page_id Shop page ID, as resolved by wc_get_page_id( 'shop' ).
+	 * @return string Shop base slug.
+	 */
+	private function get_shop_base_slug( int $shop_page_id ): string {
+		return (string) ( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
+	}
+
+	/**
+	 * Resolve a posted product permalink choice to the value that gets persisted for it.
+	 *
+	 * The render path checks a radio by comparing the stored base against this, and the save path
+	 * stores what this returns, so the two agree by construction. Restating either side's rules
+	 * separately is what made every predefined structure revert to "Custom base".
+	 * See https://github.com/woocommerce/woocommerce/issues/29050.
+	 *
+	 * Must run inside a wc_switch_to_site_locale() window: the Default base is a translated slug,
+	 * and an administrator whose profile language differs from the site language would otherwise
+	 * store one translation and compare against another.
+	 *
+	 * @param string      $posted_base      Posted `product_permalink` radio value.
+	 * @param string|null $posted_structure Posted `product_permalink_structure` value, or null when that field is absent or not a string.
+	 * @return string The base as it is stored.
+	 */
+	private function get_stored_product_base( string $posted_base, ?string $posted_structure = null ): string {
+		$default_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
+
+		if ( 'custom' === $posted_base ) {
+			if ( null === $posted_structure ) {
+				// A missing or non-string field resolves to the default base, so the stored slug
+				// stays deterministic and in the site locale.
+				$base = $default_base;
+			} else {
+				// Remove every `#` so the base cannot open a URL fragment, prepend the leading
+				// slash, then collapse each run of slashes into one.
+				$base = (string) preg_replace( '~/+~', '/', '/' . str_replace( '#', '', trim( $posted_structure ) ) );
+			}
+
+			// This is an invalid base structure and breaks pages.
+			if ( '/%product_cat%/' === trailingslashit( $base ) ) {
+				$base = '/' . $default_base . $base;
+			}
+		} else {
+			// The Default radio posts an empty value; store the site-locale slug.
+			$base = '' === $posted_base ? $default_base : $posted_base;
+		}
+
+		$base = wc_sanitize_permalink( $base );
+
+		/*
+		 * A base equal to the Default structure is reported in Default's bare form. The Custom
+		 * base field is the next tab stop after the radio group and focusing it selects Custom
+		 * base, so a single Tab from Default posts the field's prefilled `/product/` through the
+		 * custom branch, which prepends a slash. The two forms are not interchangeable: under
+		 * index.php (PATHINFO) permalinks the leading slash reaches register_post_type() and
+		 * produces an `index.php//product/%product%` permastruct whose URLs do not resolve, while
+		 * the bare slug works everywhere. Converging on the bare form keeps Default checked after
+		 * that keystroke and never persists the broken shape.
+		 */
+		return '/' . $default_base === $base ? $default_base : $base;
+	}
+
+	/**
 	 * Show the settings.
 	 */
 	public function settings() {
@@ -102,9 +168,7 @@ class WC_Admin_Permalink_Settings {
 
 		/*
 		 * Resolve the Shop page and the translated slugs inside the same window settings_save()
-		 * opens, so the values compared below are the values a save would store. Without it, an
-		 * administrator whose profile language differs from the site language stores one
-		 * translation and compares against another, and no radio ever matches.
+		 * opens, so the values compared below are the values a save would store.
 		 *
 		 * wc_get_page_id() is resolved here too because settings_save() resolves it inside its own
 		 * window, and the woocommerce_get_shop_page_id filter multilingual plugins attach to can
@@ -115,45 +179,28 @@ class WC_Admin_Permalink_Settings {
 		 * See https://github.com/woocommerce/woocommerce/issues/67507.
 		 */
 		wc_switch_to_site_locale();
-		$shop_page_id         = wc_get_page_id( 'shop' );
-		$base_slug            = urldecode( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
-		$default_product_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
+		$shop_page_id = wc_get_page_id( 'shop' );
+		$base_slug    = urldecode( $this->get_shop_base_slug( $shop_page_id ) );
+
+		// The value each radio posts. The Shop entries exist only when their rows render below, so
+		// a stored base matching a hidden row reports as Custom instead of checking nothing.
+		$structures = array( 0 => '' );
+		if ( $shop_page_id ) {
+			$structures[1] = '/' . trailingslashit( $base_slug );
+			$structures[2] = '/' . trailingslashit( $base_slug ) . trailingslashit( '%product_cat%' );
+		}
+
+		// What a save would store for each of them, so the comparison below cannot drift from
+		// settings_save().
+		$stored_forms = array_map( array( $this, 'get_stored_product_base' ), $structures );
 		wc_restore_locale();
 
-		$structures = array(
-			0 => '',
-			1 => '/' . trailingslashit( $base_slug ),
-			2 => '/' . trailingslashit( $base_slug ) . trailingslashit( '%product_cat%' ),
-		);
-
-		/*
-		 * Must match what settings_save() stores rather than what the radios post:
-		 * wc_sanitize_permalink() strips the trailing slash, and Default is stored as the
-		 * translated product slug, not as the empty value its radio carries. Otherwise no radio
-		 * matches and the screen falls through to Custom base.
-		 * See https://github.com/woocommerce/woocommerce/issues/29050.
-		 */
-		$structures_for_comparison = array(
-			0 => $default_product_base,
-			1 => wc_sanitize_permalink( $structures[1] ),
-			2 => wc_sanitize_permalink( $structures[2] ),
-		);
-
+		$default_product_base      = $stored_forms[0];
 		$stored_product_base       = $this->permalinks['product_base'];
 		$default_product_structure = trailingslashit( '/' . ltrim( $default_product_base, '/' ) );
 
 		// The index of the predefined structure the stored base corresponds to, or false for a custom one.
-		$selected_structure = array_search( $stored_product_base, $structures_for_comparison, true );
-
-		/*
-		 * The Shop rows below render only when a Shop page resolves, yet the stored base can still
-		 * match one of them -- wc_get_page_id() returns 0 when the woocommerce_get_shop_page_id
-		 * filter yields a truthy non-numeric value. Report such a base as Custom so exactly one
-		 * rendered radio is always checked.
-		 */
-		if ( ! $shop_page_id && in_array( $selected_structure, array( 1, 2 ), true ) ) {
-			$selected_structure = false;
-		}
+		$selected_structure = array_search( $stored_product_base, $stored_forms, true );
 
 		$product_permalink_structure = 0 === $selected_structure
 			? $default_product_structure
@@ -188,9 +235,7 @@ class WC_Admin_Permalink_Settings {
 		<script type="text/javascript">
 			jQuery( function() {
 				jQuery('input.wctog').on( 'change', function() {
-					// Fall back to the radio value for markup that copies the .wctog class
-					// without carrying the attribute.
-					jQuery('#woocommerce_permalink_structure').val( jQuery( this ).attr( 'data-permalink-structure' ) || jQuery( this ).val() );
+					jQuery('#woocommerce_permalink_structure').val( jQuery( this ).attr( 'data-permalink-structure' ) );
 				});
 				jQuery('.permalink-structure input').on( 'change', function() {
 					jQuery('.wc-permalink-structure').find('code.non-default-example, code.default-example').hide();
@@ -231,60 +276,21 @@ class WC_Admin_Permalink_Settings {
 
 			/*
 			 * Generate product base. The form only ever posts strings for these two fields, but
-			 * nothing enforces that, and trim() and wc_sanitize_permalink() both require one.
-			 * A non-string value in either field resolves to the default product base.
+			 * nothing enforces that, and the resolver requires one. A non-string value in either
+			 * field resolves to the default product base.
 			 */
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
-			$posted_product_base = isset( $_POST['product_permalink'] ) && is_string( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
-			$product_base        = sanitize_text_field( $posted_product_base );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by sanitize_text_field().
+			$product_base = sanitize_text_field( isset( $_POST['product_permalink'] ) && is_string( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '' );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() inside the resolver.
+			$posted_structure = isset( $_POST['product_permalink_structure'] ) && is_string( $_POST['product_permalink_structure'] ) ? wp_unslash( $_POST['product_permalink_structure'] ) : null;
 
-			// Resolved inside the wc_switch_to_site_locale() window opened above, so every branch
-			// below stores the same site-locale slug settings() compares against.
-			$default_product_base = _x( 'product', 'slug', 'woocommerce' );
-
-			if ( 'custom' === $product_base ) {
-				if ( isset( $_POST['product_permalink_structure'] ) && is_string( $_POST['product_permalink_structure'] ) ) {
-					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
-					$posted_structure = trim( wp_unslash( $_POST['product_permalink_structure'] ) );
-					// Remove every `#` so the base cannot open a URL fragment, prepend the leading
-					// slash, then collapse each run of slashes into one. The pattern is `/+`; the
-					// `#` around it is only the regex delimiter.
-					$product_base = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
-				} else {
-					// A missing or non-string field resolves to the default base, so the stored
-					// slug stays deterministic and in the site locale.
-					$product_base = $default_product_base;
-				}
-
-				// This is an invalid base structure and breaks pages.
-				if ( '/%product_cat%/' === trailingslashit( $product_base ) ) {
-					$product_base = '/' . $default_product_base . $product_base;
-				}
-			} elseif ( empty( $product_base ) ) {
-				// The Default radio posts an empty value; store the site-locale slug.
-				$product_base = $default_product_base;
-			}
-
-			$permalinks['product_base'] = wc_sanitize_permalink( $product_base );
-
-			/*
-			 * A custom base equal to the Default structure is stored in Default's bare form. The
-			 * Custom base field is the next tab stop after the radio group and focusing it selects
-			 * Custom base, so a single Tab from Default posts the field's prefilled `/product/`
-			 * through the custom branch, which prepends a slash. The two stored forms are not
-			 * interchangeable: under index.php (PATHINFO) permalinks the leading slash reaches
-			 * register_post_type() and produces an `index.php//product/%product%` permastruct whose
-			 * URLs do not resolve, while the bare slug works everywhere. Converging on the bare
-			 * form keeps Default checked after that keystroke and never persists the broken shape.
-			 */
-			$sanitized_default_base = wc_sanitize_permalink( $default_product_base );
-			if ( '/' . $sanitized_default_base === $permalinks['product_base'] ) {
-				$permalinks['product_base'] = $sanitized_default_base;
-			}
+			// Resolved inside the wc_switch_to_site_locale() window opened above, so the stored
+			// value is the same site-locale form settings() compares against.
+			$permalinks['product_base'] = $this->get_stored_product_base( $product_base, $posted_structure );
 
 			// Shop base may require verbose page rules if nesting pages.
 			$shop_page_id   = wc_get_page_id( 'shop' );
-			$shop_permalink = ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
+			$shop_permalink = $this->get_shop_base_slug( $shop_page_id );
 
 			if ( $shop_page_id && stristr( trim( $permalinks['product_base'], '/' ), $shop_permalink ) ) {
 				$permalinks['use_verbose_page_rules'] = true;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -246,7 +246,10 @@ class WC_Admin_Permalink_Settings {
 				if ( isset( $_POST['product_permalink_structure'] ) && is_string( $_POST['product_permalink_structure'] ) ) {
 					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
 					$posted_structure = trim( wp_unslash( $_POST['product_permalink_structure'] ) );
-					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
+					// Remove every `#` so the base cannot open a URL fragment, prepend the leading
+					// slash, then collapse each run of slashes into one. The pattern is `/+`; the
+					// `#` around it is only the regex delimiter.
+					$product_base = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
 					// A missing or non-string field resolves to the default base, so the stored
 					// slug stays deterministic and in the site locale.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -96,7 +96,10 @@ class WC_Admin_Permalink_Settings {
 	/**
 	 * Resolve the Shop page URI that serves as the Shop base, or the default slug.
 	 *
-	 * Shared by the render and the save paths so both describe the same base.
+	 * Shared by the render and the save paths so both resolve the base the same way.
+	 *
+	 * wc_get_page_id() returns -1 when no page is set, so the ID is tested against zero rather
+	 * than for truthiness -- and the page it names can still be gone, which get_post() catches.
 	 *
 	 * @param int $shop_page_id Shop page ID, as resolved by wc_get_page_id( 'shop' ).
 	 * @return string Shop base slug.
@@ -113,14 +116,14 @@ class WC_Admin_Permalink_Settings {
 	 * them separately -- which is what made every predefined structure revert to "Custom base".
 	 * See https://github.com/woocommerce/woocommerce/issues/29050.
 	 *
+	 * Must run inside a wc_switch_to_site_locale() window: the Default base is a translated slug,
+	 * and an administrator whose profile language differs from the site language would otherwise
+	 * store one translation and compare against another.
+	 *
 	 * Sharing the rules is not the same as receiving identical input: the save path runs the
 	 * posted value through sanitize_text_field() first, which strips percent-encoded octets, so a
 	 * Shop page whose slug carries a literal percent-escape can still resolve differently on the
 	 * two sides.
-	 *
-	 * Must run inside a wc_switch_to_site_locale() window: the Default base is a translated slug,
-	 * and an administrator whose profile language differs from the site language would otherwise
-	 * store one translation and compare against another.
 	 *
 	 * @param string      $posted_base      Posted `product_permalink` radio value.
 	 * @param string|null $posted_structure Posted `product_permalink_structure` value, or null when that field is absent or not a string.
@@ -140,7 +143,8 @@ class WC_Admin_Permalink_Settings {
 				$base = (string) preg_replace( '~/+~', '/', '/' . str_replace( '#', '', trim( $posted_structure ) ) );
 			}
 
-			// This is an invalid base structure and breaks pages.
+			// A base of nothing but the category token gives products the same URL shape as the
+			// category archives they sit under, so the two collide. Prefix the default base.
 			if ( '/%product_cat%/' === trailingslashit( $base ) ) {
 				$base = '/' . $default_base . $base;
 			}
@@ -152,10 +156,16 @@ class WC_Admin_Permalink_Settings {
 		$base = wc_sanitize_permalink( $base );
 
 		/*
-		 * An empty base is never stored. wc_get_permalink_structure() drops it and refills the
-		 * option from the request locale, outside any locale window, persisting a slug the site
-		 * locale never chose -- the same divergence this resolver exists to prevent. A custom base
-		 * that is blank, whitespace, or nothing but hashes and slashes all sanitize down to this.
+		 * Resolve an empty base to the default one. A custom base that is blank, whitespace, or
+		 * nothing but hashes and slashes sanitizes down to empty, and an empty base does not
+		 * survive: wc_get_permalink_structure() drops it and refills the option from the request
+		 * locale, outside any locale window, persisting a slug the site locale never chose -- the
+		 * same divergence this resolver exists to prevent.
+		 *
+		 * This narrows that window rather than closing it. The default base is itself a translated
+		 * slug run through wc_sanitize_permalink(), so a translation or a gettext filter that
+		 * resolves it to something sanitizing away -- `/` untrailingslashits to nothing -- leaves
+		 * this assigning empty to empty.
 		 */
 		if ( '' === $base ) {
 			$base = $default_base;
@@ -290,9 +300,10 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) );
 
 			/*
-			 * Generate product base. The form only ever posts strings for these two fields, but
-			 * nothing enforces that, and the resolver requires one. A non-string value in either
-			 * field resolves to the default product base.
+			 * The form only ever posts strings for these two fields, but nothing enforces that,
+			 * and the resolver requires one. A non-string radio value resolves to the default
+			 * product base; a non-string structure is passed as null, which resolves to the
+			 * default base only when the radio selects the custom branch that reads it.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by sanitize_text_field().
 			$product_base = sanitize_text_field( isset( $_POST['product_permalink'] ) && is_string( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -233,10 +233,8 @@ class WC_Admin_Permalink_Settings {
 			/*
 			 * Generate product base. The form only ever posts scalars for these two fields, but
 			 * nothing enforces that, and unguarded an array reaches trim() and
-			 * wc_sanitize_permalink(), which both expect a string. Each field falls back
-			 * differently: a non-scalar product_permalink becomes the empty string and is resolved
-			 * by the Default branch further down, while a non-scalar product_permalink_structure is
-			 * treated as an absent field and resolved to '/' inside the custom branch.
+			 * wc_sanitize_permalink(), which both expect a string. A non-scalar value in either
+			 * field resolves to the default product base.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
 			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
@@ -252,7 +250,11 @@ class WC_Admin_Permalink_Settings {
 					$posted_structure = trim( (string) wp_unslash( $_POST['product_permalink_structure'] ) );
 					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
-					$product_base = '/';
+					// A missing or non-scalar field: previously stored '/', which
+					// wc_sanitize_permalink() collapsed to '', leaving the option for
+					// wc_get_permalink_structure() to refill in whatever locale the next request
+					// ran in. Resolve it to the default base here, deterministically.
+					$product_base = $default_product_base;
 				}
 
 				// This is an invalid base structure and breaks pages.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -147,6 +147,16 @@ class WC_Admin_Permalink_Settings {
 		$base = wc_sanitize_permalink( $base );
 
 		/*
+		 * An empty base is never stored. wc_get_permalink_structure() drops it and refills the
+		 * option from the request locale, outside any locale window, persisting a slug the site
+		 * locale never chose -- the same divergence this resolver exists to prevent. A custom base
+		 * that is blank, whitespace, or nothing but hashes and slashes all sanitize down to this.
+		 */
+		if ( '' === $base ) {
+			$base = $default_base;
+		}
+
+		/*
 		 * A base equal to the Default structure is reported in Default's bare form. The Custom
 		 * base field is the next tab stop after the radio group and focusing it selects Custom
 		 * base, so a single Tab from Default posts the field's prefilled `/product/` through the

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -131,20 +131,28 @@ class WC_Admin_Permalink_Settings {
 			1 => wc_sanitize_permalink( $structures[1] ),
 			2 => wc_sanitize_permalink( $structures[2] ),
 		);
+
+		$default_product_structure = trailingslashit( '/' . ltrim( $default_product_base, '/' ) );
+
+		if ( $default_product_base === $this->permalinks['product_base'] ) {
+			$product_permalink_structure = $default_product_structure;
+		} else {
+			$product_permalink_structure = $this->permalinks['product_base'] ? trailingslashit( $this->permalinks['product_base'] ) : '';
+		}
 		?>
 		<table class="form-table wc-permalink-structure">
 			<tbody>
 				<tr>
-					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" class="wctog" <?php checked( $structures_for_comparison[0], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
+					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" data-permalink-structure="<?php echo esc_attr( $default_product_structure ); ?>" class="wctog" <?php checked( $structures_for_comparison[0], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
 					<td><code class="default-example"><?php echo esc_html( home_url() ); ?>/?product=sample-product</code> <code class="non-default-example"><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $default_product_base ); ?>/sample-product/</code></td>
 				</tr>
 				<?php if ( $shop_page_id ) : ?>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( $structures_for_comparison[1], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( $structures_for_comparison[1], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/sample-product/</code></td>
 					</tr>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( $structures_for_comparison[2], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" data-permalink-structure="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( $structures_for_comparison[2], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/product-category/sample-product/</code></td>
 					</tr>
 				<?php endif; ?>
@@ -152,7 +160,7 @@ class WC_Admin_Permalink_Settings {
 					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( in_array( $this->permalinks['product_base'], $structures_for_comparison, true ), false ); ?> />
 						<?php esc_html_e( 'Custom base', 'woocommerce' ); ?></label></th>
 					<td>
-						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $this->permalinks['product_base'] ? trailingslashit( $this->permalinks['product_base'] ) : '' ); ?>" class="regular-text code"> <span class="description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
+						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code"> <span class="description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
 					</td>
 				</tr>
 			</tbody>
@@ -161,7 +169,9 @@ class WC_Admin_Permalink_Settings {
 		<script type="text/javascript">
 			jQuery( function() {
 				jQuery('input.wctog').on( 'change', function() {
-					jQuery('#woocommerce_permalink_structure').val( jQuery( this ).val() );
+					// Fall back to the radio value for markup that copies the .wctog class
+					// without carrying the attribute.
+					jQuery('#woocommerce_permalink_structure').val( jQuery( this ).attr( 'data-permalink-structure' ) || jQuery( this ).val() );
 				});
 				jQuery('.permalink-structure input').on( 'change', function() {
 					jQuery('.wc-permalink-structure').find('code.non-default-example, code.default-example').hide();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -102,32 +102,46 @@ class WC_Admin_Permalink_Settings {
 
 		$shop_page_id = wc_get_page_id( 'shop' );
 		$base_slug    = urldecode( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
-		$product_base = _x( 'product', 'default-slug', 'woocommerce' );
 
 		$structures = array(
 			0 => '',
 			1 => '/' . trailingslashit( $base_slug ),
 			2 => '/' . trailingslashit( $base_slug ) . trailingslashit( '%product_cat%' ),
 		);
+
+		$default_product_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
+
+		/*
+		 * Must match what settings_save() stores rather than what the radios post:
+		 * wc_sanitize_permalink() strips the trailing slash, and Default is stored as the
+		 * translated product slug, not as the empty value its radio carries. Otherwise no radio
+		 * matches and the screen falls through to Custom base.
+		 * See https://github.com/woocommerce/woocommerce/issues/29050.
+		 */
+		$structures_for_comparison = array(
+			0 => $default_product_base,
+			1 => wc_sanitize_permalink( $structures[1] ),
+			2 => wc_sanitize_permalink( $structures[2] ),
+		);
 		?>
 		<table class="form-table wc-permalink-structure">
 			<tbody>
 				<tr>
-					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" class="wctog" <?php checked( $structures[0], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
-					<td><code class="default-example"><?php echo esc_html( home_url() ); ?>/?product=sample-product</code> <code class="non-default-example"><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $product_base ); ?>/sample-product/</code></td>
+					<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[0] ); ?>" class="wctog" <?php checked( $structures_for_comparison[0], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Default', 'woocommerce' ); ?></label></th>
+					<td><code class="default-example"><?php echo esc_html( home_url() ); ?>/?product=sample-product</code> <code class="non-default-example"><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $default_product_base ); ?>/sample-product/</code></td>
 				</tr>
 				<?php if ( $shop_page_id ) : ?>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( $structures[1], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" class="wctog" <?php checked( $structures_for_comparison[1], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/sample-product/</code></td>
 					</tr>
 					<tr>
-						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( $structures[2], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
+						<th><label><input name="product_permalink" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" class="wctog" <?php checked( $structures_for_comparison[2], $this->permalinks['product_base'] ); ?> /> <?php esc_html_e( 'Shop base with category', 'woocommerce' ); ?></label></th>
 						<td><code><?php echo esc_html( home_url() ); ?>/<?php echo esc_html( $base_slug ); ?>/product-category/sample-product/</code></td>
 					</tr>
 				<?php endif; ?>
 				<tr>
-					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( in_array( $this->permalinks['product_base'], $structures, true ), false ); ?> />
+					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( in_array( $this->permalinks['product_base'], $structures_for_comparison, true ), false ); ?> />
 						<?php esc_html_e( 'Custom base', 'woocommerce' ); ?></label></th>
 					<td>
 						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $this->permalinks['product_base'] ? trailingslashit( $this->permalinks['product_base'] ) : '' ); ?>" class="regular-text code"> <span class="description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -146,19 +146,6 @@ class WC_Admin_Permalink_Settings {
 		// The index of the predefined structure the stored base corresponds to, or false for a custom one.
 		$selected_structure = array_search( $stored_product_base, $structures_for_comparison, true );
 
-		/*
-		 * The Custom base field is the next tab stop after the radio group, and focusing it selects
-		 * Custom base. Saving from there posts the field's prefilled value through the custom
-		 * branch, which always prepends a slash, so Default comes back as `/product` where the
-		 * Default radio stores a bare `product`. Both describe the same structure -- WordPress
-		 * strips leading slashes when it builds the rewrite rules -- so report the choice the
-		 * merchant made rather than a Custom base they never typed. Saving Default again rewrites
-		 * the stored value to its bare form.
-		 */
-		if ( false === $selected_structure && untrailingslashit( $default_product_structure ) === $stored_product_base ) {
-			$selected_structure = 0;
-		}
-
 		$product_permalink_structure = 0 === $selected_structure
 			? $default_product_structure
 			: ( $stored_product_base ? trailingslashit( $stored_product_base ) : '' );
@@ -245,6 +232,10 @@ class WC_Admin_Permalink_Settings {
 			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
 			$product_base        = sanitize_text_field( (string) $posted_product_base );
 
+			// Resolved inside the wc_switch_to_site_locale() window opened above, so every branch
+			// below stores the same site-locale slug settings() compares against.
+			$default_product_base = _x( 'product', 'slug', 'woocommerce' );
+
 			if ( 'custom' === $product_base ) {
 				if ( isset( $_POST['product_permalink_structure'] ) && is_scalar( $_POST['product_permalink_structure'] ) ) {
 					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
@@ -256,16 +247,29 @@ class WC_Admin_Permalink_Settings {
 
 				// This is an invalid base structure and breaks pages.
 				if ( '/%product_cat%/' === trailingslashit( $product_base ) ) {
-					$product_base = '/' . _x( 'product', 'slug', 'woocommerce' ) . $product_base;
+					$product_base = '/' . $default_product_base . $product_base;
 				}
 			} elseif ( empty( $product_base ) ) {
-				// The Default radio posts an empty value; store the translated slug settings()
-				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so a
-				// stored base always agrees with what the screen compares it to.
-				$product_base = _x( 'product', 'slug', 'woocommerce' );
+				// The Default radio posts an empty value; store the site-locale slug.
+				$product_base = $default_product_base;
 			}
 
 			$permalinks['product_base'] = wc_sanitize_permalink( $product_base );
+
+			/*
+			 * A custom base describing the Default structure is stored in Default's bare form. The
+			 * Custom base field is the next tab stop after the radio group and focusing it selects
+			 * Custom base, so a single Tab from Default posts the field's prefilled `/product/`
+			 * through the custom branch, which prepends a slash. The two stored forms are not
+			 * interchangeable: under index.php (PATHINFO) permalinks the leading slash reaches
+			 * register_post_type() and produces an `index.php//product/%product%` permastruct whose
+			 * URLs do not resolve, while the bare slug works everywhere. Converging on the bare
+			 * form keeps Default checked after that keystroke and never persists the broken shape.
+			 */
+			$sanitized_default_base = wc_sanitize_permalink( $default_product_base );
+			if ( '/' . $sanitized_default_base === $permalinks['product_base'] ) {
+				$permalinks['product_base'] = $sanitized_default_base;
+			}
 
 			// Shop base may require verbose page rules if nesting pages.
 			$shop_page_id   = wc_get_page_id( 'shop' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -109,6 +109,11 @@ class WC_Admin_Permalink_Settings {
 		 * wc_get_page_id() is resolved here too because settings_save() resolves it inside its own
 		 * window, and the woocommerce_get_shop_page_id filter multilingual plugins attach to can
 		 * return a different page per locale.
+		 *
+		 * This aligns the two paths for a product_base that is already persisted. It cannot align
+		 * one that is not: wc_get_permalink_structure() initializes a missing default in the
+		 * request locale, outside any window, before this screen ever renders. That is pre-existing
+		 * behavior, tracked separately.
 		 */
 		wc_switch_to_site_locale();
 		$shop_page_id         = wc_get_page_id( 'shop' );
@@ -229,9 +234,12 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) );
 
 			/*
-			 * Generate product base. Both fields post a scalar; anything else is coerced to the
-			 * empty string, which the Default branch below resolves. Unguarded, an array reaches
-			 * trim() and wc_sanitize_permalink(), which both expect a string.
+			 * Generate product base. The form only ever posts scalars for these two fields, but
+			 * nothing enforces that, and unguarded an array reaches trim() and
+			 * wc_sanitize_permalink(), which both expect a string. Each field falls back
+			 * differently: a non-scalar product_permalink becomes the empty string and is resolved
+			 * by the Default branch further down, while a non-scalar product_permalink_structure is
+			 * treated as an absent field and resolved to '/' inside the custom branch.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
 			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
@@ -252,8 +260,8 @@ class WC_Admin_Permalink_Settings {
 				}
 			} elseif ( empty( $product_base ) ) {
 				// The Default radio posts an empty value; store the translated slug settings()
-				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so
-				// they agree by construction.
+				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so a
+				// stored base always agrees with what the screen compares it to.
 				$product_base = _x( 'product', 'slug', 'woocommerce' );
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -101,15 +101,23 @@ class WC_Admin_Permalink_Settings {
 		echo wp_kses_post( wpautop( sprintf( __( 'If you like, you may enter custom structures for your product URLs here. For example, using <code>shop</code> would make your product links like <code>%sshop/sample-product/</code>. This setting affects product URLs only, not things such as product categories.', 'woocommerce' ), esc_url( home_url( '/' ) ) ) ) );
 
 		$shop_page_id = wc_get_page_id( 'shop' );
-		$base_slug    = urldecode( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
+
+		/*
+		 * Resolve the translated slugs inside the same window settings_save() opens, so the
+		 * values compared below are the values a save would store. Without it, an administrator
+		 * whose profile language differs from the site language stores one translation and
+		 * compares against another, and no radio ever matches.
+		 */
+		wc_switch_to_site_locale();
+		$base_slug            = urldecode( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
+		$default_product_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
+		wc_restore_locale();
 
 		$structures = array(
 			0 => '',
 			1 => '/' . trailingslashit( $base_slug ),
 			2 => '/' . trailingslashit( $base_slug ) . trailingslashit( '%product_cat%' ),
 		);
-
-		$default_product_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
 
 		/*
 		 * Must match what settings_save() stores rather than what the radios post:
@@ -207,6 +215,9 @@ class WC_Admin_Permalink_Settings {
 					$product_base = '/' . _x( 'product', 'slug', 'woocommerce' ) . $product_base;
 				}
 			} elseif ( empty( $product_base ) ) {
+				// The Default radio posts an empty value; store the translated slug settings()
+				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so
+				// they agree by construction.
 				$product_base = _x( 'product', 'slug', 'woocommerce' );
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -110,10 +110,9 @@ class WC_Admin_Permalink_Settings {
 		 * window, and the woocommerce_get_shop_page_id filter multilingual plugins attach to can
 		 * return a different page per locale.
 		 *
-		 * This aligns the two paths for a product_base that is already persisted. It cannot align
-		 * one that is not: wc_get_permalink_structure() initializes a missing default in the
-		 * request locale, outside any window, before this screen ever renders. That is pre-existing
-		 * behavior, tracked separately.
+		 * This holds only for a persisted product_base: wc_get_permalink_structure() initializes a
+		 * missing one in the request locale, outside any window, before this screen renders.
+		 * See https://github.com/woocommerce/woocommerce/issues/67507.
 		 */
 		wc_switch_to_site_locale();
 		$shop_page_id         = wc_get_page_id( 'shop' );
@@ -231,10 +230,9 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) );
 
 			/*
-			 * Generate product base. The form only ever posts scalars for these two fields, but
-			 * nothing enforces that, and unguarded an array reaches trim() and
-			 * wc_sanitize_permalink(), which both expect a string. A non-string value in either
-			 * field resolves to the default product base.
+			 * Generate product base. The form only ever posts strings for these two fields, but
+			 * nothing enforces that, and trim() and wc_sanitize_permalink() both require one.
+			 * A non-string value in either field resolves to the default product base.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
 			$posted_product_base = isset( $_POST['product_permalink'] ) && is_string( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
@@ -250,10 +248,8 @@ class WC_Admin_Permalink_Settings {
 					$posted_structure = trim( wp_unslash( $_POST['product_permalink_structure'] ) );
 					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
-					// A missing or non-string field: previously stored '/', which
-					// wc_sanitize_permalink() collapsed to '', leaving the option for
-					// wc_get_permalink_structure() to refill in whatever locale the next request
-					// ran in. Resolve it to the default base here, deterministically.
+					// A missing or non-string field resolves to the default base, so the stored
+					// slug stays deterministic and in the site locale.
 					$product_base = $default_product_base;
 				}
 
@@ -269,7 +265,7 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['product_base'] = wc_sanitize_permalink( $product_base );
 
 			/*
-			 * A custom base describing the Default structure is stored in Default's bare form. The
+			 * A custom base equal to the Default structure is stored in Default's bare form. The
 			 * Custom base field is the next tab stop after the radio group and focusing it selects
 			 * Custom base, so a single Tab from Default posts the field's prefilled `/product/`
 			 * through the custom branch, which prepends a slash. The two stored forms are not

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -100,15 +100,18 @@ class WC_Admin_Permalink_Settings {
 		/* translators: %s: Home URL */
 		echo wp_kses_post( wpautop( sprintf( __( 'If you like, you may enter custom structures for your product URLs here. For example, using <code>shop</code> would make your product links like <code>%sshop/sample-product/</code>. This setting affects product URLs only, not things such as product categories.', 'woocommerce' ), esc_url( home_url( '/' ) ) ) ) );
 
-		$shop_page_id = wc_get_page_id( 'shop' );
-
 		/*
-		 * Resolve the translated slugs inside the same window settings_save() opens, so the
-		 * values compared below are the values a save would store. Without it, an administrator
-		 * whose profile language differs from the site language stores one translation and
-		 * compares against another, and no radio ever matches.
+		 * Resolve the Shop page and the translated slugs inside the same window settings_save()
+		 * opens, so the values compared below are the values a save would store. Without it, an
+		 * administrator whose profile language differs from the site language stores one
+		 * translation and compares against another, and no radio ever matches.
+		 *
+		 * wc_get_page_id() is resolved here too because settings_save() resolves it inside its own
+		 * window, and the woocommerce_get_shop_page_id filter multilingual plugins attach to can
+		 * return a different page per locale.
 		 */
 		wc_switch_to_site_locale();
+		$shop_page_id         = wc_get_page_id( 'shop' );
 		$base_slug            = urldecode( ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' ) );
 		$default_product_base = wc_sanitize_permalink( _x( 'product', 'slug', 'woocommerce' ) );
 		wc_restore_locale();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -109,9 +109,14 @@ class WC_Admin_Permalink_Settings {
 	 * Resolve a posted product permalink choice to the value that gets persisted for it.
 	 *
 	 * The render path checks a radio by comparing the stored base against this, and the save path
-	 * stores what this returns, so the two agree by construction. Restating either side's rules
-	 * separately is what made every predefined structure revert to "Custom base".
+	 * stores what this returns, so both derive the base from one set of rules instead of restating
+	 * them separately -- which is what made every predefined structure revert to "Custom base".
 	 * See https://github.com/woocommerce/woocommerce/issues/29050.
+	 *
+	 * Sharing the rules is not the same as receiving identical input: the save path runs the
+	 * posted value through sanitize_text_field() first, which strips percent-encoded octets, so a
+	 * Shop page whose slug carries a literal percent-escape can still resolve differently on the
+	 * two sides.
 	 *
 	 * Must run inside a wc_switch_to_site_locale() window: the Default base is a translated slug,
 	 * and an administrator whose profile language differs from the site language would otherwise

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -233,24 +233,24 @@ class WC_Admin_Permalink_Settings {
 			/*
 			 * Generate product base. The form only ever posts scalars for these two fields, but
 			 * nothing enforces that, and unguarded an array reaches trim() and
-			 * wc_sanitize_permalink(), which both expect a string. A non-scalar value in either
+			 * wc_sanitize_permalink(), which both expect a string. A non-string value in either
 			 * field resolves to the default product base.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
-			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
-			$product_base        = sanitize_text_field( (string) $posted_product_base );
+			$posted_product_base = isset( $_POST['product_permalink'] ) && is_string( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
+			$product_base        = sanitize_text_field( $posted_product_base );
 
 			// Resolved inside the wc_switch_to_site_locale() window opened above, so every branch
 			// below stores the same site-locale slug settings() compares against.
 			$default_product_base = _x( 'product', 'slug', 'woocommerce' );
 
 			if ( 'custom' === $product_base ) {
-				if ( isset( $_POST['product_permalink_structure'] ) && is_scalar( $_POST['product_permalink_structure'] ) ) {
+				if ( isset( $_POST['product_permalink_structure'] ) && is_string( $_POST['product_permalink_structure'] ) ) {
 					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
-					$posted_structure = trim( (string) wp_unslash( $_POST['product_permalink_structure'] ) );
+					$posted_structure = trim( wp_unslash( $_POST['product_permalink_structure'] ) );
 					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
-					// A missing or non-scalar field: previously stored '/', which
+					// A missing or non-string field: previously stored '/', which
 					// wc_sanitize_permalink() collapsed to '', leaving the option for
 					// wc_get_permalink_structure() to refill in whatever locale the next request
 					// ran in. Resolve it to the default base here, deterministically.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -146,6 +146,16 @@ class WC_Admin_Permalink_Settings {
 		// The index of the predefined structure the stored base corresponds to, or false for a custom one.
 		$selected_structure = array_search( $stored_product_base, $structures_for_comparison, true );
 
+		/*
+		 * The Shop rows below render only when a Shop page resolves, yet the stored base can still
+		 * match one of them -- wc_get_page_id() returns 0 when the woocommerce_get_shop_page_id
+		 * filter yields a truthy non-numeric value. Report such a base as Custom so exactly one
+		 * rendered radio is always checked.
+		 */
+		if ( ! $shop_page_id && in_array( $selected_structure, array( 1, 2 ), true ) ) {
+			$selected_structure = false;
+		}
+
 		$product_permalink_structure = 0 === $selected_structure
 			? $default_product_structure
 			: ( $stored_product_base ? trailingslashit( $stored_product_base ) : '' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -241,7 +241,7 @@ class WC_Admin_Permalink_Settings {
 					<th><label><input name="product_permalink" id="woocommerce_custom_selection" type="radio" value="custom" class="tog" <?php checked( false === $selected_structure ); ?> />
 						<?php esc_html_e( 'Custom base', 'woocommerce' ); ?></label></th>
 					<td>
-						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code" aria-label="<?php esc_attr_e( 'Custom base', 'woocommerce' ); ?>" aria-describedby="woocommerce_permalink_structure_description"> <span class="description" id="woocommerce_permalink_structure_description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
+						<input name="product_permalink_structure" id="woocommerce_permalink_structure" type="text" value="<?php echo esc_attr( $product_permalink_structure ); ?>" class="regular-text code" aria-label="<?php esc_attr_e( 'Custom product permalink base', 'woocommerce' ); ?>" aria-describedby="woocommerce_permalink_structure_description"> <span class="description" id="woocommerce_permalink_structure_description"><?php esc_html_e( 'Enter a custom base to use. A base must be set or WordPress will use default instead.', 'woocommerce' ); ?></span>
 					</td>
 				</tr>
 			</tbody>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -109,6 +109,11 @@ class WC_Admin_Permalink_Settings {
 		 * wc_get_page_id() is resolved here too because settings_save() resolves it inside its own
 		 * window, and the woocommerce_get_shop_page_id filter multilingual plugins attach to can
 		 * return a different page per locale.
+		 *
+		 * This aligns the two paths for a product_base that is already persisted. It cannot align
+		 * one that is not: wc_get_permalink_structure() initializes a missing default in the
+		 * request locale, outside any window, before this screen ever renders. That is pre-existing
+		 * behavior, tracked separately.
 		 */
 		wc_switch_to_site_locale();
 		$shop_page_id         = wc_get_page_id( 'shop' );
@@ -229,9 +234,12 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) ); // WPCS: input var ok, sanitization ok.
 
 			/*
-			 * Generate product base. Both fields post a scalar; anything else is coerced to the
-			 * empty string, which the Default branch below resolves. Unguarded, an array reaches
-			 * trim() and wc_sanitize_permalink(), which both expect a string.
+			 * Generate product base. The form only ever posts scalars for these two fields, but
+			 * nothing enforces that, and unguarded an array reaches trim() and
+			 * wc_sanitize_permalink(), which both expect a string. Each field falls back
+			 * differently: a non-scalar product_permalink becomes the empty string and is resolved
+			 * by the Default branch further down, while a non-scalar product_permalink_structure is
+			 * treated as an absent field and resolved to '/' inside the custom branch.
 			 */
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
 			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
@@ -252,8 +260,8 @@ class WC_Admin_Permalink_Settings {
 				}
 			} elseif ( empty( $product_base ) ) {
 				// The Default radio posts an empty value; store the translated slug settings()
-				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so
-				// they agree by construction.
+				// compares against. Both resolve inside a wc_switch_to_site_locale() window, so a
+				// stored base always agrees with what the screen compares it to.
 				$product_base = _x( 'product', 'slug', 'woocommerce' );
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-permalink-settings.php
@@ -210,12 +210,20 @@ class WC_Admin_Permalink_Settings {
 			$permalinks['tag_base']       = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_tag_slug'] ) ); // WPCS: input var ok, sanitization ok.
 			$permalinks['attribute_base'] = wc_sanitize_permalink( wp_unslash( $_POST['woocommerce_product_attribute_slug'] ) ); // WPCS: input var ok, sanitization ok.
 
-			// Generate product base.
-			$product_base = isset( $_POST['product_permalink'] ) ? wc_clean( wp_unslash( $_POST['product_permalink'] ) ) : ''; // WPCS: input var ok, sanitization ok.
+			/*
+			 * Generate product base. Both fields post a scalar; anything else is coerced to the
+			 * empty string, which the Default branch below resolves. Unguarded, an array reaches
+			 * trim() and wc_sanitize_permalink(), which both expect a string.
+			 */
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized on the next line.
+			$posted_product_base = isset( $_POST['product_permalink'] ) && is_scalar( $_POST['product_permalink'] ) ? wp_unslash( $_POST['product_permalink'] ) : '';
+			$product_base        = sanitize_text_field( (string) $posted_product_base );
 
 			if ( 'custom' === $product_base ) {
-				if ( isset( $_POST['product_permalink_structure'] ) ) { // WPCS: input var ok.
-					$product_base = preg_replace( '#/+#', '/', '/' . str_replace( '#', '', trim( wp_unslash( $_POST['product_permalink_structure'] ) ) ) ); // WPCS: input var ok, sanitization ok.
+				if ( isset( $_POST['product_permalink_structure'] ) && is_scalar( $_POST['product_permalink_structure'] ) ) {
+					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized by wc_sanitize_permalink() below.
+					$posted_structure = trim( (string) wp_unslash( $_POST['product_permalink_structure'] ) );
+					$product_base     = (string) preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $posted_structure ) );
 				} else {
 					$product_base = '/';
 				}

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -2365,12 +2365,6 @@ parameters:
 			path: includes/admin/class-wc-admin-permalink-settings.php
 
 		-
-			message: '#^Parameter \#1 \$str of function urldecode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-admin-permalink-settings.php
-
-		-
 			message: '#^Method WC_Admin_Pointers\:\:create_product_tutorial\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -2371,18 +2371,6 @@ parameters:
 			path: includes/admin/class-wc-admin-permalink-settings.php
 
 		-
-			message: '#^Parameter \#1 \$value of function trailingslashit expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-admin-permalink-settings.php
-
-		-
-			message: '#^Parameter \#1 \$value of function wc_sanitize_permalink expects string, array\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/admin/class-wc-admin-permalink-settings.php
-
-		-
 			message: '#^Method WC_Admin_Pointers\:\:create_product_tutorial\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -171,7 +171,8 @@ const serialRunSpecs = [
 	// Mutate global WooCommerce settings (store address/currency/country, tax)
 	// that other workers' cart/checkout/storefront specs depend on.
 	'**/tests/settings/settings-general.spec.ts',
-	// Saves and restores the global product permalink structure.
+	// Mutates the global woocommerce_permalinks option (product base and the
+	// derived use_verbose_page_rules flag) and restores it in teardown.
 	'**/tests/settings/product-permalinks.spec.ts',
 	'**/tests/settings/settings-tax.spec.ts',
 	// Toggles the global `settings-ui` feature flag and resets all e2e feature flags

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -168,6 +168,8 @@ const serialRunSpecs = [
 	// Mutate global WooCommerce settings (store address/currency/country, tax)
 	// that other workers' cart/checkout/storefront specs depend on.
 	'**/tests/settings/settings-general.spec.ts',
+	// Saves and restores the global product permalink structure.
+	'**/tests/settings/product-permalinks.spec.ts',
 	'**/tests/settings/settings-tax.spec.ts',
 	// Unchecks and saves `woocommerce_enable_reviews`, flipping that global option
 	// to `no` mid-run (restored only in afterAll). While off, the front-end Reviews

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -171,6 +171,8 @@ const serialRunSpecs = [
 	// Mutate global WooCommerce settings (store address/currency/country, tax)
 	// that other workers' cart/checkout/storefront specs depend on.
 	'**/tests/settings/settings-general.spec.ts',
+	// Saves and restores the global product permalink structure.
+	'**/tests/settings/product-permalinks.spec.ts',
 	'**/tests/settings/settings-tax.spec.ts',
 	// Toggles the global `settings-ui` feature flag and resets all e2e feature flags
 	// in afterAll.

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -38,11 +38,19 @@ test.describe( 'Product permalink settings', () => {
 
 		await expect( productPermalinkRadios ).toHaveCount( 4 );
 
+		// Every WP-CLI call in this spec is a plain database operation, so plugins and themes are
+		// skipped: earlier specs in the serial suite can leave heavyweight extensions installed
+		// (the onboarding wizard installs the default set), and booting them under WP-CLI can
+		// exhaust the CLI container's memory limit before the command runs.
+		const optionCliFlags = '--skip-plugins --skip-themes';
+
 		// Snapshot the whole option rather than the visible form state: the journey's Shop base
 		// saves also flip the derived `use_verbose_page_rules` flag, which no form field exposes,
 		// so a UI-driven restore could never put it back.
 		const originalPermalinks = (
-			await wpCLI( 'wp option get woocommerce_permalinks --format=json' )
+			await wpCLI(
+				`wp option get woocommerce_permalinks --format=json ${ optionCliFlags }`
+			)
 		).stdout.trim();
 
 		try {
@@ -130,18 +138,22 @@ test.describe( 'Product permalink settings', () => {
 			const storedPermalinks = JSON.parse(
 				(
 					await wpCLI(
-						'wp option get woocommerce_permalinks --format=json'
+						`wp option get woocommerce_permalinks --format=json ${ optionCliFlags }`
 					)
 				).stdout.trim()
 			);
 			expect( storedPermalinks.product_base ).toBe( expectedBareSlug );
 		} finally {
 			await wpCLI(
-				`wp option update woocommerce_permalinks '${ originalPermalinks }' --format=json`
+				`wp option update woocommerce_permalinks '${ originalPermalinks }' --format=json ${ optionCliFlags }`
 			);
 			// The option alone does not rebuild the persisted rewrite rules the front end matches
-			// against; a save on the Permalinks screen would have flushed them, so do the same.
-			await wpCLI( 'wp rewrite flush --hard' );
+			// against. Emptying them makes WordPress regenerate on the next request with every
+			// plugin loaded — `wp rewrite flush` under --skip-plugins would persist a rule set
+			// missing all plugin rewrites.
+			await wpCLI(
+				`wp option update rewrite_rules '' ${ optionCliFlags }`
+			);
 		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -5,6 +5,21 @@ import { expect, test } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { wpCLI } from '../../utils/cli';
 
+/**
+ * Wrap a value as a single shell argument.
+ *
+ * `wpCLI()` builds one command string and runs it through `exec()`, which hands it to a shell, so
+ * an interpolated value has to survive shell parsing. A permalink base can legitimately contain a
+ * single quote — `wc_sanitize_permalink()` leaves them intact, so a custom base of `shop's` is
+ * stored verbatim — and an unquoted one would break the command. `'\''` ends the quoted run,
+ * emits a literal quote, and opens the next one.
+ *
+ * @param value Value to pass as a single argument.
+ * @return The value quoted for the shell.
+ */
+const asShellArgument = ( value: string ) =>
+	`'${ value.replaceAll( "'", `'\\''` ) }'`;
+
 test.describe( 'Product permalink settings', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -145,7 +160,9 @@ test.describe( 'Product permalink settings', () => {
 			expect( storedPermalinks.product_base ).toBe( expectedBareSlug );
 		} finally {
 			await wpCLI(
-				`wp option update woocommerce_permalinks '${ originalPermalinks }' --format=json ${ optionCliFlags }`
+				`wp option update woocommerce_permalinks ${ asShellArgument(
+					originalPermalinks
+				) } --format=json ${ optionCliFlags }`
 			);
 			// The option alone does not rebuild the persisted rewrite rules the front end matches
 			// against. Emptying them makes WordPress regenerate on the next request with every

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -3,6 +3,7 @@
  */
 import { expect, test } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+import { wpCLI } from '../../utils/cli';
 
 test.describe( 'Product permalink settings', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
@@ -36,14 +37,12 @@ test.describe( 'Product permalink settings', () => {
 
 		await expect( productPermalinkRadios ).toHaveCount( 4 );
 
-		const originalCheckedIndex = await productPermalinkRadios.evaluateAll(
-			( radios ) =>
-				radios.findIndex(
-					( radio ) => ( radio as HTMLInputElement ).checked
-				)
-		);
-		const originalCustomBase = await customBase.inputValue();
-		expect( originalCheckedIndex ).toBeGreaterThanOrEqual( 0 );
+		// Snapshot the whole option rather than the visible form state: the journey's Shop base
+		// saves also flip the derived `use_verbose_page_rules` flag, which no form field exposes,
+		// so a UI-driven restore could never put it back.
+		const originalPermalinks = (
+			await wpCLI( 'wp option get woocommerce_permalinks --format=json' )
+		 ).stdout.trim();
 
 		try {
 			const defaultRadio = productPermalinkRadios.nth( 0 );
@@ -105,14 +104,12 @@ test.describe( 'Product permalink settings', () => {
 			await expect( defaultRadio ).toHaveValue( '' );
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
 		} finally {
-			await page.goto( 'wp-admin/options-permalink.php' );
-
-			await productPermalinkRadios.nth( originalCheckedIndex ).check();
-			if ( originalCheckedIndex === 3 ) {
-				await customBase.fill( originalCustomBase );
-			}
-
-			await saveAndReload();
+			await wpCLI(
+				`wp option update woocommerce_permalinks '${ originalPermalinks }' --format=json`
+			);
+			// The option alone does not rebuild the persisted rewrite rules the front end matches
+			// against; a save on the Permalinks screen would have flushed them, so do the same.
+			await wpCLI( 'wp rewrite flush --hard' );
 		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -25,14 +25,28 @@ test.describe( 'Product permalink settings', () => {
 
 	test( 'saved product permalink structures stay selected after a reload', async ( {
 		page,
-		baseURL,
 	} ) => {
-		const resolvedBaseURL = baseURL ?? '';
-		expect( resolvedBaseURL, 'Playwright baseURL is required.' ).not.toBe(
-			''
-		);
+		// Every WP-CLI call in this spec is a plain database operation, so plugins and themes are
+		// skipped: earlier specs in the serial suite can leave heavyweight extensions installed
+		// (the onboarding wizard installs the default set), and booting them under WP-CLI can
+		// exhaust the CLI container's memory limit before the command runs.
+		const optionCliFlags = '--skip-plugins --skip-themes';
+		// Snapshot the whole option rather than the visible form state: the journey's Shop base
+		// saves also flip the derived `use_verbose_page_rules` flag, which no form field exposes,
+		// so a UI-driven restore could never put it back.
+		const readPermalinks = async () =>
+			(
+				await wpCLI(
+					`wp option get woocommerce_permalinks --format=json ${ optionCliFlags }`
+				)
+			).stdout.trim();
 
-		await page.goto( 'wp-admin/options-permalink.php' );
+		// The snapshot only has to precede the first save, and spawning the WP-CLI container costs
+		// seconds, so overlap it with the page load rather than queueing behind it.
+		const [ , originalPermalinks ] = await Promise.all( [
+			page.goto( 'wp-admin/options-permalink.php' ),
+			readPermalinks(),
+		] );
 
 		const productPermalinkRadios = page.locator(
 			'input[name="product_permalink"]'
@@ -53,21 +67,6 @@ test.describe( 'Product permalink settings', () => {
 
 		await expect( productPermalinkRadios ).toHaveCount( 4 );
 
-		// Every WP-CLI call in this spec is a plain database operation, so plugins and themes are
-		// skipped: earlier specs in the serial suite can leave heavyweight extensions installed
-		// (the onboarding wizard installs the default set), and booting them under WP-CLI can
-		// exhaust the CLI container's memory limit before the command runs.
-		const optionCliFlags = '--skip-plugins --skip-themes';
-
-		// Snapshot the whole option rather than the visible form state: the journey's Shop base
-		// saves also flip the derived `use_verbose_page_rules` flag, which no form field exposes,
-		// so a UI-driven restore could never put it back.
-		const originalPermalinks = (
-			await wpCLI(
-				`wp option get woocommerce_permalinks --format=json ${ optionCliFlags }`
-			)
-		).stdout.trim();
-
 		try {
 			const defaultRadio = productPermalinkRadios.nth( 0 );
 			const shopBaseRadio = productPermalinkRadios.nth( 1 );
@@ -75,29 +74,25 @@ test.describe( 'Product permalink settings', () => {
 			const defaultRow = page
 				.getByRole( 'row' )
 				.filter( { has: defaultRadio } );
-			const defaultPreview = new URL(
+			// Derive the base from the rendered preview rather than hardcoding a translated
+			// product slug. Matching the segment before `sample-product` off the end of the URL
+			// keeps this independent of the install layout, so a subdirectory install needs no
+			// separate site-path arithmetic.
+			const defaultPreview =
 				(
 					await defaultRow
 						.locator( 'code.non-default-example' )
 						.textContent()
-				)?.trim() ?? ''
+				)?.trim() ?? '';
+			const previewBase = defaultPreview.match(
+				/\/([^/]+)\/sample-product\/$/
 			);
-			// Derive the canonical `/base/` from the preview rather than hardcoding a translated
-			// product slug. `/\/$/` drops the trailing slash so a root install contributes an
-			// empty prefix and a subdirectory install (`/wp/`) contributes `/wp`.
-			const sitePath = new URL( resolvedBaseURL ).pathname.replace(
-				/\/$/,
-				''
-			);
-			// Assert the example segment first, so a changed preview fails here instead of
-			// silently yielding a wrong base.
-			expect( defaultPreview.pathname ).toMatch( /\/sample-product\/$/ );
-			const expectedDefaultBase = defaultPreview.pathname
-				.slice( sitePath.length )
-				.replace( /sample-product\/$/, '' );
-
-			// A non-empty, slash-delimited path such as `/product/`.
-			expect( expectedDefaultBase ).toMatch( /^\/.+\/$/ );
+			expect(
+				previewBase,
+				`Unexpected Default preview: ${ defaultPreview }`
+			).not.toBeNull();
+			const expectedBareSlug = previewBase?.[ 1 ] ?? '';
+			const expectedDefaultBase = `/${ expectedBareSlug }/`;
 
 			// Establish Default as the starting point rather than assuming the store already uses
 			// it — the preceding assertion about the Custom field only holds from a known state.
@@ -146,17 +141,7 @@ test.describe( 'Product permalink settings', () => {
 			await expect( defaultRadio ).toBeChecked();
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
 
-			const expectedBareSlug = expectedDefaultBase.replace(
-				/^\/|\/$/g,
-				''
-			);
-			const storedPermalinks = JSON.parse(
-				(
-					await wpCLI(
-						`wp option get woocommerce_permalinks --format=json ${ optionCliFlags }`
-					)
-				).stdout.trim()
-			);
+			const storedPermalinks = JSON.parse( await readPermalinks() );
 			expect( storedPermalinks.product_base ).toBe( expectedBareSlug );
 		} finally {
 			await wpCLI(

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -103,6 +103,34 @@ test.describe( 'Product permalink settings', () => {
 			await expect( defaultRadio ).toBeChecked();
 			await expect( defaultRadio ).toHaveValue( '' );
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
+
+			// A single Tab from the checked radio lands on the Custom base field — the radios
+			// share one tab stop — and focusing the field selects Custom base. Saving from there
+			// posts the prefilled Default structure through the custom branch, which the save
+			// path normalizes back to Default's bare slug: the slash-prefixed form it would
+			// otherwise store builds broken rewrite rules under index.php (PATHINFO) permalinks.
+			await customBase.focus();
+			await expect(
+				page.locator( '#woocommerce_custom_selection' )
+			).toBeChecked();
+
+			await saveAndReload();
+
+			await expect( defaultRadio ).toBeChecked();
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
+
+			const expectedBareSlug = expectedDefaultBase.replace(
+				/^\/|\/$/g,
+				''
+			);
+			const storedPermalinks = JSON.parse(
+				(
+					await wpCLI(
+						'wp option get woocommerce_permalinks --format=json'
+					)
+				 ).stdout.trim()
+			);
+			expect( storedPermalinks.product_base ).toBe( expectedBareSlug );
 		} finally {
 			await wpCLI(
 				`wp option update woocommerce_permalinks '${ originalPermalinks }' --format=json`

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal dependencies
+ */
+import { expect, test } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+
+test.describe( 'Product permalink settings', () => {
+	test.use( { storageState: ADMIN_STATE_PATH } );
+
+	test( 'saved product permalink structures stay selected after a reload', async ( {
+		page,
+		baseURL,
+	} ) => {
+		if ( ! baseURL ) {
+			throw new Error( 'Playwright baseURL is required.' );
+		}
+
+		await page.goto( 'wp-admin/options-permalink.php' );
+
+		const productPermalinkRadios = page.locator(
+			'input[name="product_permalink"]'
+		);
+		const customBase = page.locator( '#woocommerce_permalink_structure' );
+		const saveChanges = page.getByRole( 'button', {
+			name: 'Save Changes',
+		} );
+		const saveAndWaitForSubmit = () =>
+			Promise.all( [
+				page.waitForResponse(
+					( response ) =>
+						response.request().method() === 'POST' &&
+						response.url().includes( 'options-permalink.php' )
+				),
+				saveChanges.click(),
+			] );
+
+		await expect( productPermalinkRadios ).toHaveCount( 4 );
+
+		const originalCheckedIndex = await productPermalinkRadios.evaluateAll(
+			( radios ) =>
+				radios.findIndex(
+					( radio ) => ( radio as HTMLInputElement ).checked
+				)
+		);
+		const originalCustomBase = await customBase.inputValue();
+		expect( originalCheckedIndex ).toBeGreaterThanOrEqual( 0 );
+
+		try {
+			const defaultRadio = productPermalinkRadios.nth( 0 );
+			const shopBaseRadio = productPermalinkRadios.nth( 1 );
+			const defaultRow = page
+				.getByRole( 'row' )
+				.filter( { has: defaultRadio } );
+			const defaultPreview = new URL(
+				(
+					await defaultRow
+						.locator( 'code.non-default-example' )
+						.textContent()
+				)?.trim() ?? ''
+			);
+			// Derive the canonical `/base/` from the preview rather than hardcoding a translated
+			// product slug. `/\/$/` drops the trailing slash so a root install contributes an
+			// empty prefix and a subdirectory install (`/wp/`) contributes `/wp`.
+			const sitePath = new URL( baseURL ).pathname.replace( /\/$/, '' );
+			// Assert the example segment first, so a changed preview fails here instead of
+			// silently yielding a wrong base.
+			expect( defaultPreview.pathname ).toMatch( /\/sample-product\/$/ );
+			const expectedDefaultBase = defaultPreview.pathname
+				.slice( sitePath.length )
+				.replace( /sample-product\/$/, '' );
+
+			// A non-empty, slash-delimited path such as `/product/`.
+			expect( expectedDefaultBase ).toMatch( /^\/.+\/$/ );
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
+
+			// Shop base posts its structure verbatim; Default posts an empty value and relies on
+			// the data attribute. Both have to survive a save, and issue #29050 reported all of
+			// them reverting to Custom base.
+			const shopBaseStructure = await shopBaseRadio.inputValue();
+
+			await shopBaseRadio.check();
+			await expect( customBase ).toHaveValue( shopBaseStructure );
+
+			await saveAndWaitForSubmit();
+
+			await expect( shopBaseRadio ).toBeChecked();
+			await expect( customBase ).toHaveValue( shopBaseStructure );
+
+			await defaultRadio.check();
+			await expect( defaultRadio ).toHaveValue( '' );
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
+
+			await saveAndWaitForSubmit();
+
+			await expect( defaultRadio ).toBeChecked();
+			await expect( defaultRadio ).toHaveValue( '' );
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
+		} finally {
+			await page.goto( 'wp-admin/options-permalink.php' );
+
+			await productPermalinkRadios.nth( originalCheckedIndex ).check();
+			if ( originalCheckedIndex === 3 ) {
+				await customBase.fill( originalCustomBase );
+			}
+
+			await saveAndWaitForSubmit();
+		}
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -24,15 +24,15 @@ test.describe( 'Product permalink settings', () => {
 		const saveChanges = page.getByRole( 'button', {
 			name: 'Save Changes',
 		} );
-		const saveAndWaitForSubmit = () =>
-			Promise.all( [
-				page.waitForResponse(
-					( response ) =>
-						response.request().method() === 'POST' &&
-						response.url().includes( 'options-permalink.php' )
-				),
-				saveChanges.click(),
-			] );
+		// WordPress processes the POST and redirects back, so the assertions after a save have to
+		// run against the reloaded document. Waiting on the POST response alone would let them
+		// resolve against the pre-submit DOM, which still shows whatever was just checked — the
+		// reload this test exists to verify would never be observed.
+		const saveAndReload = async () => {
+			const reloaded = page.waitForEvent( 'load' );
+			await saveChanges.click();
+			await reloaded;
+		};
 
 		await expect( productPermalinkRadios ).toHaveCount( 4 );
 
@@ -48,6 +48,7 @@ test.describe( 'Product permalink settings', () => {
 		try {
 			const defaultRadio = productPermalinkRadios.nth( 0 );
 			const shopBaseRadio = productPermalinkRadios.nth( 1 );
+			const shopCategoryRadio = productPermalinkRadios.nth( 2 );
 			const defaultRow = page
 				.getByRole( 'row' )
 				.filter( { has: defaultRadio } );
@@ -71,26 +72,34 @@ test.describe( 'Product permalink settings', () => {
 
 			// A non-empty, slash-delimited path such as `/product/`.
 			expect( expectedDefaultBase ).toMatch( /^\/.+\/$/ );
+
+			// Establish Default as the starting point rather than assuming the store already uses
+			// it — the preceding assertion about the Custom field only holds from a known state.
+			await defaultRadio.check();
+			await saveAndReload();
+			await expect( defaultRadio ).toBeChecked();
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
 
-			// Shop base posts its structure verbatim; Default posts an empty value and relies on
-			// the data attribute. Both have to survive a save, and issue #29050 reported all of
-			// them reverting to Custom base.
-			const shopBaseStructure = await shopBaseRadio.inputValue();
+			// Shop base and Shop base with category post their structure verbatim; Default posts an
+			// empty value and relies on the data attribute. Issue #29050 reported all three
+			// reverting to Custom base, so each one round-trips through a real save here.
+			for ( const radio of [ shopBaseRadio, shopCategoryRadio ] ) {
+				const structure = await radio.inputValue();
 
-			await shopBaseRadio.check();
-			await expect( customBase ).toHaveValue( shopBaseStructure );
+				await radio.check();
+				await expect( customBase ).toHaveValue( structure );
 
-			await saveAndWaitForSubmit();
+				await saveAndReload();
 
-			await expect( shopBaseRadio ).toBeChecked();
-			await expect( customBase ).toHaveValue( shopBaseStructure );
+				await expect( radio ).toBeChecked();
+				await expect( customBase ).toHaveValue( structure );
+			}
 
 			await defaultRadio.check();
 			await expect( defaultRadio ).toHaveValue( '' );
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
 
-			await saveAndWaitForSubmit();
+			await saveAndReload();
 
 			await expect( defaultRadio ).toBeChecked();
 			await expect( defaultRadio ).toHaveValue( '' );
@@ -103,7 +112,7 @@ test.describe( 'Product permalink settings', () => {
 				await customBase.fill( originalCustomBase );
 			}
 
-			await saveAndWaitForSubmit();
+			await saveAndReload();
 		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -12,9 +12,10 @@ test.describe( 'Product permalink settings', () => {
 		page,
 		baseURL,
 	} ) => {
-		if ( ! baseURL ) {
-			throw new Error( 'Playwright baseURL is required.' );
-		}
+		const resolvedBaseURL = baseURL ?? '';
+		expect( resolvedBaseURL, 'Playwright baseURL is required.' ).not.toBe(
+			''
+		);
 
 		await page.goto( 'wp-admin/options-permalink.php' );
 
@@ -42,7 +43,7 @@ test.describe( 'Product permalink settings', () => {
 		// so a UI-driven restore could never put it back.
 		const originalPermalinks = (
 			await wpCLI( 'wp option get woocommerce_permalinks --format=json' )
-		 ).stdout.trim();
+		).stdout.trim();
 
 		try {
 			const defaultRadio = productPermalinkRadios.nth( 0 );
@@ -61,7 +62,10 @@ test.describe( 'Product permalink settings', () => {
 			// Derive the canonical `/base/` from the preview rather than hardcoding a translated
 			// product slug. `/\/$/` drops the trailing slash so a root install contributes an
 			// empty prefix and a subdirectory install (`/wp/`) contributes `/wp`.
-			const sitePath = new URL( baseURL ).pathname.replace( /\/$/, '' );
+			const sitePath = new URL( resolvedBaseURL ).pathname.replace(
+				/\/$/,
+				''
+			);
 			// Assert the example segment first, so a changed preview fails here instead of
 			// silently yielding a wrong base.
 			expect( defaultPreview.pathname ).toMatch( /\/sample-product\/$/ );
@@ -128,7 +132,7 @@ test.describe( 'Product permalink settings', () => {
 					await wpCLI(
 						'wp option get woocommerce_permalinks --format=json'
 					)
-				 ).stdout.trim()
+				).stdout.trim()
 			);
 			expect( storedPermalinks.product_base ).toBe( expectedBareSlug );
 		} finally {

--- a/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/settings/product-permalinks.spec.ts
@@ -126,15 +126,29 @@ test.describe( 'Product permalink settings', () => {
 			await expect( defaultRadio ).toHaveValue( '' );
 			await expect( customBase ).toHaveValue( expectedDefaultBase );
 
-			// A single Tab from the checked radio lands on the Custom base field — the radios
-			// share one tab stop — and focusing the field selects Custom base. Saving from there
-			// posts the prefilled Default structure through the custom branch, which the save
-			// path normalizes back to Default's bare slug: the slash-prefixed form it would
-			// otherwise store builds broken rewrite rules under index.php (PATHINFO) permalinks.
+			// A single Tab from the checked radio lands on the Custom base field, because the
+			// radios share one tab stop. Focus alone must leave the checked radio where it is:
+			// flipping it there would move a keyboard user off the structure the store uses,
+			// undoing what this screen was fixed to report.
+			const customSelection = page.locator(
+				'#woocommerce_custom_selection'
+			);
+
 			await customBase.focus();
-			await expect(
-				page.locator( '#woocommerce_custom_selection' )
-			).toBeChecked();
+
+			await expect( defaultRadio ).toBeChecked();
+			await expect( customSelection ).not.toBeChecked();
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
+
+			// A real click does select Custom base, and leaves the prefilled Default structure in
+			// the field. Saving from there posts that structure through the custom branch, which
+			// the save path normalizes back to Default's bare slug: the slash-prefixed form it
+			// would otherwise store builds broken rewrite rules under index.php (PATHINFO)
+			// permalinks.
+			await customBase.click();
+
+			await expect( customSelection ).toBeChecked();
+			await expect( customBase ).toHaveValue( expectedDefaultBase );
 
 			await saveAndReload();
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -365,6 +365,37 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A custom base carrying no usable characters sanitizes down to the empty string, and an empty
+	 * product_base never survives: wc_get_permalink_structure() drops it and refills the option
+	 * from the request locale, outside any locale window, then writes it back. An administrator
+	 * browsing in their own language therefore persisted that language's slug. Resolving to the
+	 * site-locale default at save time keeps the stored value deterministic.
+	 *
+	 * The locales have to diverge for this to be observable: when they agree, the refill produces
+	 * the same slug the fix stores and nothing looks wrong.
+	 *
+	 * @testdox Should store the site-locale Default base when the posted custom structure sanitizes to nothing.
+	 *
+	 * @testWith [""]
+	 *           ["   "]
+	 *           ["###"]
+	 *           ["/"]
+	 *           ["///"]
+	 *
+	 * @param string $posted_structure Posted `product_permalink_structure` value.
+	 */
+	public function test_custom_base_that_sanitizes_to_nothing_falls_back_to_the_default_base( string $posted_structure ): void {
+		$this->ensure_shop_page();
+		$this->set_up_french_admin_user();
+		$this->activate_french_product_slug_translation();
+
+		$html = $this->save_and_render( 'custom', $posted_structure );
+
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'], 'An empty base must never reach the option, where the request locale would refill it.' );
+		$this->assert_only_radio_checked( $html, 'default' );
+	}
+
+	/**
 	 * Both permalink fields are free-form request input; an array reaching trim() or
 	 * wc_sanitize_permalink() is a fatal, since both are declared to take a string. The custom
 	 * branch has its own path: a scalar 'custom' radio with an array structure field used to store

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -331,6 +331,43 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A Shop page slug equal to the default product slug makes "Default" and "Shop base"
+	 * indistinguishable once stored: both persist the bare default base, so the checked-state
+	 * search — which maps a stored base back to whichever predefined choice would persist it —
+	 * has two valid answers and reports the first.
+	 *
+	 * Reporting "Shop base" instead would only move the wrong label to the merchant who picked
+	 * Default. The two forms cannot be told apart at storage either: the slashed `/product` that
+	 * would distinguish them is the shape that breaks PATHINFO permalinks, which is why the base
+	 * is normalized to the bare form in the first place.
+	 *
+	 * Nothing downstream depends on which label renders — the stored base is byte-identical, so
+	 * the product URLs and the derived `use_verbose_page_rules` flag are too.
+	 *
+	 * @testdox Should report "Default" when the Shop slug makes both choices store the same base.
+	 */
+	public function test_shop_base_equal_to_the_default_base_reports_as_default(): void {
+		$shop_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Product',
+				'post_name'   => 'product',
+				'post_status' => 'publish',
+			)
+		);
+		update_option( 'woocommerce_shop_page_id', $shop_id );
+
+		$base_slug = urldecode( get_page_uri( $shop_id ) );
+		$this->assertSame( 'product', $base_slug, 'The fixture Shop page should share the default product slug.' );
+
+		$html = $this->save_and_render( '/' . trailingslashit( $base_slug ) );
+
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'], 'Both choices store the bare default base.' );
+		$this->assert_only_radio_checked( $html, 'default' );
+	}
+
+
+	/**
 	 * A custom base is normalized before it is stored: every `#` is removed so the base cannot
 	 * open a URL fragment, and each run of slashes collapses into one.
 	 *

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -371,6 +371,33 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * The Shop rows are gated on wc_get_page_id( 'shop' ), which returns 0 when the
+	 * woocommerce_get_shop_page_id filter yields a truthy non-numeric value. A stored base
+	 * matching a hidden Shop row must fall back to Custom base — otherwise no rendered radio is
+	 * checked at all.
+	 *
+	 * @testdox Should check "Custom base" when the stored structure's Shop row is not rendered.
+	 */
+	public function test_shop_structure_falls_back_to_custom_when_shop_rows_are_hidden(): void {
+		$permalinks                 = (array) get_option( 'woocommerce_permalinks', array() );
+		$permalinks['product_base'] = '/shop';
+		update_option( 'woocommerce_permalinks', $permalinks );
+
+		$non_numeric_shop_page       = static fn() => 'abc';
+		$this->registered_cleanups[] = static function () use ( $non_numeric_shop_page ): void {
+			remove_filter( 'woocommerce_get_shop_page_id', $non_numeric_shop_page, 10 );
+		};
+		add_filter( 'woocommerce_get_shop_page_id', $non_numeric_shop_page );
+
+		$xpath  = $this->get_xpath( $this->render_settings() );
+		$radios = $xpath->query( '//input[@name="product_permalink"]' );
+
+		$this->assertSame( 2, $radios->length, 'Only the Default and Custom base radios should render without a Shop page.' );
+		$this->assertFalse( $radios->item( 0 )->hasAttribute( 'checked' ), 'Default must not be checked for a stored Shop-style base.' );
+		$this->assertTrue( $radios->item( 1 )->hasAttribute( 'checked' ), 'Custom base should be checked when the matching Shop row is not rendered.' );
+	}
+
+	/**
 	 * Both permalink fields are free-form request input; an array reaching trim() or
 	 * wc_sanitize_permalink() is a fatal, since both are declared to take a string.
 	 *

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -371,6 +371,21 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A custom base is normalized before it is stored: every `#` is removed so the base cannot
+	 * open a URL fragment, and each run of slashes collapses into one.
+	 *
+	 * @testdox Should collapse repeated slashes and remove hashes from a custom base.
+	 */
+	public function test_custom_base_repeated_slashes_and_hashes_are_normalized(): void {
+		$this->ensure_shop_page();
+
+		$html = $this->save_and_render( 'custom', '//widgets///gad#gets' );
+
+		$this->assertSame( '/widgets/gadgets', get_option( 'woocommerce_permalinks' )['product_base'] );
+		$this->assert_only_radio_checked( $html, 'custom' );
+	}
+
+	/**
 	 * The Shop rows are gated on wc_get_page_id( 'shop' ), which returns 0 when the
 	 * woocommerce_get_shop_page_id filter yields a truthy non-numeric value. A stored base
 	 * matching a hidden Shop row must fall back to Custom base — otherwise no rendered radio is

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -286,6 +286,27 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * The Default radio keeps posting an empty value, so the payload stays byte-identical to what
+	 * every earlier version submitted; the resolved structure moves to a data attribute that only
+	 * the Custom-base field reads.
+	 *
+	 * @testdox Should expose the Default structure without changing the value it submits.
+	 */
+	public function test_default_radio_exposes_its_structure_without_changing_its_value(): void {
+		$this->ensure_shop_page();
+
+		$xpath         = $this->get_xpath( $this->save_and_render( '' ) );
+		$default_radio = $xpath->query( '(//input[@name="product_permalink"])[1]' )->item( 0 );
+		$custom_input  = $xpath->query( '//input[@id="woocommerce_permalink_structure"]' )->item( 0 );
+
+		$this->assertInstanceOf( DOMElement::class, $default_radio );
+		$this->assertInstanceOf( DOMElement::class, $custom_input );
+		$this->assertSame( '', $default_radio->getAttribute( 'value' ), 'The Default radio value must remain empty.' );
+		$this->assertSame( '/product/', $default_radio->getAttribute( 'data-permalink-structure' ) );
+		$this->assertSame( '/product/', $custom_input->getAttribute( 'value' ) );
+	}
+
+	/**
 	 * @testdox Should keep "Shop base" checked when the Shop page is nested under a parent.
 	 */
 	public function test_shop_base_stays_checked_for_a_nested_shop_page(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -309,13 +309,14 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	/**
 	 * The Custom base field is the next tab stop after the radio group, and focusing it selects
 	 * Custom base — so a Tab keystroke is enough to post the field's prefilled Default structure
-	 * through the custom branch. That branch prepends a slash, storing `/product` where the
-	 * Default radio stores `product`. Both describe the same structure, so the screen has to keep
-	 * reporting Default rather than a Custom base the merchant never typed.
+	 * through the custom branch. That branch prepends a slash, and the slash-prefixed form is not
+	 * interchangeable with the bare slug the Default radio stores: under index.php (PATHINFO)
+	 * permalinks it produces an `index.php//product/%product%` permastruct whose URLs do not
+	 * resolve. The save path therefore converges the two, storing Default's bare form.
 	 *
-	 * @testdox Should keep "Default" checked when its own structure is saved through the Custom base field.
+	 * @testdox Should store the bare Default base and keep "Default" checked when its own structure is saved through the Custom base field.
 	 */
-	public function test_default_structure_saved_as_a_custom_base_stays_checked(): void {
+	public function test_default_structure_saved_as_a_custom_base_is_normalized(): void {
 		$this->ensure_shop_page();
 
 		$xpath        = $this->get_xpath( $this->render_settings() );
@@ -324,11 +325,35 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 
 		$html = $this->save_and_render( 'custom', $custom_input->getAttribute( 'value' ) );
 
-		$this->assertSame( '/product', get_option( 'woocommerce_permalinks' )['product_base'], 'The custom branch stores the slash-prefixed form.' );
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'], 'The Default-equivalent custom base should be normalized to the bare slug.' );
 		$this->assert_only_radio_checked( $html, 'default' );
+	}
 
-		// Saving Default from there rewrites the stored value to its bare form.
-		$this->assert_only_radio_checked( $this->save_and_render( '' ), 'default' );
+	/**
+	 * A pre-existing slash-prefixed `/product` — persisted by versions that stored the Tab-saved
+	 * Default structure verbatim — is reported honestly as a Custom base rather than as Default:
+	 * under PATHINFO permalinks the stored form genuinely behaves differently, and nothing is
+	 * rewritten on render. Saving any predefined choice from there converges the stored value.
+	 *
+	 * @testdox Should report a legacy slash-prefixed Default base as a Custom base until a save converges it.
+	 */
+	public function test_legacy_slash_prefixed_default_base_shows_as_custom(): void {
+		$this->ensure_shop_page();
+
+		$permalinks                 = (array) get_option( 'woocommerce_permalinks', array() );
+		$permalinks['product_base'] = '/product';
+		update_option( 'woocommerce_permalinks', $permalinks );
+
+		$xpath        = $this->get_xpath( $this->render_settings() );
+		$custom_input = $xpath->query( '//input[@id="woocommerce_permalink_structure"]' )->item( 0 );
+
+		$this->assertSame( '/product', get_option( 'woocommerce_permalinks' )['product_base'], 'The render must not rewrite the stored value.' );
+		$this->assertInstanceOf( DOMElement::class, $custom_input );
+		$this->assertSame( '/product/', $custom_input->getAttribute( 'value' ) );
+		$this->assert_only_radio_checked( $this->render_settings(), 'custom' );
+
+		// A save posting that same value through the custom branch converges it to the bare form.
+		$this->assert_only_radio_checked( $this->save_and_render( 'custom', '/product/' ), 'default' );
 		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -383,6 +383,28 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A base of nothing but the category token gives products the same URL shape as the category
+	 * archives they sit under, so the two collide. The save path prefixes the default base rather
+	 * than storing the token alone. Guard carried unchanged from #13374.
+	 *
+	 * @testdox Should prefix the default base when a custom base is nothing but the category token.
+	 *
+	 * @testWith ["%product_cat%"]
+	 *           ["/%product_cat%/"]
+	 *           ["//%product_cat%//"]
+	 *
+	 * @param string $posted_structure Custom base as posted by the form.
+	 */
+	public function test_custom_base_of_only_the_category_token_is_prefixed( string $posted_structure ): void {
+		$this->ensure_shop_page();
+
+		$html = $this->save_and_render( 'custom', $posted_structure );
+
+		$this->assertSame( '/product/%product_cat%', get_option( 'woocommerce_permalinks' )['product_base'] );
+		$this->assert_only_radio_checked( $html, 'custom' );
+	}
+
+	/**
 	 * The Shop rows are gated on wc_get_page_id( 'shop' ), which returns 0 when the
 	 * woocommerce_get_shop_page_id filter yields a truthy non-numeric value. A stored base
 	 * matching a hidden Shop row must fall back to Custom base — otherwise no rendered radio is

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -102,6 +102,48 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Translate the product slug to French, but only for requests running in fr_FR.
+	 *
+	 * Lets a test tell the two locales apart: the site-locale value stays `product`, so any
+	 * `produit` that reaches the stored option or the comparison came from the request locale.
+	 * Removal runs from the cleanup registry, so call sites need no try/finally unwinding.
+	 */
+	private function activate_french_product_slug_translation(): void {
+		$translate_product_slug = static function ( string $translation, string $text, string $context, string $domain ): string {
+			if ( 'woocommerce' === $domain && 'slug' === $context && 'product' === $text && 'fr_FR' === determine_locale() ) {
+				return 'produit';
+			}
+
+			return $translation;
+		};
+
+		add_filter( 'gettext_with_context', $translate_product_slug, 10, 4 );
+		$this->registered_cleanups[] = static function () use ( $translate_product_slug ): void {
+			remove_filter( 'gettext_with_context', $translate_product_slug, 10 );
+		};
+	}
+
+	/**
+	 * Simulate an admin request whose user locale (fr_FR) diverges from the en_US site locale.
+	 *
+	 * This is the divergence the fix closes: WordPress resolves admin translations in the current
+	 * user's language, while both the save path and the checked-state comparison must resolve the
+	 * persisted slug in the site's language.
+	 */
+	private function set_up_french_admin_user(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'   => 'administrator',
+				'locale' => 'fr_FR',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$this->assertSame( 'en_US', get_locale(), 'The site locale should remain English.' );
+		$this->assertSame( 'fr_FR', determine_locale(), 'The admin request should use the current user locale.' );
+	}
+
+	/**
 	 * Save a product permalink choice through the real save path and render the settings HTML.
 	 *
 	 * WordPress's own Permalinks page redirects after processing the POST (see
@@ -223,6 +265,24 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 
 		$this->assertSame( $expected_stored, get_option( 'woocommerce_permalinks' )['product_base'], 'The stored product base must not change.' );
 		$this->assert_only_radio_checked( $html, $choice );
+	}
+
+	/**
+	 * settings_save() resolves the Default slug in the site locale; settings() has to compare
+	 * against the same locale, or an administrator browsing the admin in their own language saves
+	 * one translation and is shown the comparison against another.
+	 *
+	 * @testdox Should keep "Default" checked when the user and site locales differ.
+	 */
+	public function test_default_structure_stays_checked_when_user_and_site_locales_differ(): void {
+		$this->ensure_shop_page();
+		$this->set_up_french_admin_user();
+		$this->activate_french_product_slug_translation();
+
+		$html = $this->save_and_render( '' );
+
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'], 'The Default base should be stored in the site locale.' );
+		$this->assert_only_radio_checked( $html, 'default' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -9,13 +9,6 @@ declare( strict_types = 1 );
 class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 
 	/**
-	 * Cleanup callbacks registered by test helpers, run in tearDown() even when assertions fail.
-	 *
-	 * @var Closure[]
-	 */
-	private $registered_cleanups = array();
-
-	/**
 	 * Set up the admin context and load the class under test.
 	 */
 	public function setUp(): void {
@@ -23,38 +16,6 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		set_current_screen( 'options-permalink' );
 		require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
 		require_once WC_ABSPATH . 'includes/admin/class-wc-admin-permalink-settings.php';
-	}
-
-	/**
-	 * Reset superglobals after each test.
-	 *
-	 * Options changed during a test need no manual restoration: WC_Unit_Test_Case wraps each test
-	 * in a DB transaction and flushes the object cache, so option state reverts on its own.
-	 */
-	public function tearDown(): void {
-		foreach ( array_reverse( $this->registered_cleanups ) as $cleanup ) {
-			$cleanup();
-		}
-		$this->registered_cleanups = array();
-
-		wp_set_current_user( 0 );
-		$this->reset_permalink_post_data();
-		parent::tearDown();
-	}
-
-	/**
-	 * Remove every permalink field this test class writes to $_POST.
-	 */
-	private function reset_permalink_post_data(): void {
-		unset(
-			$_POST['permalink_structure'],
-			$_POST['wc-permalinks-nonce'],
-			$_POST['woocommerce_product_category_slug'],
-			$_POST['woocommerce_product_tag_slug'],
-			$_POST['woocommerce_product_attribute_slug'],
-			$_POST['product_permalink'],
-			$_POST['product_permalink_structure']
-		);
 	}
 
 	/**
@@ -106,7 +67,6 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	 *
 	 * Lets a test tell the two locales apart: the site-locale value stays `product`, so any
 	 * `produit` that reaches the stored option or the comparison came from the request locale.
-	 * Removal runs from the cleanup registry, so call sites need no try/finally unwinding.
 	 */
 	private function activate_french_product_slug_translation(): void {
 		$translate_product_slug = static function ( string $translation, string $text, string $context, string $domain ): string {
@@ -118,9 +78,6 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		};
 
 		add_filter( 'gettext_with_context', $translate_product_slug, 10, 4 );
-		$this->registered_cleanups[] = static function () use ( $translate_product_slug ): void {
-			remove_filter( 'gettext_with_context', $translate_product_slug, 10 );
-		};
 	}
 
 	/**
@@ -151,11 +108,14 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	 * same `WC_Admin_Permalink_Settings` instance in production. Mirror that with two separate
 	 * instantiations rather than reusing one.
 	 *
-	 * @param string      $product_permalink           Posted `product_permalink` radio value.
-	 * @param string|null $product_permalink_structure Posted `product_permalink_structure` text value, if any.
+	 * Both posted values are typed loosely on purpose: the fields are free-form request input, and
+	 * some tests post arrays to exercise the non-string fallbacks.
+	 *
+	 * @param mixed $product_permalink           Posted `product_permalink` radio value.
+	 * @param mixed $product_permalink_structure Posted `product_permalink_structure` value, or null to leave the field out.
 	 * @return string Rendered settings HTML.
 	 */
-	private function save_and_render( string $product_permalink, ?string $product_permalink_structure = null ): string {
+	private function save_and_render( $product_permalink, $product_permalink_structure = null ): string {
 		$_POST['permalink_structure']                = '';
 		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
 		$_POST['woocommerce_product_category_slug']  = 'product-category';
@@ -172,7 +132,7 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		// First request: the save-time instance persists the new structure and is discarded.
 		new WC_Admin_Permalink_Settings();
 
-		$this->reset_permalink_post_data();
+		$_POST = array();
 
 		// Second request (post-redirect): a fresh instance reads back the now-persisted value.
 		return $this->render_settings();
@@ -210,16 +170,16 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	/**
 	 * Assert that exactly one of the four product permalink radios is checked, and that it's the expected one.
 	 *
-	 * @param string $html        Rendered settings HTML.
-	 * @param string $expected_id Either 'default', 'shop_base', 'shop_base_category', or 'custom'.
+	 * @param string   $html        Rendered settings HTML.
+	 * @param string   $expected_id One of the $labels entries.
+	 * @param string[] $labels      Rows expected to render, in document order. Defaults to all four.
 	 */
-	private function assert_only_radio_checked( string $html, string $expected_id ): void {
+	private function assert_only_radio_checked( string $html, string $expected_id, array $labels = array( 'default', 'shop_base', 'shop_base_category', 'custom' ) ): void {
 		$xpath  = $this->get_xpath( $html );
 		$radios = $xpath->query( '//input[@name="product_permalink"]' );
 
-		$this->assertSame( 4, $radios->length, 'Expected exactly 4 product_permalink radios in the rendered markup.' );
+		$this->assertSame( count( $labels ), $radios->length, 'Unexpected number of product_permalink radios in the rendered markup.' );
 
-		$labels         = array( 'default', 'shop_base', 'shop_base_category', 'custom' );
 		$checked_labels = array();
 
 		foreach ( $radios as $index => $radio ) {
@@ -344,13 +304,13 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		$permalinks['product_base'] = '/product';
 		update_option( 'woocommerce_permalinks', $permalinks );
 
-		$xpath        = $this->get_xpath( $this->render_settings() );
-		$custom_input = $xpath->query( '//input[@id="woocommerce_permalink_structure"]' )->item( 0 );
+		$html         = $this->render_settings();
+		$custom_input = $this->get_xpath( $html )->query( '//input[@id="woocommerce_permalink_structure"]' )->item( 0 );
 
 		$this->assertSame( '/product', get_option( 'woocommerce_permalinks' )['product_base'], 'The render must not rewrite the stored value.' );
 		$this->assertInstanceOf( DOMElement::class, $custom_input );
 		$this->assertSame( '/product/', $custom_input->getAttribute( 'value' ) );
-		$this->assert_only_radio_checked( $this->render_settings(), 'custom' );
+		$this->assert_only_radio_checked( $html, 'custom' );
 
 		// A save posting that same value through the custom branch converges it to the bare form.
 		$this->assert_only_radio_checked( $this->save_and_render( 'custom', '/product/' ), 'default' );
@@ -398,67 +358,34 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		$permalinks['product_base'] = '/shop';
 		update_option( 'woocommerce_permalinks', $permalinks );
 
-		$non_numeric_shop_page       = static fn() => 'abc';
-		$this->registered_cleanups[] = static function () use ( $non_numeric_shop_page ): void {
-			remove_filter( 'woocommerce_get_shop_page_id', $non_numeric_shop_page, 10 );
-		};
-		add_filter( 'woocommerce_get_shop_page_id', $non_numeric_shop_page );
+		add_filter( 'woocommerce_get_shop_page_id', static fn() => 'abc' );
 
-		$xpath  = $this->get_xpath( $this->render_settings() );
-		$radios = $xpath->query( '//input[@name="product_permalink"]' );
-
-		$this->assertSame( 2, $radios->length, 'Only the Default and Custom base radios should render without a Shop page.' );
-		$this->assertFalse( $radios->item( 0 )->hasAttribute( 'checked' ), 'Default must not be checked for a stored Shop-style base.' );
-		$this->assertTrue( $radios->item( 1 )->hasAttribute( 'checked' ), 'Custom base should be checked when the matching Shop row is not rendered.' );
+		// Only the Default and Custom base rows render without a Shop page.
+		$this->assert_only_radio_checked( $this->render_settings(), 'custom', array( 'default', 'custom' ) );
 	}
 
 	/**
 	 * Both permalink fields are free-form request input; an array reaching trim() or
-	 * wc_sanitize_permalink() is a fatal, since both are declared to take a string.
+	 * wc_sanitize_permalink() is a fatal, since both are declared to take a string. The custom
+	 * branch has its own path: a scalar 'custom' radio with an array structure field used to store
+	 * '/', which wc_sanitize_permalink() collapses to '', leaving wc_get_permalink_structure() to
+	 * refill the option in the next request's locale. Both now resolve to the default base
+	 * directly, in the site locale.
 	 *
-	 * @testdox Should fall back to the Default base when the posted permalink fields are not scalar.
+	 * @testdox Should fall back to the Default base when a posted permalink field is not a string.
+	 *
+	 * @testWith [["custom"], ["widgets"]]
+	 *           ["custom", ["widgets"]]
+	 *
+	 * @param mixed $product_permalink           Posted `product_permalink` value.
+	 * @param mixed $product_permalink_structure Posted `product_permalink_structure` value.
 	 */
-	public function test_non_scalar_posted_fields_fall_back_to_the_default_base(): void {
+	public function test_non_string_posted_fields_fall_back_to_the_default_base( $product_permalink, $product_permalink_structure ): void {
 		$this->ensure_shop_page();
 
-		$_POST['permalink_structure']                = '';
-		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
-		$_POST['woocommerce_product_category_slug']  = 'product-category';
-		$_POST['woocommerce_product_tag_slug']       = 'product-tag';
-		$_POST['woocommerce_product_attribute_slug'] = '';
-		$_POST['product_permalink']                  = array( 'custom' );
-		$_POST['product_permalink_structure']        = array( 'widgets' );
-
-		new WC_Admin_Permalink_Settings();
-		$this->reset_permalink_post_data();
+		$html = $this->save_and_render( $product_permalink, $product_permalink_structure );
 
 		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
-		$this->assert_only_radio_checked( $this->render_settings(), 'default' );
-	}
-
-	/**
-	 * The Custom branch has its own non-scalar path: a scalar 'custom' radio with an array
-	 * structure field. It used to store '/', which wc_sanitize_permalink() collapses to '',
-	 * leaving wc_get_permalink_structure() to refill the option in the next request's locale.
-	 * It now resolves to the default base directly, in the site locale.
-	 *
-	 * @testdox Should fall back to the Default base when only the posted custom structure is not scalar.
-	 */
-	public function test_non_scalar_custom_structure_falls_back_to_the_default_base(): void {
-		$this->ensure_shop_page();
-
-		$_POST['permalink_structure']                = '';
-		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
-		$_POST['woocommerce_product_category_slug']  = 'product-category';
-		$_POST['woocommerce_product_tag_slug']       = 'product-tag';
-		$_POST['woocommerce_product_attribute_slug'] = '';
-		$_POST['product_permalink']                  = 'custom';
-		$_POST['product_permalink_structure']        = array( 'widgets' );
-
-		new WC_Admin_Permalink_Settings();
-		$this->reset_permalink_post_data();
-
-		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
-		$this->assert_only_radio_checked( $this->render_settings(), 'default' );
+		$this->assert_only_radio_checked( $html, 'default' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -307,6 +307,32 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * The Custom base field is the next tab stop after the radio group, and focusing it selects
+	 * Custom base — so a Tab keystroke is enough to post the field's prefilled Default structure
+	 * through the custom branch. That branch prepends a slash, storing `/product` where the
+	 * Default radio stores `product`. Both describe the same structure, so the screen has to keep
+	 * reporting Default rather than a Custom base the merchant never typed.
+	 *
+	 * @testdox Should keep "Default" checked when its own structure is saved through the Custom base field.
+	 */
+	public function test_default_structure_saved_as_a_custom_base_stays_checked(): void {
+		$this->ensure_shop_page();
+
+		$xpath        = $this->get_xpath( $this->render_settings() );
+		$custom_input = $xpath->query( '//input[@id="woocommerce_permalink_structure"]' )->item( 0 );
+		$this->assertInstanceOf( DOMElement::class, $custom_input );
+
+		$html = $this->save_and_render( 'custom', $custom_input->getAttribute( 'value' ) );
+
+		$this->assertSame( '/product', get_option( 'woocommerce_permalinks' )['product_base'], 'The custom branch stores the slash-prefixed form.' );
+		$this->assert_only_radio_checked( $html, 'default' );
+
+		// Saving Default from there rewrites the stored value to its bare form.
+		$this->assert_only_radio_checked( $this->save_and_render( '' ), 'default' );
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
+	}
+
+	/**
 	 * @testdox Should keep "Shop base" checked when the Shop page is nested under a parent.
 	 */
 	public function test_shop_base_stays_checked_for_a_nested_shop_page(): void {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -319,4 +319,27 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		$this->assert_only_radio_checked( $html, 'shop_base' );
 	}
 
+	/**
+	 * Both permalink fields are free-form request input; an array reaching trim() or
+	 * wc_sanitize_permalink() is a fatal, since both are declared to take a string.
+	 *
+	 * @testdox Should fall back to the Default base when the posted permalink fields are not scalar.
+	 */
+	public function test_non_scalar_posted_fields_fall_back_to_the_default_base(): void {
+		$this->ensure_shop_page();
+
+		$_POST['permalink_structure']                = '';
+		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
+		$_POST['woocommerce_product_category_slug']  = 'product-category';
+		$_POST['woocommerce_product_tag_slug']       = 'product-tag';
+		$_POST['woocommerce_product_attribute_slug'] = '';
+		$_POST['product_permalink']                  = array( 'custom' );
+		$_POST['product_permalink_structure']        = array( 'widgets' );
+
+		new WC_Admin_Permalink_Settings();
+		$this->reset_permalink_post_data();
+
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
+		$this->assert_only_radio_checked( $this->render_settings(), 'default' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -420,4 +420,30 @@ class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
 		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
 		$this->assert_only_radio_checked( $this->render_settings(), 'default' );
 	}
+
+	/**
+	 * The Custom branch has its own non-scalar path: a scalar 'custom' radio with an array
+	 * structure field. It used to store '/', which wc_sanitize_permalink() collapses to '',
+	 * leaving wc_get_permalink_structure() to refill the option in the next request's locale.
+	 * It now resolves to the default base directly, in the site locale.
+	 *
+	 * @testdox Should fall back to the Default base when only the posted custom structure is not scalar.
+	 */
+	public function test_non_scalar_custom_structure_falls_back_to_the_default_base(): void {
+		$this->ensure_shop_page();
+
+		$_POST['permalink_structure']                = '';
+		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
+		$_POST['woocommerce_product_category_slug']  = 'product-category';
+		$_POST['woocommerce_product_tag_slug']       = 'product-tag';
+		$_POST['woocommerce_product_attribute_slug'] = '';
+		$_POST['product_permalink']                  = 'custom';
+		$_POST['product_permalink_structure']        = array( 'widgets' );
+
+		new WC_Admin_Permalink_Settings();
+		$this->reset_permalink_post_data();
+
+		$this->assertSame( 'product', get_option( 'woocommerce_permalinks' )['product_base'] );
+		$this->assert_only_radio_checked( $this->render_settings(), 'default' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-permalink-settings-test.php
@@ -1,0 +1,241 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for WC_Admin_Permalink_Settings.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+class WC_Admin_Permalink_Settings_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Cleanup callbacks registered by test helpers, run in tearDown() even when assertions fail.
+	 *
+	 * @var Closure[]
+	 */
+	private $registered_cleanups = array();
+
+	/**
+	 * Set up the admin context and load the class under test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		set_current_screen( 'options-permalink' );
+		require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+		require_once WC_ABSPATH . 'includes/admin/class-wc-admin-permalink-settings.php';
+	}
+
+	/**
+	 * Reset superglobals after each test.
+	 *
+	 * Options changed during a test need no manual restoration: WC_Unit_Test_Case wraps each test
+	 * in a DB transaction and flushes the object cache, so option state reverts on its own.
+	 */
+	public function tearDown(): void {
+		foreach ( array_reverse( $this->registered_cleanups ) as $cleanup ) {
+			$cleanup();
+		}
+		$this->registered_cleanups = array();
+
+		wp_set_current_user( 0 );
+		$this->reset_permalink_post_data();
+		parent::tearDown();
+	}
+
+	/**
+	 * Remove every permalink field this test class writes to $_POST.
+	 */
+	private function reset_permalink_post_data(): void {
+		unset(
+			$_POST['permalink_structure'],
+			$_POST['wc-permalinks-nonce'],
+			$_POST['woocommerce_product_category_slug'],
+			$_POST['woocommerce_product_tag_slug'],
+			$_POST['woocommerce_product_attribute_slug'],
+			$_POST['product_permalink'],
+			$_POST['product_permalink_structure']
+		);
+	}
+
+	/**
+	 * Ensure `wc_get_page_id( 'shop' )` resolves to a real, existing post.
+	 *
+	 * The install-time `woocommerce_shop_page_id` option can point at a page whose row was
+	 * rolled back by an earlier test's DB transaction, leaving a stale ID with no matching post.
+	 *
+	 * @return int Shop page ID.
+	 */
+	private function ensure_shop_page(): int {
+		return (int) wc_create_page( 'shop', 'woocommerce_shop_page_id', 'Shop' );
+	}
+
+	/**
+	 * Create a Shop page nested under a parent, so its URI is multi-segment (`stores/shop`).
+	 *
+	 * The checked-state comparison runs both the rendered structure and the stored value through
+	 * wc_sanitize_permalink(), which only holds up if a multi-segment URI survives it unchanged.
+	 *
+	 * @return int Shop page ID.
+	 */
+	private function ensure_nested_shop_page(): int {
+		$parent_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Stores',
+				'post_name'   => 'stores',
+				'post_status' => 'publish',
+			)
+		);
+		$shop_id   = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Shop',
+				'post_name'   => 'shop',
+				'post_status' => 'publish',
+				'post_parent' => $parent_id,
+			)
+		);
+
+		update_option( 'woocommerce_shop_page_id', $shop_id );
+
+		return (int) $shop_id;
+	}
+
+	/**
+	 * Save a product permalink choice through the real save path and render the settings HTML.
+	 *
+	 * WordPress's own Permalinks page redirects after processing the POST (see
+	 * `wp-admin/options-permalink.php`), so a save and its resulting render never happen on the
+	 * same `WC_Admin_Permalink_Settings` instance in production. Mirror that with two separate
+	 * instantiations rather than reusing one.
+	 *
+	 * @param string      $product_permalink           Posted `product_permalink` radio value.
+	 * @param string|null $product_permalink_structure Posted `product_permalink_structure` text value, if any.
+	 * @return string Rendered settings HTML.
+	 */
+	private function save_and_render( string $product_permalink, ?string $product_permalink_structure = null ): string {
+		$_POST['permalink_structure']                = '';
+		$_POST['wc-permalinks-nonce']                = wp_create_nonce( 'wc-permalinks' );
+		$_POST['woocommerce_product_category_slug']  = 'product-category';
+		$_POST['woocommerce_product_tag_slug']       = 'product-tag';
+		$_POST['woocommerce_product_attribute_slug'] = '';
+		$_POST['product_permalink']                  = $product_permalink;
+
+		if ( null !== $product_permalink_structure ) {
+			$_POST['product_permalink_structure'] = $product_permalink_structure;
+		} else {
+			unset( $_POST['product_permalink_structure'] );
+		}
+
+		// First request: the save-time instance persists the new structure and is discarded.
+		new WC_Admin_Permalink_Settings();
+
+		$this->reset_permalink_post_data();
+
+		// Second request (post-redirect): a fresh instance reads back the now-persisted value.
+		return $this->render_settings();
+	}
+
+	/**
+	 * Render the permalink settings section HTML from a fresh instance.
+	 *
+	 * @return string Rendered settings HTML.
+	 */
+	private function render_settings(): string {
+		$sut = new WC_Admin_Permalink_Settings();
+
+		return (string) $this->capture_output_from( array( $sut, 'settings' ) );
+	}
+
+	/**
+	 * Parse rendered settings HTML into an XPath query object.
+	 *
+	 * @param string $html Rendered settings HTML.
+	 * @return DOMXPath Query object for the parsed document.
+	 */
+	private function get_xpath( string $html ): DOMXPath {
+		$document       = new DOMDocument();
+		$previous_state = libxml_use_internal_errors( true );
+		$loaded         = $document->loadHTML( $html );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_state );
+
+		$this->assertTrue( $loaded, 'The permalink settings output should be valid enough for DOM parsing.' );
+
+		return new DOMXPath( $document );
+	}
+
+	/**
+	 * Assert that exactly one of the four product permalink radios is checked, and that it's the expected one.
+	 *
+	 * @param string $html        Rendered settings HTML.
+	 * @param string $expected_id Either 'default', 'shop_base', 'shop_base_category', or 'custom'.
+	 */
+	private function assert_only_radio_checked( string $html, string $expected_id ): void {
+		$xpath  = $this->get_xpath( $html );
+		$radios = $xpath->query( '//input[@name="product_permalink"]' );
+
+		$this->assertSame( 4, $radios->length, 'Expected exactly 4 product_permalink radios in the rendered markup.' );
+
+		$labels         = array( 'default', 'shop_base', 'shop_base_category', 'custom' );
+		$checked_labels = array();
+
+		foreach ( $radios as $index => $radio ) {
+			if ( $radio->hasAttribute( 'checked' ) ) {
+				$checked_labels[] = $labels[ $index ];
+			}
+		}
+
+		$this->assertSame(
+			array( $expected_id ),
+			$checked_labels,
+			"Expected only the '{$expected_id}' radio to be checked."
+		);
+	}
+
+	/**
+	 * Issue #29050: every predefined structure reverted to "Custom base" on the next render,
+	 * because the comparison used the raw radio values while the save path stored
+	 * wc_sanitize_permalink() output — and mapped the Default radio's empty value to a slug.
+	 *
+	 * @testdox Should keep the saved structure checked, and store the same value as before, for every choice.
+	 *
+	 * @testWith ["default"]
+	 *           ["shop_base"]
+	 *           ["shop_base_category"]
+	 *           ["custom"]
+	 *
+	 * @param string $choice Which product permalink option to save.
+	 */
+	public function test_saved_structure_stays_checked( string $choice ): void {
+		$base_slug = urldecode( get_page_uri( $this->ensure_shop_page() ) );
+
+		$cases = array(
+			'default'            => array( '', null, 'product' ),
+			'shop_base'          => array( '/' . trailingslashit( $base_slug ), null, '/' . $base_slug ),
+			'shop_base_category' => array( '/' . trailingslashit( $base_slug ) . trailingslashit( '%product_cat%' ), null, '/' . $base_slug . '/%product_cat%' ),
+			'custom'             => array( 'custom', 'widgets', '/widgets' ),
+		);
+
+		list( $posted_base, $posted_structure, $expected_stored ) = $cases[ $choice ];
+
+		$html = $this->save_and_render( $posted_base, $posted_structure );
+
+		$this->assertSame( $expected_stored, get_option( 'woocommerce_permalinks' )['product_base'], 'The stored product base must not change.' );
+		$this->assert_only_radio_checked( $html, $choice );
+	}
+
+	/**
+	 * @testdox Should keep "Shop base" checked when the Shop page is nested under a parent.
+	 */
+	public function test_shop_base_stays_checked_for_a_nested_shop_page(): void {
+		$base_slug = urldecode( get_page_uri( $this->ensure_nested_shop_page() ) );
+		$this->assertSame( 'stores/shop', $base_slug, 'The fixture should produce a multi-segment page URI.' );
+
+		$html = $this->save_and_render( '/' . trailingslashit( $base_slug ) );
+
+		$this->assertSame( '/stores/shop', get_option( 'woocommerce_permalinks' )['product_base'] );
+		$this->assert_only_radio_checked( $html, 'shop_base' );
+	}
+
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On WP Admin → Settings → Permalinks → Product permalinks, saving "Default", "Shop base", or "Shop base with category" left "Custom base" selected after the reload. The chosen structure was stored and applied correctly — only the checked state was wrong, which still misreports the store's configuration and invites the merchant to re-save something that was never broken. Reported since 2021 (#29050).

The two sides of the screen derived the product base from separate copies of the same rules, and the copies disagreed. `settings_save()` stored the chosen structure through `wc_sanitize_permalink()`, which strips the trailing slash, and mapped the Default radio's empty value to the translated product slug. The render path compared that stored value against the **raw** radio values, so nothing ever matched: `/shop/` against the stored `/shop`, and `''` against the stored `product`.

**The fix is one resolver.** A private `get_stored_product_base()` maps a posted radio choice to the value that gets persisted for it. `settings_save()` stores what it returns; `settings()` runs each radio's posted value through it to build the set of values a save would produce, and checks the radio whose entry matches what is stored. Both sides now derive the base from one set of rules instead of restating them, which is what made every predefined structure revert.

That resolver also owns the normalization the save path used to inline: hashes stripped so a base cannot open a URL fragment, slash runs collapsed, the invalid `/%product_cat%/` structure prefixed with the default base, and an empty result resolved to the default base rather than left for `wc_get_permalink_structure()` to refill in the next request's locale.

**Both sides resolve translated slugs in the site locale.** `settings_save()` has opened a `wc_switch_to_site_locale()` window since 3.1; `settings()` did not, so a German store administered in English stored `produkt` and compared against `product`. The render path now opens the same window, and resolves `wc_get_page_id( 'shop' )` inside it too — `woocommerce_get_shop_page_id` is a documented extension point that multilingual plugins use to return a different page per locale, so resolving it outside the window let the two paths pick different Shop pages.

**The Custom base field is prefilled from a data attribute rather than the radio's value.** Selecting a predefined structure copied the radio's own value into the field, so "Default" blanked it. Each radio now carries an additive `data-permalink-structure` attribute holding the structure it represents, and the script reads that. Radio `value` attributes keep their raw form, so the submitted payload is byte-identical to before.

**A custom base equal to the Default structure is stored in Default's bare form.** The custom branch prepends a slash, so `/product/` typed into the field would persist as `/product` where the Default radio stores `product`. The two are not interchangeable: under `index.php`-based (PATHINFO) permalinks the leading slash reaches `register_post_type()` and produces an `index.php//product/%product%` permastruct whose product URLs 404, while the bare slug works everywhere. Converging on save means that shape is never persisted. See behavior change 4 for why a single keystroke reaches this path.

**Focusing the Custom base field no longer selects it.** The four radios share a name, so they are one tab stop and the field is the next one — and the field selected its radio on `focus`, so tabbing forward off the checked radio moved the checked state to "Custom base". On trunk that was invisible, because the radio already showed "Custom base" whatever the store used. Now that the screen reports the real structure, the same handler visibly undoes it. The field is bound to the pair core binds on its own structure field instead: WordPress selects its Custom radio on `click input` and uses `focus` only to record that the caret has entered the field (`wp-admin/js/common.js:728`, `:733`). Clicking into the field and typing in it still select "Custom base"; arriving by keyboard no longer does.

**Form input is guarded before it reaches the resolver.** `$_POST` members are only ever strings or arrays, so both permalink fields are `is_string`-checked; a non-string value in either resolves to the default base instead of reaching `trim()` or `wc_sanitize_permalink()` as an array. Three PHPStan baseline entries are removed as genuinely resolved by the new typed signatures.

**The Custom base field has an accessible name.** The wrapping label belongs to the radio, so the input had none. It now carries an `aria-label` naming what it sets — distinct from the adjacent radio's visible label, which the row `<th>` already exposes as the field's row header — and an `aria-describedby` pointing at its description.

Closes #29050. (Also reported in #67323, closed as a duplicate.)

### Backward-compatibility impact:

No PHP signatures, hooks, field names, IDs, or classes changed. Both new methods are private. `wc_switch_to_site_locale()` / `wc_restore_locale()` and `wc_get_permalink_structure()` are untouched — the latter is byte-identical to trunk — so nothing outside the Permalinks admin screen changes: no new queries, option reads, file I/O, or hooks on any front-end, REST, cron, or CLI path. Default still submits an empty raw radio value, explicit saves still store the bare site-locale slug such as `product`, and existing non-empty settings are never rewritten on render.

**Multisite: not tested.** The screen reads and writes a single site-scoped option, `woocommerce_permalinks`, through `get_option()` / `update_option()`, and this PR changes neither which option is read nor where it is read from — there is no `get_site_option()`, network-admin surface, or cross-site path involved. Stated as `AGENTS.md` asks, but not exercised on a multisite install.

Four behavior changes worth disclosing:

1. **The screen's render now opens a `wc_switch_to_site_locale()` window**, so `switch_locale` / `restore_previous_locale` can fire on that one admin page view when the viewing administrator's language differs from the site's. The save path has done this since 3.1; only the render is new.
2. **A non-string `product_permalink` or `product_permalink_structure` now resolves to Default.** Every value the form can submit behaves exactly as before; the structure field previously stored `''` on this path and left `wc_get_permalink_structure()` to refill the option in the next request's locale, and now stores the site-locale default slug directly.
3. **The Custom base field is prefilled with the effective default structure** (`/product/`) when the stored base equals the default, where it previously rendered without its leading slash. The field is only read when "Custom base" is selected, so this does not change what a save stores. It also carries an `aria-label` and an `aria-describedby` now.
4. **Saving a custom base identical to the Default structure stores Default's bare slug.** Under `index.php`-based (PATHINFO) permalinks the slash-prefixed form yields an `index.php//product/%product%` permastruct whose product URLs 404 (verified against a PATHINFO-routing env: the bare form returns 200, the slashed form 404s on both URL shapes). Under pretty permalinks the two behave identically, because `home_url()` absorbs the leading slash.

   *Why this path is reachable without typing anything:* on a store using Default the Custom base field renders prefilled with `/product/`, and clicking into it selects "Custom base". A click then Save posts the Default structure through the custom branch without a character being typed. Before this PR that silently persisted the slash-prefixed form, breaking product URLs on PATHINFO stores; now it persists the same value clicking Default would. Until this PR's focus-handler change a single Tab did the same thing, which is what made the path worth closing in the first place.

   *Scope:* the convergence happens on save, uniformly for every entry path, and only for the exact Default structure — a genuine custom base that merely resembles it is untouched. This also means a permalink-screen save that edits an unrelated field, say the category base, converges an already-persisted `/product` to `product`, since the form re-posts the product base it renders; on a PATHINFO store that converts a broken state into a working one. Nothing is rewritten on render: a legacy stored `/product` shows honestly as "Custom base" with `/product/` in the field until a save converges it.

### Known limitations

- **`wc_get_permalink_structure()` still persists localized defaults in the request locale.** Pre-existing trunk behavior, tracked in #67507 and addressed by #67939, deliberately out of scope here. Self-healing on this screen: the value shows honestly as a custom base, and one click on Default writes the site-locale slug for good.
- **A Shop page slug equal to the default product slug reports as "Default".** On such a store both choices persist the same bare base, so the mapping from stored value back to radio has two valid answers and the first wins. Reporting "Shop base" instead would only move the wrong label onto the merchant who picked Default, and the two cannot be told apart at storage either — the slashed `/product` that would distinguish them is the shape that breaks PATHINFO permalinks. Nothing downstream reads the label: the stored base is identical either way, so the product URLs and the derived `use_verbose_page_rules` flag are too. Pinned by a test.
- **Migration-era stores still land on "Custom base", and any save converges them.** `wc_update_200_permalinks()` wrote `product_base` as a bare `shop` / `shop/%product_cat%`, which the strict comparison cannot match against the radios' `/shop`-prefixed structures, so the screen reports "Custom base" with the bare value prefilled in the field. Left alone deliberately, but the honest display is all this PR gives: because the form re-posts the Custom base field it renders, **any** save of this screen rewrites a bare `shop` to `/shop` — including one that only edits the category base. Measured on a store seeded with the migration-era value, and identical with this file swapped for its trunk version, so it is neither introduced nor fixed here. Closing it means changing what the Shop radios store, which `WC_Breadcrumb` and `wc_fix_rewrite_rules()` pattern-match in slash-prefixed form — out of scope. (Raised in review; the earlier wording here claimed the value survived until an explicit user choice, which is not what the code does.)
- **`use_verbose_page_rules` is still write-once.** The flag has one writer, a condition with no `else`, so picking "Shop base" and later switching back to "Default" leaves it set forever, and `stristr()` substring-matches, so a custom base of `/webshop` sets it on a store whose Shop slug is `shop`. Both measured. Pre-existing trunk behavior on a line this PR does not touch — it only extracts the Shop-slug lookup into a behavior-identical helper. Filed separately as #68029, with why neither half is a one-line fix.
- **A leading-slash Shop or custom base still breaks PATHINFO stores.** Every value the custom branch and the Shop radios have ever stored has a leading slash, so this is long-standing trunk behavior for *any* non-Default selection on such stores, out of this PR's scope. This PR stops adding to it — the Default structure no longer persists slash-prefixed — without touching what Shop saves store, since consumers like `WC_Breadcrumb` and `wc_fix_rewrite_rules()` pattern-match the slash-prefixed forms.
- **"Shop base" slugs are left as-is, matching core.** Their no-Shop-page fallback (`_x( 'shop', 'default-slug' )`) is translatable too, but `settings_save()` stores whatever those radios submit — the same pattern core uses for its own "Numeric" structure, where `_x( 'archives', 'sample permalink base' )` is baked into the stored value and never wrapped in `switch_to_locale()`.
- **A changed slug translation still flips the radio.** `settings()` recomputes the expected slug and compares it against the stored one, so a language-pack update that retranslates `_x( 'product', 'slug' )` reintroduces the mismatch. Fixing it means persisting the choice rather than the slug — rejected, because `woocommerce_permalinks` is written directly by WP-CLI and extensions, so a stale marker would show the **wrong** radio, worse than falling back to "Custom base".
- **The empty-base fallback narrows its window rather than closing it.** A custom base that sanitizes down to nothing resolves to the default base, so `wc_get_permalink_structure()` is not left to refill the option in the request locale. The default base is itself a translated slug run through `wc_sanitize_permalink()`, though, so a translation or a `gettext_with_context` filter that resolves it to something sanitizing away — `/` untrailingslashits to nothing — leaves the fallback assigning empty to empty. Reaching it takes a filter or translation that empties the slug; no shipped language pack does. Documented at the guard.
- **The render and save paths do not receive identically pre-sanitized input.** The save path runs the posted value through `sanitize_text_field()` first, which strips percent-encoded octets, so a Shop page whose slug carries a literal percent-escape can resolve differently on the two sides. Reaching it requires typing a percent-escape sequence into the Shop page title, and the asymmetry predates this PR — the code replaced here ran the same field through `wc_clean()`, which dispatches scalars to the same sanitizer.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to WP Admin → Settings → Permalinks → Product permalinks.
2. Select "Default", Save Changes, reload. Confirm "Default" stays checked (not "Custom base"), the "Custom base" input shows `/product/`, and a product URL resolves under `/product/`.
3. Repeat for "Shop base" and "Shop base with category" (a Shop page must exist). Confirm each stays checked after save + reload, the "Custom base" input gets `/shop/` and `/shop/%product_cat%/` respectively, and product URLs resolve under the new structure.
4. Confirm "Custom base" still behaves as before: clicking into the text field auto-selects it; type a structure, save, reload — it stays checked and product URLs resolve under it.
5. Keyboard behavior: with "Default" selected, press Tab once from the radio. Focus lands on the Custom base field — the four radios are one tab stop — and **"Default" must stay checked**, with `/product/` in the field. Then type a character, and confirm "Custom base" takes over.
6. Click normalization (behavior change 4): reload with "Default" selected and click into the Custom base field without editing it. "Custom base" takes over and the field still holds `/product/`. Save Changes, reload. Confirm **"Default" is the checked radio again**, that `woocommerce_permalinks` holds a bare `product` — not `/product` — straight away (`wp option get woocommerce_permalinks --format=json`), and that product URLs still resolve under `/product/` exactly as in step 2.
7. Legacy slashed base (behavior change 4, scope): seed `wp option patch update woocommerce_permalinks product_base '/product'`, reload the screen. Confirm "Custom base" is checked with `/product/` in the field and the stored option untouched. Save Changes without editing anything — confirm "Default" is now checked and the stored value converged to `product`. Optionally repeat on `/index.php/%postname%/` permalinks: before the save the product URLs 404; after it they resolve.
8. Mixed-locale: first install the French WooCommerce translations (`wp language plugin install woocommerce fr_FR`) — without them `_x( 'product', 'slug' )` returns `product` in both locales and this step passes whether or not the fix works. Then, on an English site with a French administrator profile, confirm Default is selected, its preview reads `/product/sample-product/` rather than `/produit/sample-product/`, the Custom field shows `/product/`, and saving Default stores a bare `product_base` of `product`.
9. Accessibility: inspect the Custom base text field and confirm its `aria-label` names the field itself rather than repeating the adjacent radio's visible "Custom base" label, and that its `aria-describedby` resolves to the description beside it. With a screen reader, the field should announce that distinct name followed by the description, instead of the radio's label twice under two roles.
10. From `plugins/woocommerce`: `pnpm test:php:env -- --filter WC_Admin_Permalink_Settings_Test`
11. From `plugins/woocommerce`: start the e2e environment with `pnpm env:e2e`, then run `BASE_URL=http://localhost:<port> WP_BASE_URL=http://localhost:<port> WP_ENV_PORT=<port> pnpm test:e2e:default --project=core-serial product-permalinks`. The wrapper scripts neither start the environment nor set `BASE_URL`: without those variables Playwright falls back to `http://localhost:8086` and global setup fails on any checkout whose e2e environment listens elsewhere.

<!-- End testing instructions -->

### Testing that has already taken place:

- **PHPUnit:** 22 tests, 112 assertions — green at the branch tip. Every case runs through the real `settings()` / `settings_save()` entry points across two instances, mirroring WordPress's post-redirect reload, and asserts the checked radio by parsing the rendered HTML rather than matching markup strings.
- **Mutation-verified.** Each retained test was checked against a deliberate mutation of the code it covers:

  | Test | Mutation | Result |
  |---|---|---|
  | `test_saved_structure_stays_checked` (×4) | comparison reverted to the raw `$structures` | 6/8 fail |
  | `..._when_user_and_site_locales_differ` | `wc_switch_to_site_locale()` window removed | fails alone |
  | `test_default_radio_exposes_its_structure_without_changing_its_value` | `data-permalink-structure` set to `$structures[0]` | fails alone |
  | `test_non_string_posted_fields_fall_back_to_the_default_base` | `is_string` guard removed | errors |
  | `test_default_structure_saved_as_a_custom_base_is_normalized` + `test_legacy_slash_prefixed_default_base_shows_as_custom` | save-side normalization removed | both fail, alone |
  | `test_shop_structure_falls_back_to_custom_when_shop_rows_are_hidden` | unrendered-row fallback removed | fails alone |
  | `test_custom_base_that_sanitizes_to_nothing_falls_back_to_the_default_base` | empty-base fallback removed | fails alone (stored `''`, as predicted) |
  | `test_custom_base_of_only_the_category_token_is_prefixed` (×3) | `/%product_cat%/` guard removed | all 3 fail, alone |

- **Browser:** the serial Playwright journey saves Default, then "Shop base", then "Shop base with category", then Default again through the real page, asserting after each reload that the radio is still selected and the Custom field shows the effective structure. A final leg covers the focus handler and the convergence together: from the Default state it focuses the Custom base field and asserts **Default is still checked**, then clicks into it and asserts "Custom base" takes over with the prefilled structure intact, then saves and asserts the reloaded page reports Default with the stored `product_base` normalized to the bare slug (read back over WP-CLI). Green against this clone's e2e environment; mutation-verified by restoring the `focus` binding, which fails that leg on the first assertion and nothing else. It waits on the load event of the document WordPress's redirect produces, so every post-save assertion reads the reloaded page rather than the pre-submit DOM. It establishes Default as the starting state instead of assuming the store already uses it, derives the expected base from the rendered preview — asserting the preview's shape first, so a changed preview fails at its cause — and restores the entire `woocommerce_permalinks` option in `finally` over WP-CLI, including the derived `use_verbose_page_rules` flag the Shop base saves set and no form field can put back, followed by the rewrite flush a screen save would have done. It is registered in `serialRunSpecs` because it mutates that global option.
- **Live store, round 3.** The two findings that drove this round were reproduced before being acted on, on a real store driven through the browser. One Tab from the checked Default radio landed on the Custom base field and flipped the checked radio to "Custom base"; with the handler rebound, the same Tab leaves Default checked, a typed character selects "Custom base", a click selects it with `/product/` intact, and saving from there stores a bare `product` with Default checked on reload. "Shop base" round-trips unchanged. Separately, a store seeded with the migration-era bare `shop` renders "Custom base" with `shop/` prefilled and stores `/shop` after a save that edits only the category base — the basis for the corrected Known limitations wording above.
- **Quality:** changed-file and branch-diff PHP lint, JS lint, PHPStan (clean; all three removed baseline entries confirmed resolved, not relocated), and `git diff --check`.
- **Not covered:** multisite, WPML/Polylang.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually (`plugins/woocommerce/changelog/67323-fix-product-permalink-radio-checked-state`).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze the PR and post a draft comment for you to review and edit.
</details>



