### PR TITLE
fix: Preserve custom attachment metadata when regenerating images

### DIFF
--- a/plugins/woocommerce/changelog/60577-fix-attachment-metadata-loss
+++ b/plugins/woocommerce/changelog/60577-fix-attachment-metadata-loss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve third party attachment metadata keys when regenerating product images.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
@@ -166,6 +166,10 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 
 		// If something went wrong lets just remove the item from the queue.
 		if ( is_wp_error( $new_metadata ) || empty( $new_metadata ) ) {
+			if ( is_array( $old_metadata ) ) {
+				wp_update_attachment_metadata( $this->attachment_id, $old_metadata );
+			}
+
 			return false;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
@@ -148,7 +148,8 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 			return false;
 		}
 
-		$old_metadata = wp_get_attachment_metadata( $this->attachment_id );
+		// Unfiltered, so the keys carried over below come from the stored value.
+		$old_metadata = wp_get_attachment_metadata( $this->attachment_id, true );
 
 		// We only want to regen WC images.
 		add_filter( 'intermediate_image_sizes', array( $this, 'adjust_intermediate_image_sizes' ) );
@@ -174,6 +175,11 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 					$new_metadata['sizes'][ $old_size ] = $old_metadata['sizes'][ $old_size ];
 				}
 			}
+		}
+
+		// Restore the top level keys regeneration does not own.
+		if ( is_array( $old_metadata ) ) {
+			$new_metadata += $old_metadata;
 		}
 
 		// Update the meta data with the new size values.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -446,6 +446,8 @@ class WC_Regenerate_Images {
 
 		// If something went wrong lets just return the original image.
 		if ( is_wp_error( $new_metadata ) || empty( $new_metadata ) ) {
+			wp_update_attachment_metadata( $attachment_id, $metadata );
+
 			return $image;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -427,7 +427,8 @@ class WC_Regenerate_Images {
 			}
 		}
 
-		$metadata = wp_get_attachment_metadata( $attachment_id );
+		// Unfiltered: this is the base for a write, so it must be the stored value.
+		$metadata = wp_get_attachment_metadata( $attachment_id, true );
 
 		// Fix for images with no metadata.
 		if ( ! is_array( $metadata ) ) {

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -342,6 +342,7 @@ class WC_Unit_Tests_Bootstrap {
 		require_once dirname( $this->tests_dir ) . '/php/helpers/LoggerSpyTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/MetaDataAssertionTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/CorePayPalGatewayTrait.php';
+		require_once dirname( $this->tests_dir ) . '/php/helpers/ImageAttachmentTrait.php';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/helpers/ImageAttachmentTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/ImageAttachmentTrait.php
@@ -58,4 +58,56 @@ trait ImageAttachmentTrait {
 
 		wp_update_attachment_metadata( $attachment_id, array_merge( $metadata, $custom_keys ) );
 	}
+
+	/**
+	 * Delete a generated size, both the file and its metadata entry.
+	 *
+	 * @param int    $attachment_id Attachment to strip the size from.
+	 * @param string $size          Size name.
+	 * @return string Path of the deleted file.
+	 */
+	private function delete_attachment_size( int $attachment_id, string $size ): string {
+		$metadata = wp_get_attachment_metadata( $attachment_id, true );
+		$path     = $this->get_attachment_size_path( $attachment_id, $metadata, $size );
+
+		wp_delete_file( $path );
+
+		unset( $metadata['sizes'][ $size ] );
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return $path;
+	}
+
+	/**
+	 * Assert that a size exists as a real image file of the dimensions its metadata records.
+	 *
+	 * @param int    $attachment_id Attachment to check.
+	 * @param string $size          Size name.
+	 */
+	private function assert_size_exists( int $attachment_id, string $size ): void {
+		$metadata = wp_get_attachment_metadata( $attachment_id, true );
+
+		$this->assertArrayHasKey( $size, $metadata['sizes'], "The $size size should be recorded in the metadata" );
+
+		$path = $this->get_attachment_size_path( $attachment_id, $metadata, $size );
+
+		$this->assertFileExists( $path, "The $size file should be on disk" );
+
+		$dimensions = getimagesize( $path );
+
+		$this->assertSame( (int) $metadata['sizes'][ $size ]['width'], $dimensions[0], "The $size file should be as wide as its metadata records" );
+		$this->assertSame( (int) $metadata['sizes'][ $size ]['height'], $dimensions[1], "The $size file should be as tall as its metadata records" );
+	}
+
+	/**
+	 * Absolute path of a generated size.
+	 *
+	 * @param int    $attachment_id Attachment the size belongs to.
+	 * @param array  $metadata      Stored attachment metadata.
+	 * @param string $size          Size name.
+	 * @return string
+	 */
+	private function get_attachment_size_path( int $attachment_id, array $metadata, string $size ): string {
+		return trailingslashit( dirname( get_attached_file( $attachment_id ) ) ) . $metadata['sizes'][ $size ]['file'];
+	}
 }

--- a/plugins/woocommerce/tests/php/helpers/ImageAttachmentTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/ImageAttachmentTrait.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Helpers;
+
+/**
+ * Trait ImageAttachmentTrait.
+ *
+ * Image attachment fixtures backed by real files on disk, so tests can exercise code
+ * that reads the image itself rather than just the attachment post.
+ *
+ * The files land in the uploads directory, so call remove_added_uploads() from tearDown().
+ */
+trait ImageAttachmentTrait {
+
+	/**
+	 * Create an attachment backed by a real image file.
+	 *
+	 * @param int    $width    Width in pixels.
+	 * @param int    $height   Height in pixels.
+	 * @param string $filename File name to write into the uploads directory.
+	 * @return int Attachment ID.
+	 */
+	private function create_image_attachment( int $width, int $height, string $filename ): int {
+		$uploads = wp_upload_dir();
+		$file    = trailingslashit( $uploads['path'] ) . $filename;
+
+		wp_mkdir_p( $uploads['path'] );
+
+		$image = imagecreatetruecolor( $width, $height );
+		imagefilledrectangle( $image, 0, 0, $width, $height, imagecolorallocate( $image, 120, 60, 30 ) );
+		imagejpeg( $image, $file, 90 );
+		imagedestroy( $image );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'WC image attachment test',
+				'post_status'    => 'inherit',
+			),
+			$file
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Add top level metadata keys that WordPress does not own.
+	 *
+	 * @param int   $attachment_id Attachment to add the keys to.
+	 * @param array $custom_keys   Metadata keyed by name.
+	 */
+	private function add_custom_attachment_metadata( int $attachment_id, array $custom_keys ): void {
+		$metadata = wp_get_attachment_metadata( $attachment_id, true );
+
+		wp_update_attachment_metadata( $attachment_id, array_merge( $metadata, $custom_keys ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
@@ -1,10 +1,14 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Tests\Helpers\ImageAttachmentTrait;
+
 /**
  * Tests for the WC_Regenerate_Images_Request class.
  */
 class WC_Regenerate_Images_Request_Test extends WC_Unit_Test_Case {
+
+	use ImageAttachmentTrait;
 
 	/**
 	 * The System Under Test.
@@ -12,13 +16,6 @@ class WC_Regenerate_Images_Request_Test extends WC_Unit_Test_Case {
 	 * @var WC_Regenerate_Images_Request
 	 */
 	private $sut;
-
-	/**
-	 * Attachment created by a test, removed on teardown.
-	 *
-	 * @var int
-	 */
-	private $attachment_id = 0;
 
 	/**
 	 * Set up test fixtures.
@@ -32,61 +29,30 @@ class WC_Regenerate_Images_Request_Test extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
-		if ( $this->attachment_id ) {
-			wp_delete_attachment( $this->attachment_id, true );
-			$this->attachment_id = 0;
-		}
+		$this->remove_added_uploads();
 
 		parent::tearDown();
-	}
-
-	/**
-	 * Create an attachment backed by a real image file.
-	 *
-	 * @return int Attachment ID.
-	 */
-	private function create_attachment(): int {
-		$uploads = wp_upload_dir();
-		$file    = trailingslashit( $uploads['path'] ) . 'wc-regen-request-test.jpg';
-
-		wp_mkdir_p( $uploads['path'] );
-
-		$image = imagecreatetruecolor( 1200, 800 );
-		imagefilledrectangle( $image, 0, 0, 1200, 800, imagecolorallocate( $image, 30, 90, 140 ) );
-		imagejpeg( $image, $file, 90 );
-		imagedestroy( $image );
-
-		$attachment_id = wp_insert_attachment(
-			array(
-				'post_mime_type' => 'image/jpeg',
-				'post_title'     => 'WC regen request test',
-				'post_status'    => 'inherit',
-			),
-			$file
-		);
-
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
-
-		return $attachment_id;
 	}
 
 	/**
 	 * @testdox Bulk regeneration should keep top level metadata keys it does not own.
 	 */
 	public function test_task_preserves_custom_metadata_keys(): void {
-		$this->attachment_id = $this->create_attachment();
+		$attachment_id = $this->create_image_attachment( 1200, 800, 'wc-regen-request-test.jpg' );
 
-		$metadata                  = wp_get_attachment_metadata( $this->attachment_id, true );
-		$metadata['test_api_meta'] = array( 'last_modified' => 1708332626 );
-		$metadata['test_cdn_id']   = 'abc123';
-		wp_update_attachment_metadata( $this->attachment_id, $metadata );
+		$this->add_custom_attachment_metadata(
+			$attachment_id,
+			array(
+				'test_api_meta' => array( 'last_modified' => 1708332626 ),
+				'test_cdn_id'   => 'abc123',
+			)
+		);
 
 		$task = new ReflectionMethod( WC_Regenerate_Images_Request::class, 'task' );
 		$task->setAccessible( true );
-		$task->invoke( $this->sut, array( 'attachment_id' => $this->attachment_id ) );
+		$task->invoke( $this->sut, array( 'attachment_id' => $attachment_id ) );
 
-		$stored = get_post_meta( $this->attachment_id, '_wp_attachment_metadata', true );
+		$stored = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
 
 		$this->assertArrayHasKey( 'test_api_meta', $stored, 'Third party metadata keys should survive bulk regeneration' );
 		$this->assertArrayHasKey( 'test_cdn_id', $stored, 'Third party metadata keys should survive bulk regeneration' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
@@ -48,9 +48,15 @@ class WC_Regenerate_Images_Request_Test extends WC_Unit_Test_Case {
 			)
 		);
 
+		$thumbnail = $this->delete_attachment_size( $attachment_id, 'woocommerce_thumbnail' );
+
+		$this->assertFileDoesNotExist( $thumbnail, 'The size should be missing before regeneration runs' );
+
 		$task = new ReflectionMethod( WC_Regenerate_Images_Request::class, 'task' );
 		$task->setAccessible( true );
 		$task->invoke( $this->sut, array( 'attachment_id' => $attachment_id ) );
+
+		$this->assert_size_exists( $attachment_id, 'woocommerce_thumbnail' );
 
 		$stored = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-request-test.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Regenerate_Images_Request class.
+ */
+class WC_Regenerate_Images_Request_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Regenerate_Images_Request
+	 */
+	private $sut;
+
+	/**
+	 * Attachment created by a test, removed on teardown.
+	 *
+	 * @var int
+	 */
+	private $attachment_id = 0;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new WC_Regenerate_Images_Request();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		if ( $this->attachment_id ) {
+			wp_delete_attachment( $this->attachment_id, true );
+			$this->attachment_id = 0;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Create an attachment backed by a real image file.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment(): int {
+		$uploads = wp_upload_dir();
+		$file    = trailingslashit( $uploads['path'] ) . 'wc-regen-request-test.jpg';
+
+		wp_mkdir_p( $uploads['path'] );
+
+		$image = imagecreatetruecolor( 1200, 800 );
+		imagefilledrectangle( $image, 0, 0, 1200, 800, imagecolorallocate( $image, 30, 90, 140 ) );
+		imagejpeg( $image, $file, 90 );
+		imagedestroy( $image );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'WC regen request test',
+				'post_status'    => 'inherit',
+			),
+			$file
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * @testdox Bulk regeneration should keep top level metadata keys it does not own.
+	 */
+	public function test_task_preserves_custom_metadata_keys(): void {
+		$this->attachment_id = $this->create_attachment();
+
+		$metadata                  = wp_get_attachment_metadata( $this->attachment_id, true );
+		$metadata['test_api_meta'] = array( 'last_modified' => 1708332626 );
+		$metadata['test_cdn_id']   = 'abc123';
+		wp_update_attachment_metadata( $this->attachment_id, $metadata );
+
+		$task = new ReflectionMethod( WC_Regenerate_Images_Request::class, 'task' );
+		$task->setAccessible( true );
+		$task->invoke( $this->sut, array( 'attachment_id' => $this->attachment_id ) );
+
+		$stored = get_post_meta( $this->attachment_id, '_wp_attachment_metadata', true );
+
+		$this->assertArrayHasKey( 'test_api_meta', $stored, 'Third party metadata keys should survive bulk regeneration' );
+		$this->assertArrayHasKey( 'test_cdn_id', $stored, 'Third party metadata keys should survive bulk regeneration' );
+		$this->assertNotEmpty( $stored['sizes'], 'Bulk regeneration should still write the generated sizes' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -61,7 +61,8 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 		$image    = array( wp_get_attachment_url( $attachment_id ), 900, 300, false );
 		$returned = WC_Regenerate_Images::maybe_resize_image( $image, $attachment_id, 'woocommerce_thumbnail', false );
 
-		$target = wc_get_image_size( 'woocommerce_thumbnail' );
+		// The registered size, not wc_get_image_size(), is what regeneration produces.
+		$target = wp_get_registered_image_subsizes()['woocommerce_thumbnail'];
 
 		$this->assertSame(
 			array( (int) $target['width'], (int) $target['height'] ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -1,0 +1,97 @@
+<?php
+declare( strict_types = 1 );
+
+/**
+ * Tests for the WC_Regenerate_Images class.
+ */
+class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Attachment created by a test, removed on teardown.
+	 *
+	 * @var int
+	 */
+	private $attachment_id = 0;
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		if ( $this->attachment_id ) {
+			wp_delete_attachment( $this->attachment_id, true );
+			$this->attachment_id = 0;
+		}
+
+		remove_all_filters( 'wp_get_attachment_metadata' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Create an attachment backed by a real image file.
+	 *
+	 * Wide on purpose: maybe_resize_image() only regenerates on an aspect ratio mismatch.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function create_attachment(): int {
+		$uploads = wp_upload_dir();
+		$file    = trailingslashit( $uploads['path'] ) . 'wc-regen-test.jpg';
+
+		wp_mkdir_p( $uploads['path'] );
+
+		$image = imagecreatetruecolor( 900, 300 );
+		imagefilledrectangle( $image, 0, 0, 900, 300, imagecolorallocate( $image, 120, 60, 30 ) );
+		imagejpeg( $image, $file, 90 );
+		imagedestroy( $image );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'WC regen test',
+				'post_status'    => 'inherit',
+			),
+			$file
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * @testdox Resizing an image on the fly should not persist a filtered view of the metadata.
+	 */
+	public function test_resize_does_not_persist_filtered_metadata(): void {
+		$this->attachment_id = $this->create_attachment();
+
+		$metadata                  = wp_get_attachment_metadata( $this->attachment_id, true );
+		$metadata['test_api_meta'] = array( 'last_modified' => 1708332626 );
+		wp_update_attachment_metadata( $this->attachment_id, $metadata );
+
+		// A co-installed plugin hides its own key from readers.
+		add_filter(
+			'wp_get_attachment_metadata',
+			function ( $data ) {
+				if ( is_array( $data ) ) {
+					unset( $data['test_api_meta'] );
+				}
+
+				return $data;
+			}
+		);
+
+		// Full size dimensions, which is what image_downsize() returns when the size is missing.
+		$image = array( wp_get_attachment_url( $this->attachment_id ), 900, 300, false );
+		WC_Regenerate_Images::maybe_resize_image( $image, $this->attachment_id, 'woocommerce_thumbnail', false );
+
+		$stored = get_post_meta( $this->attachment_id, '_wp_attachment_metadata', true );
+
+		$this->assertArrayHasKey(
+			'test_api_meta',
+			$stored,
+			'Metadata hidden by a wp_get_attachment_metadata filter should survive on-the-fly regeneration'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -1,17 +1,14 @@
 <?php
 declare( strict_types = 1 );
 
+use Automattic\WooCommerce\Tests\Helpers\ImageAttachmentTrait;
+
 /**
  * Tests for the WC_Regenerate_Images class.
  */
 class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 
-	/**
-	 * Attachment created by a test, removed on teardown.
-	 *
-	 * @var int
-	 */
-	private $attachment_id = 0;
+	use ImageAttachmentTrait;
 
 	/**
 	 * Metadata filter callback added by a test, removed on teardown.
@@ -24,10 +21,7 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
-		if ( $this->attachment_id ) {
-			wp_delete_attachment( $this->attachment_id, true );
-			$this->attachment_id = 0;
-		}
+		$this->remove_added_uploads();
 
 		if ( $this->metadata_filter ) {
 			remove_filter( 'wp_get_attachment_metadata', $this->metadata_filter );
@@ -38,47 +32,13 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Create an attachment backed by a real image file.
-	 *
-	 * Wide on purpose: maybe_resize_image() only regenerates on an aspect ratio mismatch.
-	 *
-	 * @return int Attachment ID.
-	 */
-	private function create_attachment(): int {
-		$uploads = wp_upload_dir();
-		$file    = trailingslashit( $uploads['path'] ) . 'wc-regen-test.jpg';
-
-		wp_mkdir_p( $uploads['path'] );
-
-		$image = imagecreatetruecolor( 900, 300 );
-		imagefilledrectangle( $image, 0, 0, 900, 300, imagecolorallocate( $image, 120, 60, 30 ) );
-		imagejpeg( $image, $file, 90 );
-		imagedestroy( $image );
-
-		$attachment_id = wp_insert_attachment(
-			array(
-				'post_mime_type' => 'image/jpeg',
-				'post_title'     => 'WC regen test',
-				'post_status'    => 'inherit',
-			),
-			$file
-		);
-
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
-
-		return $attachment_id;
-	}
-
-	/**
 	 * @testdox Resizing an image on the fly should not persist a filtered view of the metadata.
 	 */
 	public function test_resize_does_not_persist_filtered_metadata(): void {
-		$this->attachment_id = $this->create_attachment();
+		// Wide on purpose: maybe_resize_image() only regenerates on an aspect ratio mismatch.
+		$attachment_id = $this->create_image_attachment( 900, 300, 'wc-regen-test.jpg' );
 
-		$metadata                  = wp_get_attachment_metadata( $this->attachment_id, true );
-		$metadata['test_api_meta'] = array( 'last_modified' => 1708332626 );
-		wp_update_attachment_metadata( $this->attachment_id, $metadata );
+		$this->add_custom_attachment_metadata( $attachment_id, array( 'test_api_meta' => array( 'last_modified' => 1708332626 ) ) );
 
 		// A co-installed plugin hides its own key from readers.
 		$this->metadata_filter = function ( $data ) {
@@ -91,10 +51,10 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 		add_filter( 'wp_get_attachment_metadata', $this->metadata_filter );
 
 		// Full size dimensions, which is what image_downsize() returns when the size is missing.
-		$image = array( wp_get_attachment_url( $this->attachment_id ), 900, 300, false );
-		WC_Regenerate_Images::maybe_resize_image( $image, $this->attachment_id, 'woocommerce_thumbnail', false );
+		$image = array( wp_get_attachment_url( $attachment_id ), 900, 300, false );
+		WC_Regenerate_Images::maybe_resize_image( $image, $attachment_id, 'woocommerce_thumbnail', false );
 
-		$stored = get_post_meta( $this->attachment_id, '_wp_attachment_metadata', true );
+		$stored = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
 
 		$this->assertArrayHasKey(
 			'test_api_meta',

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -14,6 +14,13 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 	private $attachment_id = 0;
 
 	/**
+	 * Metadata filter callback added by a test, removed on teardown.
+	 *
+	 * @var callable|null
+	 */
+	private $metadata_filter = null;
+
+	/**
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
@@ -22,7 +29,10 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 			$this->attachment_id = 0;
 		}
 
-		remove_all_filters( 'wp_get_attachment_metadata' );
+		if ( $this->metadata_filter ) {
+			remove_filter( 'wp_get_attachment_metadata', $this->metadata_filter );
+			$this->metadata_filter = null;
+		}
 
 		parent::tearDown();
 	}
@@ -71,16 +81,14 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 		wp_update_attachment_metadata( $this->attachment_id, $metadata );
 
 		// A co-installed plugin hides its own key from readers.
-		add_filter(
-			'wp_get_attachment_metadata',
-			function ( $data ) {
-				if ( is_array( $data ) ) {
-					unset( $data['test_api_meta'] );
-				}
-
-				return $data;
+		$this->metadata_filter = function ( $data ) {
+			if ( is_array( $data ) ) {
+				unset( $data['test_api_meta'] );
 			}
-		);
+
+			return $data;
+		};
+		add_filter( 'wp_get_attachment_metadata', $this->metadata_filter );
 
 		// Full size dimensions, which is what image_downsize() returns when the size is missing.
 		$image = array( wp_get_attachment_url( $this->attachment_id ), 900, 300, false );

--- a/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-regenerate-images-test.php
@@ -50,9 +50,26 @@ class WC_Regenerate_Images_Test extends WC_Unit_Test_Case {
 		};
 		add_filter( 'wp_get_attachment_metadata', $this->metadata_filter );
 
+		$this->assertArrayNotHasKey( 'test_api_meta', wp_get_attachment_metadata( $attachment_id ), 'The filter should hide the key from readers' );
+		$this->assertArrayHasKey( 'test_api_meta', wp_get_attachment_metadata( $attachment_id, true ), 'The stored value should keep the key' );
+
+		$thumbnail = $this->delete_attachment_size( $attachment_id, 'woocommerce_thumbnail' );
+
+		$this->assertFileDoesNotExist( $thumbnail, 'The size should be missing before regeneration runs' );
+
 		// Full size dimensions, which is what image_downsize() returns when the size is missing.
-		$image = array( wp_get_attachment_url( $attachment_id ), 900, 300, false );
-		WC_Regenerate_Images::maybe_resize_image( $image, $attachment_id, 'woocommerce_thumbnail', false );
+		$image    = array( wp_get_attachment_url( $attachment_id ), 900, 300, false );
+		$returned = WC_Regenerate_Images::maybe_resize_image( $image, $attachment_id, 'woocommerce_thumbnail', false );
+
+		$target = wc_get_image_size( 'woocommerce_thumbnail' );
+
+		$this->assertSame(
+			array( (int) $target['width'], (int) $target['height'] ),
+			array( $returned[1], $returned[2] ),
+			'The resized image should be returned, not the original'
+		);
+
+		$this->assert_size_exists( $attachment_id, 'woocommerce_thumbnail' );
 
 		$stored = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Complements #66271, which covers the failed regeneration case of #60577. This covers the other two ways regeneration loses metadata. Breakdown is in my comment on the issue.

- #### Read the metadata unfiltered before writing it back in `resize_and_return_image()`

The method captures metadata with the `wp_get_attachment_metadata` filter applied, then writes it back. A plugin filtering that metadata for display gets its filtering persisted and the keys it hides deleted from the DB. A read-modify-write cycle needs the stored value, so the capture now passes `$unfiltered = true`.

- #### Keep foreign top level keys in `WC_Regenerate_Images_Request::task()`

The bulk job behind Regenerate shop thumbnails saves a freshly generated array and only carries over `sizes`. Every custom top level key is dropped, media library wide. The job now restores the keys regeneration does not own.

**Note:** no overlap with the changed lines of #66271, but both PRs add `tests/php/includes/class-wc-regenerate-images-test.php` since that's the conventional name. Whichever lands second merges its test methods into the shared file.

Also note that there is some backwards compatibility impact. `wp_get_attachment_metadata` filter output is no longer persisted and previously-dropped third-party keys now survive regeneration.

Refs #60577.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Covered by new unit tests, one per path. Both fail on trunk. Run with:

```
pnpm --filter="@woocommerce/plugin-woocommerce" test:php:env --filter="WC_Regenerate_Images"
```

Manual check for the bulk path:

1. Add a custom key to a product image's `_wp_attachment_metadata` (integrations and offload plugins store keys like this).
2. Run WooCommerce > Status > Tools > Regenerate shop thumbnails and let the job finish.
3. On trunk the key is gone afterwards. On this branch it survives and `sizes` is intact.

<!-- End testing instructions -->

### Testing that has already taken place:

Unit tests above plus the manual steps, on wp-env with PHP 8.1.34 and only WooCommerce active. PHPCS and PHPStan report nothing new on the changed files.

Background: on the client site where I found this, an integration stored `api_meta` on product images, product page renders wiped it.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Changelog entry is committed in the branch at `plugins/woocommerce/changelog/60577-fix-attachment-metadata-loss` (patch / fix), the manual route the template suggests for forks.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
