### PR TITLE
Update coding guidelines to prefer using logical CSS properties over physical ones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ plugins/woocommerce/
 
 - Prefer vanilla JavaScript/TypeScript over jQuery for new or modified code. Keep existing jQuery when a rewrite is out of scope.
 
+**CSS:**
+
+- Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
+
 ## Development Workflow
 
 1. Make code changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ plugins/woocommerce/
 
 **CSS:**
 
-- Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
+- Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline-start`, or `inset-inline-end`, instead of physical properties like `margin-left` or `right`.
 
 ## Development Workflow
 

--- a/plugins/woocommerce/changelog/update-coding-guidelines-css-logical-properties-over-physical-ones
+++ b/plugins/woocommerce/changelog/update-coding-guidelines-css-logical-properties-over-physical-ones
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update coding guidelines to prefer using logical CSS properties over physical ones
+
+

--- a/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
+++ b/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
@@ -68,9 +68,9 @@ Naming is not strictly tied to the DOM so it **doesn’t matter how many nested 
 
 ## RTL Styles
 
-Always prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
+Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
 
-Even though Blocks uses the internal `WebpackRTLPlugin` exported from `@woocommerce/internal-build/style-build` to generate specific CSS files for RTL languages, these might be not be used if Gutenberg inlines the styles, so it shouldn't be trusted.
+Even though Blocks uses the internal `WebpackRTLPlugin` exported from `@woocommerce/internal-build/style-build` to generate specific CSS files for RTL languages, these might not be used if Gutenberg inlines the styles, so it shouldn't be trusted.
 
 ## SCSS File Naming Conventions for Blocks
 

--- a/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
+++ b/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
@@ -68,31 +68,9 @@ Naming is not strictly tied to the DOM so it **doesn’t matter how many nested 
 
 ## RTL Styles
 
-Blocks uses the internal `WebpackRTLPlugin` exported from `@woocommerce/internal-build/style-build` to generate styles for Right-to-Left languages. These are generated automatically.
+Always prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
 
-To make adjustments to the generated RTL styles, for example, excluding certain rules from the RTL stylesheets, you should use the [control directives here](https://rtlcss.com/learn/usage-guide/control-directives/index.html).
-
-For example, you can exclude individual lines:
-
-```css
-.code {
-	/*rtl:ignore*/
-	direction: ltr;
-	/*rtl:ignore*/
-	text-align: left;
-}
-```
-
-Or exclude blocks of CSS:
-
-```css
-.code {
-	/*rtl:begin:ignore*/
-	direction: ltr;
-	text-align: left;
-	/*rtl:end:ignore*/
-}
-```
+Even though Blocks uses the internal `WebpackRTLPlugin` exported from `@woocommerce/internal-build/style-build` to generate specific CSS files for RTL languages, these might be not be used if Gutenberg inlines the styles, so it shouldn't be trusted.
 
 ## SCSS File Naming Conventions for Blocks
 

--- a/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
+++ b/plugins/woocommerce/client/blocks/docs/contributors/coding-guidelines.md
@@ -68,7 +68,7 @@ Naming is not strictly tied to the DOM so it **doesn’t matter how many nested 
 
 ## RTL Styles
 
-Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline`, `padding-block`, or `inset-inline-start`, instead of physical properties like `margin-left` or `right`.
+Prefer logical CSS properties that work well in LTR and RTL languages like `margin-inline-start`, or `inset-inline-end`, instead of physical properties like `margin-left` or `right`.
 
 Even though Blocks uses the internal `WebpackRTLPlugin` exported from `@woocommerce/internal-build/style-build` to generate specific CSS files for RTL languages, these might not be used if Gutenberg inlines the styles, so it shouldn't be trusted.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Gutenberg might inline blocks styles, in which case the RTL styles aren't applied. This PR updates `AGENTS.md` and `coding-guidelines.md` to mention we should prioritize using logical CSS properties.

See https://github.com/woocommerce/woocommerce/pull/67453.

### How to test the changes in this Pull Request:

1. Read the updated docs and verify you agree.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->
