### PR TITLE
Return 400 instead of 500 for status-less engine errors on the wc/v3 refunds compute_totals path

### DIFF
--- a/plugins/woocommerce/changelog/fix-v3-refunds-error-status
+++ b/plugins/woocommerce/changelog/fix-v3-refunds-error-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return HTTP 400 instead of 500 for invalid refund_tax and auto-compute inputs on the wc/v3 refunds compute_totals path, by adding the missing HTTP status to five shared-engine validation errors and defaulting status-less engine errors to 400 at the v3 boundary.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -349,6 +349,8 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	 * uses `woocommerce_rest_*`, so errors crossing into a v3 response are
 	 * renamed at this boundary. Codes that already carry the prefix pass through
 	 * unchanged, and the message and data (including the HTTP status) are kept.
+	 * An engine error whose data carries no HTTP status is backfilled with 400,
+	 * the same default the wc/v4 envelope applies, so it is not served as a 500.
 	 *
 	 * @param WP_Error $error The error whose code should be prefixed.
 	 *
@@ -361,7 +363,15 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 			return $error;
 		}
 
-		return new WP_Error( 'woocommerce_rest_' . $code, $error->get_error_message(), $error->get_error_data() );
+		$data = $error->get_error_data();
+		if ( ! is_array( $data ) ) {
+			$data = array();
+		}
+		if ( ! isset( $data['status'] ) ) {
+			$data['status'] = 400;
+		}
+
+		return new WP_Error( 'woocommerce_rest_' . $code, $error->get_error_message(), $data );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -349,8 +349,11 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	 * uses `woocommerce_rest_*`, so errors crossing into a v3 response are
 	 * renamed at this boundary. Codes that already carry the prefix pass through
 	 * unchanged, and the message and data (including the HTTP status) are kept.
-	 * An engine error whose data carries no HTTP status is backfilled with 400,
-	 * the same default the wc/v4 envelope applies, so it is not served as a 500.
+	 * An unprefixed engine error whose data carries no HTTP status is backfilled
+	 * with 400, the same default the wc/v4 envelope applies, so it is not served
+	 * as a 500. An already-prefixed code returns untouched above and so misses
+	 * that backfill, which leaves no gap: every prefixed error reaching this
+	 * endpoint is built by normalize_line_item() with an explicit status.
 	 *
 	 * @param WP_Error $error The error whose code should be prefixed.
 	 *
@@ -363,6 +366,11 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 			return $error;
 		}
 
+		// Every DataUtils error site attaches array data; the guard below is here
+		// so a non-array payload cannot turn the $data['status'] write into a
+		// fatal. Replacing such a payload rather than nesting it mirrors the wc/v4
+		// envelope, which likewise reads a status only out of array data and drops
+		// the rest, so both versions answer an identical error identically.
 		$data = $error->get_error_data();
 		if ( ! is_array( $data ) ) {
 			$data = array();

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -498,6 +498,13 @@ class DataUtils {
 						$already_refunded_tax = (float) ( $refund_data['tax_totals'][ $line_item_id ][ $tax_id ] ?? 0.0 );
 						$remaining_tax        = abs( $stored_tax ) - $already_refunded_tax;
 						if ( abs( $requested_tax ) > NumberUtil::round( $remaining_tax, $price_decimals ) ) {
+							// 400, not the 422 the over-refund caps above use: this is the
+							// status the released wc/v4 envelope already backfills for this
+							// error, so anything else would change a shipped response. It
+							// also keeps the code-to-status mapping one-to-one across this
+							// file — invalid_refund_amount is 400 at every site, sharing the
+							// code with the wrong-sign guard above, which is malformed
+							// input, while each 422 carries its own over-refund code.
 							return new WP_Error(
 								'invalid_refund_amount',
 								sprintf(

--- a/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
+++ b/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Refunds/DataUtils.php
@@ -262,7 +262,8 @@ class DataUtils {
 			if ( $refund_total_missing && isset( $line_item['refund_tax'] ) ) {
 				return new WP_Error(
 					'invalid_line_item',
-					__( 'refund_tax cannot be combined with an auto-computed refund_total. Provide refund_total explicitly when supplying refund_tax.', 'woocommerce' )
+					__( 'refund_tax cannot be combined with an auto-computed refund_total. Provide refund_total explicitly when supplying refund_tax.', 'woocommerce' ),
+					array( 'status' => WP_Http::BAD_REQUEST )
 				);
 			}
 
@@ -299,7 +300,8 @@ class DataUtils {
 						/* translators: %d: line item id */
 						__( 'Cannot auto-compute refund for line item %d: source quantity is zero. Provide an explicit refund_total.', 'woocommerce' ),
 						(int) $line_item_id
-					)
+					),
+					array( 'status' => WP_Http::BAD_REQUEST )
 				);
 			}
 
@@ -449,7 +451,7 @@ class DataUtils {
 
 					foreach ( $line_item['refund_tax'] as $refund_tax ) {
 						if ( ! isset( $refund_tax['id'], $refund_tax['refund_total'] ) ) {
-							return new WP_Error( 'invalid_line_item', __( 'Tax id and refund_total are required.', 'woocommerce' ) );
+							return new WP_Error( 'invalid_line_item', __( 'Tax id and refund_total are required.', 'woocommerce' ), array( 'status' => WP_Http::BAD_REQUEST ) );
 						}
 						$tax_id           = $refund_tax['id'];
 						$tax_refund_total = $refund_tax['refund_total'];
@@ -461,7 +463,8 @@ class DataUtils {
 								/* translators: %s: tax IDs */
 									__( 'Line item tax not found. Must be: %s.', 'woocommerce' ),
 									implode( ', ', $allowed_tax_ids )
-								)
+								),
+								array( 'status' => WP_Http::BAD_REQUEST )
 							);
 						}
 
@@ -501,7 +504,8 @@ class DataUtils {
 								/* translators: %s: remaining refundable tax total */
 									__( 'Refund tax total cannot be greater than the remaining refundable tax for this line item (%s).', 'woocommerce' ),
 									wc_format_decimal( $remaining_tax, $price_decimals )
-								)
+								),
+								array( 'status' => WP_Http::BAD_REQUEST )
 							);
 						}
 					}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-computed-totals-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-computed-totals-test.php
@@ -266,6 +266,131 @@ class WC_REST_Order_Refunds_Computed_Totals_Test extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
+	 * @testdox refund_tax combined with an auto-computed refund_total returns 400, not 500.
+	 */
+	public function test_refund_tax_with_auto_computed_total_returns_400(): void {
+		$tax_rate_id = $this->create_tax_rate( 10.0 );
+		$order       = $this->create_order_with_product_and_tax( 100.00, 1, $tax_rate_id, 10.00 );
+		$item_id     = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_create_request(
+			$order->get_id(),
+			array(
+				'compute_totals' => true,
+				'line_items'     => array(
+					array(
+						'id'         => $item_id,
+						'quantity'   => 1,
+						'refund_tax' => array(
+							array(
+								'id'           => $tax_rate_id,
+								'refund_total' => 5.00,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_line_item', $response->get_data()['code'] );
+		$this->assertCount( 0, wc_get_order( $order->get_id() )->get_refunds() );
+	}
+
+	/**
+	 * @testdox A refund_tax entry referencing a tax id not on the line returns 400, not 500.
+	 */
+	public function test_refund_tax_unknown_tax_id_returns_400(): void {
+		$tax_rate_id = $this->create_tax_rate( 10.0 );
+		$order       = $this->create_order_with_product_and_tax( 100.00, 1, $tax_rate_id, 10.00 );
+		$item_id     = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_create_request(
+			$order->get_id(),
+			array(
+				'compute_totals' => true,
+				'line_items'     => array(
+					array(
+						'id'           => $item_id,
+						'refund_total' => 50.00,
+						'refund_tax'   => array(
+							array(
+								'id'           => $tax_rate_id + 999,
+								'refund_total' => 5.00,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_line_item', $response->get_data()['code'] );
+		$this->assertCount( 0, wc_get_order( $order->get_id() )->get_refunds() );
+	}
+
+	/**
+	 * @testdox A refund_tax entry missing id or refund_total returns 400, not 500.
+	 */
+	public function test_refund_tax_missing_fields_returns_400(): void {
+		$tax_rate_id = $this->create_tax_rate( 10.0 );
+		$order       = $this->create_order_with_product_and_tax( 100.00, 1, $tax_rate_id, 10.00 );
+		$item_id     = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_create_request(
+			$order->get_id(),
+			array(
+				'compute_totals' => true,
+				'line_items'     => array(
+					array(
+						'id'           => $item_id,
+						'refund_total' => 50.00,
+						'refund_tax'   => array(
+							array( 'id' => $tax_rate_id ),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_line_item', $response->get_data()['code'] );
+		$this->assertCount( 0, wc_get_order( $order->get_id() )->get_refunds() );
+	}
+
+	/**
+	 * @testdox A refund_tax total exceeding the remaining refundable tax returns 400, not 500.
+	 */
+	public function test_refund_tax_exceeding_remaining_tax_returns_400(): void {
+		$tax_rate_id = $this->create_tax_rate( 10.0 );
+		$order       = $this->create_order_with_product_and_tax( 100.00, 1, $tax_rate_id, 10.00 );
+		$item_id     = $this->get_first_line_item_id( $order );
+
+		$response = $this->do_create_request(
+			$order->get_id(),
+			array(
+				'compute_totals' => true,
+				'line_items'     => array(
+					array(
+						'id'           => $item_id,
+						'refund_total' => 50.00,
+						'refund_tax'   => array(
+							array(
+								'id'           => $tax_rate_id,
+								'refund_total' => 50.00,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_refund_amount', $response->get_data()['code'] );
+		$this->assertCount( 0, wc_get_order( $order->get_id() )->get_refunds() );
+	}
+
+	/**
 	 * @testdox A quantity-form refund after a partial amount refund is clamped to the line's remaining refundable amount.
 	 */
 	public function test_quantity_refund_clamped_to_remaining(): void {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-computed-totals-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-computed-totals-test.php
@@ -391,6 +391,47 @@ class WC_REST_Order_Refunds_Computed_Totals_Test extends WC_REST_Unit_Test_Case 
 	}
 
 	/**
+	 * @testdox Auto-computing a refund against a line whose source quantity is zero returns 400, not 500.
+	 */
+	public function test_zero_source_quantity_auto_compute_returns_400(): void {
+		// create_order_with_product() cannot build a zero-quantity line, so the order
+		// is assembled here. The order total is non-zero so the order is not treated
+		// as already fully refunded, which would fail earlier with a different error.
+		$order = wc_create_order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'quantity' => 0,
+				'subtotal' => 0,
+				'total'    => 0,
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->save();
+
+		$response = $this->do_create_request(
+			$order->get_id(),
+			array(
+				'compute_totals' => true,
+				'line_items'     => array(
+					array(
+						'id'       => $item->get_id(),
+						'quantity' => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_line_item', $response->get_data()['code'] );
+		$this->assertStringContainsString( 'source quantity is zero', $response->get_data()['message'] );
+		$this->assertCount( 0, wc_get_order( $order->get_id() )->get_refunds() );
+	}
+
+	/**
 	 * @testdox A quantity-form refund after a partial amount refund is clamped to the line's remaining refundable amount.
 	 */
 	public function test_quantity_refund_clamped_to_remaining(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`POST /wc/v3/orders/{id}/refunds` with `compute_totals: true` returns **HTTP 500 for four client input errors that should be 400**. The request is rejected correctly and no refund is created, but the status tells the caller "server fault, safe to retry" instead of "your request is invalid".

Cause: five validation errors in the shared refunds engine (`DataUtils::validate_line_items`) carry no HTTP status in their error data. wc/v4 never surfaced this because its envelope backfills 400 for status-less errors; the wc/v3 boundary (`prefix_error_code()`) forwards error data verbatim, so WordPress falls back to 500.

| Input on the `compute_totals` create path | Before | After |
| --- | --- | --- |
| `refund_tax` combined with an auto-computed `refund_total` | 500 | 400 |
| auto-compute against a line whose source quantity is zero | 500 | 400 |
| `refund_tax` id not present on the line | 500 | 400 |
| `refund_tax` total above the line's remaining refundable tax | 500 | 400 |
| `refund_tax` entry missing `id` or `refund_total` | 400 | 400 |

The last is already intercepted by the v3 controller's line-item normalization; the engine-side status is defense in depth.

This PR:

- adds `array( 'status' => WP_Http::BAD_REQUEST )` to the five engine sites — the same status wc/v4 already emits for them through its backfill, so wc/v4 responses are unchanged
- backfills status 400 for any status-less engine error at the v3 boundary, mirroring the wc/v4 envelope default, so a future site added without a status degrades to 400 rather than 500
- adds five regression tests through the wc/v3 create endpoint; four fail with 500 against unfixed code, the fifth pins the normalization-level 400. The fifth covers the zero-source-quantity auto-compute case, which was already covered at unit level and through wc/v4 but not through wc/v3

**No released version is affected.** Two released surfaces touch this code, and neither moves.

The **classic wc/v3 refund create** does not route through `prefix_error_code()` at all: the helper has exactly two call sites, `preview_refund()` and `create_refund_with_computed_totals()`, both introduced in 11.1.0 and unreleased.

**wc/v4** is unchanged because 400 is precisely what its envelope already backfills at each of the five sites (`Controller.php:369` and `:455` fall back to `WP_Http::BAD_REQUEST` for status-less errors). `DataUtils` itself ships at 11.0.1 as part of the v4 surface, so pinning the statuses to the value v4 already emits is what keeps that surface frozen — and it is why the tax over-refund cap stays 400 rather than moving to the 422 the sibling caps use.

Error codes, messages, hooks and signatures are unchanged, and no shipped version of WooCommerce has ever returned the 500 this removes.

**Why this should land in 11.1.0.** The affected path ships in 11.1.0. Fixed now, the change is invisible to everyone. Fixed later, it becomes a status change on a live endpoint that warrants a developer advisory — and until then, every client with standard retry-on-5xx logic treats a permanently invalid request as transient, while stores log a 500 for a request the server rejected correctly.

Reachability is low and independent of that decision: the first-party POS clients send only `id` plus exactly one of `quantity`/`refund_total` on this path and never `refund_tax`, so four of the five cases require a hand-built request.

Found by AI regression review: WOOAIRR-29 (internal). The five engine sites predate #67043, but were reachable only through wc/v4 — which backfills the status — until #67043 exposed them through a boundary that forwards error data verbatim. WOOAIRR-29 identified four of the five; the tax over-refund cap was found while fixing them and is patched here too.

On review feedback, the two `prefix_error_code()` cases raised in the inline comments — the already-prefixed early return skipping the backfill, and non-array error data being replaced — are documented rather than restructured. Both are unreachable by construction (only `DataUtils` reaches the helper, and it emits unprefixed codes with array data exclusively), and changing either would alter response shape for a case nothing produces.

(For Bug Fixes) Bug introduced in PR #67043.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with taxes enabled, create an order with one taxed product line and note the line item id and its tax rate id.
2. `POST /wp-json/wc/v3/orders/{id}/refunds` with body: `{"compute_totals": true, "line_items": [{"id": <line_item_id>, "refund_total": 5, "refund_tax": [{"id": 999999, "refund_total": 1}]}]}`.
3. Without this PR the response is HTTP 500 with code `woocommerce_rest_invalid_line_item`. With this PR it is HTTP 400 with the same code and message.
4. Repeat with `{"id": <line_item_id>, "quantity": 1, "refund_tax": [{"id": <tax_rate_id>, "refund_total": 1}]}` (no `refund_total`): HTTP 400 instead of 500.
5. Verify no refund is created in any of these cases, and that a valid `compute_totals` request still creates a refund and returns 201.
6. Sanity-check wc/v4 is unchanged: send the same invalid bodies to `POST /wp-json/wc/v4/refunds` and confirm they still return 400 with the same codes and messages.

<!-- End testing instructions -->

### Testing that has already taken place:

- Full refunds test matrix in wp-env: 311 tests, 1072 assertions, green (`WC_REST_Order_Refunds_Preview_Test`, `WC_REST_Order_Refunds_Computed_Totals_Test`, the wc/v4 controller and preview suites, `DataUtilsTest`, and the v1/v2/v3 refund controller suites). Three of the four new tests were run against the unfixed code and fail with "500 matches expected 400".
- `phpcs-changed` (branch diff) and PHPStan report no issues on the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

Milestone 11.1.0 assigned manually: the affected path ships in 11.1.0, so this needs to be cherry-picked to `release/11.1` rather than ride the next-version default.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Return HTTP 400 instead of 500 for invalid refund_tax and auto-compute inputs on the wc/v3 refunds compute_totals path, by adding the missing HTTP status to five shared-engine validation errors and defaulting status-less engine errors to 400 at the v3 boundary.

</details>

The changelog file was added by hand rather than by the CI job: `plugins/woocommerce/changelog/fix-v3-refunds-error-status`. Its contents match the details above.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

Neither applies: the affected endpoint path is new and unreleased in the same version as this fix, so no shipped behavior changes and there is nothing for extension developers to detect or act on.

### Use of AI Tools

Authored with AI assistance (Claude Code); reviewed and tested by the author.

