### PR TITLE
Fix admin script 404s when the minified-js feature is enabled on core builds

### DIFF
--- a/plugins/woocommerce/changelog/66575-fix-minified-js-feature-404
+++ b/plugins/woocommerce/changelog/66575-fix-minified-js-feature-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Serve minified admin scripts only when the minified file actually exists, preventing broken admin pages when the minified-js feature is force-enabled (e.g. via WooCommerce Beta Tester) on builds that do not ship minified JS files.

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -89,10 +89,12 @@ class WCAdminAssets {
 	public static function get_url( $file, $ext ) {
 		$suffix = '';
 
-		// Potentially enqueue minified JavaScript.
+		// Potentially enqueue minified JavaScript, but only if the minified file exists.
+		// Core builds do not ship minified JS files, so this also guards against the
+		// 'minified-js' feature being force-enabled (e.g. via WooCommerce Beta Tester).
 		if ( $ext === 'js' ) {
 			$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-			$suffix       = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
+			$suffix       = self::should_use_minified_js_file( $script_debug ) && is_readable( WC_ADMIN_ABSPATH . self::get_path( $ext ) . $file . '.min.' . $ext ) ? '.min' : '';
 		}
 
 		return plugins_url( self::get_path( $ext ) . $file . $suffix . '.' . $ext, WC_ADMIN_PLUGIN_FILE );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-assets.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-assets.php
@@ -19,25 +19,25 @@ class WC_Admin_Tests_WCAdminAssets extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		add_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20, 1 );
+		add_filter( 'woocommerce_admin_features', array( $this, 'turn_on_minified_js_feature' ), 20, 1 );
 	}
 
 	/**
 	 * Tear Down
 	 */
 	public function tearDown(): void {
-		remove_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20 );
+		remove_filter( 'woocommerce_admin_features', array( $this, 'turn_on_minified_js_feature' ), 20 );
 
 		parent::tearDown();
 	}
 
 	/**
-	 * Filter to enable unminified-js feature.
+	 * Filter to enable the minified-js feature.
 	 *
 	 * @param  array $features Array of active features.
 	 */
-	public static function turn_on_unminified_js_feature( $features ) {
-		return array_merge( $features, array( 'unminified-js' ) );
+	public static function turn_on_minified_js_feature( $features ) {
+		return array_merge( $features, array( 'minified-js' ) );
 	}
 
 	/**
@@ -50,13 +50,11 @@ class WC_Admin_Tests_WCAdminAssets extends WP_UnitTestCase {
 		$parts           = explode( '/', $result );
 		$final_file_name = array_pop( $parts );
 
-		// Since this can vary depending on the env the tests are running in, we will make this assertion based upon the SCRIPT_DEBUG value.
-		$expected_value = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? 'flavortown.js' : 'flavortown.min.js';
-
+		// No minified build of this file exists, so the unminified file name should be served regardless of SCRIPT_DEBUG.
 		$this->assertEquals(
-			$expected_value,
+			'flavortown.js',
 			$final_file_name,
-			'the anticipated js file name should use .min when SCRIPT_DEBUG is off, and have no .min when SCRIPT_DEBUG is on.'
+			'the anticipated js file name should not use .min when no minified file exists.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/WCAdminAssetsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/WCAdminAssetsTest.php
@@ -1,0 +1,100 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the WCAdminAssets class.
+ */
+class WCAdminAssetsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Path of the temporary minified JS file created by a test, if any.
+	 *
+	 * @var string|null
+	 */
+	private $temp_min_file = null;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'woocommerce_admin_features', array( $this, 'enable_minified_js_feature' ), 20 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_admin_features', array( $this, 'enable_minified_js_feature' ), 20 );
+
+		if ( $this->temp_min_file && file_exists( $this->temp_min_file ) ) {
+			wp_delete_file( $this->temp_min_file );
+			$this->temp_min_file = null;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback to enable the minified-js feature.
+	 *
+	 * @param array $features Array of active features.
+	 * @return array
+	 */
+	public function enable_minified_js_feature( $features ) {
+		return array_merge( $features, array( 'minified-js' ) );
+	}
+
+	/**
+	 * Skips the test when SCRIPT_DEBUG is on, as the minified file is never served then and the test would pass vacuously.
+	 */
+	private function skip_if_script_debug(): void {
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$this->markTestSkipped( 'Minified files are never served when SCRIPT_DEBUG is on.' );
+		}
+	}
+
+	/**
+	 * @testdox get_url should not use the .min suffix when the minified file does not exist, even with the minified-js feature enabled.
+	 */
+	public function test_get_url_falls_back_to_unminified_file_when_minified_file_is_missing(): void {
+		$this->skip_if_script_debug();
+
+		$url = WCAdminAssets::get_url( 'nonexistent-test-script/index', 'js' );
+
+		$this->assertStringEndsWith(
+			'nonexistent-test-script/index.js',
+			$url,
+			'The unminified file name should be served when no minified file exists.'
+		);
+	}
+
+	/**
+	 * @testdox get_url should use the .min suffix when the minified file exists, the minified-js feature is enabled and SCRIPT_DEBUG is off.
+	 */
+	public function test_get_url_uses_minified_file_when_it_exists(): void {
+		$this->skip_if_script_debug();
+
+		$dist_js_path = WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER;
+		if ( ! wp_is_writable( $dist_js_path ) ) {
+			$this->markTestSkipped( 'The admin dist JS folder is not writable.' );
+		}
+
+		$this->temp_min_file = $dist_js_path . 'wc-admin-assets-test.min.js';
+		file_put_contents( $this->temp_min_file, '/* test */' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$url = WCAdminAssets::get_url( 'wc-admin-assets-test', 'js' );
+
+		$this->assertStringEndsWith(
+			'wc-admin-assets-test.min.js',
+			$url,
+			'The minified file name should be served when the minified file exists and SCRIPT_DEBUG is off.'
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Enabling the `minified-js` feature (e.g. via the WooCommerce Beta Tester's Features tab) on a site where `SCRIPT_DEBUG` is off makes `WCAdminAssets::get_url()` request every admin script as `*.min.js`. Core builds do not ship minified JS files (`client/admin/webpack.config.js` only emits the `.min` suffix for non-core builds), so every wc-admin script 404s and all WooCommerce admin React pages render empty — silently, because the `.asset.php` registry lookup already falls back to the non-minified file.

This PR makes `get_url()` append the `.min` suffix only when the minified file actually exists on disk, mirroring the fallback already used in `get_script_asset_filename()`. It also fixes the legacy `WC_Admin_Tests_WCAdminAssets` test, which enabled a nonexistent `unminified-js` feature flag and only passed because the PHPUnit bootstrap loads `development.json` (where `minified-js` is `true`).

Closes #66575, closes WOOPLUG-7071

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Use a site where `SCRIPT_DEBUG` is not defined or is `false` (`wp-env` with default config works).
2. Install and activate WooCommerce Beta Tester, then go to Tools > WCA Test Helper > Features and enable `minified-js`.
3. On trunk: open any WooCommerce admin React page (e.g. WooCommerce > Settings > Site visibility). The page content does not render and the browser network tab shows 404s for `assets/client/admin/*.min.js`.
4. Switch to this branch and reload the page. The page renders normally and all scripts load with their unminified file names.
5. Run the unit tests: `pnpm test:php:env -- --filter WCAdminAssets` (from `plugins/woocommerce`). All 4 tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

- Verified on a clean `wp-env` install (PHP 8.1, `SCRIPT_DEBUG` false) that the new `WCAdminAssetsTest` regression test fails against trunk and passes with this fix.
- `pnpm test:php:env -- --filter WCAdminAssets` — 4 tests pass (new `WCAdminAssetsTest` plus updated legacy `WC_Admin_Tests_WCAdminAssets`).
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified source file are clean.

Backward-compatibility impact: `WCAdminAssets::get_url()` keeps its signature. Behavior changes only in the case that is currently broken — the feature flag enabled while the minified file is missing — where it now serves the existing unminified file instead of a 404 URL. Non-core builds that ship `.min.js` files are unaffected; the only added cost is one `is_readable()` stat per JS asset URL, and only when the `minified-js` feature is enabled.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This PR was authored with the assistance of AI tooling (Claude Code, with an independent review pass by OpenAI Codex). All changes were reviewed and tested by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaVK9SYLqVAUQf1DRpau2T