### PR TITLE
Fix Mini-Cart inner block registration

### DIFF
--- a/plugins/woocommerce/changelog/codex-fix-mini-cart-inner-block-registration
+++ b/plugins/woocommerce/changelog/codex-fix-mini-cart-inner-block-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore Mini-Cart inner blocks in the Site Editor.

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -27,6 +27,7 @@
 		"./assets/js/blocks/checkout/inner-blocks/register-components.ts",
 		"./assets/js/blocks/cart/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/cart/inner-blocks/register-components.ts",
+		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/**/index.tsx",
 		"./assets/js/base/components/**/*.{tsx,ts}",
 		"./assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx",
 		"./assets/js/blocks/cart-checkout-shared/view-switcher/index.tsx",

--- a/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
@@ -75,7 +75,6 @@ test.describe( 'Merchant → Mini Cart', () => {
 			);
 
 			await expect( filledMiniCart ).toBeVisible();
-			// Only the active view is visible, but both must render in the editor.
 			await expect( emptyMiniCart ).toBeAttached();
 		} );
 	} );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
@@ -57,5 +57,26 @@ test.describe( 'Merchant → Mini Cart', () => {
 			await expect( miniCartButton ).toBeVisible();
 			await expect( miniCartButton ).toBeDisabled();
 		} );
+
+		test( 'renders filled and empty views in the Mini-Cart template part', async ( {
+			editor,
+			admin,
+		} ) => {
+			await admin.visitSiteEditor( {
+				postType: 'wp_template_part',
+			} );
+			await editor.openTemplate( { templateName: 'Mini-Cart' } );
+
+			const filledMiniCart = await editor.getBlockByName(
+				'woocommerce/filled-mini-cart-contents-block'
+			);
+			const emptyMiniCart = await editor.getBlockByName(
+				'woocommerce/empty-mini-cart-contents-block'
+			);
+
+			await expect( filledMiniCart ).toBeVisible();
+			// Only the active view is visible, but both must render in the editor.
+			await expect( emptyMiniCart ).toBeAttached();
+		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Mini-Cart inner blocks were tree-shaken from editor bundles because their registration entry points were no longer marked as side effects, causing unsupported blocks in the Site Editor. This restores those entry points to the package `sideEffects` list. This risk was [raised during review of the original PR](https://github.com/woocommerce/woocommerce/pull/66091#discussion_r3508025579).

Bug introduced in PR #66091.

### Screenshots or screen recordings:

Before | After
-- | --
<img width="1368" height="1257" alt="image" src="https://github.com/user-attachments/assets/e46f641f-5710-4aee-9de8-21d15aa94dd5" /> | <img width="1364" height="1258" alt="image" src="https://github.com/user-attachments/assets/4084fb37-79ed-4f4e-aa1d-a5f632e3c754" />


Not applicable; this restores the existing Mini-Cart editor implementation.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open the Mini-Cart template part in Appearance > Editor > Patterns > Mini Cart.
2. Confirm its filled, empty, and nested blocks load without unsupported-block notices.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm wc:build` completed successfully.
- Verified all 11 Mini-Cart inner block registrations are present in both editor bundles.
- Built and linked to a local WordPress 7.1-beta4 site; the site responds successfully.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>