### PR TITLE
Post the email editor test reminder on fork pull requests

### DIFF
--- a/.github/workflows/pr-email-editor-test-reminder.yml
+++ b/.github/workflows/pr-email-editor-test-reminder.yml
@@ -28,6 +28,9 @@ jobs:
                   # Check out the base branch, never the pull request head. The job
                   # holds a write token, so it must not run code from the PR.
                   ref: ${{ github.event.pull_request.base.sha }}
+                  # Keep the token out of the local git config. No later step runs
+                  # git, so nothing here needs it.
+                  persist-credentials: false
 
             - name: Setup Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pr-email-editor-test-reminder.yml
+++ b/.github/workflows/pr-email-editor-test-reminder.yml
@@ -1,7 +1,12 @@
 name: Email Editor Test Reminder
 
+# Runs on `pull_request_target` rather than `pull_request` so it also works for
+# pull requests opened from a fork. On `pull_request` a fork gets a read-only
+# token, which a `permissions:` block cannot raise, so posting the reminder
+# comment fails with a 403. This workflow only ever checks out and runs base
+# branch code, so it never executes anything a fork controls.
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened]
 
 concurrency:
@@ -19,6 +24,10 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  # Check out the base branch, never the pull request head. The job
+                  # holds a write token, so it must not run code from the PR.
+                  ref: ${{ github.event.pull_request.base.sha }}
 
             - name: Setup Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `Email Editor Test Reminder` workflow fails on every pull request opened from a fork that touches `packages/php/email-editor`. It runs on `pull_request`, so a fork gets a read-only `GITHUB_TOKEN`, and a `permissions:` block cannot raise it. Posting the reminder comment then fails with a 403 and the PR shows a red check that has nothing to do with its code.

This switches the trigger to `pull_request_target`, which runs in the base repo context and gets a write token for fork pull requests. `changelog-auto-add.yml` and `docs-needed-detection.yml` already use the same pattern.

It also pins `actions/checkout` to `github.event.pull_request.base.sha`. That was already the default under `pull_request_target`, but making it explicit keeps a later edit from pulling in pull request code while the job holds a write token.

Example of the failure: [run 31485658060](https://github.com/woocommerce/woocommerce/actions/runs/31485658060/job/93760697182) on #67519.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This cannot be verified from this pull request. `pull_request_target` reads the workflow file from the base branch, so this PR still runs the old `pull_request` definition.

1. Review the diff, in particular that `actions/checkout` resolves to the base commit and that no step runs code from the pull request.
2. After merge, open or push to a fork pull request that touches `packages/php/email-editor`. #67519 works if it is still open.
3. Confirm the `Check and add test reminder comment` job passes and the reminder comment appears on the PR.
4. Confirm a fork pull request that does not touch `packages/php/email-editor` still passes, with no comment added.

<!-- End testing instructions -->

### Testing that has already taken place:

- Confirmed the cause from the job log: `403 Resource not accessible by integration` on `POST /repos/woocommerce/woocommerce/issues/67519/comments`, with 4946 rate limit remaining. The same branch failed identically the day before.
- Ruled out a wrong permission scope. The 403 lists `issues=write; pull_requests=write` as alternatives and the workflow already declares `pull-requests: write`.
- Ruled out a repo-wide read-only default. The comment posts fine on same-repo PRs, for example #67466 and #67443.
- Checked both helper scripts work unchanged. They only use `context.repo` and `context.issue.number`, and `context.issue` resolves through `payload.issue || payload.pull_request || payload`, so it returns the PR number under either trigger.
- Security review of the change: checkout is pinned to the base commit, the file has no `run:` steps and no install, build, or cache restore, and its only two `${{ }}` expressions are `pull_request.number` and `base.sha`, neither of which is attacker-controlled or reaches a shell. `contents: read` caps the blast radius so the token cannot push code. All three actions are official and SHA-pinned.

One thing worth knowing for future edits: `pull_request_target` is easy to get wrong. Adding `ref: head.sha` or any install or build step here would turn it into arbitrary code execution holding a write token. The pinned ref and the two comments in the diff are there to prevent that.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

CI only. This changes a file under `.github/workflows/` and ships nothing in the plugin or any package. `ci.yml` scopes changelog validation to `{packages,plugins}/*`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Claude Code was used to investigate the failing job, audit the workflow for the security concerns above, and draft the change and this description. I reviewed the diff and the reasoning, and I take responsibility for it.
