### PR TITLE
Fix dropdown button arrow shifting sideways when open in RTL

### DIFF
--- a/packages/js/components/changelog/fix-53727-rtl-dropdown-arrow
+++ b/packages/js/components/changelog/fix-53727-rtl-dropdown-arrow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep the dropdown button arrow in place when open in RTL languages

--- a/packages/js/components/src/dropdown-button/style.scss
+++ b/packages/js/components/src/dropdown-button/style.scss
@@ -15,7 +15,9 @@
 			no-repeat right 0 top 55%;
 		position: absolute;
 		right: 14px;
-		width: 32px;
+		// Match the glyph width so the mask anchor can't skew the arrow's
+		// edge distance when rtlcss mirrors the box but not the mask.
+		width: 20px;
 		height: 48px;
 	}
 

--- a/packages/js/components/src/dropdown-button/style.scss
+++ b/packages/js/components/src/dropdown-button/style.scss
@@ -21,7 +21,10 @@
 
 	&.is-open {
 		&::after {
-			transform: translateX(12px) translateY(2px) rotate(180deg);
+			// scaleY instead of rotate(180deg): the glyph is horizontally
+			// symmetric, and a purely vertical flip needs no translateX
+			// compensation, which rtlcss would flip the wrong way in RTL.
+			transform: translateY(2px) scaleY(-1);
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In RTL languages, the arrow icon of the analytics dropdown buttons (date range picker and report "Show" filter) jumped ~24px to the left when the dropdown opened. The open-state arrow was flipped with `rotate(180deg)` plus a `translateX(12px)` that compensates the rotation's horizontal displacement; rtlcss flips the sign of the translateX, but the rotation's displacement doesn't flip with it, so in RTL the two shifts added up instead of cancelling. The chevron glyph is horizontally symmetric, so the rotation is replaced with `scaleY(-1)`, a purely vertical flip that needs no horizontal compensation and renders identically in LTR.

Closes #53727.

(For Bug Fixes) Bug introduced in woocommerce/woocommerce-admin#3357.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="512" height="51" alt="before-open" src="https://github.com/user-attachments/assets/192d79a0-80c1-4a90-af94-fc4987ab126b" /> | <img width="512" height="51" alt="after-open" src="https://github.com/user-attachments/assets/6da5ce6f-1d48-4396-a754-19135d60e0bb" /> |

### How to test the changes in this Pull Request:

1. On an RTL site (e.g. `wp language core install he_IL --activate`, and optionally `wp language plugin install woocommerce he_IL` to translate the WooCommerce admin strings too - the bug reproduces either way), go to Analytics > Overview.
2. Click the "Date range" filter button.
3. Confirm the arrow flips upward in place instead of jumping to the left edge of the button. Close it and confirm it doesn't jump back.
4. Repeat on Analytics > Orders with the "Show" filter, and once on an LTR (English) site to confirm no change there.

### Testing that has already taken place:

- Verified the fix live on a local site running WooCommerce built from this branch, with the `he_IL` core and WooCommerce language packs installed and active: arrow now flips in place on both the date range picker and the report "Show" filter; geometry checked via computed styles before/after. The screenshots above are from that site.
- Verified LTR is pixel-identical (the replaced rotation was a visual no-op horizontally for the symmetric glyph).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually in `packages/js/components/changelog/fix-53727-rtl-dropdown-arrow`.

### Use of AI Tools

Authored with AI assistance (Claude Code); reviewed and tested by me.

