### PR TITLE
Preserve responsive Settings UI shell gutter alignment

### DIFF
--- a/plugins/woocommerce/changelog/fix-settings-ui-responsive-gutter
+++ b/plugins/woocommerce/changelog/fix-settings-ui-responsive-gutter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep responsive Settings UI shell gutters synchronized with WPDS spacing tokens.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/settings-ui.scss
@@ -283,33 +283,35 @@ body.woocommerce_page_wc-settings.woocommerce-settings-ui-page {
 	}
 
 	@media (max-width: 960px) {
+		--wc-settings-ui-shell-gutter: var(--wpds-dimension-padding-2xl);
+
 		#mainform {
-			padding: 0 var(--wpds-dimension-padding-2xl)
+			padding: 0 var(--wc-settings-ui-shell-gutter)
 				var(--wpds-dimension-padding-3xl);
 		}
 
 		.wc-settings-ui-shell {
-			margin-left: calc(var(--wpds-dimension-gap-xl) * -1);
-			margin-right: calc(var(--wpds-dimension-gap-xl) * -1);
+			margin-left: calc(var(--wc-settings-ui-shell-gutter) * -1);
+			margin-right: calc(var(--wc-settings-ui-shell-gutter) * -1);
 		}
 
 		.wc-settings-ui-shell__header {
-			padding-left: var(--wpds-dimension-padding-2xl);
-			padding-right: var(--wpds-dimension-padding-2xl);
+			padding-left: var(--wc-settings-ui-shell-gutter);
+			padding-right: var(--wc-settings-ui-shell-gutter);
 		}
 
 		.wc-settings-ui-shell__tabs {
-			padding-left: var(--wpds-dimension-padding-2xl);
-			padding-right: var(--wpds-dimension-padding-2xl);
+			padding-left: var(--wc-settings-ui-shell-gutter);
+			padding-right: var(--wc-settings-ui-shell-gutter);
 		}
 
 		.wc-settings-ui-shell__notice {
-			margin-left: var(--wpds-dimension-gap-xl);
-			margin-right: var(--wpds-dimension-gap-xl);
+			margin-left: var(--wc-settings-ui-shell-gutter);
+			margin-right: var(--wc-settings-ui-shell-gutter);
 		}
 
 		.wc-settings-ui {
-			margin: 48px var(--wpds-dimension-gap-xl)
+			margin: 48px var(--wc-settings-ui-shell-gutter)
 				var(--wpds-dimension-gap-2xl);
 			max-width: none;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PR #67150 was merged before its final review-follow-up commit was pushed, so this small PR carries that missed change separately. The responsive Settings UI shell now routes every aligned padding and margin through one local gutter property, preventing independent WPDS padding and gap token changes from shifting the shell or introducing horizontal overflow.

Related: #67150.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — the shared gutter resolves to the same `24px` value, so no rendered change is expected.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open **WooCommerce > Settings > Products > Inventory** and resize the viewport to `960px` or narrower.
2. Confirm the shell header, tabs, notices, and settings content remain aligned without horizontal overflow.
3. In browser developer tools, temporarily change `--wc-settings-ui-shell-gutter` from `24px` to another value and confirm all responsive horizontal padding and margins move together.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused Stylelint passed without warnings or errors.
- The changed stylesheet compiled successfully with Sass.
- `git diff --check` passed against `trunk`.
- The full admin bundle was not rerun because the local workspace currently has unrelated dependency/toolchain failures; the affected stylesheet was compiled directly instead.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set the milestone to the first available milestone that is not in the past (unless otherwise specified).


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
