### PR TITLE
Fix order withdrawal matching fields

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-withdrawal-match-email-order-number
+++ b/plugins/woocommerce/changelog/fix-order-withdrawal-match-email-order-number
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Match order withdrawal requests by email address and order number

--- a/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
+++ b/plugins/woocommerce/src/Internal/OrderWithdrawal/OrderWithdrawalFormProcessor.php
@@ -364,7 +364,7 @@ final class OrderWithdrawalFormProcessor {
 	}
 
 	/**
-	 * Get an order only when every submitted order-identifying field matches.
+	 * Get an order only when the submitted email and order number match.
 	 *
 	 * @param array<string,string> $data Form data.
 	 */
@@ -417,15 +417,13 @@ final class OrderWithdrawalFormProcessor {
 	}
 
 	/**
-	 * Whether a candidate order exactly matches the submitted identifying data.
+	 * Whether a candidate order matches the submitted email and order number.
 	 *
 	 * @param WC_Order             $order Candidate order.
 	 * @param array<string,string> $data  Form data.
 	 */
 	private function order_matches_form_data( WC_Order $order, array $data ): bool {
 		return $this->normalize_order_number( (string) $order->get_order_number() ) === $this->normalize_order_number( $data[ self::FIELD_ORDER_NUMBER ] )
-			&& $this->text_values_match( $order->get_billing_first_name( 'edit' ), $data[ self::FIELD_FIRST_NAME ] )
-			&& $this->text_values_match( $order->get_billing_last_name( 'edit' ), $data[ self::FIELD_LAST_NAME ] )
 			&& $this->text_values_match( $order->get_billing_email( 'edit' ), $data[ self::FIELD_EMAIL ] );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -343,6 +343,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertTrue( $this->order_has_note_containing( $target_order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The intended order should receive a withdrawal note.' );
 			$this->assertFalse( $this->order_has_note_containing( $different_order, 'Order withdrawal requested' ), 'The order with a different order number should not receive a withdrawal note.' );
 			$this->assert_order_withdrawal_requested( $target_order );
+			$this->assert_order_withdrawal_not_requested( $different_order );
 		} finally {
 			remove_filter( 'woocommerce_order_number', $filter, 10 );
 			$capture['remove']();
@@ -1082,6 +1083,18 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 
 		$this->assertInstanceOf( WC_Order::class, $updated_order, 'The order should still exist.' );
 		$this->assertSame( 'yes', $updated_order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ), 'The matched order should be flagged as having a withdrawal request.' );
+	}
+
+	/**
+	 * Assert that an order has not been flagged as having a withdrawal request.
+	 *
+	 * @param WC_Order $order Order.
+	 */
+	private function assert_order_withdrawal_not_requested( WC_Order $order ): void {
+		$updated_order = wc_get_order( $order->get_id() );
+
+		$this->assertInstanceOf( WC_Order::class, $updated_order, 'The order should still exist.' );
+		$this->assertNotSame( 'yes', $updated_order->get_meta( self::ORDER_WITHDRAWAL_REQUESTED_META_KEY, true, 'edit' ), 'The unmatched order should not be flagged as having a withdrawal request.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderWithdrawal/OrderWithdrawalTest.php
@@ -305,24 +305,21 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not match an order that shares the email but has a different billing name.
+	 * @testdox Should match an order by the submitted order number when multiple orders share the email.
 	 */
-	public function test_process_current_request_matches_only_order_with_same_email_and_billing_name(): void {
-		$target_order         = $this->create_order_for_form_data();
-		$different_name_order = $this->create_order_for_form_data(
-			array(
-				OrderWithdrawalFormProcessor::FIELD_FIRST_NAME => 'Janet',
-				OrderWithdrawalFormProcessor::FIELD_LAST_NAME  => 'Smith',
-			)
-		);
-		$custom_order_number  = 'CUSTOM-1001';
-		$capture              = $this->capture_wp_mail();
-		$filter               = static function ( $order_number, $filtered_order ) use ( $target_order, $different_name_order, $custom_order_number ) {
-			if (
-				$filtered_order instanceof WC_Order
-				&& in_array( $filtered_order->get_id(), array( $target_order->get_id(), $different_name_order->get_id() ), true )
-			) {
-				return $custom_order_number;
+	public function test_process_current_request_matches_same_email_order_by_order_number(): void {
+		$target_order        = $this->create_order_for_form_data();
+		$different_order     = $this->create_order_for_form_data();
+		$target_order_number = 'CUSTOM-1001';
+		$other_order_number  = 'CUSTOM-2002';
+		$capture             = $this->capture_wp_mail();
+		$filter              = static function ( $order_number, $filtered_order ) use ( $target_order, $different_order, $target_order_number, $other_order_number ) {
+			if ( $filtered_order instanceof WC_Order && $target_order->get_id() === $filtered_order->get_id() ) {
+				return $target_order_number;
+			}
+
+			if ( $filtered_order instanceof WC_Order && $different_order->get_id() === $filtered_order->get_id() ) {
+				return $other_order_number;
 			}
 
 			return $order_number;
@@ -333,7 +330,7 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 		try {
 			$this->prepare_post_request(
 				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
-				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => $custom_order_number )
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => $target_order_number )
 			);
 
 			$state          = $this->sut->process_current_request();
@@ -342,12 +339,43 @@ class OrderWithdrawalTest extends WC_Unit_Test_Case {
 			$this->assertSame( 'confirmation', $state->screen, 'Matching submissions should reach the confirmation screen.' );
 			$this->assertCount( 2, $capture['captures'], 'The customer and merchant emails should both be sent.' );
 			$this->assertStringContainsString( str_replace( '&', '&amp;', $target_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should link to the intended order.' );
-			$this->assertStringNotContainsString( str_replace( '&', '&amp;', $different_name_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should not link to the order with a different billing name.' );
+			$this->assertStringNotContainsString( str_replace( '&', '&amp;', $different_order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should not link to the order with a different order number.' );
 			$this->assertTrue( $this->order_has_note_containing( $target_order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The intended order should receive a withdrawal note.' );
-			$this->assertFalse( $this->order_has_note_containing( $different_name_order, 'Order withdrawal requested' ), 'The order with a different billing name should not receive a withdrawal note.' );
+			$this->assertFalse( $this->order_has_note_containing( $different_order, 'Order withdrawal requested' ), 'The order with a different order number should not receive a withdrawal note.' );
 			$this->assert_order_withdrawal_requested( $target_order );
 		} finally {
 			remove_filter( 'woocommerce_order_number', $filter, 10 );
+			$capture['remove']();
+		}
+	}
+
+	/**
+	 * @testdox Should match an order with the correct email and order number even when the billing name differs.
+	 */
+	public function test_process_current_request_matches_order_with_different_billing_name(): void {
+		$order   = $this->create_order_for_form_data(
+			array(
+				OrderWithdrawalFormProcessor::FIELD_FIRST_NAME => 'Janet',
+				OrderWithdrawalFormProcessor::FIELD_LAST_NAME  => 'Smith',
+			)
+		);
+		$capture = $this->capture_wp_mail();
+
+		try {
+			$this->prepare_post_request(
+				OrderWithdrawalFormProcessor::ACTION_CONFIRM,
+				array( OrderWithdrawalFormProcessor::FIELD_ORDER_NUMBER => (string) $order->get_id() )
+			);
+
+			$state          = $this->sut->process_current_request();
+			$merchant_email = $this->get_captured_mail_to( (string) get_option( 'admin_email' ), $capture['captures'] );
+
+			$this->assertSame( 'confirmation', $state->screen, 'Matching submissions should reach the confirmation screen.' );
+			$this->assertCount( 2, $capture['captures'], 'The customer and merchant emails should both be sent.' );
+			$this->assertStringContainsString( str_replace( '&', '&amp;', $order->get_edit_order_url() ), (string) $merchant_email['message'], 'The merchant email should link to the matched order.' );
+			$this->assertTrue( $this->order_has_note_containing( $order, self::ORDER_NOTE_WITHDRAWAL_REQUESTED ), 'The order should receive a withdrawal note even when the billing name differs.' );
+			$this->assert_order_withdrawal_requested( $order );
+		} finally {
 			$capture['remove']();
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Order withdrawal requests should match an order when the submitted email address and order number identify it. This removes first and last name checks from the automatic order matching logic while keeping those fields available for validation and notification details.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order with a known billing email address and billing first/last name.
2. Submit the order withdrawal form using the same order number and billing email address, but enter different first and last names.
3. Confirm the request is matched to the order and WooCommerce adds the order withdrawal note/inbox notification for that order.
4. Submit another order withdrawal form using the same order number but a different email address.
5. Confirm the request is not matched automatically to the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Unit tests
- Manual tests above

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was prepared with AI assistance and reviewed by the author.
