### PR TITLE
Fix product search filters applying to only a single OR group

### DIFF
--- a/plugins/woocommerce/changelog/67392-search-or-group-filters
+++ b/plugins/woocommerce/changelog/67392-search-or-group-filters
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Product searches with terms containing " or " now apply the include, exclude, status, product type and post type filters to every OR group instead of only a single group, so admin product pickers no longer suggest drafts, excluded products or wrong-type products for such terms.
+Product searches with terms containing " or " now apply the include, exclude, status, product type and post type filters to every OR group instead of only a single group, so admin product pickers no longer suggest drafts, excluded products or wrong-type products matched by those groups.

--- a/plugins/woocommerce/changelog/67392-search-or-group-filters
+++ b/plugins/woocommerce/changelog/67392-search-or-group-filters
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Product searches with terms containing " or " now apply the include, exclude, status, product type and post type filters to every OR group instead of only the last one, so admin product pickers no longer suggest drafts, excluded products or wrong-type products for such terms.
+Product searches with terms containing " or " now apply the include, exclude, status, product type and post type filters to every OR group instead of only a single group, so admin product pickers no longer suggest drafts, excluded products or wrong-type products for such terms.

--- a/plugins/woocommerce/changelog/67392-search-or-group-filters
+++ b/plugins/woocommerce/changelog/67392-search-or-group-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product searches with terms containing " or " now apply the include, exclude, status, product type and post type filters to every OR group instead of only the last one, so admin product pickers no longer suggest drafts, excluded products or wrong-type products for such terms.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2067,7 +2067,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		if ( ! empty( $search_queries ) ) {
-			$search_where = ' AND (' . implode( ') OR (', $search_queries ) . ') ';
+			$search_where = ' AND ((' . implode( ') OR (', $search_queries ) . ')) ';
 		}
 
 		if ( ! empty( $include ) && is_array( $include ) ) {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -76,6 +76,131 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Create a simple product with the given name and status, for OR-term search tests.
+	 *
+	 * @param string $name   Product name.
+	 * @param string $status Post status.
+	 * @return WC_Product_Simple The saved product.
+	 */
+	private function create_search_test_product( string $name, string $status = 'publish' ): WC_Product_Simple {
+		$product = new WC_Product_Simple();
+		$product->set_name( $name );
+		$product->set_status( $status );
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the exclude list to every OR group.
+	 */
+	public function test_search_products_or_term_applies_exclude(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha product' );
+		$beta  = $this->create_search_test_product( 'Searchable beta product' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product', '', false, true, null, null, array( $alpha->get_id() ) );
+
+		$this->assertNotContains( $alpha->get_id(), $results, 'Excluded product matched by the first OR group should not be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Non-excluded product should still be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the include list to every OR group.
+	 */
+	public function test_search_products_or_term_applies_include(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha product' );
+		$beta  = $this->create_search_test_product( 'Searchable beta product' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product', '', false, true, null, array( $beta->get_id() ) );
+
+		$this->assertNotContains( $alpha->get_id(), $results, 'Product outside the include list matched by the first OR group should not be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Included product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the status filter to every OR group.
+	 */
+	public function test_search_products_or_term_applies_status_filter(): void {
+		$draft = $this->create_search_test_product( 'Searchable gamma product', 'draft' );
+		$beta  = $this->create_search_test_product( 'Searchable beta product' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable gamma product or Searchable beta product', '', false, false );
+
+		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the first OR group should not be returned when searching published only' );
+		$this->assertContains( $beta->get_id(), $results, 'Published product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the product type filter to every OR group.
+	 */
+	public function test_search_products_or_term_applies_type_filter(): void {
+		$plain        = $this->create_search_test_product( 'Searchable alpha product' );
+		$downloadable = $this->create_search_test_product( 'Searchable beta product' );
+		$downloadable->set_downloadable( true );
+		$downloadable->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product', 'downloadable', false, true );
+
+		$this->assertNotContains( $plain->get_id(), $results, 'Non-downloadable product matched by the first OR group should not be returned for a downloadable search' );
+		$this->assertContains( $downloadable->get_id(), $results, 'Downloadable product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the post type constraint to every OR group.
+	 */
+	public function test_search_products_or_term_applies_post_type(): void {
+		$alpha   = $this->create_search_test_product( 'Searchable alpha product' );
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Searchable beta product page',
+			)
+		);
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product page', '', false, true );
+
+		$this->assertNotContains( $page_id, $results, 'A page matched by the last OR group should not be returned from a product search' );
+		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
+	}
+
+	/**
+	 * @testdox Search with a three-group OR term should apply the status filter to the middle group.
+	 */
+	public function test_search_products_or_term_applies_status_filter_to_middle_group(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha product' );
+		$draft = $this->create_search_test_product( 'Searchable gamma product', 'draft' );
+		$beta  = $this->create_search_test_product( 'Searchable beta product' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable gamma product or Searchable beta product', '', false, false );
+
+		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the middle OR group should not be returned when searching published only' );
+		$this->assertContains( $alpha->get_id(), $results, 'Published product matched by the first OR group should be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Published product matched by the last OR group should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term without extra filters should return matches from every OR group.
+	 */
+	public function test_search_products_or_term_returns_all_groups(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha product' );
+		$beta  = $this->create_search_test_product( 'Searchable beta product' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product', '', false, true );
+
+		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Product matched by the second OR group should be returned' );
+	}
+
+	/**
 	 * Ensure product rating counts are calculated correctly.
 	 *
 	 * @return void
@@ -381,130 +506,5 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertSame( '20.000000', get_post_meta( $product_id, 'total_sales', true ) );
 		$store->update_product_sales( $product_id, 30.5, 'set' );
 		$this->assertSame( '30.500000', get_post_meta( $product_id, 'total_sales', true ) );
-	}
-
-	/**
-	 * Create a simple product with the given name and status, for OR-term search tests.
-	 *
-	 * @param string $name   Product name.
-	 * @param string $status Post status.
-	 * @return WC_Product_Simple The saved product.
-	 */
-	private function create_search_test_product( string $name, string $status = 'publish' ): WC_Product_Simple {
-		$product = new WC_Product_Simple();
-		$product->set_name( $name );
-		$product->set_status( $status );
-		$product->set_regular_price( '10' );
-		$product->save();
-
-		return $product;
-	}
-
-	/**
-	 * @testdox Search with an OR term should apply the exclude list to every OR group.
-	 */
-	public function test_search_products_or_term_applies_exclude(): void {
-		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
-		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true, null, null, array( $alpha->get_id() ) );
-
-		$this->assertNotContains( $alpha->get_id(), $results, 'Excluded product matched by the first OR group should not be returned' );
-		$this->assertContains( $beta->get_id(), $results, 'Non-excluded product should still be returned' );
-	}
-
-	/**
-	 * @testdox Search with an OR term should apply the include list to every OR group.
-	 */
-	public function test_search_products_or_term_applies_include(): void {
-		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
-		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true, null, array( $beta->get_id() ) );
-
-		$this->assertNotContains( $alpha->get_id(), $results, 'Product outside the include list matched by the first OR group should not be returned' );
-		$this->assertContains( $beta->get_id(), $results, 'Included product should be returned' );
-	}
-
-	/**
-	 * @testdox Search with an OR term should apply the status filter to every OR group.
-	 */
-	public function test_search_products_or_term_applies_status_filter(): void {
-		$draft = $this->create_search_test_product( 'Searchable gamma widget', 'draft' );
-		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable gamma widget or Searchable beta widget', '', false, false );
-
-		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the first OR group should not be returned when searching published only' );
-		$this->assertContains( $beta->get_id(), $results, 'Published product should be returned' );
-	}
-
-	/**
-	 * @testdox Search with an OR term should apply the product type filter to every OR group.
-	 */
-	public function test_search_products_or_term_applies_type_filter(): void {
-		$plain        = $this->create_search_test_product( 'Searchable alpha widget' );
-		$downloadable = $this->create_search_test_product( 'Searchable beta widget' );
-		$downloadable->set_downloadable( true );
-		$downloadable->save();
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', 'downloadable', false, true );
-
-		$this->assertNotContains( $plain->get_id(), $results, 'Non-downloadable product matched by the first OR group should not be returned for a downloadable search' );
-		$this->assertContains( $downloadable->get_id(), $results, 'Downloadable product should be returned' );
-	}
-
-	/**
-	 * @testdox Search with an OR term should apply the post type constraint to every OR group.
-	 */
-	public function test_search_products_or_term_applies_post_type(): void {
-		$alpha   = $this->create_search_test_product( 'Searchable alpha widget' );
-		$page_id = wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Searchable beta widget page',
-			)
-		);
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget page', '', false, true );
-
-		$this->assertNotContains( $page_id, $results, 'A page matched by the last OR group should not be returned from a product search' );
-		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
-	}
-
-	/**
-	 * @testdox Search with a three-group OR term should apply the status filter to the middle group.
-	 */
-	public function test_search_products_or_term_applies_status_filter_to_middle_group(): void {
-		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
-		$draft = $this->create_search_test_product( 'Searchable gamma widget', 'draft' );
-		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable gamma widget or Searchable beta widget', '', false, false );
-
-		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the middle OR group should not be returned when searching published only' );
-		$this->assertContains( $alpha->get_id(), $results, 'Published product matched by the first OR group should be returned' );
-		$this->assertContains( $beta->get_id(), $results, 'Published product matched by the last OR group should be returned' );
-	}
-
-	/**
-	 * @testdox Search with an OR term without extra filters should return matches from every OR group.
-	 */
-	public function test_search_products_or_term_returns_all_groups(): void {
-		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
-		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
-
-		$data_store = WC_Data_Store::load( 'product' );
-		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true );
-
-		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
-		$this->assertContains( $beta->get_id(), $results, 'Product matched by the second OR group should be returned' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -151,6 +151,29 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Search with an OR term including variations should apply the type and status filters to every OR group.
+	 */
+	public function test_search_products_or_term_applies_filters_with_variations(): void {
+		$plain = $this->create_search_test_product( 'Searchable alpha product' );
+
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Searchable beta product' );
+		$parent->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->set_regular_price( '10' );
+		$variation->set_downloadable( true );
+		$variation->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product', 'downloadable', true, false );
+
+		$this->assertNotContains( $plain->get_id(), $results, 'Non-downloadable product matched by the first OR group should not be returned for a downloadable variations search' );
+		$this->assertContains( $variation->get_id(), $results, 'Downloadable variation matched by the second OR group should be returned' );
+	}
+
+	/**
 	 * @testdox Search with an OR term should apply the post type constraint to every OR group.
 	 */
 	public function test_search_products_or_term_applies_post_type(): void {
@@ -162,6 +185,8 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 				'post_title'  => 'Searchable beta product page',
 			)
 		);
+
+		$this->assertGreaterThan( 0, $page_id, 'Page fixture should have been created' );
 
 		$data_store = WC_Data_Store::load( 'product' );
 		$results    = $data_store->search_products( 'Searchable alpha product or Searchable beta product page', '', false, true );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -382,4 +382,113 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$store->update_product_sales( $product_id, 30.5, 'set' );
 		$this->assertSame( '30.500000', get_post_meta( $product_id, 'total_sales', true ) );
 	}
+
+	/**
+	 * Create a simple product with the given name and status, for OR-term search tests.
+	 *
+	 * @param string $name   Product name.
+	 * @param string $status Post status.
+	 * @return WC_Product_Simple The saved product.
+	 */
+	private function create_search_test_product( string $name, string $status = 'publish' ): WC_Product_Simple {
+		$product = new WC_Product_Simple();
+		$product->set_name( $name );
+		$product->set_status( $status );
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the exclude list to every OR group.
+	 */
+	public function test_search_products_or_term_applies_exclude(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
+		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true, null, null, array( $alpha->get_id() ) );
+
+		$this->assertNotContains( $alpha->get_id(), $results, 'Excluded product matched by the first OR group should not be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Non-excluded product should still be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the include list to every OR group.
+	 */
+	public function test_search_products_or_term_applies_include(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
+		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true, null, array( $beta->get_id() ) );
+
+		$this->assertNotContains( $alpha->get_id(), $results, 'Product outside the include list matched by the first OR group should not be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Included product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the status filter to every OR group.
+	 */
+	public function test_search_products_or_term_applies_status_filter(): void {
+		$draft = $this->create_search_test_product( 'Searchable gamma widget', 'draft' );
+		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable gamma widget or Searchable beta widget', '', false, false );
+
+		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the first OR group should not be returned when searching published only' );
+		$this->assertContains( $beta->get_id(), $results, 'Published product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the product type filter to every OR group.
+	 */
+	public function test_search_products_or_term_applies_type_filter(): void {
+		$plain        = $this->create_search_test_product( 'Searchable alpha widget' );
+		$downloadable = $this->create_search_test_product( 'Searchable beta widget' );
+		$downloadable->set_downloadable( true );
+		$downloadable->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', 'downloadable', false, true );
+
+		$this->assertNotContains( $plain->get_id(), $results, 'Non-downloadable product matched by the first OR group should not be returned for a downloadable search' );
+		$this->assertContains( $downloadable->get_id(), $results, 'Downloadable product should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term should apply the post type constraint to every OR group.
+	 */
+	public function test_search_products_or_term_applies_post_type(): void {
+		$alpha   = $this->create_search_test_product( 'Searchable alpha widget' );
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Searchable beta widget page',
+			)
+		);
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget page', '', false, true );
+
+		$this->assertNotContains( $page_id, $results, 'A page matched by the last OR group should not be returned from a product search' );
+		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
+	}
+
+	/**
+	 * @testdox Search with an OR term without extra filters should return matches from every OR group.
+	 */
+	public function test_search_products_or_term_returns_all_groups(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
+		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable beta widget', '', false, true );
+
+		$this->assertContains( $alpha->get_id(), $results, 'Product matched by the first OR group should be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Product matched by the second OR group should be returned' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -479,6 +479,22 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Search with a three-group OR term should apply the status filter to the middle group.
+	 */
+	public function test_search_products_or_term_applies_status_filter_to_middle_group(): void {
+		$alpha = $this->create_search_test_product( 'Searchable alpha widget' );
+		$draft = $this->create_search_test_product( 'Searchable gamma widget', 'draft' );
+		$beta  = $this->create_search_test_product( 'Searchable beta widget' );
+
+		$data_store = WC_Data_Store::load( 'product' );
+		$results    = $data_store->search_products( 'Searchable alpha widget or Searchable gamma widget or Searchable beta widget', '', false, false );
+
+		$this->assertNotContains( $draft->get_id(), $results, 'Draft product matched by the middle OR group should not be returned when searching published only' );
+		$this->assertContains( $alpha->get_id(), $results, 'Published product matched by the first OR group should be returned' );
+		$this->assertContains( $beta->get_id(), $results, 'Published product matched by the last OR group should be returned' );
+	}
+
+	/**
 	 * @testdox Search with an OR term without extra filters should return matches from every OR group.
 	 */
 	public function test_search_products_or_term_returns_all_groups(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

`WC_Product_Data_Store_CPT::search_products()` joins OR search groups as `AND (group1) OR (group2)` without wrapping the disjunction in its own parentheses. `AND` binds tighter than `OR`, so the include, exclude, status and product type clauses apply only to the last group and the post type constraint only to the first. Search terms containing `" or "` could surface drafts, excluded products, or wrong-type products in admin product pickers.

This wraps the disjunction in an extra pair of parentheses so every filter applies to every group, and adds regression coverage for each leak. Single-group terms are unchanged.

Backward compatibility: No signature, hook, or filter changes. Multi-group OR searches lose only rows that violated the caller's `include`, `exclude`, status, and type arguments; since those rows consumed `LIMIT` slots, previously crowded-out legitimate products can also newly appear. Existing linked product selections are unaffected as they render from stored meta, not through this method. Multisite was not tested; no site-scoped state is touched.

Closes #67392.

Bug introduced in PR #16291 (status, type, and post type halves) and PR #23246 (include and exclude halves).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create two published products, "Alpha widget" and "Beta widget", and a draft product "Gamma widget".
2. Edit "Alpha widget", open **Linked Products**, and in the **Upsells** field type `Alpha widget or Beta widget`. Confirm "Alpha widget" itself is not suggested.
3. In the same field type `Gamma widget or Beta widget`. Confirm the draft "Gamma widget" is not suggested.
4. Type `Beta widget` alone and confirm it is still suggested.
5. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Data_Store_CPT_Test`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Reproduced all five leaks on trunk in wp-env using PHP 8.1.34. Seven of the eight new tests go red on trunk and green with the fix; `test_search_products_or_term_returns_all_groups` passes on both and guards against future over-narrowing.
- `WC_Product_Data_Store_CPT_Test` (22 tests) and legacy `WC_Tests_Product_Data_Store` (35 tests) pass.
- Full PHP unit suite: 13,493 tests, 2 failures in unrelated ProductFeed file-locking tests that fail identically without this change.
- PHPStan and PHP lint checks on the changed files completed without errors.
- An adversarial change-risk review found no blocking concerns.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

