### PR TITLE
Update code ownership and community review routing

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,71 +1,537 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
-# Every community PR gets a broad first-response team. More specific matches add domain reviewers.
+# Community PRs are routed by product area. Rules accumulate when a PR spans areas.
+# Product mappings follow WooCommerce's cross-functional triage structure; shared
+# backend and developer-tooling fallbacks use recent contribution activity.
 
-"**/*":
-  - team: woo-fse
+# Repository infrastructure and developer tooling.
+'.github/**/*':
+    - adimoldovan
 
-".github/**/*":
-  - adimoldovan
+'{.codecov.yml,.coderabbit.yml,CODEOWNERS}':
+    - adimoldovan
 
-"docs/**/*":
-  - team: developer-advocacy
+'{.ai,.claude,.codex,.cursor,.husky,.linear}/**/*':
+    - gigitux
 
-"packages/js/csv-export/**/*":
-  - team: somewherewarm
+'{.editorconfig,.gitattributes,.gitignore,.npmrc,.nvmrc,.pnpmfile.cjs,.prettierrc.js,.stylelintrc,.syncpackrc,AGENTS.md,CLAUDE.md,eslint.config.mjs,package.json,phpcs.xml,pnpm-workspace.yaml,tsconfig.base.json}':
+    - gigitux
 
-"packages/js/currency/**/*":
-  - team: rubik
+'docs/**/*':
+    - team: developer-advocacy
 
-"packages/js/data/**/*":
-  - team: ventures
+'{CODE_OF_CONDUCT,CONTRIBUTING,DEVELOPMENT,README,SECURITY}.md':
+    - team: developer-advocacy
 
-"packages/js/date/**/*":
-  - team: rubik
+'tools/**/*':
+    - gigitux
 
-"packages/js/e2e-utils-playwright/**/*":
-  - adimoldovan
+'packages/js/{create-woo-extension,dependency-extraction-webpack-plugin,eslint-plugin,internal-build,internal-js-tests}/**/*':
+    - gigitux
 
-"packages/js/eslint-plugin/**/*":
-  - gigitux
+'packages/js/e2e-utils-playwright/**/*':
+    - adimoldovan
 
-"packages/js/navigation/**/*":
-  - team: somewherewarm
+'packages/php/{monorepo-plugin,remote-specs-validation}/**/*':
+    - gigitux
 
-"packages/js/number/**/*":
-  - team: rubik
+'plugins/woocommerce/{bin,lib,php-stubs}/**/*':
+    - gigitux
 
-"packages/js/onboarding/**/*":
-  - team: rubik
+'plugins/woocommerce/client/admin/{bin,config}/**/*':
+    - gigitux
 
-"packages/js/tracks/**/*":
-  - team: ventures
+'plugins/woocommerce/tests/{Tools,bin,cli,e2e,metrics,performance}/**/*':
+    - adimoldovan
 
-"packages/js/email-editor/**/*":
-  - team: ballade
+# Blocks, patterns, products, inventory, search, and storefront (Woo FSE / Kirigami).
+'packages/js/{block-templates,components,experimental,experimental-products-app,expression-evaluation,sanitize}/**/*':
+    - team: woo-fse
 
-"packages/php/email-editor/**/*":
-  - team: ballade
+'plugins/woocommerce/{.wordpress-org,i18n}/**/*':
+    - team: developer-advocacy
 
-"plugins/woocommerce/templates/**/*":
-  - team: rubik
+'plugins/woocommerce-beta-tester/**/*':
+    - team: woo-fse
 
-"plugins/woocommerce/templates/emails/**/*":
-  - team: ballade
+'plugins/woocommerce/patterns/**/*':
+    - team: woo-fse
 
-"plugins/woocommerce/src/Blocks/**/*":
-  - team: rubik
+'plugins/woocommerce/client/blocks/**/*':
+    - team: woo-fse
 
-"plugins/woocommerce/src/StoreApi/**/*":
-  - team: rubik
+'plugins/woocommerce/client/admin/client/{components,error-boundary,hooks,lib,stylesheets,typings,utils,wp-admin-scripts}/**/*':
+    - team: woo-fse
 
-"plugins/woocommerce/client/blocks/**/*":
-  - team: rubik
+'plugins/woocommerce/client/admin/client/*':
+    - team: woo-fse
 
-"plugins/woocommerce/src/Internal/EmailEditor/**/*":
-  - team: ballade
+'plugins/woocommerce/client/admin/docs/**/*':
+    - team: developer-advocacy
 
-"plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/**/*":
-  - team: ballade
+'plugins/woocommerce/client/legacy/**/*{attribute,product,variation}*':
+    - team: woo-fse
 
-"tools/**/*":
-  - gigitux
+'plugins/woocommerce/src/{Blocks,LayoutTemplates}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/src/Admin/BlockTemplates/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/src/Internal/{CostOfGoodsSold,Customers,ProductAttributes,ProductAttributesLookup,ProductDownloads,ProductFeed,ProductFilters,ProductGallery,ProductImage,VariationGallery}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/includes/{blocks,customizer,shortcodes,theme-support,walkers,widgets}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/includes/{class-wc-customer*,class-wc-product*,wc-customer*,wc-product*,wc-stock-functions.php}':
+    - team: woo-fse
+
+'plugins/woocommerce/includes/data-stores/class-wc-{customer,product}*':
+    - team: woo-fse
+
+'plugins/woocommerce/templates/{auth,block-notices,brands,global,loop,myaccount,notices,parts,product-form,single-product,templates}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/templates/*':
+    - team: woo-fse
+
+'plugins/woocommerce/packages/**/*':
+    - team: woo-fse
+
+# Cart, checkout, orders, onboarding, Store API, and shared backend (Rubik).
+'packages/js/{currency,customer-effort-score,date,extend-cart-checkout-block,number,onboarding}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/client/blocks/assets/js/blocks/{add-to-wishlist-button,cart,cart-checkout-shared,checkout,coupon-code,mini-cart,order-confirmation,payment-method-icons,saved-for-later,shopper-lists,wishlist}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/client/admin/client/{core-profiler,customize-store,launch-your-store,task-lists}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/assets/images/{core-profiler,onboarding,task_list}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/{Checkout,StoreApi}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/{Abilities,Api,Caches,Caching,Database,Enums,Proxies,Utilities,Vendor}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/Internal/{Abilities,AbilitiesApi,Agentic,Api,BatchProcessing,Caches,ComingSoon,CustomerEmailVerification,DataStores,DependencyManagement,Features,LegacyAssets,Logging,MCP,OrderReviews,Orders,OrderWithdrawal,PushNotifications,ReceiptRendering,RestApi,ShopperLists,StockNotifications,Traits,TransientFiles}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/Internal/{AddressProvider,POS}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/src/Internal/Admin/{Agentic,Logging,Onboarding,Orders,Schedulers}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/Internal/Admin/*':
+    - team: rubik
+
+'plugins/woocommerce/src/Internal/Admin/{ProductForm,ProductReviews}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/includes/*':
+    - team: rubik
+
+'plugins/woocommerce/includes/{abstracts,data-stores,interfaces,legacy,libraries,log-handlers,queue,rest-api,traits}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/includes/admin/{list-tables,meta-boxes}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/src/Admin/API/**/*':
+    - team: rubik
+
+'plugins/woocommerce/templates/{cart,checkout,order}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/**/*{cart,checkout,order,rest-api,store-api,webhook}*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/{Api,Caching,Database,Proxies,Utilities}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Internal/{Abilities,AbilitiesApi,Agentic,Api,BatchProcessing,Caches,ComingSoon,CustomerEmailVerification,DataStores,DependencyManagement,Features,LegacyAssets,LegacyPhpApi,Logging,MCP,OrderReviews,Orders,OrderWithdrawal,PushNotifications,ReceiptRendering,RestApi,ShopperLists,StockNotifications,Telemetry,Traits,TransientFiles}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{Agentic,Logging,Onboarding,Orders,Schedulers}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Internal/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Admin/API/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/includes/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/includes/{abstracts,admin,data-stores,rest-api}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/legacy/unit-tests/{admin,cart,checkout,core,crud,order,order-items,packages,page-functions,privacy,queue,rest-api,session,totals,webhooks}/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/legacy/unit-tests/{formatting,libraries,log}/**/*':
+    - team: rubik
+
+# Email and store marketing (Ballade).
+'packages/js/email-editor/**/*':
+    - team: ballade
+
+'packages/php/email-editor/**/*':
+    - team: ballade
+
+'plugins/woocommerce/client/admin/client/{abandoned-cart-recovery,marketing,settings-email}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/src/Admin/Marketing/**/*':
+    - team: ballade
+
+'plugins/woocommerce/src/Internal/{AbandonedCartRecovery,Email,EmailEditor}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/src/Internal/Admin/{EmailImprovements,EmailPreview,Emails,Marketing}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/includes/{emails,react-admin/emails}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/includes/{class-wc-coupon*,class-wc-email*,wc-coupon*,wc-email*}':
+    - team: ballade
+
+'plugins/woocommerce/templates/emails/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/**/*{coupon,email,mailer,marketing}*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/src/Internal/{AbandonedCartRecovery,Email,EmailEditor}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{EmailImprovements,EmailPreview,Emails,Marketing}/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/src/Admin/Marketing/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/*Marketing*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/*Marketing*/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/php/includes/emails/**/*':
+    - team: ballade
+
+'plugins/woocommerce/tests/legacy/unit-tests/{coupon,discounts,email}/**/*':
+    - team: ballade
+
+# Payments and settings (Moltres).
+'packages/js/settings-ui/**/*':
+    - team: moltres
+
+'plugins/woocommerce/client/admin/client/{payments,payments-welcome,settings,settings-payments,settings-recommendations}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/src/Gateways/**/*':
+    - team: moltres
+
+'plugins/woocommerce/src/Admin/Settings/**/*':
+    - team: moltres
+
+'plugins/woocommerce/src/Internal/Settings/**/*':
+    - team: moltres
+
+'plugins/woocommerce/includes/{gateways,payment-tokens}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/includes/admin/settings/**/*':
+    - team: moltres
+
+'plugins/woocommerce/includes/admin/*settings*':
+    - team: moltres
+
+'plugins/woocommerce/tests/**/*{gateway,payment,setting}*':
+    - team: moltres
+
+'plugins/woocommerce/src/Internal/Admin/{Settings,WCPayPromotion}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/php/src/Gateways/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/php/src/Internal/Settings/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{Settings,WCPayPromotion}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/php/src/Admin/Settings/**/*':
+    - team: moltres
+
+'plugins/woocommerce/assets/images/{payment-methods,payment-methods-cards,payment_methods,settings-payments}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/php/includes/{gateways,settings}/**/*':
+    - team: moltres
+
+'plugins/woocommerce/tests/legacy/unit-tests/{gateways,payment-gateways,payment-tokens,settings}/**/*':
+    - team: moltres
+
+# Shipping and tax (Escargot).
+'plugins/woocommerce/client/admin/client/{shipping,tax}/**/*':
+    - team: escargot
+
+'plugins/woocommerce/src/Internal/Tax/**/*':
+    - team: escargot
+
+'plugins/woocommerce/includes/shipping/**/*':
+    - team: escargot
+
+'plugins/woocommerce/includes/{class-wc-shipping*,class-wc-tax*,wc-shipping*,wc-tax*}':
+    - team: escargot
+
+'plugins/woocommerce/tests/**/*{shipping,tax}*':
+    - team: escargot
+
+'plugins/woocommerce/tests/php/src/Internal/Tax/**/*':
+    - team: escargot
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{ShippingPartnerSuggestions,TaxSettingsRecommendations}/**/*':
+    - team: escargot
+
+'plugins/woocommerce/tests/php/includes/shipping/**/*':
+    - team: escargot
+
+'plugins/woocommerce/tests/legacy/unit-tests/{countries,shipping,tax}/**/*':
+    - team: escargot
+
+'plugins/woocommerce/assets/images/{shipping_partners,shipping_providers}/**/*':
+    - team: escargot
+
+# Reports, analytics, tracking, and experimentation (Ventures).
+'packages/js/{data,explat,tracks}/**/*':
+    - team: ventures
+
+'packages/php/woocommerce-analytics/**/*':
+    - team: ventures
+
+'plugins/woocommerce/client/admin/client/{analytics,order-attribution-install-banner}/**/*':
+    - team: ventures
+
+'plugins/woocommerce/src/Admin/API/Reports/**/*':
+    - team: ventures
+
+'plugins/woocommerce/includes/{product-usage,tracks}/**/*':
+    - team: ventures
+
+'plugins/woocommerce/includes/admin/reports/**/*':
+    - team: ventures
+
+'plugins/woocommerce/tests/**/*{analytic,report,track}*':
+    - team: ventures
+
+'plugins/woocommerce/src/Internal/Admin/Reports/**/*':
+    - team: ventures
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/Reports/**/*':
+    - team: ventures
+
+'plugins/woocommerce/tests/php/src/Admin/API/Reports/**/*':
+    - team: ventures
+
+'plugins/woocommerce/tests/php/src/Admin/*Report*':
+    - team: ventures
+
+'plugins/woocommerce/tests/php/src/Internal/McStatsTest.php':
+    - team: ventures
+
+'plugins/woocommerce/tests/php/includes/tracks/**/*':
+    - team: ventures
+
+# Import/export, store utilities, and wayfinding (SomewhereWarm).
+'packages/js/{admin-layout,csv-export,navigation,notices}/**/*':
+    - team: somewherewarm
+
+'packages/php/blueprint/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/client/admin/client/{activity-panel,blueprint,dashboard,embedded-body-layout,guided-tours,header,homescreen,inbox-panel,layout,store-management-links}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/src/Admin/{Composer,DateTimeProvider,Features,Notes,Overrides,RemoteInboxNotifications,Schedulers}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/src/Internal/{CLI,Integrations,Jetpack,Utilities}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/src/Internal/Admin/{ImportExport,Notes}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/includes/{cli,export,import,integrations}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/includes/admin/{helper,importers,notes,plugin-updates,views}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/sample-data/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/**/*{export,import,navigation,notice,tool}*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/php/src/Internal/{CLI,Integration,Utilities}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{ImportExport,Notes}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/php/src/Admin/Features/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/php/src/Admin/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/php/includes/{cli,exporter,importer}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/legacy/unit-tests/{exporter,geolocation,importer,integrations,util}/**/*':
+    - team: somewherewarm
+
+'plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/**/*':
+    - team: somewherewarm
+
+# WooCommerce.com and Marketplace connections (Desire).
+'plugins/woocommerce/client/admin/client/marketplace/**/*':
+    - team: desire
+
+'plugins/woocommerce/src/Admin/{PluginsInstallLoggers,PluginsProvider,RemoteSpecs}/**/*':
+    - team: desire
+
+'plugins/woocommerce/src/Internal/WCCom/**/*':
+    - team: desire
+
+'plugins/woocommerce/includes/wccom-site/**/*':
+    - team: desire
+
+'plugins/woocommerce/includes/admin/marketplace-suggestions/**/*':
+    - team: desire
+
+'plugins/woocommerce/src/Internal/Admin/{RemoteFreeExtensions,Suggestions}/**/*':
+    - team: desire
+
+'plugins/woocommerce/tests/php/src/Internal/WCCom/**/*':
+    - team: desire
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{RemoteFreeExtensions,Suggestions}/**/*':
+    - team: desire
+
+# Existing specialist ownership that sits outside the core triage table.
+'plugins/woocommerce/client/blocks/assets/js/base/stores/**/*':
+    - team: billow
+
+'plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php':
+    - team: billow
+
+'packages/php/woocommerce-subscriptions-engine/**/*':
+    - team: chronos
+
+'plugins/woocommerce/client/admin/client/{mobile-app-login,mobile-banner}/**/*':
+    - jorgemucientes
+
+# Logging has no named core team in the triage map; recent eligible activity is
+# split between Rubik and Moltres, with Rubik covering the shared backend fallback.
+'packages/js/remote-logging/**/*':
+    - team: rubik
+
+# Product and storefront tests mirror the Woo FSE-owned source areas.
+'plugins/woocommerce/tests/php/src/Blocks/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/php/src/Blocks/StoreApi/**/*':
+    - team: rubik
+
+'plugins/woocommerce/tests/php/src/Internal/{AddressProvider,CostOfGoodsSold,Customers,POS,ProductAttributes,ProductAttributesLookup,ProductDownloads,ProductFeed,ProductFilters,ProductGallery,VariationGallery}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/php/src/Internal/Admin/{ProductForm,ProductReviews}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/php/src/Internal/{AssignDefaultCategoryTest.php,DownloadPermissionsAdjusterTest.php}':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/legacy/unit-tests/{account,attributes,blocks,customer,product,shortcodes,templates,widgets}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/php/includes/data-stores/class-wc-{customer,product}*':
+    - team: woo-fse
+
+# Legacy client assets are routed only when their product area is identifiable.
+'plugins/woocommerce/client/legacy/**/*{cart,checkout,order}*':
+    - team: rubik
+
+'plugins/woocommerce/client/legacy/**/*{coupon,email,marketing}*':
+    - team: ballade
+
+'plugins/woocommerce/client/legacy/**/*{gateway,payment,setting}*':
+    - team: moltres
+
+'plugins/woocommerce/client/legacy/**/*{shipping,tax}*':
+    - team: escargot
+
+'plugins/woocommerce/client/legacy/**/*{analytic,report,track}*':
+    - team: ventures
+
+# Built assets are ancillary; identifiable product-area assets follow the same route.
+'plugins/woocommerce/assets/**/*{cart,checkout,order,onboarding,core-profiler,task-list,task_list,customize-store}*':
+    - team: rubik
+
+'plugins/woocommerce/assets/**/*{coupon,email,marketing}*':
+    - team: ballade
+
+'plugins/woocommerce/assets/**/*{gateway,payment,setting}*':
+    - team: moltres
+
+'plugins/woocommerce/assets/**/*{shipping,tax}*':
+    - team: escargot
+
+'plugins/woocommerce/assets/**/*{analytic,report,track}*':
+    - team: ventures
+
+'plugins/woocommerce/assets/**/*{export,import,navigation,notice}*':
+    - team: somewherewarm
+
+'plugins/woocommerce/assets/**/*{marketplace,wccom}*':
+    - team: desire
+
+# Product-area image assets follow the same ownership as their implementation.
+'plugins/woocommerce/assets/images/marketing/**/*':
+    - team: ballade
+
+'plugins/woocommerce/assets/images/{pattern-placeholders,product_data,template-placeholders}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/client/legacy/css/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/client/legacy/js/frontend/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/assets/{client,fonts}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/assets/images/{icons,pinata,previews}/**/*':
+    - team: woo-fse
+
+'plugins/woocommerce/tests/php/src/{AutoloaderTest.php,CLAUDE.md}':
+    - gigitux
+
+# Test harness internals are routed to the active test-infrastructure owner.
+'plugins/woocommerce/tests/{legacy/framework,legacy/data,php/bin,php/framework,php/helpers}/**/*':
+    - adimoldovan

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,25 +1,17 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
-#
-# nerrad is the interim reviewer for the paths formerly owned by the flux team
-# (removed), pending a replacement team.
+# Every community PR gets a broad first-response team. More specific matches add domain reviewers.
 
-"*":
-  - nerrad
+"**/*":
+  - team: woo-fse
 
 ".github/**/*":
-  - nerrad
+  - adimoldovan
 
-"bin/*":
-  - nerrad
+"bin/**/*":
+  - kalessil
 
 "docs/**/*":
   - team: developer-advocacy
-
-"packages/js/api/**/*":
-  - nerrad
-
-"packages/js/components/**/*":
-  - team: woo-fse
 
 "packages/js/csv-export/**/*":
   - team: somewherewarm
@@ -27,26 +19,17 @@
 "packages/js/currency/**/*":
   - team: rubik
 
-"packages/js/customer-effort-score/**/*":
-  - team: woo-fse
-
 "packages/js/data/**/*":
   - team: ventures
 
 "packages/js/date/**/*":
   - team: rubik
 
-"packages/js/dependency-extraction-webpack-plugin/**/*":
-  - nerrad
+"packages/js/e2e-utils-playwright/**/*":
+  - adimoldovan
 
 "packages/js/eslint-plugin/**/*":
-  - nerrad
-
-"packages/js/experimental/**/*":
-  - team: woo-fse
-
-"packages/js/explat/**/*":
-  - team: woo-fse
+  - manzoorwanijk
 
 "packages/js/navigation/**/*":
   - team: somewherewarm
@@ -58,7 +41,7 @@
   - team: rubik
 
 "packages/js/tracks/**/*":
-  - nerrad
+  - team: ventures
 
 "packages/js/email-editor/**/*":
   - team: ballade
@@ -66,39 +49,20 @@
 "packages/php/email-editor/**/*":
   - team: ballade
 
-"plugins/woocommerce/**/*":
-  - nerrad
-
 "plugins/woocommerce/templates/**/*":
   - team: rubik
-  - team: woo-fse
 
 "plugins/woocommerce/templates/emails/**/*":
   - team: ballade
 
-"plugins/woocommerce/src/Admin/**/*":
-  - team: woo-fse
-
 "plugins/woocommerce/src/Blocks/**/*":
   - team: rubik
-  - team: woo-fse
-
-"plugins/woocommerce/src/Internal/Admin/**/*":
-  - team: woo-fse
 
 "plugins/woocommerce/src/StoreApi/**/*":
   - team: rubik
-  - team: woo-fse
-
-"plugins/woocommerce/client/admin/**/*":
-  - team: woo-fse
 
 "plugins/woocommerce/client/blocks/**/*":
   - team: rubik
-  - team: woo-fse
-
-"plugins/woocommerce-beta-tester/**/*":
-  - nerrad
 
 "plugins/woocommerce/src/Internal/EmailEditor/**/*":
   - team: ballade
@@ -107,10 +71,4 @@
   - team: ballade
 
 "tools/**/*":
-  - nerrad
-
-'**/composer.json':
-  - nerrad
-
-'**/package.json':
-  - nerrad
+  - manzoorwanijk

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -7,9 +7,6 @@
 ".github/**/*":
   - adimoldovan
 
-"bin/**/*":
-  - kalessil
-
 "docs/**/*":
   - team: developer-advocacy
 
@@ -29,7 +26,7 @@
   - adimoldovan
 
 "packages/js/eslint-plugin/**/*":
-  - manzoorwanijk
+  - gigitux
 
 "packages/js/navigation/**/*":
   - team: somewherewarm
@@ -71,4 +68,4 @@
   - team: ballade
 
 "tools/**/*":
-  - manzoorwanijk
+  - gigitux

--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,20 +1,11 @@
 # See https://github.com/shufo/auto-assign-reviewer-by-files/blob/main/README.md for configuration format
 # Community PRs are routed by product area. Rules accumulate when a PR spans areas.
-# Product mappings follow WooCommerce's cross-functional triage structure; shared
+# Product mappings follow WooCommerce's current triage structure; shared
 # backend and developer-tooling fallbacks use recent contribution activity.
 
 # Repository infrastructure and developer tooling.
 '.github/**/*':
     - adimoldovan
-
-'{.codecov.yml,.coderabbit.yml,CODEOWNERS}':
-    - adimoldovan
-
-'{.ai,.claude,.codex,.cursor,.husky,.linear}/**/*':
-    - gigitux
-
-'{.editorconfig,.gitattributes,.gitignore,.npmrc,.nvmrc,.pnpmfile.cjs,.prettierrc.js,.stylelintrc,.syncpackrc,AGENTS.md,CLAUDE.md,eslint.config.mjs,package.json,phpcs.xml,pnpm-workspace.yaml,tsconfig.base.json}':
-    - gigitux
 
 'docs/**/*':
     - team: developer-advocacy
@@ -32,12 +23,6 @@
     - adimoldovan
 
 'packages/php/{monorepo-plugin,remote-specs-validation}/**/*':
-    - gigitux
-
-'plugins/woocommerce/{bin,lib,php-stubs}/**/*':
-    - gigitux
-
-'plugins/woocommerce/client/admin/{bin,config}/**/*':
     - gigitux
 
 'plugins/woocommerce/tests/{Tools,bin,cli,e2e,metrics,performance}/**/*':

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,17 +1,10 @@
-# Monorepo CI and package managers manifests.
+# Monorepo CI.
 /.github/ @adimoldovan
-**/composer.json @woocommerce/woo-fse
-**/package.json @woocommerce/woo-fse
 
 # Monorepo tooling folders.
-/tools/ @gigitux
-/packages/js/eslint-plugin/ @gigitux
-/packages/js/dependency-extraction-webpack-plugin/ @woocommerce/woo-fse
 /packages/js/e2e-utils-playwright/ @adimoldovan
 
 # Files in root of repository
-/.* @woocommerce/woo-fse
-/*.* @woocommerce/woo-fse
 /changelog.txt
 /pnpm-lock.yaml
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,18 @@
 # Monorepo CI and package managers manifests.
-/.github/ @nerrad
-**/composer.json @nerrad
-**/package.json @nerrad
+/.github/ @adimoldovan
+**/composer.json @woocommerce/woo-fse
+**/package.json @woocommerce/woo-fse
 
 # Monorepo tooling folders.
-/bin/ @nerrad
-/tools/ @nerrad
-/packages/js/eslint-plugin/ @nerrad
-/packages/js/dependency-extraction-webpack-plugin/ @nerrad
-/packages/js/e2e-utils-playwright/ @nerrad
+/bin/ @kalessil
+/tools/ @manzoorwanijk
+/packages/js/eslint-plugin/ @manzoorwanijk
+/packages/js/dependency-extraction-webpack-plugin/ @woocommerce/woo-fse
+/packages/js/e2e-utils-playwright/ @adimoldovan
 
 # Files in root of repository
-/.* @nerrad
-/*.* @nerrad
+/.* @woocommerce/woo-fse
+/*.* @woocommerce/woo-fse
 /changelog.txt
 /pnpm-lock.yaml
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,9 +4,8 @@
 **/package.json @woocommerce/woo-fse
 
 # Monorepo tooling folders.
-/bin/ @kalessil
-/tools/ @manzoorwanijk
-/packages/js/eslint-plugin/ @manzoorwanijk
+/tools/ @gigitux
+/packages/js/eslint-plugin/ @gigitux
 /packages/js/dependency-extraction-webpack-plugin/ @woocommerce/woo-fse
 /packages/js/e2e-utils-playwright/ @adimoldovan
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The former Flux paths still pointed to `@nerrad` as an interim owner and community reviewer. This replaces the CI and E2E assignments with active owners selected from the last six months of path-level contribution and review activity, while leaving general manifests, root files, and developer tooling without a mandatory code owner. Community PRs touching `tools/` or the ESLint plugin are routed to `@gigitux`, who approved three of the six recent tooling/ESLint PRs sampled and is one of the repository's most active recent contributors.

Community PRs are now assigned by the product area they touch rather than sending every PR to one fallback team. The routes align with the current cross-functional Woo Core ownership structure: Woo FSE for blocks/products/storefront, Rubik for cart/checkout/orders/onboarding/Store API, Ballade for email/marketing, Moltres for payments/settings, Escargot for shipping/tax, Ventures for analytics, SomewhereWarm for import/export/store tools/wayfinding, and Desire for WooCommerce.com/Marketplace. Existing specialist routes for Billow, Chronos, Developer Advocacy, CI/E2E, mobile, and developer tooling are retained or expanded.

Shared backend and developer-tooling paths that do not have an explicit product owner use the most common eligible recent contributor team or individual. Rules accumulate only when a PR genuinely crosses areas; ancillary changelog, lock, and generic generated-asset files do not add a catch-all reviewer.

Root `bin/` and the reviewed generic configuration, manifest, and developer-experience support paths are intentionally left without a CODEOWNER. Root `bin/` and selected plugin DevEx support paths also have no community-review rule, so developers changing them remain responsible for their changes.

All newly assigned individuals have `admin` access and all assigned teams have `maintain` access to this repository. This changes repository metadata and review routing only; it does not affect shipped code or public compatibility surfaces.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Review `CODEOWNERS` and confirm `@nerrad` is absent, CI/E2E paths have active replacements, and the reviewed manifest, root, and tooling paths are intentionally unowned.
2. Review `.github/project-community-pr-assigner.yml` and confirm representative product paths request the owning area team without a universal fallback.
3. Confirm the branch reports no CODEOWNERS errors and every named individual/team has write, maintain, or admin repository access.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- GitHub's branch-specific CODEOWNERS endpoint returned no syntax or ownership errors.
- A local smoke test using the pinned action's `minimatch` 3.x and `yaml` 1.x dependencies confirmed representative paths receive the expected area reviewer or cross-functional reviewer set.
- The proposed rules were evaluated against the latest 100 open PRs: all 13 community-authored PRs in that sample received at least one route, with different teams selected according to their changed paths.
- Live GitHub permission checks confirmed `admin` for `adimoldovan`, `gigitux`, and `jorgemucientes`, and `maintain` for all 11 referenced reviewer teams.
- The reviewer YAML parses successfully, `nerrad` is absent from both routing files, and `git diff --check` passes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Repository metadata and review routing only; nothing is shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

*\*left by Biff (AI agent) on behalf of Darren*
