### PR TITLE
List the open PRs that block the release ZIP build

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -86,7 +86,7 @@ jobs:
             error="Source branch '$BRANCH' does not exist."
             if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\..+$ ]]; then
               minor="${BASH_REMATCH[2]}"
-              error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
+              error="$error Try 'release/$minor' or '$minor' instead."
             fi
             echo "::error::$error"
             exit 1

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -152,11 +152,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-            # Helper to fail with console error and summary message.
+            # Helper to fail with a console error and summary message. An optional second
+            # argument adds more detail (e.g. a PR list) to the summary only.
             fail() {
               echo "::error::$1"
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "❌ Build failed: $1" >> $GITHUB_STEP_SUMMARY
+              if [[ -n "$2" ]]; then
+                echo "$2" >> $GITHUB_STEP_SUMMARY
+              fi
               exit 1
             }
 
@@ -214,18 +218,18 @@ jobs:
             blocking_total=$( echo "$search_result" | jq '.issueCount' )
             blocking_prs=$( echo "$search_result" | jq '.nodes' )
             if (( blocking_total > 0 )); then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "Open PRs blocking the release (oldest first):" >> $GITHUB_STEP_SUMMARY
-              echo "$blocking_prs" | jq -r '.[] | "- [#\(.number)](\(.url)) " + .title' >> $GITHUB_STEP_SUMMARY
-              if (( blocking_total > 20 )); then
-                search_url="https://github.com/${GH_REPO}/pulls?q=$( echo -n "$pr_query" | jq -sRr @uri )"
-                echo "- ... and $(( blocking_total - 20 )) more ([view all]($search_url))" >> $GITHUB_STEP_SUMMARY
-              fi
-              if [[ $branch_plugin_version == *-beta* ]]; then
-                echo "" >> $GITHUB_STEP_SUMMARY
-                echo "If a PR can't be merged or closed right now, temporarily marking it as a draft or changing its milestone can be used as a workaround." >> $GITHUB_STEP_SUMMARY
-              fi
-              fail "There are open PRs blocking the release."
+              details=$( {
+                echo "$blocking_prs" | jq -r '.[] | "- [#\(.number)](\(.url)) " + .title'
+                if (( blocking_total > 20 )); then
+                  search_url="https://github.com/${GH_REPO}/pulls?q=$( echo -n "$pr_query" | jq -sRr @uri )"
+                  echo "- ... and $(( blocking_total - 20 )) more ([view all]($search_url))"
+                fi
+                if [[ $branch_plugin_version == *-beta* ]]; then
+                  echo ""
+                  echo "If a PR can't be merged or closed right now, temporarily marking it as a draft or changing its milestone can be used as a workaround."
+                fi
+              } )
+              fail "There are open PRs against the release branch ($BRANCH) or with milestone '$milestone'." "$details"
             fi
 
             # Changelog section must have at least one entry.

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
             error="Source branch '$BRANCH' does not exist."
-            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\..+$ ]]; then
               minor="${BASH_REMATCH[2]}"
               error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
             fi

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -84,9 +84,8 @@ jobs:
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
             error="Source branch '$BRANCH' does not exist."
-            if [[ "$BRANCH" =~ ^(release/)?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              minor="${BRANCH%.*}"
-              minor="${minor#release/}"
+            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+              minor="${BASH_REMATCH[2]}"
               error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
             fi
             echo "::error::$error"

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -150,7 +150,7 @@ jobs:
             fail() {
               echo "::error::$1"
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "❌ Build failed. See annotations or workflow logs for details." >> $GITHUB_STEP_SUMMARY
+              echo "❌ Build failed: $1" >> $GITHUB_STEP_SUMMARY
               exit 1
             }
 
@@ -195,17 +195,31 @@ jobs:
               fi
             fi
 
-            # No non-draft PRs against release branch should remain open.
-            count=$( gh pr list --search "is:open draft:false base:$BRANCH" --limit 1 --json number | jq length )
-            if (( count > 0 )); then
-              fail "There are open PRs against the release branch ($BRANCH)."
-            fi
-
-            # No non-draft PRs with same milestone as main version should remain open.
+            # No non-draft PRs against the release branch, or carrying its milestone, should remain open.
             milestone="$version_prefix.0"
-            count=$( gh pr list --search "is:open draft:false milestone:$milestone" --limit 1 --json number | jq length )
-            if (( count > 0 )); then
-              fail "There are open PRs with milestone '$milestone'."
+            pr_query="repo:$GH_REPO is:pr is:open draft:false (base:$BRANCH OR milestone:$milestone) sort:created-asc"
+            search_result=$( gh api graphql -f query='
+              query($q: String!, $limit: Int!) {
+                search(query: $q, type: ISSUE_ADVANCED, first: $limit) {
+                  issueCount
+                  nodes { ... on PullRequest { number title url } }
+                }
+              }' -f q="$pr_query" -F limit=20 --jq '.data.search' )
+            blocking_total=$( echo "$search_result" | jq '.issueCount' )
+            blocking_prs=$( echo "$search_result" | jq '.nodes' )
+            if (( blocking_total > 0 )); then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Open PRs blocking the release (oldest first):" >> $GITHUB_STEP_SUMMARY
+              echo "$blocking_prs" | jq -r '.[] | "- [#\(.number)](\(.url)) " + .title' >> $GITHUB_STEP_SUMMARY
+              if (( blocking_total > 20 )); then
+                search_url="https://github.com/${GH_REPO}/pulls?q=$( echo -n "$pr_query" | jq -sRr @uri )"
+                echo "- ... and $(( blocking_total - 20 )) more ([view all]($search_url))" >> $GITHUB_STEP_SUMMARY
+              fi
+              if [[ $branch_plugin_version == *-beta* ]]; then
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "If a PR can't be merged or closed right now, temporarily marking it as a draft or changing its milestone can be used as a workaround." >> $GITHUB_STEP_SUMMARY
+              fi
+              fail "There are open PRs blocking the release."
             fi
 
             # Changelog section must have at least one entry.

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -219,7 +219,7 @@ jobs:
             blocking_prs=$( echo "$search_result" | jq '.nodes' )
             if (( blocking_total > 0 )); then
               details=$( {
-                echo "$blocking_prs" | jq -r '.[] | "- [#\(.number)](\(.url)) " + .title'
+                echo "$blocking_prs" | jq -r '.[] | "- *[\(.title) #\(.number)](\(.url))*"'
                 if (( blocking_total > 20 )); then
                   search_url="https://github.com/${GH_REPO}/pulls?q=$( echo -n "$pr_query" | jq -sRr @uri )"
                   echo "- ... and $(( blocking_total - 20 )) more ([view all]($search_url))"

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -83,7 +83,13 @@ jobs:
           BRANCH: ${{ steps.normalize-branch.outputs.branch }}
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
-            echo "::error::Source branch '$BRANCH' does not exist."
+            error="Source branch '$BRANCH' does not exist."
+            if [[ "$BRANCH" =~ ^(release/)?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              minor="${BRANCH%.*}"
+              minor="${minor#release/}"
+              error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
+            fi
+            echo "::error::$error"
             exit 1
           fi
 

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -225,7 +225,7 @@ jobs:
                 fi
                 if [[ $branch_plugin_version == *-beta* ]]; then
                   echo ""
-                  echo "If a PR can't be merged or closed right now, temporarily marking it as a draft or changing its milestone can be used as a workaround."
+                  echo "If a PR can't be merged or closed right now, temporarily marking it as a draft can be used as a workaround."
                 fi
               } )
               fail "There are open PRs against the release branch ($BRANCH) or with milestone '$milestone'." "$details"

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -196,16 +196,22 @@ jobs:
             fi
 
             # No non-draft PRs against release branch should remain open.
-            count=$( gh pr list --search "is:open draft:false base:$BRANCH" --limit 1 --json number | jq length )
-            if (( count > 0 )); then
-              fail "There are open PRs against the release branch ($BRANCH)."
+            open_prs=$( gh pr list --search "is:open draft:false base:$BRANCH" --limit 50 --json number,title,url --jq '.[] | "- \(.url): \(.title)"' )
+            if [[ -n "$open_prs" ]]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Open PRs against the release branch ($BRANCH):" >> $GITHUB_STEP_SUMMARY
+              echo "$open_prs" >> $GITHUB_STEP_SUMMARY
+              fail "There are open PRs against the release branch ($BRANCH). See the workflow summary for the list."
             fi
 
             # No non-draft PRs with same milestone as main version should remain open.
             milestone="$version_prefix.0"
-            count=$( gh pr list --search "is:open draft:false milestone:$milestone" --limit 1 --json number | jq length )
-            if (( count > 0 )); then
-              fail "There are open PRs with milestone '$milestone'."
+            open_prs=$( gh pr list --search "is:open draft:false milestone:$milestone" --limit 50 --json number,title,url --jq '.[] | "- \(.url): \(.title)"' )
+            if [[ -n "$open_prs" ]]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Open PRs with milestone '$milestone':" >> $GITHUB_STEP_SUMMARY
+              echo "$open_prs" >> $GITHUB_STEP_SUMMARY
+              fail "There are open PRs with milestone '$milestone'. See the workflow summary for the list."
             fi
 
             # Changelog section must have at least one entry.

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} "$BRANCH" > /dev/null; then
             error="Source branch '$BRANCH' does not exist."
-            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\..+$ ]]; then
               minor="${BASH_REMATCH[2]}"
               error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
             fi

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -62,7 +62,13 @@ jobs:
           BRANCH: ${{ steps.normalize-branch.outputs.branch }}
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} "$BRANCH" > /dev/null; then
-            echo "::error::Source branch '$BRANCH' does not exist."
+            error="Source branch '$BRANCH' does not exist."
+            if [[ "$BRANCH" =~ ^(release/)?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              minor="${BRANCH%.*}"
+              minor="${minor#release/}"
+              error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
+            fi
+            echo "::error::$error"
             exit 1
           fi
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -63,9 +63,8 @@ jobs:
         run: |
           if ! git ls-remote --exit-code --heads https://github.com/${GITHUB_REPOSITORY} "$BRANCH" > /dev/null; then
             error="Source branch '$BRANCH' does not exist."
-            if [[ "$BRANCH" =~ ^(release/)?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              minor="${BRANCH%.*}"
-              minor="${minor#release/}"
+            if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+              minor="${BASH_REMATCH[2]}"
               error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
             fi
             echo "::error::$error"

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -65,7 +65,7 @@ jobs:
             error="Source branch '$BRANCH' does not exist."
             if [[ "$BRANCH" =~ ^(release/)?([0-9]+\.[0-9]+)\..+$ ]]; then
               minor="${BASH_REMATCH[2]}"
-              error="$error Release branches are named by minor version — enter either the full branch name ('release/$minor') or just the minor version ('$minor')."
+              error="$error Try 'release/$minor' or '$minor' instead."
             fi
             echo "::error::$error"
             exit 1

--- a/.linear/release-kickoff-beta.md
+++ b/.linear/release-kickoff-beta.md
@@ -13,7 +13,7 @@ Keep the _[Release Troubleshooting & Recovery](https://developer.woocommerce.com
 ### 1. Pre-build checks
 
 - [ ] Confirm [GitHub services](https://www.githubstatus.com/) are operational.
-- [ ] Verify no open [issues]({repository_url}/issues?q=is:open+is:issue+milestone:{release_milestone}) or [pull requests]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) exist against the `{release_milestone}` milestone. Ping authors to merge or close; if that can't happen yet, mark the PR as a draft or move it off the milestone.
+- [ ] Verify no open [issues]({repository_url}/issues?q=is:open+is:issue+milestone:{release_milestone}) or [pull requests]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) exist against the `{release_milestone}` milestone. Ping authors to merge or close; if that can't happen yet, mark the PR as a draft.
 - [ ] Ensure that there aren't any pull requests [with label "cherry pick failed"]({repository_url}/pulls?q=is:pr+label:%22cherry+pick+failed%22) that apply to this release that haven't been actioned.
 - [ ] Confirm the `Stable tag` value [in the readme.txt on the release branch]({repository_url}/blob/{release_branch}/plugins/woocommerce/readme.txt#L7) matches the one [on WordPress.org's `trunk`](https://plugins.trac.wordpress.org/browser/woocommerce/trunk/readme.txt#L7).
 

--- a/.linear/release-kickoff-beta.md
+++ b/.linear/release-kickoff-beta.md
@@ -13,7 +13,7 @@ Keep the _[Release Troubleshooting & Recovery](https://developer.woocommerce.com
 ### 1. Pre-build checks
 
 - [ ] Confirm [GitHub services](https://www.githubstatus.com/) are operational.
-- [ ] Verify no open [issues]({repository_url}/issues?q=is:open+is:issue+milestone:{release_milestone}) or [pull requests]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) exist against the `{release_milestone}` milestone. Ping authors as needed to merge or close.
+- [ ] Verify no open [issues]({repository_url}/issues?q=is:open+is:issue+milestone:{release_milestone}) or [pull requests]({repository_url}/pulls?q=is:open+is:pr+draft:false+milestone:{release_milestone}) exist against the `{release_milestone}` milestone. Ping authors to merge or close; if that can't happen yet, mark the PR as a draft or move it off the milestone.
 - [ ] Ensure that there aren't any pull requests [with label "cherry pick failed"]({repository_url}/pulls?q=is:pr+label:%22cherry+pick+failed%22) that apply to this release that haven't been actioned.
 - [ ] Confirm the `Stable tag` value [in the readme.txt on the release branch]({repository_url}/blob/{release_branch}/plugins/woocommerce/readme.txt#L7) matches the one [on WordPress.org's `trunk`](https://plugins.trac.wordpress.org/browser/woocommerce/trunk/readme.txt#L7).
 

--- a/docs/contribution/releases/building-and-publishing.md
+++ b/docs/contribution/releases/building-and-publishing.md
@@ -29,7 +29,7 @@ Keep the _[Release Troubleshooting & Recovery](/docs/contribution/releases/troub
 #### 1. Pre-build checks
 
 - [ ] Confirm [GitHub services](https://www.githubstatus.com/) are operational.
-- [ ] Verify no open issues or pull requests exist against the [release milestone](https://github.com/woocommerce/woocommerce/milestones/). Ping authors as needed to merge or close.
+- [ ] Verify no open issues or pull requests exist against the [release milestone](https://github.com/woocommerce/woocommerce/milestones/). Ping authors as needed to merge or close; for betas, marking a PR as a draft or moving it off the milestone works as a temporary workaround.
 - [ ] Ensure that there aren't any pull requests [with label "cherry pick failed"](https://github.com/woocommerce/woocommerce/pulls?q=is:pr+label:%22cherry+pick+failed%22) that apply to this release that haven't been actioned.
 - [ ] Confirm the `Stable tag` value in the readme.txt on the release branch matches the one [on WordPress.org's `trunk`](https://plugins.trac.wordpress.org/browser/woocommerce/trunk/readme.txt#L7).
 

--- a/docs/contribution/releases/building-and-publishing.md
+++ b/docs/contribution/releases/building-and-publishing.md
@@ -29,7 +29,7 @@ Keep the _[Release Troubleshooting & Recovery](/docs/contribution/releases/troub
 #### 1. Pre-build checks
 
 - [ ] Confirm [GitHub services](https://www.githubstatus.com/) are operational.
-- [ ] Verify no open issues or pull requests exist against the [release milestone](https://github.com/woocommerce/woocommerce/milestones/). Ping authors as needed to merge or close; for betas, marking a PR as a draft or moving it off the milestone works as a temporary workaround.
+- [ ] Verify no open issues or pull requests exist against the [release milestone](https://github.com/woocommerce/woocommerce/milestones/). Ping authors as needed to merge or close; for betas, marking a PR as a draft works as a temporary workaround.
 - [ ] Ensure that there aren't any pull requests [with label "cherry pick failed"](https://github.com/woocommerce/woocommerce/pulls?q=is:pr+label:%22cherry+pick+failed%22) that apply to this release that haven't been actioned.
 - [ ] Confirm the `Stable tag` value in the readme.txt on the release branch matches the one [on WordPress.org's `trunk`](https://plugins.trac.wordpress.org/browser/woocommerce/trunk/readme.txt#L7).
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The **Release: Build ZIP file** workflow already checked for open PRs against the release branch and open PRs with the release milestone, but only reported a generic failure. This PR:

- Combines both checks into a single search and lists every blocking PR in the job summary, each linked.
- For beta builds only, notes that temporarily marking a PR as a draft or moving it off the milestone is an acceptable workaround. RC and stable builds still require the PRs to actually be merged or closed.

Separately, it improves the error message in a couple other workflows regarding expected input.

### How to test the changes in this Pull Request:

1. Setup:
   1. Push this branch to `trunk` in a fork.
   2. Make sure `release/11.0` and `release/11.1` exist on the fork.
   3. On `release/11.0`, change the plugin version in `plugins/woocommerce/woocommerce.php` to `11.0.2` via the GH UI.
   4. Ensure your fork has the two milestones `11.0.0` and `11.1.0`.
   5. Using the GitHub UI, open PRs against `release/11.0` (no milestone), `trunk` (milestone `11.0.0`) and `release/11.1`.
2. Run **Release: Build ZIP file** from `trunk` with branch `11.0` and "Create GitHub release" checked. It should fail at "Pre-build verification" and the summary should list the two blocking PRs from step 1.v. against `trunk` (milestone  `11.0.0`) and against `release/11.0`.
3. Close or merge the two blocking PRs and re-run the workflow. It should now pass verification and proceed to the build.
4. Run **Release: Build ZIP file** (or **Release: Bump version number**) from `trunk` with branch `11.0.5` (a nonexistent branch shaped like a patch version). The error should include the hint about entering `release/11.0` or `11.0` instead.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This only changes internal release-process GitHub Actions workflows and documentation.

</details>