### PR TITLE
Fix REST API HTTP auth to return clear HTTPS-required error instead of misleading permissions error

### DIFF
--- a/plugins/woocommerce/changelog/67439-fix-rest-api-http-auth-error-message
+++ b/plugins/woocommerce/changelog/67439-fix-rest-api-http-auth-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return a clear HTTPS-required error when REST API authentication is attempted over HTTP with API keys, instead of falling through to a misleading permissions error.

--- a/plugins/woocommerce/changelog/fix-rest-api-http-auth-error-message
+++ b/plugins/woocommerce/changelog/fix-rest-api-http-auth-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return a clear "HTTPS is required" error when REST API authentication is attempted over HTTP with API keys, instead of falling through to a misleading permissions error.

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -97,10 +97,26 @@ class WC_REST_Authentication {
 
 		if ( is_ssl() ) {
 			$user_id = $this->perform_basic_authentication();
-		}
 
-		if ( $user_id ) {
-			return $user_id;
+			if ( $user_id ) {
+				return $user_id;
+			}
+		} else {
+			// Check if client attempted Basic Auth without SSL.
+			$has_basic_auth = ( ! empty( $_GET['consumer_key'] ) && ! empty( $_GET['consumer_secret'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				|| ( ! empty( $_SERVER['PHP_AUTH_USER'] ) && ! empty( $_SERVER['PHP_AUTH_PW'] ) );
+
+			if ( $has_basic_auth ) {
+				$this->set_error(
+					new WP_Error(
+						'woocommerce_rest_authentication_error',
+						__( 'HTTPS is required for API key authentication. Please use an HTTPS connection, or use OAuth 1.0a authentication for non-SSL requests.', 'woocommerce' ),
+						array( 'status' => 401 )
+					)
+				);
+
+				return false;
+			}
 		}
 
 		return $this->perform_oauth_authentication();
@@ -204,6 +220,14 @@ class WC_REST_Authentication {
 		// Get user data.
 		$this->user = $this->get_user_data_by_consumer_key( $consumer_key );
 		if ( empty( $this->user ) ) {
+			$this->set_error(
+				new WP_Error(
+					'woocommerce_rest_authentication_error',
+					__( 'Consumer key is invalid.', 'woocommerce' ),
+					array( 'status' => 401 )
+				)
+			);
+
 			return false;
 		}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -95,6 +95,7 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
 		$this->assertStringContainsString( 'HTTPS is required', $response->get_error_message() );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
 
 		remove_filter( 'is_ssl', '__return_false' );
 		unset( $_SERVER['REQUEST_URI'], $_GET['consumer_key'], $_GET['consumer_secret'], $_SERVER['HTTPS'] );
@@ -117,6 +118,7 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
 		$this->assertStringContainsString( 'HTTPS is required', $response->get_error_message() );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
 
 		remove_filter( 'is_ssl', '__return_false' );
 		unset( $_SERVER['REQUEST_URI'], $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $_SERVER['HTTPS'] );
@@ -139,6 +141,7 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
 		$this->assertSame( 'Consumer key is invalid.', $response->get_error_message() );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
 
 		remove_filter( 'is_ssl', '__return_true' );
 		unset( $_SERVER['REQUEST_URI'], $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $_SERVER['HTTPS'] );

--- a/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/class-wc-rest-authentication-tests.php
@@ -4,6 +4,21 @@
  * Tests relating to our REST authentication logic.
  */
 class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_REST_Authentication
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = WC_REST_Authentication::instance();
+	}
 	/**
 	 * The default behaviour is to record a last_access datetime only once per request.
 	 *
@@ -61,5 +76,92 @@ class WC_REST_Authentication_Tests extends WC_REST_Unit_Test_Case {
 		$authenticated_user->setAccessible( false );
 		$update_last_access->setAccessible( false );
 		add_filter( 'woocommerce_disable_rest_api_access_log', $last_access_spy );
+	}
+
+	/**
+	 * @testdox API key query credentials over HTTP should return an HTTPS-required error.
+	 */
+	public function test_query_string_auth_over_http_returns_https_required_error(): void {
+		$this->reset_auth_state();
+
+		$_SERVER['REQUEST_URI']  = '/wp-json/wc/v3/products';
+		$_GET['consumer_key']    = 'ck_test';
+		$_GET['consumer_secret'] = 'cs_test';
+		$_SERVER['HTTPS']        = 'off';
+		add_filter( 'is_ssl', '__return_false' );
+
+		$response = $this->do_rest_get_request( '/wc/v3/products' );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
+		$this->assertStringContainsString( 'HTTPS is required', $response->get_error_message() );
+
+		remove_filter( 'is_ssl', '__return_false' );
+		unset( $_SERVER['REQUEST_URI'], $_GET['consumer_key'], $_GET['consumer_secret'], $_SERVER['HTTPS'] );
+	}
+
+	/**
+	 * @testdox Basic auth credentials over HTTP should return an HTTPS-required error.
+	 */
+	public function test_basic_auth_over_http_returns_https_required_error(): void {
+		$this->reset_auth_state();
+
+		$_SERVER['REQUEST_URI']   = '/wp-json/wc/v3/products';
+		$_SERVER['PHP_AUTH_USER'] = 'ck_test';
+		$_SERVER['PHP_AUTH_PW']   = 'cs_test';
+		$_SERVER['HTTPS']         = 'off';
+		add_filter( 'is_ssl', '__return_false' );
+
+		$response = $this->do_rest_get_request( '/wc/v3/products' );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
+		$this->assertStringContainsString( 'HTTPS is required', $response->get_error_message() );
+
+		remove_filter( 'is_ssl', '__return_false' );
+		unset( $_SERVER['REQUEST_URI'], $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $_SERVER['HTTPS'] );
+	}
+
+	/**
+	 * @testdox Invalid consumer key over HTTPS should return a consumer-key-invalid error.
+	 */
+	public function test_invalid_consumer_key_over_https_returns_error(): void {
+		$this->reset_auth_state();
+
+		$_SERVER['REQUEST_URI']   = '/wp-json/wc/v3/products';
+		$_SERVER['PHP_AUTH_USER'] = 'ck_nonexistent';
+		$_SERVER['PHP_AUTH_PW']   = 'cs_nonexistent';
+		$_SERVER['HTTPS']         = 'on';
+		add_filter( 'is_ssl', '__return_true' );
+
+		$response = $this->do_rest_get_request( '/wc/v3/products' );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'woocommerce_rest_authentication_error', $response->get_error_code() );
+		$this->assertSame( 'Consumer key is invalid.', $response->get_error_message() );
+
+		remove_filter( 'is_ssl', '__return_true' );
+		unset( $_SERVER['REQUEST_URI'], $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $_SERVER['HTTPS'] );
+	}
+
+	/**
+	 * Reset authentication state to prevent cross-test pollution.
+	 */
+	private function reset_auth_state(): void {
+		$error_prop = new ReflectionProperty( $this->sut, 'error' );
+		$error_prop->setAccessible( true );
+		$error_prop->setValue( $this->sut, null );
+
+		$user_prop = new ReflectionProperty( $this->sut, 'user' );
+		$user_prop->setAccessible( true );
+		$user_prop->setValue( $this->sut, null );
+
+		$auth_method_prop = new ReflectionProperty( $this->sut, 'auth_method' );
+		$auth_method_prop->setAccessible( true );
+		$auth_method_prop->setValue( $this->sut, '' );
+
+		$error_prop->setAccessible( false );
+		$user_prop->setAccessible( false );
+		$auth_method_prop->setAccessible( false );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When REST API requests are made over HTTP (non-SSL) with valid API keys, WooCommerce silently skips Basic Authentication and falls through to endpoint permission checks, returning the misleading error `woocommerce_rest_cannot_view: "Sorry, you cannot list resources"` instead of saying HTTPS is required.

**Root Cause:** In `class-wc-rest-authentication.php`, the `authenticate()` method only calls `perform_basic_authentication()` when `is_ssl()` is true. When SSL is false, it falls through to `perform_oauth_authentication()` which returns false (no OAuth params), `$this->error` is never set, and the endpoint permission check fires with the confusing generic error.

**Changes (both in `includes/class-wc-rest-authentication.php`):**

1. **`authenticate()` method:** When `is_ssl()` is false and Basic Auth credentials are detected (either via `$_GET` params or `PHP_AUTH_USER`/`PHP_AUTH_PW`), set a `WP_Error` with message: *"HTTPS is required for API key authentication. Please use an HTTPS connection, or use OAuth 1.0a authentication for non-SSL requests."* and return false — this causes `check_authentication_error()` to surface the clear error before endpoint permission checks run.

2. **`perform_basic_authentication()` method:** When the consumer key lookup returns no user, set an error *"Consumer key is invalid."* — consistent with the same error already set in `perform_oauth_authentication()`.

### How to test the changes in this Pull Request:

1. Make a REST API request over HTTP (not HTTPS) with valid API keys:
   ```bash
   curl -u "ck_xxx:cs_xxx" http://localhost:8888/wp-json/wc/v3/products
   ```
2. Before: returns `{"code":"woocommerce_rest_cannot_view","message":"Sorry, you cannot list resources.","data":{"status":401}}`
3. After: returns `{"code":"woocommerce_rest_authentication_error","message":"HTTPS is required for API key authentication. Please use an HTTPS connection, or use OAuth 1.0a authentication for non-SSL requests.","data":{"status":401}}`

### Testing that has already taken place:

- PHPCS linting passes with 0 errors and 0 warnings.
- Manually verified the logic flow: when `is_ssl()` is false and Basic Auth params are present, `set_error()` is called with the correct `WP_Error` which `check_authentication_error()` surfaces on the `rest_authentication_errors` filter (priority 15), short-circuiting REST processing before endpoint permission checks.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the "Add changelog to PR" CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [x] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Return a clear HTTPS-required error when REST API authentication is attempted over HTTP with API keys, instead of falling through to a misleading permissions error.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
