### PR TITLE
Fix shopper blocked by their own stock hold after order cancellation

### DIFF
--- a/plugins/woocommerce/changelog/67354-fix-own-stock-reservation-lockout
+++ b/plugins/woocommerce/changelog/67354-fix-own-stock-reservation-lockout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Harden the cart stock check so a boolean false stored in the order_awaiting_payment session value (e.g. after a customer cancels an unpaid order) no longer skips the store_api_draft_order fallback, which could otherwise cause a shopper to be blocked by their own held order.
+Fix a shopper being blocked in the checkout shortcode by a stock hold created by their own cancelled order.

--- a/plugins/woocommerce/changelog/67354-fix-own-stock-reservation-lockout
+++ b/plugins/woocommerce/changelog/67354-fix-own-stock-reservation-lockout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Harden the cart stock check so a boolean false stored in the order_awaiting_payment session value (e.g. after a customer cancels an unpaid order) no longer skips the store_api_draft_order fallback, which could otherwise cause a shopper to be blocked by their own held order.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -881,7 +881,11 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function check_cart_item_stock() {
 		$error               = new WP_Error();
 		$product_qty_in_cart = $this->get_cart_item_quantities();
-		// Read via get() rather than the magic property: WC_Session::__isset() returns true for a stored `false` (written by payment_complete()/cancel_order()), which would otherwise skip the store_api_draft_order fallback. Treat any falsy awaiting value as "no order".
+		// Identify the shopper's own order so its stock hold is not counted against them.
+		// The classic checkout stores an order ID in `order_awaiting_payment`, but completing a
+		// payment or cancelling an unpaid order writes `false` there instead of unsetting it, so
+		// treat any falsy value as "no order" and fall back to the Store API draft order. Read the
+		// value with get(), because WC_Session::__isset() reports a stored `false` as set.
 		$order_awaiting_payment   = absint( WC()->session->get( 'order_awaiting_payment' ) );
 		$current_session_order_id = $order_awaiting_payment ? $order_awaiting_payment : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
 
@@ -1710,9 +1714,8 @@ class WC_Cart extends WC_Legacy_Cart {
 						'state'     => $this->get_customer()->get_shipping_state(),
 						'postcode'  => $this->get_customer()->get_shipping_postcode(),
 						'city'      => $this->get_customer()->get_shipping_city(),
-						'address'   => $this->get_customer()->get_shipping_address(),
-						// This is an alias of address_1, provided for backwards compatibility.
-														'address_1' => $this->get_customer()->get_shipping_address_1(),
+						'address'   => $this->get_customer()->get_shipping_address(), // This is an alias of address_1, provided for backwards compatibility.
+						'address_1' => $this->get_customer()->get_shipping_address_1(),
 						'address_2' => $this->get_customer()->get_shipping_address_2(),
 					),
 					'cart_subtotal'   => $this->get_displayed_subtotal(),

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -879,9 +879,11 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool|WP_Error
 	 */
 	public function check_cart_item_stock() {
-		$error                    = new WP_Error();
-		$product_qty_in_cart      = $this->get_cart_item_quantities();
-		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
+		$error               = new WP_Error();
+		$product_qty_in_cart = $this->get_cart_item_quantities();
+		// Read via get() rather than the magic property: WC_Session::__isset() returns true for a stored `false` (written by payment_complete()/cancel_order()), which would otherwise skip the store_api_draft_order fallback. Treat any falsy awaiting value as "no order".
+		$order_awaiting_payment   = absint( WC()->session->get( 'order_awaiting_payment' ) );
+		$current_session_order_id = $order_awaiting_payment ? $order_awaiting_payment : absint( WC()->session->get( 'store_api_draft_order', 0 ) );
 
 		foreach ( $this->get_cart() as $values ) {
 			$product = $values['data'];
@@ -1708,8 +1710,9 @@ class WC_Cart extends WC_Legacy_Cart {
 						'state'     => $this->get_customer()->get_shipping_state(),
 						'postcode'  => $this->get_customer()->get_shipping_postcode(),
 						'city'      => $this->get_customer()->get_shipping_city(),
-						'address'   => $this->get_customer()->get_shipping_address(), // This is an alias of address_1, provided for backwards compatibility.
-						'address_1' => $this->get_customer()->get_shipping_address_1(),
+						'address'   => $this->get_customer()->get_shipping_address(),
+						// This is an alias of address_1, provided for backwards compatibility.
+														'address_1' => $this->get_customer()->get_shipping_address_1(),
 						'address_2' => $this->get_customer()->get_shipping_address_2(),
 					),
 					'cart_subtotal'   => $this->get_displayed_subtotal(),

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -915,6 +915,22 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	 * @return array{0: WC_Product, 1: WC_Order} The product and the order holding its stock.
 	 */
 	private function create_last_unit_product_held_by_order(): array {
+		$product       = $this->create_stock_managed_product( 1 );
+		$holding_order = $this->create_order_holding_stock( $product, 1 );
+
+		// Sanity check: the separate order really holds the only unit.
+		$this->assertEquals( 1, wc_get_held_stock_quantity( wc_get_product( $product->get_id() ), 0 ) );
+
+		return array( $product, $holding_order );
+	}
+
+	/**
+	 * Create a simple product that manages stock, with no backorders.
+	 *
+	 * @param int $stock_quantity How many units the product has in stock.
+	 * @return WC_Product The product.
+	 */
+	private function create_stock_managed_product( int $stock_quantity ): WC_Product {
 		update_option( 'woocommerce_manage_stock', 'yes' );
 		update_option( 'woocommerce_hold_stock_minutes', 60 );
 		// ReserveStock is only enabled once the reserved-stock table has shipped (schema >= 430).
@@ -922,23 +938,31 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_manage_stock( true );
-		$product->set_stock_quantity( 1 );
+		$product->set_stock_quantity( $stock_quantity );
 		$product->set_backorders( 'no' );
 		$product->set_stock_status( 'instock' );
 		$product->save();
 
+		return $product;
+	}
+
+	/**
+	 * Create an unpaid order that holds a quantity of a product, as an in-progress checkout does.
+	 *
+	 * @param WC_Product $product  The product to hold stock for.
+	 * @param int        $quantity How many units the order holds.
+	 * @return WC_Order The order holding the stock.
+	 */
+	private function create_order_holding_stock( WC_Product $product, int $quantity ): WC_Order {
 		$holding_order = WC_Helper_Order::create_order();
 		$holding_order->remove_order_items();
-		$holding_order->add_product( wc_get_product( $product->get_id() ), 1 );
+		$holding_order->add_product( wc_get_product( $product->get_id() ), $quantity );
 		$holding_order->set_status( OrderStatus::PENDING );
 		$holding_order->save();
 
 		( new ReserveStock() )->reserve_stock_for_order( $holding_order, 60 );
 
-		// Sanity check: the separate order really holds the only unit.
-		$this->assertEquals( 1, wc_get_held_stock_quantity( wc_get_product( $product->get_id() ), 0 ) );
-
-		return array( $product, $holding_order );
+		return $holding_order;
 	}
 
 	/**
@@ -1007,6 +1031,35 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$result = WC()->cart->check_cart_item_stock();
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertContains( 'out-of-stock', $result->get_error_codes() );
+	}
+
+	/**
+	 * @testdox check_cart_item_stock prefers order_awaiting_payment over store_api_draft_order when both point at a live hold (the classic checkout order wins).
+	 */
+	public function test_check_cart_item_stock_prefers_order_awaiting_payment_over_draft_order() {
+		// Three units in stock: the classic checkout order holds two of them, the draft order holds one.
+		$product       = $this->create_stock_managed_product( 3 );
+		$classic_order = $this->create_order_holding_stock( $product, 2 );
+		$draft_order   = $this->create_order_holding_stock( $product, 1 );
+
+		// Sanity check: between them, the two orders hold all three units.
+		$this->assertEquals( 3, wc_get_held_stock_quantity( wc_get_product( $product->get_id() ), 0 ) );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+
+		WC()->session->set( 'order_awaiting_payment', $classic_order->get_id() );
+		WC()->session->set( 'store_api_draft_order', $draft_order->get_id() );
+
+		/*
+		 * Excluding the classic order leaves one unit held, so the two units in the cart fit into
+		 * the three in stock. Excluding the draft order instead would leave two units held and
+		 * block the cart, so this assertion only holds while order_awaiting_payment takes priority.
+		 */
+		$this->assertTrue(
+			WC()->cart->check_cart_item_stock(),
+			'order_awaiting_payment must take priority over store_api_draft_order when both hold stock.'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Tests\Cart.
  */
 
+use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 
@@ -903,6 +904,109 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		// Clean up.
 		$order->delete( true );
+	}
+
+	/**
+	 * Set up a stock-managed product with exactly one unit, held by a separate unpaid order.
+	 *
+	 * Mirrors the state an abandoned checkout leaves behind: the last unit is reserved by an
+	 * order that belongs to the shopper's own session.
+	 *
+	 * @return array{0: WC_Product, 1: WC_Order} The product and the order holding its stock.
+	 */
+	private function create_last_unit_product_held_by_order(): array {
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		update_option( 'woocommerce_hold_stock_minutes', 60 );
+		// ReserveStock is only enabled once the reserved-stock table has shipped (schema >= 430).
+		update_option( 'woocommerce_schema_version', 430 );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1 );
+		$product->set_backorders( 'no' );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$holding_order = WC_Helper_Order::create_order();
+		$holding_order->remove_order_items();
+		$holding_order->add_product( wc_get_product( $product->get_id() ), 1 );
+		$holding_order->set_status( OrderStatus::PENDING );
+		$holding_order->save();
+
+		( new ReserveStock() )->reserve_stock_for_order( $holding_order, 60 );
+
+		// Sanity check: the separate order really holds the only unit.
+		$this->assertEquals( 1, wc_get_held_stock_quantity( wc_get_product( $product->get_id() ), 0 ) );
+
+		return array( $product, $holding_order );
+	}
+
+	/**
+	 * @testdox check_cart_item_stock does not block the shopper when their own hold is tracked by store_api_draft_order and order_awaiting_payment is boolean false (Cause A: payment_complete() writes false, not unset).
+	 */
+	public function test_check_cart_item_stock_not_blocked_by_own_hold_when_awaiting_payment_is_false() {
+		list( $product, $holding_order ) = $this->create_last_unit_product_held_by_order();
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// The draft pointer correctly identifies the shopper's own holding order...
+		WC()->session->set( 'store_api_draft_order', $holding_order->get_id() );
+		// ...but a completed payment earlier in the session left this as boolean false rather than unsetting it.
+		WC()->session->set( 'order_awaiting_payment', false );
+
+		$this->assertTrue(
+			WC()->cart->check_cart_item_stock(),
+			'A boolean-false order_awaiting_payment must fall through to the store_api_draft_order pointer, not skip it.'
+		);
+	}
+
+	/**
+	 * @testdox check_cart_item_stock does not block the shopper when only store_api_draft_order identifies their own hold (baseline fallback, no order_awaiting_payment set).
+	 */
+	public function test_check_cart_item_stock_not_blocked_by_own_hold_via_draft_fallback() {
+		list( $product, $holding_order ) = $this->create_last_unit_product_held_by_order();
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		WC()->session->set( 'store_api_draft_order', $holding_order->get_id() );
+		WC()->session->set( 'order_awaiting_payment', null );
+
+		$this->assertTrue( WC()->cart->check_cart_item_stock() );
+	}
+
+	/**
+	 * @testdox check_cart_item_stock uses order_awaiting_payment to exclude the shopper's own hold when it holds a real order id.
+	 */
+	public function test_check_cart_item_stock_uses_order_awaiting_payment_when_set() {
+		list( $product, $holding_order ) = $this->create_last_unit_product_held_by_order();
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		WC()->session->set( 'store_api_draft_order', 0 );
+		WC()->session->set( 'order_awaiting_payment', $holding_order->get_id() );
+
+		$this->assertTrue( WC()->cart->check_cart_item_stock() );
+	}
+
+	/**
+	 * @testdox check_cart_item_stock still blocks when a live hold is NOT identified as the shopper's own (oversell safety: the fix must not relax holds it cannot attribute to this session).
+	 */
+	public function test_check_cart_item_stock_blocks_when_hold_is_not_the_shoppers_own() {
+		list( $product ) = $this->create_last_unit_product_held_by_order();
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Session points at neither the holding order nor any awaiting order.
+		WC()->session->set( 'store_api_draft_order', 0 );
+		WC()->session->set( 'order_awaiting_payment', false );
+
+		$result = WC()->cart->check_cart_item_stock();
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'out-of-stock', $result->get_error_codes() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

**Where this shows up:** the `[woocommerce_checkout]` shortcode only. The Cart and Checkout blocks never reach this code.

`WC_Cart::check_cart_item_stock()` reads `order_awaiting_payment` through the magic property. `WC_Session::__isset()` returns `true` for a stored boolean `false`, so the ternary takes its first branch, `absint( false )` yields `0`, and the `store_api_draft_order` fallback (added in #42796) is never consulted — which can cause a shopper to be blocked by a stock reservation their own session created.

This reads the value via `get()` and treats any falsy value (`false`/`null`/`0`) as "no order", so the fallback is used as intended. The change removes the reliance on the `__isset`/`false` interaction and is oversell-safe: a `false` value means the tracked order already completed or was cancelled, so its stock was already reduced or its hold released.

**Scope — please read before reviewing:** this addresses only the single-order, stored-`false` path. In testing, the completed-payment write of `false` is unset again by `destroy_cart_session()` when the cart empties, so that path self-heals; the reachable trigger for a persistent `false` is the customer order-cancel path (`WC_Form_Handler` / `WC_Abstract_Order::cancel_order()`). This PR **does not** address the single-id exclusion in `check_cart_item_stock()` — the primary reproduction in #67354, which needs two or more of the shopper's own unpaid orders holding the same product. That case cannot be relaxed without risking an oversell (a genuinely `pending` order may still settle), and is left for separate discussion on the issue.

Refs #67354.

### How to test the changes in this Pull Request:

**Automated (fastest):**

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter test_check_cart_item_stock
```

The `test_check_cart_item_stock_not_blocked_by_own_hold_when_awaiting_payment_is_false` test fails against `trunk` (with the exact "0 available" message from the issue) and passes with this change. `test_check_cart_item_stock_blocks_when_hold_is_not_the_shoppers_own` asserts that a hold which *cannot* be attributed to the shopper still blocks — i.e. the fix does not relax oversell protection.

**Manual, as a shopper.**

Setup:

1. **Product X**: simple, manage stock on, stock quantity `1`, backorders "Do not allow". This is the one the shopper gets locked out of.
2. **Product Y**: any product that does **not** manage stock.
3. Settings → Products → Inventory → Hold stock (minutes) = `60`.
4. Keep the block Checkout page. Add a second page containing `[woocommerce_checkout]`.
5. A gateway that leaves orders unpaid: PayPal sandbox, or the mu-plugin below. No core gateway works — cheque, BACS and COD all move the order to a status that releases the hold.

Steps, as one logged-in shopper. **Never empty the cart at any point.**

1. Cart **product Y** only. Check out, then abandon the payment. This leaves **order A** as *Pending payment*.
2. Add **product X** to the cart as well, leaving Y in it. Go to the **block** Checkout, place the order, abandon the payment. **Order B** now holds X's only unit, and the session points `store_api_draft_order` at it.
3. My account → Orders → **cancel order A**, not order B. This is the only step that writes boolean `false` into `order_awaiting_payment`.
4. Open the `[woocommerce_checkout]` page.

Before this change: *"Sorry, we do not have enough "X" in stock to fulfill your order (0 available)."* After: the checkout loads.

To confirm the session is in the right state before step 4:

```php
var_dump(
    WC()->session->get( 'order_awaiting_payment' ),  // must be bool(false), not an order id and not null
    WC()->session->get( 'store_api_draft_order' )    // must be order B's id
);
```

Three things that stop it reproducing:

- **Never empty the cart.** `destroy_cart_session()` sets `order_awaiting_payment` to `null` on `woocommerce_cart_emptied`, and `set_session()` nulls `store_api_draft_order` whenever the cart is empty. A `null` is not the state under test: `isset()` is false for `null`, so even unfixed code reaches the fallback and nothing reproduces.
- **Cancel order A, not order B.** `wc_release_stock_for_order` runs on `woocommerce_order_status_cancelled`, so cancelling B would release the very hold under test. That is why two orders are needed.
- **Product Y must not manage stock**, or order B cannot reserve it while order A still holds it.

Also: leaving the block checkout and returning does **not** reproduce it — the Store API reuses the same draft pointer, so the shopper stays excluded.

<details>

<summary>mu-plugin: a gateway that leaves the order unpaid</summary>

Drop in `wp-content/mu-plugins/`. Registers for both checkouts. `process_payment()` does nothing, so the order stays `pending` and the cart is untouched.

```php
<?php
/**
 * Plugin Name: Abandoned payment test gateway
 * Description: Adds a payment method that leaves the order unpaid, the way abandoning an off-site payment does. Test use only.
 *
 * @package abandoned-payment-test-gateway
 */

declare(strict_types=1);

add_action(
	'plugins_loaded',
	function () {
		if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
			return;
		}

		/**
		 * A gateway that never completes the payment.
		 */
		class WC_Gateway_Abandoned_Payment_Test extends WC_Payment_Gateway {
			/**
			 * Constructor.
			 */
			public function __construct() {
				$this->id                 = 'abandoned-payment-test';
				$this->method_title       = 'Abandoned payment (test)';
				$this->method_description = 'Leaves the order unpaid and the cart intact.';
				$this->title              = 'Abandoned payment (test)';
				$this->has_fields         = false;
				$this->supports           = array( 'products' );
				$this->enabled            = 'yes';
			}

			/**
			 * Process the payment.
			 *
			 * The order keeps its pending status, so it also keeps its stock reservation.
			 * The cart is left alone, so the session keeps store_api_draft_order.
			 *
			 * @param int $order_id Order ID.
			 * @return array
			 */
			public function process_payment( $order_id ) {
				$order = wc_get_order( $order_id );

				return array(
					'result'   => 'success',
					'redirect' => $order->get_checkout_payment_url(),
				);
			}
		}

		add_filter(
			'woocommerce_payment_gateways',
			function ( $gateways ) {
				$gateways[] = 'WC_Gateway_Abandoned_Payment_Test';
				return $gateways;
			}
		);
	}
);

add_action(
	'woocommerce_blocks_payment_method_type_registration',
	function ( $registry ) {
		$registry->register(
			new class() extends \Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType {
				/**
				 * Payment method name.
				 *
				 * @var string
				 */
				protected $name = 'abandoned-payment-test';

				/**
				 * Initialize.
				 */
				public function initialize() {}

				/**
				 * Check if the payment method is active.
				 *
				 * @return bool
				 */
				public function is_active() {
					return true;
				}

				/**
				 * Get payment method script handles.
				 *
				 * @return array
				 */
				public function get_payment_method_script_handles() {
					wp_register_script( 'abandoned-payment-test-blocks', '', array( 'wc-blocks-registry', 'wp-element' ), '1.0.0', true );
					wp_add_inline_script( 'abandoned-payment-test-blocks', $this->get_inline_script() );
					return array( 'abandoned-payment-test-blocks' );
				}

				/**
				 * Get payment method data.
				 *
				 * @return array
				 */
				public function get_payment_method_data() {
					return array(
						'title'       => 'Abandoned payment (test)',
						'description' => 'Leaves the order unpaid.',
					);
				}

				/**
				 * Get the inline script that registers the payment method.
				 *
				 * @return string
				 */
				private function get_inline_script() {
					return <<<'JS'
( function () {
	const { registerPaymentMethod } = wc.wcBlocksRegistry;
	const { createElement } = wp.element;

	const Content = function () {
		return createElement( 'p', null, 'The order stays unpaid, as an abandoned off-site payment does.' );
	};

	registerPaymentMethod( {
		name: 'abandoned-payment-test',
		label: 'Abandoned payment (test)',
		ariaLabel: 'Abandoned payment (test)',
		content: createElement( Content, null, null ),
		edit: createElement( Content, null, null ),
		canMakePayment: function () { return true; },
		supports: { features: [ 'products' ] },
	} );
} )();
JS;
				}
			}
		);
	}
);
```

</details>

**Deterministic (isolates the session state, which is what actually varies).** Create one simple product with stock management on, `_stock = 1`, backorders off. Then run this against the store (e.g. `wp shell`), substituting the product id:

```php
$product = wc_get_product( PRODUCT_ID );

// One of the shopper's own orders holds the last unit, exactly as an in-progress checkout would.
$held = wc_create_order();
$held->add_product( $product, 1 );
$held->set_status( 'pending' );
$held->save();
( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $held, 60 );

WC()->cart->empty_cart();
WC()->cart->add_to_cart( $product->get_id(), 1 );

// store_api_draft_order correctly identifies the shopper's own held order...
WC()->session->set( 'store_api_draft_order', $held->get_id() );
// ...but an earlier order cancellation in this session left order_awaiting_payment as boolean false.
WC()->session->set( 'order_awaiting_payment', false );

var_dump( WC()->cart->check_cart_item_stock() );
// Before this change: WP_Error - "...we do not have enough ... in stock ... (0 available)..."
// After this change:  bool(true)
```

The only thing that changes between "blocked" and "not blocked" is the `order_awaiting_payment => false` line skipping the `store_api_draft_order` fallback.

### Testing that has already taken place:

- Walked the four shopper steps end to end in a browser, on a store with block cart/checkout plus a `[woocommerce_checkout]` page. Confirmed the session reached `order_awaiting_payment => bool(false)` with `store_api_draft_order` pointing at the holding order, that the pre-fix file produces the exact "(0 available)" notice, and that restoring the fix clears it with nothing else changed.
- Verified on a local site that the completed-payment write of `false` does not persist (`destroy_cart_session()` unsets `order_awaiting_payment` on cart empty), and that the customer order-cancel path leaves it as boolean `false` without emptying the cart.
- Added four PHPUnit tests around `check_cart_item_stock()`; the stored-`false` test was confirmed to fail against the original code and pass with the fix. `phpcs` (per-file and branch diff) and PHPStan are clean on the changed file.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually (plugins/woocommerce/changelog/67354-fix-own-stock-reservation-lockout).

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This pull request was authored with the assistance of an AI coding agent (Claude). All code, tests, and analysis were reviewed by a human before submission.





