### PR TITLE
Clarify variation taxonomy attribute values

### DIFF
--- a/plugins/woocommerce/changelog/docs-variation-attribute-term-slugs
+++ b/plugins/woocommerce/changelog/docs-variation-attribute-term-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Clarify that variation taxonomy attribute values must use term slugs.

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -512,9 +512,8 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * specific attributes using name-value pairs. Taxonomy attribute values must use term
 	 * slugs, which can be URL-encoded and differ from the term name.
 	 *
-	 * For example, a variation with a global "Size" attribute whose term name is "7½"
 	 * For example, if a global "Size" attribute has a term named "7½", whose stored
-     * slug is "7%c2%bd", configure the variation using that term slug:
+	 * slug is "7%c2%bd", configure the variation using that term slug:
 	 *
 	 * $variation->set_attributes(
 	 *     array(

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -509,9 +509,14 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 	/**
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
-	 * specific attributes using name value pairs.
+	 * specific attributes using name-value pairs. Taxonomy attribute values must use term
+	 * slugs, which can be URL-encoded and differ from the term name (for example, a term
+	 * named "7½" can have the slug "7%c2%bd").
 	 *
-	 * @param array $raw_attributes array of raw attributes.
+	 * @param array $raw_attributes Array of raw attributes.
+	 *
+	 * @since 3.0.0
+	 * @since 11.1.0 Clarified that taxonomy attribute values must use term slugs.
 	 */
 	public function set_attributes( $raw_attributes ) {
 		$raw_attributes = (array) $raw_attributes;

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -510,13 +510,20 @@ class WC_Product_Variation extends WC_Product_Simple {
 	/**
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
 	 * specific attributes using name-value pairs. Taxonomy attribute values must use term
-	 * slugs, which can be URL-encoded and differ from the term name (for example, a term
-	 * named "7½" can have the slug "7%c2%bd").
+	 * slugs, which can be URL-encoded and differ from the term name.
+	 *
+	 * For example, a variation with a global "Size" attribute whose term name is "7½"
+	 * should be configured using the "7%c2%bd" term slug:
+	 *
+	 * $variation->set_attributes(
+	 *     array(
+	 *         'pa_size' => '7%c2%bd',
+	 *     )
+	 * );
 	 *
 	 * @param array $raw_attributes Array of raw attributes.
 	 *
 	 * @since 3.0.0
-	 * @since 11.1.0 Clarified that taxonomy attribute values must use term slugs.
 	 */
 	public function set_attributes( $raw_attributes ) {
 		$raw_attributes = (array) $raw_attributes;

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -513,7 +513,8 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * slugs, which can be URL-encoded and differ from the term name.
 	 *
 	 * For example, a variation with a global "Size" attribute whose term name is "7½"
-	 * should be configured using the "7%c2%bd" term slug:
+	 * For example, if a global "Size" attribute has a term named "7½", whose stored
+     * slug is "7%c2%bd", configure the variation using that term slug:
 	 *
 	 * $variation->set_attributes(
 	 *     array(


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Variation taxonomy attributes are stored and matched using term slugs, but the `WC_Product_Variation::set_attributes()` docblock does not state that requirement. Clarify that callers must supply term slugs and that canonical slugs can be URL-encoded and differ from display names, such as the term name `7½` and slug `7%c2%bd`.


In https://github.com/woocommerce/woocommerce/pull/67435, I explored another solution, but I don't think that it is worth it. 
This is a documentation-only change; runtime behavior and the public method signature remain unchanged.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to #26233.

Slack thread: p1785951060946139-slack-C02SGH7JBGS

<!-- Begin testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set to the first available milestone that is not in the past (unless otherwise specified).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze the PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to draft the documentation and PR description and to run the repository verification commands. The resulting changes were reviewed by the author.