### PR TITLE
Include product brands in term recounts

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-brand-term-recounts
+++ b/plugins/woocommerce/changelog/fix-product-brand-term-recounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Include product brands in visibility-aware product term recounts.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -74,10 +74,6 @@ class WC_Brands {
 		// Layered nav widget compatibility.
 		add_filter( 'woocommerce_layered_nav_term_html', array( $this, 'woocommerce_brands_update_layered_nav_link' ), 10, 4 );
 
-		// Filter the list of taxonomies overridden for the original term count.
-		add_action( 'woocommerce_product_set_stock_status', array( $this, 'recount_after_stock_change' ) );
-		add_action( 'woocommerce_update_options_products_inventory', array( $this, 'recount_all_brands' ) );
-
 		// Block theme integration.
 		add_filter( 'hooked_block_types', array( $this, 'hook_product_brand_block' ), 10, 4 );
 		add_filter( 'hooked_block_core/post-terms', array( $this, 'configure_product_brand_block' ), 10, 5 );

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -569,6 +569,11 @@ function wc_recount_after_stock_change( $product_id ) {
 		if ( is_array( $product_terms ) ) {
 			wp_update_term_count( array_column( $product_terms, 'term_taxonomy_id' ), 'product_tag' );
 		}
+
+		$product_terms = get_the_terms( $product_id, 'product_brand' );
+		if ( is_array( $product_terms ) ) {
+			wp_update_term_count( array_column( $product_terms, 'term_taxonomy_id' ), 'product_brand' );
+		}
 	} else {
 		_wc_recount_terms_by_product( $product_id );
 	}
@@ -577,7 +582,7 @@ add_action( 'woocommerce_product_set_stock_status', 'wc_recount_after_stock_chan
 
 
 /**
- * Overrides the original term count for product categories and tags with the product count.
+ * Overrides the original term count for product categories, tags, and brands with the product count
  * that takes catalog visibility into account.
  *
  * @param array        $terms      List of terms.
@@ -719,7 +724,7 @@ function wc_get_product_visibility_term_ids() {
 }
 
 /**
- * Recounts all terms for product categories and product tags.
+ * Recounts all terms for product categories, tags, and brands.
  *
  * @since 5.2
  *
@@ -746,10 +751,23 @@ function wc_recount_all_terms( bool $include_callback = true ) {
 		)
 	);
 	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), $include_callback, false );
+
+	$product_brands         = get_terms(
+		array(
+			'taxonomy'   => 'product_brand',
+			'hide_empty' => false,
+			'fields'     => 'id=>parent',
+		)
+	);
+	$product_brand_taxonomy = get_taxonomy( 'product_brand' );
+
+	if ( is_array( $product_brands ) && $product_brand_taxonomy instanceof WP_Taxonomy ) {
+		_wc_term_recount( $product_brands, $product_brand_taxonomy, $include_callback, false );
+	}
 }
 
 /**
- * Recounts terms by product.
+ * Recounts product category, tag, and brand terms by product.
  *
  * @since 5.2
  * @param int $product_id The ID of the product.
@@ -782,5 +800,21 @@ function _wc_recount_terms_by_product( $product_id = '' ) {
 		}
 
 		_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
+	}
+
+	$product_terms = get_the_terms( $product_id, 'product_brand' );
+
+	if ( is_array( $product_terms ) ) {
+		$product_brands = array();
+
+		foreach ( $product_terms as $term ) {
+			$product_brands[ $term->term_id ] = $term->parent;
+		}
+
+		$product_brand_taxonomy = get_taxonomy( 'product_brand' );
+
+		if ( $product_brand_taxonomy instanceof WP_Taxonomy ) {
+			_wc_term_recount( $product_brands, $product_brand_taxonomy, false, false );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -32,6 +32,13 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->terms['tag1'] = wp_insert_term( 'Tag 1', 'product_tag' );
 		$this->terms['tag2'] = wp_insert_term( 'Tag 2', 'product_tag' );
 
+		$this->terms['brand_parent'] = wp_insert_term( 'Parent brand', 'product_brand' );
+		$this->terms['brand_child']  = wp_insert_term(
+			'Child brand',
+			'product_brand',
+			array( 'parent' => $this->terms['brand_parent']['term_id'] )
+		);
+
 		$this->products['product1'] = WC_Helper_Product::create_simple_product(
 			true,
 			array(
@@ -54,6 +61,10 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 				'tag_ids'      => array( $this->terms['tag1']['term_id'], $this->terms['tag2']['term_id'] ),
 			)
 		);
+
+		wp_set_object_terms( $this->products['product1']->get_id(), array( $this->terms['brand_child']['term_id'] ), 'product_brand' );
+		wp_set_object_terms( $this->products['product2']->get_id(), array( $this->terms['brand_child']['term_id'] ), 'product_brand' );
+		wp_set_object_terms( $this->products['product3']->get_id(), array( $this->terms['brand_parent']['term_id'] ), 'product_brand' );
 	}
 
 	/**
@@ -81,7 +92,7 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_term_count_baseline(): void {
 		$terms       = get_terms(
 			array(
-				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'taxonomy'   => array( 'product_cat', 'product_tag', 'product_brand' ),
 				'hide_empty' => false,
 			)
 		);
@@ -92,6 +103,8 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+		$this->assertEquals( 3, $term_counts[ $this->terms['brand_parent']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['brand_child']['term_id'] ] );
 	}
 
 	/**
@@ -106,7 +119,7 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 
 		$terms       = get_terms(
 			array(
-				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'taxonomy'   => array( 'product_cat', 'product_tag', 'product_brand' ),
 				'hide_empty' => false,
 			)
 		);
@@ -117,6 +130,8 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 1, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['brand_parent']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['brand_child']['term_id'] ] );
 	}
 
 	/**
@@ -130,7 +145,7 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 
 		$terms       = get_terms(
 			array(
-				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'taxonomy'   => array( 'product_cat', 'product_tag', 'product_brand' ),
 				'hide_empty' => false,
 			)
 		);
@@ -141,6 +156,28 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertEquals( 0, $term_counts[ $this->terms['child2']['term_id'] ] );
 		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
 		$this->assertEquals( 1, $term_counts[ $this->terms['tag2']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['brand_parent']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['brand_child']['term_id'] ] );
+
+		delete_option( 'woocommerce_hide_out_of_stock_items' );
+	}
+
+	/**
+	 * @testdox Recounting terms for one product updates its brand and brand ancestors.
+	 */
+	public function test_recount_terms_by_product_includes_brands(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+		wp_set_object_terms(
+			$this->products['product1']->get_id(),
+			ProductStockStatus::OUT_OF_STOCK,
+			'product_visibility',
+			true
+		);
+
+		_wc_recount_terms_by_product( $this->products['product1']->get_id() );
+
+		$this->assertSame( '1', get_term_meta( $this->terms['brand_parent']['term_id'], 'product_count_product_brand', true ) );
+		$this->assertSame( '0', get_term_meta( $this->terms['brand_child']['term_id'], 'product_count_product_brand', true ) );
 
 		delete_option( 'woocommerce_hide_out_of_stock_items' );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Product brands currently maintain visibility-aware term counts through separate `WC_Brands` callbacks. This means callers of the shared WooCommerce recount functions update product categories and tags but can leave brand counts stale. It also makes normal stock and inventory-setting updates run a second, Brands-only recount after the shared recount.

This PR:

- includes `product_brand` in the deferred stock recount path;
- includes all product brands in `wc_recount_all_terms()`;
- includes a product's brands and brand ancestors in `_wc_recount_terms_by_product()`;
- removes WooCommerce's duplicate Brands callback registrations; and
- extends the term-function test coverage to product brands.

The existing public `WC_Brands::recount_after_stock_change()` and `WC_Brands::recount_all_brands()` methods remain unchanged for direct callers. 

I found this opportunity, while I was working on https://github.com/woocommerce/woocommerce/pull/67624.


### How to test the changes in this Pull Request:

1. Create a product category, a product tag, a parent product brand, and a child brand.
2. Create two products and assign both to the category, tag, and child brand:
    - Keep the first product in stock.
    - Set the second product to out of stock.
3. Enable **Hide out of stock items from the catalog** under **WooCommerce > Settings > Products > Inventory**.
4. Check the term counts under **Products > Categories**, **Products > Tags**, and **Products > Brands**. Confirm the category, tag, parent brand, and child brand each have a count of `1`.
5. Change the in-stock product to out of stock. Confirm all four counts change to `0`.
6. Change the other product to in stock. Confirm all four counts return to `1`.


### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A patch/fix changelog entry was created manually at `plugins/woocommerce/changelog/fix-product-brand-term-recounts`.

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

OpenAI Codex was used to implement the changes, extend the tests, run validation, and draft this pull request description. The contributor remains responsible for reviewing and maintaining the submitted code.
