### PR TITLE
Fix: Product Reviews responsive style

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-reviews-block-supports
+++ b/plugins/woocommerce/changelog/fix-product-reviews-block-supports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply block support styles to legacy Product Reviews block wrappers.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * ProductReviews class.
@@ -74,10 +73,10 @@ class ProductReviews extends AbstractBlock {
 		$reviews = ob_get_clean();
 
 		return sprintf(
-			'<div class="wp-block-woocommerce-product-reviews %1$s">
+			'<div %1$s>
 				%2$s
 			</div>',
-			StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) ),
+			get_block_wrapper_attributes( array( 'class' => 'wp-block-woocommerce-product-reviews' ) ),
 			$reviews
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #66546 .

This PR adds support for the product reviews block and improves responsive styling. The issue was caused by our custom utility. Switching to the WordPress wrapper fixes the block's styling.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


https://github.com/user-attachments/assets/bbe65650-8861-4268-aa74-75b61fb3c03d

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On the Apache site for this branch, open **Appearance > Editor > Templates > Single Product**, select the existing Product Reviews block used by the Album product, and follow the viewport controls in the [responsive styling call for testing](https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/).
2. Confirm the saved text/background colors, font size, padding, and border visibly change between Default, Tablet, and Mobile preview.
3. Open the existing product at desktop, tablet, and mobile widths and confirm the works on the frontend too.
<details>
<summary>Detailed instructions</summary>

#### Confirm the saved editor states

1. Go to **Appearance > Editor > Templates > Single Product** and open List View.
2. Select the existing Product Reviews block. Confirm it is the only Product Reviews block in the template and do not save template changes.
4. In the block settings, select each responsive state and enable **Show state on canvas** when offered. Confirm the wrapper and review form preview update to these saved values:
    - **Default:** text `#111111`, background `#f6f7f7`, font size `32px`, padding `24px`, and a `4px` solid `#111111` border with `12px` radius.
    - **Tablet:** text `#007cba`, background `#e7f5ff`, font size `26px`, padding `16px`, and a `3px` solid `#007cba` border with `8px` radius.
    - **Mobile:** text `#d63638`, background `#fff0f0`, font size `20px`, padding `8px`, and a `2px` solid `#d63638` border with `4px` radius.
5. Leave the Site Editor without saving. The fixture is already configured; discard any accidental inspector change rather than changing block structure.

#### Validate the frontends

1. Open `http://woo-next.test/product/album/` in a `1440 × 900` viewport. Confirm exactly one `.wp-block-woocommerce-product-reviews` wrapper renders, it has no `data-wp-interactive` attribute, the review form is visible, and the saved colors, typography, padding, and border are absent. Do not interact with or modify this site.
2. Open `http://woo-next.test/slot_13/product/album/` in a `1440 × 900` viewport. Confirm:
    - the response is HTTP 200;
    - exactly one Product Reviews wrapper renders;
    - the wrapper has no `data-wp-interactive` attribute;
    - the review form is visible and inherits the wrapper's text color and font size; and
    - the Default colors, font size, padding, border width/color/style, and radius listed above are applied.
3. Resize the branch page to `700 × 900`. Confirm the Tablet values listed above apply to the wrapper and form, and the page has no horizontal overflow.
4. Resize the branch page to `390 × 844`. Confirm the Mobile values listed above apply to the wrapper and form, and the page has no horizontal overflow.
6. Return to `1440 × 900`, reload, and confirm the Default values, single legacy wrapper, and visible form persist.
7. Confirm there are no page errors, console errors, failed requests, or HTTP responses of 400 or higher throughout the validation.

#### Cleanup

- No content or template cleanup is required because the validation is read-only. Close the editor without saving.

</details>

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
