### PR TITLE
[Payments NOX] Fix inconsistent focus indicators

### DIFF
--- a/packages/js/onboarding/changelog/fix-payment-methods-count-theme-colors
+++ b/packages/js/onboarding/changelog/fix-payment-methods-count-theme-colors
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Make the payment methods "+N" badge follow the admin colour scheme on hover, and match its focus ring width to the surrounding controls.
+Make the payment methods "+N" badge follow the admin colour scheme on hover, match its focus ring width to the surrounding controls, and align its size with the payment method logos beside it.

--- a/packages/js/onboarding/changelog/fix-payment-methods-count-theme-colors
+++ b/packages/js/onboarding/changelog/fix-payment-methods-count-theme-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the payment methods "+N" badge follow the admin colour scheme on hover, and match its focus ring width to the surrounding controls.

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
@@ -22,6 +22,9 @@
 	&-count {
 		width: 38px;
 		height: 24px;
+		// Carries the same 2px as the bordered logos so the badge matches their
+		// 40x26 footprint, and gives the hover border something to paint on.
+		border: 1px solid transparent;
 		background-color: rgba($gray-700, 0.10);
 		color: $gray-900;
 		text-align: center;

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
@@ -33,7 +33,10 @@
 
 	&-count:hover {
 		cursor: pointer;
-		color: var(--wp-admin-theme-color, #3858e9);
+		// Hold the label at $gray-900 rather than the theme colour: the tint below is
+		// derived from that same colour, so theming both drops the pair under 4.5:1 on
+		// the lighter schemes (2.48:1 on Sunrise). Only the tint and border follow the theme.
+		color: $gray-900;
 		background-color: rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.15);
 		border-color: var(--wp-admin-theme-color, #3858e9);
 	}

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
@@ -33,13 +33,13 @@
 
 	&-count:hover {
 		cursor: pointer;
-		color: rgba(56, 88, 233, 1);
-		background-color: rgba(56, 88, 233, 0.15);
-		border-color: rgba(56, 88, 233, 1);
+		color: var(--wp-admin-theme-color, #3858e9);
+		background-color: rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.15);
+		border-color: var(--wp-admin-theme-color, #3858e9);
 	}
 
 	&-count:focus {
-		outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
+		outline: 2px solid var(--wp-admin-theme-color, #007cba);
 		outline-offset: 1px;
 	}
 
@@ -48,7 +48,7 @@
 	}
 
 	&-count:focus-visible {
-		outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
+		outline: 2px solid var(--wp-admin-theme-color, #007cba);
 		outline-offset: 1px;
 	}
 }

--- a/plugins/woocommerce/changelog/fix-nox-focus-ring-consistency
+++ b/plugins/woocommerce/changelog/fix-nox-focus-ring-consistency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Make focus indicators consistent on the Payments settings screen: stop the "More payment options" ring from appearing on mouse click, give it room to breathe, round the square rings on the drag handle and section header, and give the Official badge a themed focus ring instead of the browser default.
+Make focus indicators consistent on the Payments settings screen: stop the "More payment options" ring from appearing on mouse click, give it room to breathe, round the square rings on the drag handle and section header, and give the Official badge, the category info icons and the status badge info icon themed focus rings instead of the browser default. The highlighted row in the business location selector now follows the admin colour scheme too.

--- a/plugins/woocommerce/changelog/fix-nox-focus-ring-consistency
+++ b/plugins/woocommerce/changelog/fix-nox-focus-ring-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make focus indicators consistent on the Payments settings screen: stop the "More payment options" ring from appearing on mouse click, give it room to breathe, round the square rings on the drag handle and section header, and give the Official badge a themed focus ring instead of the browser default.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/country-selector/country-selector.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/country-selector/country-selector.scss
@@ -12,11 +12,16 @@
 
 	&__item {
 		padding: $gap-small;
-		margin: 0;
+		// Inset to the same width as the search field and the Apply button
+		// instead of running the full width of the popover. The left padding
+		// and the check mark below drop by the same 12px so the row's contents
+		// stay where they were.
+		margin: 0 12px;
 		line-height: initial;
 		cursor: pointer;
 		position: relative;
-		padding-left: 48px;
+		padding-left: 36px;
+		border-radius: 2px;
 
 		&.is-highlighted {
 			background: rgba(var(--wp-admin-theme-color-rgb, 0, 124, 186), 0.08);
@@ -26,7 +31,7 @@
 
 		svg {
 			position: absolute;
-			left: 20px;
+			left: 8px;
 			top: 50%;
 			-ms-transform: translateY(-50%);
 			transform: translateY(-50%);
@@ -40,7 +45,11 @@
 
 	&__button {
 		width: 100%;
-		margin: 0 1px;
+		// No margin: any here makes the button overhang its track, sliding it
+		// under the indicator's divider and leaving the focus ring 1px wider on
+		// the sides than on the top and bottom. The gap the divider needs is
+		// owned by the indicator, so it disappears when the indicator does.
+		margin: 0;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
@@ -149,10 +158,12 @@
 }
 
 .components-button.components-country-select-control__button {
+	// Inset far enough to sit clear of both the container border and the
+	// indicator's divider, rather than hugging them.
 	&:focus {
 		box-shadow: none !important;
 		outline: 2px solid var(--wp-admin-theme-color, #007cba) !important;
-		outline-offset: -2px;
+		outline-offset: -4px;
 	}
 
 	&:focus:not(:focus-visible) {
@@ -162,7 +173,7 @@
 	&:focus-visible {
 		box-shadow: none !important;
 		outline: 2px solid var(--wp-admin-theme-color, #007cba) !important;
-		outline-offset: -2px;
+		outline-offset: -4px;
 	}
 }
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/country-selector/country-selector.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/country-selector/country-selector.scss
@@ -24,7 +24,7 @@
 		border-radius: 2px;
 
 		&.is-highlighted {
-			background: rgba(var(--wp-admin-theme-color-rgb, 0, 124, 186), 0.08);
+			background: rgba(var(--wp-admin-theme-color--rgb, 0, 124, 186), 0.08);
 			outline: 2px solid var(--wp-admin-theme-color, #007cba);
 			outline-offset: -2px;
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/sortable/sortable.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/sortable/sortable.scss
@@ -9,6 +9,7 @@
 		margin-right: $gap;
 		align-self: stretch;
 		align-content: center;
+		border-radius: 2px;
 
 		&:hover {
 			cursor: grab;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
@@ -25,5 +25,20 @@
 		cursor: pointer;
 		display: inline-flex;
 		align-items: center;
+		border-radius: 2px;
+
+		&:focus {
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 0;
+		}
+
+		&:focus:not(:focus-visible) {
+			outline: none;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 0;
+		}
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -522,7 +522,7 @@
 
 		&:focus {
 			outline: 2px solid var(--wp-admin-theme-color, #007cba);
-			outline-offset: 2px;
+			outline-offset: 0;
 		}
 
 		&:focus:not(:focus-visible) {
@@ -531,7 +531,7 @@
 
 		&:focus-visible {
 			outline: 2px solid var(--wp-admin-theme-color, #007cba);
-			outline-offset: 2px;
+			outline-offset: 0;
 		}
 
 		> img {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -306,6 +306,21 @@
 				&__icon-container {
 					height: 16px;
 					cursor: pointer;
+					border-radius: 2px;
+
+					&:focus {
+						outline: 2px solid var(--wp-admin-theme-color, #007cba);
+						outline-offset: 0;
+					}
+
+					&:focus:not(:focus-visible) {
+						outline: none;
+					}
+
+					&:focus-visible {
+						outline: 2px solid var(--wp-admin-theme-color, #007cba);
+						outline-offset: 0;
+					}
 				}
 
 				&__icon {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -101,12 +101,33 @@
 				height: 28px;
 				cursor: pointer;
 				padding-top: 8px;
-				margin-left: auto;
+				// This 1px is the gap the divider is drawn into. It belongs to
+				// the indicator so that it disappears along with it when the
+				// business location matches the store's country.
+				margin-left: 1px;
 				border-radius: 2px;
+				position: relative;
 
+				// Drawn into that gap rather than as a border inside either box.
+				// A border would sit inside this element, pushing the icon
+				// off-centre and leaving the focus ring 1px closer to the
+				// divider than to the other three sides.
+				&::before {
+					content: "";
+					position: absolute;
+					left: -1px;
+					top: 50%;
+					transform: translateY(-50%);
+					width: 1px;
+					height: 20px;
+					background-color: $gray-200;
+				}
+
+				// Matches the select segment's inset so both rings sit clear of
+				// the container border and the divider between them.
 				&:focus {
-					outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
-					outline-offset: -1.5px;
+					outline: 2px solid var(--wp-admin-theme-color, #007cba);
+					outline-offset: -4px;
 				}
 
 				&:focus:not(:focus-visible) {
@@ -114,14 +135,14 @@
 				}
 
 				&:focus-visible {
-					outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
-					outline-offset: -1.5px;
+					outline: 2px solid var(--wp-admin-theme-color, #007cba);
+					outline-offset: -4px;
 				}
 
 				&-icon {
-					border-left: 1px solid $gray-200;
 					height: 20px;
-					padding: 0 5px;
+					// Wide enough that the inset ring clears the icon.
+					padding: 0 8px;
 
 					svg {
 						fill: $alert-yellow;
@@ -158,14 +179,38 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			width: 100%;
 			background: none;
 			border: none;
-			padding: 0;
+			// Nested corners follow inner = outer - gap. The card is 4px and the
+			// ring clears it by more than that, so the ring wants to be square;
+			// 0 here is as close as it gets, since the ring's own radius is this
+			// value plus the 2px offset. Anything larger reads rounder than the
+			// card that contains it.
+			border-radius: 0;
 			cursor: pointer;
 			text-align: left;
 
+			// A ring's corner radius is border-radius + outline-offset, so the
+			// offset cannot be used to buy clearance without also rounding the
+			// ring past the 4px every other control on this screen uses.
+			// Grow the box with padding instead and cancel it with a matching
+			// negative margin, which leaves the title and chevron in place.
+			// $grid-unit-10 of clearance fits inside the card's padding at every
+			// breakpoint, so it needs no responsive override.
+			width: calc(100% + 2 * #{$grid-unit-10});
+			margin: -$grid-unit-10;
+			padding: $grid-unit-10;
+
 			&:focus {
+				outline: 2px solid var(--wp-admin-theme-color, #007cba);
+				outline-offset: 2px;
+			}
+
+			&:focus:not(:focus-visible) {
+				outline: none;
+			}
+
+			&:focus-visible {
 				outline: 2px solid var(--wp-admin-theme-color, #007cba);
 				outline-offset: 2px;
 			}
@@ -220,7 +265,9 @@
 
 		&.is-expanded {
 			.other-payment-gateways__header {
-				margin-bottom: $grid-unit-40;
+				// The header's $grid-unit-10 of padding contributes the rest, so
+				// the content still sits $grid-unit-40 below the title.
+				margin-bottom: $grid-unit-30;
 			}
 		}
 
@@ -384,7 +431,10 @@
 
 		@media screen and (max-width: $break-medium) {
 			margin: 32px $gap 0 $gap;
-			padding: $gap-smaller $gap;
+			// One step down from the desktop $grid-unit-30, and uniform: the
+			// former $gap-smaller left the title crowded against the top border
+			// while the sides kept a full $gap.
+			padding: $gap;
 		}
 	}
 
@@ -468,6 +518,21 @@
 		align-items: center;
 		gap: 2px;
 		padding: 2px 4px 2px 2px;
+		border-radius: 2px;
+
+		&:focus {
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 2px;
+		}
+
+		&:focus:not(:focus-visible) {
+			outline: none;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 2px;
+		}
 
 		> img {
 			height: 16px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The "More payment options" header painted its focus ring on mouse click, not only on keyboard focus, because it uses a bare `:focus` rule without the `:focus:not(:focus-visible)` guard that its sibling indicators received. The ring has been there since January, but WordPress 6.9 made the "modern" admin colour scheme the default, moving `--wp-admin-theme-color` from `#2271b1` to `#3858e9` and making it far more noticeable.

Auditing the rest of the screen turned up more drift: the drag handle and the section header rendered square rings while everything else was rounded, the Official badge had no focus style at all and fell through to Chrome's default `#005fcc` ring, and the two Business location segments drew rings that hugged the divider between them — with that divider's border also pushing the warning icon 1px off centre.

Two layout issues surfaced while checking this responsively and are fixed here too: the card's padding below `$break-medium` was `$gap-smaller $gap`, off-grid and asymmetric, leaving the title crowded against the top border while the sides kept a full `$gap`. It is now a uniform `$gap`, one step down from the desktop `$grid-unit-30`, which also leaves the header's ring room to sit inside the card at narrow widths; and the country rows in the Business location dropdown ran the full popover width while the search field and Apply button were inset, so they now match.

(For Bug Fixes) Bug introduced in PR #62841.

### Screenshots or screen recordings:

#### 1. "More payment options" — mouse click
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="440" alt="before-1-header-mouse-click" src="https://github.com/user-attachments/assets/479ffa91-d477-4086-88be-e999f7e4823c" /> | <img width="2000" height="440" alt="after-1-header-mouse-click" src="https://github.com/user-attachments/assets/12f1dfa3-555a-4d42-93ed-6107260b6d2c" /> |

  Clicking the header painted a focus ring. It no longer does; keyboard focus is unaffected.

#### 2. "More payment options" — keyboard focus
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="440" alt="before-2-header-keyboard" src="https://github.com/user-attachments/assets/9d2c13eb-5d1e-4844-88e4-010c03f5747a" /> | <img width="2000" height="440" alt="after-2-header-keyboard" src="https://github.com/user-attachments/assets/6c87d3df-eeeb-4789-afd7-2d6f7f44d0ac" /> |

  The ring was clamped 2px off the title. It now clears it by 10px and is square, so it doesn't read rounder than the 4px card around it.

#### 3. Drag handle
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="300" alt="before-3-drag-handle" src="https://github.com/user-attachments/assets/5df3ba1f-e83e-4a30-9a60-db765643c550" /> | <img width="2000" height="300" alt="after-3-drag-handle" src="https://github.com/user-attachments/assets/2918ee57-2f01-42dd-8332-ca2f3990ce68" /> |

  Square ring → 2px, matching every other control.

#### 4. Official badge
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="300" alt="before-9-badge-colour-scheme" src="https://github.com/user-attachments/assets/bc44c1cd-bcd7-45ac-a9f5-f20dd5b00a52" /> | <img width="2000" height="300" alt="after-9-badge-colour-scheme" src="https://github.com/user-attachments/assets/66ec9b8b-4bf2-47c2-8c71-8376fa5984f0" /> |

  No focus style at all — Chrome's default `1px auto #005fcc`, ignoring the admin colour scheme. Now a themed 2px ring.

#### 5. Business location select
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="300" alt="before-5-location-select" src="https://github.com/user-attachments/assets/1ae1b089-f9da-4252-b520-84d1d7338092" /> | <img width="2000" height="300" alt="after-5-location-select" src="https://github.com/user-attachments/assets/6500d717-ee90-4123-a066-4853d98e91b5" /> |

  The ring hugged the container border and the divider (1px). Now 4px on all four sides.

#### 6. Business location warning icon
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="300" alt="before-6-location-warning-icon" src="https://github.com/user-attachments/assets/cd3728d6-7d0e-4736-a629-c23961a7c1d3" /> | <img width="2000" height="300" alt="after-6-location-warning-icon" src="https://github.com/user-attachments/assets/ed853969-6582-4e42-bd28-428fe8ba6674" /> |

  The divider sat inside the focusable box, pushing the icon 1px off centre and squeezing the ring. Now 4px all round, icon centred.

#### 7. Country dropdown row width
  | Before | After |
  | ------ | ----- |
  | <img width="2000" height="1120" alt="before-7-dropdown-row-width" src="https://github.com/user-attachments/assets/db6d7143-83c6-4514-9c69-d9eb60bed85b" /> | <img width="2000" height="1120" alt="after-7-dropdown-row-width" src="https://github.com/user-attachments/assets/66019f84-5063-4450-b15b-902a20a75d1f" /> |

  Rows ran the full 280px popover width while Search and Apply were inset to 256px. All three now match.

#### 8. Narrow viewport (760px)
  | Before | After |
  | ------ | ----- |
  | <img width="1520" height="520" alt="before-8-narrow-760-card-padding" src="https://github.com/user-attachments/assets/3395f780-5b20-42a7-8739-280612cf3230" /> | <img width="1520" height="520" alt="after-8-narrow-760-card-padding" src="https://github.com/user-attachments/assets/28f628e5-b5b6-4257-be02-e7cd697e92a0" /> |

  Card padding was `8px 16px`, crowding the title against the top border. Now a uniform 16px.

#### 9. Incentive badge info icon (admin colour scheme: Sunrise)
  | Before | After |
  | ------ | ----- |
  | <img width="2700" height="510" alt="before-11-incentive-badge-info" src="https://github.com/user-attachments/assets/3ca41396-5572-4362-800e-707dedd66357" /> | <img width="2700" height="510" alt="after-11-incentive-badge-info" src="https://github.com/user-attachments/assets/9bcf538b-9af2-4ad1-8e58-f942d474eb80" /> |

  The `ⓘ` that opens the incentive's terms popover had no focus style, falling through to the browser's default blue ring while the rest of the screen was themed. It now uses `--wp-admin-theme-color`. This is `StatusBadge`'s info trigger, so every status badge with popover content is fixed, not just incentives.

#### 10. "More payment options" category info icon (Sunrise)
  | Before | After |
  | ------ | ----- |
  | <img width="2700" height="510" alt="before-14-category-info-icon" src="https://github.com/user-attachments/assets/bab61f69-adc6-47ce-bc59-5c54197462b5" /> | <img width="2700" height="510" alt="after-14-category-info-icon" src="https://github.com/user-attachments/assets/7efa21b3-c051-4568-8da2-b9e376e65da0" /> |

Same defect on the `ⓘ` beside each category heading inside the expanded section.

#### 11. WooPayments "+N" payment methods badge — focus (Sunrise)
  | Before | After |
  | ------ | ----- |
  | <img width="2700" height="510" alt="before-12-methods-count-focus" src="https://github.com/user-attachments/assets/a3a25bf5-2f64-4fe6-bd60-d66be95f377a" /> | <img width="2700" height="510" alt="after-12-methods-count-focus" src="https://github.com/user-attachments/assets/8cd43f71-b52c-430e-9a83-ed6103c027f9" /> |

Its focus ring was `1.5px` where every other control on the screen uses `2px`.

#### 12. WooPayments "+N" payment methods badge — hover (Sunrise)
  | Before | After |
  | ------ | ----- |
  | <img width="2700" height="510" alt="before-13-methods-count-hover" src="https://github.com/user-attachments/assets/4aa98f04-c870-450d-bb79-a8d59e980ef0" /> | <img width="2700" height="510" alt="after-13-methods-count-hover" src="https://github.com/user-attachments/assets/a83a98ad-6f57-4dd9-85be-6660a2036bc9" /> |

The hover state hardcoded the default scheme's blue for text, background and border, so it stayed blue on every colour scheme.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and build the admin client (`pnpm --filter='@woocommerce/plugin-woocommerce' build:admin`). Hard-reload the admin afterwards — the asset `?ver=` does not change, so a normal reload will serve cached CSS.
2. Go to **WooCommerce → Settings → Payments**.
3. **Click** the "More payment options" header with the mouse. It should expand and collapse as before, with **no focus ring drawn**.
4. Press <kbd>Tab</kbd> until the header receives focus. A square ring should appear, clearly clear of the title and fully inside the card. Confirm <kbd>Enter</kbd> and <kbd>Space</kbd> still toggle the section.
5. Tab through the rest of the screen — drag handles, Official badges, Install/Enable buttons, the ellipsis menus, the "Take offline payments" chevron. Every ring should be rounded consistently and use the admin colour scheme. The Official badge in particular previously showed the browser's default blue, which ignored the colour scheme.
6. Set **Business location** to a country other than the store's own so the yellow warning icon appears. Focus the location select, then the warning icon. Both rings should sit evenly inside their own segment, clear of the container border and of the divider between them, with the icon centred in its ring.
7. Open the Business location dropdown. The highlighted country row should be the same width as the Search field and the Apply button, with the check mark and label unmoved.
8. Set Business location to the store's own country so the warning icon disappears. The select should fill the control with its ring still even on all four sides — no leftover gap where the icon used to be.
9. Narrow the browser below 782px and again to a phone width. The "More payment options" ring must stay inside the card at every width, and the card's padding should be even on all sides rather than tight at the top.
10. Optionally switch the admin colour scheme (**Users → Profile**) and confirm the rings follow it.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Manually verified in `wp-env` on WordPress 7.0.2 with WooCommerce `11.1.0-dev`, Twenty Twenty-Five, and the default `modern` admin colour scheme, against built assets rather than injected CSS.

Every figure below is a computed-style measurement taken in the browser with the control focused, not an estimate:

- **Input modality** — with a real mouse click the header matches `:focus` but not `:focus-visible`, and no outline is painted; a real <kbd>Tab</kbd> keypress paints the ring. Layout is unchanged in both states: the title sits 25px from the card edge and the chevron 25px from the right, as before, and the expanded gap below the header measures exactly 32px.
- **Ring consistency** — the drag handle, Official badge, Install/Enable buttons, ellipsis menus and chevron all report the same 2px element radius and 2px ring. The two Business location segments report 4px on all four sides with the warning icon exactly centred (0px off).
- **Responsive** — swept at 1400px, 782px, 760px and 390px. The header's ring is inside the card at every width, the dropdown row matches the Apply button's width at every width, and the location rings hold their 4px insets. The 760px case is the one that previously put the ring 1px outside the card.
- **Both indicator states** — verified with the Business location matching the store country (warning icon hidden) and differing from it (icon shown).
- `stylelint` passes on all three changed SCSS files.

Not covered: RTL, Windows High Contrast / forced-colors mode, and Safari/Firefox — all changes are `outline`/`border-radius`/box-model only, but a second pair of eyes on RTL would be welcome given the dropdown row and divider changes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Authored with Claude Code (Claude Opus 5). The assistant traced the regression, ran the computed-style audit and responsive sweep in a browser against the local `wp-env` build, and wrote the SCSS changes and this description. Each visual change was reviewed and directed by me iteratively, and I take responsibility for the result.

