### PR TITLE
Prevent single product wrapper margin

### DIFF
--- a/plugins/woocommerce/changelog/fix-single-product-wrapper-margin
+++ b/plugins/woocommerce/changelog/fix-single-product-wrapper-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent extra top spacing on block-based single product templates

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -18,6 +18,13 @@
 	}
 }
 
+// Keep the compatibility wrapper layout-neutral. WordPress applies the root
+// block gap to every direct child of `.wp-site-blocks`.
+:where(body.single-product .wp-site-blocks) >
+	.woocommerce:where(.product) {
+	margin-block-start: 0;
+}
+
 .clear {
 	clear: both;
 }

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -18,8 +18,9 @@
 	}
 }
 
-// Keep the compatibility wrapper layout-neutral. WordPress applies the root
-// block gap to every direct child of `.wp-site-blocks`.
+// WordPress applies the block gap to every direct child of `.wp-site-blocks`.
+// WooCommerce injects a product wrapper that cannot be styled through block
+// settings, so reset its margin to keep the wrapper layout-neutral.
 :where(body.single-product .wp-site-blocks) >
 	.woocommerce:where(.product) {
 	margin-block-start: 0;

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -20,7 +20,7 @@
 
 // WordPress applies the block gap to every direct child of `.wp-site-blocks`.
 // WooCommerce injects a product wrapper that cannot be styled through block
-// settings, so reset its margin to keep the wrapper layout-neutral.
+// settings, so we reset its margin to keep the wrapper layout-neutral.
 :where(body.single-product .wp-site-blocks) >
 	.woocommerce:where(.product) {
 	margin-block-start: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce injects its legacy-compatible `.woocommerce.product` div wrapper around block-based single-product content which cannot be styled like a block. However, it gets styles from Gutenberg, especially if theme applies:

```
"styles": {
  "spacing": {
    "blockGap": "var(--wp--preset--spacing--20)"
  }
}
```

this targets:

```
:where(.wp-site-blocks) > * {
    margin-block-start: var(--wp--preset--spacing--20);
}
```

So there's no way to opt out the legacy wrapper from it causing Single Product to always having unnecessary margin.

This adds a low-specificity block-theme rule that keeps the compatibility wrapper layout-neutral. Theme-authored selectors and inline styles remain able to override it.

Specificity is as follows:

```
/* Gutenberg */
:where(.wp-site-blocks) > *              /* 0-0-0 */

/* WooCommerce */
:where(...) > .woocommerce:where(...)    /* 0-1-0 */
```

which I think is acceptable.

Related to [woocommerce/woo-themes#375](https://github.com/woocommerce/woo-themes/issues/375) and [woocommerce/woo-themes#404](https://github.com/woocommerce/woo-themes/pull/404).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

The original regression and expected result are shown in the [Woo Themes review](https://github.com/woocommerce/woo-themes/pull/404#pullrequestreview-4875750580).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Activate a block theme whose `theme.json` defines a root `styles.spacing.blockGap` value.
2. Open a product page and confirm WooCommerce injects `.woocommerce.product` directly below `.wp-site-blocks`.
3. Confirm the compatibility wrapper has no block-start margin and no extra gap appears above the product content.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Installed dependencies with `pnpm install --frozen-lockfile`.
- Built WooCommerce successfully with `pnpm wc:build`.
- Linked the built plugin into a Local site running the Purple block theme and confirmed the product page returns HTTP 200, contains the injected wrapper, and serves the compiled rule.
- `git diff --check` passes.
- The legacy CSS lint command currently reports the existing repository-wide baseline of unrelated errors; the changed SCSS compiles successfully as part of the full build.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the CSS interaction, prepare the change, run verification, and draft this pull request. The implementation and results were reviewed by the author.
