### PR TITLE
Fix product JS file count test for WordPress 7.1

### DIFF
--- a/plugins/woocommerce/changelog/fix-wp-71-product-js-file-count
+++ b/plugins/woocommerce/changelog/fix-wp-71-product-js-file-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the JS file count test for WordPress 7.1.

--- a/plugins/woocommerce/tests/e2e/tests/js-file-monitor/monitor-js-file-number.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/js-file-monitor/monitor-js-file-number.spec.ts
@@ -49,7 +49,8 @@ const pageGroups = [
 			{
 				name: 'Add new product',
 				url: 'wp-admin/post-new.php?post_type=product',
-				expectedCount: 150,
+				// WP 7.1 adds the wp-tooltip and wp-sync core scripts.
+				expectedCount: 152,
 			},
 			{
 				name: 'Analytics page',
@@ -76,10 +77,11 @@ for ( const group of pageGroups ) {
 				// networkidle is needed to ensure all JS files are loaded and avoid race conditions
 				// eslint-disable-next-line playwright/no-networkidle
 				await page.goto( url, { waitUntil: 'networkidle' } );
-				const javascriptFiles = await page.$$eval(
-					'script[src]',
-					( scripts ) => scripts.map( ( s ) => s.src )
-				);
+				const javascriptFiles = await page
+					.locator( 'script[src]' )
+					.evaluateAll( ( scripts ) =>
+						scripts.map( ( script ) => script.src )
+					);
 
 				expect
 					.soft(

--- a/plugins/woocommerce/tests/e2e/tests/js-file-monitor/monitor-js-file-number.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/js-file-monitor/monitor-js-file-number.spec.ts
@@ -49,8 +49,7 @@ const pageGroups = [
 			{
 				name: 'Add new product',
 				url: 'wp-admin/post-new.php?post_type=product',
-				// WP 7.1 adds the wp-tooltip and wp-sync core scripts.
-				expectedCount: 152,
+				expectedCount: 151,
 			},
 			{
 				name: 'Analytics page',
@@ -77,11 +76,10 @@ for ( const group of pageGroups ) {
 				// networkidle is needed to ensure all JS files are loaded and avoid race conditions
 				// eslint-disable-next-line playwright/no-networkidle
 				await page.goto( url, { waitUntil: 'networkidle' } );
-				const javascriptFiles = await page
-					.locator( 'script[src]' )
-					.evaluateAll( ( scripts ) =>
-						scripts.map( ( script ) => script.src )
-					);
+				const javascriptFiles = await page.$$eval(
+					'script[src]',
+					( scripts ) => scripts.map( ( s ) => s.src )
+				);
 
 				expect
 					.soft(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently `tests/e2e/tests/js-file-monitor/monitor-js-file-number.spec.ts` is failing on WordPress 7.1: https://github.com/woocommerce/woocommerce/actions/runs/30973940537/job/92204014224

WordPress 7.1 loads the new `wp-tooltip` and `wp-sync` Core scripts on the Add Product page, increasing its script count from 149 to 151 and exceeding the existing limit. This PR updates the E2E test.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure that the CI E2E tests job are green.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Targeted Playwright test on the local `wp-env` environment with WordPress 7.1 Beta 4: passed (`151 <= 152`).
- `pnpm lint:changes:branch:js`: passed with no warnings or errors.
- Compared normalized script URLs between WordPress 7.0.2 and 7.1 Beta 4; only `wp-tooltip.js` and `sync.min.js` were added.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
