### PR TITLE
Fix variation taxonomy attribute value normalization

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-attribute-term-slugs
+++ b/plugins/woocommerce/changelog/fix-variation-attribute-term-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Normalize product variation taxonomy attribute names to term slugs.

--- a/plugins/woocommerce/changelog/fix-variation-attribute-term-slugs
+++ b/plugins/woocommerce/changelog/fix-variation-attribute-term-slugs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Normalize product variation taxonomy attribute names to term slugs.
+Accept term objects when setting product variation taxonomy attributes.

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -509,9 +509,13 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 	/**
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
-	 * specific attributes using name value pairs.
+	 * specific attributes using name-value pairs. Taxonomy attribute values are converted
+	 * to term slugs when a matching term exists.
 	 *
-	 * @param array $raw_attributes array of raw attributes.
+	 * @param array<string, string> $raw_attributes Array of raw attributes.
+	 *
+	 * @since 3.0.0
+	 * @since 11.1.0 Taxonomy attribute values are normalized to term slugs.
 	 */
 	public function set_attributes( $raw_attributes ) {
 		$raw_attributes = (array) $raw_attributes;
@@ -522,6 +526,19 @@ class WC_Product_Variation extends WC_Product_Simple {
 			if ( 0 === strpos( $key, 'attribute_' ) ) {
 				$key = substr( $key, 10 );
 			}
+
+			if ( is_string( $value ) && '' !== $value && taxonomy_exists( $key ) ) {
+				$term = get_term_by( 'slug', $value, $key );
+
+				if ( ! $term ) {
+					$term = get_term_by( 'name', $value, $key );
+				}
+
+				if ( $term && ! is_wp_error( $term ) ) {
+					$value = $term->slug;
+				}
+			}
+
 			$attributes[ $key ] = $value;
 		}
 		$this->set_prop( 'attributes', $attributes );

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -509,13 +509,14 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 	/**
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
-	 * specific attributes using name-value pairs. Taxonomy attribute values are converted
-	 * to term slugs when a matching term exists.
+	 * specific attributes using name-value pairs. WP_Term values for product attribute
+	 * taxonomies are stored as term slugs.
 	 *
-	 * @param array<string, string> $raw_attributes Array of raw attributes.
+	 * @param array $raw_attributes Array of raw attributes.
+	 * @throws WC_Data_Exception When a WP_Term does not match a product attribute taxonomy.
 	 *
 	 * @since 3.0.0
-	 * @since 11.1.0 Taxonomy attribute values are normalized to term slugs.
+	 * @since 11.1.0 WP_Term values are supported for product attribute taxonomies.
 	 */
 	public function set_attributes( $raw_attributes ) {
 		$raw_attributes = (array) $raw_attributes;
@@ -527,16 +528,20 @@ class WC_Product_Variation extends WC_Product_Simple {
 				$key = substr( $key, 10 );
 			}
 
-			if ( is_string( $value ) && '' !== $value && taxonomy_exists( $key ) ) {
-				$term = get_term_by( 'slug', $value, $key );
-
-				if ( ! $term ) {
-					$term = get_term_by( 'name', $value, $key );
+			if ( $value instanceof WP_Term ) {
+				if ( $key !== $value->taxonomy || ! taxonomy_is_product_attribute( $key ) ) {
+					$this->error(
+						'product_invalid_attribute_term',
+						sprintf(
+							/* translators: 1: Term name, 2: Product attribute taxonomy name. */
+							__( 'The term "%1$s" is not valid for the "%2$s" product attribute.', 'woocommerce' ),
+							$value->name,
+							$key
+						)
+					);
 				}
 
-				if ( $term && ! is_wp_error( $term ) ) {
-					$value = $term->slug;
-				}
+				$value = $value->slug;
 			}
 
 			$attributes[ $key ] = $value;

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -123,22 +123,24 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox A taxonomy attribute term name is normalized to its slug and persisted as such.
+	 * @testdox A product attribute term object is stored as its slug without querying terms.
 	 */
-	public function test_set_attributes_normalizes_taxonomy_term_name_to_slug(): void {
+	public function test_set_attributes_accepts_product_attribute_term(): void {
 		$term_data = wp_insert_term( '7½', 'pa_size' );
 		$this->assertNotWPError( $term_data, 'The test term should be created.' );
 
 		$term = get_term( $term_data['term_id'], 'pa_size' );
 		$this->assertInstanceOf( WP_Term::class, $term, 'The created term should be available.' );
 
-		$this->variation->set_attributes( array( 'pa_size' => $term->name ) );
+		$queries_before = get_num_queries();
+		$this->variation->set_attributes( array( 'pa_size' => $term ) );
 
 		$this->assertSame(
 			array( 'pa_size' => $term->slug ),
 			$this->variation->get_attributes(),
 			'The in-memory attribute should use the term slug.'
 		);
+		$this->assertSame( $queries_before, get_num_queries(), 'Setting attributes should not query terms.' );
 
 		$this->variation->save();
 
@@ -154,6 +156,35 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 			$reloaded_variation->get_attributes()['pa_size'],
 			'The reloaded variation should contain the term slug.'
 		);
+	}
+
+	/**
+	 * @testdox A term from a non-product taxonomy is rejected as a variation attribute value.
+	 */
+	public function test_set_attributes_rejects_non_product_attribute_term(): void {
+		$term_data = wp_insert_term( 'Custom display', 'category' );
+		$this->assertNotWPError( $term_data, 'The test category should be created.' );
+
+		$term = get_term( $term_data['term_id'], 'category' );
+		$this->assertInstanceOf( WP_Term::class, $term, 'The created term should be available.' );
+
+		$this->expectException( WC_Data_Exception::class );
+		$this->expectExceptionMessage( 'The term "Custom display" is not valid for the "category" product attribute.' );
+
+		$this->variation->set_attributes( array( 'category' => $term ) );
+	}
+
+	/**
+	 * @testdox A product attribute term is rejected when its taxonomy does not match the attribute key.
+	 */
+	public function test_set_attributes_rejects_term_for_different_product_attribute(): void {
+		$term = get_term_by( 'slug', 'small', 'pa_size' );
+		$this->assertInstanceOf( WP_Term::class, $term, 'The size term should be available.' );
+
+		$this->expectException( WC_Data_Exception::class );
+		$this->expectExceptionMessage( 'The term "small" is not valid for the "pa_colour" product attribute.' );
+
+		$this->variation->set_attributes( array( 'pa_colour' => $term ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variation-test.php
@@ -123,6 +123,40 @@ class WC_Product_Variation_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A taxonomy attribute term name is normalized to its slug and persisted as such.
+	 */
+	public function test_set_attributes_normalizes_taxonomy_term_name_to_slug(): void {
+		$term_data = wp_insert_term( '7½', 'pa_size' );
+		$this->assertNotWPError( $term_data, 'The test term should be created.' );
+
+		$term = get_term( $term_data['term_id'], 'pa_size' );
+		$this->assertInstanceOf( WP_Term::class, $term, 'The created term should be available.' );
+
+		$this->variation->set_attributes( array( 'pa_size' => $term->name ) );
+
+		$this->assertSame(
+			array( 'pa_size' => $term->slug ),
+			$this->variation->get_attributes(),
+			'The in-memory attribute should use the term slug.'
+		);
+
+		$this->variation->save();
+
+		$this->assertSame(
+			$term->slug,
+			get_post_meta( $this->variation->get_id(), 'attribute_pa_size', true ),
+			'The variation attribute post meta should contain the term slug.'
+		);
+
+		$reloaded_variation = new WC_Product_Variation( $this->variation->get_id() );
+		$this->assertSame(
+			$term->slug,
+			$reloaded_variation->get_attributes()['pa_size'],
+			'The reloaded variation should contain the term slug.'
+		);
+	}
+
+	/**
 	 * @testdox A variation's viewability follows its parent's status.
 	 */
 	public function test_is_viewable_variation_follows_parent_status() {


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Programmatic calls to `WC_Product_Variation::set_attributes()` need to store taxonomy term slugs because variation matching compares against slugs. Passing display names such as `7½` can otherwise persist a value that does not match the term's canonical slug.

This PR reduces the ambiguity, allowing developers to pass a `WP_Term` object. In this way, it stores the term's slug directly. 


<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue being fixed. If one doesn't exist, please create one. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #26233.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a global product attribute with the taxonomy `pa_shoe-size`, add a `7½` term, and assign it to a variable product as a variation attribute.
2. Retrieve the term and pass the `WP_Term` object to the variation:

    ```php
    $term = get_term_by( 'name', '7½', 'pa_shoe-size' );
    $variation->set_attributes( array( 'pa_shoe-size' => $term ) );
    $variation->save();
    ```

3. Confirm `get_attributes()['pa_shoe-size']` and the `attribute_pa_shoe-size` post meta contain the canonical slug (`7%c2%bd`).
4. Pass a category `WP_Term` as an attribute value and confirm `set_attributes()` throws `WC_Data_Exception`.
5. Pass a `pa_shoe-size` term under a different product attribute key and confirm `set_attributes()` throws `WC_Data_Exception`.
6. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Product_Variation_Test`.

<!-- End testing instructions -->

### Testing that has already taken place

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, ensure no sensitive information such as API keys, passwords, or user data is included. -->

- `WC_Product_Variation_Test`: 14 tests and 32 assertions passed using the repository's `wp-env` PHP 8.1 test environment.
- PHP coding standards checks passed for the changed files and full branch diff.
- PHPStan passed for `includes/class-wc-product-variation.php`.
- A query-count regression assertion confirms passing a `WP_Term` to `set_attributes()` performs no term queries.
- Regression tests cover persistence, reloading, unrelated WordPress taxonomies, and mismatched product attribute taxonomies.

### Milestone

<!-- DO NOT remove or modify this section other than checking the box. -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively, manually set the first available milestone that is not in the past unless otherwise specified.

### Changelog entry

<!-- You can optionally enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the "Add changelog to PR" CI job to create and push the entry to the branch. -->

<!-- Due to organization permissions, the job might fail for PRs created from a fork. Possible solutions: -->
<!-- * Create the entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it to the branch. -->
<!-- * Create it from the PR using `pnpm utils changefile pr-number-here -o github-org-name-here`. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required, specify that below and provide a comment. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one. -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one. -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Updates existing functionality
-   [ ] Dev - Development-related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Addresses performance issues
-   [ ] Enhancement - Improves existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select whether this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants or store owners will notice.

- Example: "New bulk editing for products" or "Improved checkout performance."

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes, plugins, or extensions.

- Example: "Hook signature change" or "Deprecated filter."

An AI will analyze this PR and post a draft comment for review and editing.
</details>
