### PR TITLE
Email editor: Center table header cells by default

### DIFF
--- a/packages/php/email-editor/changelog/fix-wooplug-7408-table-header-alignment
+++ b/packages/php/email-editor/changelog/fix-wooplug-7408-table-header-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Center table header cells in rendered emails when no alignment is set, so they match the editor canvas instead of falling back to left.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-table.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-table.php
@@ -366,6 +366,11 @@ class Table extends Abstract_Block_Renderer {
 			return 'left';
 		}
 
+		// Header cells fall back to center, which is what the browser stylesheet gives them in the editor.
+		if ( 'TH' === $html->get_tag() ) {
+			return 'center';
+		}
+
 		return $rendering_context->get_default_text_align();
 	}
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Table_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Table_Test.php
@@ -632,6 +632,46 @@ class Table_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it centers header cells without alignment, like the editor does, while body cells stay left.
+	 */
+	public function testItCentersHeaderCellsWithoutExplicitAlignment(): void {
+		$parsed_table = $this->parsed_table;
+		unset( $parsed_table['attrs']['textAlign'] );
+		$parsed_table['innerHTML'] = $this->simple_table_content;
+
+		$rendered = $this->table_renderer->render( $this->simple_table_content, $parsed_table, $this->rendering_context );
+
+		$html = new \WP_HTML_Tag_Processor( $rendered );
+
+		$this->assertTrue( $html->next_tag( array( 'tag_name' => 'TH' ) ) );
+		$this->assertStringContainsString( 'text-align: center;', (string) $html->get_attribute( 'style' ) );
+
+		$this->assertTrue( $html->next_tag( array( 'tag_name' => 'TD' ) ) );
+		$this->assertStringContainsString( 'text-align: left;', (string) $html->get_attribute( 'style' ) );
+	}
+
+	/**
+	 * Test it keeps explicit header cell alignment instead of the centered fallback.
+	 */
+	public function testItPreservesExplicitHeaderCellAlignment(): void {
+		$content = '<table><thead><tr><th class="has-text-align-right">Header</th><th data-align="left">Header 2</th></tr></thead></table>';
+
+		$parsed_table = $this->parsed_table;
+		unset( $parsed_table['attrs']['textAlign'] );
+		$parsed_table['innerHTML'] = $content;
+
+		$rendered = $this->table_renderer->render( $content, $parsed_table, $this->rendering_context );
+
+		$html = new \WP_HTML_Tag_Processor( $rendered );
+
+		$this->assertTrue( $html->next_tag( array( 'tag_name' => 'TH' ) ) );
+		$this->assertStringContainsString( 'text-align: right;', (string) $html->get_attribute( 'style' ) );
+
+		$this->assertTrue( $html->next_tag( array( 'tag_name' => 'TH' ) ) );
+		$this->assertStringContainsString( 'text-align: left;', (string) $html->get_attribute( 'style' ) );
+	}
+
+	/**
 	 * Test it applies fixed table layout when has-fixed-layout class is present
 	 */
 	public function testItAppliesFixedTableLayout(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Table headers looked centered in the editor but left aligned in the sent email. The browser stylesheet centers `<th>` text in the editor, but the renderer used the default text alignment instead.

Now `Table::get_cell_text_alignment()` falls back to `center` for `<th>` cells. Body cells keep the default. Explicit alignment (`data-align` or a `has-text-align-*` class) still wins, so headers with explicitly set alignment are not changed.

Closes [WOOPLUG-7408: Table header alignment differs between editor and rendered email](https://linear.app/a8c/issue/WOOPLUG-7408/table-header-alignment-differs-between-editor-and-rendered-email).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Editor | Email Before | Email After |
| ------ | ------ | ----- |
| <img width="1246" height="1498" alt="AunYPeugbMtZggsC@2x" src="https://github.com/user-attachments/assets/fd016815-da82-4ec8-b813-e70daef9c00e" /> | <img width="1240" height="1556" alt="XOTM8L1Lt7Py8vDU@2x" src="https://github.com/user-attachments/assets/73788e9e-1e78-44e3-91b0-227ed99f0bfa" /> | <img width="1236" height="1554" alt="ZPejo7R76jcRo2BK@2x" src="https://github.com/user-attachments/assets/5a21ab76-758d-43a2-b88f-7d590a581f2d" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Open any email in the block email editor WooCommerce → Settings → Emails.
2. Add a Table block with a header сецтион and a few body cells. Do not change any alignment.
3. In the editor, the header text is centered and the body text is left aligned.
4. Send a test email or open the email preview. The header text should be centered too.
5. Back in the editor, set one header cell to right aligned and check the alignment in the rendered email again.
6. That cell stays right aligned and other headers stay centered.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
