### PR TITLE
[Email Editor] Fix long unbreakable words breaking email layout

### DIFF
--- a/packages/php/email-editor/changelog/fix-paragraph-heading-long-word-overflow
+++ b/packages/php/email-editor/changelog/fix-paragraph-heading-long-word-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent long unbreakable words in paragraph, heading, and site title blocks from expanding the wrapping table and breaking the rendered email layout.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -66,7 +66,8 @@ class Text extends Abstract_Block_Renderer {
 
 		$block_styles      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'border', 'background-color', 'color', 'typography' ) );
 		$additional_styles = array(
-			'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices.
+			'min-width'  => '100%', // prevent Gmail App from shrinking the table on mobile devices.
+			'word-break' => 'break-word', // prevent long unbreakable words (e.g. URLs) from expanding the table and breaking the email layout.
 		);
 
 		// Add fallback text color when no custom text color or preset text color is set.

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -146,6 +146,7 @@ class Initializer {
 		$allowed_styles[] = 'mso-padding-alt';
 		$allowed_styles[] = 'mso-font-width';
 		$allowed_styles[] = 'mso-text-raise';
+		$allowed_styles[] = 'word-break';
 		return $allowed_styles;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Long unbreakable strings (e.g. run-on text with no spaces) in paragraph, heading, and site title blocks were not wrapping in rendered emails. Instead, the table cell these blocks render into expanded past its `width:100%`, breaking the entire email layout and pushing surrounding content off-screen.

Root cause: the shared `Text` block renderer (`core/paragraph`, `core/heading`, `core/site-title`) never applied `word-break: break-word` to its wrapping table cell. Additionally, `word-break` is not in WordPress core's default `safe_style_css` allowlist, so it also needed to be added to this package's existing `safe_style_css` filter (the same mechanism already used for `display` and the `mso-*` properties) to avoid being silently stripped during CSS sanitization.

Closes #67376.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1470" height="837" alt="Screenshot 2026-08-10 at 2 07 47 PM" src="https://github.com/user-attachments/assets/8ba186b6-c2f5-45c5-94fc-67461ebdaed7" /> | <img width="1470" height="841" alt="Screenshot 2026-08-10 at 2 06 49 PM" src="https://github.com/user-attachments/assets/f0dff1aa-a455-46fd-8ca0-e92d215838d6" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable the block email editor: **WooCommerce → Settings → Advanced → Features -> Block Email Editor (alpha)**.
2. Edit a transactional email that uses the block editor, e.g. **WooCommerce → Settings → Emails → New order**.
3. Add a paragraph block and enter a long string with no spaces (e.g. `overflowtestoverflowtestoverflowtestoverflowtestoverflowtestoverflowtestoverflowtestoverflowtestoverflowtestoverflowtest...`).
4. Use the editor's **Preview** action to view the rendered email, and inspect the `<td class="email-text-block">` wrapping the paragraph and confirm it now includes `word-break:break-word;` in its inline style.
5. Confirm the long string wraps within the email's content column instead of expanding the layout, and that surrounding blocks (columns, buttons, other text) are unaffected.
6. Repeat with a heading block to confirm the shared renderer fix applies there too.

<!-- End testing instructions -->

### Testing that has already taken place:

- Full `packages/php/email-editor` test suite passes.
- `phpcs` and `PHPStan` clean on all changed files.
- Manually verified in a local wp-env environment: reproduced the layout break from the linked issue, confirmed it's resolved after the fix, and confirmed the rendered `<td>` carries `word-break:break-word;`.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
