### PR TITLE
Speed up block template customization end-to-end tests

### DIFF
--- a/plugins/woocommerce/changelog/optimize-template-customization-e2e-rest
+++ b/plugins/woocommerce/changelog/optimize-template-customization-e2e-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Speed up block template customization end-to-end tests using REST API setup and cleanup.

--- a/plugins/woocommerce/tests/e2e/tests/blocks/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/templates/template-customization.block_theme.spec.ts
@@ -21,6 +21,11 @@ test.describe( 'Template customization', () => {
 			testData.templateType === 'wp_template'
 				? 'template'
 				: 'template part';
+		const templateOrigin =
+			testData.templateType === 'wp_template'
+				? BLOCK_THEME_SLUG
+				: 'woocommerce/woocommerce';
+		const templateId = `${ templateOrigin }//${ testData.templatePath }`;
 
 		test( `"${ testData.templateName }" template can be modified and reverted`, async ( {
 			admin,
@@ -41,12 +46,8 @@ test.describe( 'Template customization', () => {
 					templateName: testData.templateName,
 				} );
 			} else {
-				const templateSlug =
-					testData.templateType === 'wp_template'
-						? BLOCK_THEME_SLUG
-						: 'woocommerce/woocommerce';
 				await admin.visitSiteEditor( {
-					postId: `${ templateSlug }//${ testData.templatePath }`,
+					postId: templateId,
 					postType: testData.templateType,
 					canvas: 'edit',
 				} );
@@ -80,12 +81,10 @@ test.describe( 'Template customization', () => {
 			await expect( page.getByText( userText ).first() ).toBeVisible();
 
 			// Verify the edition can be reverted.
-			await admin.visitSiteEditor( {
-				postType: testData.templateType,
-			} );
-			await editor.revertTemplate( {
-				templateName: testData.templateName,
-			} );
+			await requestUtils.revertTemplate(
+				testData.templateType,
+				templateId
+			);
 			await testData.visitPage( {
 				admin,
 				editor,
@@ -97,37 +96,22 @@ test.describe( 'Template customization', () => {
 		} );
 
 		if ( testData.fallbackTemplate ) {
-			test( `"${ testData.templateName }" template defaults to the "${ testData.fallbackTemplate.templateName }" template`, async ( {
+			const fallbackTemplate = testData.fallbackTemplate;
+
+			test( `"${ testData.templateName }" template defaults to the "${ fallbackTemplate.templateName }" template`, async ( {
 				admin,
 				frontendUtils,
 				requestUtils,
 				editor,
 				page,
 			} ) => {
-				const templateSlug =
-					testData.templateType === 'wp_template'
-						? BLOCK_THEME_SLUG
-						: 'woocommerce/woocommerce';
-				// Edit fallback template and verify changes are visible.
-				await admin.visitSiteEditor( {
-					postId: `${ templateSlug }//${ testData.fallbackTemplate?.templatePath }`,
-					postType: testData.templateType,
-					canvas: 'edit',
-				} );
-
-				await editor.canvas
-					.locator( 'body' )
-					.waitFor( { timeout: 20000 } );
-
-				await editor.insertBlock( {
-					name: 'core/paragraph',
-					attributes: {
-						content: fallbackTemplateUserText,
-					},
-				} );
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
+				// Customize the fallback template and verify changes are visible.
+				const fallbackTemplateId = `${ templateOrigin }//${ fallbackTemplate.templatePath }`;
+				await requestUtils.updateTemplateContent(
+					testData.templateType,
+					fallbackTemplateId,
+					`<!-- wp:paragraph --><p>${ fallbackTemplateUserText }</p><!-- /wp:paragraph -->`
+				);
 				await testData.visitPage( {
 					admin,
 					editor,
@@ -140,13 +124,10 @@ test.describe( 'Template customization', () => {
 				).toBeVisible();
 
 				// Verify the edition can be reverted.
-				await admin.visitSiteEditor( {
-					postType: testData.templateType,
-				} );
-
-				await editor.revertTemplate( {
-					templateName: testData.fallbackTemplate?.templateName || '',
-				} );
+				await requestUtils.revertTemplate(
+					testData.templateType,
+					fallbackTemplateId
+				);
 
 				await testData.visitPage( {
 					admin,
@@ -198,11 +179,11 @@ test.describe( 'Template customization', () => {
 
 			await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
 
-			// Edit the theme template. The theme template is not
-			// directly available from the UI, because the customized
-			// one takes priority, so we go directly to its URL.
+			// Edit the theme template. The theme template is not directly
+			// available from the UI because the customized one takes priority.
+			const themeTemplateId = `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`;
 			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
+				postId: themeTemplateId,
 				postType: testData.templateType,
 				canvas: 'edit',
 			} );
@@ -231,17 +212,13 @@ test.describe( 'Template customization', () => {
 			).toBeHidden();
 
 			// Revert edition and verify the user-modified WC template is used.
-			// Note: we need to revert it from the admin (instead of calling
-			// `deleteAllTemplates()`). This way, we verify there are no
-			// duplicate templates with the same name.
+			// Revert the exact template rather than selecting it by its display
+			// name, which can be shared by templates from different origins.
 			// See: https://github.com/woocommerce/woocommerce/issues/42220
-			await admin.visitSiteEditor( {
-				postType: testData.templateType,
-			} );
-
-			await editor.revertTemplate( {
-				templateName: testData.templateName,
-			} );
+			await requestUtils.revertTemplate(
+				testData.templateType,
+				themeTemplateId
+			);
 
 			await testData.visitPage( {
 				admin,

--- a/plugins/woocommerce/tests/e2e/tests/blocks/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/templates/template-customization.block_theme_with_templates.spec.ts
@@ -27,6 +27,7 @@ test.describe( 'Template customization', () => {
 			testData.templateType === 'wp_template'
 				? 'template'
 				: 'template part';
+		const templateId = `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`;
 
 		test.describe( `${ testData.templateName } template`, () => {
 			test( "theme template has priority over WooCommerce's and can be modified", async ( {
@@ -38,7 +39,7 @@ test.describe( 'Template customization', () => {
 			} ) => {
 				// Edit the theme template.
 				await admin.visitSiteEditor( {
-					postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
+					postId: templateId,
 					postType: testData.templateType,
 					canvas: 'edit',
 				} );
@@ -76,12 +77,10 @@ test.describe( 'Template customization', () => {
 				).toBeVisible();
 
 				// Revert edition and verify the template from the theme is used.
-				await admin.visitSiteEditor( {
-					postType: testData.templateType,
-				} );
-				await editor.revertTemplate( {
-					templateName: testData.templateName,
-				} );
+				await requestUtils.revertTemplate(
+					testData.templateType,
+					templateId
+				);
 
 				await testData.visitPage( {
 					admin,
@@ -102,34 +101,22 @@ test.describe( 'Template customization', () => {
 			} );
 
 			if ( testData.fallbackTemplate ) {
-				test( `theme template has priority over user-modified ${ testData.fallbackTemplate.templateName } template`, async ( {
+				const fallbackTemplate = testData.fallbackTemplate;
+
+				test( `theme template has priority over user-modified ${ fallbackTemplate.templateName } template`, async ( {
 					admin,
 					frontendUtils,
 					requestUtils,
 					editor,
 					page,
 				} ) => {
-					// Edit default template and verify changes are not visible,
-					// as the theme template has priority.
-					await admin.visitSiteEditor( {
-						postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.fallbackTemplate?.templatePath }`,
-						postType: testData.templateType,
-						canvas: 'edit',
-					} );
-
-					await editor.canvas
-						.locator( 'body' )
-						.waitFor( { timeout: 20000 } );
-
-					await editor.insertBlock( {
-						name: 'core/paragraph',
-						attributes: {
-							content: fallbackTemplateUserText,
-						},
-					} );
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: true,
-					} );
+					// Customize the fallback template and verify changes are not
+					// visible, as the theme template has priority.
+					await requestUtils.updateTemplateContent(
+						testData.templateType,
+						`${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ fallbackTemplate.templatePath }`,
+						`<!-- wp:paragraph --><p>${ fallbackTemplateUserText }</p><!-- /wp:paragraph -->`
+					);
 					await testData.visitPage( {
 						admin,
 						editor,

--- a/plugins/woocommerce/tests/e2e/utils/blocks/request-utils/index.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/request-utils/index.ts
@@ -8,7 +8,9 @@ import { RequestUtils as CoreRequestUtils } from '@wordpress/e2e-test-utils-play
  */
 import { createPostFromFile, PostCompiler } from './posts';
 import {
+	updateTemplateContent,
 	getTemplates,
+	getTemplate,
 	revertTemplate,
 	createTemplateFromFile,
 	TemplateCompiler,
@@ -16,8 +18,13 @@ import {
 import { resetFeatureFlag, setFeatureFlag } from './feature-flag';
 
 export class RequestUtils extends CoreRequestUtils {
+	/** @borrows updateTemplateContent as this.updateTemplateContent */
+	updateTemplateContent: typeof updateTemplateContent =
+		updateTemplateContent.bind( this );
 	/** @borrows getTemplates as this.getTemplates */
 	getTemplates: typeof getTemplates = getTemplates.bind( this );
+	/** @borrows getTemplate as this.getTemplate */
+	getTemplate: typeof getTemplate = getTemplate.bind( this );
 	/** @borrows revertTemplate as this.revertTemplate */
 	revertTemplate: typeof revertTemplate = revertTemplate.bind( this );
 	/** @borrows createPostFromFile as this.createPostFromFile */

--- a/plugins/woocommerce/tests/e2e/utils/blocks/request-utils/templates.ts
+++ b/plugins/woocommerce/tests/e2e/utils/blocks/request-utils/templates.ts
@@ -20,40 +20,98 @@ export interface WPTemplate {
 	wp_id: number;
 	id: string;
 	type: WPTemplateType;
+	origin: 'plugin' | 'theme' | null;
+	content: {
+		raw: string;
+	};
 }
 
 export interface TemplateCompiler {
 	compile: ( data?: unknown ) => Promise< WPTemplate >;
 }
 
+function getTemplateRestPath(
+	templateType: WPTemplateType,
+	templateId?: string
+) {
+	const endpoint =
+		templateType === 'wp_template' ? 'templates' : 'template-parts';
+
+	return `/wp/v2/${ endpoint }${ templateId ? `/${ templateId }` : '' }`;
+}
+
 /**
  * Retrieves all available templates.
  */
-export async function getTemplates( this: RequestUtils ) {
+export async function getTemplates(
+	this: RequestUtils,
+	templateType: WPTemplateType = 'wp_template'
+) {
 	const templates = await this.rest< WPTemplate[] >( {
 		method: 'GET',
-		path: '/wp/v2/templates',
+		path: getTemplateRestPath( templateType ),
 	} );
 
 	return templates;
 }
 
 /**
+ * Retrieves a template or template part.
+ */
+export async function getTemplate(
+	this: RequestUtils,
+	templateType: WPTemplateType,
+	templateId: string
+) {
+	return await this.rest< WPTemplate >( {
+		method: 'GET',
+		path: getTemplateRestPath( templateType, templateId ),
+	} );
+}
+
+/**
+ * Updates the content of a template or template part.
+ */
+export async function updateTemplateContent(
+	this: RequestUtils,
+	templateType: WPTemplateType,
+	templateId: string,
+	content: string
+) {
+	return await this.rest< WPTemplate >( {
+		method: 'POST',
+		path: getTemplateRestPath( templateType, templateId ),
+		data: {
+			id: templateId,
+			content,
+		},
+	} );
+}
+
+/**
  * Reverts a template to its original state.
  */
-export async function revertTemplate( this: RequestUtils, slug: string ) {
-	const restPath = `/wp/v2/templates/${ slug }`;
-
-	const template = await this.rest( {
-		method: 'GET',
-		path: restPath,
-	} );
+export async function revertTemplate(
+	this: RequestUtils,
+	templateType: WPTemplateType,
+	templateId: string
+) {
+	const restPath = getTemplateRestPath( templateType, templateId );
+	const template = await this.getTemplate( templateType, templateId );
+	if ( template.origin === null ) {
+		await this.rest( {
+			method: 'DELETE',
+			path: restPath,
+			params: { force: true },
+		} );
+		return;
+	}
 
 	await this.rest( {
 		method: 'POST',
 		path: restPath,
 		data: {
-			id: slug,
+			id: templateId,
 			content: template.content.raw,
 			source: 'theme',
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Selector-based template setup and reset made these customization tests slow and flaky, particularly when templates from different origins shared a display name.

Use exact template type/ID REST requests for setup and cleanup while preserving Site Editor interactions that provide UI regression coverage. Theme/plugin-backed customizations are restored to their source, while user-created templates without a backing source are deleted.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the blocks e2e environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:start:blocks`.
2. From `plugins/woocommerce`, run `pnpm playwright test --config=tests/e2e/playwright.config.ts --project=blocks-chromium tests/blocks/templates/template-customization.block_theme_with_templates.spec.ts tests/blocks/templates/template-customization.block_theme.spec.ts`.
3. Confirm the template customization, fallback priority, and reset scenarios pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

The two specs were benchmarked locally against the Docker-based blocks e2e environment using one Chromium worker:

| Run | Wall time | Result |
| --- | ---: | --- |
| Selector-based baseline | 322.03s | 26 passed, 6 selector-reset failures |
| REST implementation | 195.63s | 31 passed, 1 unrelated checkout-address timeout |

The final combined run was 39.3% faster. The remaining Order Confirmation failure happens while waiting for the checkout address form, before the new REST cleanup runs, and reproduced in isolation. Focused fallback-priority coverage passed in both specs.

`pnpm lint:changes:branch:js` completed with zero errors and four known e2e configuration/rule warnings (`import/no-unresolved` for the e2e alias and two existing conditional-test warnings).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex assisted with implementation, benchmarking, validation, and drafting this Pull Request description.
