### PR TITLE
[Email Editor] Fix social links spacing in rendered emails

### DIFF
--- a/packages/php/email-editor/changelog/fix-social-links-rendered-spacing
+++ b/packages/php/email-editor/changelog/fix-social-links-rendered-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render spacing between Social Links icons in emails and match pill-shape icon padding with the editor.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
@@ -43,9 +43,20 @@ class Social_Links extends Abstract_Block_Renderer {
 
 		$inner_blocks = $parsed_block['innerBlocks'] ?? array();
 
-		$content = '';
+		$content                = '';
+		$is_first_rendered_link = true;
 		foreach ( $inner_blocks as $block ) {
-			$content .= $this->generate_social_link_content( $block, $attrs );
+			$social_link_content = $this->generate_social_link_content(
+				$block,
+				$attrs,
+				! $is_first_rendered_link,
+				$rendering_context->get_start_side()
+			);
+			if ( '' === $social_link_content ) {
+				continue;
+			}
+			$is_first_rendered_link = false;
+			$content               .= $social_link_content;
 		}
 
 		return str_replace(
@@ -58,11 +69,13 @@ class Social_Links extends Abstract_Block_Renderer {
 	/**
 	 * Generates the social link content.
 	 *
-	 * @param array $block The block data.
-	 * @param array $parent_block_attrs The parent block attributes.
+	 * @param array  $block The block data.
+	 * @param array  $parent_block_attrs The parent block attributes.
+	 * @param bool   $render_gap Whether to render a gap before the item.
+	 * @param string $gap_side The physical side used for the horizontal gap.
 	 * @return string The generated content.
 	 */
-	private function generate_social_link_content( $block, $parent_block_attrs ) {
+	private function generate_social_link_content( $block, $parent_block_attrs, bool $render_gap = false, string $gap_side = 'left' ) {
 		$service_name = $block['attrs']['service'] ?? '';
 		$service_url  = $block['attrs']['url'] ?? '';
 		$label        = $block['attrs']['label'] ?? '';
@@ -122,10 +135,11 @@ class Social_Links extends Abstract_Block_Renderer {
 
 		$main_table_styles = $this->compile_css(
 			array(
-				'background-color' => $icon_background_color_value,
-				'border-radius'    => '9999px',
-				'display'          => 'inline-table',
-				'float'            => 'none',
+				'background-color'    => $icon_background_color_value,
+				'border-radius'       => '9999px',
+				'display'             => 'inline-table',
+				'float'               => 'none',
+				'margin-' . $gap_side => $render_gap ? '16px' : '',
 			)
 		);
 
@@ -153,8 +167,8 @@ class Social_Links extends Abstract_Block_Renderer {
 		);
 
 		if ( $is_pill_shape ) {
-			$row_container_styles['padding-left']  = '17px';
-			$row_container_styles['padding-right'] = '17px';
+			$row_container_styles['padding-left']  = '0.667em';
+			$row_container_styles['padding-right'] = '0.667em';
 		}
 		$row_container_styles = $this->compile_css( $row_container_styles );
 
@@ -206,7 +220,11 @@ class Social_Links extends Abstract_Block_Renderer {
 
 		$main_table = Table_Wrapper_Helper::render_table_wrapper( $social_link_content, $main_table_attrs, array(), $main_row_attrs, false );
 
-		return Table_Wrapper_Helper::render_outlook_table_cell( $main_table );
+		$outlook_cell_attrs = array(
+			'style' => $render_gap ? 'padding-' . $gap_side . ':16px;' : '',
+		);
+
+		return Table_Wrapper_Helper::render_outlook_table_cell( $main_table, $outlook_cell_attrs );
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
@@ -167,8 +167,9 @@ class Social_Links extends Abstract_Block_Renderer {
 		);
 
 		if ( $is_pill_shape ) {
-			$row_container_styles['padding-left']  = '0.667em';
-			$row_container_styles['padding-right'] = '0.667em';
+			$pill_shape_horizontal_padding         = round( $font_size_value * 2 / 3, 2 ) . 'px';
+			$row_container_styles['padding-left']  = $pill_shape_horizontal_padding;
+			$row_container_styles['padding-right'] = $pill_shape_horizontal_padding;
 		}
 		$row_container_styles = $this->compile_css( $row_container_styles );
 

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -119,8 +119,11 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
 		$this->checkValidHTML( $rendered );
-		$this->assertStringContainsString( 'padding-left:16px;', $rendered );
-		$this->assertStringContainsString( 'padding-right:16px;', $rendered );
+		$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
+		foreach ( $link_wrappers as $link_wrapper ) {
+			$this->assertStringContainsString( 'padding-left:16px;', $link_wrapper );
+			$this->assertStringContainsString( 'padding-right:16px;', $link_wrapper );
+		}
 	}
 
 	/**
@@ -141,8 +144,11 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 			$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
 			$this->checkValidHTML( $rendered );
-			$this->assertStringContainsString( "padding-left:{$expected_padding};", $rendered );
-			$this->assertStringContainsString( "padding-right:{$expected_padding};", $rendered );
+			$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
+			foreach ( $link_wrappers as $link_wrapper ) {
+				$this->assertStringContainsString( "padding-left:{$expected_padding};", $link_wrapper );
+				$this->assertStringContainsString( "padding-right:{$expected_padding};", $link_wrapper );
+			}
 		}
 	}
 
@@ -156,16 +162,11 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
 		$this->checkValidHTML( $rendered );
-		$this->assertSame(
-			1,
-			substr_count( $rendered, 'margin-left:16px;' ),
-			'Only the second social link should have a standard-client horizontal gap.'
-		);
-		$this->assertSame(
-			1,
-			substr_count( $rendered, 'padding-left:16px;' ),
-			'Only the second social link should have an Outlook horizontal gap.'
-		);
+		$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
+		$this->assertStringNotContainsString( 'margin-left:16px;', $link_wrappers['facebook'] );
+		$this->assertStringNotContainsString( 'padding-left:16px;', $link_wrappers['facebook'] );
+		$this->assertStringContainsString( 'margin-left:16px;', $link_wrappers['twitter'] );
+		$this->assertStringContainsString( 'padding-left:16px;', $link_wrappers['twitter'] );
 	}
 
 	/**
@@ -179,16 +180,11 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $rtl_rendering_context );
 		$this->checkValidHTML( $rendered );
-		$this->assertSame(
-			1,
-			substr_count( $rendered, 'margin-right:16px;' ),
-			'Only the second social link should have a standard-client horizontal gap in RTL.'
-		);
-		$this->assertSame(
-			1,
-			substr_count( $rendered, 'padding-right:16px;' ),
-			'Only the second social link should have an Outlook horizontal gap in RTL.'
-		);
+		$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
+		$this->assertStringNotContainsString( 'margin-right:16px;', $link_wrappers['facebook'] );
+		$this->assertStringNotContainsString( 'padding-right:16px;', $link_wrappers['facebook'] );
+		$this->assertStringContainsString( 'margin-right:16px;', $link_wrappers['twitter'] );
+		$this->assertStringContainsString( 'padding-right:16px;', $link_wrappers['twitter'] );
 	}
 
 	/**
@@ -283,5 +279,50 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$non_existing_service_icon_url = $this->social_links_renderer->get_service_icon_url( 'non-existing-service' );
 		$this->assertEquals( '', $non_existing_service_icon_url );
+	}
+
+	/**
+	 * Gets the rendered wrapper fragment for each social link.
+	 *
+	 * @param string $rendered The rendered social links block.
+	 * @return array<string, string>
+	 */
+	private function getRenderedSocialLinkWrappers( string $rendered ): array {
+		$urls = array(
+			'facebook' => 'https://facebook.com',
+			'twitter'  => 'https://twitter.com',
+		);
+
+		$wrapper_starts = array();
+		foreach ( $urls as $service => $url ) {
+			$url_position = strpos( $rendered, 'href="' . $url . '"' );
+			if ( false === $url_position ) {
+				$this->fail( sprintf( 'Expected to find rendered %s social link.', $service ) );
+			}
+
+			$content_before_url = substr( $rendered, 0, $url_position );
+			$wrapper_start      = strrpos( $content_before_url, '<!--[if mso | IE]><td' );
+			if ( false === $wrapper_start ) {
+				$this->fail( sprintf( 'Expected to find rendered %s social link wrapper.', $service ) );
+			}
+
+			$wrapper_starts[ $service ] = $wrapper_start;
+		}
+
+		asort( $wrapper_starts );
+
+		$link_wrappers    = array();
+		$ordered_services = array_keys( $wrapper_starts );
+		foreach ( $ordered_services as $index => $service ) {
+			$wrapper_start = $wrapper_starts[ $service ];
+			$next_service  = $ordered_services[ $index + 1 ] ?? null;
+			$wrapper_end   = null === $next_service ? strlen( $rendered ) : $wrapper_starts[ $next_service ];
+
+			$link_wrappers[ $service ] = substr( $rendered, $wrapper_start, $wrapper_end - $wrapper_start );
+		}
+
+		$this->assertCount( 2, $link_wrappers );
+
+		return $link_wrappers;
 	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -146,6 +146,29 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it renders a gap between social link items in RTL.
+	 */
+	public function testItRendersRtlGapBetweenSocialLinkItems(): void {
+		$parsed_social_links                        = $this->parsed_social_links;
+		$parsed_social_links['attrs']['className']  = '';
+		$parsed_social_links['attrs']['showLabels'] = false;
+		$rtl_rendering_context                      = new Rendering_Context( $this->rendering_context->get_theme_json(), array( 'is_rtl' => true ) );
+
+		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $rtl_rendering_context );
+		$this->checkValidHTML( $rendered );
+		$this->assertSame(
+			1,
+			substr_count( $rendered, 'margin-right:16px;' ),
+			'Only the second social link should have a standard-client horizontal gap in RTL.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $rendered, 'padding-right:16px;' ),
+			'Only the second social link should have an Outlook horizontal gap in RTL.'
+		);
+	}
+
+	/**
 	 * Test it renders social links with different sizes
 	 */
 	public function testItRendersSocialLinksWithDifferentSizes(): void {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -119,8 +119,31 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
 		$this->checkValidHTML( $rendered );
-		$this->assertStringContainsString( 'padding-left:0.667em;', $rendered );
-		$this->assertStringContainsString( 'padding-right:0.667em;', $rendered );
+		$this->assertStringContainsString( 'padding-left:16px;', $rendered );
+		$this->assertStringContainsString( 'padding-right:16px;', $rendered );
+	}
+
+	/**
+	 * Test it renders pill shape padding based on the selected icon size.
+	 */
+	public function testItRendersSocialLinksWithPillShapePaddingForDifferentSizes(): void {
+		$sizes = array(
+			'has-small-icon-size'  => '10.67px',
+			'has-normal-icon-size' => '16px',
+			'has-large-icon-size'  => '24px',
+			'has-huge-icon-size'   => '32px',
+		);
+
+		foreach ( $sizes as $size_class => $expected_padding ) {
+			$parsed_social_links                       = $this->parsed_social_links;
+			$parsed_social_links['attrs']['className'] = 'is-style-pill-shape';
+			$parsed_social_links['attrs']['size']      = $size_class;
+
+			$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
+			$this->checkValidHTML( $rendered );
+			$this->assertStringContainsString( "padding-left:{$expected_padding};", $rendered );
+			$this->assertStringContainsString( "padding-right:{$expected_padding};", $rendered );
+		}
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -119,8 +119,30 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 
 		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
 		$this->checkValidHTML( $rendered );
-		$this->assertStringContainsString( 'padding-left:17px;', $rendered );
-		$this->assertStringContainsString( 'padding-right:17px;', $rendered );
+		$this->assertStringContainsString( 'padding-left:0.667em;', $rendered );
+		$this->assertStringContainsString( 'padding-right:0.667em;', $rendered );
+	}
+
+	/**
+	 * Test it renders a gap between social link items.
+	 */
+	public function testItRendersGapBetweenSocialLinkItems(): void {
+		$parsed_social_links                        = $this->parsed_social_links;
+		$parsed_social_links['attrs']['className']  = '';
+		$parsed_social_links['attrs']['showLabels'] = false;
+
+		$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
+		$this->checkValidHTML( $rendered );
+		$this->assertSame(
+			1,
+			substr_count( $rendered, 'margin-left:16px;' ),
+			'Only the second social link should have a standard-client horizontal gap.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $rendered, 'padding-left:16px;' ),
+			'Only the second social link should have an Outlook horizontal gap.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Social Links icons in rendered block emails touched each other because the email renderer emitted adjacent inline tables without the editor's horizontal gap. This adds email-safe spacing between rendered social link items for standard clients and Outlook, and updates pill-shape icon padding to match the editor.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #67375.

(For Bug Fixes) Bug introduced in PR #58194.

### Screenshots or screen recordings:

After
<img width="2688" height="1068" alt="CleanShot 2026-08-12 at 18 03 34@2x" src="https://github.com/user-attachments/assets/00b62848-6b54-4a75-aeea-7558c3e0059a" />
<img width="3160" height="1048" alt="CleanShot 2026-08-12 at 18 03 10@2x" src="https://github.com/user-attachments/assets/65f9b833-1ee2-440b-9d32-63575a584361" />
<img width="1788" height="1520" alt="CleanShot 2026-08-12 at 14 47 19@2x" src="https://github.com/user-attachments/assets/a79dbc82-88fb-486a-964c-0481e992899e" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the Email Editor package test environment from `packages/php/email-editor`.
2. Render an email containing a Social Links block with at least two icons using the Default or Pill Shape style.
3. Confirm the rendered email output shows visible horizontal spacing between the social icons.
4. Confirm Pill Shape icons use the same horizontal padding as the editor.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested locally with the `packages/php/email-editor` wp-env test environment.

- `wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist --filter Social_Links_Test`
- `wp-env run tests-cli --env-cwd=wp-content/plugins/email-editor ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist --filter Core_Renderers_Rtl_Test::testSocialLinksUseRtlDefaultAlignment`
- `composer run phpcs -- src/Integrations/Core/Renderer/Blocks/class-social-links.php tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php`
- `./run-phpstan.sh --skip-cleanup` from `packages/php/email-editor/tasks/phpstan`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to implement and test this change.
