### PR TITLE
[Backport to release/11.0] Sanitize single dismissible store notice before rendering

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-notices-single-notice-xss
+++ b/plugins/woocommerce/changelog/fix-store-notices-single-notice-xss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sanitize the single dismissible store notice before rendering so entity-encoded HTML in Store API error messages (e.g. a product name) cannot execute script on the Cart and Checkout blocks.

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -144,7 +144,7 @@ const StoreNotices = ( {
 							key={ 'store-notice-' + status }
 							{ ...noticeProps }
 						>
-							<RawHTML>{ noticeGroup[ 0 ].content }</RawHTML>
+							<RawHTML>{ uniqueNotices[ 0 ].content }</RawHTML>
 						</StoreNotice>
 					) : (
 						<StoreNotice

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/test/index.tsx
@@ -180,6 +180,40 @@ describe( 'StoreNoticesContainer', () => {
 		);
 	} );
 
+	it( 'Sanitizes HTML in a single dismissible notice before rendering', async () => {
+		// The notice-creation pipeline (e.g. notify-errors.ts) decodes entities
+		// before storing the message, so live HTML can reach the notice content.
+		// The single-notice render branch must sanitize it via RawHTML rather than
+		// injecting it as-is. See XSS regression.
+		dispatch( noticesStore ).createErrorNotice(
+			'PWNXSS <img src=x onerror="window.__xss=1">',
+			{
+				id: 'custom-xss-test-error',
+				context: 'test-context',
+			}
+		);
+		const { container } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+		// The disallowed <img> must be stripped, so no image element is injected.
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.innerHTML ).not.toContain( 'onerror' );
+		// The harmless text is still shown (visible + spoken message).
+		expect( screen.getAllByText( /PWNXSS/i ).length ).toBeGreaterThan( 0 );
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'custom-xss-test-error',
+				'test-context'
+			)
+		);
+		await waitFor( () => {
+			return (
+				select( noticesStore ).getNotices( 'test-context' ).length === 0
+			);
+		} );
+	} );
+
 	it( 'Combine same notices from several contexts', async () => {
 		dispatch( noticesStore ).createErrorNotice( 'Custom generic error', {
 			id: 'custom-subcontext-test-error',


### PR DESCRIPTION
Manual backport of #66820 to `release/11.0` for 11.0.1.

The automated cherry-pick never fired: #66820 merged to trunk on 2026-07-22 with milestone 11.1.0, and the bot only acts on the milestone set at merge time. Cherry-picked `5af2d32d75` cleanly (no conflicts); changelog entry included in the original commit.

Context: p1786102760318799-slack-C8X6Q7XQU