### PR TITLE
[Payments NOX] Use Helcim setup state for account connectivity

### DIFF
--- a/plugins/woocommerce/changelog/fix-67378-helcim-account-connected
+++ b/plugins/woocommerce/changelog/fix-67378-helcim-account-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure Helcim account connectivity follows the gateway's setup status.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
@@ -19,33 +19,6 @@ defined( 'ABSPATH' ) || exit;
 class Helcim extends PaymentGateway {
 
 	/**
-	 * Check if the payment gateway needs setup.
-	 *
-	 * Overrides the parent fallback to avoid re-entering account connectivity.
-	 *
-	 * @param WC_Payment_Gateway $payment_gateway The payment gateway object.
-	 *
-	 * @return bool True if the payment gateway needs setup, false otherwise.
-	 */
-	public function needs_setup( WC_Payment_Gateway $payment_gateway ): bool {
-		try {
-			return wc_string_to_bool( $payment_gateway->needs_setup() );
-		} catch ( Throwable $e ) {
-			// Do nothing but log so we can investigate.
-			SafeGlobalFunctionProxy::wc_get_logger()->debug(
-				'Failed to determine if gateway needs setup: ' . $e->getMessage(),
-				array(
-					'gateway'   => $payment_gateway->id,
-					'source'    => 'settings-payments',
-					'exception' => $e,
-				)
-			);
-		}
-
-		return ! parent::is_account_connected( $payment_gateway );
-	}
-
-	/**
 	 * Check if the payment gateway has a payments processor account connected.
 	 *
 	 * @param WC_Payment_Gateway $payment_gateway The payment gateway object.
@@ -54,7 +27,21 @@ class Helcim extends PaymentGateway {
 	 *              If the payment gateway does not provide the information, it will return true.
 	 */
 	public function is_account_connected( WC_Payment_Gateway $payment_gateway ): bool {
-		return ! $this->needs_setup( $payment_gateway );
+		try {
+			return ! wc_string_to_bool( $payment_gateway->needs_setup() );
+		} catch ( Throwable $e ) {
+			// Do nothing but log so we can investigate.
+			SafeGlobalFunctionProxy::wc_get_logger()->debug(
+				'Failed to determine if gateway has an account connected: ' . $e->getMessage(),
+				array(
+					'gateway'   => $payment_gateway->id,
+					'source'    => 'settings-payments',
+					'exception' => $e,
+				)
+			);
+		}
+
+		return parent::is_account_connected( $payment_gateway );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
@@ -28,13 +28,7 @@ class Helcim extends PaymentGateway {
 	 */
 	public function is_account_connected( WC_Payment_Gateway $payment_gateway ): bool {
 		try {
-			$sandbox_mode = $this->is_helcim_in_sandbox_mode( $payment_gateway );
-			// Let null results bubble up to the parent class.
-			if ( null !== $sandbox_mode ) {
-				$token_key = $sandbox_mode ? 'sandbox_api_token' : 'live_api_token';
-
-				return '' !== trim( (string) $payment_gateway->get_option( $token_key, '' ) );
-			}
+			return ! wc_string_to_bool( $payment_gateway->needs_setup() );
 		} catch ( Throwable $e ) {
 			// Do nothing but log so we can investigate.
 			SafeGlobalFunctionProxy::wc_get_logger()->debug(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/Helcim.php
@@ -19,20 +19,21 @@ defined( 'ABSPATH' ) || exit;
 class Helcim extends PaymentGateway {
 
 	/**
-	 * Check if the payment gateway has a payments processor account connected.
+	 * Check if the payment gateway needs setup.
+	 *
+	 * Overrides the parent fallback to avoid re-entering account connectivity.
 	 *
 	 * @param WC_Payment_Gateway $payment_gateway The payment gateway object.
 	 *
-	 * @return bool True if the payment gateway account is connected, false otherwise.
-	 *              If the payment gateway does not provide the information, it will return true.
+	 * @return bool True if the payment gateway needs setup, false otherwise.
 	 */
-	public function is_account_connected( WC_Payment_Gateway $payment_gateway ): bool {
+	public function needs_setup( WC_Payment_Gateway $payment_gateway ): bool {
 		try {
-			return ! wc_string_to_bool( $payment_gateway->needs_setup() );
+			return wc_string_to_bool( $payment_gateway->needs_setup() );
 		} catch ( Throwable $e ) {
 			// Do nothing but log so we can investigate.
 			SafeGlobalFunctionProxy::wc_get_logger()->debug(
-				'Failed to determine if gateway has an account connected: ' . $e->getMessage(),
+				'Failed to determine if gateway needs setup: ' . $e->getMessage(),
 				array(
 					'gateway'   => $payment_gateway->id,
 					'source'    => 'settings-payments',
@@ -41,7 +42,19 @@ class Helcim extends PaymentGateway {
 			);
 		}
 
-		return parent::is_account_connected( $payment_gateway );
+		return ! parent::is_account_connected( $payment_gateway );
+	}
+
+	/**
+	 * Check if the payment gateway has a payments processor account connected.
+	 *
+	 * @param WC_Payment_Gateway $payment_gateway The payment gateway object.
+	 *
+	 * @return bool True if the payment gateway account is connected, false otherwise.
+	 *              If the payment gateway does not provide the information, it will return true.
+	 */
+	public function is_account_connected( WC_Payment_Gateway $payment_gateway ): bool {
+		return ! $this->needs_setup( $payment_gateway );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProx
 use Automattic\WooCommerce\Testing\Tools\TestingContainer;
 use Automattic\WooCommerce\Tests\Internal\Admin\Settings\Mocks\FakePaymentGateway;
 use PHPUnit\Framework\MockObject\MockObject;
+use WC_Payment_Gateway;
 use WC_Unit_Test_Case;
 
 /**
@@ -123,22 +124,15 @@ class HelcimTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should report a legacy gateway connected when it has no custom setup requirement.
+	 * @testdox Should report a legacy gateway connected when it inherits the default setup requirement.
 	 */
-	public function test_is_account_connected_true_for_legacy_gateway_without_custom_setup_requirement(): void {
-		$fake_gateway = new FakePaymentGateway(
-			'helcimjs',
-			array(
-				'settings'    => array(
-					'legacy_api_token' => 'real_legacy_live_token',
-				),
-				'needs_setup' => false,
-			),
-		);
+	public function test_is_account_connected_true_for_legacy_gateway_with_default_setup_requirement(): void {
+		$legacy_gateway     = new class() extends WC_Payment_Gateway {};
+		$legacy_gateway->id = 'helcimjs';
 
 		$this->assertTrue(
-			$this->sut->is_account_connected( $fake_gateway ),
-			'Legacy gateways should retain the generic fail-open connected state.'
+			$this->sut->is_account_connected( $legacy_gateway ),
+			'Legacy gateways inheriting the default setup requirement should retain the connected state.'
 		);
 	}
 
@@ -152,7 +146,7 @@ class HelcimTest extends WC_Unit_Test_Case {
 				'settings'          => array(
 					'environment' => 'live',
 				),
-				'account_connected' => true,
+				'account_connected' => false,
 			),
 		) extends FakePaymentGateway {
 			/**
@@ -165,9 +159,9 @@ class HelcimTest extends WC_Unit_Test_Case {
 			}
 		};
 
-		$this->assertTrue(
+		$this->assertFalse(
 			$this->sut->is_account_connected( $fake_gateway ),
-			'Setup check failures should use the generic account-connected heuristic.'
+			'Setup check failures should return the generic account-connected heuristic result.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
@@ -91,6 +91,37 @@ class HelcimTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should query the gateway setup requirement once.
+	 */
+	public function test_needs_setup_queries_gateway_once(): void {
+		$fake_gateway = new class( 'helcimjs', array( 'needs_setup' => false ) ) extends FakePaymentGateway {
+			/**
+			 * Number of setup checks.
+			 *
+			 * @var int
+			 */
+			public int $needs_setup_calls = 0;
+
+			/**
+			 * Count and return the configured setup requirement.
+			 *
+			 * @return bool
+			 */
+			public function needs_setup() {
+				++$this->needs_setup_calls;
+				return parent::needs_setup();
+			}
+		};
+
+		$this->assertFalse( $this->sut->needs_setup( $fake_gateway ) );
+		$this->assertSame(
+			1,
+			$fake_gateway->needs_setup_calls,
+			'The provider should not re-enter account connectivity after the gateway gives a definitive setup result.'
+		);
+	}
+
+	/**
 	 * @testdox Should be in test mode when the environment is sandbox.
 	 */
 	public function test_is_in_test_mode_true_in_sandbox(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
@@ -49,53 +49,45 @@ class HelcimTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should report account connected when a sandbox API token is set in sandbox mode.
+	 * @testdox Should report account connected when the gateway does not need setup.
 	 */
-	public function test_is_account_connected_true_when_sandbox_token_set(): void {
+	public function test_is_account_connected_true_when_gateway_does_not_need_setup(): void {
 		$fake_gateway = new FakePaymentGateway(
 			'helcimjs',
 			array(
-				'settings' => array(
+				'settings'    => array(
+					'environment'       => 'live',
+					'renamed_api_token' => 'bogus_live_token',
+				),
+				'needs_setup' => false,
+			),
+		);
+
+		$this->assertTrue(
+			$this->sut->is_account_connected( $fake_gateway ),
+			'The gateway setup requirement should be authoritative when its token option keys change.'
+		);
+	}
+
+	/**
+	 * @testdox Should report account not connected when the gateway needs setup.
+	 */
+	public function test_is_account_connected_false_when_gateway_needs_setup(): void {
+		$fake_gateway = new FakePaymentGateway(
+			'helcimjs',
+			array(
+				'settings'    => array(
 					'environment'       => 'sandbox',
-					'sandbox_api_token' => 'bogus_sandbox_token',
+					'sandbox_api_token' => 'stale_or_irrelevant_token',
 				),
+				'needs_setup' => true,
 			),
 		);
 
-		$this->assertTrue( $this->sut->is_account_connected( $fake_gateway ) );
-	}
-
-	/**
-	 * @testdox Should report account not connected when no sandbox API token is set in sandbox mode.
-	 */
-	public function test_is_account_connected_false_when_sandbox_token_missing(): void {
-		$fake_gateway = new FakePaymentGateway(
-			'helcimjs',
-			array(
-				'settings' => array(
-					'environment' => 'sandbox',
-				),
-			),
+		$this->assertFalse(
+			$this->sut->is_account_connected( $fake_gateway ),
+			'The gateway setup requirement should take precedence over assumed token option keys.'
 		);
-
-		$this->assertFalse( $this->sut->is_account_connected( $fake_gateway ) );
-	}
-
-	/**
-	 * @testdox Should report account connected when a live API token is set in live mode.
-	 */
-	public function test_is_account_connected_true_when_live_token_set(): void {
-		$fake_gateway = new FakePaymentGateway(
-			'helcimjs',
-			array(
-				'settings' => array(
-					'environment'    => 'live',
-					'live_api_token' => 'bogus_live_token',
-				),
-			),
-		);
-
-		$this->assertTrue( $this->sut->is_account_connected( $fake_gateway ) );
 	}
 
 	/**
@@ -131,43 +123,52 @@ class HelcimTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should fall back to the generic account-connected heuristic when the environment option is entirely absent.
+	 * @testdox Should report a legacy gateway connected when it has no custom setup requirement.
 	 */
-	public function test_is_account_connected_falls_back_when_environment_option_missing(): void {
-		// Simulates a pre-v5 Helcim install: same gateway id, but no 'environment'
-		// option was ever registered, so it's absent from both settings and form_fields.
+	public function test_is_account_connected_true_for_legacy_gateway_without_custom_setup_requirement(): void {
 		$fake_gateway = new FakePaymentGateway(
 			'helcimjs',
 			array(
-				'settings'          => array(
+				'settings'    => array(
 					'legacy_api_token' => 'real_legacy_live_token',
 				),
-				'account_connected' => true,
+				'needs_setup' => false,
 			),
 		);
 
-		$this->assertTrue( $this->sut->is_account_connected( $fake_gateway ) );
+		$this->assertTrue(
+			$this->sut->is_account_connected( $fake_gateway ),
+			'Legacy gateways should retain the generic fail-open connected state.'
+		);
 	}
 
 	/**
-	 * @testdox Should fall back to the generic account-connected heuristic for an unrecognized environment value.
+	 * @testdox Should fall back to the generic account-connected heuristic when the setup check fails.
 	 */
-	public function test_is_account_connected_falls_back_for_unrecognized_environment(): void {
-		// account_connected is true here (not false) so the assertion can't pass
-		// by coincidence: an incorrectly-sandbox or incorrectly-live read would
-		// look up an absent token option and return false either way, while only
-		// a correct null (unrecognized -> defer to parent) read reaches this true.
-		$fake_gateway = new FakePaymentGateway(
+	public function test_is_account_connected_falls_back_when_setup_check_fails(): void {
+		$fake_gateway = new class(
 			'helcimjs',
 			array(
 				'settings'          => array(
-					'environment' => 'staging',
+					'environment' => 'live',
 				),
 				'account_connected' => true,
 			),
-		);
+		) extends FakePaymentGateway {
+			/**
+			 * Simulate a gateway setup check failure.
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function needs_setup() {
+				throw new \RuntimeException( 'Failed to check the gateway setup.' );
+			}
+		};
 
-		$this->assertTrue( $this->sut->is_account_connected( $fake_gateway ) );
+		$this->assertTrue(
+			$this->sut->is_account_connected( $fake_gateway ),
+			'Setup check failures should use the generic account-connected heuristic.'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/HelcimTest.php
@@ -91,37 +91,6 @@ class HelcimTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should query the gateway setup requirement once.
-	 */
-	public function test_needs_setup_queries_gateway_once(): void {
-		$fake_gateway = new class( 'helcimjs', array( 'needs_setup' => false ) ) extends FakePaymentGateway {
-			/**
-			 * Number of setup checks.
-			 *
-			 * @var int
-			 */
-			public int $needs_setup_calls = 0;
-
-			/**
-			 * Count and return the configured setup requirement.
-			 *
-			 * @return bool
-			 */
-			public function needs_setup() {
-				++$this->needs_setup_calls;
-				return parent::needs_setup();
-			}
-		};
-
-		$this->assertFalse( $this->sut->needs_setup( $fake_gateway ) );
-		$this->assertSame(
-			1,
-			$fake_gateway->needs_setup_calls,
-			'The provider should not re-enter account connectivity after the gateway gives a definitive setup result.'
-		);
-	}
-
-	/**
 	 * @testdox Should be in test mode when the environment is sandbox.
 	 */
 	public function test_is_in_test_mode_true_in_sandbox(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Helcim's current settings match the credential option keys added in #66960, but duplicating that extension-owned schema makes WooCommerce vulnerable to future key changes. This derives `account_connected` from the gateway's standard `needs_setup()` contract instead, keeping Helcim authoritative about its setup state while preserving the generic fallback if the check fails.

Because the base provider derives `needs_setup` and the onboarding fallbacks from `account_connected`, those signals now follow Helcim's setup result as well.

Helcim's password-field validation trims tokens during normal settings saves. A whitespace-only token inserted by directly mutating the serialized option would now be treated as connected because this change intentionally delegates edge-case interpretation to Helcim's `needs_setup()` contract.

This does not change any externally exposed signatures, hooks, or serialized contracts. It adds no site-scoped storage and has no multisite-specific behavior.

Closes #67378
Closes WOOPLUG-7413

Bug introduced in PR #66960.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, start the test environment with `pnpm env:test:start`.
2. Run `pnpm run test:php:env -- --filter HelcimTest`.
3. Confirm all eight tests pass, including configured and unconfigured gateways, a legacy gateway inheriting WooCommerce's default setup requirement, changed token-key assumptions, and an exception fallback that returns the generic account-connected result.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `HelcimTest`: 8 tests and 8 assertions passed on WordPress 7.0.2, PHP 8.1.34, and PHPUnit 9.6.29 in the isolated `wp-env` test environment.
- PHPStan passed for `Helcim.php`.
- Both required WooCommerce PHP lint passes completed successfully.
- The staged verification gate and `git diff --check` passed.
- Automated mutation testing did not run because the healthy test container lacks a coverage extension; the verification dispatcher stopped at its environment preflight.
- A targeted manual mutation hardcoded the exception fallback to true; the corrected test failed as expected, and the restored suite passed.
- Multisite was not tested; this change adds no site-scoped reads or writes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-67378-helcim-account-connected`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>


