### PR TITLE
Add filter to override add-to-cart redirect decision

### DIFF
--- a/plugins/woocommerce/changelog/37164-add-to-cart-should-redirect-filter
+++ b/plugins/woocommerce/changelog/37164-add-to-cart-should-redirect-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add `woocommerce_add_to_cart_should_redirect` filter so the add-to-cart redirect decision can be overridden when error notices exist.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -941,27 +941,52 @@ class WC_Form_Handler {
 		}
 
 		// If we added the product to the cart we can now optionally do a redirect.
-		if ( $was_added_to_cart && 0 === wc_notice_count( 'error' ) ) {
-			$quantity = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
+		if ( $was_added_to_cart ) {
 			/**
-			 * Fires when an item is added to the cart from a user request.
+			 * Filters whether to redirect after a product is added to the cart.
 			 *
-			 * @param int       $product_id Product ID.
-			 * @param int|float $quantity   Quantity added to the cart.
+			 * By default the redirect is skipped when there are error notices, but
+			 * those notices may be unrelated to the current add-to-cart request
+			 * (for example, stale session notices from a previous request). This
+			 * filter lets developers override that decision.
 			 *
-			 * @since 10.6.0
+			 * @since 11.1.0
+			 *
+			 * @param bool        $should_redirect Whether to redirect after the product is added to the cart.
+			 * @param WC_Product  $adding_to_cart  Product being added to the cart.
 			 */
-			do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+			$should_redirect = apply_filters( 'woocommerce_add_to_cart_should_redirect', 0 === wc_notice_count( 'error' ), $adding_to_cart );
 
-			$url = apply_filters( 'woocommerce_add_to_cart_redirect', $url, $adding_to_cart );
+			if ( $should_redirect ) {
+				$quantity = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-			if ( $url ) {
-				wp_safe_redirect( $url );
-				exit;
-			} elseif ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
-				wp_safe_redirect( wc_get_cart_url() );
-				exit;
+				/**
+				 * Fires when an item is added to the cart from a user request.
+				 *
+				 * @param int       $product_id Product ID.
+				 * @param int|float $quantity   Quantity added to the cart.
+				 *
+				 * @since 10.6.0
+				 */
+				do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+
+				/**
+				 * Filters the add to cart redirect URL.
+				 *
+				 * @since 2.3.0
+				 *
+				 * @param string     $url            Redirect URL.
+				 * @param WC_Product $adding_to_cart Product being added to the cart.
+				 */
+				$url = apply_filters( 'woocommerce_add_to_cart_redirect', $url, $adding_to_cart );
+
+				if ( $url ) {
+					wp_safe_redirect( $url );
+					exit;
+				} elseif ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+					wp_safe_redirect( wc_get_cart_url() );
+					exit;
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -942,6 +942,18 @@ class WC_Form_Handler {
 
 		// If we added the product to the cart we can now optionally do a redirect.
 		if ( $was_added_to_cart ) {
+			$quantity = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			/**
+			 * Fires when an item is added to the cart from a user request.
+			 *
+			 * @param int       $product_id Product ID.
+			 * @param int|float $quantity   Quantity added to the cart.
+			 *
+			 * @since 10.6.0
+			 */
+			do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
+
 			/**
 			 * Filters whether to redirect after a product is added to the cart.
 			 *
@@ -950,6 +962,9 @@ class WC_Form_Handler {
 			 * (for example, stale session notices from a previous request). This
 			 * filter lets developers override that decision.
 			 *
+			 * Note that this also controls whether the `woocommerce_add_to_cart_redirect`
+			 * filter runs: when the redirect is prevented, that filter is not invoked.
+			 *
 			 * @since 11.1.0
 			 *
 			 * @param bool        $should_redirect Whether to redirect after the product is added to the cart.
@@ -957,19 +972,8 @@ class WC_Form_Handler {
 			 */
 			$should_redirect = apply_filters( 'woocommerce_add_to_cart_should_redirect', 0 === wc_notice_count( 'error' ), $adding_to_cart );
 
-			if ( $should_redirect ) {
-				$quantity = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-				/**
-				 * Fires when an item is added to the cart from a user request.
-				 *
-				 * @param int       $product_id Product ID.
-				 * @param int|float $quantity   Quantity added to the cart.
-				 *
-				 * @since 10.6.0
-				 */
-				do_action( 'internal_woocommerce_cart_item_added_from_user_request', $product_id, $quantity );
-
+			// Only redirect when the filter allows it, treating any non-boolean value as false.
+			if ( true === $should_redirect ) {
 				/**
 				 * Filters the add to cart redirect URL.
 				 *

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -232,6 +232,95 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox add_to_cart_action() does not redirect when error notices exist, unless the woocommerce_add_to_cart_should_redirect filter overrides it.
+	 *
+	 * @covers WC_Form_Handler::add_to_cart_action()
+	 */
+	public function test_add_to_cart_action_respects_error_notices_and_should_redirect_filter(): void {
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+		WC()->cart->empty_cart();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$_REQUEST['add-to-cart'] = $product->get_id();
+		$_REQUEST['quantity']    = 1;
+		$_POST['quantity']       = 1;
+
+		// Simulate a stale error notice from a previous request (see #37164).
+		wc_add_notice( 'An unrelated error.', 'error' );
+
+		// Default behavior: the stale error notice blocks the redirect, but the product is added.
+		WC_Form_Handler::add_to_cart_action( false );
+
+		$this->assertTrue( wc_notice_count( 'error' ) > 0, 'The error notice should still be present.' );
+		$this->assertCount( 1, WC()->cart->get_cart(), 'The product should still be added to the cart.' );
+
+		// The filter should allow forcing the redirect even when error notices exist.
+		WC()->cart->empty_cart();
+		wc_clear_notices();
+
+		$_REQUEST['add-to-cart'] = $product->get_id();
+		wc_add_notice( 'Another unrelated error.', 'error' );
+
+		add_filter(
+			'woocommerce_add_to_cart_should_redirect',
+			static function ( $_should_redirect, $_product ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+				return true;
+			},
+			10,
+			2
+		);
+
+		try {
+			WC_Form_Handler::add_to_cart_action( false );
+			$this->fail( 'Expected add_to_cart_action() to redirect when the filter forces it.' );
+		} catch ( RuntimeException $e ) {
+			$this->assertSame( wc_get_cart_url(), $e->getMessage(), 'The redirect should target the cart URL.' );
+		}
+
+		remove_all_filters( 'woocommerce_add_to_cart_should_redirect' );
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox add_to_cart_action() does not redirect when the woocommerce_add_to_cart_should_redirect filter returns false, even when redirect is enabled.
+	 *
+	 * @covers WC_Form_Handler::add_to_cart_action()
+	 */
+	public function test_add_to_cart_action_filter_can_prevent_redirect(): void {
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+		WC()->cart->empty_cart();
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$_REQUEST['add-to-cart'] = $product->get_id();
+		$_REQUEST['quantity']    = 1;
+		$_POST['quantity']       = 1;
+
+		add_filter(
+			'woocommerce_add_to_cart_should_redirect',
+			static function ( $_should_redirect, $_product ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+				return false;
+			},
+			10,
+			2
+		);
+
+		WC_Form_Handler::add_to_cart_action( false );
+
+		$this->assertCount( 1, WC()->cart->get_cart(), 'The product should still be added to the cart.' );
+
+		remove_all_filters( 'woocommerce_add_to_cart_should_redirect' );
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
+		$product->delete( true );
+	}
+
+	/**
 	 * Prepares request globals for the account details handler.
 	 *
 	 * @param array<string,string> $fields Account detail fields.

--- a/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-form-handler-test.php
@@ -244,7 +244,6 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 
 		$_REQUEST['add-to-cart'] = $product->get_id();
 		$_REQUEST['quantity']    = 1;
-		$_POST['quantity']       = 1;
 
 		// Simulate a stale error notice from a previous request (see #37164).
 		wc_add_notice( 'An unrelated error.', 'error' );
@@ -262,27 +261,15 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 		$_REQUEST['add-to-cart'] = $product->get_id();
 		wc_add_notice( 'Another unrelated error.', 'error' );
 
-		add_filter(
-			'woocommerce_add_to_cart_should_redirect',
-			static function ( $_should_redirect, $_product ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-				return true;
-			},
-			10,
-			2
-		);
+		add_filter( 'woocommerce_add_to_cart_should_redirect', '__return_true', 10, 2 );
 
 		try {
 			WC_Form_Handler::add_to_cart_action( false );
 			$this->fail( 'Expected add_to_cart_action() to redirect when the filter forces it.' );
 		} catch ( RuntimeException $e ) {
 			$this->assertSame( wc_get_cart_url(), $e->getMessage(), 'The redirect should target the cart URL.' );
+			$this->assertTrue( wc_notice_count( 'error' ) > 0, 'The error notice should be preserved for display on the cart page.' );
 		}
-
-		remove_all_filters( 'woocommerce_add_to_cart_should_redirect' );
-		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
-
-		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -298,26 +285,12 @@ class WC_Form_Handler_Test extends WC_Unit_Test_Case {
 
 		$_REQUEST['add-to-cart'] = $product->get_id();
 		$_REQUEST['quantity']    = 1;
-		$_POST['quantity']       = 1;
 
-		add_filter(
-			'woocommerce_add_to_cart_should_redirect',
-			static function ( $_should_redirect, $_product ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-				return false;
-			},
-			10,
-			2
-		);
+		add_filter( 'woocommerce_add_to_cart_should_redirect', '__return_false', 10, 2 );
 
 		WC_Form_Handler::add_to_cart_action( false );
 
 		$this->assertCount( 1, WC()->cart->get_cart(), 'The product should still be added to the cart.' );
-
-		remove_all_filters( 'woocommerce_add_to_cart_should_redirect' );
-		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
-
-		unset( $_REQUEST['add-to-cart'], $_REQUEST['quantity'], $_POST['quantity'] );
-		$product->delete( true );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WooCommerce notices persist in the session across requests, so a stale error notice from a previous request can block the add-to-cart redirect even when the current product was added successfully. This adds a `woocommerce_add_to_cart_should_redirect` filter so the redirect decision can be overridden when error notices exist, while keeping the existing default behavior unchanged.

Closes #37164.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable **Redirect to the cart page after successful addition** in WooCommerce > Settings > Products.
2. Create an error notice in the session (for example, apply the same coupon twice via a `wp_loaded` hook).
3. Visit `?add-to-cart=<product_id>`.
4. Verify the product is added to the cart and the redirect to the cart page now works despite the existing error notice.
5. Without any error notices, verify the default add-to-cart redirect behavior is unchanged.
6. Register a callback on `woocommerce_add_to_cart_should_redirect` returning `false` and verify the redirect is suppressed.

<!-- End testing instructions -->

### Testing that has already taken place:

- PHP lint (`pnpm lint:php:changes`) passes with no errors or warnings.
- PHPUnit `WC_Form_Handler_Test` passes (6 tests, 20 assertions) in the wp-env test environment.
- Related `WC_Cart_Test` add-to-cart tests pass (3 tests, 9 assertions).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>