### PR TITLE
Fix Search dependency on wcSettings

### DIFF
--- a/packages/js/components/changelog/39772-search-wcsettings
+++ b/packages/js/components/changelog/39772-search-wcsettings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the Search variations autocompleter from failing when wcSettings is unavailable.

--- a/packages/js/components/src/phone-number-input/utils.ts
+++ b/packages/js/components/src/phone-number-input/utils.ts
@@ -72,7 +72,7 @@ const countryNames: Record< string, string > = mapValues(
 	{
 		AC: 'Ascension Island',
 		XK: 'Kosovo',
-		...( window.wcSettings?.countries || [] ),
+		...( window.wcSettings?.countries || {} ),
 	},
 	( name ) => decodeHtmlEntities( name )
 );

--- a/packages/js/components/src/search/autocompleters/test/variations.test.ts
+++ b/packages/js/components/src/search/autocompleters/test/variations.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import variations from '../variations';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getQuery: jest.fn( () => ( {} ) ),
+} ) );
+
+describe( 'variations autocompleter', () => {
+	const hadWcSettings = 'wcSettings' in window;
+	const originalWcSettings = window.wcSettings;
+	const variation = {
+		id: 1,
+		name: 'T-shirt',
+		attributes: [ { option: 'Red' }, { option: 'Large' } ],
+		sku: 'TSHIRT-RED-LARGE',
+	};
+
+	afterEach( () => {
+		if ( hadWcSettings ) {
+			window.wcSettings = originalWcSettings;
+		} else {
+			delete window.wcSettings;
+		}
+	} );
+
+	it( 'uses the default separator when wcSettings is unavailable', () => {
+		delete window.wcSettings;
+
+		expect( variations.getOptionKeywords( variation ) ).toEqual( [
+			'T-shirt - Red, Large',
+			'TSHIRT-RED-LARGE',
+		] );
+	} );
+
+	it( 'uses the separator configured in wcSettings', () => {
+		window.wcSettings = {
+			variationTitleAttributesSeparator: ' | ',
+			countries: {},
+		};
+
+		expect( variations.getOptionKeywords( variation ) ).toEqual( [
+			'T-shirt | Red, Large',
+			'TSHIRT-RED-LARGE',
+		] );
+	} );
+} );

--- a/packages/js/components/src/search/autocompleters/variations.tsx
+++ b/packages/js/components/src/search/autocompleters/variations.tsx
@@ -30,7 +30,7 @@ function getVariationName( {
 	name: string;
 } ) {
 	const separator =
-		window.wcSettings.variationTitleAttributesSeparator || ' - ';
+		window.wcSettings?.variationTitleAttributesSeparator || ' - ';
 
 	if ( name.indexOf( separator ) > -1 ) {
 		return name;

--- a/packages/js/components/typings/global.d.ts
+++ b/packages/js/components/typings/global.d.ts
@@ -1,6 +1,6 @@
 declare global {
 	interface Window {
-		wcSettings: {
+		wcSettings?: {
 			variationTitleAttributesSeparator?: string;
 			countries: Record< string, string >;
 		};
@@ -9,4 +9,3 @@ declare global {
 
 /*~ If your module exports nothing, you'll need this line. Otherwise, delete it */
 export {};
-


### PR DESCRIPTION
### Submission Review Guidelines:

* I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
* I have checked to ensure there aren't other open Pull Requests for the same update/change.
* I have reviewed my code for security best practices.
* Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`@woocommerce/components` assumed `window.wcSettings` existed when formatting variation names, causing Search consumers in third-party packages to throw when WooCommerce settings were not localized. Make `wcSettings` optional, fall back to the existing default separator when it is unavailable, and add regression coverage while preserving configured separators inside WooCommerce.

Closes woocommerce/woocommerce#39772.

Bug introduced in PR [#35724](<https://github.com/woocommerce/woocommerce/issues/35724>).

### Screenshots or screen recordings:

Not applicable; this change has no visual impact.

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/components test:js variations` from the repository root.
2. Confirm both variations autocompleter tests pass, including the case where `window.wcSettings` is unavailable and the case with a configured separator.
3. Run `pnpm --filter=@woocommerce/components build` and confirm the package builds successfully.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

> **Note:** Check the box above to have the milestone automatically assigned when merged.<br>Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [X] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details><summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

* Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

* Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.

</details>

### Use of AI Tools

Codex was used to inspect the issue and repository history, implement the fix and tests, run the validation commands listed above, and prepare this Pull Request description.