### PR TITLE
Fix transient files directory on stream-wrapper uploads (S3-Uploads / VIP)

### DIFF
--- a/plugins/woocommerce/changelog/65739-fix-transient-files-cleanup-stream-wrapper
+++ b/plugins/woocommerce/changelog/65739-fix-transient-files-cleanup-stream-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Delete expired transient files on sites whose uploads directory is a stream wrapper path, such as S3-Uploads and WordPress VIP installs, where the cleanup previously reported success without deleting anything.

--- a/plugins/woocommerce/changelog/65739-fix-transient-files-stream-wrapper-realpath
+++ b/plugins/woocommerce/changelog/65739-fix-transient-files-stream-wrapper-realpath
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep the transient files directory working on sites whose uploads directory is a stream wrapper path, such as S3-Uploads and WordPress VIP installs.

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -39,6 +39,11 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	private const CLEANUP_ACTION_GROUP = 'wc_batch_processes';
 
 	/**
+	 * Regular expression matching a path that starts with a URL scheme, e.g. "s3://bucket/uploads".
+	 */
+	private const URL_SCHEME_REGEX = '#^[a-z][a-z0-9+.\-]*://#i';
+
+	/**
 	 * The instance of LegacyProxy to use.
 	 *
 	 * @var LegacyProxy
@@ -101,8 +106,8 @@ class TransientFilesEngine implements RegisterHooksInterface {
 		 */
 		$transient_files_directory = apply_filters( 'woocommerce_transient_files_directory', $default_transient_files_directory );
 
-		$realpathed_transient_files_directory = $this->legacy_proxy->call_function( 'realpath', $transient_files_directory );
-		if ( false === $realpathed_transient_files_directory ) {
+		$resolved_transient_files_directory = $this->resolve_directory_if_it_exists( $transient_files_directory );
+		if ( false === $resolved_transient_files_directory ) {
 			if ( $transient_files_directory === $default_transient_files_directory ) {
 				if ( ! $this->legacy_proxy->call_function( 'wp_mkdir_p', $transient_files_directory ) ) {
 					throw new Exception( "Can't create directory: $transient_files_directory" );
@@ -114,13 +119,35 @@ class TransientFilesEngine implements RegisterHooksInterface {
 				$wp_filesystem->put_contents( $transient_files_directory . '/.htaccess', 'deny from all' );
 				$wp_filesystem->put_contents( $transient_files_directory . '/index.html', '' );
 
-				$realpathed_transient_files_directory = $this->legacy_proxy->call_function( 'realpath', $transient_files_directory );
+				$resolved_transient_files_directory = $this->resolve_directory_if_it_exists( $transient_files_directory );
+				if ( false === $resolved_transient_files_directory ) {
+					throw new Exception( esc_html( "The directory was created but can't be resolved: $transient_files_directory" ) );
+				}
 			} else {
 				throw new Exception( "The base transient files directory doesn't exist: $transient_files_directory" );
 			}
 		}
 
-		return untrailingslashit( $realpathed_transient_files_directory );
+		return untrailingslashit( $resolved_transient_files_directory );
+	}
+
+	/**
+	 * Get the canonical path of a directory, if the directory exists.
+	 *
+	 * Paths handled by a stream wrapper can't be resolved with realpath, which returns false for them and would
+	 * turn a perfectly valid directory into an empty string. Sites that store uploads through a stream wrapper
+	 * (the S3-Uploads plugin and WordPress VIP, where wp_upload_dir returns something like "s3://bucket/uploads")
+	 * hit that case, so for scheme-prefixed paths the path is kept verbatim and only its existence is verified.
+	 *
+	 * @param string $directory The directory to resolve.
+	 * @return string|false The canonical path of the directory, or false if the directory doesn't exist.
+	 */
+	private function resolve_directory_if_it_exists( string $directory ) {
+		if ( 1 === preg_match( self::URL_SCHEME_REGEX, $directory ) ) {
+			return $this->legacy_proxy->call_function( 'is_dir', $directory ) ? $directory : false;
+		}
+
+		return $this->legacy_proxy->call_function( 'realpath', $directory );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -39,9 +39,10 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	private const CLEANUP_ACTION_GROUP = 'wc_batch_processes';
 
 	/**
-	 * Regular expression matching a path that starts with a URL scheme, e.g. "s3://bucket/uploads".
+	 * Regular expression matching the name of a directory that holds the files expiring on a given date.
+	 * Equivalent to the "[2-9][0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]" glob pattern used previously.
 	 */
-	private const URL_SCHEME_REGEX = '#^[a-z][a-z0-9+.\-]*://#i';
+	private const EXPIRATION_DATE_DIRECTORY_REGEX = '/^[2-9]\d{3}-[01]\d-[0-3]\d$/';
 
 	/**
 	 * The instance of LegacyProxy to use.
@@ -138,13 +139,16 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 * Paths handled by a stream wrapper can't be resolved with realpath, which returns false for them and would
 	 * turn a perfectly valid directory into an empty string. Sites that store uploads through a stream wrapper
 	 * (the S3-Uploads plugin and WordPress VIP, where wp_upload_dir returns something like "s3://bucket/uploads")
-	 * hit that case, so for scheme-prefixed paths the path is kept verbatim and only its existence is verified.
+	 * hit that case, so for those the path is kept verbatim and only its existence is verified.
+	 *
+	 * wp_is_stream only recognizes schemes that have a wrapper actually registered, so a path that merely looks
+	 * like a URL still goes through realpath, as it did before.
 	 *
 	 * @param string $directory The directory to resolve.
 	 * @return string|false The canonical path of the directory, or false if the directory doesn't exist.
 	 */
 	private function resolve_directory_if_it_exists( string $directory ) {
-		if ( 1 === preg_match( self::URL_SCHEME_REGEX, $directory ) ) {
+		if ( wp_is_stream( $directory ) ) {
 			return $this->legacy_proxy->call_function( 'is_dir', $directory ) ? $directory : false;
 		}
 
@@ -295,25 +299,52 @@ class TransientFilesEngine implements RegisterHooksInterface {
 	 *
 	 * @param int $limit Maximum number of files to delete.
 	 * @return array "deleted_count" with the number of files actually deleted, "files_remain" that will be true if there are still files left to delete.
-	 * @throws Exception The base directory for transient files (possibly changed via filter) doesn't exist.
+	 * @throws Exception The base directory for transient files (possibly changed via filter) doesn't exist, or its contents can't be listed.
 	 */
 	public function delete_expired_files( int $limit = 1000 ): array {
 		$expiration_date_gmt = $this->legacy_proxy->call_function( 'gmdate', 'Y-m-d' );
 		$base_dir            = $this->get_transient_files_directory();
-		$subdirs             = glob( $base_dir . '/[2-9][0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]', GLOB_ONLYDIR );
-		if ( false === $subdirs ) {
+
+		/*
+		 * scandir, not glob: glob doesn't support stream wrappers (it always goes to the local filesystem)
+		 * and returns an empty array for paths like "s3://bucket/uploads", which would silently turn the
+		 * cleanup into a no-op on those sites. scandir returns bare names rather than full paths.
+		 */
+		$entries = scandir( $base_dir );
+		if ( false === $entries ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Not rendered as output, and consistent with the other throws in this class.
 			throw new Exception( "Error when getting the list of subdirectories of $base_dir" );
 		}
 
-		$subdirs         = array_map( fn( $name ) => substr( $name, strlen( $name ) - 10, 10 ), $subdirs );
+		$subdirs = array_values(
+			array_filter(
+				$entries,
+				fn( $name ) => 1 === preg_match( self::EXPIRATION_DATE_DIRECTORY_REGEX, $name ) && is_dir( $base_dir . '/' . $name )
+			)
+		);
+
 		$expired_subdirs = array_filter( $subdirs, fn( $name ) => $name < $expiration_date_gmt );
 		asort( $subdirs ); // We want to delete files starting with the oldest expiration month.
 
 		$remaining_limit = $limit;
 		$limit_reached   = false;
 		foreach ( $expired_subdirs as $subdir ) {
-			$full_dir_path   = $base_dir . '/' . $subdir;
-			$files_to_delete = glob( $full_dir_path . '/*' );
+			$full_dir_path = $base_dir . '/' . $subdir;
+
+			$dir_entries = scandir( $full_dir_path );
+			if ( false === $dir_entries ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Not rendered as output, and consistent with the other throws in this class.
+				throw new Exception( "Error when getting the list of files in $full_dir_path" );
+			}
+
+			$files_to_delete = array_values(
+				array_map(
+					fn( $name ) => $full_dir_path . '/' . $name,
+					// Skip dot files, matching what the "*" glob pattern used to do. This also drops "." and "..".
+					array_filter( $dir_entries, fn( $name ) => '.' !== $name[0] )
+				)
+			);
+
 			if ( count( $files_to_delete ) > $remaining_limit ) {
 				$limit_reached   = true;
 				$files_to_delete = array_slice( $files_to_delete, 0, $remaining_limit );

--- a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
+++ b/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php
@@ -121,7 +121,8 @@ class TransientFilesEngine implements RegisterHooksInterface {
 
 				$resolved_transient_files_directory = $this->resolve_directory_if_it_exists( $transient_files_directory );
 				if ( false === $resolved_transient_files_directory ) {
-					throw new Exception( esc_html( "The directory was created but can't be resolved: $transient_files_directory" ) );
+					// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Not rendered as output, and consistent with the other throws in this method.
+					throw new Exception( "The directory was created but can't be resolved: $transient_files_directory" );
 				}
 			} else {
 				throw new Exception( "The base transient files directory doesn't exist: $transient_files_directory" );

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
@@ -273,6 +273,68 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox get_transient_files_directory keeps the scheme of stream wrapper uploads directories (S3-Uploads, VIP).
+	 */
+	public function test_get_transient_files_directory_preserves_stream_wrapper_scheme() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
+				'is_dir'        => fn() => true,
+				// realpath can't resolve stream wrapper paths, it always returns false for them.
+				'realpath'      => fn() => false,
+			)
+		);
+
+		$result = $this->sut->get_transient_files_directory();
+
+		$this->assertEquals( 's3://bucket/uploads/woocommerce_transient_files', $result );
+	}
+
+	/**
+	 * @testdox get_transient_files_directory throws if a stream wrapper directory supplied via hook doesn't exist.
+	 */
+	public function test_get_transient_files_directory_throws_if_stream_wrapper_directory_does_not_exist() {
+		add_filter( 'woocommerce_transient_files_directory', fn() => 's3://bucket/custom-dir' );
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
+				'is_dir'        => fn() => false,
+			)
+		);
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( "The base transient files directory doesn't exist: s3://bucket/custom-dir" );
+
+		try {
+			$this->sut->get_transient_files_directory();
+		} finally {
+			remove_all_filters( 'woocommerce_transient_files_directory' );
+		}
+	}
+
+	/**
+	 * @testdox create_transient_file builds the file path inside the uploads directory on stream wrapper uploads directories.
+	 */
+	public function test_create_transient_file_builds_path_inside_stream_wrapper_uploads_directory() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
+				'is_dir'        => fn( $directory ) => 's3://bucket/uploads/woocommerce_transient_files' === $directory,
+				'wp_mkdir_p'    => fn() => false,
+				'realpath'      => fn() => false,
+				'gmdate'        => fn( $format, $date = null ) =>
+					is_null( $date ) && 'Y-m-d' === $format ? '2023-12-01' : gmdate( $format, $date ),
+			)
+		);
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( "Can't create directory: s3://bucket/uploads/woocommerce_transient_files/2023-12-02" );
+
+		$this->sut->create_transient_file( 'foobar', '2023-12-02' );
+	}
+
+	/**
 	 * @testdox get_transient_file_path returns null for a file that doesn't exist, including wrongly formatted names.
 	 *
 	 * @testWith [""]

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
@@ -31,6 +31,18 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	protected static string $transient_files_dir;
 
 	/**
+	 * The scheme registered by the stream wrapper used to simulate S3-Uploads/VIP style uploads directories.
+	 */
+	private const STREAM_SCHEME = 'wctransienttest';
+
+	/**
+	 * The local directory that the test stream wrapper maps its paths onto.
+	 *
+	 * @var string
+	 */
+	private string $stream_root;
+
+	/**
 	 * Runs before each test.
 	 */
 	public function setUp(): void {
@@ -38,8 +50,42 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		$this->reset_container_resolutions();
 
 		self::rmdir_recursive( self::$transient_files_dir, false );
+
+		$this->stream_root = sys_get_temp_dir() . '/wc-stream-uploads-' . wp_generate_uuid4();
+		wp_mkdir_p( $this->stream_root . '/uploads' );
+		TransientFilesTestStreamWrapper::register( self::STREAM_SCHEME, $this->stream_root );
+
 		$this->sut = $this->get_instance_of( TransientFilesEngine::class );
 		$this->sut->register();
+	}
+
+	/**
+	 * Runs after each test.
+	 */
+	public function tearDown(): void {
+		TransientFilesTestStreamWrapper::unregister( self::STREAM_SCHEME );
+		self::rmdir_recursive( $this->stream_root, true );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the wrapper path of the uploads directory served by the test stream wrapper.
+	 *
+	 * @return string The wrapper path, e.g. "wctransienttest://uploads".
+	 */
+	private function stream_uploads_dir(): string {
+		return self::STREAM_SCHEME . '://uploads';
+	}
+
+	/**
+	 * Get the local path that a wrapper path maps onto, for asserting against the real filesystem.
+	 *
+	 * @param string $relative_path Path relative to the wrapper root, without a leading slash.
+	 * @return string The equivalent local path.
+	 */
+	private function local_path_for( string $relative_path ): string {
+		return $this->stream_root . '/' . $relative_path;
 	}
 
 	/**
@@ -278,33 +324,48 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	public function test_get_transient_files_directory_preserves_stream_wrapper_scheme() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
-				'is_dir'        => fn() => true,
-				// realpath can't resolve stream wrapper paths, it always returns false for them.
-				'realpath'      => fn() => false,
+				'wp_upload_dir' => fn() => array( 'basedir' => $this->stream_uploads_dir() ),
 			)
 		);
 
 		$result = $this->sut->get_transient_files_directory();
 
-		$this->assertEquals( 's3://bucket/uploads/woocommerce_transient_files', $result );
+		$this->assertEquals( $this->stream_uploads_dir() . '/woocommerce_transient_files', $result );
+		$this->assertDirectoryExists( $this->local_path_for( 'uploads/woocommerce_transient_files' ) );
+		$this->assertFalse( realpath( $result ), 'realpath is expected to fail on wrapper paths; that is the bug being guarded against' );
+	}
+
+	/**
+	 * @testdox get_transient_files_directory uses realpath for scheme-shaped paths that have no wrapper registered.
+	 */
+	public function test_get_transient_files_directory_uses_realpath_when_no_wrapper_is_registered() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => 'notregistered://bucket/uploads' ),
+				'realpath'      => fn( $path ) => '/real/' . $path,
+			)
+		);
+
+		$result = $this->sut->get_transient_files_directory();
+
+		$this->assertEquals( '/real/notregistered://bucket/uploads/woocommerce_transient_files', $result );
 	}
 
 	/**
 	 * @testdox get_transient_files_directory throws if a stream wrapper directory supplied via hook doesn't exist.
 	 */
 	public function test_get_transient_files_directory_throws_if_stream_wrapper_directory_does_not_exist() {
-		add_filter( 'woocommerce_transient_files_directory', fn() => 's3://bucket/custom-dir' );
+		$missing_dir = self::STREAM_SCHEME . '://custom-dir';
+		add_filter( 'woocommerce_transient_files_directory', fn() => $missing_dir );
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
-				'is_dir'        => fn() => false,
+				'wp_upload_dir' => fn() => array( 'basedir' => $this->stream_uploads_dir() ),
 			)
 		);
 
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( "The base transient files directory doesn't exist: s3://bucket/custom-dir" );
+		$this->expectExceptionMessage( "The base transient files directory doesn't exist: $missing_dir" );
 
 		try {
 			$this->sut->get_transient_files_directory();
@@ -314,24 +375,106 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox create_transient_file builds the file path inside the uploads directory on stream wrapper uploads directories.
+	 * @testdox get_transient_files_directory throws if the created directory still can't be resolved.
 	 */
-	public function test_create_transient_file_builds_path_inside_stream_wrapper_uploads_directory() {
+	public function test_get_transient_files_directory_throws_if_created_directory_cannot_be_resolved() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wp_upload_dir' => fn() => array( 'basedir' => 's3://bucket/uploads' ),
-				'is_dir'        => fn( $directory ) => 's3://bucket/uploads/woocommerce_transient_files' === $directory,
-				'wp_mkdir_p'    => fn() => false,
+				'wp_upload_dir' => fn() => array( 'basedir' => '/wordpress/uploads' ),
 				'realpath'      => fn() => false,
+				'wp_mkdir_p'    => fn() => true,
+			)
+		);
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( "The directory was created but can't be resolved: /wordpress/uploads/woocommerce_transient_files" );
+
+		$this->sut->get_transient_files_directory();
+	}
+
+	/**
+	 * @testdox create_transient_file writes the file inside the uploads directory on stream wrapper uploads directories.
+	 */
+	public function test_create_transient_file_writes_inside_stream_wrapper_uploads_directory() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => $this->stream_uploads_dir() ),
+				'random_bytes'  => fn() => implode( array_map( 'chr', array( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ) ) ),
 				'gmdate'        => fn( $format, $date = null ) =>
 					is_null( $date ) && 'Y-m-d' === $format ? '2023-12-01' : gmdate( $format, $date ),
 			)
 		);
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( "Can't create directory: s3://bucket/uploads/woocommerce_transient_files/2023-12-02" );
+		$result = $this->sut->create_transient_file( 'foobar', '2023-12-02' );
 
-		$this->sut->create_transient_file( 'foobar', '2023-12-02' );
+		$this->assertEquals( '7e7c02000102030405060708090a0b0c0d0e0f', $result );
+
+		$expected_wrapper_path = $this->stream_uploads_dir() . '/woocommerce_transient_files/2023-12-02/000102030405060708090a0b0c0d0e0f';
+		$this->assertEquals( $expected_wrapper_path, $this->sut->get_transient_file_path( $result ) );
+
+		$local_path = $this->local_path_for( 'uploads/woocommerce_transient_files/2023-12-02/000102030405060708090a0b0c0d0e0f' );
+		$this->assertFileExists( $local_path );
+		$this->assertEquals( 'foobar', file_get_contents( $local_path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * @testdox delete_expired_files deletes expired files on stream wrapper uploads directories.
+	 */
+	public function test_delete_expired_files_works_on_stream_wrapper_uploads_directory() {
+		$today = '2023-12-01';
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => $this->stream_uploads_dir() ),
+				'gmdate'        => function ( $format, $date = null ) use ( &$today ) {
+					return is_null( $date ) && 'Y-m-d' === $format ? $today : gmdate( $format, $date );
+				},
+			)
+		);
+
+		$expired_file     = $this->sut->create_transient_file( 'expired', '2023-12-01' );
+		$not_expired_file = $this->sut->create_transient_file( 'not expired', '2023-12-31' );
+
+		$today = '2023-12-15';
+
+		$result = $this->sut->delete_expired_files();
+
+		$this->assertEquals( 1, $result['deleted_count'], 'The expired file should have been deleted' );
+		$this->assertFalse( $result['files_remain'] );
+		$this->assertNull( $this->sut->get_transient_file_path( $expired_file ) );
+		$this->assertNotNull( $this->sut->get_transient_file_path( $not_expired_file ) );
+		$this->assertDirectoryDoesNotExist( $this->local_path_for( 'uploads/woocommerce_transient_files/2023-12-01' ) );
+		$this->assertDirectoryExists( $this->local_path_for( 'uploads/woocommerce_transient_files/2023-12-31' ) );
+	}
+
+	/**
+	 * @testdox delete_expired_files ignores directories that aren't named after an expiration date.
+	 */
+	public function test_delete_expired_files_ignores_non_date_directories_on_stream_wrapper() {
+		$today = '2023-12-01';
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wp_upload_dir' => fn() => array( 'basedir' => $this->stream_uploads_dir() ),
+				'gmdate'        => function ( $format, $date = null ) use ( &$today ) {
+					return is_null( $date ) && 'Y-m-d' === $format ? $today : gmdate( $format, $date );
+				},
+			)
+		);
+
+		$this->sut->create_transient_file( 'expired', '2023-12-01' );
+
+		$base_dir = $this->local_path_for( 'uploads/woocommerce_transient_files' );
+		wp_mkdir_p( $base_dir . '/not-a-date' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write is fine in a test fixture.
+		file_put_contents( $base_dir . '/not-a-date/keepme', 'keep' );
+
+		$today = '2023-12-15';
+
+		$result = $this->sut->delete_expired_files();
+
+		$this->assertEquals( 1, $result['deleted_count'] );
+		$this->assertFileExists( $base_dir . '/not-a-date/keepme' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesTestStreamWrapper.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesTestStreamWrapper.php
@@ -1,0 +1,311 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\TransientFiles;
+
+/**
+ * A stream wrapper backed by a local directory, for testing code that runs on installs where the
+ * uploads directory is a stream wrapper path (the S3-Uploads plugin, WordPress VIP).
+ *
+ * Registering a real wrapper rather than mocking filesystem functions is what makes these tests
+ * meaningful: wp_is_stream only recognizes schemes that have a wrapper actually registered, and
+ * glob() fails on wrapper paths in a way no mock reproduces.
+ *
+ * Note that stream_metadata must be implemented even though it does nothing here, because
+ * WP_Filesystem_Direct::put_contents() calls chmod() on every file it writes.
+ */
+class TransientFilesTestStreamWrapper {
+
+	/**
+	 * The stream context, set by PHP. Unused, but the wrapper protocol requires the property to exist.
+	 *
+	 * @var resource|null
+	 */
+	public $context;
+
+	/**
+	 * Local directory that the wrapper maps paths onto.
+	 *
+	 * @var string
+	 */
+	private static string $root = '';
+
+	/**
+	 * The scheme this wrapper is registered under, including the "://" separator.
+	 *
+	 * @var string
+	 */
+	private static string $scheme = '';
+
+	/**
+	 * The directory handle currently open. PHP only calls the dir_* methods after a successful dir_opendir.
+	 *
+	 * @var resource
+	 */
+	private $dir_handle;
+
+	/**
+	 * The file handle currently open. PHP only calls the stream_* methods after a successful stream_open.
+	 *
+	 * @var resource
+	 */
+	private $file_handle;
+
+	/**
+	 * Register the wrapper and point it at a local directory.
+	 *
+	 * @param string $scheme The scheme to register, without the "://" separator.
+	 * @param string $root The local directory to map wrapper paths onto.
+	 */
+	public static function register( string $scheme, string $root ): void {
+		self::$scheme = $scheme . '://';
+		self::$root   = untrailingslashit( $root );
+
+		if ( in_array( $scheme, stream_get_wrappers(), true ) ) {
+			stream_wrapper_unregister( $scheme );
+		}
+
+		stream_wrapper_register( $scheme, self::class );
+	}
+
+	/**
+	 * Unregister the wrapper.
+	 *
+	 * @param string $scheme The scheme to unregister, without the "://" separator.
+	 */
+	public static function unregister( string $scheme ): void {
+		if ( in_array( $scheme, stream_get_wrappers(), true ) ) {
+			stream_wrapper_unregister( $scheme );
+		}
+
+		self::$scheme = '';
+		self::$root   = '';
+	}
+
+	/**
+	 * Translate a wrapper path into the local path it maps onto.
+	 *
+	 * @param string $path The wrapper path.
+	 * @return string The equivalent local path.
+	 */
+	private function local_path( string $path ): string {
+		return self::$root . '/' . ltrim( substr( $path, strlen( self::$scheme ) ), '/' );
+	}
+
+	/**
+	 * Open a directory.
+	 *
+	 * @param string $path The directory to open.
+	 * @param int    $options Options, unused.
+	 * @return bool True if the directory was opened.
+	 */
+	public function dir_opendir( string $path, int $options ): bool {
+		unset( $options );
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- A missing directory is a valid outcome here.
+		$handle = @opendir( $this->local_path( $path ) );
+		if ( false === $handle ) {
+			return false;
+		}
+
+		$this->dir_handle = $handle;
+		return true;
+	}
+
+	/**
+	 * Read the next entry from the open directory.
+	 *
+	 * @return string|false The entry name, or false when there are no more entries.
+	 */
+	public function dir_readdir() {
+		return readdir( $this->dir_handle );
+	}
+
+	/**
+	 * Close the open directory.
+	 *
+	 * @return bool Always true.
+	 */
+	public function dir_closedir(): bool {
+		closedir( $this->dir_handle );
+		return true;
+	}
+
+	/**
+	 * Rewind the open directory.
+	 *
+	 * @return bool Always true.
+	 */
+	public function dir_rewinddir(): bool {
+		rewinddir( $this->dir_handle );
+		return true;
+	}
+
+	/**
+	 * Get information about a path.
+	 *
+	 * @param string $path The path to stat.
+	 * @param int    $flags Flags, unused.
+	 * @return array|false The stat information, or false if the path doesn't exist.
+	 */
+	public function url_stat( string $path, int $flags ) {
+		unset( $flags );
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- A missing path is a valid outcome here.
+		return @stat( $this->local_path( $path ) );
+	}
+
+	/**
+	 * Open a file.
+	 *
+	 * @param string $path The file to open.
+	 * @param string $mode The mode to open the file with.
+	 * @param int    $options Options, unused.
+	 * @param string $opened_path Set to the opened path, unused.
+	 * @return bool True if the file was opened.
+	 */
+	public function stream_open( string $path, string $mode, int $options, &$opened_path ): bool {
+		unset( $options, $opened_path );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged -- This is the wrapper backing the filesystem, it can't route through WP_Filesystem.
+		$handle = @fopen( $this->local_path( $path ), $mode );
+		if ( false === $handle ) {
+			return false;
+		}
+
+		$this->file_handle = $handle;
+		return true;
+	}
+
+	/**
+	 * Read from the open file.
+	 *
+	 * @param int $count Number of bytes to read.
+	 * @return string|false The bytes read.
+	 */
+	public function stream_read( int $count ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- This is the wrapper backing the filesystem.
+		return fread( $this->file_handle, $count );
+	}
+
+	/**
+	 * Write to the open file.
+	 *
+	 * @param string $data The data to write.
+	 * @return int The number of bytes written.
+	 */
+	public function stream_write( string $data ): int {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- This is the wrapper backing the filesystem.
+		return (int) fwrite( $this->file_handle, $data );
+	}
+
+	/**
+	 * Is the end of the open file reached?
+	 *
+	 * @return bool True if the end of the file is reached.
+	 */
+	public function stream_eof(): bool {
+		return feof( $this->file_handle );
+	}
+
+	/**
+	 * Get information about the open file.
+	 *
+	 * @return array|false The stat information.
+	 */
+	public function stream_stat() {
+		return fstat( $this->file_handle );
+	}
+
+	/**
+	 * Get the current position in the open file.
+	 *
+	 * @return int The current position.
+	 */
+	public function stream_tell(): int {
+		return (int) ftell( $this->file_handle );
+	}
+
+	/**
+	 * Move the position in the open file.
+	 *
+	 * @param int $offset The offset to move to.
+	 * @param int $whence How the offset is interpreted.
+	 * @return bool True if the position was changed.
+	 */
+	public function stream_seek( int $offset, int $whence = SEEK_SET ): bool {
+		return 0 === fseek( $this->file_handle, $offset, $whence );
+	}
+
+	/**
+	 * Flush the open file.
+	 *
+	 * @return bool True if the flush succeeded.
+	 */
+	public function stream_flush(): bool {
+		return fflush( $this->file_handle );
+	}
+
+	/**
+	 * Close the open file.
+	 *
+	 * @return bool Always true.
+	 */
+	public function stream_close(): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This is the wrapper backing the filesystem.
+		fclose( $this->file_handle );
+		return true;
+	}
+
+	/**
+	 * Set metadata on a path. Does nothing, but must exist: WP_Filesystem_Direct::put_contents()
+	 * calls chmod() on every file it writes, and without this the call raises a PHP warning.
+	 *
+	 * @param string $path The path to act on.
+	 * @param int    $option The metadata to set.
+	 * @param mixed  $value The value to set.
+	 * @return bool Always true.
+	 */
+	public function stream_metadata( string $path, int $option, $value ): bool {
+		unset( $path, $option, $value );
+		return true;
+	}
+
+	/**
+	 * Delete a file.
+	 *
+	 * @param string $path The file to delete.
+	 * @return bool True if the file was deleted.
+	 */
+	public function unlink( string $path ): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged -- This is the wrapper backing the filesystem.
+		return @unlink( $this->local_path( $path ) );
+	}
+
+	/**
+	 * Create a directory.
+	 *
+	 * @param string $path The directory to create.
+	 * @param int    $mode The permissions for the new directory.
+	 * @param int    $options Options, the recursive flag is honored.
+	 * @return bool True if the directory was created.
+	 */
+	public function mkdir( string $path, int $mode, int $options ): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir, WordPress.PHP.NoSilencedErrors.Discouraged
+		return @mkdir( $this->local_path( $path ), $mode, (bool) ( $options & STREAM_MKDIR_RECURSIVE ) );
+	}
+
+	/**
+	 * Delete a directory.
+	 *
+	 * @param string $path The directory to delete.
+	 * @param int    $options Options, unused.
+	 * @return bool True if the directory was deleted.
+	 */
+	public function rmdir( string $path, int $options ): bool {
+		unset( $options );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir, WordPress.PHP.NoSilencedErrors.Discouraged -- This is the wrapper backing the filesystem.
+		return @rmdir( $this->local_path( $path ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Two related defects that both stem from PHP functions which don't understand stream wrappers. On sites where `wp_upload_dir()['basedir']` is something like `s3://bucket/uploads` — the S3-Uploads plugin, WordPress VIP — the transient files feature is broken end to end.

**1. `realpath()` in `get_transient_files_directory()`**

`realpath()` returns `false` for wrapper paths, and that `false` flowed into `untrailingslashit()` and became an empty string. `create_transient_file()` then built its paths from that empty base, so it either threw `Can't create directory: /<date>` or wrote outside the uploads location.

A new private helper, `resolve_directory_if_it_exists()`, checks `wp_is_stream()` and, for wrapper paths, keeps the path verbatim and verifies existence with `is_dir()` instead of `realpath()`. Plain local paths still go through `realpath()` exactly as before. Because the existence check is preserved, the "the base transient files directory doesn't exist" exception still fires for a filtered directory that isn't there.

`wp_is_stream()` only matches schemes that have a wrapper actually registered, so a path that merely looks like a URL still takes the `realpath()` route — that avoids the `is_dir(): Unable to find the wrapper` warning a plain scheme regex would introduce.

**2. `glob()` in `delete_expired_files()`**

`glob()` does not support stream wrappers at all — it delegates to system `glob(3)` and never consults a registered wrapper. Both `glob()` calls in the cleanup path returned an empty array on wrapper paths. Because `glob()` returns `[]` rather than `false`, the existing `false === $subdirs` throw never fired: the cleanup reported `deleted_count => 0`, rescheduled itself for the next day, and reported success indefinitely while expired files accumulated in the bucket forever with no error anywhere.

Both call sites now enumerate with `scandir()`, which dispatches to the wrapper. The rest of the cleanup path already worked: `wp_delete_file()` calls `unlink()`, and `delete_directory_if_not_empty()` uses `FilesystemIterator` and `rmdir()`, all of which reach the wrapper correctly.

Note that item 2 is not a regression introduced by item 1. Before this PR the feature threw on these installs, so nothing was being cleaned up either. But fixing only item 1 would move those sites from "fails loudly" to "works, silently retains expired receipt data forever", which is the worse failure mode — hence both in one PR.

Fixes #65739.
Fixes WOOAIRR-43.

The `realpath()` logic has been in place since the transient files engine was introduced in a8b0f88bad (WooCommerce 8.5.0), as has the `glob()` enumeration; neither was introduced by a recent change. PR #64666 touched the surrounding filesystem writes but left both untouched.

**Two pre-existing issues found while working on this, deliberately left alone:**

-   `asort( $subdirs )` runs *after* `$expired_subdirs` is derived from it, so the "delete files starting with the oldest expiration month" comment is not actually honored today. Changing deletion order is out of scope for a fix PR.
-   The `.htaccess` / `index.html` guard files written by `get_transient_files_directory()` are inert on S3 — there is no Apache to read them, and `WP_Filesystem_Direct::put_contents()` calls `chmod()` on them, which on a real S3 stream is likely to fail outright. Directory protection there depends on bucket ACLs. Filenames are 32 random hex characters, so this is not readily exploitable.

### Backward compatibility

-   `get_transient_files_directory()` and `delete_expired_files()` are public methods on a class in the `Internal` namespace and are reachable from outside the plugin. Both signatures and `delete_expired_files()`'s return shape are unchanged.
-   `get_transient_files_directory()`'s **return value changes for registered-wrapper paths only**: it now returns the wrapper path (e.g. `s3://bucket/uploads/woocommerce_transient_files`) where it previously returned an empty string. Plain local paths are unaffected.
-   **The enumeration change in `delete_expired_files()` affects every install, not just wrapper ones — this is the main compatibility risk in this PR.** The `scandir()` filter is equivalent to the glob patterns it replaces: `[2-9][0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]` and `^[2-9]\d{3}-[01]\d-[0-3]\d$` match the same 10-character set; `GLOB_ONLYDIR` is replaced by an explicit `is_dir()`; `glob('*')` skips dot files, so the file scan filters on a leading dot (which also drops `.` and `..`); both functions sort ascending; and `false` still maps to the same throw. One behavioral difference: `glob()` returned `[]` silently for a directory that vanished mid-run, whereas `scandir()` returns `false` and would now throw. The path comes from the enumeration a few lines earlier, so that is a narrow TOCTOU window, and throwing is more truthful than silently reporting zero deletions.
-   The `woocommerce_transient_files_directory` filter contract is unchanged (string in, string out). A filtered `s3://…` directory that exists will now be accepted where it previously threw; one that does not exist still throws with the same message.
-   No hooks, script/style handles, or database schema are touched.

### How to test the changes in this Pull Request:

Automated coverage (this is what I can verify — see below for what I cannot):

1. Check out this branch and run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter TransientFilesEngineTest`.
2. Confirm all tests pass, including the ones that exercise a registered stream wrapper.
3. Check out `trunk`, apply only the test files from this branch, and re-run. The stream-wrapper tests fail without the source changes — the cleanup ones report `deleted_count => 0`.

Manual, on a stream wrapper install (needs S3-Uploads or a VIP environment — I could not run this):

1. Set up a site where `wp_upload_dir()['basedir']` returns an `s3://…` path.
2. Create a transient file, e.g. `wc_get_container()->get( TransientFilesEngine::class )->create_transient_file( 'test', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) )`. Confirm it lands inside the uploads location rather than at the filesystem root.
3. Create one with an expiration date in the past, then run the expired files cleanup from **WooCommerce → Status → Tools**. Confirm the expired file is deleted, its date directory is removed, and unexpired files are left alone.
4. Confirm a plain local install is unaffected: files land in `wp-content/uploads/woocommerce_transient_files/<date>/` and cleanup still deletes only expired ones.

### Testing that has already taken place:

-   Unit tests: `TransientFilesEngineTest` passes in wp-env (PHP 8.1, PHPUnit 9.6.29) — 42 tests, 167 assertions, run repeatedly.
-   The tests now register a **real filesystem-backed stream wrapper** rather than mocking `is_dir()`. That was necessary rather than cosmetic: `wp_is_stream()` only recognizes registered schemes, and `glob()`'s failure on wrapper paths cannot be reproduced by a mock. The wrapper lives in `TransientFilesTestStreamWrapper.php` and implements `stream_metadata` because `WP_Filesystem_Direct::put_contents()` calls `chmod()` on every file it writes.
-   Negative check: with the test files applied to the unfixed source, the new stream-wrapper tests fail, so they are not vacuous.
-   Wrapper behavior was measured directly rather than assumed. Against a registered wrapper on PHP 8.1: `is_dir` true, `realpath` false, `glob` returns an empty array for both patterns, `scandir` lists correctly, `is_file` true, `FilesystemIterator` valid, `unlink` and `rmdir` both succeed. Reproduced independently on PHP 8.5.
-   `phpcs` (per-file and `phpcs-changed` against trunk) and PHPStan on the modified source are clean. Nothing was added to `phpstan-baseline.neon`.

**What has not been verified, and cannot be here:** whether any of this works against **real** S3-Uploads or VIP infrastructure. A local filesystem-backed wrapper proves the calls reach the wrapper at all; it does not prove S3's wrapper implements `dir_readdir`, `unlink` and `rmdir` the way the local stand-in does, nor that `WP_Filesystem_Direct`'s `chmod()` call succeeds there. Green unit tests prove the directory is no longer an empty string and that cleanup enumerates through the wrapper; they do not prove transient files work end to end on VIP. Testing on a real S3-Uploads or VIP install would be valuable before this is considered fully closed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

Changelog entries were added manually: `plugins/woocommerce/changelog/65739-fix-transient-files-stream-wrapper-realpath` and `plugins/woocommerce/changelog/65739-fix-transient-files-cleanup-stream-wrapper`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Keep the transient files directory working, and expired transient files getting deleted, on sites whose uploads directory is a stream wrapper path, such as S3-Uploads and WordPress VIP installs.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)
