### PR TITLE
[DO NOT MERGE] Verify e2e overflow routing while CI_QUEUE_OVERFLOW=1

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1854,3 +1854,5 @@ final class WooCommerce {
 		}
 	}
 }
+
+// Temporary no-op comment: verifying CI_QUEUE_OVERFLOW e2e runner routing (DEVPROD-1148). Do not merge.


### PR DESCRIPTION
## Summary
Throwaway draft PR: a no-op comment on an `includes/**` PHP file to spawn e2e + unit suites while the queue-overflow switch is on, verifying that e2e jobs land on the **Woo Core Dedicated CI** runner group and non-e2e jobs stay on `ubuntu-latest` (#67639 / #67640 post-merge test plan).

Will be closed without merging once routing is confirmed.

## Test Plan
- [x] e2e matrix jobs' *Set up job* logs show runner group **Woo Core Dedicated CI**
- [x] PHP unit / lint jobs show `ubuntu-latest` (hosted pool)
- [x] Close PR, reset the variable if the sentinel hasn't already