### PR TITLE
Fix coupon checks for customerless order types

### DIFF
--- a/plugins/woocommerce/changelog/fix-30922-abstract-order-customer-id
+++ b/plugins/woocommerce/changelog/fix-30922-abstract-order-customer-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent coupon application from calling get_customer_id on order types without a customer concept.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1438,6 +1438,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * Check whether this order type has a customer concept.
+	 *
+	 * @return bool
+	 */
+	private function has_customer_id_method(): bool {
+		return method_exists( $this, 'get_customer_id' );
+	}
+
+	/**
 	 * Apply a coupon to the order and recalculate totals.
 	 *
 	 * @since 3.2.0
@@ -1481,9 +1490,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$data_store = $coupon->get_data_store();
-
 		// Check specific for guest checkouts here as well since WC_Cart handles that separately in check_customer_coupons.
-		if ( $data_store && 0 === $this->get_customer_id() ) {
+		if ( $data_store && $this->has_customer_id_method() && 0 === $this->get_customer_id() ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1443,7 +1443,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return bool
 	 */
 	private function has_customer_id_method(): bool {
-		return method_exists( $this, 'get_customer_id' );
+		return is_callable( array( $this, 'get_customer_id' ) );
 	}
 
 	/**
@@ -1491,7 +1491,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$data_store = $coupon->get_data_store();
 		// Check specific for guest checkouts here as well since WC_Cart handles that separately in check_customer_coupons.
-		if ( $data_store && $this->has_customer_id_method() && 0 === $this->get_customer_id() ) {
+		if ( $data_store && ( ! $this->has_customer_id_method() || 0 === $this->get_customer_id() ) ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -167,6 +167,45 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Applying a coupon to an order without a customer concept does not fail.
+	 */
+	public function test_apply_coupon_without_get_customer_id_method(): void {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'price' => 10 ) );
+		$coupon  = WC_Helper_Coupon::create_coupon();
+
+		// phpcs:disable Squiz.Commenting.FunctionComment.Missing -- Test fixture methods are self-explanatory.
+		$order = new class() extends WC_Abstract_Order {
+			public function get_billing_email() {
+				return '';
+			}
+
+			public function recalculate_coupons() {
+				return true;
+			}
+
+			public function save() {
+				return 0;
+			}
+
+			protected function get_tax_location( $args = array() ) {
+				return array(
+					'country'  => '',
+					'state'    => '',
+					'postcode' => '',
+					'city'     => '',
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+
+		$order->add_product( $product );
+
+		$result = $order->apply_coupon( $coupon );
+
+		$this->assertTrue( $result, 'Orders without a customer concept should accept valid coupons.' );
+	}
+
+	/**
 	 * @testdox 'add_product' passes the order supplied in '$args' to 'wc_get_price_excluding_tax', and uses the obtained price as total and subtotal for the line item.
 	 */
 	public function test_add_product_passes_order_to_wc_get_price_excluding_tax() {

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -206,6 +206,105 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Applying a coupon to a customerless order preserves per-user usage limits by billing email.
+	 */
+	public function test_apply_coupon_without_get_customer_id_method_checks_usage_by_billing_email(): void {
+		$billing_email = 'customerless-order@example.com';
+		$product       = WC_Helper_Product::create_simple_product( true, array( 'price' => 10 ) );
+		$coupon        = WC_Helper_Coupon::create_coupon();
+		$coupon->set_usage_limit_per_user( 1 );
+		$coupon->save();
+		$coupon->increase_usage_count( $billing_email );
+
+		// phpcs:disable Squiz.Commenting.FunctionComment.Missing -- Test fixture methods are self-explanatory.
+		$order = new class($billing_email) extends WC_Abstract_Order {
+			/**
+			 * Billing email for the test order.
+			 *
+			 * @var string
+			 */
+			private $billing_email;
+
+			public function __construct( $billing_email ) {
+				parent::__construct();
+				$this->billing_email = $billing_email;
+			}
+
+			public function get_billing_email() {
+				return $this->billing_email;
+			}
+
+			public function recalculate_coupons() {
+				return true;
+			}
+
+			public function save() {
+				return 0;
+			}
+
+			protected function get_tax_location( $args = array() ) {
+				return array(
+					'country'  => '',
+					'state'    => '',
+					'postcode' => '',
+					'city'     => '',
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+
+		$order->add_product( $product );
+
+		$result = $order->apply_coupon( $coupon );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_coupon', $result->get_error_code() );
+	}
+
+	/**
+	 * @testdox Applying a coupon does not call an inaccessible customer ID method.
+	 */
+	public function test_apply_coupon_with_private_get_customer_id_method(): void {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'price' => 10 ) );
+		$coupon  = WC_Helper_Coupon::create_coupon();
+
+		// phpcs:disable Squiz.Commenting.FunctionComment.Missing -- Test fixture methods are self-explanatory.
+		$order = new class() extends WC_Abstract_Order {
+			private function get_customer_id() {
+				return 0;
+			}
+
+			public function get_billing_email() {
+				return '';
+			}
+
+			public function recalculate_coupons() {
+				return true;
+			}
+
+			public function save() {
+				return 0;
+			}
+
+			protected function get_tax_location( $args = array() ) {
+				return array(
+					'country'  => '',
+					'state'    => '',
+					'postcode' => '',
+					'city'     => '',
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+
+		$order->add_product( $product );
+
+		$result = $order->apply_coupon( $coupon );
+
+		$this->assertTrue( $result, 'Orders with an inaccessible customer ID method should accept valid coupons.' );
+	}
+
+	/**
 	 * @testdox 'add_product' passes the order supplied in '$args' to 'wc_get_price_excluding_tax', and uses the obtained price as total and subtotal for the line item.
 	 */
 	public function test_add_product_passes_order_to_wc_get_price_excluding_tax() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`WC_Abstract_Order::apply_coupon()` assumes that every descendant implements `get_customer_id()`, although customerless order types are valid descendants of the abstract class. Guard the guest-specific coupon usage check behind a private capability check and add regression coverage for applying a coupon to an order type without a customer concept.

This does not change a public signature or hook. Existing `WC_Order` behavior is preserved, while custom customerless order types no longer fail at the guest-specific check.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #30922.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `WC_Abstract_Order_Test::test_apply_coupon_without_get_customer_id_method` in the PHP unit test environment.
2. Confirm the fixture extends `WC_Abstract_Order`, provides the non-customer capabilities needed to apply a coupon, and intentionally does not implement `get_customer_id()`.
3. Confirm `apply_coupon()` returns `true` instead of throwing an undefined-method error.
4. Run the existing coupon-application tests in `WC_Abstract_Order_Test` and confirm they remain green.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Docker `wp-env`, PHP 8.1.34, WordPress trunk, WooCommerce trunk.
- Focused coupon suite: 5 tests and 33 assertions passed.
- Regression proof: the new test fails at `get_customer_id()` without the guard and passes with this change.
- `phpcs-changed` passed for both modified PHP files.
- PHPStan passed for `includes/abstracts/abstract-wc-order.php` with no baseline changes.
- Exploratory full-class run: 36 tests passed; one unrelated existing test failed because WordPress trunk now requires a non-empty password in its `wp_create_user()` call.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-30922-abstract-order-customer-id`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to research the issue, prepare the implementation and regression test, and run the local validation workflow. The contributor reviewed the resulting diff and takes responsibility for the submission.
