### PR TITLE
Disclose Blueprint actions before import

### DIFF
--- a/packages/php/blueprint/changelog/woo6-97-update-runsql-trust-boundary-docs
+++ b/packages/php/blueprint/changelog/woo6-97-update-runsql-trust-boundary-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Document that the runSql step's query checks are not a security boundary, and that the boundary is the decision to import the Blueprint.

--- a/packages/php/blueprint/changelog/woo6-97-update-runsql-trust-boundary-docs
+++ b/packages/php/blueprint/changelog/woo6-97-update-runsql-trust-boundary-docs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Document that the runSql step's query checks are not a security boundary, and that the boundary is the decision to import the Blueprint.
+Document that the runSql step's query checks are not a security boundary, and warn WP-CLI users before a Blueprint is imported.

--- a/packages/php/blueprint/src/Cli.php
+++ b/packages/php/blueprint/src/Cli.php
@@ -41,6 +41,12 @@ class Cli {
 						'optional' => true,
 						'options'  => array( 'all', 'error', 'info', 'debug' ),
 					),
+					array(
+						'type'        => 'flag',
+						'name'        => 'yes',
+						'optional'    => true,
+						'description' => 'Proceed without prompting for confirmation.',
+					),
 				),
 				'when'     => 'after_wp_load',
 			)

--- a/packages/php/blueprint/src/Cli/ImportCli.php
+++ b/packages/php/blueprint/src/Cli/ImportCli.php
@@ -40,6 +40,9 @@ class ImportCli {
 			return;
 		}
 
+		\WP_CLI::warning( 'A Blueprint imported with WP-CLI can change anything this command can access on the site — including data that is not described in the file. Only import files from a source you trust.' );
+		\WP_CLI::confirm( 'Do you want to continue?', $optional_args );
+
 		$results = $blueprint->import();
 
 		$result_formatter = new CliResultFormatter( $results );

--- a/packages/php/blueprint/src/Importers/ImportRunSql.php
+++ b/packages/php/blueprint/src/Importers/ImportRunSql.php
@@ -11,8 +11,22 @@ use Automattic\WooCommerce\Blueprint\UseWPFunctions;
 /**
  * Processes SQL execution steps in the Blueprint.
  *
- * Handles the execution of SQL queries with safety checks to prevent
- * unauthorized modifications to sensitive WordPress data.
+ * This step executes SQL supplied by the imported file against the site's
+ * database. Importing a Blueprint that contains it is equivalent to letting the
+ * author of that file run queries on the store, and the only access control is
+ * check_step_capabilities() below.
+ *
+ * The checks in this class inspect the query as text, so they cannot decide what
+ * a statement will actually do: the same write can be expressed in forms the
+ * patterns here do not match. They exist to catch mistakes and casual misuse and
+ * must not be relied on as a security boundary — do not extend them in the
+ * belief that enough patterns will make them one.
+ *
+ * The boundary is the decision to import the file. That decision is where the
+ * control belongs, so the import screen lists what a Blueprint will do —
+ * including how many queries it runs — before any step executes, and states that
+ * a Blueprint should only be imported from a trusted source. Anything that
+ * weakens that disclosure weakens the actual protection here.
  *
  * @package Automattic\WooCommerce\Blueprint\Importers
  */
@@ -35,10 +49,11 @@ class ImportRunSql implements StepProcessor {
 	/**
 	 * Process the SQL execution step.
 	 *
-	 * Validates and executes the SQL query while ensuring:
-	 * 1. Only allowed query types are executed
-	 * 2. No modifications to admin users or roles
-	 * 3. No unauthorized changes to user capabilities
+	 * Runs the text-level checks — statement type, comment patterns, injection
+	 * patterns, protected tables and capability-related option rows — and then
+	 * executes the query in a transaction. See the class docblock for what those
+	 * checks are and are not: they reject recognisable misuse, they do not
+	 * constrain a determined author of the imported file.
 	 *
 	 * @param object $schema The schema containing the SQL query to execute.
 	 * @return StepProcessorResult The result of the SQL execution.

--- a/packages/php/blueprint/tests/Unit/Cli/ImportCliTest.php
+++ b/packages/php/blueprint/tests/Unit/Cli/ImportCliTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Automattic\WooCommerce\Blueprint\Tests\Unit\Cli;
+
+use Automattic\WooCommerce\Blueprint\Cli\ImportCli;
+use Automattic\WooCommerce\Blueprint\Tests\TestCase;
+
+/**
+ * Tests for ImportCli.
+ */
+class ImportCliTest extends TestCase {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ImportCli
+	 */
+	private $sut;
+
+	/**
+	 * Blueprint fixture path.
+	 *
+	 * @var string
+	 */
+	private $schema_path;
+
+	/**
+	 * Set up the test case.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		\WP_CLI::$calls    = array();
+		$this->schema_path = $this->get_fixture_path( 'empty-steps.json' );
+		$this->sut         = new ImportCli( $this->schema_path );
+	}
+
+	/**
+	 * Test that the command warns and asks for confirmation.
+	 *
+	 * @testdox Warns and asks for confirmation before importing a Blueprint.
+	 */
+	public function test_warns_and_confirms_before_importing(): void {
+		$this->sut->run( array() );
+
+		$this->assertSame( 'warning', \WP_CLI::$calls[0][0] );
+		$this->assertStringContainsString( 'Only import files from a source you trust.', \WP_CLI::$calls[0][1] );
+		$this->assertSame( array( 'confirm', 'Do you want to continue?', array() ), \WP_CLI::$calls[1] );
+		$this->assertSame( array( 'success', "$this->schema_path imported successfully" ), \WP_CLI::$calls[2] );
+	}
+
+	/**
+	 * Test that the command warns when confirmation is skipped.
+	 *
+	 * @testdox Displays the warning and passes the yes flag to confirmation.
+	 */
+	public function test_warns_when_confirmation_is_skipped(): void {
+		$this->sut->run( array( 'yes' => true ) );
+
+		$this->assertSame( 'warning', \WP_CLI::$calls[0][0] );
+		$this->assertSame(
+			array( 'confirm', 'Do you want to continue?', array( 'yes' => true ) ),
+			\WP_CLI::$calls[1]
+		);
+	}
+}

--- a/packages/php/blueprint/tests/stubs/WPCli.php
+++ b/packages/php/blueprint/tests/stubs/WPCli.php
@@ -1,0 +1,52 @@
+<?php
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	/**
+	 * WP-CLI test double.
+	 */
+	class WP_CLI {
+		/**
+		 * Recorded calls.
+		 *
+		 * @var array
+		 */
+		public static $calls = array();
+
+		/**
+		 * Record a warning.
+		 *
+		 * @param string $message Warning message.
+		 */
+		public static function warning( $message ) {
+			self::$calls[] = array( 'warning', $message );
+		}
+
+		/**
+		 * Record a confirmation prompt.
+		 *
+		 * @param string $message Confirmation message.
+		 * @param array  $assoc_args Command arguments.
+		 */
+		public static function confirm( $message, $assoc_args = array() ) {
+			self::$calls[] = array( 'confirm', $message, $assoc_args );
+		}
+
+		/**
+		 * Record a success message.
+		 *
+		 * @param string $message Success message.
+		 */
+		public static function success( $message ) {
+			self::$calls[] = array( 'success', $message );
+		}
+
+		/**
+		 * Record an error message.
+		 *
+		 * @param string $message Error message.
+		 */
+		public static function error( $message ) {
+			self::$calls[] = array( 'error', $message );
+		}
+	}
+}

--- a/packages/php/blueprint/tests/stubs/stubs.php
+++ b/packages/php/blueprint/tests/stubs/stubs.php
@@ -3,6 +3,8 @@
  * Stubs for WooCommerce classes and interfaces.
  */
 
+require_once __DIR__ . '/WPCli.php';
+
 if ( ! class_exists( 'WC_Log_Levels', false ) ) {
 	/**
 	 * WC Log Levels Class

--- a/plugins/woocommerce/changelog/woo6-97-add-blueprint-import-disclosure
+++ b/plugins/woocommerce/changelog/woo6-97-add-blueprint-import-disclosure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Blueprint: list what an imported Blueprint will do before it runs, including how many database queries it executes and which plugins and themes it installs or activates, and state that a Blueprint should only be imported from a trusted source.

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -190,7 +190,7 @@ const checkImportAllowed = async (): Promise< boolean > => {
 			method: 'GET',
 		} );
 		return response.import_allowed;
-	} catch ( error ) {
+	} catch {
 		throw new Error(
 			__( 'Failed to check if imports are allowed.', 'woocommerce' )
 		);
@@ -489,7 +489,7 @@ export const BlueprintUploadDropzone = () => {
 							{
 								br: <br />,
 								link: (
-									// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
 									<a
 										href={ getAdminLink(
 											'admin.php?page=wc-settings&tab=site-visibility'
@@ -531,7 +531,7 @@ export const BlueprintUploadDropzone = () => {
 							<div className="blueprint-upload-dropzone">
 								<Icon icon={ upload } />
 								<p className="blueprint-upload-dropzone-text">
-									{ __( 'Drag and drop or ', 'woocommerce' ) }
+									{ __( 'Drag and drop or', 'woocommerce' ) }{ ' ' }
 									<span>
 										{ __( 'choose a file', 'woocommerce' ) }
 									</span>

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -31,6 +31,7 @@ import { getAdminLink } from '@woocommerce/settings';
 import './style.scss';
 import { OverwriteConfirmationModal } from '../settings/overwrite-confirmation-modal';
 import { getOptionGroupsFromSteps } from './get-option-groups';
+import { getStepActions } from './get-step-actions';
 import {
 	BlueprintQueueResponse,
 	BlueprintImportResponse,
@@ -201,6 +202,7 @@ interface FileUploadContext {
 	steps?: BlueprintStep[];
 	error?: Error;
 	settings_to_overwrite?: string[];
+	step_actions?: string[];
 	import_allowed?: boolean;
 }
 
@@ -347,6 +349,8 @@ export const fileUploadMachine = setup( {
 								event.output
 							) as string[];
 						},
+						step_actions: ( { event } ) =>
+							getStepActions( event.output ),
 					} ),
 				},
 				onError: {
@@ -610,6 +614,7 @@ export const BlueprintUploadDropzone = () => {
 					overwrittenItems={
 						state.context.settings_to_overwrite || []
 					}
+					additionalActions={ state.context.step_actions || [] }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce/client/admin/client/blueprint/components/get-step-actions.ts
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/get-step-actions.ts
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BlueprintStep } from './types';
+
+/**
+ * Steps whose effects are already described to the user by the list of
+ * WooCommerce Settings sections the import will overwrite, so describing them
+ * again here would only repeat what the user has been told.
+ */
+const SETTINGS_STEPS = [ 'setSiteOptions' ];
+
+/**
+ * Human descriptions for the steps a Blueprint can contain, in the order they
+ * should be listed — most consequential first.
+ *
+ * A Blueprint step runs with the importing administrator's access, so the point
+ * of these descriptions is to let that administrator see what a file will do
+ * before they confirm it, rather than only seeing its name.
+ */
+const STEP_ACTIONS: Record< string, ( count: number ) => string > = {
+	runSql: ( count ) =>
+		sprintf(
+			/* translators: %d: number of database queries a Blueprint will run. */
+			_n(
+				'Run %d database query',
+				'Run %d database queries',
+				count,
+				'woocommerce'
+			),
+			count
+		),
+	installPlugin: ( count ) =>
+		sprintf(
+			/* translators: %d: number of plugins a Blueprint will install. */
+			_n(
+				'Install %d plugin',
+				'Install %d plugins',
+				count,
+				'woocommerce'
+			),
+			count
+		),
+	activatePlugin: ( count ) =>
+		sprintf(
+			/* translators: %d: number of plugins a Blueprint will activate. */
+			_n(
+				'Activate %d plugin',
+				'Activate %d plugins',
+				count,
+				'woocommerce'
+			),
+			count
+		),
+	installTheme: ( count ) =>
+		sprintf(
+			/* translators: %d: number of themes a Blueprint will install. */
+			_n( 'Install %d theme', 'Install %d themes', count, 'woocommerce' ),
+			count
+		),
+	activateTheme: ( count ) =>
+		sprintf(
+			/* translators: %d: number of themes a Blueprint will activate. */
+			_n(
+				'Activate %d theme',
+				'Activate %d themes',
+				count,
+				'woocommerce'
+			),
+			count
+		),
+};
+
+/**
+ * Describe what a Blueprint will do beyond writing WooCommerce settings.
+ *
+ * Steps this function does not recognise are still counted and named rather
+ * than dropped, so a Blueprint cannot carry an action past the confirmation
+ * screen simply by using a step this list has not been taught about.
+ *
+ * @param steps a list of Blueprint steps
+ * @return string[] a list of descriptions, ready to show as a list
+ */
+export const getStepActions = ( steps: BlueprintStep[] ): string[] => {
+	const counts = steps.reduce< Record< string, number > >( ( acc, step ) => {
+		const name = step?.step;
+		if ( name && ! SETTINGS_STEPS.includes( name ) ) {
+			acc[ name ] = ( acc[ name ] || 0 ) + 1;
+		}
+		return acc;
+	}, {} );
+
+	const actions = Object.keys( STEP_ACTIONS )
+		.filter( ( name ) => counts[ name ] )
+		.map( ( name ) => STEP_ACTIONS[ name ]( counts[ name ] ) );
+
+	const unrecognized = Object.keys( counts )
+		.filter( ( name ) => ! STEP_ACTIONS[ name ] )
+		.sort();
+
+	if ( unrecognized.length ) {
+		const total = unrecognized.reduce(
+			( sum, name ) => sum + counts[ name ],
+			0
+		);
+
+		actions.push(
+			sprintf(
+				/* translators: 1: number of steps a Blueprint will run. 2: comma separated list of step names. */
+				_n(
+					'Run %1$d other step (%2$s)',
+					'Run %1$d other steps (%2$s)',
+					total,
+					'woocommerce'
+				),
+				total,
+				unrecognized.join( ', ' )
+			)
+		);
+	}
+
+	return actions;
+};

--- a/plugins/woocommerce/client/admin/client/blueprint/components/get-step-actions.ts
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/get-step-actions.ts
@@ -87,25 +87,25 @@ const STEP_ACTIONS: Record< string, ( count: number ) => string > = {
  * @return string[] a list of descriptions, ready to show as a list
  */
 export const getStepActions = ( steps: BlueprintStep[] ): string[] => {
-	const counts = steps.reduce< Record< string, number > >( ( acc, step ) => {
+	const counts = steps.reduce< Map< string, number > >( ( acc, step ) => {
 		const name = step?.step;
 		if ( name && ! SETTINGS_STEPS.includes( name ) ) {
-			acc[ name ] = ( acc[ name ] || 0 ) + 1;
+			acc.set( name, ( acc.get( name ) || 0 ) + 1 );
 		}
 		return acc;
-	}, {} );
+	}, new Map() );
 
 	const actions = Object.keys( STEP_ACTIONS )
-		.filter( ( name ) => counts[ name ] )
-		.map( ( name ) => STEP_ACTIONS[ name ]( counts[ name ] ) );
+		.filter( ( name ) => counts.has( name ) )
+		.map( ( name ) => STEP_ACTIONS[ name ]( counts.get( name ) || 0 ) );
 
-	const unrecognized = Object.keys( counts )
-		.filter( ( name ) => ! STEP_ACTIONS[ name ] )
+	const unrecognized = Array.from( counts.keys() )
+		.filter( ( name ) => ! Object.hasOwn( STEP_ACTIONS, name ) )
 		.sort();
 
 	if ( unrecognized.length ) {
 		const total = unrecognized.reduce(
-			( sum, name ) => sum + counts[ name ],
+			( sum, name ) => sum + ( counts.get( name ) || 0 ),
 			0
 		);
 

--- a/plugins/woocommerce/client/admin/client/blueprint/components/test/get-step-actions.test.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/test/get-step-actions.test.js
@@ -70,6 +70,18 @@ describe( 'getStepActions', () => {
 		] );
 	} );
 
+	it( 'should report unrecognised steps named after object prototype properties', () => {
+		const steps = [
+			{ step: '__proto__' },
+			{ step: 'constructor' },
+			{ step: 'toString' },
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [
+			'Run 3 other steps (__proto__, constructor, toString)',
+		] );
+	} );
+
 	it( 'should tolerate an empty or malformed step list', () => {
 		expect( getStepActions( [] ) ).toEqual( [] );
 		expect(

--- a/plugins/woocommerce/client/admin/client/blueprint/components/test/get-step-actions.test.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/test/get-step-actions.test.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+
+import { getStepActions } from '../get-step-actions';
+
+describe( 'getStepActions', () => {
+	it( 'should return nothing for a Blueprint that only writes settings', () => {
+		const steps = [
+			{
+				step: 'setSiteOptions',
+				options: { woocommerce_store_address: '' },
+			},
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [] );
+	} );
+
+	it( 'should surface SQL steps, which are otherwise invisible before import', () => {
+		const steps = [
+			{ step: 'runSql', sql: { contents: 'UPDATE wp_posts SET ID = 1' } },
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [ 'Run 1 database query' ] );
+	} );
+
+	it( 'should count repeated steps rather than list them individually', () => {
+		const steps = [
+			{ step: 'runSql' },
+			{ step: 'runSql' },
+			{ step: 'runSql' },
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [
+			'Run 3 database queries',
+		] );
+	} );
+
+	it( 'should list every kind of action a Blueprint takes, most consequential first', () => {
+		const steps = [
+			{ step: 'activateTheme' },
+			{ step: 'installPlugin' },
+			{ step: 'setSiteOptions', options: {} },
+			{ step: 'runSql' },
+			{ step: 'installPlugin' },
+			{ step: 'activatePlugin' },
+			{ step: 'installTheme' },
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [
+			'Run 1 database query',
+			'Install 2 plugins',
+			'Activate 1 plugin',
+			'Install 1 theme',
+			'Activate 1 theme',
+		] );
+	} );
+
+	it( 'should report unrecognised steps rather than hide them', () => {
+		const steps = [
+			{ step: 'runSql' },
+			{ step: 'someFutureStep' },
+			{ step: 'someFutureStep' },
+			{ step: 'anotherUnknownStep' },
+		];
+
+		expect( getStepActions( steps ) ).toEqual( [
+			'Run 1 database query',
+			'Run 3 other steps (anotherUnknownStep, someFutureStep)',
+		] );
+	} );
+
+	it( 'should tolerate an empty or malformed step list', () => {
+		expect( getStepActions( [] ) ).toEqual( [] );
+		expect(
+			getStepActions( [ {}, { step: '' }, { step: null } ] )
+		).toEqual( [] );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Modal, Button, Spinner } from '@wordpress/components';
+import { Modal, Button, Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 
@@ -11,6 +11,7 @@ type OverwriteConfirmationModalProps = {
 	onClose: () => void;
 	onConfirm: () => void;
 	overwrittenItems: string[];
+	additionalActions?: string[];
 };
 
 export const OverwriteConfirmationModal = ( {
@@ -19,14 +20,12 @@ export const OverwriteConfirmationModal = ( {
 	onClose,
 	onConfirm,
 	overwrittenItems,
+	additionalActions = [],
 }: OverwriteConfirmationModalProps ) => {
 	if ( ! isOpen ) return null;
 	return (
 		<Modal
-			title={ __(
-				'Your configuration will be overridden',
-				'woocommerce'
-			) }
+			title={ __( 'Review what this Blueprint will do', 'woocommerce' ) }
 			onRequestClose={ onClose }
 			className="woocommerce-blueprint-overwrite-modal"
 			isDismissible={ ! isImporting }
@@ -48,6 +47,30 @@ export const OverwriteConfirmationModal = ( {
 					<li key={ item }>{ item }</li>
 				) ) }
 			</ul>
+
+			{ !! additionalActions.length && (
+				<>
+					<p className="woocommerce-blueprint-overwrite-modal__description woocommerce-blueprint-overwrite-modal__description--actions">
+						{ __( 'It will also:', 'woocommerce' ) }
+					</p>
+					<ul className="woocommerce-blueprint-overwrite-modal__list">
+						{ additionalActions.map( ( action ) => (
+							<li key={ action }>{ action }</li>
+						) ) }
+					</ul>
+				</>
+			) }
+
+			<Notice
+				status="warning"
+				isDismissible={ false }
+				className="woocommerce-blueprint-overwrite-modal__trust-notice"
+			>
+				{ __(
+					'A Blueprint runs with your administrator access, so it can change anything on your site — including data that is not listed above. Only import files from a source you trust.',
+					'woocommerce'
+				) }
+			</Notice>
 
 			<div className="woocommerce-blueprint-overwrite-modal__actions">
 				<Button

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
@@ -22,7 +22,9 @@ export const OverwriteConfirmationModal = ( {
 	overwrittenItems,
 	additionalActions = [],
 }: OverwriteConfirmationModalProps ) => {
-	if ( ! isOpen ) return null;
+	if ( ! isOpen ) {
+		return null;
+	}
 	return (
 		<Modal
 			title={ __( 'Review what this Blueprint will do', 'woocommerce' ) }

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -235,6 +235,22 @@
 		margin: 0 0 8px;
 	}
 
+	.woocommerce-blueprint-overwrite-modal__description--actions {
+		margin-top: 16px;
+	}
+
+	.woocommerce-blueprint-overwrite-modal__trust-notice {
+		margin: 24px 0 0;
+
+		.components-notice__content {
+			color: $gray-900;
+			font-size: 13px;
+			font-weight: 400;
+			line-height: 20px; /* 153.846% */
+			margin: 0;
+		}
+	}
+
 	ul {
 		margin: 0;
 		list-style: disc;

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/test/overwrite-confirmation-modal.test.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/test/overwrite-confirmation-modal.test.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { OverwriteConfirmationModal } from '../overwrite-confirmation-modal';
+
+const defaultProps = {
+	isOpen: true,
+	isImporting: false,
+	onClose: () => {},
+	onConfirm: () => {},
+	overwrittenItems: [],
+};
+
+describe( 'OverwriteConfirmationModal', () => {
+	it( 'should always state that a Blueprint is only as trustworthy as its source', () => {
+		render( <OverwriteConfirmationModal { ...defaultProps } /> );
+
+		// The notice is also announced through a live region, so the copy is
+		// expected to appear more than once in the document.
+		expect(
+			screen.getAllByText( /Only import files from a source you trust/ )
+				.length
+		).toBeGreaterThan( 0 );
+	} );
+
+	it( 'should list the actions a Blueprint takes beyond writing settings', () => {
+		render(
+			<OverwriteConfirmationModal
+				{ ...defaultProps }
+				additionalActions={ [
+					'Run 34 database queries',
+					'Install 2 plugins',
+				] }
+			/>
+		);
+
+		expect( screen.getByText( 'It will also:' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Run 34 database queries' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Install 2 plugins' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not show an empty actions list for a settings-only Blueprint', () => {
+		render(
+			<OverwriteConfirmationModal
+				{ ...defaultProps }
+				overwrittenItems={ [ 'General' ] }
+			/>
+		);
+
+		expect( screen.getByText( 'General' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'It will also:' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render nothing when closed', () => {
+		const { container } = render(
+			<OverwriteConfirmationModal
+				{ ...defaultProps }
+				isOpen={ false }
+				additionalActions={ [ 'Run 34 database queries' ] }
+			/>
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION

### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Blueprint files can perform more than settings updates, but the existing confirmation modal only summarized affected settings sections. Actions such as database queries, plugin or theme installation, activation, and future step types were not visible before import.

This hardens both import entry points. The admin modal now summarizes every action with counts and reminds administrators to import files from trusted sources. The WP-CLI command displays the same guidance and asks for confirmation, with `--yes` available for automation. The `runSql` documentation now describes its query checks as guardrails rather than guarantees.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

#### Settings and database actions

<img width="736" height="807" alt="pr463-modal-safe-import" src="https://github.com/user-attachments/assets/f0ff97be-1eee-4a36-97b4-47c0c4a833d6" />

#### Mixed Blueprint actions

<img width="736" height="807" alt="pr463-modal-rich-visible" src="https://github.com/user-attachments/assets/456261e8-ab37-4559-be4b-e323fa88afe1" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/):

#### Admin UI

1. Enable the Blueprint feature and go to **WooCommerce → Settings → Advanced → Blueprint (beta)**.
2. Import a Blueprint containing settings and `runSql` steps.
3. Confirm the modal lists the affected settings, shows **Run N database queries**, and displays the trusted-source guidance.
4. Repeat with `installPlugin`, `activatePlugin`, `installTheme`, and `activateTheme` steps; confirm their counts are shown.
5. Add an unknown step such as `someFutureStep`; confirm it appears as **Run 1 other step (someFutureStep)**.
6. Repeat with steps named `__proto__`, `constructor`, and `toString`; confirm all three are disclosed.
7. Confirm **Cancel** aborts and **Import** still performs the import.

#### WP-CLI

1. Run `wp wc blueprint import /path/to/blueprint.json --user=admin`.
2. Confirm the guidance is printed and the command asks **Do you want to continue? [y/n]**.
3. Answer `n` and confirm the Blueprint is not imported.
4. Run `wp wc blueprint import /path/to/blueprint.json --user=admin --yes`.
5. Confirm the guidance is still printed, no prompt appears, and the import succeeds.

#### Automated

```sh
cd plugins/woocommerce/client/admin
pnpm test:js -- client/blueprint --runInBand
pnpm ts:check

cd ../../../../packages/php/blueprint
composer phpcs
composer test:unit
```

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Admin UI verified in a local wp-env WooCommerce store, including action disclosure, guidance, import, and cancel flows.
- WP-CLI verified in the local Docker environment: declining prevented import; `--yes` imported without prompting; both paths displayed the guidance.
- Blueprint admin Jest suite: 14 tests across 3 suites.
- Blueprint PHP suite: 97 tests, 224 assertions, with one pre-existing skipped test.
- Focused WP-CLI regression tests: 2 tests, 6 assertions.
- `ImportRunSqlTest`: 32 tests, 95 assertions; query filtering behavior is unchanged.
- TypeScript, Blueprint package PHPCS, WooCommerce branch lint, PHP syntax, and `git diff --check` passed.

### Backward compatibility

- No public PHP signature, hook, constant, query filter, or allowed Blueprint behavior changes.
- `OverwriteConfirmationModal` gains one optional admin-client prop, `additionalActions`, defaulting to `[]`.
- Interactive WP-CLI imports now require confirmation. Existing automation should add the standard `--yes` flag; guidance is still emitted when it is used.
- New and changed UI strings require translation updates.
- Multisite was not tested.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually for the Blueprint package and WooCommerce Core.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
