### PR TITLE
Fix product editor content shift on initial load

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-editor-content-shift
+++ b/plugins/woocommerce/changelog/fix-product-editor-content-shift
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent product editor content from shifting during initial page load.

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
@@ -77,10 +77,10 @@ const findWrapElement = ( wpBody: HTMLElement ) => {
  */
 const renderNotices = ( wpBody: HTMLElement, wrap: Element ) => {
 	const noticeContainer = document.createElement( 'div' );
+	// Preserve the wrap's initial top spacing when this container breaks its adjacent-sibling selector.
+	noticeContainer.className = 'woocommerce-layout';
 	createRoot( wpBody.insertBefore( noticeContainer, wrap ) ).render(
-		<div className="woocommerce-layout">
-			<NoticeArea />
-		</div>
+		<NoticeArea />
 	);
 };
 

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
@@ -65,11 +65,6 @@ describe( 'embedded-layout', () => {
 		expect(
 			mockEmbeddedRoot.classList.contains( 'is-embed-loading' )
 		).toBeFalsy();
-		const noticeLayout = document.querySelector(
-			'#wpbody-content > .woocommerce-layout'
-		);
-		expect( noticeLayout ).toBeInTheDocument();
-		expect( noticeLayout?.nextElementSibling ).toHaveClass( 'wrap' );
 		expect( result ).toBeTruthy();
 	} );
 

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
@@ -65,6 +65,11 @@ describe( 'embedded-layout', () => {
 		expect(
 			mockEmbeddedRoot.classList.contains( 'is-embed-loading' )
 		).toBeFalsy();
+		const noticeLayout = document.querySelector(
+			'#wpbody-content > .woocommerce-layout'
+		);
+		expect( noticeLayout ).toBeInTheDocument();
+		expect( noticeLayout?.nextElementSibling ).toHaveClass( 'wrap' );
 		expect( result ).toBeTruthy();
 	} );
 

--- a/plugins/woocommerce/client/admin/client/header/style.scss
+++ b/plugins/woocommerce/client/admin/client/header/style.scss
@@ -234,6 +234,10 @@
 // Firefox 121+). Older browsers fall through to the JS-driven class
 // path above and still work — they just get the small flash.
 body:has(.wrap > h1.wp-heading-inline) {
+	#wpbody {
+		margin-top: $adminbar-height;
+	}
+
 	.woocommerce-layout__header-heading {
 		display: none;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Classic product screens render the compact 32px WooCommerce header, but `#wpbody` initially reserved the standard 60px header height. Once React measured the compact header, the product editor moved upward by 28px. This change reserves the compact height from the initial paint and assigns the notices layout class before inserting its container so the existing 10px spacing transfers without an intermediate frame.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes the content shift described in #29588.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

https://github.com/user-attachments/assets/a216f298-ff12-4f09-a60a-24dbfbf89a07


https://github.com/user-attachments/assets/755ccac2-7b8e-4cdf-9ea7-4508e85e9bfb



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Navigate to `/wp-admin/post-new.php?post_type=product`.
2. Hard-refresh the page and observe the "Add new product" heading while the WooCommerce header and notices initialize.
3. Confirm the product editor remains in the same vertical position throughout the initial load.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
