### PR TITLE
Use consistent markup for single and multiple store notices

### DIFF
--- a/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
+++ b/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Render Cart and Checkout notices with the same list markup whether there is one notice or several, so a single set of styles applies to both. A single error notice now also shows the "Please fix the following error before continuing" summary, which was previously only shown when there were several.
+Render Cart and Checkout notices with the same list markup whether there is one notice or several, and expose each notice's id as `data-id` on its list item.

--- a/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
+++ b/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Render Cart and Checkout notices with the same list markup whether there is one notice or several, so a single set of styles applies to both.
+Render Cart and Checkout notices with the same list markup whether there is one notice or several, so a single set of styles applies to both. A single error notice now also shows the "Please fix the following error before continuing" summary, which was previously only shown when there were several.

--- a/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
+++ b/plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render Cart and Checkout notices with the same list markup whether there is one notice or several, so a single set of styles applies to both.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/notice-banner/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/notice-banner/style.scss
@@ -41,6 +41,19 @@
 			}
 		}
 
+		// Notice contents are always a list, whether there is one notice or
+		// several, so the markers are removed to keep a single notice reading
+		// as plain text. `role="list"` on the element preserves the semantics.
+		ul.wc-block-components-notice-banner__list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+
+			li + li {
+				margin-block-start: $gap-smaller;
+			}
+		}
+
 		// Legacy notice compatibility.
 		.wc-forward {
 			float: right;

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/store-notices.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _n } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useRef, useEffect, RawHTML } from '@wordpress/element';
 import { sanitizeHTML } from '@woocommerce/sanitize';
@@ -15,6 +15,30 @@ import type { NoticeBannerProps } from '@woocommerce/base-components/notice-bann
  * Internal dependencies
  */
 import StoreNotice from '../store-notice';
+
+/**
+ * Renders notice contents as a list, so a single notice and multiple notices
+ * share the same markup and can be styled with a single set of rules.
+ *
+ * `role="list"` is needed because the list markers are removed with CSS, which
+ * strips the implicit list semantics in some browsers.
+ */
+const StoreNoticeList = ( {
+	notices,
+}: {
+	notices: ( Pick< NoticeType, 'id' | 'content' > &
+		Partial< Pick< NoticeType, 'context' > > )[];
+} ): JSX.Element => (
+	// The role is not redundant here, see above.
+	// eslint-disable-next-line jsx-a11y/no-redundant-roles
+	<ul className="wc-block-components-notice-banner__list" role="list">
+		{ notices.map( ( notice ) => (
+			<li key={ notice.id + '-' + notice.context }>
+				<RawHTML>{ notice.content }</RawHTML>
+			</li>
+		) ) }
+	</ul>
+);
 
 const StoreNotices = ( {
 	className,
@@ -103,9 +127,16 @@ const StoreNotices = ( {
 					key={ notice.id + '-' + notice.context }
 					{ ...notice }
 				>
-					<RawHTML>
-						{ sanitizeHTML( decodeEntities( notice.content ) ) }
-					</RawHTML>
+					<StoreNoticeList
+						notices={ [
+							{
+								...notice,
+								content: sanitizeHTML(
+									decodeEntities( notice.content )
+								),
+							},
+						] }
+					/>
 				</StoreNotice>
 			) ) }
 			{ Object.entries( dismissibleNoticeGroups ).map(
@@ -139,35 +170,22 @@ const StoreNotices = ( {
 							} );
 						},
 					};
-					return uniqueNotices.length === 1 ? (
-						<StoreNotice
-							key={ 'store-notice-' + status }
-							{ ...noticeProps }
-						>
-							<RawHTML>{ uniqueNotices[ 0 ].content }</RawHTML>
-						</StoreNotice>
-					) : (
+					return (
 						<StoreNotice
 							key={ 'store-notice-' + status }
 							{ ...noticeProps }
 							summary={
 								status === 'error'
-									? __(
+									? _n(
+											'Please fix the following error before continuing',
 											'Please fix the following errors before continuing',
+											uniqueNotices.length,
 											'woocommerce'
 									  )
 									: ''
 							}
 						>
-							<ul>
-								{ uniqueNotices.map( ( notice ) => (
-									<li
-										key={ notice.id + '-' + notice.context }
-									>
-										<RawHTML>{ notice.content }</RawHTML>
-									</li>
-								) ) }
-							</ul>
+							<StoreNoticeList notices={ uniqueNotices } />
 						</StoreNotice>
 					);
 				}

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/store-notices.tsx
@@ -22,6 +22,12 @@ import StoreNotice from '../store-notice';
  *
  * `role="list"` is needed because the list markers are removed with CSS, which
  * strips the implicit list semantics in some browsers.
+ *
+ * `data-id` mirrors the classic notice templates, which expose the notice id on
+ * each `li` via `wc_get_notice_data_attr()`. Store API errors surface their
+ * error code as the notice id (e.g. `woocommerce_rest_cart_coupon_error`), so
+ * this gives themes and scripts the same per-notice hook the shortcode
+ * checkout has.
  */
 const StoreNoticeList = ( {
 	notices,
@@ -33,7 +39,7 @@ const StoreNoticeList = ( {
 	// eslint-disable-next-line jsx-a11y/no-redundant-roles
 	<ul className="wc-block-components-notice-banner__list" role="list">
 		{ notices.map( ( notice ) => (
-			<li key={ notice.id + '-' + notice.context }>
+			<li key={ notice.id + '-' + notice.context } data-id={ notice.id }>
 				<RawHTML>{ notice.content }</RawHTML>
 			</li>
 		) ) }

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
@@ -268,6 +268,47 @@ describe( 'StoreNoticesContainer', () => {
 		);
 	} );
 
+	it( 'Exposes the notice id as data-id on each list item', async () => {
+		// The classic notice templates put the notice id on the li via
+		// wc_get_notice_data_attr(), and Store API errors use their error code as
+		// the notice id. Keep the same hook here so scripts and themes can target
+		// an individual notice.
+		dispatch( noticesStore ).createErrorNotice( 'First data-id error', {
+			id: 'woocommerce_rest_cart_coupon_error',
+			context: 'test-context',
+		} );
+		dispatch( noticesStore ).createErrorNotice( 'Second data-id error', {
+			id: 'woocommerce_rest_invalid_postcode',
+			context: 'test-context',
+		} );
+		const { container } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+
+		expect(
+			[ ...container.querySelectorAll( 'li' ) ].map( ( item ) =>
+				item.getAttribute( 'data-id' )
+			)
+		).toEqual( [
+			'woocommerce_rest_cart_coupon_error',
+			'woocommerce_rest_invalid_postcode',
+		] );
+
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'woocommerce_rest_cart_coupon_error',
+				'test-context'
+			)
+		);
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'woocommerce_rest_invalid_postcode',
+				'test-context'
+			)
+		);
+	} );
+
 	it( 'Renders a non-dismissible notice with the same list markup, without a summary', async () => {
 		dispatch( noticesStore ).createErrorNotice(
 			'Non-dismissible list error',

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
@@ -3,7 +3,7 @@
  */
 import { store as noticesStore } from '@wordpress/notices';
 import { dispatch, select } from '@wordpress/data';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -263,6 +263,76 @@ describe( 'StoreNoticesContainer', () => {
 		await act( () =>
 			dispatch( noticesStore ).removeNotice(
 				'second-list-error',
+				'test-context'
+			)
+		);
+	} );
+
+	it( 'Renders a non-dismissible notice with the same list markup, without a summary', async () => {
+		dispatch( noticesStore ).createErrorNotice(
+			'Non-dismissible list error',
+			{
+				id: 'non-dismissible-list-error',
+				context: 'test-context',
+				isDismissible: false,
+			}
+		);
+		const { container } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+
+		const lists = within( container ).getAllByRole( 'list' );
+		expect( lists ).toHaveLength( 1 );
+		expect( within( lists[ 0 ] ).getAllByRole( 'listitem' ) ).toHaveLength(
+			1
+		);
+		expect( lists[ 0 ] ).toHaveClass(
+			'wc-block-components-notice-banner__list'
+		);
+		// Each non-dismissible notice is its own banner, so it carries no summary.
+		expect(
+			container.querySelector(
+				'.wc-block-components-notice-banner__summary'
+			)
+		).toBeNull();
+
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'non-dismissible-list-error',
+				'test-context'
+			)
+		);
+	} );
+
+	it( 'Renders non-error notices with the same list markup, without a summary', async () => {
+		dispatch( noticesStore ).createSuccessNotice( 'Coupon applied', {
+			id: 'success-list-notice',
+			context: 'test-context',
+		} );
+		const { container } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+
+		const lists = within( container ).getAllByRole( 'list' );
+		expect( lists ).toHaveLength( 1 );
+		expect( within( lists[ 0 ] ).getAllByRole( 'listitem' ) ).toHaveLength(
+			1
+		);
+		expect( lists[ 0 ] ).toHaveClass(
+			'wc-block-components-notice-banner__list'
+		);
+		// The summary is only rendered for the error status.
+		expect(
+			container.querySelector(
+				'.wc-block-components-notice-banner__summary'
+			)
+		).toBeNull();
+
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'success-list-notice',
 				'test-context'
 			)
 		);

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/store-notices-container/test/index.tsx
@@ -214,6 +214,60 @@ describe( 'StoreNoticesContainer', () => {
 		} );
 	} );
 
+	it( 'Renders a single notice with the same list markup as multiple notices', async () => {
+		dispatch( noticesStore ).createErrorNotice( 'Single list error', {
+			id: 'single-list-error',
+			context: 'test-context',
+		} );
+		const { container, rerender } = render(
+			<StoreNoticesContainer context="test-context" />
+		);
+		const singleList = container.querySelectorAll(
+			'.wc-block-components-notice-banner__list'
+		);
+		expect( singleList ).toHaveLength( 1 );
+		expect( singleList[ 0 ].getAttribute( 'role' ) ).toBe( 'list' );
+		expect( singleList[ 0 ].querySelectorAll( 'li' ) ).toHaveLength( 1 );
+		expect(
+			screen.getAllByText(
+				/Please fix the following error before continuing/i
+			).length
+		).toBeGreaterThan( 0 );
+
+		await act( () =>
+			dispatch( noticesStore ).createErrorNotice( 'Second list error', {
+				id: 'second-list-error',
+				context: 'test-context',
+			} )
+		);
+		rerender( <StoreNoticesContainer context="test-context" /> );
+
+		const multipleList = container.querySelectorAll(
+			'.wc-block-components-notice-banner__list'
+		);
+		expect( multipleList ).toHaveLength( 1 );
+		expect( multipleList[ 0 ].querySelectorAll( 'li' ) ).toHaveLength( 2 );
+		expect(
+			screen.getAllByText(
+				/Please fix the following errors before continuing/i
+			).length
+		).toBeGreaterThan( 0 );
+
+		// Clean up notices.
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'single-list-error',
+				'test-context'
+			)
+		);
+		await act( () =>
+			dispatch( noticesStore ).removeNotice(
+				'second-list-error',
+				'test-context'
+			)
+		);
+	} );
+
 	it( 'Combine same notices from several contexts', async () => {
 		dispatch( noticesStore ).createErrorNotice( 'Custom generic error', {
 			id: 'custom-subcontext-test-error',


### PR DESCRIPTION
### Submission Review Guidelines:

- [X] I have followed the [WooCommerce Contributing Guidelines](<https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md>) and the [WordPress Coding Standards](<https://make.wordpress.org/core/handbook/best-practices/coding-standards/>).
- [X] I have checked to ensure there aren't other open [Pull Requests](<https://github.com/woocommerce/woocommerce/pulls>) for the same update/change.
- [X] I have reviewed my code for [security best practices](<https://developer.wordpress.org/apis/security/>).

### Changes proposed in this Pull Request:

Cart and Checkout notices rendered two different structures depending on how many there were: a group of notices became a `<ul>`/`<li>` list under a summary heading, while a single notice was dropped straight into `.wc-block-components-notice-banner__content` as bare content. Store owners and extension developers therefore needed two sets of CSS rules for what a shopper sees as the same component, and scripting against the notices meant reading from two different places.

Every branch of `StoreNotices` now emits the same markup:

```html
<div class="wc-block-components-notice-banner__content">
  <p class="wc-block-components-notice-banner__summary">Please fix the following error before continuing</p>
  <ul class="wc-block-components-notice-banner__list" role="list">
    <li data-id="woocommerce_rest_invalid_postcode">Please enter a valid postcode.</li>
  </ul>
</div>
```

This implements the engineering direction in the issue thread: *"use* `<li>` *even for a single error but include no bullets."*

Design decisions worth flagging for review:

* **The list markers are removed** (`list-style: none`, no indent), so a single notice looks the same to a shopper as it does today — a lone bullet reads like a rendering mistake. This is the option picked in the issue thread over keeping the native marker.
* `role="list"` **is explicit** because removing the markers strips the implicit list semantics in Safari/VoiceOver. That's why the `jsx-a11y/no-redundant-roles` rule is suppressed on that element, with a comment explaining why it isn't actually redundant.
* **Each** `<li>` **carries** `data-id`, which is the second half of the issue's expected behavior. The classic notice templates already expose the notice id on the `li` via `wc_get_notice_data_attr()`, and block notices had no equivalent hook. Store API errors surface their error code as the notice id, so a real notice reads `data-id="woocommerce_rest_cart_coupon_error"` — usable for both styling and scripting.
* **The summary is now pluralized** with `_n()`, so a single error reads "Please fix the following error before continuing" instead of "errors". This is a new string pair; the plural form is unchanged from the existing one.
* **A single error now shows the summary heading**, which it didn't before. This follows from grouping being unconditional, and matches the design comps in the issue.

Three things deliberately left out of scope:

* **Snackbar notices are unchanged.** They render through `snackbar-notices.tsx` → `SnackbarList`, which passes content straight to `NoticeBanner`, so a snackbar still puts bare content inside `.wc-block-components-notice-banner__content` (e.g. "Coupon code X has been applied to your cart"). That is the same shape inconsistency this PR removes from `StoreNotices`, but snackbars are a separate component and the issue's direction is about the error banner, so unifying them is a follow-up rather than part of this fix.
* Dismissible and non-dismissible notices still render as separate banners rather than being merged into one. That's a related inconsistency raised in the same thread ([comment](<https://linear.app/a8c/issue/WOOPLUG-1969/inconsistent-checkout-error-handling>)), but it's a behavior change rather than a markup one, and it never got a ruling.
* A single non-dismissible error still has no summary heading, since each one is its own banner and repeating the heading per banner would read badly.

The WooPayments inconsistencies raised in the same thread are tracked separately in [WOOPMNT-6364](https://linear.app/a8c/issue/WOOPMNT-6364/checkout-card-field-validation-notices-are-inconsistent-with-the-rest) and are untouched here.

Closes woocommerce/woocommerce#44613.

(For Bug Fixes) Bug introduced in PR # — not a regression from a single PR; the markup split has been present since the notice banner rewrite in 8.5.

### Backward compatibility

`StoreNoticesContainer` is exported from `@woocommerce/blocks-components` (`wc.blocksComponents`), so its rendered output is consumed outside core. The change is **additive in the DOM but not byte-identical**: the wrapper classes, banner classes, and notice text are unchanged, and the previous multi-notice markup gains only a `data-id` attribute, but CSS or JS that specifically targeted a *single* notice as a direct text child of `.wc-block-components-notice-banner__content` will now find a `ul > li` in between. That is the intended fix — the issue asks for exactly this — and the new `.wc-block-components-notice-banner__list` class plus `data-id` give stable hooks. No PHP signatures, hooks, filters, script handles, or store state are touched.

### Screenshots or screen recordings:

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/094d423f-3181-483e-a893-0a70810f1538 " alt="Screenshot 2026-08-11 at 15 01 07" width="574" data-linear-height="220" /></td>
<td><img src="https://github.com/user-attachments/assets/e6da0268-0b42-48cd-b756-ab9ed3730b2b " alt="Screenshot 2026-08-11 at 15 01 12" width="574" data-linear-height="238" /></td>
</tr>
</tbody>
</table>

### How to test the changes in this Pull Request:

 1. Check out this branch and build the Blocks client: `pnpm --filter='@woocommerce/plugin-woocommerce' build:blocks` (or run the watcher). Hard-refresh so the rebuilt assets load.
 2. Make sure your Cart and Checkout pages use the **block** versions, not the classic shortcode, and go to Checkout.
 3. In the browser console, add a single error notice:

    ```js
    wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Please enter a valid postcode.', { context: 'wc/checkout', id: 'woocommerce_rest_invalid_postcode' } );
    ```

    Field validation renders inline on the field rather than in the banner, so dispatching directly is the reliable way to reach this code path.
 4. Inspect the notice. **Expected:** the content is a `<ul class="wc-block-components-notice-banner__list" role="list">` with one `<li data-id="woocommerce_rest_invalid_postcode">`, preceded by the summary "Please fix the following **error** before continuing". **Expected:** no bullet marker and no left indent, so the banner looks the same as it does on `trunk` — the `<li>` should line up exactly with the summary text.
 5. Add a second error:

    ```js
    wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Please enter a valid phone number.', { context: 'wc/checkout', id: 'woocommerce_rest_invalid_phone' } );
    ```

    **Expected:** identical structure with two `<li>` elements each carrying their own `data-id`, and the summary now reads "**errors**". Compare the two inspected trees — they should differ only in the number of list items. On `trunk`, the single-notice case has no `ul`/`li` at all.
 6. Verify a real, server-driven single-error banner. Create a coupon, apply it in Cart, then delete the coupon and reload Cart. **Expected:** WooCommerce auto-removes it and renders a single-error banner with the singular summary, one `<li>`, and `data-id="woocommerce_rest_cart_coupon_error"`.<br>Note that two flows do **not** exercise this code path: an invalid coupon code renders inline in the coupon form as `.wc-block-components-validation-error` (no banner at all), and a successfully applied coupon renders as a **snackbar**, which this PR does not change.
 7. Verify a non-dismissible notice keeps its own banner and has no heading:

    ```js
    wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Non-dismissible error.', { context: 'wc/checkout', isDismissible: false } );
    ```
 8. Verify a success notice in the banner (not the snackbar) gets the list markup but **no** summary heading:

    ```js
    wp.data.dispatch( 'core/notices' ).createSuccessNotice( 'Coupon code applied successfully.', { context: 'wc/checkout' } );
    ```
 9. Repeat step 3 on a block theme (TT4/TT5) and on Storefront, watching for a stray bullet or indent reintroduced by theme styles.
10. With VoiceOver in Safari, confirm the single-error banner still announces as a list containing one item.

### Testing that has already taken place:

* Unit tests in `store-notices-container/test/index.tsx` asserting that one notice and two notices produce the same list markup, that the list carries `role="list"`, that each `li` exposes its notice id as `data-id`, and that the summary is correctly singularized/pluralized. The suite passes (12 tests).
* Manual browser verification on a block theme (TT5) with the block Cart and Checkout, covering steps 3–8:
  * Single dismissible error → summary in the **singular**, one `<li data-id="…">` inside `ul.wc-block-components-notice-banner__list[role=list]`.
  * Two errors → same tree with two `<li>`, summary switches to the plural.
  * No bullet and no indent confirmed by computed style (`list-style-type: none`, `padding-inline-start: 0`) and by geometry — the `<li>` left edge is at exactly the same x as the summary text.
  * Non-dismissible error → own banner, list markup, no summary.
  * Success notice in the banner → list markup, no summary.
  * Real server-driven flow → a coupon auto-removed because it no longer exists produced a single-error banner with the singular summary and one list item.
* ESLint clean on the changed files (only the pre-existing `'JSX' is not defined` / `import/named` warnings shared by that directory), Stylelint clean on the changed stylesheet, and `ts:check` reports nothing new.
* Reviewed the E2E specs that touch notices — they select by class and then `getByText`, so the added wrapper doesn't affect them. The E2E suite itself has not been run.
* **Not yet done:** step 9 on Storefront (only TT5 was tested) and the step 10 VoiceOver/Safari check.

### Milestone

- [X] Automatically assign milestone for the [**next WooCommerce version**](<../blob/trunk/plugins/woocommerce/woocommerce.php#L6>)

### Changelog entry

Added manually in `plugins/woocommerce/changelog/44613-fix-inconsistent-checkout-error-handling` — patch / fix. It's user-facing in the sense that store owners styling their checkout will see the markup settle into one shape, so it's worth a line in the release notes.

### Release Communication

- [X] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Authored with Claude Code (Claude Opus 5). The implementation, tests, and this description were AI-generated from the issue thread and reviewed by me; I take responsibility for the contents.