### PR TITLE
Avoid orphaning order item meta when its deletion fails

### DIFF
--- a/plugins/woocommerce/changelog/fix-66830-delete-items-unchecked-query
+++ b/plugins/woocommerce/changelog/fix-66830-delete-items-unchecked-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep order items in place when deleting their item meta fails, so the meta is not left orphaned.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -796,10 +796,33 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		if ( ! empty( $type ) ) {
-			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order_id, $type ) );
+			$itemmeta_deleted = $wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order_id, $type ) );
+		} else {
+			$itemmeta_deleted = $wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order_id ) );
+		}
+
+		/*
+		 * Deleting the item rows after the item meta deletion failed would orphan that meta, since
+		 * the rows it is joined against would be gone. Leaving both in place keeps the data
+		 * recoverable: a subsequent delete cleans up what this one could not.
+		 */
+		if ( false === $itemmeta_deleted ) {
+			wc_get_logger()->error(
+				sprintf(
+					'Failed to delete order item meta for order %1$d, leaving the order items in place. Database error: %2$s',
+					$order_id,
+					$wpdb->last_error
+				),
+				array( 'source' => 'order-data-store' )
+			);
+
+			$this->clear_caches( $order );
+			return;
+		}
+
+		if ( ! empty( $type ) ) {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $order_id, $type ) );
 		} else {
-			$wpdb->query( $wpdb->prepare( "DELETE itemmeta FROM {$wpdb->prefix}woocommerce_order_itemmeta as itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items as items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order_id ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order_id ) );
 		}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -614,6 +614,59 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Deleting order items should leave the item rows in place when the item meta deletion fails.
+	 */
+	public function test_delete_items_keeps_items_when_itemmeta_deletion_fails() {
+		global $wpdb;
+
+		$order    = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+
+		$count_items    = fn() => (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count_itemmeta = fn() => (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items AS items ON itemmeta.order_item_id = items.order_item_id WHERE items.order_id = %d", $order_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$items_before    = $count_items();
+		$itemmeta_before = $count_itemmeta();
+		$this->assertGreaterThan( 0, $items_before, 'The order should start out with item rows.' );
+		$this->assertGreaterThan( 0, $itemmeta_before, 'The order should start out with item meta rows.' );
+
+		// Point the item meta DELETE at a table that does not exist, so that it fails the way a database error would.
+		$break_itemmeta_delete = function ( $query ) use ( $wpdb ) {
+			if ( 0 === strpos( $query, 'DELETE itemmeta' ) ) {
+				return "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta_missing WHERE order_item_id = 0";
+			}
+
+			return $query;
+		};
+
+		$logged_errors = array();
+		$logger        = $this->getMockBuilder( WC_Logger_Interface::class )->getMock();
+		$logger->method( 'error' )->willReturnCallback(
+			function ( $message ) use ( &$logged_errors ) {
+				$logged_errors[] = $message;
+			}
+		);
+		$logger_filter = fn() => $logger;
+
+		add_filter( 'query', $break_itemmeta_delete );
+		add_filter( 'woocommerce_logging_class', $logger_filter );
+		$previously_suppressed = $wpdb->suppress_errors( true );
+
+		try {
+			$order->get_data_store()->delete_items( $order );
+		} finally {
+			$wpdb->suppress_errors( $previously_suppressed );
+			remove_filter( 'woocommerce_logging_class', $logger_filter );
+			remove_filter( 'query', $break_itemmeta_delete );
+		}
+
+		$this->assertSame( $items_before, $count_items(), 'Order item rows should survive a failed item meta deletion.' );
+		$this->assertSame( $itemmeta_before, $count_itemmeta(), 'Order item meta rows should survive a failed item meta deletion.' );
+		$this->assertNotEmpty( $logged_errors, 'The failed item meta deletion should be logged as an error.' );
+		$this->assertStringContainsString( "order {$order_id}", $logged_errors[0], 'The logged error should name the order.' );
+	}
+
+	/**
 	 * @testDox Creating an order with a draft status should not trigger the "woocommerce_new_order" action.
 	 */
 	public function test_create_draft_order_doesnt_trigger_hook() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`Abstract_WC_Order_Data_Store_CPT::delete_items()` ran two unchecked `DELETE` queries back to back — first against `woocommerce_order_itemmeta`, then against `woocommerce_order_items`. The second one ran regardless of what the first returned, so if the item meta delete hit a database error, the item rows were removed anyway and the meta was left with nothing to join against.

This PR captures the return value of the item meta `DELETE`. When it is `false`, the method logs the database error from `$wpdb->last_error`, clears the order caches as before, and returns without touching the item rows. Leaving both sets of rows in place keeps the data recoverable — a later delete cleans up what this one could not.

A full transaction wrapper was deliberately not used here, for the reasons laid out in the issue: MySQL has no nested transactions (an inner `START TRANSACTION` would prematurely commit the HPOS data-sync transaction), the order tables are not guaranteed to be InnoDB, and WooCommerce keeps `wc_transaction_query()` out of the order-save path on purpose.

Closes #66830.

#### Backward compatibility

-   **No interface break.** `delete_items( $order, $type = null )` is declared in `includes/interfaces/class-wc-abstract-order-data-store-interface.php` (line 33). The signature is unchanged and the method still returns nothing, so implementers and callers are unaffected.
-   **HPOS is covered by the same change.** `OrdersTableDataStore` extends `Abstract_WC_Order_Data_Store_CPT` and inherits `delete_items()` rather than overriding it, so the guard applies to HPOS stores as well as post-based ones. No overridable method that was previously invoked is skipped on the success path.
-   **Behavior change to be aware of:** when the item meta `DELETE` fails, order item rows now survive instead of being deleted. Previously they were deleted and their meta orphaned. Callers that treated `delete_items()` as unconditionally emptying the item tables will now see rows remain in that error case. `delete_items()` never reported success or failure, so this is only observable by inspecting the tables afterwards. An error is now written to the log (`source` `order-data-store`) on that path, where nothing was logged before.
-   No hooks, script/style handles, or option names are added, removed, or reordered. No new global state is read.

### How to test the changes in this Pull Request:

The failure path needs a database error, which is hard to produce by hand, so the automated test is the primary verification. Both checks are worth running.

**1. Automated (covers the fix itself):**

1. Check out this branch and run:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter 'test_delete_items'
   ```
2. All three `WC_Order_Data_Store_CPT_Test` tests should pass, including the new `test_delete_items_keeps_items_when_itemmeta_deletion_fails`.
3. To confirm the new test actually catches the bug, revert only the change to `abstract-wc-order-data-store-cpt.php` (`git checkout trunk -- plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php`) and re-run. The new test should fail with `Order item rows should survive a failed item meta deletion. Failed asserting that 0 is identical to 2.` Restore the file afterwards.

**2. Manual (confirms no regression on the normal path), with HPOS both on and off:**

1. Create an order with several line items, a fee, and a shipping line, and save it.
2. Edit the order, remove some line items, and save.
3. Confirm the removed items are gone from the order and that `wp_woocommerce_order_items` / `wp_woocommerce_order_itemmeta` contain no rows for them.
4. Delete the order permanently and confirm no rows remain for it in either table.
5. Repeat with HPOS toggled to the other setting (WooCommerce → Settings → Advanced → Features).

### Testing that has already taken place:

Local wp-env environment (WordPress latest, PHP 8.1, PHPUnit 9.6.29, single site), against `trunk` at `1a57636`:

-   `WC_Order_Data_Store_CPT_Test`, `OrdersTableDataStoreTests`, and `WC_Abstract_Order_Test`: 185 tests, 1062 assertions, 1 skipped, 1 error. That error (`WC_Abstract_Order_Test::test_default_term_for_custom_taxonomy`) is pre-existing — the same suites on unmodified `trunk` give 184 tests with the identical single error. Result was reproduced across two consecutive runs.
-   The new test was verified to fail on unpatched code and pass with the fix, so it is a genuine regression test rather than a restatement of the fix.
-   `phpcs` (`lint:php:changes` and `lint:changes:branch`): clean, no errors and no warnings.
-   `phpstan analyse includes/data-stores/abstract-wc-order-data-store-cpt.php --memory-limit=2G`: no errors. Nothing added to `phpstan-baseline.neon`.

Not covered: multisite, and no manual browser testing of the order edit screen was done. The manual steps above have not been run yet.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

The changelog entry was added manually in this branch: `plugins/woocommerce/changelog/fix-66830-delete-items-unchecked-query` (Significance: patch, Type: fix).

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
