### PR TITLE
Fix external product storefront visibility

### DIFF
--- a/plugins/woocommerce/changelog/wooairr-21-external-product-visibility
+++ b/plugins/woocommerce/changelog/wooairr-21-external-product-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep external products visible in the catalog after converting them from an out-of-stock product.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -467,8 +467,8 @@ class WC_Meta_Box_Product_Data {
 	 * Persist the stock data enforced by the external product class.
 	 *
 	 * External product setters normalize stock values while the existing product data is read. The submitted
-	 * values therefore match the in-memory values and are not detected as changes, leaving stale post meta and
-	 * lookup data behind unless they are synchronized explicitly.
+	 * values therefore match the in-memory values and are not detected as changes, leaving stale stock meta,
+	 * lookup, and visibility data behind unless they are synchronized explicitly.
 	 *
 	 * @param WC_Product $product External product object.
 	 */
@@ -476,6 +476,7 @@ class WC_Meta_Box_Product_Data {
 		update_post_meta( $product->get_id(), '_manage_stock', 'no' );
 		update_post_meta( $product->get_id(), '_stock_status', ProductStockStatus::IN_STOCK );
 		update_post_meta( $product->get_id(), '_backorders', 'no' );
+		wp_remove_object_terms( $product->get_id(), ProductStockStatus::OUT_OF_STOCK, 'product_visibility' );
 
 		/**
 		 * Product data store.

--- a/plugins/woocommerce/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce/tests/e2e/playwright.config.ts
@@ -165,6 +165,9 @@ const serialRunSpecs = [
 	// Imports a fixed-content CSV (fixed SKUs/names) and asserts the imported rows
 	// on the store-wide product list — collides with concurrently created products.
 	'**/tests/product/product-import-csv.spec.ts',
+	// Toggles the global out-of-stock catalog visibility setting while verifying
+	// that converted external products remain visible on the storefront.
+	'**/tests/product/product-grouped-stock-status.spec.ts',
 	// Mutate global WooCommerce settings (store address/currency/country, tax)
 	// that other workers' cart/checkout/storefront specs depend on.
 	'**/tests/settings/settings-general.spec.ts',

--- a/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/product-grouped-stock-status.spec.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
+import type { Page } from '@playwright/test';
+import { type ApiClient, WC_API_PATH } from '@woocommerce/e2e-utils-playwright';
 
 /**
  * Internal dependencies
@@ -29,61 +30,126 @@ const test = baseTest.extend( {
 	},
 } );
 
-for ( const productType of [ 'grouped', 'external' ] ) {
-	test( `resets stock settings when converting a product to ${ productType }`, async ( {
+type ProductType = 'grouped' | 'external';
+type Product = {
+	id: number;
+	name: string;
+};
+
+async function convertProductType( page: Page, productType: ProductType ) {
+	await page.locator( '#product-type' ).selectOption( productType );
+	await page
+		.locator( '#publishing-action' )
+		.getByRole( 'button', { name: 'Update' } )
+		.click();
+}
+
+async function expectProductStockReset(
+	page: Page,
+	restApi: ApiClient,
+	product: Product,
+	productType: ProductType
+) {
+	await expect( page.locator( 'input#_manage_stock' ) ).not.toBeChecked();
+	await expect(
+		page.locator( 'input[name="_stock_status"][value="instock"]' )
+	).toBeChecked();
+	await expect(
+		page
+			.locator( 'div.notice-success > p' )
+			.filter( { hasText: 'Product updated' } )
+	).toBeVisible();
+
+	const response = await restApi.get(
+		`${ WC_API_PATH }/products/${ product.id }`
+	);
+
+	expect( response.data.type ).toBe( productType );
+	expect( response.data.manage_stock ).toBe( false );
+	expect( response.data.stock_status ).toBe( 'instock' );
+
+	const productSearch = encodeURIComponent( product.name );
+	await page.goto(
+		`wp-admin/edit.php?post_type=product&stock_status=instock&s=${ productSearch }`
+	);
+	await expect( page.locator( `#post-${ product.id }` ) ).toBeVisible();
+
+	await page.goto(
+		`wp-admin/edit.php?post_type=product&stock_status=outofstock&s=${ productSearch }`
+	);
+	await expect( page.locator( `#post-${ product.id }` ) ).toHaveCount( 0 );
+}
+
+test( 'resets stock settings when converting a product to grouped', async ( {
+	page,
+	restApi,
+	managedOutOfStockProduct,
+} ) => {
+	await page.goto(
+		`wp-admin/post.php?post=${ managedOutOfStockProduct.id }&action=edit`
+	);
+	await expect( page.locator( 'input#_manage_stock' ) ).toBeChecked();
+	await expect(
+		page.locator( 'input[name="_stock_status"][value="outofstock"]' )
+	).toBeChecked();
+
+	await convertProductType( page, 'grouped' );
+	await expectProductStockReset(
 		page,
 		restApi,
 		managedOutOfStockProduct,
-	} ) => {
+		'grouped'
+	);
+} );
+
+test( 'resets external product stock settings and keeps it visible when out-of-stock products are hidden', async ( {
+	page,
+	restApi,
+	managedOutOfStockProduct,
+} ) => {
+	const hideOutOfStockSettingEndpoint = `${ WC_API_PATH }/settings/products/woocommerce_hide_out_of_stock_items`;
+	const hideOutOfStockSetting = await restApi.get(
+		hideOutOfStockSettingEndpoint
+	);
+	const productSearch = encodeURIComponent( managedOutOfStockProduct.name );
+
+	await restApi.put( hideOutOfStockSettingEndpoint, { value: 'yes' } );
+
+	try {
+		await page.goto( `shop/?s=${ productSearch }` );
+		await expect(
+			page.getByRole( 'heading', {
+				name: managedOutOfStockProduct.name,
+				exact: true,
+			} )
+		).toHaveCount( 0 );
+
 		await page.goto(
 			`wp-admin/post.php?post=${ managedOutOfStockProduct.id }&action=edit`
 		);
-
 		await expect( page.locator( 'input#_manage_stock' ) ).toBeChecked();
 		await expect(
 			page.locator( 'input[name="_stock_status"][value="outofstock"]' )
 		).toBeChecked();
 
-		await page.locator( '#product-type' ).selectOption( productType );
+		await convertProductType( page, 'external' );
+		await expectProductStockReset(
+			page,
+			restApi,
+			managedOutOfStockProduct,
+			'external'
+		);
 
-		await expect( page.locator( 'input#_manage_stock' ) ).not.toBeChecked();
+		await page.goto( `shop/?s=${ productSearch }` );
 		await expect(
-			page.locator( 'input[name="_stock_status"][value="instock"]' )
-		).toBeChecked();
-
-		await page
-			.locator( '#publishing-action' )
-			.getByRole( 'button', { name: 'Update' } )
-			.click();
-		await expect(
-			page
-				.locator( 'div.notice-success > p' )
-				.filter( { hasText: 'Product updated' } )
+			page.getByRole( 'heading', {
+				name: managedOutOfStockProduct.name,
+				exact: true,
+			} )
 		).toBeVisible();
-
-		const response = await restApi.get(
-			`${ WC_API_PATH }/products/${ managedOutOfStockProduct.id }`
-		);
-
-		expect( response.data.type ).toBe( productType );
-		expect( response.data.manage_stock ).toBe( false );
-		expect( response.data.stock_status ).toBe( 'instock' );
-
-		const productSearch = encodeURIComponent(
-			managedOutOfStockProduct.name
-		);
-		await page.goto(
-			`wp-admin/edit.php?post_type=product&stock_status=instock&s=${ productSearch }`
-		);
-		await expect(
-			page.locator( `#post-${ managedOutOfStockProduct.id }` )
-		).toBeVisible();
-
-		await page.goto(
-			`wp-admin/edit.php?post_type=product&stock_status=outofstock&s=${ productSearch }`
-		);
-		await expect(
-			page.locator( `#post-${ managedOutOfStockProduct.id }` )
-		).toHaveCount( 0 );
-	} );
-}
+	} finally {
+		await restApi.put( hideOutOfStockSettingEndpoint, {
+			value: hideOutOfStockSetting.data.value,
+		} );
+	}
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Converting a managed, out-of-stock product to an external product persisted the in-stock meta and lookup data but left its stale `outofstock` product visibility term in place. Remove that term during the existing external-product stock synchronization so stores that hide out-of-stock products display the converted product correctly.

This adds focused end-to-end coverage for grouped and external conversions, including the storefront behavior when out-of-stock products are hidden. It does not change public APIs, hooks, or method signatures.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #67484.

Closes WOOAIRR-21

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Products > Inventory** and enable **Hide out of stock items from the catalog**.
2. Create a simple product with stock management enabled and a stock quantity of `0`, then confirm it is hidden from the storefront.
3. Edit the product, change its type to **External/Affiliate product**, and update it.
4. Confirm the product reports **In stock** in wp-admin and through the products REST API.
5. Search for the product on the storefront and confirm it is now visible.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm test:e2e:with-env default --project=core-serial tests/product/product-grouped-stock-status.spec.ts` — 4 passed, 1 setup test skipped.
- PHP changed-lines lint and PHPStan passed.
- JavaScript branch lint and Prettier passed.
- Changelog validation and `git diff --check` passed.
- Multisite was not tested. The change uses the existing site-scoped `product_visibility` taxonomy operation and does not introduce network-scoped state.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the regression, implement the fix, refactor the end-to-end coverage, run verification, and draft this Pull Request description. The changes and test results were reviewed during the session.
