### PR TITLE
Track and expose the last send time for each push token

### DIFF
--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -365,6 +365,12 @@ class PushTokenRestController extends RestApiControllerBase {
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
+					'last_send_at_gmt'      => array(
+						'description' => __( 'The date a notification for this token was last sent to WordPress.com, as GMT. This records that WordPress.com accepted the payload, not that the device received it. Null when nothing has been sent.', 'woocommerce' ),
+						'type'        => array( 'date-time', 'null' ),
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -365,9 +365,10 @@ class PushTokenRestController extends RestApiControllerBase {
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
-					'last_send_at_gmt'      => array(
+					'last_sent_at_gmt'      => array(
 						'description' => __( 'The date a notification for this token was last sent to WordPress.com, as GMT. This records that WordPress.com accepted the payload, not that the device received it. Null when nothing has been sent.', 'woocommerce' ),
-						'type'        => array( 'date-time', 'null' ),
+						'type'        => array( 'string', 'null' ),
+						'format'      => 'date-time',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),

--- a/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Controllers/PushTokenRestController.php
@@ -366,7 +366,7 @@ class PushTokenRestController extends RestApiControllerBase {
 						'readonly'    => true,
 					),
 					'last_sent_at_gmt'      => array(
-						'description' => __( 'The date a notification for this token was last sent to WordPress.com, as GMT. This records that WordPress.com accepted the payload, not that the device received it. Null when nothing has been sent.', 'woocommerce' ),
+						'description' => __( 'The date a notification for this token was last sent to WordPress.com, as GMT. This records that WordPress.com accepted the payload, not that the device received it. Null when no send has been recorded, which also covers a send whose record failed.', 'woocommerce' ),
 						'type'        => array( 'string', 'null' ),
 						'format'      => 'date-time',
 						'context'     => array( 'view' ),

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -332,20 +332,20 @@ class PushTokensDataStore {
 			) {
 				return new PushToken(
 					array(
-						'id'            => $post_id,
-						'user_id'       => $user_id,
-						'token'         => $meta['token'],
-						'device_uuid'   => $meta['device_uuid'] ?? null,
-						'platform'      => $meta['platform'],
-						'origin'        => $meta['origin'],
+						'id'               => $post_id,
+						'user_id'          => $user_id,
+						'token'            => $meta['token'],
+						'device_uuid'      => $meta['device_uuid'] ?? null,
+						'platform'         => $meta['platform'],
+						'origin'           => $meta['origin'],
 						/**
 						 * These meta items were added after the ability to store
 						 * tokens, so may not be available for older tokens. Use
 						 * sensible defaults.
 						 */
-						'device_locale' => $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE,
-						'metadata'      => $meta['metadata'] ?? array(),
-						'last_send_at_gmt'  => $meta[ self::LAST_SEND_AT_META_KEY ] ?? null,
+						'device_locale'    => $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE,
+						'metadata'         => $meta['metadata'] ?? array(),
+						'last_send_at_gmt' => $meta[ self::LAST_SEND_AT_META_KEY ] ?? null,
 					)
 				);
 			}
@@ -509,13 +509,20 @@ class PushTokensDataStore {
 		}
 
 		add_action( 'shutdown', array( $this, 'flush_last_send' ) );
+
+		// The safety net and retry jobs run under an Action Scheduler queue
+		// runner, which is routinely killed on a time limit. Shutdown functions
+		// do not run on a kill, so flush after each action as well.
+		add_action( 'action_scheduler_after_execute', array( $this, 'flush_last_send' ) );
+
 		$this->last_send_flush_registered = true;
 	}
 
 	/**
 	 * Writes the buffered last-send stamps.
 	 *
-	 * Runs on shutdown, and is safe to call directly to force the write early.
+	 * Runs on shutdown and after each Action Scheduler action, and is safe to
+	 * call directly to force the write early.
 	 *
 	 * Failure is swallowed: not knowing when a token was last used is a
 	 * diagnostic gap, and must never turn a delivered notification into a
@@ -526,6 +533,10 @@ class PushTokensDataStore {
 	 * @return void
 	 */
 	public function flush_last_send(): void {
+		// Lets a later `record_last_send()` re-assert both hooks. They stay
+		// registered either way, and `add_action()` is idempotent here.
+		$this->last_send_flush_registered = false;
+
 		if ( empty( $this->pending_last_send ) ) {
 			return;
 		}
@@ -561,8 +572,6 @@ class PushTokensDataStore {
 	 * `(post_id, meta_key)`, so the rows to update have to be identified first
 	 * either way.
 	 *
-	 * @since 11.2.0
-	 *
 	 * @param array<int, string> $chunk Map of token post ID to GMT datetime.
 	 * @return void
 	 */
@@ -589,11 +598,25 @@ class PushTokensDataStore {
 			)
 		);
 
+		// `get_col()` returns an empty array when the query fails as well as
+		// when nothing matched, and reading that as "no rows exist" would
+		// insert duplicates `wp_postmeta` has no unique key to prevent.
+		if ( '' !== $wpdb->last_error ) {
+			wc_get_logger()->warning(
+				'Could not read existing push token send stamps, skipping chunk.',
+				array(
+					'token_ids' => $post_ids,
+					'error'     => $wpdb->last_error,
+				)
+			);
+
+			return;
+		}
+
 		$existing = array_map( 'intval', (array) $existing );
 
-		// Tokens sent at the same moment share an UPDATE. Within one request
-		// that is usually every token, so this is one query in the common case,
-		// but grouping keeps each token's own send time exact when a request
+		// Tokens sent at the same moment share an UPDATE, so this is usually
+		// one query, without giving a token another's send time when a request
 		// spans a second boundary.
 		$by_timestamp = array();
 
@@ -648,8 +671,6 @@ class PushTokensDataStore {
 
 	/**
 	 * Runs a prepared statement, logging rather than throwing when it fails.
-	 *
-	 * @since 11.2.0
 	 *
 	 * @param string $query    The prepared SQL.
 	 * @param int[]  $post_ids The token post IDs the statement covers, for the log context.

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -34,6 +34,27 @@ class PushTokensDataStore {
 	private array $tokens_by_roles_cache = array();
 
 	/**
+	 * Buffered last-send stamps awaiting a write, as token post ID => GMT
+	 * datetime. Holds the most recent time recorded for each token this
+	 * request. Flushed by {@see self::flush_last_send()} on shutdown.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $pending_last_send = array();
+
+	/**
+	 * Whether the shutdown flush for `$pending_last_send` has been registered.
+	 *
+	 * @var bool
+	 */
+	private bool $last_send_flush_registered = false;
+
+	/**
+	 * How many tokens to write per statement when flushing last-send stamps.
+	 */
+	const LAST_SEND_CHUNK_SIZE = 100;
+
+	/**
 	 * Meta key holding the GMT datetime of the last successful send to WPCOM.
 	 *
 	 * Deliberately absent from `build_meta_array_from_token()`: it is written
@@ -459,15 +480,13 @@ class PushTokensDataStore {
 	/**
 	 * Records that the given tokens were successfully sent to WPCOM.
 	 *
-	 * Written as two fixed queries — a delete followed by a single multi-row
-	 * insert — rather than one `update_post_meta()` call per token. A store
-	 * with a dozen registered devices would otherwise cost dozens of round
-	 * trips on the send path, which grows with the number of devices rather
-	 * than staying constant.
-	 *
-	 * Failure is swallowed: not knowing when a token was last used is a
-	 * diagnostic gap, and must never turn a delivered notification into a
-	 * failed one.
+	 * Buffers the stamps and writes them once on shutdown rather than per call.
+	 * A single request often processes several notifications — the loopback
+	 * receives every notification a store event produced, and a bulk order
+	 * update can produce dozens — and each one would otherwise repeat the same
+	 * write against the same handful of tokens. Buffering makes the cost a
+	 * function of the request rather than of the notification count, while each
+	 * token still keeps the exact time of its own most recent send.
 	 *
 	 * @since 11.2.0
 	 *
@@ -475,80 +494,182 @@ class PushTokensDataStore {
 	 * @return void
 	 */
 	public function record_last_send( array $push_tokens ): void {
-		global $wpdb;
+		$timestamp = gmdate( 'Y-m-d H:i:s' );
 
-		$post_ids = array_values(
-			array_filter(
-				array_map(
-					fn ( PushToken $push_token ) => $push_token->get_id(),
-					$push_tokens
-				)
-			)
-		);
+		foreach ( $push_tokens as $push_token ) {
+			$id = $push_token->get_id();
 
-		if ( empty( $post_ids ) ) {
+			if ( $id ) {
+				$this->pending_last_send[ $id ] = $timestamp;
+			}
+		}
+
+		if ( empty( $this->pending_last_send ) || $this->last_send_flush_registered ) {
 			return;
 		}
 
-		$timestamp = gmdate( 'Y-m-d H:i:s' );
+		add_action( 'shutdown', array( $this, 'flush_last_send' ) );
+		$this->last_send_flush_registered = true;
+	}
 
-		/**
-		 * Both statements interpolate a placeholder list whose length depends on
-		 * the number of tokens. The interpolated strings are built here from
-		 * literals only — never from token data — and every value still travels
-		 * through `$wpdb->prepare()`, which is why the sniffs are suppressed
-		 * below rather than the queries being restructured.
-		 */
-		$id_placeholders  = implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) );
-		$row_placeholders = implode( ', ', array_fill( 0, count( $post_ids ), '( %d, %s, %s )' ) );
-
-		$insert_args = array();
-
-		foreach ( $post_ids as $post_id ) {
-			$insert_args[] = $post_id;
-			$insert_args[] = self::LAST_SEND_AT_META_KEY;
-			$insert_args[] = $timestamp;
+	/**
+	 * Writes the buffered last-send stamps.
+	 *
+	 * Runs on shutdown, and is safe to call directly to force the write early.
+	 *
+	 * Failure is swallowed: not knowing when a token was last used is a
+	 * diagnostic gap, and must never turn a delivered notification into a
+	 * failed one.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @return void
+	 */
+	public function flush_last_send(): void {
+		if ( empty( $this->pending_last_send ) ) {
+			return;
 		}
 
-		try {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN ( $id_placeholders )",
-					array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
-				)
-			);
+		$pending                 = $this->pending_last_send;
+		$this->pending_last_send = array();
 
-			$inserted = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES $row_placeholders",
-					$insert_args
-				)
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-
-			// The rows were written behind the meta API's back, so the cached
-			// meta for these posts is now stale and must be dropped.
-			wp_cache_delete_multiple( $post_ids, 'post_meta' );
-
-			if ( false === $inserted ) {
+		// Chunked so neither the `IN` list nor the number of placeholders handed
+		// to `$wpdb->prepare()` grows with the number of registered devices. A
+		// large `IN` list can also push the optimizer off the `post_id` index.
+		foreach ( array_chunk( $pending, self::LAST_SEND_CHUNK_SIZE, true ) as $chunk ) {
+			try {
+				$this->write_last_send_chunk( $chunk );
+			} catch ( Exception $e ) {
 				wc_get_logger()->warning(
 					'Failed to record last send time for push tokens.',
 					array(
-						'token_ids' => $post_ids,
-						'error'     => $wpdb->last_error,
+						'token_ids' => array_keys( $chunk ),
+						'error'     => $e->getMessage(),
 					)
 				);
 			}
-		} catch ( Exception $e ) {
-			wc_get_logger()->warning(
-				'Failed to record last send time for push tokens.',
-				array(
-					'token_ids' => $post_ids,
-					'error'     => $e->getMessage(),
-				)
-			);
-		}//end try
+		}
+	}
+
+	/**
+	 * Writes one chunk of buffered last-send stamps.
+	 *
+	 * Existing rows are updated in place rather than deleted and reinserted.
+	 * This is the busiest write path in the feature, and a delete/insert cycle
+	 * on the same rows consumes `meta_id` values permanently and fragments the
+	 * primary key, for no benefit — `wp_postmeta` has no unique key on
+	 * `(post_id, meta_key)`, so the rows to update have to be identified first
+	 * either way.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param array<int, string> $chunk Map of token post ID to GMT datetime.
+	 * @return void
+	 */
+	private function write_last_send_chunk( array $chunk ): void {
+		global $wpdb;
+
+		$post_ids = array_keys( $chunk );
+
+		/**
+		 * The statements below interpolate a placeholder list whose length
+		 * depends on the number of tokens. The interpolated strings are built
+		 * from literals only — never from token data — and every value still
+		 * travels through `$wpdb->prepare()`, which is why the sniffs are
+		 * suppressed rather than the queries being restructured.
+		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$existing = $wpdb->get_col(
+			$wpdb->prepare(
+				sprintf(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %%s AND post_id IN ( %s )",
+					implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) )
+				),
+				array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
+			)
+		);
+
+		$existing = array_map( 'intval', (array) $existing );
+
+		// Tokens sent at the same moment share an UPDATE. Within one request
+		// that is usually every token, so this is one query in the common case,
+		// but grouping keeps each token's own send time exact when a request
+		// spans a second boundary.
+		$by_timestamp = array();
+
+		foreach ( $chunk as $post_id => $timestamp ) {
+			$by_timestamp[ $timestamp ][] = $post_id;
+		}
+
+		foreach ( $by_timestamp as $timestamp => $ids ) {
+			$update_ids = array_values( array_intersect( $ids, $existing ) );
+			$insert_ids = array_values( array_diff( $ids, $existing ) );
+
+			if ( ! empty( $update_ids ) ) {
+				$this->query_or_warn(
+					$wpdb->prepare(
+						sprintf(
+							"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND post_id IN ( %s )",
+							implode( ', ', array_fill( 0, count( $update_ids ), '%d' ) )
+						),
+						array_merge( array( $timestamp, self::LAST_SEND_AT_META_KEY ), $update_ids )
+					),
+					$update_ids
+				);
+			}
+
+			if ( ! empty( $insert_ids ) ) {
+				$insert_args = array();
+
+				foreach ( $insert_ids as $post_id ) {
+					$insert_args[] = $post_id;
+					$insert_args[] = self::LAST_SEND_AT_META_KEY;
+					$insert_args[] = $timestamp;
+				}
+
+				$this->query_or_warn(
+					$wpdb->prepare(
+						sprintf(
+							"INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES %s",
+							implode( ', ', array_fill( 0, count( $insert_ids ), '( %d, %s, %s )' ) )
+						),
+						$insert_args
+					),
+					$insert_ids
+				);
+			}
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// The rows were written behind the meta API's back, so the cached meta
+		// for these posts is now stale and must be dropped.
+		wp_cache_delete_multiple( $post_ids, 'post_meta' );
+	}
+
+	/**
+	 * Runs a prepared statement, logging rather than throwing when it fails.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string $query    The prepared SQL.
+	 * @param int[]  $post_ids The token post IDs the statement covers, for the log context.
+	 * @return void
+	 */
+	private function query_or_warn( string $query, array $post_ids ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false !== $wpdb->query( $query ) ) {
+			return;
+		}
+
+		wc_get_logger()->warning(
+			'Failed to record last send time for push tokens.',
+			array(
+				'token_ids' => $post_ids,
+				'error'     => $wpdb->last_error,
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -33,6 +33,15 @@ class PushTokensDataStore {
 	 */
 	private array $tokens_by_roles_cache = array();
 
+	/**
+	 * Meta key holding the GMT datetime of the last successful send to WPCOM.
+	 *
+	 * Deliberately absent from `build_meta_array_from_token()`: it is written
+	 * only by `record_last_send()`, so an unrelated token update (e.g. the app
+	 * re-registering with a new locale) cannot clobber it.
+	 */
+	const LAST_SEND_AT_META_KEY = 'last_send_at_gmt';
+
 	const SUPPORTED_META = array(
 		'origin',
 		'device_uuid',
@@ -40,6 +49,7 @@ class PushTokensDataStore {
 		'platform',
 		'device_locale',
 		'metadata',
+		self::LAST_SEND_AT_META_KEY,
 	);
 
 	/**
@@ -130,6 +140,7 @@ class PushTokensDataStore {
 		 */
 		$push_token->set_device_locale( $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE );
 		$push_token->set_metadata( $meta['metadata'] ?? array() );
+		$push_token->set_last_send_at_gmt( $meta[ self::LAST_SEND_AT_META_KEY ] ?? null );
 
 		/**
 		 * Both timestamps come from the post record rather than meta, because
@@ -313,6 +324,7 @@ class PushTokensDataStore {
 						 */
 						'device_locale' => $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE,
 						'metadata'      => $meta['metadata'] ?? array(),
+						'last_send_at_gmt'  => $meta[ self::LAST_SEND_AT_META_KEY ] ?? null,
 					)
 				);
 			}
@@ -442,6 +454,101 @@ class PushTokensDataStore {
 
 		$this->tokens_by_roles_cache[ $cache_key ] = $result;
 		return $result;
+	}
+
+	/**
+	 * Records that the given tokens were successfully sent to WPCOM.
+	 *
+	 * Written as two fixed queries — a delete followed by a single multi-row
+	 * insert — rather than one `update_post_meta()` call per token. A store
+	 * with a dozen registered devices would otherwise cost dozens of round
+	 * trips on the send path, which grows with the number of devices rather
+	 * than staying constant.
+	 *
+	 * Failure is swallowed: not knowing when a token was last used is a
+	 * diagnostic gap, and must never turn a delivered notification into a
+	 * failed one.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param PushToken[] $push_tokens The tokens WPCOM accepted.
+	 * @return void
+	 */
+	public function record_last_send( array $push_tokens ): void {
+		global $wpdb;
+
+		$post_ids = array_values(
+			array_filter(
+				array_map(
+					fn ( PushToken $push_token ) => $push_token->get_id(),
+					$push_tokens
+				)
+			)
+		);
+
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
+		$timestamp = gmdate( 'Y-m-d H:i:s' );
+
+		/**
+		 * Both statements interpolate a placeholder list whose length depends on
+		 * the number of tokens. The interpolated strings are built here from
+		 * literals only — never from token data — and every value still travels
+		 * through `$wpdb->prepare()`, which is why the sniffs are suppressed
+		 * below rather than the queries being restructured.
+		 */
+		$id_placeholders  = implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) );
+		$row_placeholders = implode( ', ', array_fill( 0, count( $post_ids ), '( %d, %s, %s )' ) );
+
+		$insert_args = array();
+
+		foreach ( $post_ids as $post_id ) {
+			$insert_args[] = $post_id;
+			$insert_args[] = self::LAST_SEND_AT_META_KEY;
+			$insert_args[] = $timestamp;
+		}
+
+		try {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN ( $id_placeholders )",
+					array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
+				)
+			);
+
+			$inserted = $wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES $row_placeholders",
+					$insert_args
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+			// The rows were written behind the meta API's back, so the cached
+			// meta for these posts is now stale and must be dropped.
+			wp_cache_delete_multiple( $post_ids, 'post_meta' );
+
+			if ( false === $inserted ) {
+				wc_get_logger()->warning(
+					'Failed to record last send time for push tokens.',
+					array(
+						'token_ids' => $post_ids,
+						'error'     => $wpdb->last_error,
+					)
+				);
+			}
+		} catch ( Exception $e ) {
+			wc_get_logger()->warning(
+				'Failed to record last send time for push tokens.',
+				array(
+					'token_ids' => $post_ids,
+					'error'     => $e->getMessage(),
+				)
+			);
+		}//end try
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenInvali
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
 use Automattic\WooCommerce\Internal\PushNotifications\PushNotifications;
 use Exception;
+use Throwable;
 use WC_Data_Exception;
 use WP_Http;
 use WP_Query;
@@ -550,7 +551,11 @@ class PushTokensDataStore {
 		foreach ( array_chunk( $pending, self::LAST_SEND_CHUNK_SIZE, true ) as $chunk ) {
 			try {
 				$this->write_last_send_chunk( $chunk );
-			} catch ( Exception $e ) {
+			} catch ( Throwable $e ) {
+				// Throwable, not Exception. `action_scheduler_after_execute`
+				// fires between the action running and `mark_complete()`, inside
+				// the runner's own Throwable catch, so an Error escaping here
+				// would record a delivered notification's action as failed.
 				wc_get_logger()->warning(
 					'Failed to record last send time for push tokens.',
 					array(
@@ -588,32 +593,44 @@ class PushTokensDataStore {
 		 * suppressed rather than the queries being restructured.
 		 */
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$existing = $wpdb->get_col(
-			$wpdb->prepare(
-				sprintf(
-					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %%s AND post_id IN ( %s )",
-					implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) )
-				),
-				array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
-			)
+		$select = $wpdb->prepare(
+			sprintf(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %%s AND post_id IN ( %s )",
+				implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) )
+			),
+			array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
 		);
 
-		// `get_col()` returns an empty array when the query fails as well as
-		// when nothing matched, and reading that as "no rows exist" would
-		// insert duplicates `wp_postmeta` has no unique key to prevent.
-		if ( '' !== $wpdb->last_error ) {
-			wc_get_logger()->warning(
-				'Could not read existing push token send stamps, skipping chunk.',
-				array(
-					'token_ids' => $post_ids,
-					'error'     => $wpdb->last_error,
+		// `prepare()` returns null on a placeholder mismatch, and `get_col()`
+		// would then skip the query and read `last_result` from whatever ran
+		// before, so the check cannot wait until after the read.
+		if ( ! is_string( $select ) || '' === $select ) {
+			$this->warn_last_send_not_recorded( $post_ids, 'Could not build the query to read existing stamps, skipping chunk.' );
+
+			return;
+		}
+
+		// Run the statement rather than using `get_col()`, whose empty array
+		// means both "nothing matched" and "the read failed". Taking a failed
+		// read as "no rows exist" would insert duplicates that `wp_postmeta`
+		// has no unique key to prevent. `last_error` alone cannot be trusted
+		// either: `wpdb::query()` returns false before it clears the previous
+		// error when the `query` filter empties the statement.
+		$rows = $wpdb->query( $select );
+
+		if ( false === $rows ) {
+			$this->warn_last_send_not_recorded(
+				$post_ids,
+				sprintf(
+					'Could not read existing stamps, skipping chunk. %s',
+					'' !== $wpdb->last_error ? $wpdb->last_error : 'The query did not run.'
 				)
 			);
 
 			return;
 		}
 
-		$existing = array_map( 'intval', (array) $existing );
+		$existing = array_map( 'intval', wp_list_pluck( (array) $wpdb->last_result, 'post_id' ) );
 
 		// Tokens sent at the same moment share an UPDATE, so this is usually
 		// one query, without giving a token another's send time when a request
@@ -670,14 +687,37 @@ class PushTokensDataStore {
 	}
 
 	/**
-	 * Runs a prepared statement, logging rather than throwing when it fails.
+	 * Logs that last-send stamps could not be recorded.
 	 *
-	 * @param string $query    The prepared SQL.
-	 * @param int[]  $post_ids The token post IDs the statement covers, for the log context.
+	 * @param int[]  $post_ids The token post IDs affected.
+	 * @param string $error    What went wrong, and what was skipped as a result.
 	 * @return void
 	 */
-	private function query_or_warn( string $query, array $post_ids ): void {
+	private function warn_last_send_not_recorded( array $post_ids, string $error ): void {
+		wc_get_logger()->warning(
+			'Could not record last send time for push tokens.',
+			array(
+				'token_ids' => $post_ids,
+				'error'     => $error,
+			)
+		);
+	}
+
+	/**
+	 * Runs a prepared statement, logging rather than throwing when it fails.
+	 *
+	 * @param string|null $query    The prepared SQL, or null if `prepare()` failed.
+	 * @param int[]       $post_ids The token post IDs the statement covers, for the log context.
+	 * @return void
+	 */
+	private function query_or_warn( ?string $query, array $post_ids ): void {
 		global $wpdb;
+
+		if ( ! is_string( $query ) || '' === $query ) {
+			$this->warn_last_send_not_recorded( $post_ids, 'Could not build the query to write stamps.' );
+
+			return;
+		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( false !== $wpdb->query( $query ) ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -534,8 +534,10 @@ class PushTokensDataStore {
 	 * @return void
 	 */
 	public function flush_last_sent_at(): void {
-		// Lets a later `record_last_sent_at()` re-assert both hooks. They stay
-		// registered either way, and `add_action()` is idempotent here.
+		// Lets a later `record_last_sent_at()` re-assert the Action Scheduler
+		// hook, which fires once per action. It cannot re-arm `shutdown`:
+		// WP_Hook iterates a copy of its callbacks, so a stamp recorded during
+		// shutdown after this ran is dropped. No path does that today.
 		$this->last_sent_at_flush_registered = false;
 
 		if ( empty( $this->pending_last_sent_at ) ) {
@@ -559,9 +561,9 @@ class PushTokensDataStore {
 				wc_get_logger()->warning(
 					'Failed to record last sent time for push tokens.',
 					array(
-						'source'    => PushNotifications::FEATURE_NAME,
-						'token_ids' => array_keys( $chunk ),
-						'error'     => $e->getMessage(),
+						'source'      => PushNotifications::FEATURE_NAME,
+						'token_count' => count( $chunk ),
+						'error'       => $e->getMessage(),
 					)
 				);
 			}
@@ -698,9 +700,9 @@ class PushTokensDataStore {
 		wc_get_logger()->warning(
 			'Could not record last sent time for push tokens.',
 			array(
-				'source'    => PushNotifications::FEATURE_NAME,
-				'token_ids' => $post_ids,
-				'error'     => $error,
+				'source'      => PushNotifications::FEATURE_NAME,
+				'token_count' => count( $post_ids ),
+				'error'       => $error,
 			)
 		);
 	}
@@ -729,9 +731,9 @@ class PushTokensDataStore {
 		wc_get_logger()->warning(
 			'Failed to record last sent time for push tokens.',
 			array(
-				'source'    => PushNotifications::FEATURE_NAME,
-				'token_ids' => $post_ids,
-				'error'     => $wpdb->last_error,
+				'source'      => PushNotifications::FEATURE_NAME,
+				'token_count' => count( $post_ids ),
+				'error'       => $wpdb->last_error,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -37,32 +37,32 @@ class PushTokensDataStore {
 	/**
 	 * Buffered last-send stamps awaiting a write, as token post ID => GMT
 	 * datetime. Holds the most recent time recorded for each token this
-	 * request. Flushed by {@see self::flush_last_send()} on shutdown.
+	 * request. Flushed by {@see self::flush_last_sent_at()} on shutdown.
 	 *
 	 * @var array<int, string>
 	 */
-	private array $pending_last_send = array();
+	private array $pending_last_sent_at = array();
 
 	/**
-	 * Whether the shutdown flush for `$pending_last_send` has been registered.
+	 * Whether the shutdown flush for `$pending_last_sent_at` has been registered.
 	 *
 	 * @var bool
 	 */
-	private bool $last_send_flush_registered = false;
+	private bool $last_sent_at_flush_registered = false;
 
 	/**
 	 * How many tokens to write per statement when flushing last-send stamps.
 	 */
-	const LAST_SEND_CHUNK_SIZE = 100;
+	const LAST_SENT_AT_CHUNK_SIZE = 100;
 
 	/**
 	 * Meta key holding the GMT datetime of the last successful send to WPCOM.
 	 *
 	 * Deliberately absent from `build_meta_array_from_token()`: it is written
-	 * only by `record_last_send()`, so an unrelated token update (e.g. the app
+	 * only by `record_last_sent_at()`, so an unrelated token update (e.g. the app
 	 * re-registering with a new locale) cannot clobber it.
 	 */
-	const LAST_SEND_AT_META_KEY = 'last_send_at_gmt';
+	const LAST_SENT_AT_META_KEY = 'last_sent_at_gmt';
 
 	const SUPPORTED_META = array(
 		'origin',
@@ -71,7 +71,7 @@ class PushTokensDataStore {
 		'platform',
 		'device_locale',
 		'metadata',
-		self::LAST_SEND_AT_META_KEY,
+		self::LAST_SENT_AT_META_KEY,
 	);
 
 	/**
@@ -162,7 +162,7 @@ class PushTokensDataStore {
 		 */
 		$push_token->set_device_locale( $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE );
 		$push_token->set_metadata( $meta['metadata'] ?? array() );
-		$push_token->set_last_send_at_gmt( $meta[ self::LAST_SEND_AT_META_KEY ] ?? null );
+		$push_token->set_last_sent_at_gmt( $meta[ self::LAST_SENT_AT_META_KEY ] ?? null );
 
 		/**
 		 * Both timestamps come from the post record rather than meta, because
@@ -346,7 +346,7 @@ class PushTokensDataStore {
 						 */
 						'device_locale'    => $meta['device_locale'] ?? PushToken::DEFAULT_DEVICE_LOCALE,
 						'metadata'         => $meta['metadata'] ?? array(),
-						'last_send_at_gmt' => $meta[ self::LAST_SEND_AT_META_KEY ] ?? null,
+						'last_sent_at_gmt' => $meta[ self::LAST_SENT_AT_META_KEY ] ?? null,
 					)
 				);
 			}
@@ -494,29 +494,29 @@ class PushTokensDataStore {
 	 * @param PushToken[] $push_tokens The tokens WPCOM accepted.
 	 * @return void
 	 */
-	public function record_last_send( array $push_tokens ): void {
+	public function record_last_sent_at( array $push_tokens ): void {
 		$timestamp = gmdate( 'Y-m-d H:i:s' );
 
 		foreach ( $push_tokens as $push_token ) {
 			$id = $push_token->get_id();
 
 			if ( $id ) {
-				$this->pending_last_send[ $id ] = $timestamp;
+				$this->pending_last_sent_at[ $id ] = $timestamp;
 			}
 		}
 
-		if ( empty( $this->pending_last_send ) || $this->last_send_flush_registered ) {
+		if ( empty( $this->pending_last_sent_at ) || $this->last_sent_at_flush_registered ) {
 			return;
 		}
 
-		add_action( 'shutdown', array( $this, 'flush_last_send' ) );
+		add_action( 'shutdown', array( $this, 'flush_last_sent_at' ) );
 
 		// The safety net and retry jobs run under an Action Scheduler queue
 		// runner, which is routinely killed on a time limit. Shutdown functions
 		// do not run on a kill, so flush after each action as well.
-		add_action( 'action_scheduler_after_execute', array( $this, 'flush_last_send' ) );
+		add_action( 'action_scheduler_after_execute', array( $this, 'flush_last_sent_at' ) );
 
-		$this->last_send_flush_registered = true;
+		$this->last_sent_at_flush_registered = true;
 	}
 
 	/**
@@ -533,32 +533,33 @@ class PushTokensDataStore {
 	 *
 	 * @return void
 	 */
-	public function flush_last_send(): void {
-		// Lets a later `record_last_send()` re-assert both hooks. They stay
+	public function flush_last_sent_at(): void {
+		// Lets a later `record_last_sent_at()` re-assert both hooks. They stay
 		// registered either way, and `add_action()` is idempotent here.
-		$this->last_send_flush_registered = false;
+		$this->last_sent_at_flush_registered = false;
 
-		if ( empty( $this->pending_last_send ) ) {
+		if ( empty( $this->pending_last_sent_at ) ) {
 			return;
 		}
 
-		$pending                 = $this->pending_last_send;
-		$this->pending_last_send = array();
+		$pending                    = $this->pending_last_sent_at;
+		$this->pending_last_sent_at = array();
 
 		// Chunked so neither the `IN` list nor the number of placeholders handed
 		// to `$wpdb->prepare()` grows with the number of registered devices. A
 		// large `IN` list can also push the optimizer off the `post_id` index.
-		foreach ( array_chunk( $pending, self::LAST_SEND_CHUNK_SIZE, true ) as $chunk ) {
+		foreach ( array_chunk( $pending, self::LAST_SENT_AT_CHUNK_SIZE, true ) as $chunk ) {
 			try {
-				$this->write_last_send_chunk( $chunk );
+				$this->write_last_sent_at_chunk( $chunk );
 			} catch ( Throwable $e ) {
 				// Throwable, not Exception. `action_scheduler_after_execute`
 				// fires between the action running and `mark_complete()`, inside
 				// the runner's own Throwable catch, so an Error escaping here
 				// would record a delivered notification's action as failed.
 				wc_get_logger()->warning(
-					'Failed to record last send time for push tokens.',
+					'Failed to record last sent time for push tokens.',
 					array(
+						'source'    => PushNotifications::FEATURE_NAME,
 						'token_ids' => array_keys( $chunk ),
 						'error'     => $e->getMessage(),
 					)
@@ -580,7 +581,7 @@ class PushTokensDataStore {
 	 * @param array<int, string> $chunk Map of token post ID to GMT datetime.
 	 * @return void
 	 */
-	private function write_last_send_chunk( array $chunk ): void {
+	private function write_last_sent_at_chunk( array $chunk ): void {
 		global $wpdb;
 
 		$post_ids = array_keys( $chunk );
@@ -598,14 +599,14 @@ class PushTokensDataStore {
 				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %%s AND post_id IN ( %s )",
 				implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) )
 			),
-			array_merge( array( self::LAST_SEND_AT_META_KEY ), $post_ids )
+			array_merge( array( self::LAST_SENT_AT_META_KEY ), $post_ids )
 		);
 
 		// `prepare()` returns null on a placeholder mismatch, and `get_col()`
 		// would then skip the query and read `last_result` from whatever ran
 		// before, so the check cannot wait until after the read.
 		if ( ! is_string( $select ) || '' === $select ) {
-			$this->warn_last_send_not_recorded( $post_ids, 'Could not build the query to read existing stamps, skipping chunk.' );
+			$this->warn_last_sent_at_not_recorded( $post_ids, 'Could not build the query to read existing stamps, skipping chunk.' );
 
 			return;
 		}
@@ -619,7 +620,7 @@ class PushTokensDataStore {
 		$rows = $wpdb->query( $select );
 
 		if ( false === $rows ) {
-			$this->warn_last_send_not_recorded(
+			$this->warn_last_sent_at_not_recorded(
 				$post_ids,
 				sprintf(
 					'Could not read existing stamps, skipping chunk. %s',
@@ -652,7 +653,7 @@ class PushTokensDataStore {
 							"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND post_id IN ( %s )",
 							implode( ', ', array_fill( 0, count( $update_ids ), '%d' ) )
 						),
-						array_merge( array( $timestamp, self::LAST_SEND_AT_META_KEY ), $update_ids )
+						array_merge( array( $timestamp, self::LAST_SENT_AT_META_KEY ), $update_ids )
 					),
 					$update_ids
 				);
@@ -663,7 +664,7 @@ class PushTokensDataStore {
 
 				foreach ( $insert_ids as $post_id ) {
 					$insert_args[] = $post_id;
-					$insert_args[] = self::LAST_SEND_AT_META_KEY;
+					$insert_args[] = self::LAST_SENT_AT_META_KEY;
 					$insert_args[] = $timestamp;
 				}
 
@@ -693,10 +694,11 @@ class PushTokensDataStore {
 	 * @param string $error    What went wrong, and what was skipped as a result.
 	 * @return void
 	 */
-	private function warn_last_send_not_recorded( array $post_ids, string $error ): void {
+	private function warn_last_sent_at_not_recorded( array $post_ids, string $error ): void {
 		wc_get_logger()->warning(
-			'Could not record last send time for push tokens.',
+			'Could not record last sent time for push tokens.',
 			array(
+				'source'    => PushNotifications::FEATURE_NAME,
 				'token_ids' => $post_ids,
 				'error'     => $error,
 			)
@@ -714,7 +716,7 @@ class PushTokensDataStore {
 		global $wpdb;
 
 		if ( ! is_string( $query ) || '' === $query ) {
-			$this->warn_last_send_not_recorded( $post_ids, 'Could not build the query to write stamps.' );
+			$this->warn_last_sent_at_not_recorded( $post_ids, 'Could not build the query to write stamps.' );
 
 			return;
 		}
@@ -725,8 +727,9 @@ class PushTokensDataStore {
 		}
 
 		wc_get_logger()->warning(
-			'Failed to record last send time for push tokens.',
+			'Failed to record last sent time for push tokens.',
 			array(
+				'source'    => PushNotifications::FEATURE_NAME,
 				'token_ids' => $post_ids,
 				'error'     => $wpdb->last_error,
 			)

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -604,9 +604,8 @@ class PushTokensDataStore {
 			array_merge( array( self::LAST_SENT_AT_META_KEY ), $post_ids )
 		);
 
-		// `prepare()` returns null on a placeholder mismatch, and `get_col()`
-		// would then skip the query and read `last_result` from whatever ran
-		// before, so the check cannot wait until after the read.
+		// Checked before the read, not after: a null here would leave
+		// `last_result` holding whatever ran previously.
 		if ( ! is_string( $select ) || '' === $select ) {
 			$this->warn_last_sent_at_not_recorded( $post_ids, 'Could not build the query to read existing stamps, skipping chunk.' );
 
@@ -649,16 +648,19 @@ class PushTokensDataStore {
 			$insert_ids = array_values( array_diff( $ids, $existing ) );
 
 			if ( ! empty( $update_ids ) ) {
-				$this->query_or_warn(
-					$wpdb->prepare(
-						sprintf(
-							"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND post_id IN ( %s )",
-							implode( ', ', array_fill( 0, count( $update_ids ), '%d' ) )
-						),
-						array_merge( array( $timestamp, self::LAST_SENT_AT_META_KEY ), $update_ids )
+				$update = $wpdb->prepare(
+					sprintf(
+						"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND post_id IN ( %s )",
+						implode( ', ', array_fill( 0, count( $update_ids ), '%d' ) )
 					),
-					$update_ids
+					array_merge( array( $timestamp, self::LAST_SENT_AT_META_KEY ), $update_ids )
 				);
+
+				if ( ! is_string( $update ) || '' === $update ) {
+					$this->warn_last_sent_at_not_recorded( $update_ids, 'Could not build the update statement.' );
+				} elseif ( false === $wpdb->query( $update ) ) {
+					$this->warn_last_sent_at_not_recorded( $update_ids, $wpdb->last_error );
+				}
 			}
 
 			if ( ! empty( $insert_ids ) ) {
@@ -670,16 +672,19 @@ class PushTokensDataStore {
 					$insert_args[] = $timestamp;
 				}
 
-				$this->query_or_warn(
-					$wpdb->prepare(
-						sprintf(
-							"INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES %s",
-							implode( ', ', array_fill( 0, count( $insert_ids ), '( %d, %s, %s )' ) )
-						),
-						$insert_args
+				$insert = $wpdb->prepare(
+					sprintf(
+						"INSERT INTO {$wpdb->postmeta} ( post_id, meta_key, meta_value ) VALUES %s",
+						implode( ', ', array_fill( 0, count( $insert_ids ), '( %d, %s, %s )' ) )
 					),
-					$insert_ids
+					$insert_args
 				);
+
+				if ( ! is_string( $insert ) || '' === $insert ) {
+					$this->warn_last_sent_at_not_recorded( $insert_ids, 'Could not build the insert statement.' );
+				} elseif ( false === $wpdb->query( $insert ) ) {
+					$this->warn_last_sent_at_not_recorded( $insert_ids, $wpdb->last_error );
+				}
 			}
 		}
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -703,37 +708,6 @@ class PushTokensDataStore {
 				'source'      => PushNotifications::FEATURE_NAME,
 				'token_count' => count( $post_ids ),
 				'error'       => $error,
-			)
-		);
-	}
-
-	/**
-	 * Runs a prepared statement, logging rather than throwing when it fails.
-	 *
-	 * @param string|null $query    The prepared SQL, or null if `prepare()` failed.
-	 * @param int[]       $post_ids The token post IDs the statement covers, for the log context.
-	 * @return void
-	 */
-	private function query_or_warn( ?string $query, array $post_ids ): void {
-		global $wpdb;
-
-		if ( ! is_string( $query ) || '' === $query ) {
-			$this->warn_last_sent_at_not_recorded( $post_ids, 'Could not build the query to write stamps.' );
-
-			return;
-		}
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( false !== $wpdb->query( $query ) ) {
-			return;
-		}
-
-		wc_get_logger()->warning(
-			'Failed to record last sent time for push tokens.',
-			array(
-				'source'      => PushNotifications::FEATURE_NAME,
-				'token_count' => count( $post_ids ),
-				'error'       => $wpdb->last_error,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -648,12 +648,17 @@ class PushTokensDataStore {
 			$insert_ids = array_values( array_diff( $ids, $existing ) );
 
 			if ( ! empty( $update_ids ) ) {
+				// Advance-only. Each request captures its timestamp when it
+				// dispatches and writes it on shutdown, so a slow request can
+				// reach this after a later one has already written a newer
+				// value. `Y-m-d H:i:s` compares lexicographically in date
+				// order, and a zero-row match returns 0 rather than false.
 				$update = $wpdb->prepare(
 					sprintf(
-						"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND post_id IN ( %s )",
+						"UPDATE {$wpdb->postmeta} SET meta_value = %%s WHERE meta_key = %%s AND meta_value < %%s AND post_id IN ( %s )",
 						implode( ', ', array_fill( 0, count( $update_ids ), '%d' ) )
 					),
-					array_merge( array( $timestamp, self::LAST_SENT_AT_META_KEY ), $update_ids )
+					array_merge( array( $timestamp, self::LAST_SENT_AT_META_KEY, $timestamp ), $update_ids )
 				);
 
 				if ( ! is_string( $update ) || '' === $update ) {

--- a/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/DataStores/PushTokensDataStore.php
@@ -558,14 +558,7 @@ class PushTokensDataStore {
 				// fires between the action running and `mark_complete()`, inside
 				// the runner's own Throwable catch, so an Error escaping here
 				// would record a delivered notification's action as failed.
-				wc_get_logger()->warning(
-					'Failed to record last sent time for push tokens.',
-					array(
-						'source'      => PushNotifications::FEATURE_NAME,
-						'token_count' => count( $chunk ),
-						'error'       => $e->getMessage(),
-					)
-				);
+				$this->warn_last_sent_at_not_recorded( array_keys( $chunk ), $e->getMessage() );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -181,6 +181,13 @@ class PushToken {
 	private ?string $last_confirmed_at_gmt = null;
 
 	/**
+	 * The date the token was last sent to WPCOM, as an RFC3339 string in UTC (offset `+00:00`).
+	 *
+	 * @var string|null
+	 */
+	private ?string $last_send_at_gmt = null;
+
+	/**
 	 * Creates a new PushToken instance with the given data.
 	 *
 	 * @param array $data Optional array with keys: id, user_id, token, device_uuid, platform, origin.
@@ -227,6 +234,10 @@ class PushToken {
 
 		if ( array_key_exists( 'last_confirmed_at_gmt', $data ) ) {
 			$this->set_last_confirmed_at_gmt( null === $data['last_confirmed_at_gmt'] ? null : (string) $data['last_confirmed_at_gmt'] );
+		}
+
+		if ( array_key_exists( 'last_send_at_gmt', $data ) ) {
+			$this->set_last_send_at_gmt( null === $data['last_send_at_gmt'] ? null : (string) $data['last_send_at_gmt'] );
 		}
 	}
 
@@ -439,6 +450,20 @@ class PushToken {
 	}
 
 	/**
+	 * Sets the date this token was last sent to WPCOM.
+	 *
+	 * See {@see self::set_created_at_gmt()} for why this bypasses validation.
+	 *
+	 * @param string|null $last_send_at_gmt A GMT `Y-m-d H:i:s` datetime, or null if never sent.
+	 * @return void
+	 *
+	 * @since 11.2.0
+	 */
+	public function set_last_send_at_gmt( ?string $last_send_at_gmt ): void {
+		$this->last_send_at_gmt = $this->validate_gmt_datetime( $last_send_at_gmt );
+	}
+
+	/**
 	 * Returns a GMT datetime as `Y-m-d H:i:s`, or null if it is not one.
 	 *
 	 * @param string|null $datetime The GMT datetime string.
@@ -592,6 +617,22 @@ class PushToken {
 	}
 
 	/**
+	 * Gets the date this token was last sent to WPCOM, as an RFC3339 string in
+	 * UTC, or null if it has never been sent.
+	 *
+	 * This records that WPCOM accepted a payload containing the token. It is
+	 * not a delivery receipt: what happens between WPCOM and the device is
+	 * downstream of anything this plugin can observe.
+	 *
+	 * @return string|null
+	 *
+	 * @since 11.2.0
+	 */
+	public function get_last_send_at_gmt(): ?string {
+		return $this->last_send_at_gmt;
+	}
+
+	/**
 	 * Returns this token formatted for the WPCOM push notifications endpoint.
 	 *
 	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null}
@@ -617,7 +658,7 @@ class PushToken {
 	 * Metadata is cast to an object so that an empty value encodes as `{}` rather
 	 * than `[]`, matching the `object` type the schema declares for it.
 	 *
-	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null, id: int|null, device_uuid: string|null, platform: string|null, metadata: stdClass, created_at_gmt: string|null, last_confirmed_at_gmt: string|null}
+	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null, id: int|null, device_uuid: string|null, platform: string|null, metadata: stdClass, created_at_gmt: string|null, last_confirmed_at_gmt: string|null, last_send_at_gmt: string|null}
 	 *
 	 * @since 11.2.0
 	 */
@@ -631,6 +672,7 @@ class PushToken {
 				'metadata'              => (object) ( $this->metadata ?? array() ),
 				'created_at_gmt'        => $this->to_rest_datetime( $this->created_at_gmt ),
 				'last_confirmed_at_gmt' => $this->to_rest_datetime( $this->last_confirmed_at_gmt ),
+				'last_send_at_gmt'      => $this->to_rest_datetime( $this->last_send_at_gmt ),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -618,7 +618,7 @@ class PushToken {
 
 	/**
 	 * Gets the date this token was last sent to WPCOM, as an RFC3339 string in
-	 * UTC, or null if it has never been sent.
+	 * UTC (offset `+00:00`), or null if it has never been sent.
 	 *
 	 * This records that WPCOM accepted a payload containing the token. It is
 	 * not a delivery receipt: what happens between WPCOM and the device is

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -185,7 +185,7 @@ class PushToken {
 	 *
 	 * @var string|null
 	 */
-	private ?string $last_send_at_gmt = null;
+	private ?string $last_sent_at_gmt = null;
 
 	/**
 	 * Creates a new PushToken instance with the given data.
@@ -236,8 +236,8 @@ class PushToken {
 			$this->set_last_confirmed_at_gmt( null === $data['last_confirmed_at_gmt'] ? null : (string) $data['last_confirmed_at_gmt'] );
 		}
 
-		if ( array_key_exists( 'last_send_at_gmt', $data ) ) {
-			$this->set_last_send_at_gmt( null === $data['last_send_at_gmt'] ? null : (string) $data['last_send_at_gmt'] );
+		if ( array_key_exists( 'last_sent_at_gmt', $data ) ) {
+			$this->set_last_sent_at_gmt( null === $data['last_sent_at_gmt'] ? null : (string) $data['last_sent_at_gmt'] );
 		}
 	}
 
@@ -454,13 +454,13 @@ class PushToken {
 	 *
 	 * See {@see self::set_created_at_gmt()} for why this bypasses validation.
 	 *
-	 * @param string|null $last_send_at_gmt A GMT `Y-m-d H:i:s` datetime, or null if never sent.
+	 * @param string|null $last_sent_at_gmt A GMT `Y-m-d H:i:s` datetime, or null if never sent.
 	 * @return void
 	 *
 	 * @since 11.2.0
 	 */
-	public function set_last_send_at_gmt( ?string $last_send_at_gmt ): void {
-		$this->last_send_at_gmt = $this->validate_gmt_datetime( $last_send_at_gmt );
+	public function set_last_sent_at_gmt( ?string $last_sent_at_gmt ): void {
+		$this->last_sent_at_gmt = $this->validate_gmt_datetime( $last_sent_at_gmt );
 	}
 
 	/**
@@ -628,8 +628,8 @@ class PushToken {
 	 *
 	 * @since 11.2.0
 	 */
-	public function get_last_send_at_gmt(): ?string {
-		return $this->last_send_at_gmt;
+	public function get_last_sent_at_gmt(): ?string {
+		return $this->last_sent_at_gmt;
 	}
 
 	/**
@@ -658,7 +658,7 @@ class PushToken {
 	 * Metadata is cast to an object so that an empty value encodes as `{}` rather
 	 * than `[]`, matching the `object` type the schema declares for it.
 	 *
-	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null, id: int|null, device_uuid: string|null, platform: string|null, metadata: stdClass, created_at_gmt: string|null, last_confirmed_at_gmt: string|null, last_send_at_gmt: string|null}
+	 * @return array{user_id: int|null, token: string|null, origin: string|null, device_locale: string|null, id: int|null, device_uuid: string|null, platform: string|null, metadata: stdClass, created_at_gmt: string|null, last_confirmed_at_gmt: string|null, last_sent_at_gmt: string|null}
 	 *
 	 * @since 11.2.0
 	 */
@@ -672,7 +672,7 @@ class PushToken {
 				'metadata'              => (object) ( $this->metadata ?? array() ),
 				'created_at_gmt'        => $this->to_rest_datetime( $this->created_at_gmt ),
 				'last_confirmed_at_gmt' => $this->to_rest_datetime( $this->last_confirmed_at_gmt ),
-				'last_send_at_gmt'      => $this->to_rest_datetime( $this->last_send_at_gmt ),
+				'last_sent_at_gmt'      => $this->to_rest_datetime( $this->last_sent_at_gmt ),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Entities/PushToken.php
@@ -181,7 +181,7 @@ class PushToken {
 	private ?string $last_confirmed_at_gmt = null;
 
 	/**
-	 * The date the token was last sent to WPCOM, as an RFC3339 string in UTC (offset `+00:00`).
+	 * The date the token was last sent to WPCOM, as a GMT `Y-m-d H:i:s` string.
 	 *
 	 * @var string|null
 	 */
@@ -617,8 +617,8 @@ class PushToken {
 	}
 
 	/**
-	 * Gets the date this token was last sent to WPCOM, as an RFC3339 string in
-	 * UTC (offset `+00:00`), or null if it has never been sent.
+	 * Gets the date this token was last sent to WPCOM, as a GMT `Y-m-d H:i:s`
+	 * string, or null if it has never been sent.
 	 *
 	 * This records that WPCOM accepted a payload containing the token. It is
 	 * not a delivery receipt: what happens between WPCOM and the device is

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -177,6 +177,15 @@ class NotificationProcessor {
 		$result = $this->dispatcher->dispatch( $notification, $tokens );
 
 		if ( ! empty( $result['success'] ) ) {
+			/**
+			 * Stamped only on success, so the value reads unambiguously as
+			 * "WPCOM accepted a payload containing this token" — which is what
+			 * makes it useful for telling "we never targeted this device" apart
+			 * from "we targeted it and it didn't arrive" when diagnosing a
+			 * missing notification.
+			 */
+			$this->data_store->record_last_send( $tokens );
+
 			$notification->write_meta( self::SENT_META_KEY );
 			$notification->delete_meta( self::CLAIMED_META_KEY );
 			$this->cancel_safety_net( $notification );

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -184,7 +184,7 @@ class NotificationProcessor {
 			 * from "we targeted it and it didn't arrive" when diagnosing a
 			 * missing notification.
 			 */
-			$this->data_store->record_last_send( $tokens );
+			$this->data_store->record_last_sent_at( $tokens );
 
 			$notification->write_meta( self::SENT_META_KEY );
 			$notification->delete_meta( self::CLAIMED_META_KEY );

--- a/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
+++ b/plugins/woocommerce/src/Internal/PushNotifications/Services/NotificationProcessor.php
@@ -177,13 +177,7 @@ class NotificationProcessor {
 		$result = $this->dispatcher->dispatch( $notification, $tokens );
 
 		if ( ! empty( $result['success'] ) ) {
-			/**
-			 * Stamped only on success, so the value reads unambiguously as
-			 * "WPCOM accepted a payload containing this token" — which is what
-			 * makes it useful for telling "we never targeted this device" apart
-			 * from "we targeted it and it didn't arrive" when diagnosing a
-			 * missing notification.
-			 */
+			// Success only, for the reason {@see PushToken::get_last_sent_at_gmt()} gives.
 			$this->data_store->record_last_sent_at( $tokens );
 
 			$notification->write_meta( self::SENT_META_KEY );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1704,6 +1704,50 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should return the last send time for a sent token and null for an unsent one.
+	 */
+	public function test_index_returns_token_last_send_time(): void {
+		$this->mock_jetpack_connection_manager_is_connected();
+		wc_get_container()->get( PushNotifications::class )->on_init();
+
+		$data_store = wc_get_container()->get( PushTokensDataStore::class );
+
+		$sent = $data_store->create(
+			array(
+				'user_id'       => $this->user_id,
+				'token'         => 'last-send-sent-token',
+				'platform'      => PushToken::PLATFORM_APPLE,
+				'device_uuid'   => 'last-send-sent-uuid',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_IOS,
+				'device_locale' => 'en_US',
+			)
+		);
+
+		$data_store->create(
+			array(
+				'user_id'       => $this->user_id,
+				'token'         => 'last-send-unsent-token',
+				'platform'      => PushToken::PLATFORM_ANDROID,
+				'device_uuid'   => 'last-send-unsent-uuid',
+				'origin'        => PushToken::ORIGIN_WOOCOMMERCE_ANDROID,
+				'device_locale' => 'en_US',
+			)
+		);
+
+		$data_store->record_last_send( array( $sent ) );
+
+		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 100 );
+
+		$by_token = array_column( ( new PushTokenRestController() )->index( $request )->get_data()['tokens'], null, 'token' );
+
+		$this->assertArrayHasKey( 'last_send_at_gmt', $by_token['last-send-unsent-token'] );
+		$this->assertNull( $by_token['last-send-unsent-token']['last_send_at_gmt'] );
+		$this->assertNotNull( $by_token['last-send-sent-token']['last_send_at_gmt'] );
+	}
+
+	/**
 	 * @testdox Should return empty tokens array from the tokens endpoint when no tokens exist.
 	 */
 	public function test_index_returns_empty_when_no_tokens(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1735,6 +1735,7 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 		);
 
 		$data_store->record_last_send( array( $sent ) );
+		$data_store->flush_last_send();
 
 		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
 		$request->set_param( 'page', 1 );

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1234,6 +1234,7 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 				'metadata',
 				'created_at_gmt',
 				'last_confirmed_at_gmt',
+				'last_send_at_gmt',
 			),
 			array_keys( $schema['properties'] )
 		);
@@ -1508,6 +1509,7 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 				'metadata',
 				'created_at_gmt',
 				'last_confirmed_at_gmt',
+				'last_send_at_gmt',
 			),
 			array_keys( $fields )
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/PushTokenRestControllerTest.php
@@ -1234,7 +1234,7 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 				'metadata',
 				'created_at_gmt',
 				'last_confirmed_at_gmt',
-				'last_send_at_gmt',
+				'last_sent_at_gmt',
 			),
 			array_keys( $schema['properties'] )
 		);
@@ -1509,7 +1509,7 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 				'metadata',
 				'created_at_gmt',
 				'last_confirmed_at_gmt',
-				'last_send_at_gmt',
+				'last_sent_at_gmt',
 			),
 			array_keys( $fields )
 		);
@@ -1706,9 +1706,9 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should return the last send time for a sent token and null for an unsent one.
+	 * @testdox Should return the last sent time for a sent token and null for an unsent one.
 	 */
-	public function test_index_returns_token_last_send_time(): void {
+	public function test_index_returns_token_last_sent_at_time(): void {
 		$this->mock_jetpack_connection_manager_is_connected();
 		wc_get_container()->get( PushNotifications::class )->on_init();
 
@@ -1736,8 +1736,8 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$data_store->record_last_send( array( $sent ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $sent ) );
+		$data_store->flush_last_sent_at();
 
 		$request = new WP_REST_Request( 'GET', '/wc-push-notifications/push-tokens' );
 		$request->set_param( 'page', 1 );
@@ -1745,9 +1745,9 @@ class PushTokenRestControllerTest extends WC_Unit_Test_Case {
 
 		$by_token = array_column( ( new PushTokenRestController() )->index( $request )->get_data()['tokens'], null, 'token' );
 
-		$this->assertArrayHasKey( 'last_send_at_gmt', $by_token['last-send-unsent-token'] );
-		$this->assertNull( $by_token['last-send-unsent-token']['last_send_at_gmt'] );
-		$this->assertNotNull( $by_token['last-send-sent-token']['last_send_at_gmt'] );
+		$this->assertArrayHasKey( 'last_sent_at_gmt', $by_token['last-send-unsent-token'] );
+		$this->assertNull( $by_token['last-send-unsent-token']['last_sent_at_gmt'] );
+		$this->assertNotNull( $by_token['last-send-sent-token']['last_sent_at_gmt'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -1004,6 +1004,114 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Tests a token has no last send time until it has actually been sent.
+	 */
+	public function test_last_send_at_is_null_for_a_token_that_has_never_been_sent() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests recording a send stamps every supplied token with the same time.
+	 */
+	public function test_record_last_send_stamps_all_supplied_tokens() {
+		$data_store = new PushTokensDataStore();
+		$first      = $this->create_test_push_token();
+		$second     = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $first, $second ) );
+
+		$first_send_at  = $data_store->read( $first->get_id() )->get_last_send_at_gmt();
+		$second_send_at = $data_store->read( $second->get_id() )->get_last_send_at_gmt();
+
+		$this->assertNotNull( $first_send_at );
+		$this->assertSame( $first_send_at, $second_send_at );
+	}
+
+	/**
+	 * @testdox Tests recording a send twice replaces the stamp rather than accumulating rows.
+	 *
+	 * The batched write bypasses the meta API, so it has to leave exactly one
+	 * row per token behind — a duplicate would make `get_post_meta( …, true )`
+	 * return an arbitrary one of them.
+	 */
+	public function test_record_last_send_replaces_the_previous_stamp() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->record_last_send( array( $push_token ) );
+
+		$row_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$push_token->get_id(),
+				PushTokensDataStore::LAST_SEND_AT_META_KEY
+			)
+		);
+
+		$this->assertSame( 1, $row_count );
+	}
+
+	/**
+	 * @testdox Tests recording a send leaves the rest of the token record untouched.
+	 */
+	public function test_record_last_send_does_not_disturb_other_token_data() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$read = $data_store->read( $push_token->get_id() );
+
+		$this->assertSame( $push_token->get_token(), $read->get_token() );
+		$this->assertSame( $push_token->get_device_uuid(), $read->get_device_uuid() );
+		$this->assertSame( $push_token->get_device_locale(), $read->get_device_locale() );
+		$this->assertSame( $push_token->get_metadata(), $read->get_metadata() );
+	}
+
+	/**
+	 * @testdox Tests updating a token preserves its last send time.
+	 *
+	 * The app re-registers a device whenever its locale or metadata changes,
+	 * which must not wipe the send history that update path knows nothing about.
+	 */
+	public function test_updating_a_token_preserves_its_last_send_time() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$recorded = $data_store->read( $push_token->get_id() )->get_last_send_at_gmt();
+
+		$push_token->set_device_locale( 'fr_FR' );
+		$data_store->update( $push_token );
+
+		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests recording a send with no tokens is a no-op.
+	 */
+	public function test_record_last_send_ignores_an_empty_token_list() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$data_store->record_last_send( array() );
+
+		$row_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = %s",
+				PushTokensDataStore::LAST_SEND_AT_META_KEY
+			)
+		);
+
+		$this->assertSame( 0, $row_count );
+	}
+
+	/**
 	 * Creates a test push token and saves it to the database.
 	 *
 	 * @return PushToken The created push token object.

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -1218,6 +1218,97 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Tests the Action Scheduler hook flushes buffered stamps.
+	 *
+	 * The safety net and retry paths run under a queue runner that can be killed
+	 * before shutdown, so the buffer is also flushed after each action. This
+	 * exists only for a path a hook creates, so nothing else would catch its
+	 * removal.
+	 */
+	public function test_the_action_scheduler_hook_flushes_buffered_stamps() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing Action Scheduler's hook, not declaring one.
+		do_action( 'action_scheduler_after_execute', 1, null, '' );
+
+		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests a failed read of existing stamps does not insert duplicates.
+	 *
+	 * `wpdb::query()` returns false without setting `last_error` when the `query`
+	 * filter empties the statement, so a failed read must not be taken as "no
+	 * rows exist". `wp_postmeta` has no unique key to catch the duplicates that
+	 * would follow.
+	 */
+	public function test_a_failed_read_of_existing_stamps_does_not_insert_duplicates() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
+
+		$empty_the_select = function ( $query ) {
+			return false !== strpos( $query, 'SELECT post_id' ) && false !== strpos( $query, 'last_send_at_gmt' )
+				? ''
+				: $query;
+		};
+
+		add_filter( 'query', $empty_the_select );
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
+		remove_filter( 'query', $empty_the_select );
+
+		$row_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$push_token->get_id(),
+				PushTokensDataStore::LAST_SEND_AT_META_KEY
+			)
+		);
+
+		$this->assertSame( 1, $row_count );
+	}
+
+	/**
+	 * @testdox Tests an error raised while writing stamps does not escape the flush.
+	 *
+	 * The flush runs on `action_scheduler_after_execute`, which fires between an
+	 * action completing and being marked complete, so anything escaping here
+	 * records a delivered notification's action as failed. Errors do not extend
+	 * Exception, which is why the catch is on Throwable.
+	 */
+	public function test_an_error_while_writing_stamps_does_not_escape_the_flush() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$raise_an_error = function ( $query ) {
+			if ( false !== strpos( $query, 'last_send_at_gmt' ) ) {
+				throw new \Error( 'Raised for testing.' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $raise_an_error );
+
+		try {
+			$data_store->record_last_send( array( $push_token ) );
+			$data_store->flush_last_send();
+		} finally {
+			remove_filter( 'query', $raise_an_error );
+		}
+
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
 	 * @testdox Tests recording a send with no tokens is a no-op.
 	 */
 	public function test_record_last_send_ignores_an_empty_token_list() {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -1022,6 +1022,7 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$second     = $this->create_test_push_token();
 
 		$data_store->record_last_send( array( $first, $second ) );
+		$data_store->flush_last_send();
 
 		$first_send_at  = $data_store->read( $first->get_id() )->get_last_send_at_gmt();
 		$second_send_at = $data_store->read( $second->get_id() )->get_last_send_at_gmt();
@@ -1044,7 +1045,9 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$push_token = $this->create_test_push_token();
 
 		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
 		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
@@ -1065,6 +1068,7 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$push_token = $this->create_test_push_token();
 
 		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
 		$read = $data_store->read( $push_token->get_id() );
 
 		$this->assertSame( $push_token->get_token(), $read->get_token() );
@@ -1084,12 +1088,133 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$push_token = $this->create_test_push_token();
 
 		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
 		$recorded = $data_store->read( $push_token->get_id() )->get_last_send_at_gmt();
 
 		$push_token->set_device_locale( 'fr_FR' );
 		$data_store->update( $push_token );
 
 		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests recording a send defers the write until the buffer is flushed.
+	 *
+	 * A request can process many notifications against the same few tokens, so
+	 * the write is buffered and happens once rather than once per notification.
+	 */
+	public function test_record_last_send_defers_the_write_until_flushed() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+
+		$data_store->flush_last_send();
+
+		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests repeated recording before a flush results in a single write.
+	 */
+	public function test_repeated_recording_before_a_flush_writes_once() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$data_store->record_last_send( array( $push_token ) );
+		}
+
+		$data_store->flush_last_send();
+
+		$row_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$push_token->get_id(),
+				PushTokensDataStore::LAST_SEND_AT_META_KEY
+			)
+		);
+
+		$this->assertSame( 1, $row_count );
+	}
+
+	/**
+	 * @testdox Tests flushing an already flushed buffer is a no-op.
+	 */
+	public function test_flushing_twice_does_not_write_again() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
+
+		$recorded = $data_store->read( $push_token->get_id() )->get_last_send_at_gmt();
+
+		$data_store->flush_last_send();
+
+		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+	}
+
+	/**
+	 * @testdox Tests a second send updates the existing row rather than replacing it.
+	 *
+	 * The row is updated in place so that repeatedly sending to the same device
+	 * does not consume `meta_id` values or churn the primary key on what is the
+	 * busiest write path in the feature.
+	 */
+	public function test_a_second_send_updates_the_row_in_place() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
+
+		$meta_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$push_token->get_id(),
+				PushTokensDataStore::LAST_SEND_AT_META_KEY
+			)
+		);
+
+		$data_store->record_last_send( array( $push_token ) );
+		$data_store->flush_last_send();
+
+		$this->assertSame(
+			$meta_id,
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+					$push_token->get_id(),
+					PushTokensDataStore::LAST_SEND_AT_META_KEY
+				)
+			)
+		);
+	}
+
+	/**
+	 * @testdox Tests every token is stamped when the buffer spans more than one chunk.
+	 */
+	public function test_flush_stamps_every_token_across_chunks() {
+		$data_store = new PushTokensDataStore();
+		$tokens     = array();
+
+		for ( $i = 0; $i < PushTokensDataStore::LAST_SEND_CHUNK_SIZE + 5; $i++ ) {
+			$tokens[] = $this->create_test_push_token();
+		}
+
+		$data_store->record_last_send( $tokens );
+		$data_store->flush_last_send();
+
+		foreach ( $tokens as $token ) {
+			$this->assertNotNull( $data_store->read( $token->get_id() )->get_last_send_at_gmt() );
+		}
 	}
 
 	/**
@@ -1100,6 +1225,7 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 
 		$data_store = new PushTokensDataStore();
 		$data_store->record_last_send( array() );
+		$data_store->flush_last_send();
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -1004,28 +1004,28 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests a token has no last send time until it has actually been sent.
+	 * @testdox Tests a token has no last sent time until it has actually been sent.
 	 */
-	public function test_last_send_at_is_null_for_a_token_that_has_never_been_sent() {
+	public function test_last_sent_at_is_null_for_a_token_that_has_never_been_sent() {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
 	 * @testdox Tests recording a send stamps every supplied token with the same time.
 	 */
-	public function test_record_last_send_stamps_all_supplied_tokens() {
+	public function test_record_last_sent_at_stamps_all_supplied_tokens() {
 		$data_store = new PushTokensDataStore();
 		$first      = $this->create_test_push_token();
 		$second     = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $first, $second ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $first, $second ) );
+		$data_store->flush_last_sent_at();
 
-		$first_send_at  = $data_store->read( $first->get_id() )->get_last_send_at_gmt();
-		$second_send_at = $data_store->read( $second->get_id() )->get_last_send_at_gmt();
+		$first_send_at  = $data_store->read( $first->get_id() )->get_last_sent_at_gmt();
+		$second_send_at = $data_store->read( $second->get_id() )->get_last_sent_at_gmt();
 
 		$this->assertNotNull( $first_send_at );
 		$this->assertSame( $first_send_at, $second_send_at );
@@ -1038,22 +1038,22 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	 * row per token behind — a duplicate would make `get_post_meta( …, true )`
 	 * return an arbitrary one of them.
 	 */
-	public function test_record_last_send_replaces_the_previous_stamp() {
+	public function test_record_last_sent_at_replaces_the_previous_stamp() {
 		global $wpdb;
 
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
 				$push_token->get_id(),
-				PushTokensDataStore::LAST_SEND_AT_META_KEY
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
 			)
 		);
 
@@ -1063,12 +1063,12 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Tests recording a send leaves the rest of the token record untouched.
 	 */
-	public function test_record_last_send_does_not_disturb_other_token_data() {
+	public function test_record_last_sent_at_does_not_disturb_other_token_data() {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 		$read = $data_store->read( $push_token->get_id() );
 
 		$this->assertSame( $push_token->get_token(), $read->get_token() );
@@ -1078,23 +1078,23 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests updating a token preserves its last send time.
+	 * @testdox Tests updating a token preserves its last sent time.
 	 *
 	 * The app re-registers a device whenever its locale or metadata changes,
 	 * which must not wipe the send history that update path knows nothing about.
 	 */
-	public function test_updating_a_token_preserves_its_last_send_time() {
+	public function test_updating_a_token_preserves_its_last_sent_at_time() {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
-		$recorded = $data_store->read( $push_token->get_id() )->get_last_send_at_gmt();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
+		$recorded = $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt();
 
 		$push_token->set_device_locale( 'fr_FR' );
 		$data_store->update( $push_token );
 
-		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
@@ -1103,17 +1103,17 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	 * A request can process many notifications against the same few tokens, so
 	 * the write is buffered and happens once rather than once per notification.
 	 */
-	public function test_record_last_send_defers_the_write_until_flushed() {
+	public function test_record_last_sent_at_defers_the_write_until_flushed() {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
+		$data_store->record_last_sent_at( array( $push_token ) );
 
-		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 
-		$data_store->flush_last_send();
+		$data_store->flush_last_sent_at();
 
-		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
@@ -1126,16 +1126,16 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$push_token = $this->create_test_push_token();
 
 		for ( $i = 0; $i < 5; $i++ ) {
-			$data_store->record_last_send( array( $push_token ) );
+			$data_store->record_last_sent_at( array( $push_token ) );
 		}
 
-		$data_store->flush_last_send();
+		$data_store->flush_last_sent_at();
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
 				$push_token->get_id(),
-				PushTokensDataStore::LAST_SEND_AT_META_KEY
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
 			)
 		);
 
@@ -1149,14 +1149,14 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 
-		$recorded = $data_store->read( $push_token->get_id() )->get_last_send_at_gmt();
+		$recorded = $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt();
 
-		$data_store->flush_last_send();
+		$data_store->flush_last_sent_at();
 
-		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertSame( $recorded, $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
@@ -1172,19 +1172,19 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 
 		$meta_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
 				$push_token->get_id(),
-				PushTokensDataStore::LAST_SEND_AT_META_KEY
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
 			)
 		);
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 
 		$this->assertSame(
 			$meta_id,
@@ -1192,7 +1192,7 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 				$wpdb->prepare(
 					"SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
 					$push_token->get_id(),
-					PushTokensDataStore::LAST_SEND_AT_META_KEY
+					PushTokensDataStore::LAST_SENT_AT_META_KEY
 				)
 			)
 		);
@@ -1205,15 +1205,15 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new PushTokensDataStore();
 		$tokens     = array();
 
-		for ( $i = 0; $i < PushTokensDataStore::LAST_SEND_CHUNK_SIZE + 5; $i++ ) {
+		for ( $i = 0; $i < PushTokensDataStore::LAST_SENT_AT_CHUNK_SIZE + 5; $i++ ) {
 			$tokens[] = $this->create_test_push_token();
 		}
 
-		$data_store->record_last_send( $tokens );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( $tokens );
+		$data_store->flush_last_sent_at();
 
 		foreach ( $tokens as $token ) {
-			$this->assertNotNull( $data_store->read( $token->get_id() )->get_last_send_at_gmt() );
+			$this->assertNotNull( $data_store->read( $token->get_id() )->get_last_sent_at_gmt() );
 		}
 	}
 
@@ -1229,12 +1229,12 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
+		$data_store->record_last_sent_at( array( $push_token ) );
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing Action Scheduler's hook, not declaring one.
 		do_action( 'action_scheduler_after_execute', 1, null, '' );
 
-		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertNotNull( $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
@@ -1251,25 +1251,25 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$data_store = new PushTokensDataStore();
 		$push_token = $this->create_test_push_token();
 
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 
 		$empty_the_select = function ( $query ) {
-			return false !== strpos( $query, 'SELECT post_id' ) && false !== strpos( $query, 'last_send_at_gmt' )
+			return false !== strpos( $query, 'SELECT post_id' ) && false !== strpos( $query, 'last_sent_at_gmt' )
 				? ''
 				: $query;
 		};
 
 		add_filter( 'query', $empty_the_select );
-		$data_store->record_last_send( array( $push_token ) );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
 		remove_filter( 'query', $empty_the_select );
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
 				$push_token->get_id(),
-				PushTokensDataStore::LAST_SEND_AT_META_KEY
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
 			)
 		);
 
@@ -1289,7 +1289,7 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		$push_token = $this->create_test_push_token();
 
 		$raise_an_error = function ( $query ) {
-			if ( false !== strpos( $query, 'last_send_at_gmt' ) ) {
+			if ( false !== strpos( $query, 'last_sent_at_gmt' ) ) {
 				throw new \Error( 'Raised for testing.' );
 			}
 
@@ -1299,29 +1299,29 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		add_filter( 'query', $raise_an_error );
 
 		try {
-			$data_store->record_last_send( array( $push_token ) );
-			$data_store->flush_last_send();
+			$data_store->record_last_sent_at( array( $push_token ) );
+			$data_store->flush_last_sent_at();
 		} finally {
 			remove_filter( 'query', $raise_an_error );
 		}
 
-		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_send_at_gmt() );
+		$this->assertNull( $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
 	}
 
 	/**
 	 * @testdox Tests recording a send with no tokens is a no-op.
 	 */
-	public function test_record_last_send_ignores_an_empty_token_list() {
+	public function test_record_last_sent_at_ignores_an_empty_token_list() {
 		global $wpdb;
 
 		$data_store = new PushTokensDataStore();
-		$data_store->record_last_send( array() );
-		$data_store->flush_last_send();
+		$data_store->record_last_sent_at( array() );
+		$data_store->flush_last_sent_at();
 
 		$row_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = %s",
-				PushTokensDataStore::LAST_SEND_AT_META_KEY
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -1065,6 +1065,27 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Tests an older stamp does not replace a newer one.
+	 *
+	 * Each request captures its timestamp when it dispatches and writes it on
+	 * shutdown, so a slow request can reach the update after a later one has
+	 * already written a newer value. The update is advance-only so the field
+	 * cannot go backwards.
+	 */
+	public function test_an_older_stamp_does_not_replace_a_newer_one() {
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+		$newer      = gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS );
+
+		update_post_meta( $push_token->get_id(), PushTokensDataStore::LAST_SENT_AT_META_KEY, $newer );
+
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
+
+		$this->assertSame( $newer, $data_store->read( $push_token->get_id() )->get_last_sent_at_gmt() );
+	}
+
+	/**
 	 * @testdox Tests recording a send leaves the rest of the token record untouched.
 	 */
 	public function test_record_last_sent_at_does_not_disturb_other_token_data() {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/DataStores/PushTokensDataStoreTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataS
 use Automattic\WooCommerce\Internal\PushNotifications\Entities\PushToken;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenInvalidDataException;
 use Automattic\WooCommerce\Internal\PushNotifications\Exceptions\PushTokenNotFoundException;
+use Automattic\WooCommerce\RestApi\UnitTests\LoggerSpyTrait;
 use WC_Unit_Test_Case;
 
 /**
@@ -16,6 +17,9 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore
  */
 class PushTokensDataStoreTest extends WC_Unit_Test_Case {
+
+	use LoggerSpyTrait;
+
 	/**
 	 * Tear down the test case.
 	 */
@@ -1274,6 +1278,46 @@ class PushTokensDataStoreTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( 1, $row_count );
+	}
+
+	/**
+	 * @testdox Tests a write that fails without throwing is reported.
+	 *
+	 * `wpdb::query()` returns false rather than throwing when the `query` filter
+	 * empties the statement, so nothing would surface the lost stamp unless the
+	 * return value is checked. The log is the only signal that stamps are not
+	 * being recorded.
+	 */
+	public function test_a_failed_write_of_stamps_is_logged() {
+		global $wpdb;
+
+		$data_store = new PushTokensDataStore();
+		$push_token = $this->create_test_push_token();
+
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
+
+		$empty_the_update = function ( $query ) {
+			return false !== strpos( $query, 'UPDATE' ) && false !== strpos( $query, 'last_sent_at_gmt' )
+				? ''
+				: $query;
+		};
+
+		add_filter( 'query', $empty_the_update );
+		$data_store->record_last_sent_at( array( $push_token ) );
+		$data_store->flush_last_sent_at();
+		remove_filter( 'query', $empty_the_update );
+
+		$row_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$push_token->get_id(),
+				PushTokensDataStore::LAST_SENT_AT_META_KEY
+			)
+		);
+
+		$this->assertSame( 1, $row_count );
+		$this->assertLogged( 'warning', 'Could not record last sent time for push tokens.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
@@ -962,7 +962,7 @@ class PushTokenTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests an empty last send time is never reported as the current time.
+	 * @testdox Tests an empty last sent time is never reported as the current time.
 	 *
 	 * `date_create_immutable()` rejects only genuinely unparseable strings. It
 	 * reads an empty string as the current time and the MySQL zero date as year
@@ -970,12 +970,12 @@ class PushTokenTest extends WC_Unit_Test_Case {
 	 * Folding them away would make an unsent token report as sent right now,
 	 * the precise opposite of what this field is for.
 	 */
-	public function test_an_empty_last_send_time_is_not_reported_as_now() {
+	public function test_an_empty_last_sent_at_is_not_reported_as_now() {
 		foreach ( array( '', '0000-00-00 00:00:00', '   ' ) as $stored ) {
-			$push_token = new PushToken( array( 'last_send_at_gmt' => $stored ) );
+			$push_token = new PushToken( array( 'last_sent_at_gmt' => $stored ) );
 
 			$this->assertNull(
-				$push_token->get_last_send_at_gmt(),
+				$push_token->get_last_sent_at_gmt(),
 				sprintf( 'Expected null for stored value "%s".', $stored )
 			);
 		}
@@ -1037,15 +1037,15 @@ class PushTokenTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests the last send time defaults to null and is exposed in the response.
+	 * @testdox Tests the last sent time defaults to null and is exposed in the response.
 	 */
-	public function test_it_exposes_the_last_send_time() {
-		$this->assertNull( ( new PushToken() )->get_last_send_at_gmt() );
+	public function test_it_exposes_the_last_sent_at_time() {
+		$this->assertNull( ( new PushToken() )->get_last_sent_at_gmt() );
 
-		$push_token = new PushToken( array( 'last_send_at_gmt' => '2026-08-11 16:00:00' ) );
+		$push_token = new PushToken( array( 'last_sent_at_gmt' => '2026-08-11 16:00:00' ) );
 
-		$this->assertSame( '2026-08-11 16:00:00', $push_token->get_last_send_at_gmt() );
-		$this->assertSame( '2026-08-11T16:00:00', $push_token->to_rest_format()['last_send_at_gmt'] );
-		$this->assertArrayNotHasKey( 'last_send_at_gmt', $push_token->to_wpcom_format() );
+		$this->assertSame( '2026-08-11 16:00:00', $push_token->get_last_sent_at_gmt() );
+		$this->assertSame( '2026-08-11T16:00:00', $push_token->to_rest_format()['last_sent_at_gmt'] );
+		$this->assertArrayNotHasKey( 'last_sent_at_gmt', $push_token->to_wpcom_format() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
@@ -962,6 +962,26 @@ class PushTokenTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Tests an empty last send time is never reported as the current time.
+	 *
+	 * `date_create_immutable()` rejects only genuinely unparseable strings. It
+	 * reads an empty string as the current time and the MySQL zero date as year
+	 * -0001, so the guards ahead of it are load-bearing rather than redundant.
+	 * Folding them away would make an unsent token report as sent right now,
+	 * the precise opposite of what this field is for.
+	 */
+	public function test_an_empty_last_send_time_is_not_reported_as_now() {
+		foreach ( array( '', '0000-00-00 00:00:00', '   ' ) as $stored ) {
+			$push_token = new PushToken( array( 'last_send_at_gmt' => $stored ) );
+
+			$this->assertNull(
+				$push_token->get_last_send_at_gmt(),
+				sprintf( 'Expected null for stored value "%s".', $stored )
+			);
+		}
+	}
+
+	/**
 	 * @testdox Tests the REST format adds diagnostic fields without altering the WPCOM send payload.
 	 *
 	 * `to_wpcom_format()` is the per-token payload the dispatcher POSTs to WPCOM

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
@@ -1037,15 +1037,15 @@ class PushTokenTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Tests the last send time defaults to null and is exposed in RFC3339 form.
+	 * @testdox Tests the last send time defaults to null and is exposed in the response.
 	 */
 	public function test_it_exposes_the_last_send_time() {
 		$this->assertNull( ( new PushToken() )->get_last_send_at_gmt() );
 
 		$push_token = new PushToken( array( 'last_send_at_gmt' => '2026-08-11 16:00:00' ) );
 
-		$this->assertSame( '2026-08-11T16:00:00+00:00', $push_token->get_last_send_at_gmt() );
-		$this->assertSame( '2026-08-11T16:00:00+00:00', $push_token->to_rest_format()['last_send_at_gmt'] );
+		$this->assertSame( '2026-08-11 16:00:00', $push_token->get_last_send_at_gmt() );
+		$this->assertSame( '2026-08-11T16:00:00', $push_token->to_rest_format()['last_send_at_gmt'] );
 		$this->assertArrayNotHasKey( 'last_send_at_gmt', $push_token->to_wpcom_format() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Entities/PushTokenTest.php
@@ -1015,4 +1015,17 @@ class PushTokenTest extends WC_Unit_Test_Case {
 		$this->assertNull( $rest_format['device_uuid'] );
 		$this->assertNull( $rest_format['platform'] );
 	}
+
+	/**
+	 * @testdox Tests the last send time defaults to null and is exposed in RFC3339 form.
+	 */
+	public function test_it_exposes_the_last_send_time() {
+		$this->assertNull( ( new PushToken() )->get_last_send_at_gmt() );
+
+		$push_token = new PushToken( array( 'last_send_at_gmt' => '2026-08-11 16:00:00' ) );
+
+		$this->assertSame( '2026-08-11T16:00:00+00:00', $push_token->get_last_send_at_gmt() );
+		$this->assertSame( '2026-08-11T16:00:00+00:00', $push_token->to_rest_format()['last_send_at_gmt'] );
+		$this->assertArrayNotHasKey( 'last_send_at_gmt', $push_token->to_wpcom_format() );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -143,6 +143,51 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should record the last send time against the dispatched tokens on success.
+	 */
+	public function test_process_records_last_send_on_success(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => true,
+				'retry_after' => null,
+			)
+		);
+
+		$this->data_store
+			->expects( $this->once() )
+			->method( 'record_last_send' )
+			->with(
+				$this->callback(
+					function ( array $tokens ) {
+						return 1 === count( $tokens ) && 'test-token' === $tokens[0]->get_token();
+					}
+				)
+			);
+
+		$this->sut->process( new NewOrderNotification( $this->order_id ) );
+	}
+
+	/**
+	 * @testdox Should not record a last send time when the dispatch fails.
+	 *
+	 * The stamp means "WPCOM accepted a payload containing this token", so
+	 * recording it on a failed send would make a device that has never been
+	 * successfully targeted look as though it had.
+	 */
+	public function test_process_does_not_record_last_send_on_failure(): void {
+		$this->dispatcher->method( 'dispatch' )->willReturn(
+			array(
+				'success'     => false,
+				'retry_after' => null,
+			)
+		);
+
+		$this->data_store->expects( $this->never() )->method( 'record_last_send' );
+
+		$this->sut->process( new NewOrderNotification( $this->order_id ) );
+	}
+
+	/**
 	 * @testdox Should write claimed meta before sending.
 	 */
 	public function test_process_writes_claimed_meta_before_send(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Services/NotificationProcessorTest.php
@@ -143,9 +143,9 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should record the last send time against the dispatched tokens on success.
+	 * @testdox Should record the last sent time against the dispatched tokens on success.
 	 */
-	public function test_process_records_last_send_on_success(): void {
+	public function test_process_records_last_sent_at_on_success(): void {
 		$this->dispatcher->method( 'dispatch' )->willReturn(
 			array(
 				'success'     => true,
@@ -155,7 +155,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 
 		$this->data_store
 			->expects( $this->once() )
-			->method( 'record_last_send' )
+			->method( 'record_last_sent_at' )
 			->with(
 				$this->callback(
 					function ( array $tokens ) {
@@ -168,13 +168,13 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should not record a last send time when the dispatch fails.
+	 * @testdox Should not record a last sent time when the dispatch fails.
 	 *
 	 * The stamp means "WPCOM accepted a payload containing this token", so
 	 * recording it on a failed send would make a device that has never been
 	 * successfully targeted look as though it had.
 	 */
-	public function test_process_does_not_record_last_send_on_failure(): void {
+	public function test_process_does_not_record_last_sent_at_on_failure(): void {
 		$this->dispatcher->method( 'dispatch' )->willReturn(
 			array(
 				'success'     => false,
@@ -182,7 +182,7 @@ class NotificationProcessorTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->data_store->expects( $this->never() )->method( 'record_last_send' );
+		$this->data_store->expects( $this->never() )->method( 'record_last_sent_at' );
 
 		$this->sut->process( new NewOrderNotification( $this->order_id ) );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

> [!NOTE]
> **Stacked PR.** This targets `ainfra-2884-expose-created-and-updated-timestamps-on-the-push-tokens` (#67619), not `trunk`, because it extends the same entity, data store and serialisation method. Review that one first; this diff shows only the `last_send_at_gmt` work.

### Changes proposed in this Pull Request:

Part of the push notification diagnostics work ([AINFRA-2885](https://linear.app/a8c/issue/AINFRA-2885/track-and-expose-last-send-time-for-each-push-token)).

The first fork in every "I didn't get a notification" escalation is whether we ever targeted the device at all. Right now nothing is written back to a token when it is used — `NotificationProcessor::process()` fetches tokens, filters them by preference, hands them to the dispatcher, and the token record is never touched. A token included in a hundred sends looks identical to one that has never been used, so that question cannot be answered.

This is the cheapest possible slice of "what recent notifications did we attempt with this token": it needs no log table, and it separates *"we never targeted this device"* (a registration or preference problem) from *"we targeted it and it didn't arrive"* (a WPCOM, APNS/FCM, or device problem).

Specifically:

- A `last_send_at_gmt` meta value is stamped on every token WPCOM accepted, from `NotificationProcessor::process()` on the success branch.
- `PushToken` gains `last_send_at_gmt`, normalised to RFC3339 UTC like the other timestamps.
- `PushTokensDataStore` reads it and exposes `record_last_send()`; `PushTokenRestController::index()` returns it.

Three deliberate decisions worth reviewing:

**Written only on success.** The value means "WPCOM accepted a payload containing this token". Stamping it on a failed send would make a device that has never been successfully targeted look as though it had, which is precisely the distinction this field exists to draw. The getter's docblock also spells out that this is **not** a delivery receipt — what happens between WPCOM and the device is downstream of anything this plugin can observe — so the diagnostics page doesn't overstate it.

**Buffered, updated in place, and chunked.** This is the third commit, and the part most worth review. Three things, none of which costs any precision:

- **Writes are buffered and flushed once on `shutdown`** rather than once per notification. A single loopback request carries every notification a store event produced, so a bulk order update previously repeated the same write dozens of times against the same few tokens. A request with 50 notifications now costs 2 queries instead of 100. The buffer holds each token's own most recent send time, and stamps recorded in different seconds are grouped into separate statements, so no token inherits another's timestamp.
- **Existing rows are updated in place** rather than deleted and reinserted. Repeating delete-then-insert on the same rows consumes `meta_id` values permanently and fragments the primary key, on the busiest write path in the feature. One indexed `SELECT` establishes which rows exist, then `UPDATE` covers those and `INSERT` covers first-time tokens only. `wp_postmeta` has no unique key on `(post_id, meta_key)`, so there is no upsert to use and the rows have to be identified either way.
- **Both the `IN` list and the placeholder count are chunked** at 100. They previously grew with the number of registered devices, which makes `$wpdb->prepare()` do regex work proportional to that count and can push the optimizer off the `post_id` index onto a scan.

This shape is deliberate given #66786, where `get_tokens_for_roles()` had to be hotfixed for taking ~60 seconds on sites with multi-million-row user tables. The lesson taken from it is that anything on this path must cost a bounded amount regardless of store size.

Every value still goes through `$wpdb->prepare()`; only literal placeholder strings are interpolated. Because the rows are written behind the meta API's back, `wp_cache_delete_multiple( $post_ids, 'post_meta' )` drops the now-stale cache.

**Two things deliberately not changed, raised in review:**

- **Cache invalidation stays as `wp_cache_delete_multiple()` on the whole entry.** That is exactly what `update_metadata()` does for every `update_post_meta()` call in WordPress. Patching the cached entry in place would be a read-modify-write on a shared key with no compare-and-swap, so a concurrent update to any other meta key on the same token would be resurrected. The cost is also small: the flush runs on shutdown, so nothing reads meta after it in that request, and the entry is about seven keys.
- **A concurrent first send can still duplicate a row.** The SELECT and INSERT are not atomic, and `wp_postmeta` has no unique key to lean on, which is true of `update_post_meta()` itself. It is bounded to the first send per token and self-correcting in value, since both rows are then updated together, so the visible effect is a stray row rather than a wrong answer.

**Non-fatal.** A failed stamp is logged at `warning` and swallowed. Not knowing when a token was last used is a diagnostic gap; it must never turn a delivered notification into a failed one.

`build_meta_array_from_token()` deliberately omits the key, so the app re-registering a device (a new locale or metadata) cannot clobber the send history that update path knows nothing about. There is a test for this.

**Backward compatibility:** additive only. One new key on a response, one new public data store method, one new entity accessor. Nothing renamed, removed, or reordered. `NotificationProcessor::process()`'s signature and return contract are unchanged. The index route is authorised by `authorize_as_from_wpcom` (Jetpack blog-token signed), so the only consumer is WPCOM. No new PII — a timestamp against a token record the same caller already reads.

**Data growth:** one meta row per token, replaced in place on each send. It does not accumulate.

**Multisite:** unaffected — writes go to the current site's `$wpdb->postmeta` via `$wpdb`, which is already per-site.

Closes AINFRA-2885.

### Screenshots or screen recordings:

Not applicable — no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Prerequisites

Before testing, ensure:

- You have a WooCommerce site running the build from this PR, with shell access so you can run WP-CLI. A https://jurassic.ninja/ site is fine.
- Jetpack is connected on that site. Without a connection the push notifications feature does not load at all and no send is ever attempted, so nothing would be stamped and the test would look like a failure of this change.
- Nothing on the site filters `woocommerce_enhanced_push_notifications_disabled` to `true`.
- You have opened the site in the WooCommerce iOS or Android app and signed in as an administrator or shop manager. That registers a push token on its own, so there is no manual call to make.
- Order notifications are switched on for that user in the app, otherwise the token is filtered out before any send happens.
- Your store has at least one published product, with its price set to `0` so checkout needs no payment gateway.
- Your database table prefix is `wp_`. If it is not, substitute yours in the queries below.

#### Confirm a token that has never been sent to reports null

1. Print the index response:

```sh
wp eval '
$request = new WP_REST_Request( "GET", "/wc-push-notifications/push-tokens" );
$request->set_param( "page", 1 );
$request->set_param( "per_page", 100 );
$controller = new Automattic\WooCommerce\Internal\PushNotifications\Controllers\PushTokenRestController();
echo wp_json_encode( $controller->index( $request )->get_data(), JSON_PRETTY_PRINT );
'
```

   **Expected result:** each token carries a `last_send_at_gmt` key, and it is `null`.

2. Note the `id` from that response. It is written as `TOKEN_ID` below.

#### Confirm a successful send stamps the token

3. Create an order in a status that triggers a notification:

```sh
wp wc shop_order create --status=processing --user=1
```

4. Wait 60 seconds. The send normally happens on shutdown through a loopback request, and an Action Scheduler job picks it up within a minute if that request did not land.

5. Run the command from step 1 again.

   **Expected result:** `last_send_at_gmt` is now an RFC3339 timestamp close to when you created the order, for example `"2026-08-12T16:04:22+00:00"`.

#### Confirm the row is updated rather than duplicated or replaced

The write bypasses the meta API, so it has to leave exactly one row behind and reuse it. Repeated delete-and-reinsert would consume `meta_id` values permanently and churn the primary key on the busiest write path in the feature.

6. Print the stored row:

```sh
wp db query "SELECT meta_id, meta_value FROM wp_postmeta WHERE post_id = TOKEN_ID AND meta_key = 'last_send_at_gmt'"
```

7. Create a second order:

```sh
wp wc shop_order create --status=processing --user=1
```

8. Wait 60 seconds, then run the command from step 6 again.

   **Expected result:** exactly one row, `meta_value` moved to the later time, and `meta_id` unchanged. A second row would make `get_post_meta()` return an arbitrary one of the two; a changed `meta_id` would mean the row is being replaced rather than updated.

#### Confirm several notifications in one request cost one write

9. Create three orders in one command, so they are processed together:

```sh
wp eval 'for ( $i = 0; $i < 3; $i++ ) { wc_create_order( array( "status" => "processing" ) ); }'
```

10. Wait 60 seconds, then run the command from step 6 again.

    **Expected result:** still exactly one row, with `meta_id` unchanged from step 8. The stamps are buffered and written once for the request rather than once per notification.

#### Confirm a failed send does not stamp

`last_send_at_gmt` means "WordPress.com accepted a payload containing this token", so a failure must leave the previous value alone.

11. Note the current `last_send_at_gmt` by running the command from step 6.

12. Create `wp-content/mu-plugins/block-wpcom-push.php` with this content, which fails only the push notification request and leaves the rest of Jetpack working:

```php
<?php
add_filter(
	'pre_http_request',
	function ( $preempt, $args, $url ) {
		if ( false !== strpos( $url, '/push-notifications' ) ) {
			return new WP_Error( 'blocked_for_testing', 'Blocked for testing.' );
		}
		return $preempt;
	},
	10,
	3
);
```

13. Create another order:

```sh
wp wc shop_order create --status=processing --user=1
```

14. Wait 60 seconds, then run the command from step 6 again.

    **Expected result:** `meta_value` still holds the value you noted in step 11, unchanged.

15. Delete `wp-content/mu-plugins/block-wpcom-push.php`.

#### Confirm re-registering a device preserves the value

16. Change your phone's language, then reopen the WooCommerce app so it re-registers the token, and run the command from step 1 again.

    **Expected result:** `device_locale` reflects the new language, `updated_at_gmt` has moved, and `last_send_at_gmt` is unchanged. The app re-registering must not wipe send history it knows nothing about.

#### Confirm the value is not sent to WordPress.com

17. Print the payload the dispatcher builds for one token:

```sh
wp eval '
$store = wc_get_container()->get( Automattic\WooCommerce\Internal\PushNotifications\DataStores\PushTokensDataStore::class );
echo wp_json_encode( $store->read( TOKEN_ID )->to_wpcom_format(), JSON_PRETTY_PRINT );
'
```

    **Expected result:** exactly four keys, `user_id`, `token`, `origin` and `device_locale`. `last_send_at_gmt` does not appear.

#### Run the unit tests

18. Run the push notifications suite:

```sh
pnpm test:php:env -- tests/php/src/Internal/PushNotifications
```

    **Expected result:** `OK (520 tests, 1226 assertions)`.

<!-- End testing instructions -->

### Testing that has already taken place:

- `phpcs` clean on all changed files (`phpcs.xml` standard, no new errors or warnings). The direct-query sniffs are suppressed with an inline justification explaining that only literal placeholder strings are interpolated.
- `phpstan analyse` clean on all changed source files, no baseline additions.
- `php -l` clean on all changed files.
- **Full `PushNotifications` PHPUnit module green on this branch: 520 tests, 1226 assertions, 0 failures** (PHP 8.1.34, PHPUnit 9.6.29, via wp-env). That is the 501 tests passing on the base branch plus the 19 added here.

```
$ pnpm test:php:env -- tests/php/src/Internal/PushNotifications
OK (520 tests, 1226 assertions)
```

Not yet manually exercised against a live Jetpack-connected store. Worth a reviewer's attention: the batched `$wpdb` write is covered by tests asserting the row is replaced rather than duplicated and that an unrelated token update preserves the stamp, but it has not been run against a store with a large number of registered devices.

New test coverage:

- `PushTokensDataStoreTest` — `null` until first send; all supplied tokens stamped with the same time; a repeat send replacing rather than duplicating the meta row; other token fields left untouched; an update preserving the stamp; an empty token list being a no-op. Plus, for the write path: the write being deferred until flushed; five records before a flush producing one row; a second flush being a no-op; `meta_id` staying stable across sends, which is what proves the row is updated rather than replaced; and every token being stamped when the buffer spans more than one chunk.
- `NotificationProcessorTest` — `record_last_send()` called once with the dispatched tokens on success, and never called on failure.
- `PushTokenTest` — default `null`, RFC3339 exposure, present in `to_rest_format()` and absent from `to_wpcom_format()`.
- `PushTokenRestControllerTest` — a sent and an unsent token in one response, showing a populated value and a `null` respectively.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

Milestone set manually to **11.2.0**. Auto-assign is deliberately left unchecked: `trunk` is currently `11.1.0-dev`, so it would target 11.1.0, and this work is scheduled for 11.2. The `@since` tags in the diff say `11.2.0` to match.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

No user-facing or developer-facing change. The new field is written and read entirely within the push notifications feature, and the endpoint exposing it is authorised with `authorize_as_from_wpcom`, so it is callable only by WPCOM over a Jetpack blog-token signed request. There is no merchant-visible surface, no public API change, and no hook or filter added or altered.

</details>

### Release Communication

Neither — see the changelog comment above; there is nothing here for merchants or extension developers to act on.

### Use of AI Tools

Authored with Claude Code (Opus 5). The change was specified, reviewed and verified by me; static analysis (`phpcs`, `phpstan`) and the full `PushNotifications` PHPUnit module were run against the result and are green.
