### PR TITLE
Fix vertical misalignment of "Product attribute" filter tags on Analytics > Variations and Analytics > Orders

### DIFF
--- a/packages/js/components/changelog/fix-54375-attribute-filter-tag-alignment
+++ b/packages/js/components/changelog/fix-54375-attribute-filter-tag-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix vertical misalignment of the selected tag in the "Product attribute" advanced filter on Analytics > Variations and Analytics > Orders

--- a/packages/js/components/src/advanced-filters/style.scss
+++ b/packages/js/components/src/advanced-filters/style.scss
@@ -242,6 +242,10 @@
 	.woocommerce-filters-advanced__attribute-field-separator {
 		padding: 0 6px;
 	}
+
+	.woocommerce-search.woocommerce-select-control .components-base-control .woocommerce-tag {
+		margin: 1px 4px 1px 0;
+	}
 }
 
 // Overrides woocommerce-admin-page globals


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The selected "Product attribute" filter tag in **Analytics > Variations** and **Analytics > Orders** was not vertically aligned with the search icon.

**Root cause:** The filter uses `multiple={false}`, so `SelectControl` does not add the `has-inline-tags` class even though an inline tag is rendered. This causes the tag to use the default margin and appear too low.

**Fix:** Added a scoped style override in `advanced-filters/style.scss` to correctly align the tag. This avoids changing shared styles or `SelectControl`, which could affect other areas.

Closes #54375.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1470" height="836" alt="Before" src="https://github.com/user-attachments/assets/6401259f-5863-4470-bf10-94e66437d83f" /> | <img width="1468" height="832" alt="After" src="https://github.com/user-attachments/assets/a117e54f-978b-40e5-a584-54acf6156d94" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Check out this branch and start the local environment.
2. Ensure you have at least one product with an attribute (e.g. "Size" with terms "Small"/"Large") used in a variation or order.
3. Go to **Analytics > Variations** (or **Analytics > Orders**).
4. Under **Show**, select **Advanced filters**.
5. Click **Add a filter** and choose **Product attribute**.
6. In the "Attribute name" search box, search for and select an attribute (e.g. "Size").
7. In the "Attribute value" box, select a term (e.g. "Large").
8. Confirm both the "Size" and "Large" tags render vertically centered in their input boxes, in line with the search icon and the "=" separator and not pushed down.
9. Repeat on **Analytics > Orders**.



<!-- End testing instructions -->

### Testing that has already taken place:

- Reproduced the issue on a local `wp-env` WooCommerce install by adding a "Product attribute" filter (`Size` = `Large`) on Analytics > Variations and confirmed the tag's `margin` computed to `8px 6px 0 0` via browser DevTools, matching the `:not(.has-inline-tags)` rule in `search/style.scss`.
- Confirmed via DevTools that the new scoped rule in `advanced-filters/style.scss` wins the cascade against that rule.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This PR was developed with the assistance of Claude Code.
