### PR TITLE
Fix missing discount line on printed order receipts

### DIFF
--- a/plugins/woocommerce/changelog/fix-receipt-order-discount-line
+++ b/plugins/woocommerce/changelog/fix-receipt-order-discount-line
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix printed order receipts: show the discount line for orders discounted without a coupon so the amounts add up to the total paid, and stop rendering an empty payment method section.

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/ReceiptRenderingEngine.php
@@ -322,13 +322,19 @@ class ReceiptRenderingEngine {
 			'amount' => wc_price( $order->get_subtotal(), $get_price_args ),
 		);
 
-		$coupon_names = ArrayUtil::select( $order->get_coupons(), 'get_name', ArrayUtil::SELECT_BY_OBJECT_METHOD );
-		if ( ! empty( $coupon_names ) ) {
+		$coupon_names   = ArrayUtil::select( $order->get_coupons(), 'get_name', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+		$total_discount = (float) $order->get_total_discount();
+		if ( $total_discount || ! empty( $coupon_names ) ) {
+			if ( empty( $coupon_names ) ) {
+				$discount_title = __( 'Discount', 'woocommerce' );
+			} else {
+				/* translators: %s = comma-separated list of coupon codes */
+				$discount_title = sprintf( __( 'Discount (%s)', 'woocommerce' ), join( ', ', $coupon_names ) );
+			}
 			$line_items_info[] = array(
 				'type'   => 'discount',
-				/* translators: %s = comma-separated list of coupon codes */
-				'title'  => sprintf( __( 'Discount (%s)', 'woocommerce' ), join( ', ', $coupon_names ) ),
-				'amount' => wc_price( -$order->get_total_discount(), $get_price_args ),
+				'title'  => $discount_title,
+				'amount' => wc_price( -$total_discount, $get_price_args ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
@@ -22,7 +22,7 @@
 	<h3 id="payment_status_section_title"><?php echo strtoupper( $data['texts']['payment_status_section_title'] ); ?></h3>
 	<p><?php echo $data['texts']['payment_status']; ?></p>
 
-	<?php if ( isset( $data['payment_method'] ) && ( '' !== $data['payment_method'] || ! $data['show_payment_method_title'] ) ) { ?>
+	<?php if ( isset( $data['payment_method'] ) && ( '' !== trim( $data['payment_method'] ) || ! $data['show_payment_method_title'] ) ) { ?>
 		<h3 id="payment_method_section_title"><?php echo strtoupper( $data['texts']['payment_method_section_title'] ); ?></h3>
 		<p>
 			<?php if ( $data['show_payment_method_title'] ) { ?>

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
@@ -22,7 +22,7 @@
 	<h3 id="payment_status_section_title"><?php echo strtoupper( $data['texts']['payment_status_section_title'] ); ?></h3>
 	<p><?php echo $data['texts']['payment_status']; ?></p>
 
-	<?php if ( ! empty( $data['payment_method'] ) || ! $data['show_payment_method_title'] ) { ?>
+	<?php if ( isset( $data['payment_method'] ) && ( '' !== $data['payment_method'] || ! $data['show_payment_method_title'] ) ) { ?>
 		<h3 id="payment_method_section_title"><?php echo strtoupper( $data['texts']['payment_method_section_title'] ); ?></h3>
 		<p>
 			<?php if ( $data['show_payment_method_title'] ) { ?>

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
@@ -22,7 +22,7 @@
 	<h3 id="payment_status_section_title"><?php echo strtoupper( $data['texts']['payment_status_section_title'] ); ?></h3>
 	<p><?php echo $data['texts']['payment_status']; ?></p>
 
-	<?php if ( isset( $data['payment_method'] ) ) { ?>
+	<?php if ( ! empty( $data['payment_method'] ) || ! $data['show_payment_method_title'] ) { ?>
 		<h3 id="payment_method_section_title"><?php echo strtoupper( $data['texts']['payment_method_section_title'] ); ?></h3>
 		<p>
 			<?php if ( $data['show_payment_method_title'] ) { ?>

--- a/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
@@ -292,7 +292,8 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 		$rendered = $this->render_receipt( $order );
 
 		$this->assertStringContainsString( '<td>Discount</td>', $rendered );
-		$this->assertStringContainsString( wc_price( -6, array( 'currency' => $order->get_currency() ) ), $rendered );
+		$expected_amount = wp_kses_post( wc_price( -6, array( 'currency' => $order->get_currency() ) ) );
+		$this->assertStringContainsString( $expected_amount, $rendered );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ReceiptRendering/ReceiptRenderingEngineTest.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingEngine;
 use Automattic\WooCommerce\Internal\TransientFiles\TransientFilesEngine;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Order;
 
 /**
  * Tests for the ReceiptRenderingEngine class.
@@ -251,5 +252,70 @@ class ReceiptRenderingEngineTest extends \WC_Unit_Test_Case {
 
 		$filename = $this->sut->get_existing_receipt( $order );
 		$this->assertNull( $filename );
+	}
+
+	/**
+	 * Captures the HTML that 'generate_receipt' passes to the transient files engine.
+	 *
+	 * @param WC_Order $order The order to render the receipt for.
+	 * @return string The rendered receipt HTML.
+	 */
+	private function render_receipt( WC_Order $order ): string {
+		$rendered = '';
+
+		$this->tfe_mock
+			->expects( self::once() )
+			->method( 'create_transient_file' )
+			->willReturnCallback(
+				function ( $contents ) use ( &$rendered ) {
+					$rendered = $contents;
+					return 'the_generated_file_name';
+				}
+			);
+
+		$this->sut->generate_receipt( $order, null, true );
+
+		return $rendered;
+	}
+
+	/**
+	 * @testdox 'generate_receipt' renders the discount line for an order that has a line item discount but no coupons.
+	 */
+	public function test_generate_receipt_renders_discount_line_for_order_without_coupons() {
+		$order = OrderHelper::create_order();
+
+		$item = current( $order->get_items() );
+		$item->set_total( (float) $item->get_subtotal() - 6 );
+		$item->save();
+		$order->calculate_totals( false );
+
+		$rendered = $this->render_receipt( $order );
+
+		$this->assertStringContainsString( '<td>Discount</td>', $rendered );
+		$this->assertStringContainsString( wc_price( -6, array( 'currency' => $order->get_currency() ) ), $rendered );
+	}
+
+	/**
+	 * @testdox 'generate_receipt' renders no discount line for an order that has no discount at all.
+	 */
+	public function test_generate_receipt_renders_no_discount_line_when_there_is_no_discount() {
+		$order = OrderHelper::create_order();
+
+		$rendered = $this->render_receipt( $order );
+
+		$this->assertStringNotContainsString( '<td>Discount</td>', $rendered );
+	}
+
+	/**
+	 * @testdox 'generate_receipt' renders no payment method section for an order that has no payment method title.
+	 */
+	public function test_generate_receipt_renders_no_payment_method_section_when_title_is_empty() {
+		$order = OrderHelper::create_order();
+		$order->set_payment_method_title( '' );
+		$order->save();
+
+		$rendered = $this->render_receipt( $order );
+
+		$this->assertStringNotContainsString( 'payment_method_section_title', $rendered );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The discount row on printed receipts is gated on the order having coupons, but its amount comes from `get_total_discount()`. So a discount applied without a coupon — what the mobile apps create, by lowering an item's `total` below its `subtotal` — is left off the receipt while still being subtracted from the total, and the printed lines overshoot **Amount Paid**. Gate on the amount instead; coupon rows are unchanged.

Also fixes `PAYMENT METHOD` printing an empty value: the template gated on `isset()`, but `get_payment_method_title()` returns `''`.

(For Bug Fixes) Bug introduced in PR #43502 .

### Screenshots or screen recordings:

Receipt for an order with a $6 product discount and no coupon, on a live branch site. `Subtotal $65.00 − Discount $6.00 + Handling Fee $5.00 + Shipping $10.00 = Amount Paid $74.00`. Before this change the **Discount** row was absent, so the printed lines came to $80.00 against a stated $74.00.

<img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/08/wc-67661-receipt-discount-after-scaled.png" width="600" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create an order with two products, a fee and shipping. Do **not** apply a coupon.
2. Apply a discount to one product line — in the mobile app, expand the line and use **Add discount**; in the admin order editor, lower that line item's total below its subtotal. Complete the order.
3. Open the receipt, either from the mobile app (order detail → **See receipt**) or by calling `POST /wp-json/wc/v3/orders/<id>/receipt` with `force_new=true` and opening the `receipt_url` it returns.
4. A **Discount** row appears below **Subtotal**, and the printed lines sum to **Amount Paid**. Before this change the row was absent and the lines overshot by the discount.
5. Check for regressions: a coupon order still reads `Discount (CODE)`; an order with no discount shows no row; an order with no payment method title shows no empty `PAYMENT METHOD` heading; a card order still shows the card icon and last four digits.

<!-- End testing instructions -->

### Testing that has already taken place:

Originally found on a EUR store on WooCommerce 11.0.0: an order with a -6.00 product discount printed lines summing to 114.00 against an Amount Paid of 108.00.

Verified on a live branch site from an Android tablet using the WooCommerce mobile app — order #15 in the screenshot above, created with a $6 product discount and no coupon. The **Discount** row renders and the receipt reconciles.

Three unit tests added, covering the discount row for a coupon-less discount, no row when there is no discount, and no payment method section when the title is empty. All PHP unit jobs and PHPStan pass.

Not covered: the payment method section was exercised only on an order with no payment method at all, not on a card-reader payment.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code traced the bug, wrote the fix and the tests, and drafted this description. OpenAI Codex reviewed the diff independently; its one finding (a missing test) is addressed. I reviewed the change and take responsibility for it.
