### PR TITLE
Match Blueprint restricted options regardless of key spelling

### DIFF
--- a/packages/php/blueprint/changelog/woo6-96-fix-restricted-options-case-bypass
+++ b/packages/php/blueprint/changelog/woo6-96-fix-restricted-options-case-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Match Blueprint's restricted site options regardless of the casing, padding or accents used in the imported key.

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -20,6 +20,9 @@ class ImportSetSiteOptions implements StepProcessor {
 	/**
 	 * List of WordPress options that should not be modified.
 	 *
+	 * Entries must be lowercase — keys are normalised to lowercase before being
+	 * compared against this list. See is_restricted_option().
+	 *
 	 * @var array<string>
 	 */
 	private const RESTRICTED_OPTIONS = array(
@@ -49,7 +52,7 @@ class ImportSetSiteOptions implements StepProcessor {
 		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
 		foreach ( $schema->options as $key => $value ) {
 			// Skip if the option should not be modified.
-			if ( in_array( $key, self::RESTRICTED_OPTIONS, true ) ) {
+			if ( $this->is_restricted_option( $key ) ) {
 				$result->add_warn( "Cannot modify '{$key}' option: Modifying is restricted for this key." );
 				continue;
 			}
@@ -74,6 +77,83 @@ class ImportSetSiteOptions implements StepProcessor {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Check whether a blueprint is allowed to write to the given option key.
+	 *
+	 * A plain, case-sensitive comparison against RESTRICTED_OPTIONS is not enough,
+	 * because the key a blueprint supplies and the row WordPress ultimately writes to
+	 * are matched by two different sets of rules:
+	 *
+	 * - WordPress trims option names before reading or writing them, so ' wp_user_roles'
+	 *   and 'wp_user_roles' are the same option.
+	 * - Option lookups are resolved by MySQL using the table's collation, which is
+	 *   case-insensitive (and, for the utf8mb4 collations WordPress uses, also
+	 *   accent-insensitive) by default. 'wp_USER_roles' therefore reads and writes the
+	 *   existing 'wp_user_roles' row.
+	 *
+	 * This is checked in two layers. The first normalises the key and compares it against
+	 * the list, which covers case and surrounding whitespace and works even when the
+	 * restricted option does not exist yet. The second asks the database which row the key
+	 * actually resolves to and restricts the write when that row is a restricted option,
+	 * which covers equivalences string normalisation cannot model on its own.
+	 *
+	 * @param string $key The option key from the blueprint.
+	 *
+	 * @return bool True if the option must not be modified.
+	 */
+	protected function is_restricted_option( $key ): bool {
+		if ( in_array( $this->normalize_option_name( $key ), self::RESTRICTED_OPTIONS, true ) ) {
+			return true;
+		}
+
+		$stored_name = $this->get_stored_option_name( $key );
+
+		return null !== $stored_name && in_array( $this->normalize_option_name( $stored_name ), self::RESTRICTED_OPTIONS, true );
+	}
+
+	/**
+	 * Normalise an option name for comparison against RESTRICTED_OPTIONS.
+	 *
+	 * Mirrors the trimming WordPress applies to option names, and lowercases so the
+	 * comparison matches the case-insensitive collation the database uses.
+	 *
+	 * @param string $key The option key to normalise.
+	 *
+	 * @return string
+	 */
+	private function normalize_option_name( $key ): string {
+		return strtolower( trim( (string) $key ) );
+	}
+
+	/**
+	 * Resolve an option key to the option name as it is actually stored.
+	 *
+	 * Runs the lookup through the database so the key is matched using the same collation
+	 * WordPress uses when it reads and writes the option. Returns null when the key does
+	 * not resolve to an existing row, or when there is no database to ask.
+	 *
+	 * @param string $key The option key from the blueprint.
+	 *
+	 * @return string|null The stored option name, or null if the key matches no row.
+	 */
+	protected function get_stored_option_name( $key ) {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_var' ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The point of this query is to let the database resolve the key with its own collation, which a cached lookup by the supplied key cannot do.
+		$stored_name = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				trim( (string) $key )
+			)
+		);
+
+		return is_string( $stored_name ) ? $stored_name : null;
 	}
 
 	/**

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -20,8 +20,8 @@ class ImportSetSiteOptions implements StepProcessor {
 	/**
 	 * List of WordPress options that should not be modified.
 	 *
-	 * Entries must be lowercase — keys are normalised to lowercase before being
-	 * compared against this list. See is_restricted_option().
+	 * Entries must be lowercase so normalised keys can be compared directly before
+	 * the database-collation check.
 	 *
 	 * @var array<string>
 	 */
@@ -49,10 +49,11 @@ class ImportSetSiteOptions implements StepProcessor {
 	 * @return StepProcessorResult
 	 */
 	public function process( $schema ): StepProcessorResult {
-		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
+		$result                  = StepProcessorResult::success( SetSiteOptions::get_step_name() );
+		$restricted_option_names = $this->get_restricted_option_names( array_keys( (array) $schema->options ) );
 		foreach ( $schema->options as $key => $value ) {
 			// Skip if the option should not be modified.
-			if ( $this->is_restricted_option( $key ) ) {
+			if ( isset( $restricted_option_names[ (string) $key ] ) ) {
 				$result->add_warn( "Cannot modify '{$key}' option: Modifying is restricted for this key." );
 				continue;
 			}
@@ -80,37 +81,38 @@ class ImportSetSiteOptions implements StepProcessor {
 	}
 
 	/**
-	 * Check whether a blueprint is allowed to write to the given option key.
+	 * Find restricted option names among imported keys.
 	 *
-	 * A plain, case-sensitive comparison against RESTRICTED_OPTIONS is not enough,
-	 * because the key a blueprint supplies and the row WordPress ultimately writes to
-	 * are matched by two different sets of rules:
+	 * @param array<int|string> $keys Option keys from the blueprint.
 	 *
-	 * - WordPress trims option names before reading or writing them, so ' wp_user_roles'
-	 *   and 'wp_user_roles' are the same option.
-	 * - Option lookups are resolved by MySQL using the table's collation, which is
-	 *   case-insensitive (and, for the utf8mb4 collations WordPress uses, also
-	 *   accent-insensitive) by default. 'wp_USER_roles' therefore reads and writes the
-	 *   existing 'wp_user_roles' row.
-	 *
-	 * This is checked in two layers. The first normalises the key and compares it against
-	 * the list, which covers case and surrounding whitespace and works even when the
-	 * restricted option does not exist yet. The second asks the database which row the key
-	 * actually resolves to and restricts the write when that row is a restricted option,
-	 * which covers equivalences string normalisation cannot model on its own.
-	 *
-	 * @param string $key The option key from the blueprint.
-	 *
-	 * @return bool True if the option must not be modified.
+	 * @return array<int|string, bool> Restricted option names as keys.
 	 */
-	protected function is_restricted_option( $key ): bool {
-		if ( in_array( $this->normalize_option_name( $key ), self::RESTRICTED_OPTIONS, true ) ) {
-			return true;
+	private function get_restricted_option_names( array $keys ): array {
+		$restricted_option_names = array();
+		$database_candidates     = array();
+
+		foreach ( $keys as $key ) {
+			$key = (string) $key;
+			if ( in_array( self::normalize_option_name( $key ), self::RESTRICTED_OPTIONS, true ) ) {
+				$restricted_option_names[ $key ] = true;
+				continue;
+			}
+
+			$database_candidates[] = array(
+				'original' => $key,
+				'trimmed'  => trim( $key ),
+			);
 		}
 
-		$stored_name = $this->get_stored_option_name( $key );
+		$candidate_names = array_column( $database_candidates, 'trimmed' );
+		foreach ( $this->get_collation_restricted_option_indexes( $candidate_names ) as $candidate_index ) {
+			if ( ! isset( $database_candidates[ $candidate_index ] ) ) {
+				continue;
+			}
+			$restricted_option_names[ $database_candidates[ $candidate_index ]['original'] ] = true;
+		}
 
-		return null !== $stored_name && in_array( $this->normalize_option_name( $stored_name ), self::RESTRICTED_OPTIONS, true );
+		return $restricted_option_names;
 	}
 
 	/**
@@ -123,37 +125,59 @@ class ImportSetSiteOptions implements StepProcessor {
 	 *
 	 * @return string
 	 */
-	private function normalize_option_name( $key ): string {
+	private static function normalize_option_name( $key ): string {
 		return strtolower( trim( (string) $key ) );
 	}
 
 	/**
-	 * Resolve an option key to the option name as it is actually stored.
+	 * Match candidates against restricted names using the options table collation.
 	 *
-	 * Runs the lookup through the database so the key is matched using the same collation
-	 * WordPress uses when it reads and writes the option. Returns null when the key does
-	 * not resolve to an existing row, or when there is no database to ask.
+	 * The empty option_name branches give both derived tables the real column type and
+	 * collation without requiring a restricted option row to exist.
 	 *
-	 * @param string $key The option key from the blueprint.
+	 * @param array<string> $candidate_names Trimmed option names from the blueprint.
 	 *
-	 * @return string|null The stored option name, or null if the key matches no row.
+	 * @return array<int> Indexes of candidates that match a restricted option.
 	 */
-	protected function get_stored_option_name( $key ) {
+	private function get_collation_restricted_option_indexes( array $candidate_names ): array {
 		global $wpdb;
 
-		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_var' ) ) {
-			return null;
+		if ( empty( $candidate_names ) || ! isset( $wpdb ) || ! is_object( $wpdb ) || ! isset( $wpdb->options ) || ! method_exists( $wpdb, 'get_col' ) || ! method_exists( $wpdb, 'prepare' ) ) {
+			return array();
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The point of this query is to let the database resolve the key with its own collation, which a cached lookup by the supplied key cannot do.
-		$stored_name = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT option_name FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
-				trim( (string) $key )
-			)
+		$candidate_rows  = implode(
+			' UNION ALL ',
+			array_fill( 0, count( $candidate_names ), 'SELECT %d AS candidate_index, %s AS option_name' )
 		);
+		$restricted_rows = implode(
+			' UNION ALL ',
+			array_fill( 0, count( self::RESTRICTED_OPTIONS ), 'SELECT %s AS option_name' )
+		);
+		$query_args      = array();
 
-		return is_string( $stored_name ) ? $stored_name : null;
+		foreach ( $candidate_names as $candidate_index => $candidate_name ) {
+			$query_args[] = $candidate_index;
+			$query_args[] = $candidate_name;
+		}
+		$query_args = array_merge( $query_args, self::RESTRICTED_OPTIONS );
+
+		$query = "
+			SELECT DISTINCT candidates.candidate_index
+			FROM (
+				SELECT 0 AS candidate_index, option_name FROM {$wpdb->options} WHERE 1 = 0
+				UNION ALL {$candidate_rows}
+			) AS candidates
+			INNER JOIN (
+				SELECT option_name FROM {$wpdb->options} WHERE 1 = 0
+				UNION ALL {$restricted_rows}
+			) AS restricted_options USING ( option_name )
+		";
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- A single prepared comparison applies the options table's collation without an N-query loop.
+		$restricted_indexes = $wpdb->get_col( $wpdb->prepare( $query, $query_args ) );
+
+		return array_map( 'intval', $restricted_indexes );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -156,6 +156,138 @@ class ImportSetSiteOptionsTest extends TestCase {
 	}
 
 	/**
+	 * Restricted options must be matched no matter how the key is cased or padded.
+	 *
+	 * WordPress trims option names, and option lookups are resolved by MySQL's
+	 * case-insensitive collation, so 'wp_USER_roles' and ' siteurl' both land on the
+	 * genuine restricted row. A case-sensitive comparison let them through.
+	 *
+	 * @return void
+	 */
+	public function test_process_restricted_options_ignores_key_case_and_whitespace() {
+		$schema          = Mockery::mock();
+		$schema->options = array(
+			'wp_USER_roles' => array( 'customer' => array( 'capabilities' => array( 'manage_options' => true ) ) ),
+			'ADMIN_EMAIL'   => 'danger@example.com',
+			' siteurl'      => 'https://evil.example.com',
+		);
+
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		// Any write at all means the restriction was bypassed.
+		$import_set_site_options->shouldNotReceive( 'wp_update_option' );
+
+		$result = $import_set_site_options->process( $schema );
+
+		$this->assertTrue( $result->is_success() );
+
+		$messages = $result->get_messages( 'warn' );
+		$this->assertCount( 3, $messages );
+		$this->assertEquals( "Cannot modify 'wp_USER_roles' option: Modifying is restricted for this key.", $messages[0]['message'] );
+		$this->assertEquals( "Cannot modify 'ADMIN_EMAIL' option: Modifying is restricted for this key.", $messages[1]['message'] );
+		$this->assertEquals( "Cannot modify ' siteurl' option: Modifying is restricted for this key.", $messages[2]['message'] );
+
+		$this->assertNotEquals( 'danger@example.com', get_option( 'admin_email' ) );
+		$this->assertNotEquals( 'https://evil.example.com', get_option( 'siteurl' ) );
+	}
+
+	/**
+	 * A key that the database resolves to a restricted row must be restricted too.
+	 *
+	 * Normalising the string covers case and whitespace, but not every equivalence the
+	 * collation applies (accent folding, for example), so the resolved name is checked
+	 * as well. The resolution itself is stubbed here to keep the assertion independent
+	 * of which collation the test database happens to run.
+	 *
+	 * @return void
+	 */
+	public function test_process_restricts_keys_that_resolve_to_a_restricted_option() {
+		$key = "wp_us\u{00e9}r_roles";
+
+		$schema          = Mockery::mock();
+		$schema->options = array( $key => array( 'customer' => array( 'capabilities' => array( 'manage_options' => true ) ) ) );
+
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$import_set_site_options->shouldReceive( 'get_stored_option_name' )
+			->with( $key )
+			->andReturn( 'wp_user_roles' );
+		$import_set_site_options->shouldNotReceive( 'wp_update_option' );
+
+		$result = $import_set_site_options->process( $schema );
+
+		$this->assertTrue( $result->is_success() );
+
+		$messages = $result->get_messages( 'warn' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Cannot modify '{$key}' option: Modifying is restricted for this key.", $messages[0]['message'] );
+	}
+
+	/**
+	 * The database lookup must resolve a key to the option name as actually stored.
+	 *
+	 * This is the layer that catches equivalences string normalisation cannot model, so
+	 * it is asserted against a real database rather than a stub.
+	 *
+	 * @return void
+	 */
+	public function test_get_stored_option_name_resolves_key_through_the_database() {
+		$import_set_site_options = new ImportSetSiteOptions();
+
+		$method = new \ReflectionMethod( ImportSetSiteOptions::class, 'get_stored_option_name' );
+		$method->setAccessible( true );
+
+		// An exact match resolves to itself.
+		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, 'admin_email' ) );
+
+		// A differently cased key resolves to the stored name, because the lookup runs
+		// through the same case-insensitive collation WordPress writes through.
+		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, 'ADMIN_EMAIL' ) );
+
+		// Surrounding whitespace is trimmed, as WordPress trims it.
+		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, '  admin_email  ' ) );
+
+		// A key matching no row resolves to null rather than to something restricted.
+		$this->assertNull( $method->invoke( $import_set_site_options, 'blueprint_no_such_option_xyz' ) );
+	}
+
+	/**
+	 * Options that merely contain a restricted name are still writable.
+	 *
+	 * Guards against the restriction becoming an over-eager substring match.
+	 *
+	 * @return void
+	 */
+	public function test_process_allows_options_that_only_resemble_restricted_ones() {
+		$schema          = Mockery::mock();
+		$schema->options = array( 'my_siteurl_backup' => 'https://example.com' );
+
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$import_set_site_options->shouldReceive( 'wp_update_option' )
+			->with( 'my_siteurl_backup', 'https://example.com' )
+			->andReturn( true );
+		$import_set_site_options->shouldReceive( 'wp_get_option' )
+			->with( 'my_siteurl_backup' )
+			->andReturn( 'https://example.com' );
+
+		$result = $import_set_site_options->process( $schema );
+
+		$this->assertTrue( $result->is_success() );
+		$this->assertCount( 0, $result->get_messages( 'warn' ) );
+
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( 'my_siteurl_backup has been updated.', $messages[0]['message'] );
+	}
+
+	/**
 	 * Test getting the step class.
 	 *
 	 * @return void

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -156,128 +156,145 @@ class ImportSetSiteOptionsTest extends TestCase {
 	}
 
 	/**
-	 * Restricted options must be matched no matter how the key is cased or padded.
+	 * Test restricted option spelling variants.
 	 *
-	 * WordPress trims option names, and option lookups are resolved by MySQL's
-	 * case-insensitive collation, so 'wp_USER_roles' and ' siteurl' both land on the
-	 * genuine restricted row. A case-sensitive comparison let them through.
-	 *
-	 * @return void
+	 * @testdox Restricted options are matched regardless of key case, padding, or database collation.
 	 */
-	public function test_process_restricted_options_ignores_key_case_and_whitespace() {
+	public function test_process_restricted_options_ignores_key_case_and_whitespace(): void {
+		$accented_key    = "wp_us\u{00e9}r_roles";
 		$schema          = Mockery::mock();
 		$schema->options = array(
 			'wp_USER_roles' => array( 'customer' => array( 'capabilities' => array( 'manage_options' => true ) ) ),
 			'ADMIN_EMAIL'   => 'danger@example.com',
 			' siteurl'      => 'https://evil.example.com',
+			$accented_key   => array( 'customer' => array( 'capabilities' => array( 'manage_options' => true ) ) ),
 		);
 
-		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+		$sut = Mockery::mock( ImportSetSiteOptions::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
 		// Any write at all means the restriction was bypassed.
-		$import_set_site_options->shouldNotReceive( 'wp_update_option' );
+		$sut->shouldNotReceive( 'wp_update_option' );
 
-		$result = $import_set_site_options->process( $schema );
+		$result = $sut->process( $schema );
 
 		$this->assertTrue( $result->is_success() );
 
 		$messages = $result->get_messages( 'warn' );
-		$this->assertCount( 3, $messages );
+		$this->assertCount( 4, $messages );
 		$this->assertEquals( "Cannot modify 'wp_USER_roles' option: Modifying is restricted for this key.", $messages[0]['message'] );
 		$this->assertEquals( "Cannot modify 'ADMIN_EMAIL' option: Modifying is restricted for this key.", $messages[1]['message'] );
 		$this->assertEquals( "Cannot modify ' siteurl' option: Modifying is restricted for this key.", $messages[2]['message'] );
+		$this->assertEquals( "Cannot modify '{$accented_key}' option: Modifying is restricted for this key.", $messages[3]['message'] );
 
 		$this->assertNotEquals( 'danger@example.com', get_option( 'admin_email' ) );
 		$this->assertNotEquals( 'https://evil.example.com', get_option( 'siteurl' ) );
 	}
 
 	/**
-	 * A key that the database resolves to a restricted row must be restricted too.
+	 * Test an accent-equivalent key without a canonical row.
 	 *
-	 * Normalising the string covers case and whitespace, but not every equivalence the
-	 * collation applies (accent folding, for example), so the resolved name is checked
-	 * as well. The resolution itself is stubbed here to keep the assertion independent
-	 * of which collation the test database happens to run.
-	 *
-	 * @return void
+	 * @testdox Accent-equivalent keys remain restricted when the canonical option row is absent.
 	 */
-	public function test_process_restricts_keys_that_resolve_to_a_restricted_option() {
-		$key = "wp_us\u{00e9}r_roles";
+	public function test_process_restricts_collation_equivalent_key_without_canonical_row(): void {
+		global $wpdb;
+
+		$canonical_key = 'rewrite_rules';
+		$accented_key  = "r\u{00e9}write_rules";
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Preserve any equivalent row while testing its absence.
+		$original_row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT option_name, option_value, autoload FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				$canonical_key
+			),
+			ARRAY_A
+		);
+
+		delete_option( $canonical_key );
+		delete_option( $accented_key );
+
+		try {
+			$schema          = Mockery::mock();
+			$schema->options = array( $accented_key => array( 'marker' => 'blocked' ) );
+			$sut             = new ImportSetSiteOptions();
+
+			$result = $sut->process( $schema );
+
+			$this->assertTrue( $result->is_success() );
+			$messages = $result->get_messages( 'warn' );
+			$this->assertCount( 1, $messages );
+			$this->assertEquals( "Cannot modify '{$accented_key}' option: Modifying is restricted for this key.", $messages[0]['message'] );
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verify the bypass did not create an exact variant row.
+			$stored_variant = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT option_name FROM {$wpdb->options} WHERE BINARY option_name = %s LIMIT 1",
+					$accented_key
+				)
+			);
+			$this->assertNull( $stored_variant );
+		} finally {
+			delete_option( $canonical_key );
+			delete_option( $accented_key );
+			if ( is_array( $original_row ) ) {
+				add_option( $original_row['option_name'], maybe_unserialize( $original_row['option_value'] ), '', $original_row['autoload'] );
+			}
+		}
+	}
+
+	/**
+	 * Test batching of database collation checks.
+	 *
+	 * @testdox Multiple imported option names use one database-collation query.
+	 */
+	public function test_process_batches_database_collation_checks(): void {
+		global $wpdb;
 
 		$schema          = Mockery::mock();
-		$schema->options = array( $key => array( 'customer' => array( 'capabilities' => array( 'manage_options' => true ) ) ) );
-
-		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+		$schema->options = array(
+			'blueprint_alpha' => 'one',
+			'blueprint_beta'  => 'two',
+			'blueprint_gamma' => 'three',
+		);
+		$sut             = Mockery::mock( ImportSetSiteOptions::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
-		$import_set_site_options->shouldReceive( 'get_stored_option_name' )
-			->with( $key )
-			->andReturn( 'wp_user_roles' );
-		$import_set_site_options->shouldNotReceive( 'wp_update_option' );
+		$sut->shouldReceive( 'wp_update_option' )->times( 3 )->andReturn( true );
+		$sut->shouldReceive( 'wp_get_option' )->with( 'blueprint_alpha' )->andReturn( 'one' );
+		$sut->shouldReceive( 'wp_get_option' )->with( 'blueprint_beta' )->andReturn( 'two' );
+		$sut->shouldReceive( 'wp_get_option' )->with( 'blueprint_gamma' )->andReturn( 'three' );
 
-		$result = $import_set_site_options->process( $schema );
+		$query_count_before = $wpdb->num_queries;
+		$result             = $sut->process( $schema );
 
 		$this->assertTrue( $result->is_success() );
-
-		$messages = $result->get_messages( 'warn' );
-		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Cannot modify '{$key}' option: Modifying is restricted for this key.", $messages[0]['message'] );
+		$this->assertSame( 1, $wpdb->num_queries - $query_count_before );
 	}
 
 	/**
-	 * The database lookup must resolve a key to the option name as actually stored.
+	 * Test that similar unrestricted option names remain writable.
 	 *
-	 * This is the layer that catches equivalences string normalisation cannot model, so
-	 * it is asserted against a real database rather than a stub.
-	 *
-	 * @return void
+	 * @testdox Options that merely contain a restricted name remain writable.
 	 */
-	public function test_get_stored_option_name_resolves_key_through_the_database() {
-		$import_set_site_options = new ImportSetSiteOptions();
-
-		$method = new \ReflectionMethod( ImportSetSiteOptions::class, 'get_stored_option_name' );
-		$method->setAccessible( true );
-
-		// An exact match resolves to itself.
-		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, 'admin_email' ) );
-
-		// A differently cased key resolves to the stored name, because the lookup runs
-		// through the same case-insensitive collation WordPress writes through.
-		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, 'ADMIN_EMAIL' ) );
-
-		// Surrounding whitespace is trimmed, as WordPress trims it.
-		$this->assertSame( 'admin_email', $method->invoke( $import_set_site_options, '  admin_email  ' ) );
-
-		// A key matching no row resolves to null rather than to something restricted.
-		$this->assertNull( $method->invoke( $import_set_site_options, 'blueprint_no_such_option_xyz' ) );
-	}
-
-	/**
-	 * Options that merely contain a restricted name are still writable.
-	 *
-	 * Guards against the restriction becoming an over-eager substring match.
-	 *
-	 * @return void
-	 */
-	public function test_process_allows_options_that_only_resemble_restricted_ones() {
+	public function test_process_allows_options_that_only_resemble_restricted_ones(): void {
 		$schema          = Mockery::mock();
 		$schema->options = array( 'my_siteurl_backup' => 'https://example.com' );
 
-		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+		$sut = Mockery::mock( ImportSetSiteOptions::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
-		$import_set_site_options->shouldReceive( 'wp_update_option' )
+		$sut->shouldReceive( 'wp_update_option' )
 			->with( 'my_siteurl_backup', 'https://example.com' )
 			->andReturn( true );
-		$import_set_site_options->shouldReceive( 'wp_get_option' )
+		$sut->shouldReceive( 'wp_get_option' )
 			->with( 'my_siteurl_backup' )
 			->andReturn( 'https://example.com' );
 
-		$result = $import_set_site_options->process( $schema );
+		$result = $sut->process( $schema );
 
 		$this->assertTrue( $result->is_success() );
 		$this->assertCount( 0, $result->get_messages( 'warn' ) );

--- a/plugins/woocommerce/changelog/woo6-96-fix-restricted-options-case-bypass
+++ b/plugins/woocommerce/changelog/woo6-96-fix-restricted-options-case-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Blueprint: match the restricted site options list regardless of the casing, padding or accents used in an imported key, so a variant spelling can no longer overwrite a restricted option such as wp_user_roles.


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Blueprint imports compare option names in PHP before WordPress resolves them through the options table. Those comparisons could disagree for case, whitespace, or accent variants because WordPress trims option names and the database collation may consider differently spelled names equivalent.

This hardens `ImportSetSiteOptions` by normalizing imported keys and comparing remaining candidates with the actual options-table collation. Equivalent spellings now follow the same restricted-option behavior as canonical names, while unrestricted options continue importing normally. The database comparison is batched once per step.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/):

1. Enable the Blueprint feature and go to **WooCommerce → Settings → Advanced → Blueprint (beta)**.
2. Record the current value of `wp_user_roles`.
3. Import a Blueprint whose `setSiteOptions` step contains restricted option variants such as `wp_USER_roles`, ` wp_user_roles`, `wp_usér_roles`, and `réwrite_rules`, plus an unrestricted option.
4. Confirm the restricted variants produce warnings and do not change or create equivalent restricted options.
5. Confirm the unrestricted option imports successfully.
6. Run the focused test:

   ```sh
   cd packages/php/blueprint
   composer test:unit -- --filter ImportSetSiteOptionsTest
   ```

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified case, whitespace, accent, and missing-canonical-row variants against a live wp-env database.
- Imported a real JSON Blueprint through `ImportSchema`; unrestricted data was written and restricted variants produced warnings without modifying equivalent restricted options.
- Focused `ImportSetSiteOptionsTest`: 9 tests, 38 assertions.
- Full Blueprint unit suite: 99 tests, 236 assertions, with one pre-existing skipped test.
- Verified multiple unrestricted candidates use one collation query per step.
- `EXPLAIN` confirmed the zero-row branches do not scan `wp_options` and the restricted derived table uses an automatic index.
- PHP syntax checks, package PHPCS, and `git diff --check` passed.

### Backward compatibility

- No public signature, hook, interface, or stored-value format changes.
- Blueprints that use an equivalent spelling of a restricted option now receive the same warning as the canonical option name.
- The comparison derives its collation from the current site's options table, matching `update_option()` behavior. Multisite was not tested separately.
- The fast path uses no query when normalized names match directly; other candidates are checked in one prepared query per `setSiteOptions` step.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually for the Blueprint package and WooCommerce Core.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
