### PR TITLE
Fix blank Date type selector in Analytics settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooa7s-1589-date-type-selector-default
+++ b/plugins/woocommerce/changelog/fix-wooa7s-1589-date-type-selector-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Analytics: initialize the Date type selector in Analytics settings with the effective date_paid default instead of rendering blank when the option was never saved.

--- a/plugins/woocommerce/client/admin/client/analytics/settings/config.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/config.js
@@ -23,6 +23,7 @@ export const DEFAULT_ORDER_STATUSES = [
 	'on-hold',
 ];
 export const DEFAULT_DATE_RANGE = 'period=month&compare=previous_year';
+export const DEFAULT_DATE_TYPE = 'date_paid';
 export const SCHEDULED_IMPORT_SETTING_NAME =
 	'woocommerce_analytics_scheduled_import';
 
@@ -152,6 +153,7 @@ const baseConfig = {
 			'Database date field considered for Revenue and Orders reports',
 			'woocommerce'
 		),
+		defaultValue: DEFAULT_DATE_TYPE,
 	},
 };
 

--- a/plugins/woocommerce/client/admin/client/analytics/settings/test/date-type.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/test/date-type.test.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useSettings } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import Settings from '../index';
+import { config } from '../config';
+
+jest.mock( '@woocommerce/data', () => ( {
+	useSettings: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '../historical-data', () => ( {
+	__esModule: true,
+	default: () => <div>Historical Data</div>,
+} ) );
+
+jest.mock( '../default-date', () => ( {
+	__esModule: true,
+	default: () => <div>Default Date</div>,
+} ) );
+
+describe( 'Analytics settings - date type', () => {
+	const mockUpdateAndPersistSettings = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		useSettings.mockReturnValue( {
+			settingsError: false,
+			isRequesting: false,
+			isDirty: false,
+			persistSettings: jest.fn(),
+			updateAndPersistSettings: mockUpdateAndPersistSettings,
+			updateSettings: jest.fn(),
+			wcAdminSettings: {
+				woocommerce_date_type: 'date_completed',
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'defines date_paid as the default value, matching reports behavior', () => {
+		expect( config.woocommerce_date_type.defaultValue ).toBe( 'date_paid' );
+	} );
+
+	it( 'renders the date type selector with the saved value', () => {
+		render( <Settings createNotice={ jest.fn() } query={ {} } /> );
+
+		expect( screen.getByRole( 'combobox' ) ).toHaveValue(
+			'date_completed'
+		);
+	} );
+
+	it( 'resets the date type to date_paid when resetting to defaults', () => {
+		jest.spyOn( window, 'confirm' ).mockReturnValue( true );
+
+		render( <Settings createNotice={ jest.fn() } query={ {} } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: /reset defaults/i } )
+		);
+
+		expect( mockUpdateAndPersistSettings ).toHaveBeenCalledWith(
+			'wcAdminSettings',
+			expect.objectContaining( {
+				woocommerce_date_type: 'date_paid',
+			} )
+		);
+	} );
+} );

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -352,6 +352,7 @@ class Settings {
 			'option_key'  => 'woocommerce_date_type',
 			'label'       => __( 'Date Type', 'woocommerce' ),
 			'description' => __( 'Database date field considered for Revenue and Orders reports', 'woocommerce' ),
+			'default'     => 'date_paid',
 			'type'        => 'select',
 			'options'     => array(
 				'date_created'   => 'date_created',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SettingsTest.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\Settings;
+use WC_REST_Setting_Options_Controller;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the Settings class.
+ */
+class SettingsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should register the date type setting with a 'date_paid' default, matching the reports data stores.
+	 */
+	public function test_date_type_setting_has_date_paid_default(): void {
+		$sut = new Settings();
+
+		$date_type = $this->get_setting_by_id( $sut->add_settings( array() ), 'woocommerce_date_type' );
+
+		$this->assertNotNull( $date_type, 'The woocommerce_date_type setting should be registered in the wc_admin group' );
+		$this->assertSame( 'date_paid', $date_type['default'] ?? null, 'The date type default should match the date_paid fallback used by the reports data stores' );
+	}
+
+	/**
+	 * @testdox Should resolve the date type value to 'date_paid' when the option has never been saved.
+	 */
+	public function test_date_type_value_falls_back_to_date_paid_when_option_is_unset(): void {
+		delete_option( 'woocommerce_date_type' );
+
+		$date_type = $this->get_setting_by_id( $this->get_wc_admin_group_settings(), 'woocommerce_date_type' );
+
+		$this->assertNotNull( $date_type, 'The woocommerce_date_type setting should be registered in the wc_admin group' );
+		$this->assertSame( 'date_paid', $date_type['value'], 'An unset date type option should resolve to the effective default, date_paid' );
+	}
+
+	/**
+	 * @testdox Should resolve the date type value to the saved option value when one exists.
+	 */
+	public function test_date_type_value_reflects_saved_option(): void {
+		update_option( 'woocommerce_date_type', 'date_completed' );
+
+		$date_type = $this->get_setting_by_id( $this->get_wc_admin_group_settings(), 'woocommerce_date_type' );
+
+		$this->assertNotNull( $date_type, 'The woocommerce_date_type setting should be registered in the wc_admin group' );
+		$this->assertSame( 'date_completed', $date_type['value'], 'A saved date type option should be reflected as the setting value' );
+	}
+
+	/**
+	 * Get the resolved wc_admin group settings via the REST settings controller.
+	 *
+	 * @return array
+	 */
+	private function get_wc_admin_group_settings(): array {
+		$settings = ( new WC_REST_Setting_Options_Controller() )->get_group_settings( 'wc_admin' );
+
+		$this->assertIsArray( $settings, 'The wc_admin settings group should resolve to an array of settings' );
+
+		return $settings;
+	}
+
+	/**
+	 * Find a setting by id in a list of settings.
+	 *
+	 * @param array  $settings List of setting definitions.
+	 * @param string $id       Setting id to look for.
+	 * @return array|null The first matching setting, or null if none matches.
+	 */
+	private function get_setting_by_id( array $settings, string $id ): ?array {
+		foreach ( $settings as $setting ) {
+			if ( ( $setting['id'] ?? '' ) === $id ) {
+				return $setting;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

On stores where the `woocommerce_date_type` option was never saved, the Date type selector in Analytics → Settings rendered blank (stuck on the disabled "Select a date type" placeholder), while the Orders and Revenue reports were actually running on `date_paid` — merchants couldn't tell which date basis was active.

The setting was registered without a `default`, so the REST settings controller resolved the unset option to an empty string. This PR registers the setting with `'default' => 'date_paid'` (matching the fallback hardcoded in the Orders report data stores and the revenue report table) and adds the matching `defaultValue` to the client-side config, so "Reset defaults" restores `date_paid` instead of clearing the selector. Unit tests cover both sides.

**Backward compatibility:** the `/wc/v3/settings/wc_admin` REST response now reports `default: date_paid` and resolves `value` to `date_paid` (instead of `""`) when the option is unset. This is additive and aligns the API with the actual behavior of reports; nothing is written to the database, and a saved option value continues to take precedence.

(For Bug Fixes) Bug introduced in PR #36492.

Closes WOOA7S-1589

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
| ------ | ----- |
|<img width="1416" height="1050" alt="Screenshot 2026-08-06 at 8 41 52" src="https://github.com/user-attachments/assets/496db383-6337-42b2-827c-14e639f95e67" />|<img width="1431" height="1042" alt="Screenshot 2026-08-06 at 8 42 23" src="https://github.com/user-attachments/assets/58cf44f0-f56b-4c76-9066-96fc97fefa38" />|

Screenshots are with default values when the date type was not set yet.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Make sure the `woocommerce_date_type` option is absent, as on a store where it was never saved: `wp option delete woocommerce_date_type` (with wp-env: `pnpm --filter=@woocommerce/plugin-woocommerce wp-env run cli wp option delete woocommerce_date_type`).
2. Go to **Analytics → Settings** and locate the **Date type** setting.
3. Verify the selector shows **Date paid** instead of the blank "Select a date type" placeholder.
4. Select **Date created**, click **Save settings**, reload the page, and verify the selector shows **Date created**.
5. Click **Reset defaults** and confirm. Verify the selector returns to **Date paid** (before this fix it went blank).

<!-- End testing instructions -->

### Testing that has already taken place:

- New PHPUnit tests (`tests/php/src/Internal/Admin/SettingsTest.php`): setting registers with a `date_paid` default; an unset option resolves to `date_paid`; a saved option value is still reflected. All written before the fix and watched fail.
- New Jest tests (`client/analytics/settings/test/date-type.test.js`): config default, selector reflecting a saved value, and Reset defaults restoring `date_paid`.
- Related legacy REST settings and orders report API test suites pass (43 tests).
- Manual testing on a local wp-env store: verified the blank selector before the fix and the `date_paid` initialization after it, plus save/reload and Reset defaults flows.
- PHPStan, phpcs (changed lines), and ESLint are clean.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
