### PR TITLE
Product Details: Support padding, margin, background, and border

### DIFF
--- a/docs/block-development/reference/block-references.md
+++ b/docs/block-development/reference/block-references.md
@@ -1230,7 +1230,7 @@ Display a product's description, attributes, and reviews
 
 - **Name:** woocommerce/product-details
 - **Category:** woocommerce
-- **Supports:** align (full, wide), interactivity (clientNavigation)
+- **Supports:** align (full, wide), color (background, ~~text~~), interactivity (clientNavigation), spacing (margin, padding)
 - **Attributes:** align, hideTabTitle
 
 ## Product Filters - woocommerce/product-filters

--- a/plugins/woocommerce/changelog/add-product-details-style-supports
+++ b/plugins/woocommerce/changelog/add-product-details-style-supports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add background, spacing, and border style controls to the Product Details block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -10,7 +10,21 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"color": {
+			"background": true,
+			"text": false
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		}
 	},
 	"attributes": {
 		"align": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/test/block.tsx
@@ -3,7 +3,8 @@
  */
 import '@testing-library/jest-dom';
 import { screen, waitFor, within } from '@testing-library/react';
-import { createBlock, type BlockAttributes } from '@wordpress/blocks';
+import { createBlock, getBlockType, serialize } from '@wordpress/blocks';
+import type { BlockAttributes } from '@wordpress/blocks';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { useSelect } from '@wordpress/data';
@@ -60,6 +61,74 @@ jest.mock( '@woocommerce/settings', () => ( {
 } ) );
 
 describe( 'Product Details block', () => {
+	test( 'registers only the approved style supports', () => {
+		expect(
+			getBlockType( 'woocommerce/product-details' )?.supports
+		).toEqual( {
+			interactivity: { clientNavigation: true },
+			align: [ 'wide', 'full' ],
+			color: { background: true, text: false },
+			spacing: { margin: true, padding: true },
+			__experimentalBorder: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		} );
+	} );
+
+	test( 'preserves unstyled serialization', () => {
+		expect(
+			serialize( createBlock( 'woocommerce/product-details' ) )
+		).toBe(
+			'<!-- wp:woocommerce/product-details -->\n<div class="wp-block-woocommerce-product-details alignwide"></div>\n<!-- /wp:woocommerce/product-details -->'
+		);
+	} );
+
+	test( 'serializes preset and custom styles without text color', () => {
+		const content = serialize(
+			createBlock( 'woocommerce/product-details', {
+				backgroundColor: 'contrast',
+				borderColor: 'accent-1',
+				style: {
+					border: { radius: '4px', style: 'solid', width: '2px' },
+					spacing: {
+						margin: { top: 'var:preset|spacing|20', right: '0' },
+						padding: { bottom: '1rem', left: '1rem' },
+					},
+				},
+			} )
+		);
+
+		expect( content ).toContain(
+			'has-accent-1-border-color has-contrast-background-color has-background'
+		);
+		expect( content ).toContain(
+			'border-style:solid;border-width:2px;border-radius:4px;margin-top:var(--wp--preset--spacing--20);margin-right:0;padding-bottom:1rem;padding-left:1rem'
+		);
+		expect( content ).not.toContain( 'has-text-color' );
+	} );
+
+	test( 'distinguishes explicit zero styles from reset styles', () => {
+		const zero = serialize(
+			createBlock( 'woocommerce/product-details', {
+				style: {
+					border: { radius: '0', width: '0' },
+					spacing: { margin: { top: '0' }, padding: { bottom: '0' } },
+				},
+			} )
+		);
+		expect( zero ).toContain(
+			'style="border-width:0;border-radius:0;margin-top:0;padding-bottom:0"'
+		);
+		expect(
+			serialize(
+				createBlock( 'woocommerce/product-details', { style: {} } )
+			)
+		).not.toContain( 'style=' );
+	} );
+
 	describe( 'Single Product block', () => {
 		const server = setupServer(
 			http.get( '/wc-admin/options', ( { request } ) => {

--- a/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line import/no-unresolved -- Resolved by the E2E TypeScript alias.
 import { expect, test } from '@woocommerce/e2e-utils';
 
 /**
@@ -21,7 +22,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 
 		try {
 			await editor.insertBlock( { name: blockData.slug } );
-		} catch ( _error ) {
+		} catch {
 			// noop
 		}
 
@@ -30,16 +31,19 @@ test.describe( `${ blockData.slug } Block`, () => {
 		).toBeHidden();
 	} );
 
-	test( 'block can be inserted in the Site Editor', async ( {
+	test( 'style supports persist across the editor and frontend', async ( {
 		admin,
 		requestUtils,
 		editor,
+		page,
 	} ) => {
+		const unstyledContent = `<!-- wp:woocommerce/product-details -->
+<div class="wp-block-woocommerce-product-details alignwide"><!-- wp:paragraph --><p>Inner marker</p><!-- /wp:paragraph --></div>
+<!-- /wp:woocommerce/product-details -->`;
 		const template = await requestUtils.createTemplate( 'wp_template', {
-			// Single Product Details block is addable only in Single Product Templates
-			slug: 'single-product-v-neck-t-shirt',
-			title: 'Sorter',
-			content: 'placeholder',
+			slug: 'single-product',
+			title: 'Styled product details',
+			content: unstyledContent,
 		} );
 
 		await admin.visitSiteEditor( {
@@ -47,19 +51,80 @@ test.describe( `${ blockData.slug } Block`, () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
-
-		await expect(
-			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
-		).toBeVisible();
-
-		await editor.insertBlock( {
-			name: blockData.slug,
-		} );
-
 		const block = await editor.getBlockByName( blockData.slug );
+		await expect( block.getByText( 'Inner marker' ) ).toBeVisible();
+		await editor.selectBlocks( block );
+		await editor.openDocumentSettingsSidebar();
+		for ( const heading of [ 'Dimensions', 'Border' ] ) {
+			await expect(
+				page.getByRole( 'heading', { name: heading, exact: true } )
+			).toBeVisible();
+		}
+		await expect(
+			page.getByText( 'Background', { exact: true } ).first()
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Text', exact: true } )
+		).toHaveCount( 0 );
 
-		await expect( block ).toHaveText(
-			/This block displays the product description. When viewing a product page, the description content will automatically appear here./
+		await page.evaluate( ( slug ) => {
+			const productDetails = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks()
+				.find(
+					( item: { clientId: string; name: string } ) =>
+						item.name === slug
+				);
+			if ( ! productDetails ) {
+				throw new Error( 'Product Details block not found' );
+			}
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.updateBlockAttributes( productDetails.clientId, {
+					backgroundColor: 'contrast',
+					borderColor: 'accent-1',
+					style: {
+						border: {
+							radius: '4px',
+							style: 'solid',
+							width: '2px',
+						},
+						spacing: {
+							margin: { top: 'var:preset|spacing|20' },
+							padding: { left: '1rem' },
+						},
+					},
+				} );
+		}, blockData.slug );
+		await expect( block ).toHaveClass( /has-contrast-background-color/ );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		const savedContent = await page.evaluate( () =>
+			window.wp.data.select( 'core/editor' ).getEditedPostContent()
 		);
+		expect( savedContent ).toContain( '"backgroundColor":"contrast"' );
+		expect( savedContent ).toContain( '"borderColor":"accent-1"' );
+		expect( savedContent ).toContain( 'var:preset|spacing|20' );
+		expect( savedContent ).toContain( 'Inner marker' );
+		expect( savedContent ).not.toContain( 'textColor' );
+
+		await page.goto( 'product/hoodie/' );
+		const frontend = page.locator(
+			'.wp-block-woocommerce-product-details'
+		);
+		await expect( frontend ).toHaveClass( /has-accent-1-border-color/ );
+		await expect( frontend ).toHaveClass( /has-contrast-background-color/ );
+		await expect( frontend.getByText( 'Inner marker' ) ).toBeVisible();
+		const frontendStyle = await frontend.getAttribute( 'style' );
+		for ( const value of [
+			'border-radius:4px',
+			'border-style:solid',
+			'border-width:2px',
+			'margin-top:var(--wp--preset--spacing--20)',
+			'padding-left:1rem',
+		] ) {
+			expect( frontendStyle ).toContain( value );
+		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/single-product-details/single-product-details.block_theme.spec.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line import/no-unresolved -- Resolved by the E2E TypeScript alias.
 import { expect, test } from '@woocommerce/e2e-utils';
 
 /**
@@ -22,7 +21,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 
 		try {
 			await editor.insertBlock( { name: blockData.slug } );
-		} catch {
+		} catch ( _error ) {
 			// noop
 		}
 
@@ -31,19 +30,16 @@ test.describe( `${ blockData.slug } Block`, () => {
 		).toBeHidden();
 	} );
 
-	test( 'style supports persist across the editor and frontend', async ( {
+	test( 'block can be inserted in the Site Editor', async ( {
 		admin,
 		requestUtils,
 		editor,
-		page,
 	} ) => {
-		const unstyledContent = `<!-- wp:woocommerce/product-details -->
-<div class="wp-block-woocommerce-product-details alignwide"><!-- wp:paragraph --><p>Inner marker</p><!-- /wp:paragraph --></div>
-<!-- /wp:woocommerce/product-details -->`;
 		const template = await requestUtils.createTemplate( 'wp_template', {
-			slug: 'single-product',
-			title: 'Styled product details',
-			content: unstyledContent,
+			// Single Product Details block is addable only in Single Product Templates
+			slug: 'single-product-v-neck-t-shirt',
+			title: 'Sorter',
+			content: 'placeholder',
 		} );
 
 		await admin.visitSiteEditor( {
@@ -51,80 +47,19 @@ test.describe( `${ blockData.slug } Block`, () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
-		const block = await editor.getBlockByName( blockData.slug );
-		await expect( block.getByText( 'Inner marker' ) ).toBeVisible();
-		await editor.selectBlocks( block );
-		await editor.openDocumentSettingsSidebar();
-		for ( const heading of [ 'Dimensions', 'Border' ] ) {
-			await expect(
-				page.getByRole( 'heading', { name: heading, exact: true } )
-			).toBeVisible();
-		}
+
 		await expect(
-			page.getByText( 'Background', { exact: true } ).first()
+			editor.getCustomHtmlBlockContentLocator( 'placeholder' )
 		).toBeVisible();
-		await expect(
-			page.getByRole( 'button', { name: 'Text', exact: true } )
-		).toHaveCount( 0 );
 
-		await page.evaluate( ( slug ) => {
-			const productDetails = window.wp.data
-				.select( 'core/block-editor' )
-				.getBlocks()
-				.find(
-					( item: { clientId: string; name: string } ) =>
-						item.name === slug
-				);
-			if ( ! productDetails ) {
-				throw new Error( 'Product Details block not found' );
-			}
-			window.wp.data
-				.dispatch( 'core/block-editor' )
-				.updateBlockAttributes( productDetails.clientId, {
-					backgroundColor: 'contrast',
-					borderColor: 'accent-1',
-					style: {
-						border: {
-							radius: '4px',
-							style: 'solid',
-							width: '2px',
-						},
-						spacing: {
-							margin: { top: 'var:preset|spacing|20' },
-							padding: { left: '1rem' },
-						},
-					},
-				} );
-		}, blockData.slug );
-		await expect( block ).toHaveClass( /has-contrast-background-color/ );
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
+		await editor.insertBlock( {
+			name: blockData.slug,
 		} );
-		const savedContent = await page.evaluate( () =>
-			window.wp.data.select( 'core/editor' ).getEditedPostContent()
-		);
-		expect( savedContent ).toContain( '"backgroundColor":"contrast"' );
-		expect( savedContent ).toContain( '"borderColor":"accent-1"' );
-		expect( savedContent ).toContain( 'var:preset|spacing|20' );
-		expect( savedContent ).toContain( 'Inner marker' );
-		expect( savedContent ).not.toContain( 'textColor' );
 
-		await page.goto( 'product/hoodie/' );
-		const frontend = page.locator(
-			'.wp-block-woocommerce-product-details'
+		const block = await editor.getBlockByName( blockData.slug );
+
+		await expect( block ).toHaveText(
+			/This block displays the product description. When viewing a product page, the description content will automatically appear here./
 		);
-		await expect( frontend ).toHaveClass( /has-accent-1-border-color/ );
-		await expect( frontend ).toHaveClass( /has-contrast-background-color/ );
-		await expect( frontend.getByText( 'Inner marker' ) ).toBeVisible();
-		const frontendStyle = await frontend.getAttribute( 'style' );
-		for ( const value of [
-			'border-radius:4px',
-			'border-style:solid',
-			'border-width:2px',
-			'margin-top:var(--wp--preset--spacing--20)',
-			'padding-left:1rem',
-		] ) {
-			expect( frontendStyle ).toContain( value );
-		}
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR register background, padding, margin, and border support for the Product Details block.

Closes #59998.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->


https://github.com/user-attachments/assets/7e9d2cab-8cb9-4b35-8d48-98a05eaf260a

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Using a block theme, edit the Single Product template.
2. Remove the Product Details block.
3. Reinsert the Product Details block using the inserter to get the new block with accordion.
4. Select the new block and open the block settings.
5. Confirm that the background, padding, margin, and border settings are available.
6. Test each setting and save your changes.
7. Verify that the changes appear on the front end and in the editor.
8. Clear the settings.
9. Repeat the same steps using Global Styles.. 

<details>
<summary>Detailed instructions</summary>

#### Prerequisites and baseline

1. Build and activate this branch's WooCommerce assets on a WordPress site where you can administer the Site Editor and inspect the storefront in browser developer tools.
2. Activate a block theme. Use an existing published product and its complete **Single Product** template. The template must retain its real header, product-summary columns, Product Details, related products, and footer; do not replace it with isolated or reduced test markup.
3. Confirm the modern Product Details block uses the inner-block path and contains the existing Description, Additional Information, and Reviews accordion content. The legacy no-inner-block Product Details path is outside this test's scope. This does not claim compatibility with every theme, plugin, and Global Styles configuration.
4. Record the complete template's pre-test content and the current Product Details Global Styles values so both can be restored exactly. Start with no explicit background, spacing, or border values on the Product Details parent.
5. In **Appearance > Editor > Styles > Blocks > Product Details**, set the background to custom value `#d7f0e5` and set only the top padding to `7px`; save. If this block or either control is unavailable in the installed runtime, stop because the inheritance prerequisite is not satisfied.
6. Open browser developer tools. Keep the Console and Network panels available, preserve logs across navigation, and clear existing entries so errors from this test can be distinguished from earlier activity.

#### Apply and persist explicit styles

1. Go to **Appearance > Editor > Templates > Single Product**. Before editing, verify the canvas still shows the complete template context: header, product-summary columns, Product Details, related products, and footer.
2. Open **List View**. Inside the main template Group, select the **Product Details** parent—not Description, Additional Information, Reviews, or another accordion child. Verify those three existing children remain present.
3. In the parent block inspector, verify:
   - **Color** offers **Background** and does not offer **Text** color.
   - **Dimensions** offers both **Padding** and **Margin**.
   - **Border** is available with color, style, width, and radius controls.
4. Set these exact values on the Product Details parent:
   - Background: **Accent 1** preset.
   - Padding: unlink sides if needed, then set top and bottom to `24px`; leave left and right unchanged.
   - Margin: unlink sides if needed, then set top and bottom to `16px`; leave left and right unchanged.
   - Border: enable **Border** and **Radius**; choose the **Accent 2** swatch (`#650DD4`), style **Solid**, width `3px`, and top-left, top-right, bottom-right, and bottom-left radius `12px`.
5. Save the template and wait for the save-success state. Reload the editor, open List View, and re-select the Product Details parent.
6. Verify Accent 1, `24px` top/bottom padding, `16px` top/bottom margin, Accent 2/`#650DD4`, Solid, `3px`, and all four `12px` radii persisted. Verify there is no invalid-content warning and that Description, Additional Information, Reviews, and every surrounding template block remain intact.

#### Verify the storefront

1. Open the existing product that uses this Single Product template. Verify the normal storefront context remains visible around Product Details, including product image, title, price, add-to-cart controls, and product metadata.
2. Inspect the `.wp-block-woocommerce-product-details` element. Verify it contains the existing accordion content and has:
   - Accent 1 background (the accepted fixture computes to `rgb(245, 237, 255)`).
   - Border color `#650DD4` (`rgb(101, 13, 212)`), style `solid`, and width `3px`.
   - `12px` radius on every corner.
   - `16px` top and bottom margin.
   - `24px` top and bottom padding.

#### Reset, inherit, check errors, and clean up

1. Return to the Single Product template editor and select the Product Details parent through List View.
2. Use Background **Reset**, Dimensions **Options > Reset all**, and Border **Options > Reset all**. Save, wait for success, and reload.
3. Re-select Product Details. Verify it has no explicit background, spacing, or border values; no invalid-content warning appears; and its three accordion children plus every surrounding template block remain intact.
4. View the product again and inspect `.wp-block-woocommerce-product-details`. Verify it has no inline `style` attribute and no explicit style-support classes such as `has-background`, an explicit background-color class, or `has-border-color`. Verify the computed background is `#d7f0e5` (`rgb(215, 240, 229)`) and computed top padding is `7px`, inherited from Global Styles. Verify the explicit border is gone and the accordion content remains inside the wrapper.
5. In developer tools, verify there are no uncaught page errors, console errors, unexpected failed requests, or HTTP 4xx/5xx responses attributable to the flow.
6. Restore the recorded Product Details Global Styles values. If any template content differs from the recorded baseline, restore it. Save and verify the final complete template content matches the pre-test state exactly and the storefront still renders the product normally.

</details>

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
