### PR TITLE
Restore global wc-blocks compatibility handles

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-blocks-compatibility-handles
+++ b/plugins/woocommerce/changelog/fix-wc-blocks-compatibility-handles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore checkout compatibility handling for payment extensions with missing script dependencies.

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -137,10 +137,7 @@ final class AssetsController {
 			true
 		);
 
-		if ( is_admin() ) {
-			// Register deprecated script handles for backward compatibility in the admin context.
-			$this->register_deprecated_script_handles();
-		}
+		$this->register_deprecated_script_handles();
 	}
 
 	/**
@@ -151,32 +148,36 @@ final class AssetsController {
 			'wc-blocks-vendors' => array(),
 			'wc-blocks'         => array( 'wc-blocks-vendors', 'wc-block-library' ),
 		);
-		$build_path          = WC_ABSPATH . 'assets/client/blocks/';
-		$asset_files         = glob( $build_path . '*.asset.php' );
 
-		foreach ( false === $asset_files ? array() : $asset_files as $asset_file ) {
-			$script_name = basename( $asset_file, '.asset.php' );
+		if ( is_admin() ) {
+			// Discovering legacy block assets requires expensive filesystem checks, so only run this in admin requests.
+			$build_path  = WC_ABSPATH . 'assets/client/blocks/';
+			$asset_files = glob( $build_path . '*.asset.php' );
 
-			if (
-				in_array( $script_name, array( 'wc-block-library', 'wc-blocks' ), true ) ||
-				! file_exists( $build_path . $script_name . '.js' )
-			) {
-				continue;
+			foreach ( false === $asset_files ? array() : $asset_files as $asset_file ) {
+				$script_name = basename( $asset_file, '.asset.php' );
+
+				if (
+					in_array( $script_name, array( 'wc-block-library', 'wc-blocks' ), true ) ||
+					! file_exists( $build_path . $script_name . '.js' )
+				) {
+					continue;
+				}
+
+				// The file comes from WooCommerce's generated assets directory, not user input.
+				// nosemgrep audit.php.lang.security.file.inclusion-arg.
+				$asset_data = require $asset_file;
+
+				if (
+					! is_array( $asset_data ) ||
+					! in_array( 'wp-blocks', (array) ( $asset_data['dependencies'] ?? array() ), true )
+				) {
+					continue;
+				}
+
+				$legacy_handle                         = 'wc-' . $script_name . '-block';
+				$script_dependencies[ $legacy_handle ] = array( 'wc-blocks' );
 			}
-
-			// The file comes from WooCommerce's generated assets directory, not user input.
-			// nosemgrep audit.php.lang.security.file.inclusion-arg.
-			$asset_data = require $asset_file;
-
-			if (
-				! is_array( $asset_data ) ||
-				! in_array( 'wp-blocks', (array) ( $asset_data['dependencies'] ?? array() ), true )
-			) {
-				continue;
-			}
-
-			$legacy_handle                         = 'wc-' . $script_name . '-block';
-			$script_dependencies[ $legacy_handle ] = array( 'wc-blocks' );
 		}
 
 		foreach ( $script_dependencies as $handle => $dependencies ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With unified block editor assets enabled, restricting all deprecated compatibility handles to admin requests leaves `wc-blocks` unregistered on the frontend. As reported by the [AI Regression Review](https://github.com/woocommerce/woocommerce/issues/67350), this causes `Payments\Api::verify_payment_methods_dependencies()` to return early, so a payment method with missing script dependencies is not removed and can prevent Cart or Checkout from initializing. This change restores global registration for the `wc-blocks` and `wc-blocks-vendors` placeholders while keeping the expensive discovery of other legacy asset handles limited to admin requests.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes #67350.

Bug introduced in PR #67055.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure that CI is green.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-wc-blocks-compatibility-handles`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
