### PR TITLE
[Email Editor] Fix back button rendering on WordPress 7.1

### DIFF
--- a/packages/js/email-editor/changelog/update-back-button-wp71
+++ b/packages/js/email-editor/changelog/update-back-button-wp71
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Render the editor back button as a compact chevron on WordPress 7.1+ to match the redesigned header, keeping the fullscreen-style button on older versions

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -2,8 +2,15 @@
  * External dependencies
  */
 import { Button, __unstableMotion as motion } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, arrowLeft, wordpress } from '@wordpress/icons';
+import { useLayoutEffect, useRef, useState } from '@wordpress/element';
+import { __, isRTL } from '@wordpress/i18n';
+import {
+	Icon,
+	arrowLeft,
+	chevronLeft,
+	chevronRight,
+	wordpress,
+} from '@wordpress/icons';
 import { applyFilters } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
 
@@ -13,6 +20,12 @@ import { useSelect } from '@wordpress/data';
 import { BackButton } from '../../private-apis';
 import { recordEvent } from '../../events';
 import { storeName } from '../../store';
+
+// The WordPress 7.1+ header reserves a compact 32px slot for the back button
+// and renders it as a plain chevron; older versions reserve a 64px slot filled
+// with a fullscreen-style logo button. The slot width is what our button must
+// fit into, so detect it instead of the WordPress version.
+const COMPACT_SLOT_MAX_WIDTH = 48;
 
 const toggleHomeIconVariants = {
 	edit: {
@@ -38,10 +51,7 @@ const siteIconVariants = {
 	},
 };
 
-/**
- * Back button content component with animation effects.
- */
-const DefaultBackButtonContent = () => {
+function useCloseAction() {
 	const { urls } = useSelect(
 		( select ) => ( {
 			urls: select( storeName ).getUrls(),
@@ -49,11 +59,47 @@ const DefaultBackButtonContent = () => {
 		[]
 	);
 
-	function backAction() {
-		if ( urls.listings ) {
-			window.location.href = urls.back;
-		}
-	}
+	return () => {
+		recordEvent( 'header_close_button_clicked' );
+		const defaultAction = () => {
+			if ( urls.back ) {
+				window.location.href = urls.back;
+			}
+		};
+		const action = applyFilters(
+			'woocommerce_email_editor_close_action_callback',
+			defaultAction
+		);
+		( typeof action === 'function' ? action : defaultAction )();
+	};
+}
+
+/**
+ * Compact back button fitting the narrow slot of the WordPress 7.1+ header,
+ * rendered as a plain chevron matching core.
+ */
+const CompactBackButtonContent = () => {
+	const onClose = useCloseAction();
+
+	return (
+		<Button
+			size="compact"
+			icon={ isRTL() ? chevronRight : chevronLeft }
+			label={ __( 'Close editor', __i18n_text_domain__ ) }
+			showTooltip
+			tooltipPosition="middle right"
+			onClick={ onClose }
+		/>
+	);
+};
+
+/**
+ * Fullscreen-style back button filling the 64px slot of the WordPress ≤ 7.0
+ * header, rendered as the WordPress logo with a hover arrow. This button will
+ * be dropped after we drop support for WordPress 7.0.
+ */
+const FullscreenBackButtonContent = () => {
+	const onClose = useCloseAction();
 
 	return (
 		<motion.div
@@ -70,14 +116,7 @@ const DefaultBackButtonContent = () => {
 				label={ __( 'Close editor', __i18n_text_domain__ ) }
 				showTooltip
 				tooltipPosition="middle right"
-				onClick={ () => {
-					recordEvent( 'header_close_button_clicked' );
-					const action = applyFilters(
-						'woocommerce_email_editor_close_action_callback',
-						backAction
-					) as () => void;
-					action();
-				} }
+				onClick={ onClose }
 			>
 				<motion.div variants={ siteIconVariants }>
 					<div className="woocommerce-email-editor__view-mode-toggle-icon">
@@ -96,6 +135,39 @@ const DefaultBackButtonContent = () => {
 				<Icon icon={ arrowLeft } />
 			</motion.div>
 		</motion.div>
+	);
+};
+
+/**
+ * Back button content component. Picks the variant fitting the width the
+ * editor header reserves for the back button. The detection is temporary and
+ * will be dropped along with the fullscreen-style button after we drop
+ * support for WordPress 7.0.
+ */
+const DefaultBackButtonContent = () => {
+	const measureRef = useRef< HTMLDivElement >( null );
+	const [ isCompactSlot, setIsCompactSlot ] = useState< boolean | null >(
+		null
+	);
+
+	useLayoutEffect( () => {
+		const slot = measureRef.current?.closest< HTMLElement >(
+			'.editor-header__back-button'
+		);
+		const slotWidth = slot?.getBoundingClientRect().width ?? 0;
+		setIsCompactSlot(
+			slotWidth > 0 && slotWidth <= COMPACT_SLOT_MAX_WIDTH
+		);
+	}, [] );
+
+	if ( isCompactSlot === null ) {
+		return <div ref={ measureRef } />;
+	}
+
+	return isCompactSlot ? (
+		<CompactBackButtonContent />
+	) : (
+		<FullscreenBackButtonContent />
 	);
 };
 

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -62,8 +62,20 @@ function useCloseAction() {
 	return () => {
 		recordEvent( 'header_close_button_clicked' );
 		const defaultAction = () => {
-			if ( urls.back ) {
-				window.location.href = urls.back;
+			if ( ! urls.back ) {
+				return;
+			}
+			try {
+				// Resolve against the full current URL so relative paths
+				// keep the same meaning as a direct location assignment.
+				const backUrl = new URL( urls.back, window.location.href );
+				// Only navigate to web URLs so schemes like javascript:
+				// cannot reach window.location.
+				if ( [ 'http:', 'https:' ].includes( backUrl.protocol ) ) {
+					window.location.href = backUrl.href;
+				}
+			} catch {
+				// Do not navigate to an invalid URL.
 			}
 		};
 		const action = applyFilters(

--- a/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
+++ b/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
@@ -30,6 +30,8 @@ jest.mock( '@wordpress/components', () => ( {
 jest.mock( '@wordpress/icons', () => ( {
 	Icon: () => <span>Icon</span>,
 	arrowLeft: 'arrowLeft',
+	chevronLeft: 'chevronLeft',
+	chevronRight: 'chevronRight',
 	wordpress: 'wordpress',
 } ) );
 
@@ -44,6 +46,21 @@ const mockUrls = {
 	back: 'https://example.com/back',
 	listings: 'https://example.com/listings',
 	send: 'https://example.com/send',
+};
+
+// Renders the component inside the editor header's back button slot with the
+// given width. jsdom has no layout, so getBoundingClientRect is stubbed.
+const renderInSlot = ( slotWidth: number ) => {
+	jest.spyOn(
+		HTMLElement.prototype,
+		'getBoundingClientRect'
+	).mockReturnValue( { width: slotWidth } as DOMRect );
+
+	return render(
+		<div className="editor-header__back-button">
+			<BackButtonContent />
+		</div>
+	);
 };
 
 describe( 'BackButtonContent', () => {
@@ -65,6 +82,10 @@ describe( 'BackButtonContent', () => {
 				return {};
 			} )
 		);
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
 	} );
 
 	it( 'should render the back button', () => {
@@ -90,6 +111,27 @@ describe( 'BackButtonContent', () => {
 		// Verify button has onClick handler (we don't actually click to avoid navigation error)
 		expect( button ).toBeInTheDocument();
 		expect( button.onclick ).not.toBeNull();
+	} );
+
+	it( 'should render the fullscreen-style button in a wide slot (WordPress ≤ 7.0 header)', () => {
+		const { container } = renderInSlot( 64 );
+		expect(
+			container.querySelector(
+				'.woocommerce-email-editor__view-mode-toggle'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the compact button in a narrow slot (WordPress 7.1+ header)', () => {
+		const { container, getByRole } = renderInSlot( 32 );
+		expect(
+			container.querySelector(
+				'.woocommerce-email-editor__view-mode-toggle'
+			)
+		).not.toBeInTheDocument();
+		expect(
+			getByRole( 'button', { name: 'Close editor' } )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should apply woocommerce_email_editor_close_content filter to render custom component', () => {

--- a/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
+++ b/packages/js/email-editor/src/components/header/test/back-button-content.spec.tsx
@@ -7,6 +7,7 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,8 +16,8 @@ import { BackButtonContent } from '../back-button-content';
 import { storeName } from '../../../store';
 
 jest.mock( '@wordpress/components', () => ( {
-	Button: ( { children, label, onClick } ) => (
-		<button aria-label={ label } onClick={ onClick }>
+	Button: ( { children, label, onClick, icon } ) => (
+		<button aria-label={ label } onClick={ onClick } data-icon={ icon }>
 			{ children }
 		</button>
 	),
@@ -131,7 +132,15 @@ describe( 'BackButtonContent', () => {
 		).not.toBeInTheDocument();
 		expect(
 			getByRole( 'button', { name: 'Close editor' } )
-		).toBeInTheDocument();
+		).toHaveAttribute( 'data-icon', 'chevronLeft' );
+	} );
+
+	it( 'should render the right chevron in a narrow slot in RTL', () => {
+		( isRTL as jest.Mock ).mockReturnValueOnce( true );
+		const { getByRole } = renderInSlot( 32 );
+		expect(
+			getByRole( 'button', { name: 'Close editor' } )
+		).toHaveAttribute( 'data-icon', 'chevronRight' );
 	} );
 
 	it( 'should apply woocommerce_email_editor_close_content filter to render custom component', () => {

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-i18n.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-i18n.ts
@@ -1,5 +1,5 @@
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str: string ) => str,
 	sprintf: ( format: string, value: string ) => format.replace( '%s', value ),
-	isRTL: () => false,
+	isRTL: jest.fn( () => false ),
 } ) );

--- a/packages/js/email-editor/src/components/test/__mocks__/wordpress-i18n.ts
+++ b/packages/js/email-editor/src/components/test/__mocks__/wordpress-i18n.ts
@@ -1,4 +1,5 @@
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str: string ) => str,
 	sprintf: ( format: string, value: string ) => format.replace( '%s', value ),
+	isRTL: () => false,
 } ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WordPress 7.1 shows the admin bar in the editor by default and redesigned the editor header: the back-button slot shrank from 64px to 32px and core now renders it as a compact chevron. 

The email editor's fullscreen-style WordPress-logo back button no longer fits that slot — it collapses into its own padding and appears as an empty black rectangle.

We will still need to support WP 7.0 for some time, so this PR adds detection based on the width, and we render the proper button based on that. Note: this is a temporary solution and we will drop the detection once we stop supporting WP 7.0

The `woocommerce_email_editor_close_content` and `woocommerce_email_editor_close_action_callback` filters keep working unchanged for both variants.

WOOPLUG-7447
Closes https://github.com/woocommerce/woocommerce/issues/67468

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="447" height="121" alt="Screenshot 2026-08-07 at 10 09 04" src="https://github.com/user-attachments/assets/ca5ebbfc-2705-4c54-867c-4d3925d2443f" /> | <img width="474" height="138" alt="Screenshot 2026-08-07 at 10 08 37" src="https://github.com/user-attachments/assets/87fa78dd-db79-452d-a1ef-ed04699c8c77" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run wp-env with WordPress 7.1 (e.g. add `"core": "https://wordpress.org/wordpress-7.1-RC1.zip"` to `plugins/woocommerce/.wp-env.override.json` and start with `wp-env start --update`).
2. Enable the block email editor in WooCommerce → Settings → Advanced → Features.
3. Open a transactional email for editing (WooCommerce → Settings → Emails → choose an email).
4. Confirm the top-left back button renders as a compact `<` chevron (same as the regular post editor) instead of a black rectangle, and that clicking it returns to the email listing.
5. Switch wp-env back to WordPress 7.0 (`"core": "https://wordpress.org/wordpress-7.0.2.zip"`), repeat steps 3–4, and confirm the previous fullscreen-style button (WordPress logo with hover arrow) still renders and works.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Tested locally on wp-env with WordPress 7.1-RC1: the button renders as the compact chevron at desktop and mobile (375px) viewport widths, and the close action works. The WordPress ≤ 7.0 variant is covered by unit tests (it renders markup identical to trunk). Package checks pass: TypeScript build, ESLint (no new warnings), and the full Jest suite including new wide-slot/narrow-slot tests.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Change authored with the assistance of Claude Code and reviewed by the PR author.