### PR TITLE
Harden Reviews blocks tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-67434-harden-reviews-blocks-tests
+++ b/plugins/woocommerce/changelog/fix-67434-harden-reviews-blocks-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Harden Reviews blocks tests
+
+

--- a/plugins/woocommerce/changelog/fix-67434-harden-reviews-blocks-tests
+++ b/plugins/woocommerce/changelog/fix-67434-harden-reviews-blocks-tests
@@ -1,5 +1,5 @@
 Significance: patch
-Type: fix
+Type: dev
 Comment: Harden Reviews blocks tests
 
 

--- a/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/reviews.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/reviews.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-# Add a couple of reviews to Hoodie.
+# Add reviews to Hoodie. Order matters: specs treat the last created review as most recent.
+# Include three distinct ratings so latest / highest / lowest are different reviews.
 hoodie_post_id=$(wp post list --post_type=product --field=ID --name="Hoodie" --format=ids)
+wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Worst ever!" --rating=1 --user=1
 wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Nice album!" --rating=5 --user=1
 wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Not bad." --rating=4 --user=1
 

--- a/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/reviews.sh
+++ b/plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/reviews.sh
@@ -3,7 +3,7 @@
 # Add reviews to Hoodie. Order matters: specs treat the last created review as most recent.
 # Include three distinct ratings so latest / highest / lowest are different reviews.
 hoodie_post_id=$(wp post list --post_type=product --field=ID --name="Hoodie" --format=ids)
-wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Worst ever!" --rating=1 --user=1
+wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="It's ok." --rating=3 --user=1
 wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Nice album!" --rating=5 --user=1
 wp wc product_review create $hoodie_post_id --name="Jane Smith" --email="customer@woocommerceblockse2etestsuite.com" --review="Not bad." --rating=4 --user=1
 

--- a/plugins/woocommerce/tests/e2e/test-data/blocks/data/data.ts
+++ b/plugins/woocommerce/tests/e2e/test-data/blocks/data/data.ts
@@ -60,7 +60,14 @@ const customer = {
 
 // Reviews are ordered by when they were created.
 // source: plugins/woocommerce/tests/e2e/bin/blocks/scripts/parallel/reviews.sh
+// Three distinct ratings so latest / highest / lowest are different reviews.
 const hoodieReviews = [
+	{
+		name: `${ customer.first_name } ${ customer.last_name }`,
+		email: customer.email,
+		review: 'Worst ever!',
+		rating: 1,
+	},
 	{
 		name: `${ customer.first_name } ${ customer.last_name }`,
 		email: customer.email,

--- a/plugins/woocommerce/tests/e2e/test-data/blocks/data/data.ts
+++ b/plugins/woocommerce/tests/e2e/test-data/blocks/data/data.ts
@@ -65,8 +65,8 @@ const hoodieReviews = [
 	{
 		name: `${ customer.first_name } ${ customer.last_name }`,
 		email: customer.email,
-		review: 'Worst ever!',
-		rating: 1,
+		review: "It's ok.",
+		rating: 3,
 	},
 	{
 		name: `${ customer.first_name } ${ customer.last_name }`,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-category/reviews-by-category.block_theme.spec.ts
@@ -21,73 +21,92 @@ const lowestRating = [ ...hoodieReviews ].sort(
 const BLOCK_NAME = 'woocommerce/reviews-by-category';
 
 test.describe( `${ BLOCK_NAME } Block`, () => {
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.describe( 'with a category selected', () => {
+		test.beforeEach( async ( { admin, editor } ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: BLOCK_NAME } );
+
+			const blockLocator = await editor.getBlockByName( BLOCK_NAME );
+			const categoryCheckbox = blockLocator.getByRole( 'checkbox', {
+				name: 'Clothing',
+				exact: true,
+			} );
+			await categoryCheckbox.check();
+			await expect( categoryCheckbox ).toBeChecked();
+
+			await blockLocator.getByRole( 'button', { name: 'Done' } ).click();
+		} );
+
+		test( 'block can be inserted and it successfully renders a review in the editor and the frontend', async ( {
+			page,
+			editor,
+		} ) => {
+			await expect(
+				editor.canvas.getByText( hoodieReviews[ 0 ].review )
+			).toBeVisible();
+
+			await editor.publishAndVisitPost();
+
+			await expect(
+				page.getByText( hoodieReviews[ 0 ].review )
+			).toBeVisible();
+		} );
+
+		test( 'sorts by most recent review by default and can sort by highest rating', async ( {
+			page,
+			frontendUtils,
+			editor,
+		} ) => {
+			await editor.publishAndVisitPost();
+
+			const block = await frontendUtils.getBlockByName( BLOCK_NAME );
+
+			const reviews = block.locator(
+				'.wc-block-components-review-list-item__text'
+			);
+
+			await expect( reviews.first() ).toHaveText( latestReview.review );
+
+			const select = page.getByLabel( 'Order by' );
+			await select.selectOption( 'Highest rating' );
+
+			await expect( reviews.first() ).toHaveText( highestRating.review );
+		} );
+
+		test( 'can sort by lowest rating', async ( {
+			page,
+			frontendUtils,
+			editor,
+		} ) => {
+			await editor.publishAndVisitPost();
+
+			const block = await frontendUtils.getBlockByName( BLOCK_NAME );
+
+			const reviews = block.locator(
+				'.wc-block-components-review-list-item__text'
+			);
+
+			await expect( reviews.first() ).toHaveText( latestReview.review );
+
+			const select = page.getByLabel( 'Order by' );
+			await select.selectOption( 'Lowest rating' );
+
+			await expect( reviews.first() ).toHaveText( lowestRating.review );
+		} );
+	} );
+
+	test( 'renders no reviews on the frontend when published without a category selected', async ( {
+		admin,
+		editor,
+		frontendUtils,
+	} ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: BLOCK_NAME } );
-
-		const blockLocator = await editor.getBlockByName( BLOCK_NAME );
-		const categoryCheckbox = blockLocator.getByRole( 'checkbox', {
-			name: 'Clothing',
-			exact: true,
-		} );
-		await categoryCheckbox.check();
-		await expect( categoryCheckbox ).toBeChecked();
-
-		await blockLocator.getByRole( 'button', { name: 'Done' } ).click();
-	} );
-
-	test( 'block can be inserted and it successfully renders a review in the editor and the frontend', async ( {
-		page,
-		editor,
-	} ) => {
-		await expect(
-			editor.canvas.getByText( hoodieReviews[ 0 ].review )
-		).toBeVisible();
-
-		await editor.publishAndVisitPost();
-
-		await expect(
-			page.getByText( hoodieReviews[ 0 ].review )
-		).toBeVisible();
-	} );
-
-	test( 'sorts by most recent review by default and can sort by highest rating', async ( {
-		page,
-		frontendUtils,
-		editor,
-	} ) => {
 		await editor.publishAndVisitPost();
 
 		const block = await frontendUtils.getBlockByName( BLOCK_NAME );
-
-		const reviews = block.locator(
-			'.wc-block-components-review-list-item__text'
-		);
-
-		await expect( reviews.first() ).toHaveText( latestReview.review );
-
-		const select = page.getByLabel( 'Order by' );
-		await select.selectOption( 'Highest rating' );
-
-		await expect( reviews.first() ).toHaveText( highestRating.review );
-	} );
-
-	test( 'can sort by lowest rating', async ( {
-		page,
-		frontendUtils,
-		editor,
-	} ) => {
-		await editor.publishAndVisitPost();
-
-		const block = await frontendUtils.getBlockByName( BLOCK_NAME );
-
-		const reviews = block.locator(
-			'.wc-block-components-review-list-item__text'
-		);
-
-		const select = page.getByLabel( 'Order by' );
-		await select.selectOption( 'Lowest rating' );
-
-		await expect( reviews.first() ).toHaveText( lowestRating.review );
+		await expect(
+			block.locator( '.wc-block-components-review-list-item__text' )
+		).toHaveCount( 0 );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-product/reviews-by-product.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/reviews-by-product/reviews-by-product.block_theme.spec.ts
@@ -21,71 +21,88 @@ const lowestRating = [ ...hoodieReviews ].sort(
 )[ 0 ];
 
 test.describe( `${ BLOCK_NAME } Block`, () => {
-	test.beforeEach( async ( { admin, editor } ) => {
+	test.describe( 'with a product selected', () => {
+		test.beforeEach( async ( { admin, editor } ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: BLOCK_NAME } );
+
+			const productCheckbox = editor.canvas.getByLabel(
+				'Hoodie, has 3 reviews'
+			);
+			await productCheckbox.check();
+			await expect( productCheckbox ).toBeChecked();
+
+			await editor.canvas.getByRole( 'button', { name: 'Done' } ).click();
+		} );
+
+		test( 'block can be inserted and it successfully renders a review in the editor and the frontend', async ( {
+			page,
+			editor,
+		} ) => {
+			await expect(
+				editor.canvas.getByText( hoodieReviews[ 0 ].review )
+			).toBeVisible();
+
+			await editor.publishAndVisitPost();
+
+			await expect(
+				page.getByText( hoodieReviews[ 0 ].review )
+			).toBeVisible();
+		} );
+
+		test( 'sorts by most recent by default and can sort by highest rating', async ( {
+			page,
+			frontendUtils,
+			editor,
+		} ) => {
+			await editor.publishAndVisitPost();
+			const block = await frontendUtils.getBlockByName( BLOCK_NAME );
+
+			const reviews = block.locator(
+				'.wc-block-components-review-list-item__text'
+			);
+
+			await expect( reviews.first() ).toHaveText( latestReview.review );
+
+			const select = page.getByLabel( 'Order by' );
+			await select.selectOption( 'Highest rating' );
+
+			await expect( reviews.first() ).toHaveText( highestRating.review );
+		} );
+
+		test( 'can sort by lowest rating', async ( {
+			page,
+			frontendUtils,
+			editor,
+		} ) => {
+			await editor.publishAndVisitPost();
+			const block = await frontendUtils.getBlockByName( BLOCK_NAME );
+
+			const reviews = block.locator(
+				'.wc-block-components-review-list-item__text'
+			);
+
+			await expect( reviews.first() ).toHaveText( latestReview.review );
+
+			const select = page.getByLabel( 'Order by' );
+			await select.selectOption( 'Lowest rating' );
+
+			await expect( reviews.first() ).toHaveText( lowestRating.review );
+		} );
+	} );
+
+	test( 'renders no reviews on the frontend when published without a product selected', async ( {
+		admin,
+		editor,
+		frontendUtils,
+	} ) => {
 		await admin.createNewPost();
 		await editor.insertBlock( { name: BLOCK_NAME } );
-
-		const productCheckbox = editor.canvas.getByLabel(
-			'Hoodie, has 2 reviews'
-		);
-		await productCheckbox.check();
-		await expect( productCheckbox ).toBeChecked();
-
-		await editor.canvas.getByRole( 'button', { name: 'Done' } ).click();
-	} );
-
-	test( 'block can be inserted and it successfully renders a review in the editor and the frontend', async ( {
-		page,
-		editor,
-	} ) => {
-		await expect(
-			editor.canvas.getByText( hoodieReviews[ 0 ].review )
-		).toBeVisible();
-
 		await editor.publishAndVisitPost();
 
-		await expect(
-			page.getByText( hoodieReviews[ 0 ].review )
-		).toBeVisible();
-	} );
-
-	test( 'sorts by most recent by default and can sort by highest rating', async ( {
-		page,
-		frontendUtils,
-		editor,
-	} ) => {
-		await editor.publishAndVisitPost();
 		const block = await frontendUtils.getBlockByName( BLOCK_NAME );
-
-		const reviews = block.locator(
-			'.wc-block-components-review-list-item__text'
-		);
-
-		await expect( reviews.first() ).toHaveText( latestReview.review );
-
-		const select = page.getByLabel( 'Order by' );
-		await select.selectOption( 'Highest rating' );
-
-		await expect( reviews.first() ).toHaveText( highestRating.review );
-	} );
-
-	test( 'can sort by lowest rating', async ( {
-		page,
-		frontendUtils,
-		editor,
-	} ) => {
-		await editor.publishAndVisitPost();
-		const block = await frontendUtils.getBlockByName( BLOCK_NAME );
-
-		const reviews = block.locator(
-			'.wc-block-components-review-list-item__text'
-		);
-
-		await expect( reviews.first() ).toHaveText( latestReview.review );
-
-		const select = page.getByLabel( 'Order by' );
-		await select.selectOption( 'Lowest rating' );
-
-		await expect( reviews.first() ).toHaveText( lowestRating.review );
+		await expect(
+			block.locator( '.wc-block-components-review-list-item__text' )
+		).toHaveCount( 0 );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #67434.

Since #67324, a regression in the _Order by_ selector might not be caught by e2e tests because we were testing with too few reviews. This PR fixes that and adds an extra test for the case of no product/category being selected.

(For Bug Fixes) Bug introduced in PR #67324.

Note: it's easier to review this PR with the _Hide whitespace_ option.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass.
2. Optionally, make a change that breaks sorting in the reviews blocks (like commenting out [these lines](https://github.com/woocommerce/woocommerce/blob/cf804742dee8265954e3a3db79cfe66347bb9776/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/utils.js#L9-L24)) and verify tests fail.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->