### PR TITLE
Deprecate product brand recount methods

### DIFF
--- a/plugins/woocommerce/changelog/deprecate-brand-recount-methods
+++ b/plugins/woocommerce/changelog/deprecate-brand-recount-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Deprecate the WC_Brands recount methods in favor of the shared term recount functions.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -82,12 +82,12 @@ class WC_Brands {
 	/**
 	 * Recount the brands after the stock amount changes.
 	 *
-	 * @deprecated 11.1.0 Use wc_recount_after_stock_change() instead.
+	 * @deprecated 11.2.0 Use wc_recount_after_stock_change() instead.
 	 *
 	 * @param int $product_id Product ID.
 	 */
 	public function recount_after_stock_change( $product_id ) {
-		wc_deprecated_function( __METHOD__, '11.1.0', 'wc_recount_after_stock_change()' );
+		wc_deprecated_function( __METHOD__, '11.2.0', 'wc_recount_after_stock_change()' );
 
 		if ( 'yes' !== get_option( 'woocommerce_hide_out_of_stock_items' ) || empty( $product_id ) ) {
 			return;
@@ -122,10 +122,10 @@ class WC_Brands {
 	/**
 	 * Recount all brands.
 	 *
-	 * @deprecated 11.1.0 Use wc_recount_all_terms() instead.
+	 * @deprecated 11.2.0 Use wc_recount_all_terms() instead.
 	 */
 	public function recount_all_brands() {
-		wc_deprecated_function( __METHOD__, '11.1.0', 'wc_recount_all_terms()' );
+		wc_deprecated_function( __METHOD__, '11.2.0', 'wc_recount_all_terms()' );
 
 		$product_brands = get_terms(
 			array(

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -88,35 +88,7 @@ class WC_Brands {
 	 */
 	public function recount_after_stock_change( $product_id ) {
 		wc_deprecated_function( __METHOD__, '11.2.0', 'wc_recount_after_stock_change()' );
-
-		if ( 'yes' !== get_option( 'woocommerce_hide_out_of_stock_items' ) || empty( $product_id ) ) {
-			return;
-		}
-
-		$product_terms = get_the_terms( $product_id, 'product_brand' );
-
-		if ( ! $product_terms ) {
-			return;
-		}
-
-		if ( wp_defer_term_counting() ) {
-			// When deferring term counts, we're using the built in handling of `wp_update_term_count()` to deal with the deferring
-			// and, though, this will cause both the standard and stock based counts to be rerun, it is still more efficient
-			// in cases where deferred term counting was warranted.
-			$product_terms = get_the_terms( $product_id, 'product_brand' );
-			if ( is_array( $product_terms ) ) {
-				wp_update_term_count( array_column( $product_terms, 'term_taxonomy_id' ), 'product_brand' );
-			}
-			return;
-		}
-
-		$product_brands = array();
-
-		foreach ( $product_terms as $term ) {
-			$product_brands[ $term->term_id ] = $term->parent;
-		}
-
-		_wc_term_recount( $product_brands, get_taxonomy( 'product_brand' ), false, false );
+		wc_recount_after_stock_change( $product_id );
 	}
 
 	/**
@@ -126,15 +98,7 @@ class WC_Brands {
 	 */
 	public function recount_all_brands() {
 		wc_deprecated_function( __METHOD__, '11.2.0', 'wc_recount_all_terms()' );
-
-		$product_brands = get_terms(
-			array(
-				'taxonomy'   => 'product_brand',
-				'hide_empty' => false,
-				'fields'     => 'id=>parent',
-			)
-		);
-		_wc_term_recount( $product_brands, get_taxonomy( 'product_brand' ), true, false );
+		wc_recount_all_terms();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -82,9 +82,13 @@ class WC_Brands {
 	/**
 	 * Recount the brands after the stock amount changes.
 	 *
+	 * @deprecated 11.1.0 Use wc_recount_after_stock_change() instead.
+	 *
 	 * @param int $product_id Product ID.
 	 */
 	public function recount_after_stock_change( $product_id ) {
+		wc_deprecated_function( __METHOD__, '11.1.0', 'wc_recount_after_stock_change()' );
+
 		if ( 'yes' !== get_option( 'woocommerce_hide_out_of_stock_items' ) || empty( $product_id ) ) {
 			return;
 		}
@@ -117,8 +121,12 @@ class WC_Brands {
 
 	/**
 	 * Recount all brands.
+	 *
+	 * @deprecated 11.1.0 Use wc_recount_all_terms() instead.
 	 */
 	public function recount_all_brands() {
+		wc_deprecated_function( __METHOD__, '11.1.0', 'wc_recount_all_terms()' );
+
 		$product_brands = get_terms(
 			array(
 				'taxonomy'   => 'product_brand',

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -9187,12 +9187,6 @@ parameters:
 			path: includes/class-wc-brands.php
 
 		-
-			message: '#^Argument of an invalid type array\<WP_Term\>\|WP_Error supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: includes/class-wc-brands.php
-
-		-
 			message: '#^Argument of an invalid type array\<int, WP_Term\>\|WP_Error supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 2
@@ -9403,19 +9397,7 @@ parameters:
 			path: includes/class-wc-brands.php
 
 		-
-			message: '#^Parameter \#1 \$terms of function _wc_term_recount expects array, array\<int, int\>\|WP_Error given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-brands.php
-
-		-
 			message: '#^Parameter \#2 \$str of function explode expects string, array\|string given\.$#'
-			identifier: argument.type
-			count: 2
-			path: includes/class-wc-brands.php
-
-		-
-			message: '#^Parameter \#2 \$taxonomy of function _wc_term_recount expects WP_Taxonomy, WP_Taxonomy\|false given\.$#'
 			identifier: argument.type
 			count: 2
 			path: includes/class-wc-brands.php


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

[PR #67630](https://github.com/woocommerce/woocommerce/pull/67630) moved product brand counting into the shared WooCommerce term recount functions, leaving two public `WC_Brands` methods without internal callers. This follow-up deprecates `recount_after_stock_change()` in favor of `wc_recount_after_stock_change()` and `recount_all_brands()` in favor of `wc_recount_all_terms()`.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure that the CI is green.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The `WC_Brands_Test` suite passed with 14 tests and 34 assertions in the Docker-based wp-env test environment using PHP 8.1.34.
- Both required PHP lint passes completed without errors or warnings.
- PHPStan reported no errors for `includes/class-wc-brands.php`.
- Backward compatibility was reviewed: the public methods and signatures remain available, `recount_after_stock_change()` delegates the supplied product ID, and `recount_all_brands()` delegates to the centralized full-term recount.
- No UI, multisite-specific, or install-layout behavior changed. No performance profiling was run; deprecated calls now reuse the centralized recount implementation.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

- [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

- [ ] Patch
- [ ] Minor
- [ ] Major

#### Type

<!-- Choose only one -->

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to implement the deprecations, run validation, and draft this pull request. The contributor remains responsible for reviewing and maintaining the submitted code.
