### PR TITLE
[Payments NOX] Payments settings UI and UX polish

### DIFF
--- a/plugins/woocommerce/changelog/fix-payments-settings-styling
+++ b/plugins/woocommerce/changelog/fix-payments-settings-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a set of styling issues on the Payments settings screens: the white content background now reaches the bottom of the page, headings match the colour used elsewhere, the dividers under the headers are drawn consistently while the screen loads, the whole offline payments header title acts as the back control, and the offline payment method settings form is aligned and spaced evenly.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.scss
@@ -4,3 +4,18 @@
 	width: 24px;
 	min-width: 24px;
 }
+
+// With a visible label the button sits inside the page heading and stands in
+// for it, so it takes the heading's own typography and colour rather than the
+// component defaults, and carries the gap the heading used to hold.
+.woocommerce-settings-payments__back-button--with-label.has-icon {
+	height: auto;
+	width: auto;
+	min-width: 0;
+	// The chevron glyph sits $gap-smaller inside its own 24px box, so the same
+	// amount after the label keeps the focus ring visually even around both.
+	padding-right: $gap-smaller;
+	gap: $gap-smaller * 2;
+	color: inherit;
+	font: inherit;
+}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.scss
@@ -14,7 +14,7 @@
 	min-width: 0;
 	// The chevron glyph sits $gap-smaller inside its own 24px box, so the same
 	// amount after the label keeps the focus ring visually even around both.
-	padding-right: $gap-smaller;
+	padding-inline-end: $gap-smaller;
 	gap: $gap-smaller * 2;
 	color: inherit;
 	font: inherit;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/back-button.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import { type ReactNode } from 'react';
 import { __, isRTL } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
+import clsx from 'clsx';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { getHistory } from '@woocommerce/navigation';
 
@@ -13,10 +15,6 @@ import './back-button.scss';
 import { recordPaymentsEvent } from '~/settings-payments/utils';
 
 interface BackButtonProps {
-	/**
-	 * The title of the back button.
-	 */
-	title: string;
 	/**
 	 * The URL to navigate to when the back button is clicked.
 	 */
@@ -33,6 +31,13 @@ interface BackButtonProps {
 	 * The identifier of the screen from which the user is navigating back (e.g., 'woopayments_payment_methods').
 	 */
 	from?: string;
+	/**
+	 * Visible label rendered next to the chevron, inside the button. Supplying
+	 * it makes the whole label part of the click target, and the button takes
+	 * its accessible name from the label rather than from `tooltipText`, so the
+	 * name always matches what is on screen.
+	 */
+	children?: ReactNode;
 }
 
 /**
@@ -44,6 +49,7 @@ export const BackButton = ( {
 	tooltipText = __( 'WooCommerce Settings', 'woocommerce' ),
 	isRoute = false,
 	from = '',
+	children,
 }: BackButtonProps ) => {
 	const onGoBack = () => {
 		// Record the event when the user clicks the button.
@@ -62,11 +68,24 @@ export const BackButton = ( {
 	return (
 		<Tooltip text={ tooltipText }>
 			<Button
-				className="woocommerce-settings-payments__back-button"
+				// Button only sets its own has-text when the children are a
+				// plain string, so carry the distinction explicitly.
+				className={ clsx(
+					'woocommerce-settings-payments__back-button',
+					{
+						'woocommerce-settings-payments__back-button--with-label':
+							!! children,
+					}
+				) }
 				icon={ isRTL() ? chevronRight : chevronLeft }
 				onClick={ onGoBack }
-				aria-label={ tooltipText }
-			/>
+				// Without a visible label the chevron alone carries no name, so
+				// the tooltip text has to supply one. With a label, overriding
+				// the name would hide the on-screen text from it.
+				aria-label={ children ? undefined : tooltipText }
+			>
+				{ children }
+			</Button>
 		</Tooltip>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/back-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/back-button.test.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -11,6 +13,20 @@ import { BackButton } from '..';
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
+
+const push = jest.fn();
+
+// Only `getHistory` is stubbed — the rest of the module has to stay real,
+// because `@woocommerce/data` wires itself up against it on import.
+jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
+	getHistory: jest.fn(),
+} ) );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	( getHistory as jest.Mock ).mockReturnValue( { push } );
+} );
 
 describe( 'BackButton', () => {
 	describe( 'Accessible name', () => {
@@ -44,6 +60,44 @@ describe( 'BackButton', () => {
 			expect(
 				getByRole( 'button', { name: 'WooCommerce Settings' } )
 			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Going back', () => {
+		// The label sits inside the button, so clicking the words has to go
+		// back just like clicking the chevron does.
+		it( 'navigates and records the click when the visible label is clicked', () => {
+			const { getByText } = render(
+				<BackButton href="/offline" isRoute from="offline_gateway">
+					Bank transfer
+				</BackButton>
+			);
+
+			fireEvent.click( getByText( 'Bank transfer' ) );
+
+			expect( push ).toHaveBeenCalledWith( '/offline' );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'settings_payments_back_button_click',
+				expect.objectContaining( { from: 'offline_gateway' } )
+			);
+		} );
+
+		it( 'navigates and records the click when it renders icon-only', () => {
+			const { getByRole } = render(
+				<BackButton
+					href="/offline"
+					isRoute
+					tooltipText="Back to Payments"
+				/>
+			);
+
+			fireEvent.click( getByRole( 'button' ) );
+
+			expect( push ).toHaveBeenCalledWith( '/offline' );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'settings_payments_back_button_click',
+				expect.any( Object )
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/back-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/back-button.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { BackButton } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'BackButton', () => {
+	describe( 'Accessible name', () => {
+		// The label is what a sighted user reads, so it has to be what a
+		// screen reader announces too — the tooltip must not override it.
+		it( 'takes its accessible name from the visible label when one is given', () => {
+			const { getByRole } = render(
+				<BackButton href="/offline" tooltipText="Back to Payments">
+					Bank transfer
+				</BackButton>
+			);
+
+			expect(
+				getByRole( 'button', { name: 'Bank transfer' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'takes its accessible name from the tooltip text when it renders icon-only', () => {
+			const { getByRole } = render(
+				<BackButton href="/offline" tooltipText="Back to Payments" />
+			);
+
+			expect(
+				getByRole( 'button', { name: 'Back to Payments' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'falls back to the default tooltip text when no tooltip text is given', () => {
+			const { getByRole } = render( <BackButton href="/offline" /> );
+
+			expect(
+				getByRole( 'button', { name: 'WooCommerce Settings' } )
+			).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.tsx
@@ -86,11 +86,7 @@ export const Header = ( {
 				<>
 					{ backLink && (
 						<WooHeaderNavigationItem>
-							<BackButton
-								href={ backLink }
-								title={ title }
-								from={ context }
-							/>
+							<BackButton href={ backLink } from={ context } />
 						</WooHeaderNavigationItem>
 					) }
 					<WooHeaderPageTitle>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.tsx
@@ -6,17 +6,12 @@ import {
 	registerPlugin,
 	getPlugins,
 } from '@wordpress/plugins';
-import {
-	WooHeaderNavigationItem,
-	WooHeaderPageTitle,
-	WooHeaderItem,
-} from '@woocommerce/admin-layout';
+import { WooHeaderPageTitle, WooHeaderItem } from '@woocommerce/admin-layout';
 import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { BackButton } from '../buttons/back-button';
 import './header.scss';
 
 interface HeaderProps {
@@ -24,10 +19,6 @@ interface HeaderProps {
 	 * The title of the header.
 	 */
 	title: string;
-	/**
-	 * The link to go back to. If not provided, the back button will not be shown.
-	 */
-	backLink?: string;
 	/**
 	 * The description of the header.
 	 */
@@ -44,10 +35,6 @@ interface HeaderProps {
 	 * The callback function when the button is clicked.
 	 */
 	onButtonClick?: () => void;
-	/**
-	 * The context in which the header is used, e.g., 'wc_settings_payments'.
-	 */
-	context?: string;
 }
 
 const HEADER_PLUGIN_NAME = 'settings-payments-offline-header';
@@ -59,12 +46,10 @@ let hasRegisteredPlugins = false;
  */
 export const Header = ( {
 	title,
-	backLink,
 	description,
 	hasButton,
 	buttonLabel,
 	onButtonClick,
-	context = '',
 }: HeaderProps ) => {
 	if ( ! hasRegisteredPlugins ) {
 		/**
@@ -84,11 +69,6 @@ export const Header = ( {
 		registerPlugin( HEADER_PLUGIN_NAME, {
 			render: () => (
 				<>
-					{ backLink && (
-						<WooHeaderNavigationItem>
-							<BackButton href={ backLink } from={ context } />
-						</WooHeaderNavigationItem>
-					) }
 					<WooHeaderPageTitle>
 						<span className="woocommerce-settings-payments-header__title">
 							{ title }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/list-placeholder/list-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/list-placeholder/list-placeholder.scss
@@ -3,6 +3,12 @@
 	border-bottom: none; // This way we avoid a double border between items.
 	padding: 0 48px;
 
+	// The header above draws the line that closes it off, so the first row
+	// would stack a second one directly on top of it.
+	&:first-child {
+		border-top: none;
+	}
+
 	// Add back the bottom border for the last item.
 	&:nth-last-child(1 of .woocommerce-item__payment-gateway-placeholder) {
 		border-bottom: 1px solid $gray-200;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/list-placeholder/list-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/list-placeholder/list-placeholder.scss
@@ -9,6 +9,13 @@
 		border-top: none;
 	}
 
+	// @woocommerce/components' List draws the separator over this one in the
+	// lighter $gray-100, which would leave the skeleton's lines a shade off
+	// from the ones the loaded list settles on.
+	.woocommerce-list > &:not(:first-child) {
+		border-top-color: $gray-200;
+	}
+
 	// Add back the bottom border for the last item.
 	&:nth-last-child(1 of .woocommerce-item__payment-gateway-placeholder) {
 		border-bottom: 1px solid $gray-200;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/offline-payment-gateway-list/offline-payment-gateway-list.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/offline-payment-gateway-list/offline-payment-gateway-list.scss
@@ -5,6 +5,13 @@
 	.woocommerce-list__item {
 		padding: 0 48px;
 
+		// The separator comes from @woocommerce/components' List, which draws
+		// it in $gray-100 — a shade lighter than the lines bracketing the list
+		// and than the separators on the main providers list.
+		&:not(:first-child) {
+			border-top-color: $gray-200;
+		}
+
 		&.is-last {
 			border-bottom: 1px solid $gray-200;
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/offline-payment-gateway-list/offline-payment-gateway-list.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/offline-payment-gateway-list/offline-payment-gateway-list.scss
@@ -1,5 +1,6 @@
 .woocommerce-list {
-	border-top: 1px solid $gray-200;
+	// No border-top: the header above closes itself off with its own
+	// border-bottom, in every loading state.
 
 	.woocommerce-list__item {
 		padding: 0 48px;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
@@ -1,5 +1,6 @@
 .settings-payment-gateways__list {
-	border-top: 1px solid $gray-200;
+	// No border-top: the header above closes itself off with its own
+	// border-bottom, in every loading state.
 	// Without this, the window.innerWidth is not calculated correctly when elements are pushed outside the container.
 	overflow: hidden;
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/settings/settings.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/settings/settings.scss
@@ -1,3 +1,9 @@
+// Space above the first line of a section, applied to both columns so the
+// details heading and the first control start on the same line. Declared once
+// so the two cannot drift apart — previously the heading took wp-admin's
+// default h2 margin and the controls carried a hand-tuned counter-nudge.
+$settings-section-leading: $gap;
+
 .settings-layout {
 	margin: 48px 12px 0;
 	display: flex;
@@ -48,6 +54,9 @@
 		h2 {
 			font-size: 16px;
 			line-height: 24px;
+			// Stated rather than inherited from wp-admin, so the controls
+			// column has a fixed value to align against.
+			margin-top: $settings-section-leading;
 		}
 
 		p {
@@ -76,8 +85,13 @@
 	}
 
 	&__controls {
-		margin-top: 6px;	// Ensure visual alignment.
+		margin-top: $settings-section-leading;
 		flex: 1 1 auto;
+
+		// The columns stack here, so there is no heading to align against.
+		@include breakpoint( "<782px" ) {
+			margin-top: 0;
+		}
 	}
 
 	.form-field:not(:first-child) {

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/settings/settings.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/settings/settings.scss
@@ -99,16 +99,14 @@ $settings-section-leading: $gap;
 	}
 }
 
+// These controls used to carry their own 32px bottom margins, from before the
+// forms moved to DataForm. DataForm spaces its fields with a gap, so those
+// margins stacked on top of it and every field ended up 48px apart. The gap is
+// now the only thing setting that rhythm.
 .components-base-control {
-	margin-bottom: 32px;
-
 	+ .components-base-control__help {
 		margin-top: 0;
 		margin-bottom: 0;
-	}
-
-	&__help {
-		margin-bottom: 32px;
 	}
 }
 
@@ -129,7 +127,10 @@ $settings-section-leading: $gap;
 	}
 
 	&__help {
+		// Matches the 8px that Gutenberg's own help text sits below its field.
+		// No bottom margin, for the same reason as the base control above: the
+		// DataForm gap already separates this field from the next.
 		margin-top: calc(8px);
-		margin-bottom: 32px;
+		margin-bottom: 0;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -94,7 +94,7 @@ const OfflinePaymentGatewayWrapper = ( {
 							<BackButton
 								href={ getNewPath( {}, '/offline' ) }
 								tooltipText={ __(
-									'Return to payments settings',
+									'Return to offline payment methods',
 									'woocommerce'
 								) }
 								isRoute={ true }

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -90,19 +90,20 @@ const OfflinePaymentGatewayWrapper = ( {
 			<div className="settings-payments-offline__container">
 				<div className="settings-payment-gateways">
 					<div className="settings-payments-offline__header">
-						<BackButton
-							href={ getNewPath( {}, '/offline' ) }
-							title={ __(
-								'Return to payments settings',
-								'woocommerce'
-							) }
-							isRoute={ true }
-							from={ 'woopayments_payment_methods' }
-						/>
 						<h1 className="components-truncate components-text woocommerce-layout__header-heading woocommerce-layout__header-left-align settings-payments-offline__header-title">
-							<span className="woocommerce-settings-payments-header__title">
-								{ title }
-							</span>
+							<BackButton
+								href={ getNewPath( {}, '/offline' ) }
+								tooltipText={ __(
+									'Return to payments settings',
+									'woocommerce'
+								) }
+								isRoute={ true }
+								from={ 'woopayments_payment_methods' }
+							>
+								<span className="woocommerce-settings-payments-header__title">
+									{ title }
+								</span>
+							</BackButton>
 						</h1>
 					</div>
 					<Suspense fallback={ <Placeholder /> }>
@@ -216,23 +217,24 @@ export const SettingsPaymentsOfflineWrapper = () => {
 		<>
 			<div className="settings-payments-offline__container">
 				<div className="settings-payments-offline__header">
-					<BackButton
-						href={ getNewPath(
-							{ page: 'wc-settings', tab: 'checkout' },
-							'/',
-							{}
-						) }
-						title={ __(
-							'Return to payments settings',
-							'woocommerce'
-						) }
-						isRoute={ true }
-						from={ 'woopayments_payment_methods' }
-					/>
 					<h1 className="components-truncate components-text woocommerce-layout__header-heading woocommerce-layout__header-left-align">
-						<span className="woocommerce-settings-payments-header__title">
-							{ __( 'Take offline payments', 'woocommerce' ) }
-						</span>
+						<BackButton
+							href={ getNewPath(
+								{ page: 'wc-settings', tab: 'checkout' },
+								'/',
+								{}
+							) }
+							tooltipText={ __(
+								'Return to payments settings',
+								'woocommerce'
+							) }
+							isRoute={ true }
+							from={ 'woopayments_payment_methods' }
+						>
+							<span className="woocommerce-settings-payments-header__title">
+								{ __( 'Take offline payments', 'woocommerce' ) }
+							</span>
+						</BackButton>
 					</h1>
 				</div>
 				<Suspense fallback={ <ListPlaceholder rows={ 3 } /> }>

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -251,10 +251,7 @@ export const SettingsPaymentsOfflineWrapper = () => {
 export const SettingsPaymentsWooPaymentsWrapper = () => {
 	return (
 		<>
-			<Header
-				title={ __( 'Settings', 'woocommerce' ) }
-				context={ 'wc_settings_payments__woopayments' }
-			/>
+			<Header title={ __( 'Settings', 'woocommerce' ) } />
 			<Suspense
 				fallback={
 					<div>
@@ -296,10 +293,7 @@ export const SettingsPaymentsChequeWrapper = () =>
 export const SettingsPaymentsMainWrapper = () => {
 	return (
 		<>
-			<Header
-				title={ __( 'Settings', 'woocommerce' ) }
-				context={ 'wc_settings_payments__main' }
-			/>
+			<Header title={ __( 'Settings', 'woocommerce' ) } />
 			<HistoryRouter history={ getHistory() }>
 				<Routes>
 					<Route

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
@@ -35,6 +35,9 @@ body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab {
 	margin: 0 -30px;
 
 	.settings-layout {
-		margin: 0 48px 0;
+		// The horizontal 48px lines the form up with the header above it. The
+		// top, plus the section heading's own leading, puts the first line of
+		// the form roughly where it sat before the header was reworked.
+		margin: $gap 48px 0;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
@@ -21,6 +21,14 @@ body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab {
 	#mainform {
 		background-color: #fff;
 	}
+	// #mainform is only as tall as its content, while #wpcontent is held to
+	// the viewport height, so on a tall window the body grey shows below the
+	// panel. Other tabs leave #mainform grey, so the seam only appears here.
+	// The tab strip above sets its own grey and the page header is fixed with
+	// its own, so neither depends on what shows through from here.
+	#wpcontent {
+		background-color: #fff;
+	}
 }
 
 .settings-payments-offline__container {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-body.scss
@@ -18,15 +18,31 @@ body.woocommerce_page_wc-settings.woocommerce-settings-payments-tab {
 	.nav-tab-wrapper {
 		background-color: #f0f0f1;
 	}
-	#mainform {
-		background-color: #fff;
-	}
-	// #mainform is only as tall as its content, while #wpcontent is held to
-	// the viewport height, so on a tall window the body grey shows below the
-	// panel. Other tabs leave #mainform grey, so the seam only appears here.
-	// The tab strip above sets its own grey and the page header is fixed with
-	// its own, so neither depends on what shows through from here.
+	// The panel has to reach the bottom of the window, footer included, but
+	// #mainform is only as tall as its content, so the body grey used to show
+	// beneath it. Other tabs leave #mainform grey, so the seam only appears
+	// here. #wpcontent is already held to the window height, so making it a
+	// column lets #wpbody take whatever the content leaves over — no
+	// hardcoded admin-bar, page-header, or footer heights to drift when any
+	// of them change, and no arithmetic that a short page rounds differently
+	// from a long one.
 	#wpcontent {
+		display: flex;
+		flex-direction: column;
+	}
+	// The white goes on #wpbody rather than #wpcontent because #wpbody clears
+	// the fixed page header with a top margin, and a margin paints the
+	// parent's background. A white #wpcontent therefore leaks into the strip
+	// between the page header and the tab strip as soon as the content moves
+	// off its resting position, which is the continuous grey chrome region
+	// the tab strip above is establishing. #wpbody starts below that margin,
+	// so it cannot reach it. The footer is absolutely positioned against the
+	// bottom of #wpwrap and overlaps #wpbody, so it lands on the white too.
+	#wpbody {
+		background-color: #fff;
+		flex: 1;
+	}
+	#mainform {
 		background-color: #fff;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -530,11 +530,12 @@
 		align-items: center;
 
 		h1 {
-			padding-left: $gap-smaller * 2;
 			// This heading renders outside the floating header, so the shared
 			// header typography doesn't reach it — restate it to match the other
 			// settings headers. padding-top trims wp-admin's default h1 padding
-			// so the title centers against the back button.
+			// so the title centers against the back button. The gap to the
+			// chevron now lives inside the button, which sits within this
+			// heading.
 			padding-top: 4px;
 			font-size: 15px;
 			font-weight: 500;

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -4,6 +4,13 @@
 /* This is imported here to avoid build errors when importing the same file in multiple places. */
 @import "./components/modals/modals.scss";
 
+// Every Payments screen lays its header title out on a row this tall — the
+// height of the business location control, which is the tallest thing any of
+// these headers carries. Stated once and applied to each header, so the title
+// and the divider below it land in the same place on all of them and nothing
+// shifts when moving between screens.
+$payments-header-row-height: 38px;
+
 /* These keyframes and spinner style are copied from the Stripe Spinner component https://docs.stripe.com/stripe-apps/components/spinner?app-sdk-version=8  */
 @keyframes SpinnerAnimationShow {
 	0% {
@@ -74,6 +81,9 @@
 		}
 
 		&__header-title {
+			display: flex;
+			align-items: center;
+			min-height: $payments-header-row-height;
 			font-size: 16px;
 			font-weight: 600;
 			line-height: 24px;
@@ -551,10 +561,18 @@
 			// screen gives "Payment providers", so it takes that heading's
 			// scale — the floating header's lighter 15px/500 left this h1
 			// smaller than the section headings and list rows beneath it.
-			// padding-top trims wp-admin's default h1 padding so the title
-			// centers against the back button. The gap to the chevron now lives
-			// inside the button, which sits within this heading.
-			padding-top: 4px;
+			// The gap to the chevron lives inside the back button, which sits
+			// within this heading.
+			// Laying the title out as a centred flex row, rather than letting
+			// it sit on a text baseline, is what keeps it level with the main
+			// screen's title: the back button is an inline-flex box, so a
+			// baseline would leave the descender gap below it in the heading's
+			// height. Zeroing the padding drops wp-admin's own h1 padding,
+			// which the row height now covers.
+			display: flex;
+			align-items: center;
+			min-height: $payments-header-row-height;
+			padding: 0;
 			font-size: 16px;
 			font-weight: 600;
 			color: $gray-900;

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -53,6 +53,12 @@
 			justify-content: space-between;
 			padding: $gap-smaller 48px $gap-large;
 			align-items: center;
+			// Every header on this screen closes itself off with this line,
+			// rather than leaving it to whatever renders below. What renders
+			// below varies — the provider list, or the skeleton while they
+			// load — and each drawing its own top border is how the line ended
+			// up doubled in one state and missing in another.
+			border-bottom: 1px solid $gray-200;
 
 			@media screen and (max-width: $break-xlarge) {
 				padding: $gap-smaller $gap-large $gap-large;
@@ -535,6 +541,9 @@
 		display: flex;
 		padding: 8px 48px 24px;
 		align-items: center;
+		// Same ownership as the main screen's header: the line belongs to the
+		// header, on both the methods list and an individual method's page.
+		border-bottom: 1px solid $gray-200;
 
 		h1 {
 			// This heading renders outside the floating header, so the shared
@@ -552,13 +561,5 @@
 				line-height: 24px;
 			}
 		}
-	}
-
-	// Individual method pages nest their header inside
-	// .settings-payment-gateways; the list page does not. The list already
-	// draws this line as the border-top of its .woocommerce-list, so scoping it
-	// here matches the two levels without doubling up on the list.
-	.settings-payment-gateways .settings-payments-offline__header {
-		border-bottom: 1px solid $gray-200;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -71,6 +71,9 @@
 			font-size: 16px;
 			font-weight: 600;
 			line-height: 24px;
+			// Without this it inherits wp-admin's body grey, which is lighter
+			// than every other heading on the screen.
+			color: $gray-900;
 		}
 
 		&__header-select-container {
@@ -177,6 +180,10 @@
 				font-weight: 600;
 				line-height: 24px;
 				align-items: center;
+				// The header is a bare <button>, so without this the title
+				// falls to the browser's black rather than the heading colour
+				// used elsewhere on the screen.
+				color: $gray-900;
 
 				&-image {
 					width: $icon-size;

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -547,14 +547,16 @@
 
 		h1 {
 			// This heading renders outside the floating header, so the shared
-			// header typography doesn't reach it — restate it to match the other
-			// settings headers. padding-top trims wp-admin's default h1 padding
-			// so the title centers against the back button. The gap to the
-			// chevron now lives inside the button, which sits within this
-			// heading.
+			// header typography doesn't reach it. It occupies the slot the main
+			// screen gives "Payment providers", so it takes that heading's
+			// scale — the floating header's lighter 15px/500 left this h1
+			// smaller than the section headings and list rows beneath it.
+			// padding-top trims wp-admin's default h1 padding so the title
+			// centers against the back button. The gap to the chevron now lives
+			// inside the button, which sits within this heading.
 			padding-top: 4px;
-			font-size: 15px;
-			font-weight: 500;
+			font-size: 16px;
+			font-weight: 600;
 			color: $gray-900;
 
 			.woocommerce-settings-payments-header__title {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -553,4 +553,12 @@
 			}
 		}
 	}
+
+	// Individual method pages nest their header inside
+	// .settings-payment-gateways; the list page does not. The list already
+	// draws this line as the border-top of its .woocommerce-list, so scoping it
+	// here matches the two levels without doubling up on the list.
+	.settings-payment-gateways .settings-payments-offline__header {
+		border-bottom: 1px solid $gray-200;
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A collection of small corrections to the **WooCommerce → Settings → Payments** screen — mostly styling, plus one interaction fix. Each is self-contained, with its own commit, so any one can be dropped or reverted independently. They share a single changelog entry. More may be added while this is open.

A theme runs through most of these: a rule that was correct when written, left behind by a later refactor that moved the thing it was compensating for.

**1. The content panel stopped short of the page bottom.**

`#mainform` is only as tall as its content, while `#wpcontent` is held to the viewport height, so on a tall browser window the body grey showed as a band between the end of the content and the footer. Every other Settings tab leaves `#mainform` grey — matching `#wpcontent`, so the seam is invisible there. The Payments tab is the only one that paints `#mainform` white, which is what makes the seam show, and the fix is scoped to that tab's body class for the same reason.

Painting `#wpcontent` white is safe here: the tab strip above sets its own grey in the same block, and the page header is `position: fixed` with its own, so neither depends on what shows through from `#wpcontent`.

**2. Only the chevron in the offline payments header was clickable.**

The obvious target — the title beside it — did nothing. The button now renders the title inside itself and sits within the existing `<h1>`, which keeps the heading level and its text intact: a button is phrasing content, so nesting it in a heading is valid, and the whole label becomes the target. That takes the hit area from 24×24 to 188×24 without moving the chevron or the title by a pixel.

This also corrects the control's accessible name. `BackButton` took a `title` prop it never rendered, so both offline screens passed "Return to payments settings" into nothing and the button fell back to labelling itself "WooCommerce Settings". The visible title is now the accessible name, which is what WCAG 2.5.3 asks for, and the destination moves to the tooltip, exposed as `aria-describedby`. The dead prop is removed rather than left to mislead.

On a method page that tooltip now names where the link actually goes — the offline payment methods list, rather than payments settings, which is where the level above returns to.

The `header.tsx` caller renders its chevron and title into separate `WooHeader` slots, so they are not siblings and cannot nest this way; it keeps the icon-only button.

**3. Two headings used the wrong colour.**

Neither declared one, so each fell to a different default: "Payment providers" inherited wp-admin's body grey (`#3c434a`), noticeably lighter than everything around it, and "More payment options" landed on the browser's black (`#000`) because its header is a bare `<button>`. The gateway titles, category headings and offline header all use `$gray-900` (`#1e1e1e`). Both now state it.

Only the "Payment providers" change is visible; `#000` → `#1e1e1e` is imperceptible and is included for consistency, so that all headings follow the same token if it ever changes.

**4. The individual offline method pages had no divider under their header.**

The offline list page separates its header from the list with a hairline; the method pages lost their equivalent. That line came from a `border-bottom` on `.woocommerce-layout__header` added in #57999, back when these pages rendered their title into the floating admin header. #59163 moved the title into an in-page header so navigation would not full-page-refresh, which left that rule drawing a line above the *tab strip* instead. Review spotted the misplaced line and the rule was dropped — correct for the symptom, but nothing put the intended divider back.

Each header now draws that line itself, rather than leaving it to whatever renders below. Which element that was varied by page and by loading state — both lists carried a `border-top`, as did the skeleton loader's rows, and the offline list's rule ships in a lazily loaded chunk. So the line came out doubled while a list was loading, and missing once the skeleton stood alone.

**5. The controls column did not line up with its section heading.**

A design QA pass asked for these to start on the same line; the controls sat 10px above. Neither side stated its own offset — the heading took wp-admin's default `h2` margin and the controls carried a hand-tuned "ensure visual alignment" nudge measured against it, so when one moved the other had no way to follow. Both now take the same declared value and line up by construction.

The offline pages also had no space between the page header and the form, because the override that lines the form up with the header horizontally sets all four margins and zeroed the top. It now leaves the same room the section heading needs.

**6. Fields on the offline method pages were unevenly spaced.**

48px apart where the previous field had help text, 16px where it did not. These controls carried their own 32px bottom margins from before the forms moved to `DataForm` in #65731; `DataForm` separates its fields with a gap, so the margins stacked on top of it. The margins are gone and the gap is the only thing setting that rhythm — also the direction `@wordpress/components` is moving, since its own field margin is behind `__nextHasNoMarginBottom` and on the way out. Help text still sits 8px under its field, so label, field and help read as one unit.

**7. Row dividers on the offline methods list were a shade lighter than the lines around them.**

They come from `@woocommerce/components`' `List`, which draws them in `$gray-100`, while the lines bracketing that list — and the row separators on the main providers list — use `$gray-200`. Now `$gray-200` throughout.

**8. The offline page titles were smaller than their own contents, and shifted between screens.**

Both offline `h1`s took the floating settings header's 15px/500. They do not render in the floating header, though — they sit in page content, in the slot the main screen fills with "Payment providers" at 16px/600, so each page title came out lighter than the section headings and payment method rows directly beneath it. They now take that scale.

Their position was off by the same reasoning. The main screen sizes its header row against the business location control, the tallest thing in it; the offline headers have no such control, so their row was whatever the heading measured — a text line box holding an inline-flex back button, descender gap included. The title landed 3px higher than the main screen's and the divider 1.2px higher, so both jumped on the way back. That row height is now stated once and given to every header, each title laid out as a centred flex row rather than on a baseline.

Focus-indicator consistency on this screen is handled separately in #67448; there is no overlap between the two branches.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**1. Content panel background, on a tall window**

| Before | After |
| ------ | ----- |
| <img width="2160" height="1400" alt="before-21-panel-background" src="https://github.com/user-attachments/assets/66489964-9112-4e52-8f2d-0d170e1bfc06" /> | <img width="2160" height="1400" alt="after-21-panel-background" src="https://github.com/user-attachments/assets/46010463-9b0b-4461-83f4-a2825eb43108" /> |

**2. Offline payments header — focused back control**

| Before | After |
| ------ | ----- |
| <img width="1700" height="220" alt="before-15-offline-header-clickable" src="https://github.com/user-attachments/assets/61ed5edb-bc03-49c2-9f6a-d86946034c12" /> | <img width="1700" height="220" alt="after-15-offline-header-clickable" src="https://github.com/user-attachments/assets/c64d50cd-9073-4101-b06f-6f65d2aad322" /> |

Before: a small 24×24 click/focus target on the chevron alone, tooltip reading "WooCommerce Settings". After: the whole title is the target, tooltip reading "Return to payments settings".

**3. "Payment providers" heading colour**

| Before | After |
| ------ | ----- |
| <img width="2540" height="480" alt="before-16-providers-heading-colour" src="https://github.com/user-attachments/assets/75c65c9b-f0f5-42ea-9a63-a65148a0b607" /> | <img width="2540" height="480" alt="after-16-providers-heading-colour" src="https://github.com/user-attachments/assets/28d44212-0070-4f09-bf76-5ae849afc278" /> |

Shown next to a gateway title for comparison. The "More payment options" half of this fix has no visible difference, so there is nothing useful to show for it.

**4. Header divider on an individual method page**
**5. Controls aligned with the section heading, and the form's top spacing**

| Before | After |
| ------ | ----- |
| <img width="2000" height="380" alt="before-19-controls-alignment" src="https://github.com/user-attachments/assets/379d50b0-5fb8-4f93-a63c-1c514126f28b" /> | <img width="2000" height="380" alt="after-19-controls-alignment" src="https://github.com/user-attachments/assets/f4fd5860-0b46-4df4-aa27-50a8bdd31d4c" /> |

**6. Even field spacing, DS-based**

| Before | After |
| ------ | ----- |
| <img width="2100" height="1500" alt="before-20-field-spacing" src="https://github.com/user-attachments/assets/ab318757-06e2-4705-ae02-98625735ae96" /> | <img width="2100" height="1500" alt="after-20-field-spacing" src="https://github.com/user-attachments/assets/f9fd7269-fcde-4324-93b6-e1a3e037b6b0" /> |

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and build the admin client (`pnpm --filter='@woocommerce/plugin-woocommerce' build:admin`). Hard-reload the admin afterwards — the asset `?ver=` does not change, so a normal reload will serve cached CSS.

**Content panel background**

2. Go to **WooCommerce → Settings → Payments** in a browser window tall enough that the content does not fill it. Collapsing "More payment options" makes this easier to hit. The white panel should run all the way to the footer, with no grey band.
3. Confirm the tab strip and the "Settings" header above it are still grey — neither should have turned white.
4. Visit the other Settings tabs (General, Products, Advanced, …) at the same window height. They should be unchanged: content area grey, as before.

**Offline payments header**

5. Go to **Payments → Take offline payments**, then into any method. Click the title text, not the chevron — it should navigate back. Both levels behave the same way.
6. Tab to the control. The focus ring should wrap the chevron and the title together. The tooltip should read "Return to payments settings" on the list page and "Return to offline payment methods" on a method page.
7. With a screen reader, confirm it announces as *"&lt;page title&gt;, button, heading level 1"* — the heading level and text are unchanged, and the name now matches the visible text instead of saying "WooCommerce Settings".
8. Check there is exactly one hairline under the header on every Payments screen — main, offline list, and a method page. Then throttle the network in DevTools and reload each: the line should stay a single hairline while the skeleton loader is up, neither doubling nor disappearing.
9. On the offline methods list, the lines between rows should match the ones above the first row and below the last, rather than reading lighter.
10. Compare the header title between the main screen and an offline screen — same size and weight, and no vertical jump when navigating between them. On the offline list, the title should not look smaller than the method names beneath it.

**Section layout on the method pages**

11. On each of Direct bank transfer, Cheque and Cash on delivery: the first control on the right should start on the same line as the section heading on the left, and the form should sit clear of the header divider rather than hard against it.
12. Check the field rhythm down the form — every field the same distance from the next, including after fields that have help text below them, and including the "Enable for shipping methods" tree select on Cash on delivery. Help text should stay tucked just under its own field.
13. Narrow the window below 782px so the columns stack. The heading and controls should stack with normal spacing, without the alignment offset being added on top.

**Heading colours**

14. On the main Payments screen, compare "Payment providers" against the gateway titles below it. They should be the same colour; before this change the heading was visibly lighter.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Manually verified in `wp-env` on WordPress 7.0.2 with WooCommerce `11.1.0-dev` and Twenty Twenty-Five, against built assets, with WooPayments installed and connected. Figures below are computed-style and geometry measurements taken in the browser, not estimates.

**Content panel background**

- Payments, 1200×1500 window — before: white ended at `1065` with the footer at `1460`, a 395px grey band. After: that region paints `rgb(255, 255, 255)`.
- Page header and tab strip on Payments still report `rgb(240, 240, 241)`.
- Advanced tab: `#wpcontent` and `#mainform` both still `rgb(240, 240, 241)`, and the `woocommerce-settings-payments-tab` body class is absent, so the rule cannot apply.

**Offline payments header**

- Hit area 24×24 → 188×24; chevron and title unmoved (x=208 / x=248 before and after).
- Accessible name "WooCommerce Settings" → the page title; `aria-describedby` resolves to "Return to payments settings".
- Clicking the title text navigates on both the offline list and the method pages.
- Divider: `1px solid rgb(224, 224, 224)` spanning the full content width. Measured on all three screens, loaded and with the skeleton loader reconstructed in place: 1px in every case, where the skeleton previously stacked two. Header bottom edge and list top edge share a y on each screen, so moving the line from the lists to the headers did not move it.
- Offline list rows: separators `rgb(240, 240, 240)` → `rgb(224, 224, 224)`, matching the lines above the first row and below the last.

**Header title scale and position**

- Both offline `h1`s 15px/500 → 16px/600, matching "Payment providers", the section `h2`s and the list rows, all 16px/600/24.
- Title centre and divider now identical on all three screens (centre y 184, divider y 228, header height 71); the offline screens were 181 and 226.8. The main screen did not move. Chevron centre matches its title on both offline screens.
- At 600px wide the title sits 27px below the header top on both the main and offline screens.

**Section layout**

- Heading and controls both start at the same offset on all three method pages; previously the controls were 10px higher.
- Form sits 16px below the divider, putting its first line 32px from it, close to where it sat before the header was reworked.
- Below `$break-medium` the columns stack and the alignment offset is dropped; the details column keeps its existing 40px bottom margin.
- Field spacing measured on all three pages: bacs 16/16/16, cheque 16/16/16, cod 16×5 including the tree-select field. Help text remains 8px under its own field. Page height on bacs 1163 → 1035.

**Blast radius of the spacing change**

- The Settings layout these rules belong to is imported only by `settings-payments-bacs`, `-cheque` and `-cod`. The WooPayments settings screens do not use it.
- The `.components-base-control` rule is not present in the CSS loaded on the payments list page or the offline list page — checked by enumerating `document.styleSheets` on both.

**Heading colours**

- "Payment providers" `rgb(60, 67, 74)` → `rgb(30, 30, 30)`; "More payment options" `rgb(0, 0, 0)` → `rgb(30, 30, 30)`. All four headings on the screen now measure the same value.

`stylelint`, `eslint` and `pnpm ts:check` all pass.

Not covered: RTL, and screen-reader verification was by inspecting the accessibility properties rather than with an actual screen reader.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually — a single entry covering the set.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Authored with Claude Code (Claude Opus 5). The assistant traced the cause in the browser against the local `wp-env` build, wrote the fix and this description. I spotted the issue, corrected the initial diagnosis, and reviewed the result.



