### PR TITLE
Fix variation report order pluralization

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-report-order-pluralization
+++ b/plugins/woocommerce/changelog/fix-variation-report-order-pluralization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Internationalization: use the singular form for the variation report order count.

--- a/plugins/woocommerce/client/admin/client/analytics/report/variations/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/variations/table.js
@@ -242,7 +242,7 @@ class VariationsReportTable extends Component {
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: _n( 'orders', 'orders', ordersCount, 'woocommerce' ),
+				label: _n( 'order', 'orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];


### PR DESCRIPTION
## Summary

- Use the singular `order` source string when the Variations analytics report has one order.
- Retain `orders` as the plural source string.
- Add a patch changelog entry.

This supersedes the still-relevant part of #44506. The other change proposed there, adding translation context to the `Bold` design-style label, is no longer applicable because the Design with AI flow was removed in #57564.

Thanks to @jeherve for identifying and originally contributing this internationalization fix.

## Why

The report currently calls `_n( 'orders', 'orders', ordersCount, 'woocommerce' )`. That renders the plural English source for a count of one and prevents translators from supplying distinct singular and plural forms. Revenue and Taxes analytics already use the correct `order` / `orders` pair.

## Impact

The Variations analytics summary can display and translate the singular order label correctly when `ordersCount` is one. There is no behavior change for other counts.

## Validation

- `git diff --check`
- Static assertion that the corrected translation call occurs exactly once in the current Variations report
- Static assertion that the defective plural-only call is absent
- Changelog entry shape validation