### PR TITLE
Fix: review avatar spacing

### DIFF
--- a/plugins/woocommerce/changelog/fix-review-avatar-spacing
+++ b/plugins/woocommerce/changelog/fix-review-avatar-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove empty spacing from product reviews when avatars are disabled.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -761,9 +761,14 @@ p.demo_store,
 				clear: none;
 			}
 
+			&:has( ol.commentlist .comment_container > img.avatar ) > h2 {
+				margin-inline-start: 50px;
+			}
+
 			ol.commentlist {
 				@include clearfix();
 				margin: 0;
+				padding: 0;
 				width: 100%;
 				background: none;
 				list-style: none;

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -761,10 +761,6 @@ p.demo_store,
 				clear: none;
 			}
 
-			&:has( ol.commentlist .comment_container > img.avatar ) > h2 {
-				margin-inline-start: 50px;
-			}
-
 			ol.commentlist {
 				@include clearfix();
 				margin: 0;

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -806,6 +806,10 @@ p.demo_store,
 							font-size: 0.83em;
 						}
 					}
+
+					.comment_container > .comment-text:only-child {
+						margin-inline-start: 0;
+					}
 				}
 
 				ul.children {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes #62467 by removing the legacy product-review avatar gutter when `.comment-text` is the only element in its review container.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1221" height="494" alt="image" src="https://github.com/user-attachments/assets/f866ba80-1a9b-4460-b0d5-4bf972c55cd8" />     |    <img width="1221" height="552" alt="image" src="https://github.com/user-attachments/assets/ace1c166-bc76-4cc6-b2ac-b445478a508f" />   |


https://github.com/user-attachments/assets/afb717d2-59ef-4018-8d80-cb36e4570d3c


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In **Settings > Discussion**, disable **Avatar Display**, save.
4. Reload the product at desktop and mobile widths. Confirm avatar is gone and there is no left margin previously visible even when avatar is disabled.

<details><summary>Detailed instructions</summary>

#### Prerequisites and fixture

- Use a WordPress site running this branch's built WooCommerce classic frontend CSS with a theme that renders the standard WooCommerce product-review markup.
- Sign in as an administrator. Open browser DevTools so computed styles and responsive viewport sizes can be checked.
- Use a published product with reviews enabled and an approved top-level review containing one approved nested reply. The WooCommerce sample product **V-Neck T-Shirt** is suitable. If this fixture does not exist, create a product, submit and approve a review with text `Avatar spacing parent review`, add and approve a reply with text `Avatar spacing nested reply`, and record both comment IDs for cleanup.
- Record the original **Settings > Discussion > Avatar Display** value. These instructions leave it enabled; if the site originally used another value, restore that value instead during cleanup.
- Keep DevTools Console and Network panels open with recording enabled. Clear both before starting; do not continue if the page reports an attributable JavaScript error or failed HTTP request.
- For deterministic Console checks, resolve the two text elements with:

  ```js
  const topLevel = document.querySelector( '#reviews ol.commentlist > li:first-child > .comment_container > .comment-text' );
  const nestedReply = document.querySelector( '#reviews ol.commentlist > li:first-child ul.children > li:first-child > .comment_container > .comment-text' );
  ```

  For each element, use `getComputedStyle( element ).marginInlineStart`; use `element.parentElement.querySelector( ':scope > img.avatar' )` for the direct-child avatar check.

#### Avatar Display enabled

1. Go to **WP Admin > Settings > Discussion** (`/wp-admin/options-discussion.php`).
2. Scroll to **Avatars**. Check **Show Avatars** under **Avatar Display**, select **Save Changes**, and wait for the settings-saved notice.
3. Reload the Discussion page and assert **Show Avatars** is still checked.
4. Open the fixture product on the frontend, select its **Reviews** tab if it is collapsed, and verify the top-level review and nested reply are both visible.
5. Set responsive mode to `1440 × 900`. For both the top-level review and nested reply, assert:
   - an `img.avatar` is a direct child of `.comment_container`;
   - `getComputedStyle(commentText).marginInlineStart` is exactly `50px`; and
   - the text is visibly offset from the inline-start edge without overlap or clipping.
6. Capture the enabled desktop state. Change responsive mode to `390 × 844`, reload, reopen **Reviews** if needed, and repeat all three assertions for both review levels. Capture the enabled mobile state.

#### Avatar Display disabled

7. Return to **WP Admin > Settings > Discussion**. Uncheck **Show Avatars**, select **Save Changes**, wait for the settings-saved notice, reload the page, and assert the checkbox remains unchecked.
8. Return to the fixture product and reload it. At `1440 × 900`, open **Reviews** if needed and assert for both the top-level review and nested reply:
   - `.comment_container` has no direct-child `img.avatar`;
   - `.comment-text` is the only element child of `.comment_container` for the core fixture;
   - `getComputedStyle(commentText).marginInlineStart` is exactly `0px`; and
   - the text is visibly flush with the container's inline-start edge without overlap or clipping.
9. Capture the disabled desktop state. Change responsive mode to `390 × 844`, reload, reopen **Reviews** if needed, and repeat all four assertions for both review levels. Capture the disabled mobile state.
10. Confirm DevTools shows no attributable JavaScript errors, failed requests, or HTTP responses with status `400` or higher during either state.

#### Cleanup and limitations

11. Return to **WP Admin > Settings > Discussion**, check **Show Avatars**, save, reload, and explicitly assert it is checked. If the recorded original value differed, restore and verify that original value instead.
12. If temporary review comments were created, delete the nested reply and parent review, empty them from Trash, and verify neither recorded comment ID remains. Do not alter pre-existing reviews, users, product content, templates, language, or styles.
13. This manual path covers the standard legacy WooCommerce review markup in LTR at representative desktop/mobile widths. It does not claim repository E2E coverage or guarantee overrides from themes/extensions with more-specific CSS.

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
