### PR TITLE
Fix refunds reported as returning customers in Analytics > Orders

### DIFF
--- a/plugins/woocommerce/changelog/33410-fix-refund-customer-type-analytics
+++ b/plugins/woocommerce/changelog/33410-fix-refund-customer-type-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Analytics > Orders: report refunds with the customer type of the order they refund, instead of always reporting them as returning customers.

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1117,11 +1117,11 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 		}
 
 		if ( 'all' === $query_args['refunds'] ) {
-			$sql_query['where_clause'] .= 'parent_id != 0';
+			$sql_query['where_clause'] .= "{$table_name}.parent_id != 0";
 		}
 
 		if ( 'none' === $query_args['refunds'] ) {
-			$sql_query['where_clause'] .= 'parent_id = 0';
+			$sql_query['where_clause'] .= "{$table_name}.parent_id = 0";
 		}
 
 		if ( 'full' === $query_args['refunds'] || 'partial' === $query_args['refunds'] ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1117,11 +1117,11 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 		}
 
 		if ( 'all' === $query_args['refunds'] ) {
-			$sql_query['where_clause'] .= "{$table_name}.parent_id != 0";
+			$sql_query['where_clause'] .= 'parent_id != 0';
 		}
 
 		if ( 'none' === $query_args['refunds'] ) {
-			$sql_query['where_clause'] .= "{$table_name}.parent_id = 0";
+			$sql_query['where_clause'] .= 'parent_id = 0';
 		}
 
 		if ( 'full' === $query_args['refunds'] || 'partial' === $query_args['refunds'] ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -151,8 +151,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Adds the JOIN required to resolve the customer type of refund rows, which is read from the
 	 * refunded (parent) order.
 	 *
-	 * The JOIN is only added when the customer type is actually needed, so that reports that do not
-	 * select or filter by it are not charged for it.
+	 * The JOIN is only added when the customer type column is selected, so that reports that do not
+	 * ask for it are not charged for it.
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 * @return void
@@ -165,7 +165,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			! is_array( $query_args['fields'] ) ||
 			in_array( 'customer_type', $query_args['fields'], true );
 
-		if ( empty( $query_args['customer_type'] ) && ! $is_selected ) {
+		if ( ! $is_selected ) {
 			return;
 		}
 
@@ -214,8 +214,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		if ( $query_args['customer_type'] ) {
 			$returning_customer = 'returning' === $query_args['customer_type'] ? 1 : 0;
-			$parent_alias       = self::CUSTOMER_TYPE_PARENT_ALIAS;
-			$where_subquery[]   = "COALESCE( {$order_stats_lookup_table}.returning_customer, {$parent_alias}.returning_customer ) = {$returning_customer}";
+			$where_subquery[]   = "{$order_stats_lookup_table}.returning_customer = {$returning_customer}";
 		}
 
 		$refund_subquery = $this->get_refund_subquery( $query_args );

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -27,6 +27,34 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const ORDERS_STATUSES_ALL_CACHE_KEY = 'woocommerce_analytics_orders_statuses_all';
 
 	/**
+	 * Alias of the order stats table joined to resolve the customer type of refund rows.
+	 */
+	const CUSTOMER_TYPE_PARENT_ALIAS = 'customer_type_parent_stats';
+
+	/**
+	 * Columns of the order stats table that can be ordered by, and so need to be qualified with the
+	 * table name to stay unambiguous once other tables are joined.
+	 *
+	 * @var string[]
+	 */
+	const ORDER_STATS_COLUMNS = array(
+		'order_id',
+		'parent_id',
+		'date_created',
+		'date_created_gmt',
+		'date_paid',
+		'date_completed',
+		'status',
+		'customer_id',
+		'net_total',
+		'total_sales',
+		'tax_total',
+		'shipping_total',
+		'num_items_sold',
+		'returning_customer',
+	);
+
+	/**
 	 * Dynamically sets the date column name based on configuration
 	 *
 	 * @override ReportsDataStore::__construct()
@@ -99,6 +127,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name = self::get_db_table_name();
+		// Refunds are stored with a NULL returning_customer, so fall back to the value of the
+		// refunded (parent) order. See add_customer_type_join().
+		$returning_customer = 'COALESCE( ' . $table_name . '.returning_customer, ' . self::CUSTOMER_TYPE_PARENT_ALIAS . '.returning_customer )';
 		// Avoid ambiguous columns in SQL query.
 		$this->report_columns = array(
 			'order_id'         => "DISTINCT {$table_name}.order_id",
@@ -112,8 +143,33 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'net_total'        => "{$table_name}.net_total",
 			'total_sales'      => "{$table_name}.total_sales",
 			'num_items_sold'   => "{$table_name}.num_items_sold",
-			'customer_type'    => "(CASE WHEN {$table_name}.returning_customer = 0 THEN 'new' ELSE 'returning' END) as customer_type",
+			'customer_type'    => "(CASE WHEN {$returning_customer} = 0 THEN 'new' ELSE 'returning' END) as customer_type",
 		);
+	}
+
+	/**
+	 * Adds the JOIN required to resolve the customer type of refund rows, which is read from the
+	 * refunded (parent) order.
+	 *
+	 * The JOIN is only added when the customer type is actually needed, so that reports that do not
+	 * select or filter by it are not charged for it.
+	 *
+	 * @param array $query_args Query arguments supplied by the user.
+	 * @return void
+	 */
+	protected function add_customer_type_join( $query_args ) {
+		$table_name = self::get_db_table_name();
+		$alias      = self::CUSTOMER_TYPE_PARENT_ALIAS;
+
+		$is_selected = ! isset( $query_args['fields'] ) ||
+			! is_array( $query_args['fields'] ) ||
+			in_array( 'customer_type', $query_args['fields'], true );
+
+		if ( empty( $query_args['customer_type'] ) && ! $is_selected ) {
+			return;
+		}
+
+		$this->subquery->add_sql_clause( 'join', "LEFT JOIN {$table_name} {$alias} ON {$table_name}.parent_id = {$alias}.order_id" );
 	}
 
 	/**
@@ -154,9 +210,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$where_subquery[] = "{$order_stats_lookup_table}.order_id NOT IN ({$excluded_orders})";
 		}
 
+		$this->add_customer_type_join( $query_args );
+
 		if ( $query_args['customer_type'] ) {
 			$returning_customer = 'returning' === $query_args['customer_type'] ? 1 : 0;
-			$where_subquery[]   = "{$order_stats_lookup_table}.returning_customer = {$returning_customer}";
+			$parent_alias       = self::CUSTOMER_TYPE_PARENT_ALIAS;
+			$where_subquery[]   = "COALESCE( {$order_stats_lookup_table}.returning_customer, {$parent_alias}.returning_customer ) = {$returning_customer}";
 		}
 
 		$refund_subquery = $this->get_refund_subquery( $query_args );
@@ -353,8 +412,16 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @return string
 	 */
 	protected function normalize_order_by( $order_by ) {
+		$table_name = self::get_db_table_name();
+
 		if ( 'date' === $order_by ) {
-			return $this->date_column_name;
+			return "{$table_name}.{$this->date_column_name}";
+		}
+
+		// Columns of the order stats table are qualified, as the report can join other tables that
+		// share column names with it, including a second copy of the order stats table itself.
+		if ( in_array( $order_by, self::ORDER_STATS_COLUMNS, true ) ) {
+			return "{$table_name}.{$order_by}";
 		}
 
 		return $order_by;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -27,34 +27,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const ORDERS_STATUSES_ALL_CACHE_KEY = 'woocommerce_analytics_orders_statuses_all';
 
 	/**
-	 * Alias of the order stats table joined to resolve the customer type of refund rows.
-	 */
-	const CUSTOMER_TYPE_PARENT_ALIAS = 'customer_type_parent_stats';
-
-	/**
-	 * Columns of the order stats table that can be ordered by, and so need to be qualified with the
-	 * table name to stay unambiguous once other tables are joined.
-	 *
-	 * @var string[]
-	 */
-	const ORDER_STATS_COLUMNS = array(
-		'order_id',
-		'parent_id',
-		'date_created',
-		'date_created_gmt',
-		'date_paid',
-		'date_completed',
-		'status',
-		'customer_id',
-		'net_total',
-		'total_sales',
-		'tax_total',
-		'shipping_total',
-		'num_items_sold',
-		'returning_customer',
-	);
-
-	/**
 	 * Dynamically sets the date column name based on configuration
 	 *
 	 * @override ReportsDataStore::__construct()
@@ -127,9 +99,17 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name = self::get_db_table_name();
-		// Refunds are stored with a NULL returning_customer, so fall back to the value of the
-		// refunded (parent) order. See add_customer_type_join().
-		$returning_customer = 'COALESCE( ' . $table_name . '.returning_customer, ' . self::CUSTOMER_TYPE_PARENT_ALIAS . '.returning_customer )';
+
+		/*
+		 * Refunds are stored with a NULL returning_customer, as they should not count towards
+		 * returning customer counts, so fall back to the value of the refunded (parent) order.
+		 *
+		 * This is a subquery rather than a join, so that the query keeps a single order stats table
+		 * in scope. Joining a second copy of it would make every one of its columns ambiguous for
+		 * the unqualified column names that callbacks on the woocommerce_analytics_clauses_*_orders_subquery
+		 * filters may use.
+		 */
+		$returning_customer = "COALESCE( {$table_name}.returning_customer, ( SELECT customer_type_parent_stats.returning_customer FROM {$table_name} customer_type_parent_stats WHERE customer_type_parent_stats.order_id = {$table_name}.parent_id ) )";
 		// Avoid ambiguous columns in SQL query.
 		$this->report_columns = array(
 			'order_id'         => "DISTINCT {$table_name}.order_id",
@@ -145,31 +125,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'num_items_sold'   => "{$table_name}.num_items_sold",
 			'customer_type'    => "(CASE WHEN {$returning_customer} = 0 THEN 'new' ELSE 'returning' END) as customer_type",
 		);
-	}
-
-	/**
-	 * Adds the JOIN required to resolve the customer type of refund rows, which is read from the
-	 * refunded (parent) order.
-	 *
-	 * The JOIN is only added when the customer type column is selected, so that reports that do not
-	 * ask for it are not charged for it.
-	 *
-	 * @param array $query_args Query arguments supplied by the user.
-	 * @return void
-	 */
-	protected function add_customer_type_join( $query_args ) {
-		$table_name = self::get_db_table_name();
-		$alias      = self::CUSTOMER_TYPE_PARENT_ALIAS;
-
-		$is_selected = ! isset( $query_args['fields'] ) ||
-			! is_array( $query_args['fields'] ) ||
-			in_array( 'customer_type', $query_args['fields'], true );
-
-		if ( ! $is_selected ) {
-			return;
-		}
-
-		$this->subquery->add_sql_clause( 'join', "LEFT JOIN {$table_name} {$alias} ON {$table_name}.parent_id = {$alias}.order_id" );
 	}
 
 	/**
@@ -209,8 +164,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( $excluded_orders ) {
 			$where_subquery[] = "{$order_stats_lookup_table}.order_id NOT IN ({$excluded_orders})";
 		}
-
-		$this->add_customer_type_join( $query_args );
 
 		if ( $query_args['customer_type'] ) {
 			$returning_customer = 'returning' === $query_args['customer_type'] ? 1 : 0;
@@ -411,16 +364,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @return string
 	 */
 	protected function normalize_order_by( $order_by ) {
-		$table_name = self::get_db_table_name();
-
 		if ( 'date' === $order_by ) {
-			return "{$table_name}.{$this->date_column_name}";
-		}
-
-		// Columns of the order stats table are qualified, as the report can join other tables that
-		// share column names with it, including a second copy of the order stats table itself.
-		if ( in_array( $order_by, self::ORDER_STATS_COLUMNS, true ) ) {
-			return "{$table_name}.{$order_by}";
+			return $this->date_column_name;
 		}
 
 		return $order_by;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -433,9 +433,12 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should keep refunds together with the order they refund when filtering by customer type.
+	 * The customer type filter still matches orders only, so that the report table keeps agreeing
+	 * with the totals from the orders stats endpoint, which excludes refunds from that filter too.
+	 *
+	 * @testdox Should match only orders, not their refunds, when filtering by customer type.
 	 */
-	public function test_customer_type_filter_includes_refunds_of_matching_orders() {
+	public function test_customer_type_filter_matches_orders_only() {
 		WC_Helper_Reports::reset_stats_dbs();
 
 		$simple_product = new WC_Product_Simple();
@@ -445,7 +448,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 
 		$order = $this->create_guest_order( $simple_product, 'guest-33410-filter@example.org' );
 
-		$refund = wc_create_refund(
+		wc_create_refund(
 			array(
 				'amount'   => 25,
 				'order_id' => $order->get_id(),
@@ -457,13 +460,45 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$new_customer_rows = $this->get_customer_types_by_order_id( $order, array( 'customer_type' => 'new' ) );
 
 		$this->assertEqualSets(
-			array( $order->get_id(), $refund->get_id() ),
+			array( $order->get_id() ),
 			array_keys( $new_customer_rows ),
-			'Filtering by new customers should return the order and its refund'
+			'Filtering by new customers should return the order without its refund'
 		);
 
 		$returning_customer_rows = $this->get_customer_types_by_order_id( $order, array( 'customer_type' => 'returning' ) );
 
 		$this->assertEmpty( $returning_customer_rows, 'Filtering by returning customers should not return the order or its refund' );
+	}
+
+	/**
+	 * @testdox Should report the customer type of refunds when filtering by refunds.
+	 */
+	public function test_refunds_filter_returns_refunds_with_their_customer_type() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$order = $this->create_guest_order( $simple_product, 'guest-33410-refunds@example.org' );
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 25,
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$refund_rows = $this->get_customer_types_by_order_id( $order, array( 'refunds' => 'all' ) );
+
+		$this->assertEqualSets( array( $refund->get_id() ), array_keys( $refund_rows ), 'Filtering by refunds should return the refund only' );
+		$this->assertEquals( 'new', $refund_rows[ $refund->get_id() ], 'A refund should be reported with the customer type of the refunded order' );
+
+		$order_rows = $this->get_customer_types_by_order_id( $order, array( 'refunds' => 'none' ) );
+
+		$this->assertEqualSets( array( $order->get_id() ), array_keys( $order_rows ), 'Excluding refunds should return the order only' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -328,4 +328,142 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, $data->total );
 		$this->assertEquals( $order_2->get_id(), $data->data[0]['order_id'] );
 	}
+
+	/**
+	 * Creates a completed order for a guest customer, using a billing email that is not attached to
+	 * any registered user.
+	 *
+	 * @param WC_Product $product Product to add to the order.
+	 * @param string     $email   Billing email used to identify the guest customer.
+	 * @return WC_Order
+	 */
+	private function create_guest_order( $product, $email ) {
+		$order = WC_Helper_Order::create_order( 0, $product );
+		$order->set_billing_email( $email );
+		$order->set_total( 25 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Returns the customer type of every row in the report, keyed by order ID.
+	 *
+	 * @param WC_Order $order Order used to derive the reporting time frame.
+	 * @param array    $args  Extra query arguments.
+	 * @return array
+	 */
+	private function get_customer_types_by_order_id( $order, $args = array() ) {
+		$data_store = new OrdersDataStore();
+		$data       = $data_store->get_data(
+			array_merge(
+				array(
+					'after'  => gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() ),
+					'before' => gmdate( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() ),
+				),
+				$args
+			)
+		);
+
+		return wp_list_pluck( $data->data, 'customer_type', 'order_id' );
+	}
+
+	/**
+	 * @testdox Should report a refund of a customer's first order as a new customer.
+	 *
+	 * Refunds are stored without a customer type of their own, so they should report the customer
+	 * type of the order they refund instead of always being reported as returning.
+	 *
+	 * See: https://github.com/woocommerce/woocommerce/issues/33410.
+	 */
+	public function test_refund_of_first_order_is_reported_as_new_customer() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$order = $this->create_guest_order( $simple_product, 'guest-33410@example.org' );
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 25,
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$customer_types = $this->get_customer_types_by_order_id( $order );
+
+		$this->assertEquals( 'new', $customer_types[ $order->get_id() ], 'A guest customer\'s first order should be reported as new' );
+		$this->assertEquals( 'new', $customer_types[ $refund->get_id() ], 'A refund should be reported with the customer type of the refunded order' );
+	}
+
+	/**
+	 * @testdox Should report a refund of a returning customer's order as a returning customer.
+	 */
+	public function test_refund_of_later_order_is_reported_as_returning_customer() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$first_order  = $this->create_guest_order( $simple_product, 'guest-33410-returning@example.org' );
+		$second_order = $this->create_guest_order( $simple_product, 'guest-33410-returning@example.org' );
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 25,
+				'order_id' => $second_order->get_id(),
+			)
+		);
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$customer_types = $this->get_customer_types_by_order_id( $first_order );
+
+		$this->assertEquals( 'new', $customer_types[ $first_order->get_id() ], 'The first order should be reported as new' );
+		$this->assertEquals( 'returning', $customer_types[ $second_order->get_id() ], 'The second order should be reported as returning' );
+		$this->assertEquals( 'returning', $customer_types[ $refund->get_id() ], 'A refund should be reported with the customer type of the refunded order' );
+	}
+
+	/**
+	 * @testdox Should keep refunds together with the order they refund when filtering by customer type.
+	 */
+	public function test_customer_type_filter_includes_refunds_of_matching_orders() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$order = $this->create_guest_order( $simple_product, 'guest-33410-filter@example.org' );
+
+		$refund = wc_create_refund(
+			array(
+				'amount'   => 25,
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$new_customer_rows = $this->get_customer_types_by_order_id( $order, array( 'customer_type' => 'new' ) );
+
+		$this->assertEqualSets(
+			array( $order->get_id(), $refund->get_id() ),
+			array_keys( $new_customer_rows ),
+			'Filtering by new customers should return the order and its refund'
+		);
+
+		$returning_customer_rows = $this->get_customer_types_by_order_id( $order, array( 'customer_type' => 'returning' ) );
+
+		$this->assertEmpty( $returning_customer_rows, 'Filtering by returning customers should not return the order or its refund' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Refunds are written to `wc_order_stats` with a `NULL` `returning_customer`, since they should not count towards returning customer counts. The orders report mapped that column to a customer type with `WHEN returning_customer = 0 THEN 'new' ELSE 'returning'`, so the `NULL` of every refund row fell through to `ELSE` and was reported as `returning`. A refund of a customer's first order was therefore shown as "Returning" right next to the "New" order it refunded.

The customer type of refund rows is now resolved from the refunded (parent) order, through a correlated subquery in the select list:

```sql
COALESCE(
  wc_order_stats.returning_customer,
  ( SELECT p.returning_customer FROM wc_order_stats p WHERE p.order_id = wc_order_stats.parent_id )
)
```

A self-join would have been the obvious alternative, and it was the first thing tried. It is the wrong tool here: joining a second copy of the order stats table puts every one of its columns in scope twice, so any unqualified column name becomes ambiguous — including ones this data store does not control. Callbacks on the public `woocommerce_analytics_clauses_join_orders_subquery` / `..._where_orders_subquery` filters that add an unqualified base table predicate would have started failing with `Column ... is ambiguous`, breaking Analytics > Orders on stores running those extensions. The subquery keeps a single order stats table in scope, so nothing becomes ambiguous, and it is evaluated for the rows of the page being returned rather than for every row the report counts.

**Deliberately out of scope:** the `customer_type` filter still matches on the row's own `returning_customer`, so it continues to match orders only and not their refunds. Applying the same fallback to the orders report table filter alone would list refunds that the summary and chart above the table leave out of their totals, because the `orders/stats` endpoint (`Orders\Stats\DataStore` via `get_customer_subquery()`) and the customer type segmenter both still compare the refund's own `NULL`. Making refunds participate in customer type filtering consistently means changing the reported financial totals for those filters, which is a separate decision from the display bug reported here.

Closes #33410, closes WOOPLUG-716

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| Refund row of a new customer's order shows `Returning` | Refund row shows `New`, matching the order it refunds |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. On a store with WooCommerce Analytics enabled, place an order as a guest, using a billing email that has never been used on the store before.
2. Mark the order as completed, then refund it in full from the order edit screen.
3. Wait for the order and the refund to be imported into Analytics, or run `wp wc cot ...`/**Status → Tools → run the pending scheduled actions** so the `wc-admin-data` queue is processed.
4. Go to **Analytics → Orders** and set the date range to cover the order.
5. Confirm the order row shows `New` in the **Customer type** column, and confirm the refund row now shows `New` as well. Before this change, the refund row showed `Returning`.
6. Place a second order for the same guest email, complete it, and refund it. Confirm the second order and its refund both show `Returning`.
7. Confirm sorting still works: sort the table by **Date**, **Items sold**, and **Net sales**.
8. Under **Advanced filters**, filter by **Refunds → All** and by **Refunds → None**, and confirm each returns rows.
9. Filter by **Customer type → New** and **Customer type → Returning**, and confirm the results and the summary numbers above the table are unchanged from trunk.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Reviewed independently by OpenAI Codex. Its first pass caught that applying the customer type fallback to the table filter alone would disagree with the `orders/stats` totals; its second pass caught the extension-facing ambiguity of the self-join. Both are addressed in the commits — the filter is left matching orders only, and the join was replaced with the subquery described above.
- New unit tests in `WC_Admin_Tests_Reports_Orders` covering: a refund of a guest customer's first order reported as `new`, a refund of a later order reported as `returning`, the customer type filter matching orders only, and the refunds filter returning refunds with the customer type of the refunded order.
- `pnpm test:php:env -- --filter '/Reports/'` passes (298 tests). The one remaining failure, `WC_Admin_Tests_API_Reports_Taxes::test_get_reports_taxes_param`, reproduces identically on an unmodified trunk and is unrelated to this change.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on both modified files are clean.
- Not tested on multisite. The change touches only report SQL and reads no site-scoped options, so multisite behaviour is not expected to differ.

**Backwards compatibility:** no class, interface, method, or hook signature is added, removed, or changed, and no script or style handle is touched. The only change is the SQL expression behind the existing `customer_type` report column, whose two possible values (`new`, `returning`) are unchanged. The query keeps exactly the same tables in scope as before, so callbacks on the `woocommerce_analytics_clauses_*_orders_subquery` filters see the same column namespace they do today. Nothing is read from global state and no site-scoped option is touched, so admin, REST, CLI, cron, and multisite contexts are unaffected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This pull request was authored with Claude Code. The fix, tests, and this description were generated with AI assistance and reviewed by me; the diff was additionally put through an independent review by OpenAI Codex, whose findings are reflected in the commits.
