### PR TITLE
Restore approved directory synchronization review prompt

### DIFF
--- a/plugins/woocommerce/changelog/fix-67489-approved-directory-review
+++ b/plugins/woocommerce/changelog/fix-67489-approved-directory-review
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Restore the Site Health prompt to review newly synchronized approved download directories.
+Restore and harden the Site Health prompt after approved download directory synchronization.

--- a/plugins/woocommerce/changelog/fix-67489-approved-directory-review
+++ b/plugins/woocommerce/changelog/fix-67489-approved-directory-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the Site Health prompt to review newly synchronized approved download directories.

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Admin_Notices;
 use WC_Admin_Status;
 use WC_Helper_Updater;
 use WC_Install;
@@ -362,6 +363,38 @@ class SiteHealth {
 				),
 			),
 			'woocommerce_approved_download_directories_sync' => array(
+				'label' => __( 'WooCommerce approved download directories', 'woocommerce' ),
+				'badge' => 'security',
+				'check' => fn() => ! WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+				'good'  => array(
+					'label'       => __( 'WooCommerce approved download directories do not require review', 'woocommerce' ),
+					'description' => __( 'There is no completed approved download directories sync waiting for review.', 'woocommerce' ),
+				),
+				'fail'  => array(
+					'label'       => __( 'WooCommerce approved download directories need review', 'woocommerce' ),
+					'description' => __( 'The approved product download directories list was updated. Review it to confirm downloadable product files remain protected.', 'woocommerce' ),
+					'actions'     => array(
+						array(
+							'url'   => admin_url( 'admin.php?page=wc-settings&tab=products&section=download_urls' ),
+							'label' => __( 'Review approved directories', 'woocommerce' ),
+						),
+						array(
+							'url'   => wp_nonce_url(
+								add_query_arg( 'wc-hide-notice', 'download_directories_sync_complete', admin_url( 'site-health.php' ) ),
+								'woocommerce_hide_notices_nonce',
+								'_wc_notice_nonce'
+							),
+							'label' => __( 'Mark as reviewed', 'woocommerce' ),
+						),
+						array(
+							'url'     => 'https://woocommerce.com/document/approved-download-directories',
+							'label'   => __( 'Learn more about approved directories', 'woocommerce' ),
+							'new_tab' => true,
+						),
+					),
+				),
+			),
+			'woocommerce_approved_download_directories_enforcement' => array(
 				'label' => __( 'WooCommerce approved download directories', 'woocommerce' ),
 				'badge' => 'security',
 				'check' => fn() => Download_Directories::MODE_ENABLED === wc_get_container()->get( Download_Directories::class )->get_mode(),

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -368,11 +368,11 @@ class SiteHealth {
 				'check' => fn() => ! WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
 				'good'  => array(
 					'label'       => __( 'WooCommerce approved download directories do not require review', 'woocommerce' ),
-					'description' => __( 'There is no completed approved download directories sync waiting for review.', 'woocommerce' ),
+					'description' => __( 'There is no completed approved download directory synchronization waiting for review.', 'woocommerce' ),
 				),
 				'fail'  => array(
 					'label'       => __( 'WooCommerce approved download directories need review', 'woocommerce' ),
-					'description' => __( 'The approved product download directories list was updated. Review it to confirm downloadable product files remain protected.', 'woocommerce' ),
+					'description' => __( 'Approved product download directory synchronization has completed. Review the list to confirm downloadable product files remain protected.', 'woocommerce' ),
 					'actions'     => array(
 						array(
 							'url'   => admin_url( 'admin.php?page=wc-settings&tab=products&section=download_urls' ),

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Admin/SyncUI.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Admin/SyncUI.php
@@ -108,7 +108,7 @@ class SyncUI {
 	public function cancel_sync() {
 		$this->security_check();
 		wc_get_logger()->log( 'info', __( 'Approved Download Directories sync: scan has been cancelled.', 'woocommerce' ) );
-		wc_get_container()->get( Synchronize::class )->stop();
+		wc_get_container()->get( Synchronize::class )->cancel();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -158,10 +158,29 @@ class Synchronize {
 	}
 
 	/**
-	 * Stops/cancels the current synchronization task.
+	 * Completes the current synchronization task and marks its results for review.
+	 *
+	 * The persistent notice is also the acknowledgement state used by Site Health. Existing
+	 * sites can therefore keep a pending review across requests and WooCommerce updates.
 	 */
 	public function stop() {
 		WC_Admin_Notices::add_notice( 'download_directories_sync_complete', true );
+		$this->clean_up();
+	}
+
+	/**
+	 * Cancels the current synchronization task without marking its results for review.
+	 *
+	 * @since 11.1.0
+	 */
+	public function cancel(): void {
+		$this->clean_up();
+	}
+
+	/**
+	 * Cleans up synchronization state and scheduled actions.
+	 */
+	private function clean_up(): void {
 		delete_option( self::SYNC_TASK_PAGE );
 		delete_option( self::SYNC_TASK_PROGRESS );
 		$this->queue->cancel( self::SYNC_TASK );

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -37,6 +37,11 @@ class Synchronize {
 	public const SYNC_TASK_PROGRESS = 'wc_product_download_dir_sync_progress';
 
 	/**
+	 * Used to prevent an active synchronization task from continuing after cancellation.
+	 */
+	private const SYNC_TASK_CANCELLED = 'wc_product_download_dir_sync_cancelled';
+
+	/**
 	 * Number of downloadable products to be processed in each atomic sync task.
 	 */
 	public const SYNC_TASK_BATCH_SIZE = 20;
@@ -123,6 +128,7 @@ class Synchronize {
 			return false;
 		}
 
+		delete_option( self::SYNC_TASK_CANCELLED );
 		update_option( self::SYNC_TASK_PAGE, 1 );
 		$this->queue->schedule_single( time(), self::SYNC_TASK, array(), self::SYNC_TASK_GROUP );
 		wc_get_logger()->log( 'info', __( 'Approved Download Directories sync: new scan scheduled.', 'woocommerce' ) );
@@ -133,10 +139,20 @@ class Synchronize {
 	 * Runs the synchronization task.
 	 */
 	public function run() {
+		if ( $this->is_cancelled() ) {
+			$this->clean_up();
+			return;
+		}
+
 		$products = $this->get_next_set_of_downloadable_products();
 
 		foreach ( $products as $product ) {
 			$this->process_product( $product );
+		}
+
+		if ( $this->is_cancelled() ) {
+			$this->clean_up();
+			return;
 		}
 
 		// Detect if we have reached the end of the task.
@@ -164,6 +180,11 @@ class Synchronize {
 	 * sites can therefore keep a pending review across requests and WooCommerce updates.
 	 */
 	public function stop() {
+		if ( $this->is_cancelled() ) {
+			$this->clean_up();
+			return;
+		}
+
 		WC_Admin_Notices::add_notice( 'download_directories_sync_complete', true );
 		$this->clean_up();
 	}
@@ -174,7 +195,17 @@ class Synchronize {
 	 * @since 11.1.0
 	 */
 	public function cancel(): void {
+		update_option( self::SYNC_TASK_CANCELLED, true );
 		$this->clean_up();
+	}
+
+	/**
+	 * Indicates whether the current synchronization was cancelled.
+	 *
+	 * @phpstan-impure
+	 */
+	private function is_cancelled(): bool {
+		return (bool) get_option( self::SYNC_TASK_CANCELLED, false );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -140,17 +140,22 @@ class Synchronize {
 	 * Indicates whether a synchronization task is pending or running.
 	 */
 	private function has_scheduled_task(): bool {
-		return ! empty(
-			$this->queue->search(
+		foreach ( array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ) as $status ) {
+			$scheduled_tasks = $this->queue->search(
 				array(
 					'hook'     => self::SYNC_TASK,
-					'status'   => array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ),
+					'status'   => $status,
 					'per_page' => 1,
-					'orderby'  => 'none',
 				),
 				'ids'
-			)
-		);
+			);
+
+			if ( ! empty( $scheduled_tasks ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories;
 
+use ActionScheduler_Store;
 use Exception;
 use Automattic\WooCommerce\Internal\Utilities\URL;
 use WC_Admin_Notices;
@@ -123,7 +124,7 @@ class Synchronize {
 	 * @return bool
 	 */
 	public function start(): bool {
-		if ( null !== $this->queue->get_next( self::SYNC_TASK ) ) {
+		if ( $this->has_scheduled_task() ) {
 			wc_get_logger()->log( 'warning', __( 'Synchronization of approved product download directories is already in progress.', 'woocommerce' ) );
 			return false;
 		}
@@ -133,6 +134,23 @@ class Synchronize {
 		$this->queue->schedule_single( time(), self::SYNC_TASK, array(), self::SYNC_TASK_GROUP );
 		wc_get_logger()->log( 'info', __( 'Approved Download Directories sync: new scan scheduled.', 'woocommerce' ) );
 		return true;
+	}
+
+	/**
+	 * Indicates whether a synchronization task is pending or running.
+	 */
+	private function has_scheduled_task(): bool {
+		return ! empty(
+			$this->queue->search(
+				array(
+					'hook'     => self::SYNC_TASK,
+					'status'   => array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ),
+					'per_page' => 1,
+					'orderby'  => 'none',
+				),
+				'ids'
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -76,6 +76,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'recommended', $result['status'], 'A completed synchronization should require review even when approved directory rules are enforced.' );
 		$this->assertSame( 'WooCommerce approved download directories need review', $result['label'], 'The result should prompt the merchant to review synchronized directories.' );
+		$this->assertSame( '<p>Approved product download directory synchronization has completed. Review the list to confirm downloadable product files remain protected.</p>', $result['description'], 'The result should describe synchronization completion without claiming that new directories were found.' );
 		$this->assertStringContainsString( 'section=download_urls', $result['actions'], 'The result should link to the approved directory settings.' );
 		$this->assertStringContainsString( 'wc-hide-notice=download_directories_sync_complete', $result['actions'], 'The result should let the merchant mark the synchronization as reviewed.' );
 	}
@@ -88,6 +89,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 
 		$this->assertSame( 'good', $result['status'], 'No completed synchronization should require review.' );
 		$this->assertSame( 'WooCommerce approved download directories do not require review', $result['label'], 'The result should confirm that synchronized directories do not require review.' );
+		$this->assertSame( '<p>There is no completed approved download directory synchronization waiting for review.</p>', $result['description'], 'The result should confirm that no synchronization review is pending.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SiteHealthTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin;
 
 use Automattic\WooCommerce\Internal\Admin\SiteHealth;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
+use WC_Admin_Notices;
 use WC_Unit_Test_Case;
 use WP_Error;
 
@@ -27,6 +28,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 		$this->sut = new SiteHealth();
 		delete_transient( '_woocommerce_upload_directory_status' );
 		delete_option( 'wc_downloads_approved_directories_mode' );
+		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
 	}
 
 	/**
@@ -35,6 +37,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		delete_transient( '_woocommerce_upload_directory_status' );
 		delete_option( 'wc_downloads_approved_directories_mode' );
+		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
 		parent::tearDown();
 	}
 
@@ -44,7 +47,7 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	public function test_approved_download_directories_check_is_good_when_rules_are_enforced(): void {
 		wc_get_container()->get( Download_Directories::class )->set_mode( Download_Directories::MODE_ENABLED );
 
-		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_enforcement' );
 
 		$this->assertSame( 'good', $result['status'], 'Enabled approved directory rules should pass the Site Health check.' );
 		$this->assertSame( 'WooCommerce approved download directory rules are enforced', $result['label'], 'The result should report that approved directory rules are enforced.' );
@@ -54,12 +57,37 @@ class SiteHealthTest extends WC_Unit_Test_Case {
 	 * @testdox Approved download directories check recommends enabling rules when they are not enforced.
 	 */
 	public function test_approved_download_directories_check_recommends_enabling_rules_when_not_enforced(): void {
-		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_enforcement' );
 
 		$this->assertSame( 'recommended', $result['status'], 'Disabled approved directory rules should require attention in Site Health.' );
 		$this->assertSame( 'WooCommerce approved download directory rules are not enforced', $result['label'], 'The result should report that approved directory rules are not enforced.' );
 		$this->assertSame( '<p>Enable approved download directory rules to control which local and remote locations can be used for downloadable product files. This reduces the risk of exposing unintended files or connecting to unapproved remote locations.</p>', $result['description'], 'The result should explain why approved directory rules should be enabled.' );
 		$this->assertStringContainsString( 'section=download_urls', $result['actions'], 'The result should link to the approved directory settings.' );
+	}
+
+	/**
+	 * @testdox Approved download directories check recommends review after synchronization when rules are enforced.
+	 */
+	public function test_approved_download_directories_check_recommends_review_after_synchronization(): void {
+		wc_get_container()->get( Download_Directories::class )->set_mode( Download_Directories::MODE_ENABLED );
+		WC_Admin_Notices::add_notice( 'download_directories_sync_complete', true );
+
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+
+		$this->assertSame( 'recommended', $result['status'], 'A completed synchronization should require review even when approved directory rules are enforced.' );
+		$this->assertSame( 'WooCommerce approved download directories need review', $result['label'], 'The result should prompt the merchant to review synchronized directories.' );
+		$this->assertStringContainsString( 'section=download_urls', $result['actions'], 'The result should link to the approved directory settings.' );
+		$this->assertStringContainsString( 'wc-hide-notice=download_directories_sync_complete', $result['actions'], 'The result should let the merchant mark the synchronization as reviewed.' );
+	}
+
+	/**
+	 * @testdox Approved download directories check is good when no synchronization is waiting for review.
+	 */
+	public function test_approved_download_directories_check_is_good_without_completed_synchronization(): void {
+		$result = $this->sut->run_test( 'woocommerce_approved_download_directories_sync' );
+
+		$this->assertSame( 'good', $result['status'], 'No completed synchronization should require review.' );
+		$this->assertSame( 'WooCommerce approved download directories do not require review', $result['label'], 'The result should confirm that synchronized directories do not require review.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -14,6 +14,11 @@ use WC_Unit_Test_Case;
  */
 class SynchronizeTest extends WC_Unit_Test_Case {
 	/**
+	 * Option used to mark a synchronization as cancelled.
+	 */
+	private const SYNC_TASK_CANCELLED = 'wc_product_download_dir_sync_cancelled';
+
+	/**
 	 * @var Synchronize
 	 */
 	private $sut;
@@ -24,6 +29,7 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->sut = wc_get_container()->get( Synchronize::class );
+		delete_option( self::SYNC_TASK_CANCELLED );
 		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
 	}
 
@@ -31,6 +37,8 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	 * Clean up after each test.
 	 */
 	public function tearDown(): void {
+		$this->sut->cancel();
+		delete_option( self::SYNC_TASK_CANCELLED );
 		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
 		parent::tearDown();
 	}
@@ -46,7 +54,7 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Ensure basic controls to start and cancel synchronization behave as expected.
 	 */
-	public function test_basic_synchronization_controls() {
+	public function test_basic_synchronization_controls(): void {
 		$this->sut->start();
 		$this->assertTrue(
 			$this->sut->in_progress(),
@@ -71,12 +79,19 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
 			'Cancelling synchronization should not create a completed synchronization review notice.'
 		);
+
+		$this->assertTrue( $this->sut->start(), 'A new synchronization should be able to start after cancellation.' );
+		$this->sut->run();
+		$this->assertTrue(
+			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+			'A new synchronization should complete normally after a previous synchronization was cancelled.'
+		);
 	}
 
 	/**
 	 * @testdox Verify expected logging and clean-up take place during and following synchronization of download directories.
 	 */
-	public function test_sync_process() {
+	public function test_sync_process(): void {
 		$logged_messages = array();
 
 		$log_watcher = function ( string $logged_message ) use ( &$logged_messages ) {
@@ -110,7 +125,7 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Cancelling synchronization preserves a review notice that was already pending.
 	 */
-	public function test_cancellation_preserves_pending_review_notice() {
+	public function test_cancellation_preserves_pending_review_notice(): void {
 		WC_Admin_Notices::add_notice( 'download_directories_sync_complete', true );
 
 		$this->sut->start();
@@ -119,6 +134,39 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 		$this->assertTrue(
 			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
 			'Cancelling a later synchronization should not clear an existing pending review state.'
+		);
+	}
+
+	/**
+	 * @testdox Cancelling an active batch does not mark synchronization as complete.
+	 */
+	public function test_cancellation_during_active_batch_does_not_mark_sync_complete(): void {
+		$cancelled           = false;
+		$cancel_during_batch = function () use ( &$cancelled ): void {
+			if ( ! $cancelled ) {
+				$cancelled = true;
+				$this->sut->cancel();
+			}
+		};
+
+		$this->sut->start();
+		add_action( 'update_option_' . Synchronize::SYNC_TASK_PAGE, $cancel_during_batch, 10, 0 );
+
+		try {
+			$this->sut->run();
+		} finally {
+			remove_action( 'update_option_' . Synchronize::SYNC_TASK_PAGE, $cancel_during_batch, 10 );
+		}
+
+		$this->assertTrue( $cancelled, 'The test should cancel synchronization while a batch is active.' );
+		$this->assertFalse( $this->sut->in_progress(), 'An active batch should clean up synchronization state after cancellation.' );
+		$this->assertFalse(
+			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+			'An active batch should not create a completion notice after cancellation.'
+		);
+		$this->assertNull(
+			wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Queue_Interface::class )->get_next( Synchronize::SYNC_TASK ),
+			'An active batch should not schedule more synchronization work after cancellation.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\ProductDownloads\ApprovedDirectories;
 
+use ActionScheduler_Store;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use WC_Admin_Notices;
@@ -142,23 +143,33 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	 */
 	public function test_cancellation_during_active_batch_does_not_mark_sync_complete(): void {
 		$cancelled           = false;
-		$cancel_during_batch = function () use ( &$cancelled ): void {
+		$restart_result      = null;
+		$cancel_during_batch = function () use ( &$cancelled, &$restart_result ): void {
 			if ( ! $cancelled ) {
 				$cancelled = true;
 				$this->sut->cancel();
+				$restart_result = $this->sut->start();
 			}
 		};
 
 		$this->sut->start();
+		$store           = ActionScheduler_Store::instance();
+		$claim           = $store->stake_claim( 1, null, array( Synchronize::SYNC_TASK ) );
+		$claimed_actions = $claim->get_actions();
+		$this->assertCount( 1, $claimed_actions, 'The synchronization action should be marked as running for the test.' );
+		$store->log_execution( $claimed_actions[0] );
 		add_action( 'update_option_' . Synchronize::SYNC_TASK_PAGE, $cancel_during_batch, 10, 0 );
 
 		try {
 			$this->sut->run();
 		} finally {
 			remove_action( 'update_option_' . Synchronize::SYNC_TASK_PAGE, $cancel_during_batch, 10 );
+			$store->mark_complete( $claimed_actions[0] );
+			$store->release_claim( $claim );
 		}
 
 		$this->assertTrue( $cancelled, 'The test should cancel synchronization while a batch is active.' );
+		$this->assertFalse( $restart_result, 'A new synchronization should not start before the cancelled active batch returns.' );
 		$this->assertFalse( $this->sut->in_progress(), 'An active batch should clean up synchronization state after cancellation.' );
 		$this->assertFalse(
 			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
@@ -168,5 +179,6 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 			wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Queue_Interface::class )->get_next( Synchronize::SYNC_TASK ),
 			'An active batch should not schedule more synchronization work after cancellation.'
 		);
+		$this->assertTrue( $this->sut->start(), 'A new synchronization should start after the cancelled active batch has returned.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -90,6 +90,35 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Scheduled task detection uses scalar queue statuses supported by the queue interface.
+	 */
+	public function test_scheduled_task_detection_uses_scalar_statuses(): void {
+		$searched_statuses = array();
+		$queue             = $this->createMock( WC_Queue_Interface::class );
+		$queue->method( 'search' )
+			->willReturnCallback(
+				function ( array $args, string $return_format ) use ( &$searched_statuses ): array {
+					$searched_statuses[] = $args['status'];
+					$this->assertSame( 'ids', $return_format );
+
+					return ActionScheduler_Store::STATUS_RUNNING === $args['status'] ? array( 123 ) : array();
+				}
+			);
+
+		$sut            = new Synchronize();
+		$queue_property = new \ReflectionProperty( $sut, 'queue' );
+		$queue_property->setAccessible( true );
+		$queue_property->setValue( $sut, $queue );
+
+		$this->assertFalse( $sut->start(), 'A running synchronization task should prevent another synchronization from starting.' );
+		$this->assertSame(
+			array( ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING ),
+			$searched_statuses,
+			'Scheduled task detection should query each status as a scalar value.'
+		);
+	}
+
+	/**
 	 * @testdox Verify expected logging and clean-up take place during and following synchronization of download directories.
 	 */
 	public function test_sync_process(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\ProductDownloads\ApprovedDirecto
 
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WC_Admin_Notices;
 use WC_Queue_Interface;
 use WC_Unit_Test_Case;
 
@@ -23,6 +24,15 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->sut = wc_get_container()->get( Synchronize::class );
+		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		WC_Admin_Notices::remove_notice( 'download_directories_sync_complete', true );
+		parent::tearDown();
 	}
 
 	/**
@@ -34,7 +44,7 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Ensure basic controls to start and stop synchronization behave as expected.
+	 * @testdox Ensure basic controls to start and cancel synchronization behave as expected.
 	 */
 	public function test_basic_synchronization_controls() {
 		$this->sut->start();
@@ -48,15 +58,18 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 			'If a download directory synchronization process is already in progress, additional concurrent sync processes cannot be created.'
 		);
 
+		$this->sut->cancel();
 		$this->assertFalse(
-			$this->sut->start(),
-			'Synchronization process can be cancelled before it completes.'
+			$this->sut->in_progress(),
+			'Synchronization can be cancelled before it completes.'
 		);
-
-		$this->sut->stop();
 		$this->assertNull(
 			wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Queue_Interface::class )->get_next( Synchronize::SYNC_TASK ),
 			'Once synchronization has been cancelled, any related scheduled actions will also have been cleaned up.'
+		);
+		$this->assertFalse(
+			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+			'Cancelling synchronization should not create a completed synchronization review notice.'
 		);
 	}
 
@@ -86,6 +99,26 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 			'Approved Download Directories sync: scan is complete!',
 			$logged_messages,
 			'We expect that completion of the synchronization process will have been recorded in the log.'
+		);
+
+		$this->assertTrue(
+			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+			'Completed synchronization should create a persistent review notice.'
+		);
+	}
+
+	/**
+	 * @testdox Cancelling synchronization preserves a review notice that was already pending.
+	 */
+	public function test_cancellation_preserves_pending_review_notice() {
+		WC_Admin_Notices::add_notice( 'download_directories_sync_complete', true );
+
+		$this->sut->start();
+		$this->sut->cancel();
+
+		$this->assertTrue(
+			WC_Admin_Notices::has_notice( 'download_directories_sync_complete' ),
+			'Cancelling a later synchronization should not clear an existing pending review state.'
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
* I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Approved directory synchronization adds discovered directories in a disabled state so merchants can review them before allowing downloads. The enforcement-mode Site Health check introduced in woocommerce/woocommerce#67479 replaced the synchronization-review check, so stores with enforcement enabled no longer received that review prompt.

This restores the synchronization-review check under its existing test ID and registers the enforcement-mode check separately. It retains the existing persistent admin notice as the simple site-level acknowledgement state: a pending notice continues to prompt for review until explicitly dismissed.

The synchronization lifecycle is also hardened:

* Successful completion creates the persistent review notice.
* Explicit cancellation records durable site-level cancellation state before cleaning up scheduled work.
* Workers check that state before processing, after each active batch, and before marking completion, so an in-flight or stale worker cannot recreate the notice or continue the scan.
* Restart checks pending and running synchronization tasks through separate scalar-status queue queries before clearing cancellation state, so a new request cannot revive an older cancelled worker.
* A genuinely new synchronization clears the cancellation state and can complete normally after the older worker has returned.
* Cancelling a later synchronization does not erase a review notice that was already pending.
* Site Health copy reports that synchronization completed without claiming that new directories were necessarily found.

Closes woocommerce/woocommerce#67489.

Bug introduced in PR woocommerce/woocommerce#67479.

### Screenshots or screen recordings:

Not included. This restores the existing Site Health review result and actions from before woocommerce/woocommerce#67479, with clarified text.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/>), include your detailed testing instructions:

1. Enable approved download directory rules under **WooCommerce > Settings > Products > Approved download directories**.
2. Add a downloadable product whose file is in a parent directory that is not yet approved.
3. Run **Tools > Synchronize approved download directories** and wait for it to complete.
4. Open **Tools > Site Health > Status** and confirm WooCommerce recommends reviewing the approved download directories even though enforcement is enabled.
5. Confirm **Review approved directories** opens the approved-directory settings and **Mark as reviewed** dismisses the synchronization result.
6. Confirm the separate enforcement result reports that approved download directory rules are enforced.
7. Start another synchronization and cancel it before completion, including while a batch is actively updating progress. Confirm cancellation does not create a completed-sync review result or schedule more work. If a previous completed-sync review result was already pending, confirm cancellation does not dismiss it.
8. While the cancelled batch is still returning, confirm an immediate restart is rejected. After that worker has returned, start a fresh synchronization and confirm it can complete and create the review result normally.

### Testing that has already taken place:

* Manual local admin flow on wp-env (PHP 8.1): enabled enforcement in settings; ran synchronization from **WooCommerce > Status > Tools**; confirmed the completed-sync Site Health recommendation appears alongside the enforcement-good result; verified **Review approved directories** opened the newly discovered, disabled directory; and verified **Mark as reviewed** cleared the recommendation. Also cancelled a queued synchronization, confirmed cancellation did not create a review result, then started a fresh synchronization and confirmed it completed and restored the review recommendation.
* `SiteHealthTest` and `SynchronizeTest`: 12 tests and 47 assertions passed on PHP 8.1, including scalar-status queue contract coverage, rejection of an immediate restart while a cancelled batch is still active, and successful restart after that worker returns.
* Changed-file and full-branch PHP coding-standard checks passed without new errors or warnings.
* PHPStan passed for all three modified production PHP files.
* PHP syntax checks, changelog validation, the new-function compatibility check, and `git diff --check` passed.
* Performance review found no new collection loading or direct SQL. Cancellation adds only cached option reads at batch boundaries and option writes on start/cancel; the start guard uses one bounded queue lookup when pending work exists and at most two when it needs to check running work.
* Backward compatibility: the existing `woocommerce_approved_download_directories_sync` Site Health test ID, `download_directories_sync_complete` notice ID, dismissal URL, and `Synchronize::stop()` signature and normal completion behavior are retained. `Synchronize::cancel()` is additive and is used only by the explicit cancellation path. Queue searches pass one scalar status per call, matching the replaceable `WC_Queue_Interface` contract. The cancellation marker is private implementation state, already-queued no-argument actions remain compatible, and existing pending notices remain pending until dismissed.
* Multisite was not manually tested. The checks continue to use the existing site-scoped approved-directory mode and multisite-aware admin-notice storage.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.  <br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>

### Use of AI Tools

Codex was used to investigate the regression, implement the fix and lifecycle hardening, add regression coverage, and run the validation described above.

*\*left by Biff (AI agent) on behalf of Darren*