### PR TITLE
Store API: keep a fully reserved stock level as a quantity limit

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-quantity-limit-fully-reserved-stock
+++ b/plugins/woocommerce/changelog/fix-store-api-quantity-limit-fully-reserved-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: stop discarding a remaining stock of 0 when calculating quantity limits, so a product whose whole stock is reserved by pending orders no longer advertises its unreserved stock quantity as the maximum.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -71425,18 +71425,6 @@ parameters:
 			path: src/StoreApi/Utilities/QuantityLimits.php
 
 		-
-			message: '#^Parameter \#1 \$value of method Automattic\\WooCommerce\\StoreApi\\Utilities\\QuantityLimits\:\:filter_numeric_value\(\) expects float\|int, float\|int\<min, \-1\>\|int\<1, max\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/StoreApi/Utilities/QuantityLimits.php
-
-		-
-			message: '#^Parameter \#1 \.\.\.\$arg1 of function min expects non\-empty\-array, array\{0\?\: float\|int\<1, max\>, 1\?\: float\|int\<min, \-1\>\|int\<1, max\>\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/StoreApi/Utilities/QuantityLimits.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$limit\.$#'
 			identifier: property.notFound
 			count: 2

--- a/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
@@ -208,7 +208,11 @@ final class QuantityLimits {
 			$limits[] = $this->get_remaining_stock( $product );
 		}
 
-		return $this->filter_numeric_value( min( array_filter( $limits ) ), 'limit', $product, $cart_item );
+		// Remaining stock of 0 is a valid limit, so only unknown (null) stock levels are discarded.
+		// Filtering by truthiness would drop that 0 and leave the purchase limit unconstrained.
+		$limits = array_filter( $limits, static fn( $limit ) => ! is_null( $limit ) );
+
+		return $this->filter_numeric_value( min( $limits ), 'limit', $product, $cart_item );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -349,6 +349,7 @@ class WC_Unit_Tests_Bootstrap {
 		require_once dirname( $this->tests_dir ) . '/php/helpers/SerializingCacheTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/LoggerSpyTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/MetaDataAssertionTrait.php';
+		require_once dirname( $this->tests_dir ) . '/php/helpers/StockReservationOptionsTrait.php';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/helpers/StockReservationOptionsTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/StockReservationOptionsTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\WooCommerce\RestApi\UnitTests;
+
+/**
+ * Trait StockReservationOptionsTrait.
+ *
+ * Runs a callback with the options stock reservation depends on, and restores them afterwards.
+ */
+trait StockReservationOptionsTrait {
+
+	/**
+	 * Run a callback with stock reservation enabled, then restore the options it touched.
+	 *
+	 * Options that did not exist beforehand are deleted rather than written back, so a test does not
+	 * leave an empty value behind for the rest of the run.
+	 *
+	 * @param callable        $callback Callback to run.
+	 * @param string|int|null $hold_stock_minutes Value for `woocommerce_hold_stock_minutes`, or null to leave it alone.
+	 * @return mixed Whatever the callback returns.
+	 */
+	protected function with_stock_reservation_options( callable $callback, $hold_stock_minutes = null ) {
+		$option_values = array(
+			'woocommerce_manage_stock'   => 'yes',
+			// Stock reservation needs the table added in WooCommerce 4.3.
+			'woocommerce_schema_version' => 430,
+		);
+
+		if ( ! is_null( $hold_stock_minutes ) ) {
+			$option_values['woocommerce_hold_stock_minutes'] = $hold_stock_minutes;
+		}
+
+		$missing_option_value = new \stdClass();
+		$original_options     = array();
+
+		foreach ( array_keys( $option_values ) as $option_name ) {
+			$option_value                     = get_option( $option_name, $missing_option_value );
+			$original_options[ $option_name ] = array(
+				'exists' => $missing_option_value !== $option_value,
+				'value'  => $option_value,
+			);
+		}
+
+		foreach ( $option_values as $option_name => $option_value ) {
+			update_option( $option_name, $option_value );
+		}
+
+		try {
+			return $callback();
+		} finally {
+			foreach ( $original_options as $option_name => $option_data ) {
+				if ( $option_data['exists'] ) {
+					update_option( $option_name, $option_data['value'] );
+				} else {
+					delete_option( $option_name );
+				}
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/helpers/StockReservationOptionsTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/StockReservationOptionsTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\RestApi\UnitTests;
 

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -7,11 +7,14 @@
 
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
+use Automattic\WooCommerce\RestApi\UnitTests\StockReservationOptionsTrait;
 
 /**
  * Class WC_Stock_Functions_Tests.
  */
 class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
+	use StockReservationOptionsTrait;
+
 	/**
 	 * Product reused by independent stock transitions within one test method.
 	 *
@@ -81,47 +84,6 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$order->set_status( $status );
 		$order->save();
 		return $order;
-	}
-
-	/**
-	 * Run a callback with stock reservation enabled and the configured hold duration.
-	 *
-	 * @param string   $hold_stock_minutes Configured hold stock duration.
-	 * @param callable $callback Callback to run.
-	 * @return mixed
-	 */
-	private function with_stock_reservation_options( $hold_stock_minutes, $callback ) {
-		$option_names         = array(
-			'woocommerce_hold_stock_minutes',
-			'woocommerce_manage_stock',
-			'woocommerce_schema_version',
-		);
-		$missing_option_value = new stdClass();
-		$original_options     = array();
-
-		foreach ( $option_names as $option_name ) {
-			$option_value                     = get_option( $option_name, $missing_option_value );
-			$original_options[ $option_name ] = array(
-				'exists' => $missing_option_value !== $option_value,
-				'value'  => $option_value,
-			);
-		}
-
-		update_option( 'woocommerce_hold_stock_minutes', $hold_stock_minutes );
-		update_option( 'woocommerce_manage_stock', 'yes' );
-		update_option( 'woocommerce_schema_version', 430 );
-
-		try {
-			return $callback();
-		} finally {
-			foreach ( $original_options as $option_name => $option_data ) {
-				if ( $option_data['exists'] ) {
-					update_option( $option_name, $option_data['value'] );
-				} else {
-					delete_option( $option_name );
-				}
-			}
-		}
 	}
 
 	/**
@@ -358,7 +320,6 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	 */
 	public function test_reserve_stock_for_order_defaults_to_60_minutes() {
 		$minutes = $this->with_stock_reservation_options(
-			'15',
 			function () {
 				$order         = wc_create_order();
 				$reserve_stock = new ReserveStock();
@@ -368,7 +329,8 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 						$reserve_stock->reserve_stock_for_order( $order );
 					}
 				);
-			}
+			},
+			'15'
 		);
 
 		$this->assertSame(
@@ -383,7 +345,6 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	 */
 	public function test_wc_reserve_stock_for_order_passes_configured_checkout_hold_duration() {
 		$minutes = $this->with_stock_reservation_options(
-			'15',
 			function () {
 				$order = wc_create_order();
 
@@ -392,7 +353,8 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 						wc_reserve_stock_for_order( $order );
 					}
 				);
-			}
+			},
+			'15'
 		);
 
 		$this->assertSame(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -3,6 +3,9 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
 
+use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
+use Automattic\WooCommerce\Enums\OrderInternalStatus;
+use Automattic\WooCommerce\RestApi\UnitTests\StockReservationOptionsTrait;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
 
@@ -10,6 +13,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
  * QuantityLimitsTests class.
  */
 class QuantityLimitsTests extends \WC_Unit_Test_Case {
+	use StockReservationOptionsTrait;
+
 	/**
 	 * @var string
 	 */
@@ -141,6 +146,53 @@ class QuantityLimitsTests extends \WC_Unit_Test_Case {
 		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
 
 		$this->assertEquals( 10, $limits['maximum'], 'When stock management is enabled and backorders are not allowed, maximum quantity should be 10' );
+	}
+
+	/**
+	 * Test that reserved stock constrains the limit at every reservation level, including a full one.
+	 */
+	public function test_quantity_limit_when_stock_is_reserved() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 5 );
+		$product->set_backorders( 'no' );
+		$product->save();
+
+		$this->with_stock_reservation_options(
+			function () use ( $product ) {
+				$this->reserve_stock( $product, 3 );
+
+				$limits = ( new QuantityLimits() )->get_add_to_cart_limits( $product );
+				$this->assertEquals( 2, $limits['maximum'], 'With 3 of 5 reserved, maximum quantity should be the 2 that remain' );
+
+				$this->reserve_stock( $product, 2 );
+
+				$limits = ( new QuantityLimits() )->get_add_to_cart_limits( $product );
+				$this->assertEquals( 1, $limits['maximum'], 'With all 5 reserved, maximum quantity should fall back to the minimum instead of the unreserved stock quantity' );
+			}
+		);
+	}
+
+	/**
+	 * Reserve stock for a product through a pending order, the way checkout does.
+	 *
+	 * @param \WC_Product $product Product to reserve.
+	 * @param int         $quantity Quantity to reserve.
+	 */
+	private function reserve_stock( \WC_Product $product, int $quantity ) {
+		$order = wc_create_order();
+		$order->add_product( $product, $quantity );
+		$order->set_status( OrderInternalStatus::PENDING );
+		$order->save();
+
+		( new ReserveStock() )->reserve_stock_for_order( $order );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`QuantityLimits::adjust_product_quantity_limit()` collects the purchase limit and, when stock is managed without backorders, the remaining stock, then takes the lowest:

```php
$limits = [ $purchase_limit > 0 ? $purchase_limit : 9999 ];

if ( $product->managing_stock() && ! $product->backorders_allowed() ) {
    $limits[] = $this->get_remaining_stock( $product );
}

return $this->filter_numeric_value( min( array_filter( $limits ) ), 'limit', $product, $cart_item );
```

`array_filter()` without a callback drops falsy values, and a remaining stock of `0` is falsy. The reservation is therefore respected at every level except a full one:

| stock | reserved | remaining | `$limits` | after `array_filter` | reported `maximum` |
|---|---|---|---|---|---|
| 5 | 3 | 2 | `[5, 2]` | `[5, 2]` | 2 ✅ |
| 5 | 5 | 0 | `[5, 0]` | `[5]` | **5** ❌ |

At exactly the point where nothing can be bought, the limit disappears and `min()` falls back to the unreserved stock quantity.

This puts the Store API in contradiction with itself. `CartController::validate_add_to_cart()` computes the same remaining stock through `get_remaining_stock_for_product()` and rejects the item, so `/products` advertises a quantity that `/cart/add-item` refuses with `woocommerce_rest_product_partially_out_of_stock` ("there is not enough stock (0 remaining)").

The fix filters out only unknown (`null`) stock levels, which is what the truthiness check was standing in for, and keeps a legitimate `0`. Note that `get_add_to_cart_limits()` then floors the result with `max( $minimum, … )`, so the reported maximum becomes `1` rather than `0`; this PR does not change that floor.

I found this on two live stores running 10.9.4, where products with the whole stock held by pending orders were listed with a purchasable maximum while the cart rejected them.

Closes # .

### How to test the changes in this Pull Request:

1. Create a simple product, enable stock management, set the stock quantity to `5` and disallow backorders.
2. Confirm the reservation table is in use (`woocommerce_schema_version` >= `430`).
3. Create an order containing `3` of that product, set its status to `pending`, save it, and reserve its stock (`( new ReserveStock() )->reserve_stock_for_order( $order )`), the way checkout does.
4. Request the product through the Store API: `GET /wp-json/wc/store/v1/products/<id>`. `add_to_cart.maximum` is `2`, correctly reflecting the reservation.
5. Repeat step 3 with a second pending order for the remaining `2`, so all `5` are reserved.
6. Request the product again.
   - Before: `add_to_cart.maximum` is `5`, and `POST /wp-json/wc/store/v1/cart/add-item` with `{"id": <id>, "quantity": 1}` fails with `woocommerce_rest_product_partially_out_of_stock`.
   - After: `add_to_cart.maximum` is `1`.

### Testing that has already taken place:

The reported behaviour was confirmed against two production stores running WooCommerce 10.9.4, comparing `GET /wp-json/wc/store/v1/products` against `POST /wp-json/wc/store/v1/cart/add-item` for the same products. Products listed as `"is_in_stock": true` were refused by the cart with `(0 remaining)` while reporting `add_to_cart.maximum` above zero.

A regression test covering both the partial and the full reservation is added to `QuantityLimitsTests`. I was not able to run the PHP suite locally (no PHP/MySQL on the machine this was written on), so CI is the first execution of it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

