### PR TITLE
Load Catalog Sorting styles and improve width adjustments

### DIFF
--- a/plugins/woocommerce/changelog/update-catalog-sorting-content-width
+++ b/plugins/woocommerce/changelog/update-catalog-sorting-content-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Size the Catalog Sorting block to the selected option.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/block.json
@@ -15,6 +15,7 @@
 		}
 	},
 	"viewScriptModule": "woocommerce/catalog-sorting",
+	"style": "file:../woocommerce/catalog-sorting-style.css",
 	"attributes": {
 		"fontSize": {
 			"type": "string",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/style.scss
@@ -8,6 +8,7 @@
 	}
 
 	select.orderby {
+		field-sizing: content;
 		font-size: inherit;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Catalog sorting options reserve space for their widest option, leaving unnecessary space when a shorter option is selected. This PR improves it.

While adding the option I realised the Catalog Sorting stylesheet wasn't enqueued at all so I'm adding the entry in `block.json` so it's there.

Related discussion: https://github.com/woocommerce/woo-themes/pull/405#issuecomment-5250502146

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Before | After
-- | --
<img width="252" height="79" alt="image" src="https://github.com/user-attachments/assets/c97b9a15-da90-4ccd-b91c-f02e26abd3f6" /> | <img width="197" height="79" alt="image" src="https://github.com/user-attachments/assets/225c6ec9-8563-4f20-9ad3-9dc8ba359850" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Open a Shop page containing the Catalog Sorting block in a browser supporting `field-sizing`.
2. Confirm the Catalog Sorting block stylesheet is loaded on the frontend.
3. Select options with different label lengths.
4. Confirm the select width follows the selected label.
5. In an unsupported browser, confirm the select retains its native fixed sizing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- Built the WooCommerce block library successfully.
- Verified on a local Shop page that `field-sizing` computes to `content` and “Latest” reduces the select from 157px to 74px.
- `pnpm --filter=@woocommerce/block-library exec prettier --check 'assets/js/blocks/catalog-sorting/block.json'`
- `pnpm --filter=@woocommerce/block-library exec stylelint 'assets/js/blocks/catalog-sorting/style.scss'`
- `git diff --check`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze this PR and post a draft comment for review.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to inspect related styles, implement the change, diagnose frontend asset loading, run linting and builds, verify the result locally, and draft this PR.
