### PR TITLE
Update Blocks deprecation notices to use Core versions

### DIFF
--- a/plugins/woocommerce/changelog/fix-46459-core-deprecation-versions
+++ b/plugins/woocommerce/changelog/fix-46459-core-deprecation-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use WooCommerce Core versions in JavaScript deprecation notices.

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -93,33 +93,29 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 		isDoingExpressPayment: paymentIsDoingExpressPayment,
 		get isPristine() {
 			deprecated( 'isPristine', {
-				since: '9.6.0',
+				since: '7.5.0',
 				alternative: 'isIdle',
-				plugin: 'WooCommerce Blocks',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return paymentIsIdle;
 		},
 		get isFinished() {
 			deprecated( 'isFinished', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return paymentHasError || paymentIsReady;
 		},
 		get hasFailed() {
 			deprecated( 'hasFailed', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return paymentHasError;
 		},
 		get isSuccessful() {
 			deprecated( 'isSuccessful', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return paymentIsReady;
@@ -177,8 +173,8 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 			deprecated(
 				'setExpressPaymentError should only be used by Express Payment Methods (using the provided onError handler).',
 				{
+					since: '5.6.0',
 					alternative: '',
-					plugin: 'woocommerce-gutenberg-products-block',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4228',
 				}
 			);

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -173,7 +173,6 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 			deprecated(
 				'setExpressPaymentError should only be used by Express Payment Methods (using the provided onError handler).',
 				{
-					since: '5.6.0',
 					alternative: '',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4228',
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -239,7 +239,6 @@ export const CheckoutEventsProvider = ( {
 	const onCheckoutBeforeProcessing = useMemo( () => {
 		return function ( ...args: Parameters< typeof onCheckoutValidation > ) {
 			deprecated( 'onCheckoutBeforeProcessing', {
-				since: '5.4.0',
 				alternative: 'onCheckoutValidation',
 			} );
 			return onCheckoutValidation( ...args );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -239,8 +239,8 @@ export const CheckoutEventsProvider = ( {
 	const onCheckoutBeforeProcessing = useMemo( () => {
 		return function ( ...args: Parameters< typeof onCheckoutValidation > ) {
 			deprecated( 'onCheckoutBeforeProcessing', {
+				since: '5.4.0',
 				alternative: 'onCheckoutValidation',
-				plugin: 'WooCommerce Blocks',
 			} );
 			return onCheckoutValidation( ...args );
 		};
@@ -252,9 +252,8 @@ export const CheckoutEventsProvider = ( {
 	const onCheckoutValidationBeforeProcessing = useMemo( () => {
 		return function ( ...args: Parameters< typeof onCheckoutValidation > ) {
 			deprecated( 'onCheckoutValidationBeforeProcessing', {
-				since: '9.7.0',
+				since: '7.6.0',
 				alternative: 'onCheckoutValidation',
-				plugin: 'WooCommerce Blocks',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8381',
 			} );
 			return onCheckoutValidation( ...args );
@@ -267,9 +266,8 @@ export const CheckoutEventsProvider = ( {
 	const onCheckoutAfterProcessingWithSuccess = useMemo( () => {
 		return function ( ...args: Parameters< typeof onCheckoutSuccess > ) {
 			deprecated( 'onCheckoutAfterProcessingWithSuccess', {
-				since: '9.7.0',
+				since: '7.6.0',
 				alternative: 'onCheckoutSuccess',
-				plugin: 'WooCommerce Blocks',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8381',
 			} );
 			return onCheckoutSuccess( ...args );
@@ -282,9 +280,8 @@ export const CheckoutEventsProvider = ( {
 	const onCheckoutAfterProcessingWithError = useMemo( () => {
 		return function ( ...args: Parameters< typeof onCheckoutFail > ) {
 			deprecated( 'onCheckoutAfterProcessingWithError', {
-				since: '9.7.0',
+				since: '7.6.0',
 				alternative: 'onCheckoutFail',
-				plugin: 'WooCommerce Blocks',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8381',
 			} );
 			return onCheckoutFail( ...args );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
@@ -140,8 +140,8 @@ export const PaymentEventsProvider = ( {
 	const onPaymentProcessing = useMemo( () => {
 		return function ( ...args: Parameters< typeof onPaymentSetup > ) {
 			deprecated( 'onPaymentProcessing', {
+				since: '7.6.0',
 				alternative: 'onPaymentSetup',
-				plugin: 'WooCommerce Blocks',
 			} );
 			return onPaymentSetup( ...args );
 		};

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
@@ -140,7 +140,6 @@ export const PaymentEventsProvider = ( {
 	const onPaymentProcessing = useMemo( () => {
 		return function ( ...args: Parameters< typeof onPaymentSetup > ) {
 			deprecated( 'onPaymentProcessing', {
-				since: '7.6.0',
 				alternative: 'onPaymentSetup',
 			} );
 			return onPaymentSetup( ...args );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -140,7 +140,6 @@ const ExpressPaymentMethods = () => {
 			deprecated(
 				'Express Payment Methods should use the provided onError handler instead.',
 				{
-					since: '5.6.0',
 					alternative: 'onError',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4228',
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.tsx
@@ -140,8 +140,8 @@ const ExpressPaymentMethods = () => {
 			deprecated(
 				'Express Payment Methods should use the provided onError handler instead.',
 				{
+					since: '5.6.0',
 					alternative: 'onError',
-					plugin: 'woocommerce-gutenberg-products-block',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4228',
 				}
 			);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/express-payment-methods.tsx
@@ -234,7 +234,7 @@ describe( 'Express payment methods', () => {
 				// usePaymentMethodInterface hook is called so we need to expect it here otherwise
 				// the test fails on unexpected console warnings.
 				expect( console ).toHaveWarnedWith(
-					'isPristine is deprecated since version 9.6.0. Please use isIdle instead. See: https://github.com/woocommerce/woocommerce-blocks/pull/8110'
+					'isPristine is deprecated since version 7.5.0. Please use isIdle instead. See: https://github.com/woocommerce/woocommerce-blocks/pull/8110'
 				);
 			} );
 

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/payment/selectors.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/payment/selectors.ts
@@ -26,9 +26,8 @@ if ( getSetting( 'globalPaymentMethods' ) ) {
 
 export const isPaymentPristine = ( state: PaymentState ) => {
 	deprecated( 'isPaymentPristine', {
-		since: '9.6.0',
+		since: '7.5.0',
 		alternative: 'isPaymentIdle',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 	} );
 
@@ -40,9 +39,8 @@ export const isPaymentIdle = ( state: PaymentState ) =>
 
 export const isPaymentStarted = ( state: PaymentState ) => {
 	deprecated( 'isPaymentStarted', {
-		since: '9.6.0',
+		since: '7.5.0',
 		alternative: 'isExpressPaymentStarted',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 	} );
 	return state.status === PAYMENT_STATUS.EXPRESS_STARTED;
@@ -60,9 +58,8 @@ export const isPaymentReady = ( state: PaymentState ) =>
 
 export const isPaymentSuccess = ( state: PaymentState ) => {
 	deprecated( 'isPaymentSuccess', {
-		since: '9.6.0',
+		since: '7.5.0',
 		alternative: 'isPaymentReady',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 	} );
 
@@ -74,8 +71,7 @@ export const hasPaymentError = ( state: PaymentState ) =>
 
 export const isPaymentFailed = ( state: PaymentState ) => {
 	deprecated( 'isPaymentFailed', {
-		since: '9.6.0',
-		plugin: 'WooCommerce Blocks',
+		since: '7.5.0',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 	} );
 
@@ -187,18 +183,16 @@ export const expressPaymentMethodsInitialized = ( state: PaymentState ) => {
  */
 export const getCurrentStatus = ( state: PaymentState ) => {
 	deprecated( 'getCurrentStatus', {
-		since: '8.9.0',
+		since: '7.2.0',
 		alternative: 'isPaymentIdle, isPaymentProcessing, hasPaymentError',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/7666',
 	} );
 
 	return {
 		get isPristine() {
 			deprecated( 'isPristine', {
-				since: '9.6.0',
+				since: '7.5.0',
 				alternative: 'isIdle',
-				plugin: 'WooCommerce Blocks',
 			} );
 			return isPaymentIdle( state );
 		}, // isPristine is the same as isIdle.
@@ -207,8 +201,7 @@ export const getCurrentStatus = ( state: PaymentState ) => {
 		isProcessing: isPaymentProcessing( state ),
 		get isFinished() {
 			deprecated( 'isFinished', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return hasPaymentError( state ) || isPaymentReady( state );
@@ -216,16 +209,14 @@ export const getCurrentStatus = ( state: PaymentState ) => {
 		hasError: hasPaymentError( state ),
 		get hasFailed() {
 			deprecated( 'hasFailed', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return hasPaymentError( state );
 		},
 		get isSuccessful() {
 			deprecated( 'isSuccessful', {
-				since: '9.6.0',
-				plugin: 'WooCommerce Blocks',
+				since: '7.5.0',
 				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
 			} );
 			return isPaymentReady( state );

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/payment/thunks.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/payment/thunks.ts
@@ -119,9 +119,9 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					// Set this here so that old extensions still using billingData can set the billingAddress.
 					billingAddress = billingDataFromResponse as BillingAddress;
 					deprecated(
-						'returning billingData from an onPaymentProcessing observer in WooCommerce Blocks',
+						'returning billingData from an onPaymentProcessing observer',
 						{
-							version: '9.5.0',
+							version: '7.5.0',
 							alternative: 'billingAddress',
 							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/6369',
 						}
@@ -136,9 +136,9 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					shippingAddress =
 						shippingDataFromResponse.address as ShippingAddress;
 					deprecated(
-						'returning shippingData from an onPaymentProcessing observer in WooCommerce Blocks',
+						'returning shippingData from an onPaymentProcessing observer',
 						{
-							version: '9.5.0',
+							version: '7.5.0',
 							alternative: 'shippingAddress',
 							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8163',
 						}

--- a/plugins/woocommerce/client/blocks/packages/public-api/block-data/validation/actions.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/block-data/validation/actions.ts
@@ -28,9 +28,8 @@ export const clearValidationErrors = ( errors?: string[] | undefined ) => ( {
 
 export const clearAllValidationErrors = () => {
 	deprecated( 'clearAllValidationErrors', {
-		version: '9.0.0',
+		version: '7.3.0',
 		alternative: 'clearValidationErrors',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/7601',
 		hint: 'Calling `clearValidationErrors` with no arguments will clear all validation errors.',
 	} );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/filter-registry/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/filter-registry/index.ts
@@ -48,8 +48,8 @@ export const registerCheckoutFilters = (
 	 */
 	if ( Object.keys( filters ).includes( 'couponName' ) ) {
 		deprecated( 'couponName', {
+			since: '5.6.0',
 			alternative: 'coupons',
-			plugin: 'WooCommerce Blocks',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bb921d21f42e21f38df2b1c87b48e07aa4cb0538/docs/extensibility/available-filters.md#coupons',
 		} );
 	}
@@ -71,9 +71,8 @@ export const __experimentalRegisterCheckoutFilters = (
 ) => {
 	deprecated( '__experimentalRegisterCheckoutFilters', {
 		alternative: 'registerCheckoutFilters',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8346',
-		since: '9.6.0',
+		since: '7.5.0',
 		hint: '__experimentalRegisterCheckoutFilters has graduated to stable and this experimental function will be removed.',
 	} );
 	registerCheckoutFilters( namespace, filters );
@@ -279,9 +278,8 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 } ): T => {
 	deprecated( '__experimentalApplyCheckoutFilter', {
 		alternative: 'applyCheckoutFilter',
-		plugin: 'WooCommerce Blocks',
 		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8346',
-		since: '9.6.0',
+		since: '7.5.0',
 		hint: '__experimentalApplyCheckoutFilter has graduated to stable and this experimental function will be removed.',
 	} );
 	return applyCheckoutFilter( {

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/filter-registry/index.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-checkout/filter-registry/index.ts
@@ -48,7 +48,6 @@ export const registerCheckoutFilters = (
 	 */
 	if ( Object.keys( filters ).includes( 'couponName' ) ) {
 		deprecated( 'couponName', {
-			since: '5.6.0',
 			alternative: 'coupons',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bb921d21f42e21f38df2b1c87b48e07aa4cb0538/docs/extensibility/available-filters.md#coupons',
 		} );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/block-components/get-registered-block-components.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/block-components/get-registered-block-components.ts
@@ -47,9 +47,8 @@ export function getRegisteredInnerBlocks(
 	main: string
 ): Record< string, RegisteredBlockComponent > {
 	deprecated( 'getRegisteredInnerBlocks', {
-		version: '2.8.0',
+		version: '4.4.0',
 		alternative: 'getRegisteredBlockComponents',
-		plugin: 'WooCommerce Blocks',
 	} );
 	return getRegisteredBlockComponents( main );
 }

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/block-components/register-block-component.js
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/block-components/register-block-component.js
@@ -93,9 +93,8 @@ export function registerBlockComponent( options ) {
  */
 export function registerInnerBlock( options ) {
 	deprecated( 'registerInnerBlock', {
-		version: '2.8.0',
+		version: '4.4.0',
 		alternative: 'registerBlockComponent',
-		plugin: 'WooCommerce Blocks',
 		hint: '"main" has been replaced with "context" and is now optional.',
 	} );
 	assertOption( options, 'main', 'string' );

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/payment-method-config.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/payment-method-config.tsx
@@ -158,7 +158,6 @@ export default class PaymentMethodConfig
 			deprecated(
 				'Passing savePaymentInfo when registering a payment method.',
 				{
-					since: '5.1.0',
 					alternative: 'Pass showSavedCards and showSaveOption',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686',
 				}

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/payment-method-config.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/payment-method-config.tsx
@@ -158,8 +158,8 @@ export default class PaymentMethodConfig
 			deprecated(
 				'Passing savePaymentInfo when registering a payment method.',
 				{
+					since: '5.1.0',
 					alternative: 'Pass showSavedCards and showSaveOption',
-					plugin: 'woocommerce-gutenberg-products-block',
 					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686',
 				}
 			);

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/registry.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/registry.ts
@@ -45,8 +45,8 @@ export const registerPaymentMethod = (
 		// registerPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( PaymentMethodConfig );
 		deprecated( 'Passing a callback to registerPaymentMethod()', {
+			since: '4.9.0',
 			alternative: 'a config options object',
-			plugin: 'woocommerce-gutenberg-products-block',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
 		} );
 	} else {
@@ -71,8 +71,8 @@ export const registerExpressPaymentMethod = (
 		// registerExpressPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( ExpressPaymentMethodConfig );
 		deprecated( 'Passing a callback to registerExpressPaymentMethod()', {
+			since: '4.9.0',
 			alternative: 'a config options object',
-			plugin: 'woocommerce-gutenberg-products-block',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
 		} );
 	} else {

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/registry.ts
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-registry/payment-methods/registry.ts
@@ -45,7 +45,6 @@ export const registerPaymentMethod = (
 		// registerPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( PaymentMethodConfig );
 		deprecated( 'Passing a callback to registerPaymentMethod()', {
-			since: '4.9.0',
 			alternative: 'a config options object',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
 		} );
@@ -71,7 +70,6 @@ export const registerExpressPaymentMethod = (
 		// registerExpressPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( ExpressPaymentMethodConfig );
 		deprecated( 'Passing a callback to registerExpressPaymentMethod()', {
-			since: '4.9.0',
 			alternative: 'a config options object',
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

JavaScript deprecation notices still report historical WooCommerce Blocks package releases, which no longer give extension developers a useful WooCommerce Core compatibility boundary. This updates existing `since` and `version` values to the WooCommerce Core release that first bundled the corresponding Blocks release, and removes the obsolete Blocks `plugin` metadata.

#### Version mapping

The mapping uses the first WooCommerce Core release that bundled the corresponding Blocks package version, or a newer package containing it. The bundled package versions were verified against the WooCommerce release tags; the linked release posts provide the public release context.

| WooCommerce Blocks version | WooCommerce Core version | Blocks version bundled in Core |
| --- | --- | --- |
| `2.8.0` | [4.4.0](https://developer.woocommerce.com/2020/08/18/woocommerce-4-4-is-now-available/) | `3.1.0` |
| `8.9.0` | [7.2.0](https://developer.woocommerce.com/2022/12/14/woocommerce-7-2-0-released/) | `8.9.1` |
| `9.0.0` | [7.3.0](https://developer.woocommerce.com/2023/01/12/woocommerce-7-3-released/) | `9.1.5` |
| `9.5.0` and `9.6.0` | [7.5.0](https://developer.woocommerce.com/2023/03/14/woocommerce-7-5-released/) | `9.6.5` |
| `9.7.0` | [7.6.0](https://developer.woocommerce.com/2023/04/13/woocommerce-7-6-released/) | `9.8.4` |

No exports, signatures, globals, or deprecated runtime fallbacks are changed.

Closes #46459.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Inspect the updated `deprecated()` calls under `plugins/woocommerce/client/blocks`.
2. Confirm existing `since` and `version` options use WooCommerce Core release numbers instead of WooCommerce Blocks package versions, without introducing either option where it was previously absent.
3. Confirm the affected options no longer include the `plugin` key and that no API signatures or fallback behavior changed.
4. Run `pnpm --filter=@woocommerce/block-library lint:js`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Targeted Prettier check passed for all changed JavaScript and TypeScript files.
- Targeted `wp-scripts lint-js` check passed with zero errors. Six existing environment/import warnings remain.
- `git diff --check` passed.
- The full Blocks TypeScript build remains blocked by unrelated existing errors in generated Storybook files and the test harness; none reference the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze the PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to research the historical release mappings, update the deprecation metadata, run validation, and draft this pull request. The resulting changes and validation output were reviewed in the local workspace.
