### PR TITLE
[Order Review] Render `review-order` shortcode only on managed page and require order key

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-review-shortcode-key-check
+++ b/plugins/woocommerce/changelog/fix-order-review-shortcode-key-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+The `[woocommerce_review_order]` shortcode now checks the order key before rendering, instead of relying solely on the WC-managed page's own gating. Since `review-order` is a public query var, embedding the shortcode on any other page or post previously exposed a guest order's name, email, and order key to anyone who guessed the order id.

--- a/plugins/woocommerce/changelog/fix-order-review-shortcode-key-check
+++ b/plugins/woocommerce/changelog/fix-order-review-shortcode-key-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-The `[woocommerce_review_order]` shortcode now checks the order key before rendering, instead of relying solely on the WC-managed page's own gating. Since `review-order` is a public query var, embedding the shortcode on any other page or post previously exposed a guest order's name, email, and order key to anyone who guessed the order id.
+Tighten authorization checks on the review-order shortcode.

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -524,11 +524,8 @@ class Endpoint {
 	 * Render the Review Order page body for the WC-managed page.
 	 *
 	 * Called by `the_content` on the page that hosts `[woocommerce_review_order]`.
-	 * `review-order` is registered as a public query var, so `?review-order={id}`
-	 * resolves on *any* post or page that embeds the shortcode, not only the
-	 * WC-managed one — `gate_request()` only gates the canonical page. Running
-	 * `is_authorised()` here too means the shortcode stays safe even if it ends
-	 * up embedded elsewhere (e.g. a lower-privileged author's own page).
+	 * Verifies the request independently rather than assuming the caller
+	 * already did so.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -524,9 +524,11 @@ class Endpoint {
 	 * Render the Review Order page body for the WC-managed page.
 	 *
 	 * Called by `the_content` on the page that hosts `[woocommerce_review_order]`.
-	 * Returns an empty string when the request did not arrive through the
-	 * tokenised rewrite, so a logged-in admin previewing the page directly
-	 * sees nothing rather than a partial form.
+	 * `review-order` is registered as a public query var, so `?review-order={id}`
+	 * resolves on *any* post or page that embeds the shortcode, not only the
+	 * WC-managed one — `gate_request()` only gates the canonical page. Running
+	 * `is_authorised()` here too means the shortcode stays safe even if it ends
+	 * up embedded elsewhere (e.g. a lower-privileged author's own page).
 	 *
 	 * @return string
 	 */
@@ -537,10 +539,11 @@ class Endpoint {
 			return '';
 		}
 
-		$order_id = absint( $wp->query_vars[ self::QUERY_VAR ] );
-		$order    = $order_id ? wc_get_order( $order_id ) : false;
-		if ( ! $order instanceof WC_Order ) {
-			// gate_request() will already have 404'd; this is defensive.
+		$order_id  = absint( $wp->query_vars[ self::QUERY_VAR ] );
+		$order_key = $this->read_order_key();
+		$order     = $order_id ? wc_get_order( $order_id ) : false;
+
+		if ( ! $this->is_authorised( $order, $order_key ) ) {
 			return '';
 		}
 

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -532,6 +532,11 @@ class Endpoint {
 	public function render_shortcode(): string {
 		global $wp;
 
+		$page_id = (int) wc_get_page_id( self::PAGE_KEY );
+		if ( $page_id <= 0 || ! is_page( $page_id ) ) {
+			return '';
+		}
+
 		if ( ! isset( $wp->query_vars[ self::QUERY_VAR ] ) ) {
 			return '';
 		}

--- a/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
+++ b/plugins/woocommerce/src/Internal/OrderReviews/Endpoint.php
@@ -524,8 +524,7 @@ class Endpoint {
 	 * Render the Review Order page body for the WC-managed page.
 	 *
 	 * Called by `the_content` on the page that hosts `[woocommerce_review_order]`.
-	 * Verifies the request independently rather than assuming the caller
-	 * already did so.
+	 * Confirms the current page and order key before rendering.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -221,6 +221,62 @@ class EndpointTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox render_shortcode() returns nothing when no order key is supplied, even off the WC-managed page.
+	 */
+	public function test_render_shortcode_empty_without_authorisation(): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		// `review-order` is a public query var, so WP populates it from the
+		// URL on any post or page — not only the WC-managed one. Stage that
+		// directly instead of going through gate_request()'s page check.
+		global $wp;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
+		$wp                                    = new \WP();
+		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
+		$_GET                                  = array();
+
+		$this->assertSame( '', $this->endpoint->render_shortcode() );
+	}
+
+	/**
+	 * @testdox render_shortcode() returns nothing when the supplied key does not match the order.
+	 */
+	public function test_render_shortcode_empty_when_key_mismatched(): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		global $wp;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
+		$wp                                    = new \WP();
+		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
+		$_GET                                  = array( 'key' => 'wc_order_definitelywrong' );
+
+		$this->assertSame( '', $this->endpoint->render_shortcode() );
+	}
+
+	/**
+	 * @testdox render_shortcode() still renders for a correctly-keyed request.
+	 */
+	public function test_render_shortcode_renders_when_authorised(): void {
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		global $wp;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
+		$wp                                    = new \WP();
+		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
+		$_GET                                  = array( 'key' => $order->get_order_key() );
+
+		$html = $this->endpoint->render_shortcode();
+
+		$this->assertStringContainsString( 'Order #' . $order->get_order_number(), $html );
+	}
+
+	/**
 	 * @testdox The woocommerce_review_order_eligible_statuses filter widens the eligible set.
 	 */
 	public function test_eligible_statuses_filter_widens_set(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -222,47 +222,40 @@ class EndpointTest extends WC_Unit_Test_Case {
 
 	/**
 	 * @testdox render_shortcode() only renders on the managed page with a matching order key.
-	 *
-	 * @testWith [true, true, true]
-	 *           [true, false, false]
-	 *           [false, true, false]
-	 *
-	 * @param bool $on_managed_page Whether the current page is the managed Review Order page.
-	 * @param bool $correct_key     Whether the request supplies the order's real key.
-	 * @param bool $should_render   Whether render_shortcode() is expected to produce output.
 	 */
-	public function test_render_shortcode_requires_managed_page_and_key( bool $on_managed_page, bool $correct_key, bool $should_render ): void {
+	public function test_render_shortcode_requires_managed_page_and_key(): void {
 		$order = OrderHelper::create_order();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
-		$page_id = $on_managed_page
-			? (int) wc_get_page_id( Endpoint::PAGE_KEY )
-			: (int) wp_insert_post(
-				array(
-					'post_type'   => 'page',
-					'post_status' => 'publish',
-					'post_title'  => 'Some other page',
-				)
-			);
+		$page_id       = (int) wc_get_page_id( Endpoint::PAGE_KEY );
+		$other_page_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Some other page',
+			)
+		);
 
 		global $wp, $wp_query;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture.
 		$wp             = new \stdClass();
 		$wp->query_vars = array( Endpoint::QUERY_VAR => (string) $order->get_id() );
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture.
-		$wp_query                 = new WP_Query();
-		$wp_query->is_page        = true;
+		$wp_query          = new WP_Query();
+		$wp_query->is_page = true;
+
 		$wp_query->queried_object = get_post( $page_id );
-		$_GET                     = array( 'key' => $correct_key ? $order->get_order_key() : 'wc_order_definitelywrong' );
+		$_GET                     = array( 'key' => 'wc_order_definitelywrong' );
+		$this->assertSame( '', $this->endpoint->render_shortcode(), 'Wrong key on the managed page.' );
 
-		$html = $this->endpoint->render_shortcode();
+		$wp_query->queried_object = get_post( $other_page_id );
+		$_GET                     = array( 'key' => $order->get_order_key() );
+		$this->assertSame( '', $this->endpoint->render_shortcode(), 'Correct key off the managed page.' );
 
-		if ( $should_render ) {
-			$this->assertStringContainsString( 'Order #' . $order->get_order_number(), $html );
-		} else {
-			$this->assertSame( '', $html );
-		}
+		$wp_query->queried_object = get_post( $page_id );
+		$html                     = $this->endpoint->render_shortcode();
+		$this->assertStringContainsString( 'Order #' . $order->get_order_number(), $html, 'Correct key on the managed page.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -221,16 +221,13 @@ class EndpointTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox render_shortcode() returns nothing when no order key is supplied, even off the WC-managed page.
+	 * @testdox render_shortcode() returns nothing when no order key is supplied.
 	 */
 	public function test_render_shortcode_empty_without_authorisation(): void {
 		$order = OrderHelper::create_order();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
-		// `review-order` is a public query var, so WP populates it from the
-		// URL on any post or page — not only the WC-managed one. Stage that
-		// directly instead of going through gate_request()'s page check.
 		global $wp;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
 		$wp                                    = new \WP();

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -246,10 +246,6 @@ class EndpointTest extends WC_Unit_Test_Case {
 				)
 			);
 
-		// Matches the pattern in class-wc-breadcrumb-test.php: a plain object
-		// for `$wp` (render_shortcode() only reads ->query_vars) and a bare
-		// `WP_Query` with `is_page`/`queried_object` set directly, instead of
-		// running a real query.
 		global $wp, $wp_query;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture.
 		$wp             = new \stdClass();

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -221,6 +221,23 @@ class EndpointTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Stage the globals render_shortcode()/gate_request() read: a singular
+	 * query for the given page id (`is_page()`), `$wp->query_vars[ QUERY_VAR ]`
+	 * for the order id, and `$_GET['key']` for the order key.
+	 *
+	 * @param int $page_id Page id the main query should resolve to.
+	 */
+	private function stage_page_query( int $page_id ): void {
+		global $wp, $wp_query, $wp_the_query;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: singular page query so is_page() returns true.
+		$wp_query = new WP_Query( array( 'page_id' => $page_id ) );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: matching main query.
+		$wp_the_query = $wp_query;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
+		$wp = new \WP();
+	}
+
+	/**
 	 * @testdox render_shortcode() returns nothing when no order key is supplied.
 	 */
 	public function test_render_shortcode_empty_without_authorisation(): void {
@@ -228,9 +245,8 @@ class EndpointTest extends WC_Unit_Test_Case {
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
+		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
 		global $wp;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
-		$wp                                    = new \WP();
 		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
 		$_GET                                  = array();
 
@@ -245,9 +261,8 @@ class EndpointTest extends WC_Unit_Test_Case {
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
+		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
 		global $wp;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
-		$wp                                    = new \WP();
 		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
 		$_GET                                  = array( 'key' => 'wc_order_definitelywrong' );
 
@@ -255,16 +270,39 @@ class EndpointTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox render_shortcode() still renders for a correctly-keyed request.
+	 * @testdox render_shortcode() returns nothing when the current page is not the managed one, even with a valid key.
+	 */
+	public function test_render_shortcode_empty_when_not_on_managed_page(): void {
+		$other_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Some other page',
+			)
+		);
+
+		$order = OrderHelper::create_order();
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$this->stage_page_query( $other_id );
+		global $wp;
+		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
+		$_GET                                  = array( 'key' => $order->get_order_key() );
+
+		$this->assertSame( '', $this->endpoint->render_shortcode() );
+	}
+
+	/**
+	 * @testdox render_shortcode() still renders for a correctly-keyed request on the managed page.
 	 */
 	public function test_render_shortcode_renders_when_authorised(): void {
 		$order = OrderHelper::create_order();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
+		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
 		global $wp;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
-		$wp                                    = new \WP();
 		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
 		$_GET                                  = array( 'key' => $order->get_order_key() );
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/EndpointTest.php
@@ -221,94 +221,52 @@ class EndpointTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Stage the globals render_shortcode()/gate_request() read: a singular
-	 * query for the given page id (`is_page()`), `$wp->query_vars[ QUERY_VAR ]`
-	 * for the order id, and `$_GET['key']` for the order key.
+	 * @testdox render_shortcode() only renders on the managed page with a matching order key.
 	 *
-	 * @param int $page_id Page id the main query should resolve to.
+	 * @testWith [true, true, true]
+	 *           [true, false, false]
+	 *           [false, true, false]
+	 *
+	 * @param bool $on_managed_page Whether the current page is the managed Review Order page.
+	 * @param bool $correct_key     Whether the request supplies the order's real key.
+	 * @param bool $should_render   Whether render_shortcode() is expected to produce output.
 	 */
-	private function stage_page_query( int $page_id ): void {
-		global $wp, $wp_query, $wp_the_query;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: singular page query so is_page() returns true.
-		$wp_query = new WP_Query( array( 'page_id' => $page_id ) );
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: matching main query.
-		$wp_the_query = $wp_query;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture: stage a fresh WP instance carrying our query var.
-		$wp = new \WP();
-	}
-
-	/**
-	 * @testdox render_shortcode() returns nothing when no order key is supplied.
-	 */
-	public function test_render_shortcode_empty_without_authorisation(): void {
+	public function test_render_shortcode_requires_managed_page_and_key( bool $on_managed_page, bool $correct_key, bool $should_render ): void {
 		$order = OrderHelper::create_order();
 		$order->set_status( OrderStatus::COMPLETED );
 		$order->save();
 
-		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
-		global $wp;
-		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
-		$_GET                                  = array();
+		$page_id = $on_managed_page
+			? (int) wc_get_page_id( Endpoint::PAGE_KEY )
+			: (int) wp_insert_post(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+					'post_title'  => 'Some other page',
+				)
+			);
 
-		$this->assertSame( '', $this->endpoint->render_shortcode() );
-	}
-
-	/**
-	 * @testdox render_shortcode() returns nothing when the supplied key does not match the order.
-	 */
-	public function test_render_shortcode_empty_when_key_mismatched(): void {
-		$order = OrderHelper::create_order();
-		$order->set_status( OrderStatus::COMPLETED );
-		$order->save();
-
-		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
-		global $wp;
-		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
-		$_GET                                  = array( 'key' => 'wc_order_definitelywrong' );
-
-		$this->assertSame( '', $this->endpoint->render_shortcode() );
-	}
-
-	/**
-	 * @testdox render_shortcode() returns nothing when the current page is not the managed one, even with a valid key.
-	 */
-	public function test_render_shortcode_empty_when_not_on_managed_page(): void {
-		$other_id = (int) wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Some other page',
-			)
-		);
-
-		$order = OrderHelper::create_order();
-		$order->set_status( OrderStatus::COMPLETED );
-		$order->save();
-
-		$this->stage_page_query( $other_id );
-		global $wp;
-		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
-		$_GET                                  = array( 'key' => $order->get_order_key() );
-
-		$this->assertSame( '', $this->endpoint->render_shortcode() );
-	}
-
-	/**
-	 * @testdox render_shortcode() still renders for a correctly-keyed request on the managed page.
-	 */
-	public function test_render_shortcode_renders_when_authorised(): void {
-		$order = OrderHelper::create_order();
-		$order->set_status( OrderStatus::COMPLETED );
-		$order->save();
-
-		$this->stage_page_query( (int) wc_get_page_id( Endpoint::PAGE_KEY ) );
-		global $wp;
-		$wp->query_vars[ Endpoint::QUERY_VAR ] = (string) $order->get_id();
-		$_GET                                  = array( 'key' => $order->get_order_key() );
+		// Matches the pattern in class-wc-breadcrumb-test.php: a plain object
+		// for `$wp` (render_shortcode() only reads ->query_vars) and a bare
+		// `WP_Query` with `is_page`/`queried_object` set directly, instead of
+		// running a real query.
+		global $wp, $wp_query;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture.
+		$wp             = new \stdClass();
+		$wp->query_vars = array( Endpoint::QUERY_VAR => (string) $order->get_id() );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test fixture.
+		$wp_query                 = new WP_Query();
+		$wp_query->is_page        = true;
+		$wp_query->queried_object = get_post( $page_id );
+		$_GET                     = array( 'key' => $correct_key ? $order->get_order_key() : 'wc_order_definitelywrong' );
 
 		$html = $this->endpoint->render_shortcode();
 
-		$this->assertStringContainsString( 'Order #' . $order->get_order_number(), $html );
+		if ( $should_render ) {
+			$this->assertStringContainsString( 'Order #' . $order->get_order_number(), $html );
+		} else {
+			$this->assertSame( '', $html );
+		}
 	}
 
 	/**


### PR DESCRIPTION
See 454-gh-Automattic/woocommerce.