### PR TITLE
Fix Analytics revenue % change when previous period is negative

### DIFF
--- a/packages/js/number/changelog/wooplug-2965-negative-baseline-delta
+++ b/packages/js/number/changelog/wooplug-2965-negative-baseline-delta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix calculateDelta returning the wrong sign when the baseline is negative by dividing by the absolute value of the baseline (#54303).

--- a/packages/js/number/src/index.ts
+++ b/packages/js/number/src/index.ts
@@ -91,7 +91,7 @@ export function formatValue(
  * Calculates the delta/percentage change between two numbers.
  *
  * @param {number} primaryValue   the value to calculate change for.
- * @param {number} secondaryValue the baseline which to calculate the change against.
+ * @param {number} secondaryValue the baseline against which to calculate the change.
  * @return {?number} Percent change between the primaryValue from the secondaryValue.
  */
 export function calculateDelta( primaryValue: number, secondaryValue: number ) {

--- a/packages/js/number/src/index.ts
+++ b/packages/js/number/src/index.ts
@@ -91,7 +91,7 @@ export function formatValue(
  * Calculates the delta/percentage change between two numbers.
  *
  * @param {number} primaryValue   the value to calculate change for.
- * @param {number} secondaryValue the baseline which to calculdate the change against.
+ * @param {number} secondaryValue the baseline which to calculate the change against.
  * @return {?number} Percent change between the primaryValue from the secondaryValue.
  */
 export function calculateDelta( primaryValue: number, secondaryValue: number ) {
@@ -107,7 +107,7 @@ export function calculateDelta( primaryValue: number, secondaryValue: number ) {
 	}
 
 	return Math.round(
-		( ( primaryValue - secondaryValue ) / secondaryValue ) * 100
+		( ( primaryValue - secondaryValue ) / Math.abs( secondaryValue ) ) * 100
 	);
 }
 

--- a/packages/js/number/src/test/index.ts
+++ b/packages/js/number/src/test/index.ts
@@ -6,7 +6,7 @@ import { partial } from 'lodash';
 /**
  * Internal dependencies
  */
-import { numberFormat, parseNumber } from '../index';
+import { numberFormat, parseNumber, calculateDelta } from '../index';
 
 const defaultNumberFormat = partial( numberFormat, {} );
 
@@ -46,6 +46,41 @@ describe( 'numberFormat', () => {
 			precision: 3,
 		};
 		expect( numberFormat( config, '12345.6789' ) ).toBe( '12.345,679' );
+	} );
+} );
+
+describe( 'calculateDelta', () => {
+	it( 'returns a positive change when a negative baseline grows to a positive value', () => {
+		// From WOOPLUG-2965: $-755.90 → $480 is an increase, not a decrease.
+		expect( calculateDelta( 480, -755.9 ) ).toBe( 164 );
+	} );
+
+	it( 'calculates the change between two positive values', () => {
+		expect( calculateDelta( 1202.6, 685.6 ) ).toBe( 75 );
+	} );
+
+	it( 'calculates a decrease between two positive values', () => {
+		// A positive baseline is unaffected by the fix; the sign must stay negative.
+		expect( calculateDelta( 685.6, 1202.6 ) ).toBe( -43 );
+	} );
+
+	it( 'calculates the change between two negative values', () => {
+		// -450 → -900 is a further decline of 100%.
+		expect( calculateDelta( -900, -450 ) ).toBe( -100 );
+	} );
+
+	it( 'returns 0 when the baseline is 0', () => {
+		expect( calculateDelta( 480, 0 ) ).toBe( 0 );
+	} );
+
+	it( 'reports a full recovery from a negative baseline to break-even', () => {
+		// -500 → 0 is a 100% recovery of the loss.
+		expect( calculateDelta( 0, -500 ) ).toBe( 100 );
+	} );
+
+	it( 'returns null when either value is not finite', () => {
+		expect( calculateDelta( NaN, 100 ) ).toBeNull();
+		expect( calculateDelta( 100, Infinity ) ).toBeNull();
 	} );
 } );
 

--- a/packages/js/number/src/test/index.ts
+++ b/packages/js/number/src/test/index.ts
@@ -6,7 +6,7 @@ import { partial } from 'lodash';
 /**
  * Internal dependencies
  */
-import { numberFormat, parseNumber } from '../index';
+import { numberFormat, parseNumber, calculateDelta } from '../index';
 
 const defaultNumberFormat = partial( numberFormat, {} );
 
@@ -46,6 +46,36 @@ describe( 'numberFormat', () => {
 			precision: 3,
 		};
 		expect( numberFormat( config, '12345.6789' ) ).toBe( '12.345,679' );
+	} );
+} );
+
+describe( 'calculateDelta', () => {
+	it( 'returns a positive change when a negative baseline grows to a positive value', () => {
+		// From WOOPLUG-2965: $-755.90 → $480 is an increase, not a decrease.
+		expect( calculateDelta( 480, -755.9 ) ).toBe( 164 );
+	} );
+
+	it( 'calculates the change between two positive values', () => {
+		expect( calculateDelta( 1202.6, 685.6 ) ).toBe( 75 );
+	} );
+
+	it( 'calculates a decrease between two positive values', () => {
+		// A positive baseline is unaffected by the fix; the sign must stay negative.
+		expect( calculateDelta( 685.6, 1202.6 ) ).toBe( -43 );
+	} );
+
+	it( 'calculates the change between two negative values', () => {
+		// -450 → -900 is a further decline of 100%.
+		expect( calculateDelta( -900, -450 ) ).toBe( -100 );
+	} );
+
+	it( 'returns 0 when the baseline is 0', () => {
+		expect( calculateDelta( 480, 0 ) ).toBe( 0 );
+	} );
+
+	it( 'returns null when either value is not finite', () => {
+		expect( calculateDelta( NaN, 100 ) ).toBeNull();
+		expect( calculateDelta( 100, Infinity ) ).toBeNull();
 	} );
 } );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the Analytics Revenue report, comparing a period to a previous period whose net revenue was negative produced a wrong-signed percentage change (e.g. a previous period of `-$755.90` versus a current `$480` showed `-164%` instead of `+164%`). The cause is `calculateDelta()` in `@woocommerce/number` dividing by the raw baseline: `(primary - secondary) / secondary`, which inverts the direction whenever the baseline is negative.

This changes the divisor to the absolute value of the baseline — `(primary - secondary) / |secondary|` — the correct general percentage-change formula, so the delta direction is right regardless of the baseline's sign.

**Backward compatibility:** `calculateDelta()` is exported from `@woocommerce/number`. This corrects the sign for negative baselines only; there is no signature change and the output is identical for non-negative baselines.

Closes #54303

### Screenshots or screen recordings:

Verified in the Analytics → Revenue report (Net sales summary) with fixture data:

| Scenario (current vs previous) | Before | After |
| ------ | ----- | ----- |
| `$480` vs `-$755.90` | -164% | **+164%** |
| `-$100` vs `-$400` (loss shrinks) | -75% | **+75%** |
| `-$500` vs `-$100` (loss grows) | +400% | **-400%** |

### How to test the changes in this Pull Request:

1. Create an order in a past week and refund it so that week's **Net sales** is negative (the refund's negative total lands in that week; date the parent sale outside the window). Create a normal positive order in the following week.
2. Go to **Analytics → Revenue**, choose a **Custom** date range covering the positive week and set the comparison to **Previous period** (the negative week).
3. Open the summary dropdown and look at the **Net sales** percentage badge.
4. Before this fix it shows a wrong-signed percentage (e.g. `-164%` for an actual increase); after this fix it shows the correct sign (e.g. `+164%`).

### Testing that has already taken place:

- New unit tests in `packages/js/number/src/test/index.ts` cover the reported scenario and edge cases: negative baseline in both directions, two positive values (increase and decrease), zero baseline, and non-finite inputs. Full suite passes (16/16).
- Manually verified end-to-end in a local `wp-env` (WordPress + WooCommerce, HPOS enabled) against the built admin asset: the three scenarios in the table above render the correct sign in the Analytics Revenue **Net sales** badge.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually in `packages/js/number/changelog/wooplug-2965-negative-baseline-delta`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This pull request was authored with AI assistance (Claude Code): root-cause analysis, the fix, unit tests, and testing were produced with AI and reviewed by the author.