### PR TITLE
Respect the WordPress "Week Starts On" setting in Analytics week ranges

### DIFF
--- a/packages/js/date/changelog/fix-week-start-setting
+++ b/packages/js/date/changelog/fix-week-start-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect the WordPress "Week Starts On" setting in Analytics week date ranges and calendars.

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 import { getTimezoneOffset } from 'date-fns-tz';
+import { getSettings as getDateSettings } from '@wordpress/date';
 import { find, memoize } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { parse } from 'qs';
@@ -259,6 +260,34 @@ function anchorRangeToStoreTimeZone( range: DateValue ): DateValue {
 }
 
 /**
+ * Aligns the moment locale's start of the week with the WordPress
+ * "Week Starts On" setting. WordPress core applies the setting to the moment
+ * locale, but `wp.date.setSettings` then redefines the locale without a `week`
+ * key, resetting the start of the week to Sunday; without this correction,
+ * week ranges and calendar layouts ignore the setting.
+ */
+function ensureMomentStartOfWeek() {
+	const startOfWeek = getDateSettings().l10n?.startOfWeek;
+
+	if (
+		typeof startOfWeek !== 'number' ||
+		! Number.isInteger( startOfWeek ) ||
+		startOfWeek < 0 ||
+		startOfWeek > 6
+	) {
+		return;
+	}
+
+	if ( moment.localeData().firstDayOfWeek() !== startOfWeek ) {
+		moment.updateLocale( moment.locale(), {
+			week: { dow: startOfWeek },
+		} );
+	}
+}
+
+ensureMomentStartOfWeek();
+
+/**
  * Get a DateValue object for a period prior to the current period.
  *
  * @param {moment.DurationInputArg2} period  - the chosen period
@@ -269,6 +298,8 @@ export function getLastPeriod(
 	period: moment.DurationInputArg2,
 	compare: string
 ) {
+	ensureMomentStartOfWeek();
+
 	const primaryStart = getStoreTimeZoneMoment()
 		.startOf( period )
 		.subtract( 1, period );
@@ -321,6 +352,8 @@ export function getCurrentPeriod(
 	period: moment.DurationInputArg2,
 	compare: string
 ) {
+	ensureMomentStartOfWeek();
+
 	const primaryStart = getStoreTimeZoneMoment().startOf( period );
 	const primaryEnd = getStoreTimeZoneMoment();
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import moment from 'moment';
-import { format as formatDate } from '@wordpress/date';
+import {
+	format as formatDate,
+	getSettings as getDateSettings,
+	setSettings as setDateSettings,
+} from '@wordpress/date';
 import { timeFormat as d3TimeFormat } from 'd3-time-format';
 /**
  * Internal dependencies
@@ -729,6 +733,58 @@ describe( 'getLastPeriod', () => {
 				twoYearsAgoEnd.isSame( dateValue.secondaryEnd, 'day' )
 			).toBe( true );
 		} );
+	} );
+} );
+
+describe( 'start of week setting', () => {
+	const originalSettings = getDateSettings();
+	const originalDow = moment.localeData().firstDayOfWeek();
+
+	afterEach( () => {
+		setDateSettings( originalSettings );
+		moment.updateLocale( moment.locale(), {
+			week: { dow: originalDow },
+		} );
+	} );
+
+	it( 'getCurrentPeriod should start the week on the day from the WordPress setting', () => {
+		setDateSettings( {
+			...originalSettings,
+			l10n: { ...originalSettings.l10n, startOfWeek: 1 },
+		} );
+
+		const dateValue = getCurrentPeriod( 'week', 'previous_period' );
+
+		expect( dateValue.primaryStart.day() ).toBe( 1 );
+		expect( dateValue.primaryStart.isSameOrBefore( moment(), 'day' ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'getLastPeriod should start and end the week on days from the WordPress setting', () => {
+		setDateSettings( {
+			...originalSettings,
+			l10n: { ...originalSettings.l10n, startOfWeek: 3 },
+		} );
+
+		const dateValue = getLastPeriod( 'week', 'previous_period' );
+
+		expect( dateValue.primaryStart.day() ).toBe( 3 );
+		expect( dateValue.primaryEnd.day() ).toBe( 2 );
+	} );
+
+	it( 'should leave the moment default when the setting is invalid', () => {
+		setDateSettings( {
+			...originalSettings,
+			l10n: {
+				...originalSettings.l10n,
+				startOfWeek: 7 as unknown as 0,
+			},
+		} );
+
+		const dateValue = getCurrentPeriod( 'week', 'previous_period' );
+
+		expect( dateValue.primaryStart.day() ).toBe( originalDow );
 	} );
 } );
 

--- a/plugins/woocommerce/changelog/fix-week-start-setting
+++ b/plugins/woocommerce/changelog/fix-week-start-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Spread the actual @wordpress/date module in the import status bar test mock.

--- a/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
+++ b/plugins/woocommerce/client/admin/client/analytics/components/import-status-bar/test/import-status-bar.test.tsx
@@ -21,6 +21,7 @@ jest.mock( '@wordpress/data', () => ( {
 	} ) ),
 } ) );
 jest.mock( '@wordpress/date', () => ( {
+	...jest.requireActual( '@wordpress/date' ),
 	dateI18n: jest.fn( ( format, date ) => {
 		// Simple mock that returns a date-like string
 		if ( ! date ) return 'Never';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Analytics week ranges ("Week to date", "Last week") and the custom range calendar always started the week on Sunday, ignoring the WordPress "Week Starts On" setting. WordPress core applies the setting to moment's locale, but `wp.date.setSettings` then redefines the locale without a `week` key, resetting the start of the week to Sunday - while the server-side week intervals (`TimeInterval.php`) do respect the setting, so client and server disagreed on week boundaries. `@woocommerce/date` now re-applies `startOfWeek` from the `@wordpress/date` settings to the moment locale, which fixes the week presets and the calendar layout in one place.

Closes #33595.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1239" height="952" alt="before-week-to-date" src="https://github.com/user-attachments/assets/757f117a-97b6-4a55-bee9-f1ea12179903" /> | <img width="1239" height="952" alt="after-week-to-date" src="https://github.com/user-attachments/assets/fdf477df-3abd-435d-b9c8-3b24a0c9bbb7" /> |


| Before | After |
| ------ | ----- |
| <img width="336" height="667" alt="before-calendar" src="https://github.com/user-attachments/assets/72d64be4-3f89-4842-b528-20471c72b9f7" /> | <img width="336" height="667" alt="after-calendar" src="https://github.com/user-attachments/assets/39513a84-1e1f-4a42-b786-ebc24b647c0c" /> |

### How to test the changes in this Pull Request:

1. Go to Settings > General and set "Week Starts On" to Monday.
2. Go to Analytics > Revenue and select the "Week to date" date range preset.
3. Confirm the range starts on Monday (e.g. with today = Tuesday Aug 11, the range is Aug 10 - 11, matching the chart and table). Before this fix it started on the previous Sunday.
4. Open the date range dropdown again, switch to the Custom tab, and confirm the calendar week columns start with "Mo". Before this fix they started with "Su".

### Testing that has already taken place:

- Jest suite for `@woocommerce/date` passes (100 tests, 3 new covering the week start setting).
- Rebuilt the admin bundle and verified the fix live on WP 7.0.3: "Week to date" preset, chart/table alignment with server data, and the custom range calendar all follow the setting.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually (`packages/js/date/changelog/fix-week-start-setting`).

-   [ ] Automatically create a changelog entry from the details below.

### Use of AI Tools

Authored with AI assistance (Claude Code); reviewed and tested by me.
