### PR TITLE
Add extension fatal-error alerts to the release monitoring guide

### DIFF
--- a/docs/contribution/releases/monitoring.md
+++ b/docs/contribution/releases/monitoring.md
@@ -18,6 +18,14 @@ Check newly created threads on the [WordPress.org Forums](https://wordpress.org/
 
 Watch the [Newest Created Issues](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc) and verify that none are critical.
 
+## Extension Fatal-Error Alerts
+
+Every Woo-owned extension has a Grafana fatal-error alert on WP Cloud, backed by the internal *Woo\* Fatals on WP Cloud* dashboard. Alerts post to the owning team's channel and to `#woo-core-releases-notifications`. Watch that channel during the monitoring window.
+
+When an alert fires, open the linked dashboard panel to see how many sites are affected, then reply on the alert to ping the owning team - triage is theirs. If the fatal traces back to the release, treat it as a candidate critical issue (see below).
+
+Fatals from old extension versions right after a release usually mean sites updated WooCommerce without updating the extension. Check the affected versions before calling it a regression.
+
 ## Handling Critical Issues
 
 If monitoring uncovers a bug that **cannot wait** for the next scheduled release, plan a point release. Before doing so, confirm that the issue:

--- a/docs/contribution/releases/monitoring.md
+++ b/docs/contribution/releases/monitoring.md
@@ -24,7 +24,7 @@ Every Woo-owned extension has a Grafana fatal-error alert on WP Cloud, backed by
 
 When an alert fires, open the linked dashboard panel to see how many sites are affected, then reply on the alert to ping the owning team - triage is theirs. If the fatal traces back to the release, treat it as a candidate critical issue (see below).
 
-Fatals from old extension versions right after a release usually mean sites updated WooCommerce without updating the extension. Check the affected versions before calling it a regression.
+An old extension version can point to a compatibility issue, but it does not prove the release caused the fatal. Compare the affected WooCommerce and extension versions before calling it a non-regression.
 
 ## Handling Critical Issues
 


### PR DESCRIPTION
Closes ARC-1820.

### Changes proposed in this Pull Request:

Adds an "Extension Fatal-Error Alerts" section to the [release monitoring guide](https://developer.woocommerce.com/docs/contribution/releases/monitoring). Every Woo-owned extension now has a fatal-error alert that also posts to `#woo-core-releases-notifications`, but the guide only covered forums and GitHub issues. The release lead should be watching that channel too.

### How to test the changes in this Pull Request:

1. Read the updated `docs/contribution/releases/monitoring.md` and check it matches how the alerts behave.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
Docs only.

</details>

### Use of AI Tools

Drafted with AI assistance, reviewed and edited by me.
