### PR TITLE
Fix grouped products retaining out-of-stock status

### DIFF
--- a/plugins/woocommerce/changelog/fix-28979-grouped-product-stock-status
+++ b/plugins/woocommerce/changelog/fix-28979-grouped-product-stock-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix grouped products retaining an out-of-stock status after conversion from another product type.

--- a/plugins/woocommerce/changelog/fix-28979-grouped-product-stock-status
+++ b/plugins/woocommerce/changelog/fix-28979-grouped-product-stock-status
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix grouped products retaining an out-of-stock status after conversion from another product type.
+Reset stock management and stock status when converting products to grouped or external types.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -161,12 +161,21 @@ jQuery( function ( $ ) {
 			} else if ( 'grouped' === select_val ) {
 				$( 'input#_downloadable' ).prop( 'checked', false );
 				$( 'input#_virtual' ).prop( 'checked', false );
+				$( 'input#_manage_stock' )
+					.prop( 'checked', false )
+					.trigger( 'change' );
 				$( '[name="_stock_status"]' )
 					.val( [ 'instock' ] )
 					.trigger( 'change' );
 			} else if ( 'external' === select_val ) {
 				$( 'input#_downloadable' ).prop( 'checked', false );
 				$( 'input#_virtual' ).prop( 'checked', false );
+				$( 'input#_manage_stock' )
+					.prop( 'checked', false )
+					.trigger( 'change' );
+				$( '[name="_stock_status"]' )
+					.val( [ 'instock' ] )
+					.trigger( 'change' );
 			}
 
 			const cogs_field_tip = $( '._cogs_value_field' ).find(

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -161,6 +161,9 @@ jQuery( function ( $ ) {
 			} else if ( 'grouped' === select_val ) {
 				$( 'input#_downloadable' ).prop( 'checked', false );
 				$( 'input#_virtual' ).prop( 'checked', false );
+				$( '[name="_stock_status"]' )
+					.val( [ 'instock' ] )
+					.trigger( 'change' );
 			} else if ( 'external' === select_val ) {
 				$( 'input#_downloadable' ).prop( 'checked', false );
 				$( 'input#_virtual' ).prop( 'checked', false );

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
 use Automattic\WooCommerce\Internal\ProductFeed\Integrations\POSCatalog\POSProductVisibilitySync;
@@ -312,7 +313,8 @@ class WC_Meta_Box_Product_Data {
 						// Don't use wc_clean as it destroys sanitized characters.
 						$value = sanitize_title( $value );
 					} else {
-						$value = html_entity_decode( wc_clean( $value ), ENT_QUOTES, get_bloginfo( 'charset' ) ); // WPCS: sanitization ok.
+						$value = html_entity_decode( wc_clean( $value ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+						// WPCS: sanitization ok.
 					}
 
 					$attributes[ $attribute_key ] = $value;
@@ -442,7 +444,13 @@ class WC_Meta_Box_Product_Data {
 		 */
 		do_action( 'woocommerce_admin_process_product_object', $product );
 
+		$previous_product_type = WC_Product_Factory::get_product_type( $post_id );
+
 		$product->save();
+
+		if ( $product instanceof WC_Product && ProductType::EXTERNAL === $product_type && $previous_product_type !== $product_type ) {
+			self::persist_external_product_stock_data( $product );
+		}
 
 		if ( $product->is_type( ProductType::VARIABLE ) ) {
 			$original_post_title = isset( $_POST['original_post_title'] ) ? wc_clean( wp_unslash( $_POST['original_post_title'] ) ) : '';
@@ -453,6 +461,32 @@ class WC_Meta_Box_Product_Data {
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
 		/* phpcs:enable WordPress.Security.NonceVerification.Missing and WooCommerce.Commenting.CommentHooks.MissingHookComment */
+	}
+
+	/**
+	 * Persist the stock data enforced by the external product class.
+	 *
+	 * External product setters normalize stock values while the existing product data is read. The submitted
+	 * values therefore match the in-memory values and are not detected as changes, leaving stale post meta and
+	 * lookup data behind unless they are synchronized explicitly.
+	 *
+	 * @param WC_Product $product External product object.
+	 */
+	private static function persist_external_product_stock_data( WC_Product $product ): void {
+		update_post_meta( $product->get_id(), '_manage_stock', 'no' );
+		update_post_meta( $product->get_id(), '_stock_status', ProductStockStatus::IN_STOCK );
+		update_post_meta( $product->get_id(), '_backorders', 'no' );
+
+		/**
+		 * Product data store.
+		 *
+		 * @var WC_Data_Store $data_store
+		 */
+		$data_store = $product->get_data_store();
+		if ( $data_store->has_callable( 'refresh_product_lookup_table' ) ) {
+			// @phpstan-ignore-next-line method.notFound (Guarded by has_callable() and called via __call() on the underlying product data store instance.)
+			$data_store->refresh_product_lookup_table( $product->get_id() );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { test as baseTest, expect } from '../../fixtures/fixtures';
+import { ADMIN_STATE_PATH } from '../../playwright.config';
+import { getFakeProduct } from '../../utils/data';
+
+const test = baseTest.extend( {
+	storageState: ADMIN_STATE_PATH,
+	outOfStockProduct: async ( { restApi }, fixtureUse ) => {
+		const response = await restApi.post( `${ WC_API_PATH }/products`, {
+			...getFakeProduct(),
+			stock_status: 'outofstock',
+		} );
+
+		await fixtureUse( response.data );
+
+		await restApi.delete(
+			`${ WC_API_PATH }/products/${ response.data.id }`,
+			{ force: true }
+		);
+	},
+	outOfStockGroupedProduct: async ( { restApi }, fixtureUse ) => {
+		const response = await restApi.post( `${ WC_API_PATH }/products`, {
+			...getFakeProduct( { type: 'grouped' } ),
+			stock_status: 'outofstock',
+		} );
+
+		await fixtureUse( response.data );
+
+		await restApi.delete(
+			`${ WC_API_PATH }/products/${ response.data.id }`,
+			{ force: true }
+		);
+	},
+} );
+
+test( 'resets stock status when converting a product to grouped', async ( {
+	page,
+	restApi,
+	outOfStockProduct,
+} ) => {
+	await page.goto(
+		`wp-admin/post.php?post=${ outOfStockProduct.id }&action=edit`
+	);
+
+	await expect(
+		page.locator( 'input[name="_stock_status"][value="outofstock"]' )
+	).toBeChecked();
+
+	await page.locator( '#product-type' ).selectOption( 'grouped' );
+
+	await expect(
+		page.locator( 'input[name="_stock_status"][value="instock"]' )
+	).toBeChecked();
+
+	await page
+		.locator( '#publishing-action' )
+		.getByRole( 'button', { name: 'Update' } )
+		.click();
+	await expect(
+		page
+			.locator( 'div.notice-success > p' )
+			.filter( { hasText: 'Product updated' } )
+	).toBeVisible();
+
+	const response = await restApi.get(
+		`${ WC_API_PATH }/products/${ outOfStockProduct.id }`
+	);
+
+	expect( response.data.type ).toBe( 'grouped' );
+	expect( response.data.stock_status ).toBe( 'instock' );
+} );
+
+test( 'resets stock status when loading an out-of-stock grouped product', async ( {
+	page,
+	restApi,
+	outOfStockGroupedProduct,
+} ) => {
+	expect( outOfStockGroupedProduct.type ).toBe( 'grouped' );
+	expect( outOfStockGroupedProduct.stock_status ).toBe( 'outofstock' );
+
+	await page.goto(
+		`wp-admin/post.php?post=${ outOfStockGroupedProduct.id }&action=edit`
+	);
+
+	await expect(
+		page.locator( 'input[name="_stock_status"][value="instock"]' )
+	).toBeChecked();
+
+	await page
+		.locator( '#publishing-action' )
+		.getByRole( 'button', { name: 'Update' } )
+		.click();
+	await expect(
+		page
+			.locator( 'div.notice-success > p' )
+			.filter( { hasText: 'Product updated' } )
+	).toBeVisible();
+
+	const response = await restApi.get(
+		`${ WC_API_PATH }/products/${ outOfStockGroupedProduct.id }`
+	);
+
+	expect( response.data.type ).toBe( 'grouped' );
+	expect( response.data.stock_status ).toBe( 'instock' );
+} );

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
@@ -25,19 +25,6 @@ const test = baseTest.extend( {
 			{ force: true }
 		);
 	},
-	outOfStockGroupedProduct: async ( { restApi }, fixtureUse ) => {
-		const response = await restApi.post( `${ WC_API_PATH }/products`, {
-			...getFakeProduct( { type: 'grouped' } ),
-			stock_status: 'outofstock',
-		} );
-
-		await fixtureUse( response.data );
-
-		await restApi.delete(
-			`${ WC_API_PATH }/products/${ response.data.id }`,
-			{ force: true }
-		);
-	},
 } );
 
 test( 'resets stock status when converting a product to grouped', async ( {
@@ -71,40 +58,6 @@ test( 'resets stock status when converting a product to grouped', async ( {
 
 	const response = await restApi.get(
 		`${ WC_API_PATH }/products/${ outOfStockProduct.id }`
-	);
-
-	expect( response.data.type ).toBe( 'grouped' );
-	expect( response.data.stock_status ).toBe( 'instock' );
-} );
-
-test( 'resets stock status when loading an out-of-stock grouped product', async ( {
-	page,
-	restApi,
-	outOfStockGroupedProduct,
-} ) => {
-	expect( outOfStockGroupedProduct.type ).toBe( 'grouped' );
-	expect( outOfStockGroupedProduct.stock_status ).toBe( 'outofstock' );
-
-	await page.goto(
-		`wp-admin/post.php?post=${ outOfStockGroupedProduct.id }&action=edit`
-	);
-
-	await expect(
-		page.locator( 'input[name="_stock_status"][value="instock"]' )
-	).toBeChecked();
-
-	await page
-		.locator( '#publishing-action' )
-		.getByRole( 'button', { name: 'Update' } )
-		.click();
-	await expect(
-		page
-			.locator( 'div.notice-success > p' )
-			.filter( { hasText: 'Product updated' } )
-	).toBeVisible();
-
-	const response = await restApi.get(
-		`${ WC_API_PATH }/products/${ outOfStockGroupedProduct.id }`
 	);
 
 	expect( response.data.type ).toBe( 'grouped' );

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
@@ -12,9 +12,11 @@ import { getFakeProduct } from '../../utils/data';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
-	outOfStockProduct: async ( { restApi }, fixtureUse ) => {
+	managedOutOfStockProduct: async ( { restApi }, fixtureUse ) => {
 		const response = await restApi.post( `${ WC_API_PATH }/products`, {
 			...getFakeProduct(),
+			manage_stock: true,
+			stock_quantity: 0,
 			stock_status: 'outofstock',
 		} );
 
@@ -27,39 +29,44 @@ const test = baseTest.extend( {
 	},
 } );
 
-test( 'resets stock status when converting a product to grouped', async ( {
-	page,
-	restApi,
-	outOfStockProduct,
-} ) => {
-	await page.goto(
-		`wp-admin/post.php?post=${ outOfStockProduct.id }&action=edit`
-	);
+for ( const productType of [ 'grouped', 'external' ] ) {
+	test( `resets stock settings when converting a product to ${ productType }`, async ( {
+		page,
+		restApi,
+		managedOutOfStockProduct,
+	} ) => {
+		await page.goto(
+			`wp-admin/post.php?post=${ managedOutOfStockProduct.id }&action=edit`
+		);
 
-	await expect(
-		page.locator( 'input[name="_stock_status"][value="outofstock"]' )
-	).toBeChecked();
+		await expect( page.locator( 'input#_manage_stock' ) ).toBeChecked();
+		await expect(
+			page.locator( 'input[name="_stock_status"][value="outofstock"]' )
+		).toBeChecked();
 
-	await page.locator( '#product-type' ).selectOption( 'grouped' );
+		await page.locator( '#product-type' ).selectOption( productType );
 
-	await expect(
-		page.locator( 'input[name="_stock_status"][value="instock"]' )
-	).toBeChecked();
+		await expect( page.locator( 'input#_manage_stock' ) ).not.toBeChecked();
+		await expect(
+			page.locator( 'input[name="_stock_status"][value="instock"]' )
+		).toBeChecked();
 
-	await page
-		.locator( '#publishing-action' )
-		.getByRole( 'button', { name: 'Update' } )
-		.click();
-	await expect(
-		page
-			.locator( 'div.notice-success > p' )
-			.filter( { hasText: 'Product updated' } )
-	).toBeVisible();
+		await page
+			.locator( '#publishing-action' )
+			.getByRole( 'button', { name: 'Update' } )
+			.click();
+		await expect(
+			page
+				.locator( 'div.notice-success > p' )
+				.filter( { hasText: 'Product updated' } )
+		).toBeVisible();
 
-	const response = await restApi.get(
-		`${ WC_API_PATH }/products/${ outOfStockProduct.id }`
-	);
+		const response = await restApi.get(
+			`${ WC_API_PATH }/products/${ managedOutOfStockProduct.id }`
+		);
 
-	expect( response.data.type ).toBe( 'grouped' );
-	expect( response.data.stock_status ).toBe( 'instock' );
-} );
+		expect( response.data.type ).toBe( productType );
+		expect( response.data.manage_stock ).toBe( false );
+		expect( response.data.stock_status ).toBe( 'instock' );
+	} );
+}

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
@@ -68,5 +68,22 @@ for ( const productType of [ 'grouped', 'external' ] ) {
 		expect( response.data.type ).toBe( productType );
 		expect( response.data.manage_stock ).toBe( false );
 		expect( response.data.stock_status ).toBe( 'instock' );
+
+		const productSearch = encodeURIComponent(
+			managedOutOfStockProduct.name
+		);
+		await page.goto(
+			`wp-admin/edit.php?post_type=product&stock_status=instock&s=${ productSearch }`
+		);
+		await expect(
+			page.locator( `#post-${ managedOutOfStockProduct.id }` )
+		).toBeVisible();
+
+		await page.goto(
+			`wp-admin/edit.php?post_type=product&stock_status=outofstock&s=${ productSearch }`
+		);
+		await expect(
+			page.locator( `#post-${ managedOutOfStockProduct.id }` )
+		).toHaveCount( 0 );
 	} );
 }


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Grouped products do not expose stock status in the classic editor, but an out-of-stock value could remain in the hidden form control when a product was converted to grouped. This resets the control to `instock` when the editor handles a grouped product.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #28979.

### Screenshots or screen recordings

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable. The stock status control is hidden for grouped products.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a simple product and set its stock status to **Out of stock**.
2. Edit the product in the classic product editor, change its type to **Grouped product**, and click **Update**.
3. Confirm the product is now in stock using the Products list.

<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the issue, implement the change, add regression coverage, run validation, and draft this pull request description.
