### PR TITLE
Refresh scratchpads and publish on Cmd+S when the email editor opens on an unpublished email

### DIFF
--- a/plugins/woocommerce/client/admin/client/typings/index.d.ts
+++ b/plugins/woocommerce/client/admin/client/typings/index.d.ts
@@ -7,6 +7,42 @@ declare module '@woocommerce/settings' {
 			typeof val !== 'undefined' ? val : fb
 	): T;
 }
+declare module '@wordpress/keyboard-shortcuts' {
+	// The package ships no type declarations; declare the minimal surface in use.
+	export type ShortcutKeyCombination = {
+		modifier?: string;
+		character: string;
+	};
+	export declare const store: import('@wordpress/data').StoreDescriptor<
+		import('@wordpress/data').ReduxStoreConfig<
+			unknown,
+			{
+				registerShortcut: ( shortcut: {
+					name: string;
+					category: string;
+					description?: string;
+					keyCombination: ShortcutKeyCombination;
+				} ) => unknown;
+				unregisterShortcut: ( name: string ) => unknown;
+			},
+			{
+				getShortcutKeyCombination: (
+					state: unknown,
+					name: string
+				) => ShortcutKeyCombination | null;
+				getShortcutDescription: (
+					state: unknown,
+					name: string
+				) => string | undefined;
+			}
+		>
+	>;
+	export declare function useShortcut(
+		name: string,
+		callback: ( event: { preventDefault: () => void } ) => void,
+		options?: { isDisabled?: boolean }
+	): void;
+}
 declare module '@wordpress/components/build/ui' {
 	// Typescript seems unable to resolve this correctly by default, so we need to re-export it in our type defs.
 	export * from '@wordpress/components/build-types/ui';

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/__tests__/save-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/__tests__/save-button.test.tsx
@@ -29,11 +29,24 @@ const state = {
 	// Status of the post entity record as the wrap-editor filter sees it
 	// (null = record not loaded yet).
 	entityRecordStatus: null as string | null,
+	// Key combination registered for core/editor/save (null = core's
+	// EditorKeyboardShortcutsRegister has not run yet).
+	coreSaveKeyCombination: null as {
+		modifier: string;
+		character: string;
+	} | null,
 };
 
 const mockEditPost = jest.fn();
 const mockSavePost = jest.fn();
 const mockSaveEditedEntityRecord = jest.fn();
+const mockRegisterShortcut = jest.fn();
+const mockUnregisterShortcut = jest.fn();
+
+// The useShortcut callbacks registered during render, keyed by shortcut name.
+type SaveShortcutEvent = { preventDefault: jest.Mock };
+const shortcutHandlers: Record< string, ( event: SaveShortcutEvent ) => void > =
+	{};
 
 const mockStoreSelect = ( store: unknown ) => {
 	if ( store === editorStore ) {
@@ -45,6 +58,16 @@ const mockStoreSelect = ( store: unknown ) => {
 			hasNonPostEntityChanges: () => state.hasNonPostEntityChanges,
 			getCurrentPostId: () => state.currentPostId,
 			getCurrentPostType: () => 'woo_email',
+		};
+	}
+	if ( store === jest.requireMock( '@wordpress/keyboard-shortcuts' ).store ) {
+		return {
+			getShortcutKeyCombination: ( name: string ) =>
+				name === 'core/editor/save'
+					? state.coreSaveKeyCombination
+					: null,
+			getShortcutDescription: ( name: string ) =>
+				name === 'core/editor/save' ? 'Save your changes.' : undefined,
 		};
 	}
 	return {
@@ -64,15 +87,35 @@ const mockStoreSelect = ( store: unknown ) => {
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( callback: ( select: unknown ) => unknown ) =>
 		callback( mockStoreSelect ),
-	useDispatch: ( store: unknown ) =>
-		store === jest.requireMock( '@wordpress/editor' ).store
-			? { editPost: mockEditPost, savePost: mockSavePost }
-			: { saveEditedEntityRecord: mockSaveEditedEntityRecord },
+	useDispatch: ( store: unknown ) => {
+		if ( store === jest.requireMock( '@wordpress/editor' ).store ) {
+			return { editPost: mockEditPost, savePost: mockSavePost };
+		}
+		if (
+			store === jest.requireMock( '@wordpress/keyboard-shortcuts' ).store
+		) {
+			return {
+				registerShortcut: mockRegisterShortcut,
+				unregisterShortcut: mockUnregisterShortcut,
+			};
+		}
+		return { saveEditedEntityRecord: mockSaveEditedEntityRecord };
+	},
 	select: ( store: unknown ) => mockStoreSelect( store ),
 } ) );
 
 jest.mock( '@wordpress/editor', () => ( {
 	store: { name: 'core/editor' },
+} ) );
+
+jest.mock( '@wordpress/keyboard-shortcuts', () => ( {
+	store: { name: 'core/keyboard-shortcuts' },
+	useShortcut: (
+		name: string,
+		callback: ( event: { preventDefault: () => void } ) => void
+	) => {
+		shortcutHandlers[ name ] = callback;
+	},
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -114,6 +157,10 @@ describe( 'SaveButton', () => {
 		state.dirtyEntityRecords = [];
 		state.currentPostId = 5;
 		state.entityRecordStatus = null;
+		state.coreSaveKeyCombination = { modifier: 'primary', character: 's' };
+		Object.keys( shortcutHandlers ).forEach(
+			( key ) => delete shortcutHandlers[ key ]
+		);
 	} );
 
 	it( 'renders a button labeled "Save"', () => {
@@ -197,6 +244,102 @@ describe( 'SaveButton', () => {
 		render( <SaveButton /> );
 
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+	} );
+
+	describe( 'save shortcut takeover', () => {
+		const makeKeydownEvent = (): SaveShortcutEvent => ( {
+			preventDefault: jest.fn(),
+		} );
+
+		it( 'replaces the core save shortcut with its own registration', () => {
+			render( <SaveButton /> );
+
+			expect( mockUnregisterShortcut ).toHaveBeenCalledWith(
+				'core/editor/save'
+			);
+			expect( mockRegisterShortcut ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					name: 'woocommerce/email-editor/save',
+					keyCombination: { modifier: 'primary', character: 's' },
+				} )
+			);
+		} );
+
+		it( 'does not unregister anything before core registered its shortcut', () => {
+			// EditorKeyboardShortcutsRegister registers core/editor/save in its
+			// own mount effect — the takeover must wait for the store, not
+			// race the mount order.
+			state.coreSaveKeyCombination = null;
+
+			render( <SaveButton /> );
+
+			expect( mockUnregisterShortcut ).not.toHaveBeenCalled();
+			expect( mockRegisterShortcut ).not.toHaveBeenCalled();
+		} );
+
+		it( 'takes over again when core re-registers while mounted', () => {
+			const { rerender } = render( <SaveButton /> );
+			mockRegisterShortcut.mockClear();
+			mockUnregisterShortcut.mockClear();
+
+			// The store reports core/editor/save as registered again (e.g. a
+			// remounted EditorKeyboardShortcutsRegister); a rerender must
+			// repeat the takeover.
+			rerender( <SaveButton /> );
+
+			expect( mockUnregisterShortcut ).toHaveBeenCalledWith(
+				'core/editor/save'
+			);
+			expect( mockRegisterShortcut ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					name: 'woocommerce/email-editor/save',
+				} )
+			);
+		} );
+
+		it( 'publishes and saves on the shortcut like a button click', () => {
+			state.postStatus = 'draft';
+
+			render( <SaveButton /> );
+			const event = makeKeydownEvent();
+			shortcutHandlers[ 'woocommerce/email-editor/save' ]( event );
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( mockEditPost ).toHaveBeenCalledWith( {
+				status: 'publish',
+			} );
+			expect( mockSavePost ).toHaveBeenCalled();
+		} );
+
+		it( 'still prevents the browser save dialog but does not save while disabled', () => {
+			state.isSaving = true;
+
+			render( <SaveButton /> );
+			const event = makeKeydownEvent();
+			shortcutHandlers[ 'woocommerce/email-editor/save' ]( event );
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( mockSavePost ).not.toHaveBeenCalled();
+		} );
+
+		it( 'restores the core save shortcut on unmount', () => {
+			const { unmount } = render( <SaveButton /> );
+			mockRegisterShortcut.mockClear();
+			mockUnregisterShortcut.mockClear();
+
+			unmount();
+
+			expect( mockUnregisterShortcut ).toHaveBeenCalledWith(
+				'woocommerce/email-editor/save'
+			);
+			expect( mockRegisterShortcut ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					name: 'core/editor/save',
+					keyCombination: { modifier: 'primary', character: 's' },
+					description: 'Save your changes.',
+				} )
+			);
+		} );
 	} );
 
 	it( 'saves dirty non-post entities on click but not the post entity record', () => {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/save-button.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/save-button.tsx
@@ -3,15 +3,114 @@
  */
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch, select as dataSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+	type ShortcutKeyCombination,
+} from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
 import { NAME_SPACE } from './constants';
+
+const SAVE_SHORTCUT_NAME = 'woocommerce/email-editor/save';
+
+/**
+ * Take over the editor's save shortcut (Cmd/Ctrl+S) while the custom Save
+ * button is mounted, so the shortcut publishes exactly like the button.
+ *
+ * Core's handler saves a draft without publishing — with the publish step
+ * hidden behind the custom button, that leaves content invisible to sending.
+ * Every handler registered for a shortcut fires on a key match, so adding a
+ * second one would double-save; instead `core/editor/save` is unregistered
+ * (its handler stops matching) and the key combination is re-registered
+ * under an own name. Unmounting restores core's registration for the
+ * published-post phase, where the stock save flow takes over again.
+ *
+ * @param onSave     Save handler shared with the button.
+ * @param isDisabled Whether saving is currently disabled.
+ */
+function useSaveShortcutTakeover( onSave: () => void, isDisabled: boolean ) {
+	const coreShortcut = useSelect(
+		( select ) => ( {
+			keyCombination: select(
+				keyboardShortcutsStore
+			).getShortcutKeyCombination(
+				'core/editor/save'
+			) as ShortcutKeyCombination | null,
+			description: select(
+				keyboardShortcutsStore
+			).getShortcutDescription( 'core/editor/save' ) as
+				| string
+				| undefined,
+		} ),
+		[]
+	);
+	const { registerShortcut, unregisterShortcut } = useDispatch(
+		keyboardShortcutsStore
+	);
+	const stashedShortcut = useRef< {
+		keyCombination: ShortcutKeyCombination;
+		description: string | undefined;
+	} | null >( null );
+
+	// Driven by the store, not mount order: EditorKeyboardShortcutsRegister
+	// registers `core/editor/save` in its own mount effect, so a plain mount
+	// effect here could run earlier and unregister nothing. Re-runs whenever
+	// core's registration reappears while the button stays mounted, so the
+	// takeover cannot be undone by a re-registration.
+	useEffect( () => {
+		if ( ! coreShortcut.keyCombination ) {
+			return;
+		}
+		if ( ! stashedShortcut.current ) {
+			stashedShortcut.current = {
+				keyCombination: coreShortcut.keyCombination,
+				description: coreShortcut.description,
+			};
+		}
+		void unregisterShortcut( 'core/editor/save' );
+		void registerShortcut( {
+			name: SAVE_SHORTCUT_NAME,
+			category: 'global',
+			description: __( 'Save your changes.', 'woocommerce' ),
+			keyCombination: coreShortcut.keyCombination,
+		} );
+	}, [ coreShortcut, registerShortcut, unregisterShortcut ] );
+
+	useEffect( () => {
+		return () => {
+			if ( ! stashedShortcut.current ) {
+				return;
+			}
+			void unregisterShortcut( SAVE_SHORTCUT_NAME );
+			void registerShortcut( {
+				name: 'core/editor/save',
+				category: 'global',
+				description: stashedShortcut.current.description,
+				keyCombination: stashedShortcut.current.keyCombination,
+			} );
+			stashedShortcut.current = null;
+		};
+	}, [ registerShortcut, unregisterShortcut ] );
+
+	useShortcut(
+		SAVE_SHORTCUT_NAME,
+		( event: { preventDefault: () => void } ) => {
+			event.preventDefault();
+			if ( isDisabled ) {
+				return;
+			}
+			onSave();
+		}
+	);
+}
 
 /**
  * Replacement for the editor's Publish/Save button.
@@ -78,6 +177,8 @@ export function SaveButton() {
 				);
 			} );
 	};
+
+	useSaveShortcutTakeover( onClick, isDisabled );
 
 	return (
 		<Button

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -95,6 +95,7 @@
 		"@wordpress/i18n": "catalog:wp-min",
 		"@wordpress/icons": "catalog:wp-bundled",
 		"@wordpress/interface": "catalog:wp-bundled",
+		"@wordpress/keyboard-shortcuts": "catalog:wp-min",
 		"@wordpress/keycodes": "catalog:wp-min",
 		"@wordpress/media-utils": "catalog:wp-min",
 		"@wordpress/notices": "catalog:wp-min",

--- a/plugins/woocommerce/src/Internal/Admin/Emails/EmailListingRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Emails/EmailListingRestController.php
@@ -6,8 +6,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Emails;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use Automattic\WooCommerce\Internal\EmailEditor\Integration;
-use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
-use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncRegistry;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailScratchpadRefresher;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
@@ -72,10 +71,18 @@ class EmailListingRestController extends RestApiControllerBase {
 	}
 
 	/**
+	 * Scratchpad refresher instance.
+	 *
+	 * @var WCEmailScratchpadRefresher
+	 */
+	private $scratchpad_refresher;
+
+	/**
 	 * The constructor.
 	 */
 	public function __construct() {
 		$this->email_template_generator = new WCTransactionalEmailPostsGenerator();
+		$this->scratchpad_refresher     = new WCEmailScratchpadRefresher();
 	}
 
 	/**
@@ -228,9 +235,7 @@ class EmailListingRestController extends RestApiControllerBase {
 		// ID stays stable — another admin may have the editor open on it).
 		$scratchpad = $this->find_unpublished_post_for_email_type( $email_id );
 		if ( $scratchpad ) {
-			if ( $this->was_never_edited( $scratchpad ) ) {
-				$this->refresh_scratchpad_content( $scratchpad, $email );
-			}
+			$this->scratchpad_refresher->maybe_refresh( $scratchpad, $email );
 
 			return array(
 				// translators: %s: WooCommerce transactional email ID.
@@ -283,87 +288,6 @@ class EmailListingRestController extends RestApiControllerBase {
 		);
 
 		return $posts[0] ?? null;
-	}
-
-	/**
-	 * Refresh a never-edited scratchpad's content and title to the current file template.
-	 *
-	 * The title is system-owned (it only surfaces in editor chrome and is not
-	 * editable in the email editor), so it moves with the content. Keeps the
-	 * sync meta baseline in step with the new content so a later
-	 * `was_never_edited()` check still recognizes the post as untouched.
-	 *
-	 * @param \WP_Post  $scratchpad The unpublished scratchpad post.
-	 * @param \WC_Email $email      The email instance.
-	 */
-	private function refresh_scratchpad_content( \WP_Post $scratchpad, \WC_Email $email ): void {
-		$post_data       = WCTransactionalEmailPostsGenerator::build_filtered_post_data( (string) $email->id, $email );
-		$canonical       = (string) ( $post_data['post_content'] ?? '' );
-		$canonical_title = (string) ( $post_data['post_title'] ?? '' );
-
-		if ( '' === $canonical || ( $canonical === $scratchpad->post_content && $canonical_title === $scratchpad->post_title ) ) {
-			return;
-		}
-
-		$updated = wp_update_post(
-			array(
-				'ID'            => $scratchpad->ID,
-				'post_content'  => $canonical,
-				'post_title'    => $canonical_title,
-				// Omitting the key would not help: wp_update_post() fills
-				// `page_template` from the stored `_wp_page_template` meta
-				// (WP_Post::to_array()), and wp_insert_post() then rejects the
-				// update with "Invalid page template." whenever the email
-				// template is not registered (it only is while the editor
-				// package is bootstrapped). An empty value makes core skip
-				// template handling entirely, leaving the meta as is.
-				'page_template' => '',
-			),
-			true
-		);
-
-		if ( is_wp_error( $updated ) ) {
-			return;
-		}
-
-		$saved_post = get_post( $scratchpad->ID );
-		$saved_body = $saved_post instanceof \WP_Post ? (string) $saved_post->post_content : $canonical;
-
-		// Restamped for every email, not only sync-registry ones: the update
-		// above bumped `post_modified`, so without a matching hash the
-		// timestamp fallback in `was_never_edited()` would treat this
-		// scratchpad as edited forever and this refresh would never run again.
-		update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, sha1( $saved_body ) );
-
-		$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email->id );
-		if ( null !== $sync_config ) {
-			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, (string) $sync_config['version'] );
-			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, gmdate( 'Y-m-d H:i:s' ) );
-			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::LAST_CORE_RENDER_META_KEY, $canonical );
-		}
-
-		$scratchpad->post_content = $saved_body;
-		$scratchpad->post_title   = $canonical_title;
-	}
-
-	/**
-	 * Check whether an unpublished email post was never edited by the user.
-	 *
-	 * Prefers the source hash stamped at creation and refresh (content
-	 * untouched when it still matches); the timestamp fallback only applies to
-	 * posts without a valid hash, e.g. stray unpublished posts created outside
-	 * the lazy-creation flow.
-	 *
-	 * @param \WP_Post $post The post to check.
-	 * @return bool True when the post content was never edited.
-	 */
-	private function was_never_edited( \WP_Post $post ): bool {
-		$stored_hash = get_post_meta( $post->ID, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true );
-		if ( is_string( $stored_hash ) && 1 === preg_match( '/^[0-9a-f]{40}$/', $stored_hash ) ) {
-			return sha1( (string) $post->post_content ) === $stored_hash;
-		}
-
-		return $post->post_date_gmt === $post->post_modified_gmt;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailScratchpadRefresher;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateAutoApplier;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateSyncBackfill;
@@ -265,10 +266,37 @@ class Integration {
 	public function replace_editor( $replace, $post ) {
 		$current_screen = get_current_screen();
 		if ( self::EMAIL_POST_TYPE === $post->post_type && $current_screen ) {
+			$this->maybe_refresh_scratchpad( $post );
 			$this->editor_page_renderer->render();
 			return true;
 		}
 		return $replace;
+	}
+
+	/**
+	 * Refresh a never-edited scratchpad from the current file template when the
+	 * editor opens directly (bookmark, browser refresh) — the listing Edit flow
+	 * refreshes through the REST endpoint before redirecting here.
+	 *
+	 * @param WP_Post $post Post being opened in the editor.
+	 */
+	private function maybe_refresh_scratchpad( $post ): void {
+		if ( ! in_array( $post->post_status, array( 'auto-draft', 'draft' ), true ) ) {
+			return;
+		}
+
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
+		$email_type   = $post_manager->get_email_type_from_post_id( $post->ID );
+		if ( ! is_string( $email_type ) || '' === $email_type ) {
+			return;
+		}
+
+		$email = $post_manager->get_email_by_id( $email_type );
+		if ( ! $email ) {
+			return;
+		}
+
+		( new WCEmailScratchpadRefresher() )->maybe_refresh( $post, $email );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailScratchpadRefresher.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCEmailScratchpadRefresher.php
@@ -1,0 +1,112 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails;
+
+/**
+ * Refreshes never-edited editing scratchpads (unpublished `woo_email` posts)
+ * from the current file template, so the editor always opens on the content
+ * customers would receive. Edited scratchpads are never touched.
+ *
+ * @package Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails
+ * @since 11.1.0
+ *
+ * @internal
+ */
+class WCEmailScratchpadRefresher {
+
+	/**
+	 * Refresh the scratchpad from the current file template when it was never
+	 * edited by the user.
+	 *
+	 * @param \WP_Post  $scratchpad The unpublished scratchpad post.
+	 * @param \WC_Email $email      The email instance.
+	 */
+	public function maybe_refresh( \WP_Post $scratchpad, \WC_Email $email ): void {
+		if ( ! $this->was_never_edited( $scratchpad ) ) {
+			return;
+		}
+
+		$this->refresh_content( $scratchpad, $email );
+	}
+
+	/**
+	 * Check whether an unpublished email post was never edited by the user.
+	 *
+	 * Prefers the source hash stamped at creation and refresh (content
+	 * untouched when it still matches); the timestamp fallback only applies to
+	 * posts without a valid hash, e.g. stray unpublished posts created outside
+	 * the lazy-creation flow.
+	 *
+	 * @param \WP_Post $post The post to check.
+	 * @return bool True when the post content was never edited.
+	 */
+	private function was_never_edited( \WP_Post $post ): bool {
+		$stored_hash = get_post_meta( $post->ID, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true );
+		if ( is_string( $stored_hash ) && 1 === preg_match( '/^[0-9a-f]{40}$/', $stored_hash ) ) {
+			return sha1( (string) $post->post_content ) === $stored_hash;
+		}
+
+		return $post->post_date_gmt === $post->post_modified_gmt;
+	}
+
+	/**
+	 * Refresh the scratchpad's content and title to the current file template.
+	 *
+	 * The title is system-owned, so it moves with the content. Keeps the
+	 * sync meta baseline in step with the new content so a later
+	 * `was_never_edited()` check still recognizes the post as untouched.
+	 *
+	 * @param \WP_Post  $scratchpad The unpublished scratchpad post.
+	 * @param \WC_Email $email      The email instance.
+	 */
+	private function refresh_content( \WP_Post $scratchpad, \WC_Email $email ): void {
+		$post_data       = WCTransactionalEmailPostsGenerator::build_filtered_post_data( (string) $email->id, $email );
+		$canonical       = (string) ( $post_data['post_content'] ?? '' );
+		$canonical_title = (string) ( $post_data['post_title'] ?? '' );
+
+		if ( '' === $canonical || ( $canonical === $scratchpad->post_content && $canonical_title === $scratchpad->post_title ) ) {
+			return;
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'            => $scratchpad->ID,
+				'post_content'  => $canonical,
+				'post_title'    => $canonical_title,
+				// The explicit empty value makes core skip template handling
+				// entirely, leaving the stored `_wp_page_template` meta as is.
+				// With the key omitted, wp_update_post() would re-inject the
+				// stored template (WP_Post::to_array()) and fail with "Invalid
+				// page template." whenever the email template is not
+				// registered — it only is while the editor package is
+				// bootstrapped.
+				'page_template' => '',
+			),
+			true
+		);
+
+		if ( is_wp_error( $updated ) ) {
+			return;
+		}
+
+		$saved_post = get_post( $scratchpad->ID );
+		$saved_body = $saved_post instanceof \WP_Post ? (string) $saved_post->post_content : $canonical;
+
+		// Restamped for every email, not only sync-registry ones: the update
+		// above bumped `post_modified`, so without a matching hash the
+		// timestamp fallback in `was_never_edited()` would treat this
+		// scratchpad as edited forever and this refresh would never run again.
+		update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, sha1( $saved_body ) );
+
+		$sync_config = WCEmailTemplateSyncRegistry::get_email_sync_config( (string) $email->id );
+		if ( null !== $sync_config ) {
+			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::VERSION_META_KEY, (string) $sync_config['version'] );
+			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::LAST_SYNCED_AT_META_KEY, gmdate( 'Y-m-d H:i:s' ) );
+			update_post_meta( $scratchpad->ID, WCEmailTemplateDivergenceDetector::LAST_CORE_RENDER_META_KEY, $canonical );
+		}
+
+		$scratchpad->post_content = $saved_body;
+		$scratchpad->post_title   = $canonical_title;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/IntegrationTest.php
@@ -308,6 +308,121 @@ class IntegrationTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should refresh a never-edited scratchpad from the file template when the editor opens directly.
+	 */
+	public function test_editor_open_refreshes_untouched_scratchpad(): void {
+		$this->bootstrap_email_editor();
+		$this->skip_if_unsupported_environment();
+
+		$post_id = $this->create_scratchpad( 'customer_processing_order' );
+
+		$append_marker = static function ( $template_html ) {
+			return $template_html . "\n<!-- wp:paragraph --><p>FRESH_TEMPLATE_MARKER</p><!-- /wp:paragraph -->";
+		};
+		add_filter( 'woocommerce_email_block_template_html', $append_marker );
+
+		try {
+			$this->invoke_maybe_refresh_scratchpad( $post_id );
+		} finally {
+			remove_filter( 'woocommerce_email_block_template_html', $append_marker );
+		}
+
+		$refreshed = get_post( $post_id );
+		$this->assertStringContainsString( 'FRESH_TEMPLATE_MARKER', $refreshed->post_content, 'Opening the editor must refresh an untouched scratchpad to the current file template' );
+		$this->assertSame(
+			sha1( (string) $refreshed->post_content ),
+			get_post_meta( $post_id, \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCEmailTemplateDivergenceDetector::SOURCE_HASH_META_KEY, true ),
+			'The source hash must be restamped so the scratchpad still counts as never-edited'
+		);
+	}
+
+	/**
+	 * @testdox Should not touch an edited scratchpad when the editor opens directly.
+	 */
+	public function test_editor_open_leaves_edited_scratchpad_untouched(): void {
+		$this->bootstrap_email_editor();
+		$this->skip_if_unsupported_environment();
+
+		$post_id        = $this->create_scratchpad( 'customer_completed_order' );
+		$edited_content = get_post( $post_id )->post_content . "\n<!-- wp:paragraph --><p>MERCHANT_EDIT</p><!-- /wp:paragraph -->";
+		wp_update_post(
+			array(
+				'ID'            => $post_id,
+				'post_content'  => $edited_content,
+				'page_template' => '',
+			)
+		);
+
+		$append_marker = static function ( $template_html ) {
+			return $template_html . "\n<!-- wp:paragraph --><p>FRESH_TEMPLATE_MARKER</p><!-- /wp:paragraph -->";
+		};
+		add_filter( 'woocommerce_email_block_template_html', $append_marker );
+
+		try {
+			$this->invoke_maybe_refresh_scratchpad( $post_id );
+		} finally {
+			remove_filter( 'woocommerce_email_block_template_html', $append_marker );
+		}
+
+		$this->assertSame( $edited_content, get_post( $post_id )->post_content, 'An edited scratchpad must never be refreshed' );
+	}
+
+	/**
+	 * @testdox Should not touch a published email post when the editor opens directly.
+	 */
+	public function test_editor_open_leaves_published_post_untouched(): void {
+		$this->bootstrap_email_editor();
+		$this->skip_if_unsupported_environment();
+
+		$post_id = $this->create_scratchpad( 'customer_new_account' );
+		wp_update_post(
+			array(
+				'ID'            => $post_id,
+				'post_status'   => 'publish',
+				'page_template' => '',
+			)
+		);
+		$published_content = get_post( $post_id )->post_content;
+
+		$append_marker = static function ( $template_html ) {
+			return $template_html . "\n<!-- wp:paragraph --><p>FRESH_TEMPLATE_MARKER</p><!-- /wp:paragraph -->";
+		};
+		add_filter( 'woocommerce_email_block_template_html', $append_marker );
+
+		try {
+			$this->invoke_maybe_refresh_scratchpad( $post_id );
+		} finally {
+			remove_filter( 'woocommerce_email_block_template_html', $append_marker );
+		}
+
+		$this->assertSame( $published_content, get_post( $post_id )->post_content, 'A published post must never be refreshed' );
+	}
+
+	/**
+	 * Create a draft scratchpad for a core transactional email.
+	 *
+	 * @param string $email_id Core transactional email ID.
+	 * @return int The scratchpad post ID.
+	 */
+	private function create_scratchpad( string $email_id ): int {
+		$email = $this->posts_manager->get_email_by_id( $email_id );
+		$this->assertNotNull( $email, 'The core transactional email must resolve' );
+
+		return ( new \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator() )->create_draft( $email );
+	}
+
+	/**
+	 * Invoke the private editor-open refresh hook with a fresh post object.
+	 *
+	 * @param int $post_id The post to open.
+	 */
+	private function invoke_maybe_refresh_scratchpad( int $post_id ): void {
+		$method = new \ReflectionMethod( Integration::class, 'maybe_refresh_scratchpad' );
+		$method->setAccessible( true );
+		$method->invoke( $this->sut, get_post( $post_id ) );
+	}
+
+	/**
 	 * Inject a WC_Email stub mimicking a third-party email whose get_subject()
 	 * requires send-time state, and opt it into the block editor.
 	 *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3011,6 +3011,9 @@ importers:
       '@wordpress/interface':
         specifier: catalog:wp-bundled
         version: 9.18.5(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@14.16.1)
+      '@wordpress/keyboard-shortcuts':
+        specifier: catalog:wp-min
+        version: 5.33.1(react@18.3.1)
       '@wordpress/keycodes':
         specifier: catalog:wp-min
         version: 4.33.1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

> Stacked on #67025** — the base branch is that PR's branch, so this PR's diff is just its own commits. It will be rebased onto trunk after #67025 merges.

This PR completes two "editor-open" behaviors for the lazy-post flow:

**1. Follow-up to [this review discussion](https://github.com/woocommerce/woocommerce/pull/67025#discussion_r3706133631): the untouched-scratchpad refresh only ran through the listing** – so opening the email editor via a direct URL, a bookmark, or a browser refresh could show stale file template content until the next listing → Edit round-trip.

**2. The save shortcut (Cmd/Ctrl+S) publishes like the custom Save button** (follow-up to [this review discussion](https://github.com/woocommerce/woocommerce/pull/67025#discussion_r3705985553)): while the custom Save button hides the publish step, core's save shortcut still stored a draft.

**Backward-compatibility impact:** none intended. No public surface changes; the moved methods were `private` in the REST controller. The `replace_editor` hook only gains a conditional content refresh for never-edited draft scratchpads before the (already custom) editor page renders.

### How to test the changes in this Pull Request:

1. Enable the block email editor feature. In WooCommerce → Settings → Emails, click **Edit** on an email without a saved post — a draft is created and the editor opens. Do not save; note the editor URL (`post.php?post=…&action=edit`).
2. Change the email's file template (e.g. add a paragraph via the `woocommerce_email_block_template_html` filter, or edit the template file).
3. Reopen the editor URL directly (or refresh the editor tab). The content should show the updated template — before this PR it kept the stale draft copy.
4. Edit the email content and save it as a draft via the REST API (or just repeat with an edited scratchpad); reopening the editor must NOT overwrite the edits.
5. For the shortcut: open an email without a saved post from the listing, change some text, and press Cmd/Ctrl+S. The post must be **published** (check the listing status or `wp post list --post_type=woo_email`) and the change must render in the sent email — identical to clicking Save. On an already-published email, Cmd/Ctrl+S must keep the stock behavior (multi-entity save panel when e.g. template changes are pending).

### Testing that has already taken place:

- 3 new PHPUnit tests in `IntegrationTest`: direct editor open refreshes an untouched scratchpad (content + restamped source hash), leaves an edited scratchpad untouched, leaves a published post untouched.
- Existing `EmailListingRestControllerTest` still green — the listing endpoint path is unchanged, now delegating to the shared refresher.
- 5 new jest tests for the shortcut takeover: replaces the core registration, waits for core to register first (no mount-order race), publishes+saves on the shortcut, still prevents the browser save dialog while saving is disabled, restores `core/editor/save` on unmount (19 tests total in `save-button.test.tsx`).
- phpcs + PHPStan + `ts:check` + eslint clean.

### Changelog entry

No changelog entries on purpose: this PR refines behavior introduced in #67025 (not yet released) and merges to trunk together with it; #67025 carries the changelog entries for the feature.
