### PR TITLE
Fix malformed changelog entry from PR #66875

### DIFF
--- a/plugins/woocommerce/changelog/fix-66851-malformed-variation-prices
+++ b/plugins/woocommerce/changelog/fix-66851-malformed-variation-prices
@@ -1,3 +1,4 @@
 Significance: minor
 Type: fix
-Comment: Add guard against malformed data from woocommerce_variation_prices filter
+
+Add guard against malformed data from woocommerce_variation_prices filter


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PR #66875 merged with a malformed changelog file: the entry text was placed in the `Comment:` header and the entry body was left empty, which changelogger only allows for `patch` significance. Since the file is on trunk, the "Changelog validity" job now fails on every open PR. This PR moves the text from `Comment:` to the entry body; the wording is unchanged.

Bug introduced in PR #66875.

### How to test the changes in this Pull Request:

1. From `plugins/woocommerce`, run `composer exec -- changelogger validate`; it should report no errors.
2. The Changelog validity CI job on this PR should be green.

### Testing that has already taken place:

- `composer exec -- changelogger validate` passes locally on this branch and reproduces the failure on trunk.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR only repairs an existing changelog file; it introduces no change of its own.

</details>

### Use of AI Tools

I used Claude Code to diagnose the CI failure and prepare the fix; I reviewed the change.
