### PR TITLE
Add a security patch support policy to the release docs

### DIFF
--- a/.linear/release-kickoff-patch.md
+++ b/.linear/release-kickoff-patch.md
@@ -68,3 +68,4 @@ For scheduled releases, the readiness review is the one in the RC sub-issue. Poi
 
 - [ ] Wait at least 1 hour for all automations to complete and make sure to merge any follow-up [PRs]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) under the `{release_milestone}` milestone.
 - [ ] Continue monitoring for bugs related to the release for at least 3 days. See the [release monitoring guide](https://developer.woocommerce.com/docs/contribution/releases/monitoring/) for more details.
+- [ ] If this is the stable release of a new major version: move the floor forward in the [security support policy](https://developer.woocommerce.com/docs/contribution/releases/security-support/) page (last 21 major versions).

--- a/.linear/release-kickoff-patch.md
+++ b/.linear/release-kickoff-patch.md
@@ -62,10 +62,10 @@ For scheduled releases, the readiness review is the one in the RC sub-issue. Poi
 
 - [ ] Run workflow **[Release: Update stable tag]({repository_url}/actions/workflows/release-update-stable-tag.yml)**: enter `{release_version}` as _Version_ and make sure to check 'I confirm that I want to update the stable tag (this will update the SVN and GitHub stable tags).'
 - [ ] Publish the `{release_version}` [release draft]({repository_url}/releases) that was previously created, as well as any other `{release_main_version}` drafts that might exist from previous attempts. **Ensure** that "Set as the latest release" is checked for `{release_version}`.
+- [ ] If this is the stable release of a new major version: move the supported-version floor forward in the [security support policy](https://developer.woocommerce.com/docs/contribution/releases/security-support/) page (last 21 major versions).
 
 
 ### 7. Post-release tasks
 
 - [ ] Wait at least 1 hour for all automations to complete and make sure to merge any follow-up [PRs]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) under the `{release_milestone}` milestone.
 - [ ] Continue monitoring for bugs related to the release for at least 3 days. See the [release monitoring guide](https://developer.woocommerce.com/docs/contribution/releases/monitoring/) for more details.
-- [ ] If this is the stable release of a new major version: move the floor forward in the [security support policy](https://developer.woocommerce.com/docs/contribution/releases/security-support/) page (last 21 major versions).

--- a/docs/contribution/releases/README.md
+++ b/docs/contribution/releases/README.md
@@ -13,6 +13,7 @@ The WooCommerce release process is managed by a rotating release lead, paired wi
 * [Readiness and Go/No-Go](/docs/contribution/releases/readiness)
 * [Troubleshooting](/docs/contribution/releases/troubleshooting)
 * [Point Releases](/docs/contribution/releases/point-releases)
+* [Security Support](/docs/contribution/releases/security-support)
 * [Cherry-picking](/docs/contribution/releases/backporting)
 * [Pre-releases](/docs/contribution/releases/prereleases)
 * [Release Schedule](/docs/contribution/releases/schedule)

--- a/docs/contribution/releases/point-releases.md
+++ b/docs/contribution/releases/point-releases.md
@@ -17,7 +17,7 @@ Point releases are patch releases that address specific issues in an already-shi
 Changes appropriate for a point release are:
 
 - **Critical bug fixes** affecting store functionality (checkout, orders, payments, product visibility).
-- **Security patches** for urgent vulnerabilities.
+- **Security patches** for urgent vulnerabilities ([which versions receive them](/docs/contribution/releases/security-support)).
 - **Severe performance regressions** introduced by the shipped release.
 - **Compliance fixes** required for regulatory or legal reasons.
 - **Compatibility fixes** for WordPress, theme, or plugin conflicts that are breaking stores.

--- a/docs/contribution/releases/security-support.md
+++ b/docs/contribution/releases/security-support.md
@@ -1,6 +1,7 @@
 ---
 post_title: WooCommerce Security Patch Support Policy
 sidebar_label: Security Support
+sidebar_position: 10
 ---
 
 # Security Patch Support Policy

--- a/docs/contribution/releases/security-support.md
+++ b/docs/contribution/releases/security-support.md
@@ -5,7 +5,7 @@ sidebar_label: Security Support
 
 # Security Patch Support Policy
 
-WooCommerce provides security patches for the **last 21 major versions**. As of WooCommerce 11.0, that means version **9.0 and newer**.
+WooCommerce provides security patches for the **last 21 major versions**. If the current stable WooCommerce version is 11.0, that means version **9.0 and newer**.
 
 "Major version" follows WooCommerce's release numbering (`10.8`, `10.9`, `11.0`, ...), not semantic versioning. At the current release cadence, 21 major versions correspond to roughly two years of releases.
 
@@ -25,4 +25,4 @@ Security vulnerabilities must be reported privately through Automattic's HackerO
 
 ## Keeping this page current
 
-The release run-book's post-release tasks include moving the floor line above forward when the stable release of a new major version ships.
+The release run-book's publish steps include moving the supported-version floor forward when the stable release of a new major version ships.

--- a/docs/contribution/releases/security-support.md
+++ b/docs/contribution/releases/security-support.md
@@ -1,0 +1,28 @@
+---
+post_title: WooCommerce Security Patch Support Policy
+sidebar_label: Security Support
+---
+
+# Security Patch Support Policy
+
+WooCommerce provides security patches for the **last 21 major versions**. As of WooCommerce 11.0, that means version **9.0 and newer**.
+
+"Major version" follows WooCommerce's release numbering (`10.8`, `10.9`, `11.0`, ...), not semantic versioning. At the current release cadence, 21 major versions correspond to roughly two years of releases.
+
+## What this means
+
+- Security fixes are backported to every supported major version affected by the vulnerability, and ship as [point releases](/docs/contribution/releases/point-releases).
+- Versions older than the support window do not receive security patches. Stores on unsupported versions must update to a supported version to receive fixes.
+- The window is a rolling count: each new major release moves the floor up by one version.
+
+## Exceptions
+
+For critical vulnerabilities - actively exploited, or with severe impact (for example CVSS 9.0+) - the security team may patch versions beyond the standard window. How far back to patch is at the security team's discretion, weighing exploitation risk against the affected install base.
+
+## Reporting
+
+Security vulnerabilities must be reported privately through Automattic's HackerOne program: [https://hackerone.com/automattic/](https://hackerone.com/automattic/). Never report them in public issues.
+
+## Keeping this page current
+
+The release run-book's post-release tasks include moving the floor line above forward when the stable release of a new major version ships.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Security patches for older WooCommerce versions are decided case-by-case today - there is no documented support window, so merchants and extension developers can't tell which versions still receive fixes, and each incident re-opens the same question.

Document the policy in the release docs:

- New `security-support.md`: security patches cover the **last 21 major versions** (9.0 and newer as of 11.0)
- `release-kickoff-patch.md`: publish step to move the supported-version floor forward when a new major goes stable, so the page can't go stale.

Closes ARC-1872.

### How to test the changes in this Pull Request:

1. Docs-only. Review.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Documentation and release-template change only; no code shipped to stores.

</details>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

