### PR TITLE
fix: Add postcode validation for Latvia

### DIFF
--- a/plugins/woocommerce/changelog/67459-lv-postcode-validation
+++ b/plugins/woocommerce/changelog/67459-lv-postcode-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add postcode validation for Latvia, which previously accepted any value.

--- a/plugins/woocommerce/changelog/67459-lv-postcode-validation
+++ b/plugins/woocommerce/changelog/67459-lv-postcode-validation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add postcode validation for Latvia, which previously accepted any value.
+Add postcode validation for Latvia, which previously accepted invalid values.

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -143,6 +143,9 @@ class WC_Validation {
 			case 'LI':
 				$valid = (bool) preg_match( '/^(94[8-9][0-9])$/', $postcode );
 				break;
+			case 'LV':
+				$valid = (bool) preg_match( '/^(LV-)?[1-9][0-9]{3}$/i', $postcode );
+				break;
 			default:
 				$valid = true;
 				break;

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -144,7 +144,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^(94[8-9][0-9])$/', $postcode );
 				break;
 			case 'LV':
-				$valid = (bool) preg_match( '/^(LV-)?[1-9][0-9]{3}$/i', $postcode );
+				$valid = (bool) preg_match( '/^(?:LV-)?[1-9][0-9]{3}\z/i', $postcode );
 				break;
 			default:
 				$valid = true;

--- a/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
@@ -87,7 +87,18 @@ class WC_Validation_Test extends \WC_Unit_Test_Case {
 			array( false, '948A', 'LI' ),
 		);
 
-		return array_merge( $cz, $se, $li );
+		$lv = array(
+			array( true, 'LV-1050', 'LV' ),
+			array( true, 'lv-1050', 'LV' ),
+			array( true, '1050', 'LV' ),
+			array( false, 'LV-0123', 'LV' ),
+			array( false, 'LV-105', 'LV' ),
+			array( false, '10500', 'LV' ),
+			array( false, 'ZZ-1050', 'LV' ),
+			array( false, 'LV-ABCD', 'LV' ),
+		);
+
+		return array_merge( $cz, $se, $li, $lv );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-validation-test.php
@@ -96,6 +96,7 @@ class WC_Validation_Test extends \WC_Unit_Test_Case {
 			array( false, '10500', 'LV' ),
 			array( false, 'ZZ-1050', 'LV' ),
 			array( false, 'LV-ABCD', 'LV' ),
+			array( false, "LV-1050\n", 'LV' ),
 		);
 
 		return array_merge( $cz, $se, $li, $lv );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

- #### Add support for LV postcode validation
- #### Add LV cases to `WC_Validation_Test`

LV currently falls through to `default: $valid = true`, so anything passes. I added formatting support for LV in #45478 but never the validation half, so `wc_format_postcode( '1050', 'LV' )` returns `LV-1050` while `is_postcode( 'anything', 'LV' )` returns true.

The pattern is 4 digits with an optional `LV-` prefix, prefix handling like the existing DK case, case insensitive like ES and NL.

##### Documentation on the format:

https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/lvaEn.pdf
https://en.wikipedia.org/wiki/Postal_codes_in_Latvia
`LV-NNNN`

Closes #67459.

### How to test the changes in this Pull Request:

Covered by new data provider cases. Run with:

```
pnpm --filter="@woocommerce/plugin-woocommerce" test:php:env --filter="WC_Validation_Test"
```

Manual:

1. Sell to Latvia, go to checkout with a product in the cart.
2. Postcode `ZZZZ`: accepted on trunk, rejected on this branch.
3. `LV-1050`, `lv-1050` and `1050` still pass.

### Testing that has already taken place:

Test runs above on wp-env, only WooCommerce active. PHPCS and PHPStan report nothing new on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

Changelog entry is committed in the branch at `plugins/woocommerce/changelog/67459-lv-postcode-validation` (patch / fix).