### PR TITLE
Fix: responsive Product Summary styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-summary-responsive-styles
+++ b/plugins/woocommerce/changelog/fix-product-summary-responsive-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Summary: apply responsive styles to current and legacy rendered summaries.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.json
@@ -68,8 +68,10 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
-		},
-		"__experimentalSelector": ".wc-block-components-product-summary"
+		}
+	},
+	"selectors": {
+		"root": ".wp-block-woocommerce-product-summary.wc-block-components-product-summary, .wp-block-woocommerce-product-summary .wc-block-components-product-summary"
 	},
 	"ancestor": [
 		"woocommerce/all-products",

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
@@ -116,6 +116,8 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 		return (
 			<div
 				className={ clsx( className, summaryClassName, {
+					'wp-block-woocommerce-product-summary':
+						isDescendantOfAllProducts,
 					[ `${ parentClassName }__product-summary` ]:
 						parentClassName,
 				} ) }
@@ -139,6 +141,8 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 					styleProps.className,
 					summaryClassName,
 					{
+						'wp-block-woocommerce-product-summary':
+							isDescendantOfAllProducts,
 						[ `${ parentClassName }__product-summary` ]:
 							parentClassName,
 					}


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR updates the Product Summary block to support 7.1 responsive styling. This also ensures the global style continues working with the Product Summary block when used inside the All Products block (Note that the responsive styling doesn't support All Products).

Part of woocommerce/woocommerce#66546

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/4d5a4f42-6fec-46ed-9f94-5a342ce20600

### How to test the changes in this Pull Request:

Assume the branch's normal local build and site setup is already running with latest Gutenberg active and the current WooCommerce assets loaded. See [https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/](<https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/>)

1. Ensure the test product has short description set.
2. Create a page containing a Product Collection querying the newest product, with Product Summary inside Product Template and different style for background, padding on desktop/tablet/mobile for the Product Summary. Make sure to set the Block style.
3. Set the distinguishable style for each breakpoint for each property of the block.
4. See the responsive style work in both editor and frontend.
5. Repeat 2-4 but this time set the Global style for the Product Summary block and ensure Global style works as expected.

<details><summary>Detailed instructions</summary>

#### Prerequisites:

* Start from this exact branch with its built WooCommerce assets served by the assigned local WordPress site; activate Gutenberg and WooCommerce.
* Have WordPress administrator credentials. Log in at `/wp-admin/` before opening the editor or fixture page; an unauthenticated run can produce Gutenberg `users/me` 401 responses.
* Open browser developer tools and preserve the Console and Network logs for the storefront checks.

 1. In WordPress admin, open Products > Add New. Create a simple product named `Product Summary responsive fixture`, enter `Product Summary responsive evidence from the rewritten branch.` in Product short description, and publish the product.
 2. Open Appearance > Editor > Styles > Blocks > Product Summary. Record every existing Product Summary setting needed for cleanup. Set text to `#7a3e00`, background to `#fff3cd`, font weight to `700`, and padding to `18px` on all four sides. Save the Global Styles change.
 3. Open Pages > Add New. Create a page named `Product Summary responsive fixture`. Insert Product Collection, choose the newest-products collection, and configure one column showing one product.
 4. Open List View, expand Product Collection, select Product Template, and insert Product Summary inside Product Template. Select Product Summary and use the block Styles controls plus the desktop/tablet/mobile responsive controls to enter every Product Collection value from the table. Leave Block spacing unset.
 5. After Product Collection, insert the legacy All Products block, configure one column and one row, and include Product Summary in its block layout. If the inserter does not expose All Products, use an existing pre-migration All Products fixture and add the configured Product Collection to the same page; do not substitute another product-grid block.
 6. Publish the page, wait for publishing to finish, open the published page in a new storefront tab, and clear the preserved Console and Network logs before validation.
 7. Set the viewport to `1440×900` and reload. Confirm the Product Collection summary displays the fixture short description with text `#ffffff`, background `#005a87`, `28px` font size, weight `700`, line height `1.35`, `24px` padding on all sides, top margin `0px`, and bottom margin `24px`. Confirm the legacy All Products summary displays the same fixture description with text `#7a3e00`, background `#fff3cd`, weight `700`, and `18px` padding on all sides.
 8. Set the viewport to `700×900` and reload. Confirm the Product Collection summary changes to text `#052e16`, background `#bbf7d0`, `24px` font size, inherited weight `700`, inherited line height `1.35`, `18px` padding on all sides, top margin `0px`, and bottom margin `18px`. Confirm the legacy All Products summary remains amber with the unchanged Global Styles values.
 9. Set the viewport to `390×900` and reload. Confirm the Product Collection summary changes to text `#7f1d1d`, background `#fee2e2`, `20px` font size, inherited weight `700`, inherited line height `1.35`, `12px` padding on all sides, top margin `0px`, and bottom margin `12px`. Confirm the legacy All Products summary remains amber with the unchanged Global Styles values.
10. Return to `1440×900` and reload. Confirm both summaries and all desktop/legacy values persist. In Console, confirm no errors occurred. In Network, confirm no failed requests and confirm the WooCommerce Store API products request completed with HTTP `200`.
11. Trash the fixture page and product. Return to Appearance > Editor > Styles > Blocks > Product Summary, restore the settings recorded in step 2, and save. Reload the former fixture URL or inspect Pages and Products to confirm the temporary content is no longer published.

Known limitations:

* Legacy All Products does not support per-instance tablet/mobile Product Summary styles. Only its existing desktop/Global Styles behavior is expected and must remain unchanged at every viewport.
* This branch has no automated selector-ownership regression test. Manual passage does not resolve the separate decision about accepting that missing automated acceptance item.

</details>

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>