### PR TITLE
Fix approved directories Site Health status

### DIFF
--- a/plugins/woocommerce/changelog/fix-approved-directories-site-health
+++ b/plugins/woocommerce/changelog/fix-approved-directories-site-health
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Report whether approved download directory rules are enforced in Site Health.

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -10,9 +10,9 @@ namespace Automattic\WooCommerce\Internal\Admin;
 use Automattic\WooCommerce\Enums\DefaultCustomerAddress;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
-use WC_Admin_Notices;
 use WC_Admin_Status;
 use WC_Helper_Updater;
 use WC_Install;
@@ -364,26 +364,18 @@ class SiteHealth {
 			'woocommerce_approved_download_directories_sync' => array(
 				'label' => __( 'WooCommerce approved download directories', 'woocommerce' ),
 				'badge' => 'security',
-				'check' => fn() => ! WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+				'check' => fn() => Download_Directories::MODE_ENABLED === wc_get_container()->get( Download_Directories::class )->get_mode(),
 				'good'  => array(
-					'label'       => __( 'WooCommerce approved download directories do not require review', 'woocommerce' ),
-					'description' => __( 'There is no completed approved download directories sync waiting for review.', 'woocommerce' ),
+					'label'       => __( 'WooCommerce approved download directory rules are enforced', 'woocommerce' ),
+					'description' => __( 'Downloadable product files are restricted to approved directories.', 'woocommerce' ),
 				),
 				'fail'  => array(
-					'label'       => __( 'WooCommerce approved download directories need review', 'woocommerce' ),
-					'description' => __( 'The approved product download directories list was updated. Review it to confirm downloadable product files remain protected.', 'woocommerce' ),
+					'label'       => __( 'WooCommerce approved download directory rules are not enforced', 'woocommerce' ),
+					'description' => __( 'Enable approved download directory rules to restrict downloadable product files to locations approved by a site administrator.', 'woocommerce' ),
 					'actions'     => array(
 						array(
 							'url'   => admin_url( 'admin.php?page=wc-settings&tab=products&section=download_urls' ),
-							'label' => __( 'Review approved directories', 'woocommerce' ),
-						),
-						array(
-							'url'   => wp_nonce_url(
-								add_query_arg( 'wc-hide-notice', 'download_directories_sync_complete', admin_url( 'site-health.php' ) ),
-								'woocommerce_hide_notices_nonce',
-								'_wc_notice_nonce'
-							),
-							'label' => __( 'Mark as reviewed', 'woocommerce' ),
+							'label' => __( 'Review approved directory rules', 'woocommerce' ),
 						),
 						array(
 							'url'     => 'https://woocommerce.com/document/approved-download-directories',

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -371,7 +371,7 @@ class SiteHealth {
 				),
 				'fail'  => array(
 					'label'       => __( 'WooCommerce approved download directory rules are not enforced', 'woocommerce' ),
-					'description' => __( 'Enable approved download directory rules to restrict downloadable product files to locations approved by a site administrator.', 'woocommerce' ),
+					'description' => __( 'Enable approved download directory rules to control which local and remote locations can be used for downloadable product files. This reduces the risk of exposing unintended files or connecting to unapproved remote locations.', 'woocommerce' ),
 					'actions'     => array(
 						array(
 							'url'   => admin_url( 'admin.php?page=wc-settings&tab=products&section=download_urls' ),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\SiteHealth;
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use WC_Unit_Test_Case;
 use WP_Error;
 
@@ -25,6 +26,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		parent::setUp();
 		$this->sut = new SiteHealth();
 		delete_transient( '_woocommerce_upload_directory_status' );
+		delete_option( 'wc_downloads_approved_directories_mode' );
 	}
 
 	/**
@@ -32,7 +34,31 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		delete_transient( '_woocommerce_upload_directory_status' );
+		delete_option( 'wc_downloads_approved_directories_mode' );
 		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Approved download directories check is good when rules are enforced.
+	 */
+	public function test_approved_download_directories_check_is_good_when_rules_are_enforced(): void {
+		wc_get_container()->get( Download_Directories::class )->set_mode( Download_Directories::MODE_ENABLED );
+
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+
+		$this->assertSame( 'good', $result['status'], 'Enabled approved directory rules should pass the Site Health check.' );
+		$this->assertSame( 'WooCommerce approved download directory rules are enforced', $result['label'], 'The result should report that approved directory rules are enforced.' );
+	}
+
+	/**
+	 * @testdox Approved download directories check recommends enabling rules when they are not enforced.
+	 */
+	public function test_approved_download_directories_check_recommends_enabling_rules_when_not_enforced(): void {
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+
+		$this->assertSame( 'recommended', $result['status'], 'Disabled approved directory rules should require attention in Site Health.' );
+		$this->assertSame( 'WooCommerce approved download directory rules are not enforced', $result['label'], 'The result should report that approved directory rules are not enforced.' );
+		$this->assertStringContainsString( 'section=download_urls', $result['actions'], 'The result should link to the approved directory settings.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -58,6 +58,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'recommended', $result['status'], 'Disabled approved directory rules should require attention in Site Health.' );
 		$this->assertSame( 'WooCommerce approved download directory rules are not enforced', $result['label'], 'The result should report that approved directory rules are not enforced.' );
+		$this->assertSame( '<p>Enable approved download directory rules to control which local and remote locations can be used for downloadable product files. This reduces the risk of exposing unintended files or connecting to unapproved remote locations.</p>', $result['description'], 'The result should explain why approved directory rules should be enabled.' );
 		$this->assertStringContainsString( 'section=download_urls', $result['actions'], 'The result should link to the approved directory settings.' );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Approved Download Directories Site Health result checks whether a completed synchronization notice is waiting for review, rather than whether directory rules are actually enforced. As a result, a store can be reported as requiring no review while enforcement remains disabled.

This changes the test to read the Approved Download Directories mode, reports clearly whether rules are enforced, and links administrators to the rules when enforcement is disabled. Focused tests cover both enabled and disabled modes.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #64758.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
| ------ | ----- |
| <img width="640" alt="Before: Site Health reports no review required while approved download directory rules are disabled" src="https://github.com/user-attachments/assets/88efc6f3-f862-48e2-a9be-08cc5dd05f0f" /> | <img width="640" alt="After: Site Health warns that approved download directory rules are disabled and explains the security benefit" src="https://github.com/user-attachments/assets/20bf6150-56ef-47c1-91f5-8209933efb98" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Products > Approved download directories** and select **Stop Enforcing Rules** if enforcement is currently enabled.
2. Go to **Tools > Site Health > Status** and confirm that WooCommerce reports that approved download directory rules are not enforced.
3. Confirm that **Review approved directory rules** opens the Approved Download Directories settings.
4. Select **Start Enforcing Rules**, return to Site Health, and confirm that the result reports that the rules are enforced.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `SiteHealthTest`: 5 tests and 17 assertions passed on PHP 8.1.
- Changed-file and full-branch PHP linting passed without errors or warnings.
- PHPStan passed for `src/Internal/Admin/SiteHealth.php`.
- `git diff --check` passed.
- Performance review found one option read through the existing Approved Directories register and no new loops, collections, or database queries.
- No public PHP signatures, hooks, or other externally exposed contracts are changed.
- Multisite was not manually tested. The check continues to use the existing site-scoped Approved Directories mode.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to inspect the existing behavior, implement the change and focused tests, and run the validation described above.

*\*left by Biff (AI agent) on behalf of Darren*
