### PR TITLE
[DEVPROD-1148] Route e2e jobs to dedicated runner group when the queue switch is on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,10 @@ jobs:
 
   project-test-jobs:
     name: '${{ matrix.name }}'
-    runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || 'ubuntu-latest' }}
+    # CI_QUEUE_OVERFLOW is set by ci-queue-sentinel.yml when the queue backs up:
+    # e2e jobs then route to the paid group. Fork PRs are excluded — larger
+    # runners are not served to fork PRs, so their jobs would queue forever.
+    runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || ( vars.CI_QUEUE_OVERFLOW == '1' && matrix.testType == 'e2e' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) ) && fromJSON('{"group":"Woo Core Dedicated CI"}') || 'ubuntu-latest' }}
     needs: [ 'identify-jobs-to-run', 'project-jobs', 'woocommerce-plugin-build-artifact' ]
     if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.outputs.test-jobs != '[]' && ( needs.woocommerce-plugin-build-artifact.result == 'success' || needs.woocommerce-plugin-build-artifact.result == 'skipped' || needs.project-jobs.outputs.shared-plugin-build-has-required-consumers != 'true' ) }}
     env: ${{ matrix.testEnv.envVars }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,8 @@ jobs:
 
   project-test-jobs:
     name: '${{ matrix.name }}'
-    # CI_QUEUE_OVERFLOW is set by ci-queue-sentinel.yml when the queue backs up:
-    # e2e jobs then route to the paid group. Fork PRs are excluded — larger
-    # runners are not served to fork PRs, so their jobs would queue forever.
+    # While the CI_QUEUE_OVERFLOW repository variable is '1', e2e jobs route to the
+    # dedicated group. Fork PRs are excluded.
     runs-on: ${{ github.event.pull_request.user.login == 'woocommercebot' && fromJSON('{"group":"WooCommerce Release Checks"}') || ( vars.CI_QUEUE_OVERFLOW == '1' && matrix.testType == 'e2e' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) ) && fromJSON('{"group":"Woo Core Dedicated CI"}') || 'ubuntu-latest' }}
     needs: [ 'identify-jobs-to-run', 'project-jobs', 'woocommerce-plugin-build-artifact' ]
     if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) && needs.project-jobs.outputs.test-jobs != '[]' && ( needs.woocommerce-plugin-build-artifact.result == 'success' || needs.woocommerce-plugin-build-artifact.result == 'skipped' || needs.project-jobs.outputs.shared-plugin-build-has-required-consumers != 'true' ) }}


### PR DESCRIPTION
## Summary
- Route `testType == 'e2e'` matrix jobs in `ci.yml` to the **Woo Core Dedicated CI** runner group when the `CI_QUEUE_OVERFLOW` repository variable is `1`. With the variable unset or `0`, behavior is unchanged.
- Bot PRs keep their existing routing; fork PRs are excluded from group routing.
- The variable is toggled automatically by the CI Queue Sentinel (#67640) when the CI queue backs up.

## Test Plan
- Post-merge: set the variable to `1` and confirm e2e jobs land on the group while other jobs stay on `ubuntu-latest`; confirm bot-PR and fork-PR routing is unchanged; reset to `0`.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**