### PR TITLE
Fix checkout tax sync on country change

### DIFF
--- a/plugins/woocommerce/changelog/fix-67344-checkout-country-tax-sync
+++ b/plugins/woocommerce/changelog/fix-67344-checkout-country-tax-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update checkout taxes when a customer changes country before completing their address.

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/push-changes.ts
@@ -35,6 +35,44 @@ const localState = {
 };
 
 /**
+ * Gets the dirty address props that should be validated before a push.
+ *
+ * State and postcode are cleared when the country changes because their
+ * previous values may not be valid for the new country. Allow those empty
+ * dependent fields to be pushed while continuing to validate all other
+ * dirty fields.
+ */
+const getDirtyPropsForValidation = () => {
+	const getAddressDirtyPropsForValidation = (
+		dirtyProps: BaseAddressKey[],
+		address: CartBillingAddress | CartShippingAddress
+	) => {
+		if ( ! dirtyProps.includes( 'country' ) ) {
+			return dirtyProps;
+		}
+
+		return dirtyProps.filter( ( key ) => {
+			const isEmptyCountryDependentField =
+				( key === 'state' || key === 'postcode' ) &&
+				address[ key ] === '';
+
+			return ! isEmptyCountryDependentField;
+		} );
+	};
+
+	return {
+		billingAddress: getAddressDirtyPropsForValidation(
+			localState.dirtyProps.billingAddress,
+			localState.customerData.billingAddress
+		),
+		shippingAddress: getAddressDirtyPropsForValidation(
+			localState.dirtyProps.shippingAddress,
+			localState.customerData.shippingAddress
+		),
+	};
+};
+
+/**
  * Initializes the customer data cache on the first run.
  */
 const initialize = () => {
@@ -131,7 +169,7 @@ const updateCustomerData = (): void => {
 	}
 
 	// Check props are valid, or abort.
-	if ( ! validateDirtyProps( localState.dirtyProps ) ) {
+	if ( ! validateDirtyProps( getDirtyPropsForValidation() ) ) {
 		localState.doingPush = false;
 		return;
 	}

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/test/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/cart/test/push-changes.ts
@@ -8,8 +8,10 @@ import { cartStore, validationStore } from '@woocommerce/block-data';
  * Internal dependencies
  */
 import { pushChanges } from '../push-changes';
+import { STORE_KEY as VALIDATION_STORE_KEY } from '../../validation/constants';
 
 let updateCustomerDataMock = jest.fn();
+const getValidationErrorMock = jest.fn().mockReturnValue( undefined );
 let getCustomerDataMock = jest.fn().mockReturnValue( {
 	billingAddress: {
 		first_name: 'John',
@@ -65,6 +67,8 @@ jest.mock( '../update-payment-methods', () => ( {
 
 async function resetToInitialAddressMock() {
 	pushChanges( false );
+	await Promise.resolve();
+	await Promise.resolve();
 	updateCustomerDataMock.mockReset();
 	updateCustomerDataMock.mockResolvedValue( jest.fn() );
 
@@ -94,6 +98,9 @@ async function resetToInitialAddressMock() {
 		},
 	} );
 	pushChanges( false );
+	await Promise.resolve();
+	await Promise.resolve();
+	updateCustomerDataMock.mockClear();
 }
 
 describe( 'pushChanges', () => {
@@ -109,14 +116,15 @@ describe( 'pushChanges', () => {
 						getCustomerData: getCustomerDataMock,
 					};
 				}
-				if ( storeNameOrDescriptor === validationStore ) {
+				if (
+					storeNameOrDescriptor === validationStore ||
+					storeNameOrDescriptor === VALIDATION_STORE_KEY
+				) {
 					return {
 						...jest
 							.requireActual( '@wordpress/data' )
 							.select( storeNameOrDescriptor ),
-						getValidationError: jest
-							.fn()
-							.mockReturnValue( undefined ),
+						getValidationError: getValidationErrorMock,
 					};
 				}
 				return jest
@@ -140,8 +148,115 @@ describe( 'pushChanges', () => {
 			}
 		);
 	} );
-	beforeEach( () => {
-		resetToInitialAddressMock();
+	beforeEach( async () => {
+		getValidationErrorMock.mockReset().mockReturnValue( undefined );
+		await resetToInitialAddressMock();
+	} );
+
+	it( 'Pushes a billing country change when state and postcode are automatically cleared', async () => {
+		const customerData = getCustomerDataMock();
+		getCustomerDataMock.mockReturnValue( {
+			...customerData,
+			billingAddress: {
+				...customerData.billingAddress,
+				country: 'FR',
+			},
+		} );
+		getValidationErrorMock.mockImplementation( ( errorId ) =>
+			[ 'billing_state', 'billing_postcode' ].includes( errorId )
+				? { message: 'Required field', hidden: true }
+				: undefined
+		);
+
+		pushChanges( false );
+
+		await expect( updateCustomerDataMock ).toHaveBeenCalledWith(
+			{
+				billing_address: {
+					...customerData.billingAddress,
+					country: 'FR',
+					state: '',
+					postcode: '',
+				},
+			},
+			true,
+			false
+		);
+	} );
+
+	it( 'Pushes a shipping country change when state and postcode are automatically cleared', async () => {
+		const customerData = getCustomerDataMock();
+		getCustomerDataMock.mockReturnValue( {
+			...customerData,
+			shippingAddress: {
+				...customerData.shippingAddress,
+				country: 'FR',
+			},
+		} );
+		getValidationErrorMock.mockImplementation( ( errorId ) =>
+			[ 'shipping_state', 'shipping_postcode' ].includes( errorId )
+				? { message: 'Required field', hidden: true }
+				: undefined
+		);
+
+		pushChanges( false );
+
+		await expect( updateCustomerDataMock ).toHaveBeenCalledWith(
+			{
+				shipping_address: {
+					...customerData.shippingAddress,
+					country: 'FR',
+					state: '',
+					postcode: '',
+				},
+			},
+			true,
+			true
+		);
+	} );
+
+	it( 'Does not push a country change with another invalid dirty field', () => {
+		const customerData = getCustomerDataMock();
+		getCustomerDataMock.mockReturnValue( {
+			...customerData,
+			billingAddress: {
+				...customerData.billingAddress,
+				country: 'FR',
+				email: 'invalid-email',
+			},
+		} );
+		getValidationErrorMock.mockImplementation( ( errorId ) =>
+			[ 'billing_state', 'billing_postcode', 'billing_email' ].includes(
+				errorId
+			)
+				? { message: 'Invalid field', hidden: true }
+				: undefined
+		);
+
+		pushChanges( false );
+
+		expect( updateCustomerDataMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'Does not push a country change with a non-empty invalid postcode', () => {
+		const customerData = getCustomerDataMock();
+		getCustomerDataMock.mockReturnValue( {
+			...customerData,
+			billingAddress: {
+				...customerData.billingAddress,
+				country: 'FR',
+				postcode: 'INVALID',
+			},
+		} );
+		getValidationErrorMock.mockImplementation( ( errorId ) =>
+			[ 'billing_state', 'billing_postcode' ].includes( errorId )
+				? { message: 'Invalid field', hidden: true }
+				: undefined
+		);
+
+		pushChanges( false );
+
+		expect( updateCustomerDataMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'Keeps props dirty if data did not persist due to an error', async () => {


### PR DESCRIPTION
Allow customer updates when changing country clears the state and postcode. Keep other invalid address fields blocking Store API updates.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
