### PR TITLE
Ignore a stale quality_badge marketplace filter param when the badge UI cannot render

### DIFF
--- a/plugins/woocommerce/changelog/fix-iam-settings-quality-badge-fix
+++ b/plugins/woocommerce/changelog/fix-iam-settings-quality-badge-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ignore a stale quality_badge URL param in marketplace search requests when the badge is disabled or IAM settings are unavailable, so the listing cannot stay silently filtered without the toggle that clears it.

--- a/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
@@ -22,6 +22,7 @@ import Discover from '../discover/discover';
 import Products from '../products/products';
 import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
+import { isQualityBadgeFilterActive } from '../quality-badge/quality-badge-filter';
 import { fetchSearchResults, getProductType } from '../../utils/functions';
 import { SubscriptionsContextProvider } from '../../contexts/subscriptions-context';
 import { SearchResultsCountType } from '../../contexts/types';
@@ -54,6 +55,11 @@ export default function Content(): React.JSX.Element {
 	const { isLoading, setIsLoading, selectedTab, setSearchResultsCount } =
 		marketplaceContextValue;
 	const query = useQuery();
+	// The param counts only while the toggle that clears it can render.
+	const qualityBadgeFilterActive = isQualityBadgeFilterActive(
+		query,
+		marketplaceContextValue.iamSettings
+	);
 
 	const searchCompleteAnnouncement = ( count: number ): void => {
 		speak(
@@ -92,7 +98,7 @@ export default function Content(): React.JSX.Element {
 			params.append( 'term', query.term );
 		}
 
-		if ( query.quality_badge === '1' && query.tab === 'extensions' ) {
+		if ( qualityBadgeFilterActive && query.tab === 'extensions' ) {
 			params.append( 'quality_badge', '1' );
 		}
 
@@ -150,7 +156,7 @@ export default function Content(): React.JSX.Element {
 		query.category,
 		query.term,
 		query.tab,
-		query.quality_badge,
+		qualityBadgeFilterActive,
 		setIsLoadingMore,
 	] );
 
@@ -205,7 +211,7 @@ export default function Content(): React.JSX.Element {
 				params.append( 'term', query.term );
 			}
 
-			if ( query.quality_badge === '1' && query.tab === 'extensions' ) {
+			if ( qualityBadgeFilterActive && query.tab === 'extensions' ) {
 				params.append( 'quality_badge', '1' );
 			}
 
@@ -246,7 +252,7 @@ export default function Content(): React.JSX.Element {
 					// The badge filter only applies to the extensions results.
 					if (
 						category === 'extensions' &&
-						query.quality_badge === '1'
+						qualityBadgeFilterActive
 					) {
 						params.append( 'quality_badge', '1' );
 					}
@@ -342,7 +348,7 @@ export default function Content(): React.JSX.Element {
 		query.tab,
 		query.term,
 		query.category,
-		query.quality_badge,
+		qualityBadgeFilterActive,
 		setIsLoading,
 		setSearchResultsCount,
 		currentPage,

--- a/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
@@ -395,7 +395,12 @@ export default function Content(): React.JSX.Element {
 	useEffect( () => {
 		setCurrentPage( 1 );
 		setFirstNewProductId( 0 );
-	}, [ selectedTab, query?.category, query?.term, query?.quality_badge ] );
+	}, [
+		selectedTab,
+		query?.category,
+		query?.term,
+		qualityBadgeFilterActive,
+	] );
 
 	// Maintain product focus for accessibility
 	useEffect( () => {

--- a/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/quality-badge-filter.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/quality-badge-filter.tsx
@@ -19,6 +19,7 @@ import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
 import './quality-badge.scss';
 import { QualityBadgeIcon, QualityBadgePopover } from './quality-badge';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
+import { MarketplaceContextType } from '../../contexts/types';
 
 /**
  * Info button next to the filter label; opens the shared badge explanation
@@ -65,6 +66,24 @@ function QualityBadgeInfo( props: {
 				/>
 			) }
 		</>
+	);
+}
+
+/**
+ * Whether the badge filter applies to outgoing search requests. Kept in sync
+ * with the toggle's own visibility conditions: the `quality_badge` URL param
+ * counts only while the control that clears it can render, so a stale or
+ * bookmarked param cannot silently filter the listing when the badge is
+ * disabled or the IAM settings failed to load.
+ */
+export function isQualityBadgeFilterActive(
+	query: { quality_badge?: string },
+	iamSettings: MarketplaceContextType[ 'iamSettings' ] | undefined
+): boolean {
+	const badge = iamSettings?.quality_badge;
+
+	return (
+		query.quality_badge === '1' && Boolean( badge?.enabled && badge.label )
 	);
 }
 

--- a/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/test/quality-badge.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/test/quality-badge.test.tsx
@@ -298,6 +298,15 @@ describe( 'isQualityBadgeFilterActive', () => {
 		);
 	} );
 
+	it( 'ignores the param when the badge is enabled but has no label', () => {
+		expect(
+			isQualityBadgeFilterActive(
+				{ quality_badge: '1' },
+				{ quality_badge: { enabled: true, label: '', tooltip: '' } }
+			)
+		).toBe( false );
+	} );
+
 	it( 'is inactive without the param', () => {
 		expect(
 			isQualityBadgeFilterActive( {}, contextWithBadge.iamSettings )

--- a/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/test/quality-badge.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/quality-badge/test/quality-badge.test.tsx
@@ -24,7 +24,9 @@ jest.mock( '@wordpress/a11y', () => ( {
 import { speak } from '@wordpress/a11y';
 import { navigateTo, useQuery } from '@woocommerce/navigation';
 import QualityBadge from '../quality-badge';
-import QualityBadgeFilter from '../quality-badge-filter';
+import QualityBadgeFilter, {
+	isQualityBadgeFilterActive,
+} from '../quality-badge-filter';
 import { MarketplaceContext } from '../../../contexts/marketplace-context';
 import { MarketplaceContextType } from '../../../contexts/types';
 import { Product, ProductType } from '../../product-list/types';
@@ -268,6 +270,38 @@ describe( 'QualityBadge', () => {
 		expect(
 			screen.getByText( 'Excellence Verified' ).closest( 'button' )
 		).toBeNull();
+	} );
+} );
+
+describe( 'isQualityBadgeFilterActive', () => {
+	it( 'is active only when the param is set and the API has the badge enabled', () => {
+		expect(
+			isQualityBadgeFilterActive(
+				{ quality_badge: '1' },
+				contextWithBadge.iamSettings
+			)
+		).toBe( true );
+	} );
+
+	it( 'ignores a stale param when the badge is disabled', () => {
+		expect(
+			isQualityBadgeFilterActive(
+				{ quality_badge: '1' },
+				contextWithBadgeDisabled.iamSettings
+			)
+		).toBe( false );
+	} );
+
+	it( 'ignores a stale param when IAM settings are empty (failed fetch)', () => {
+		expect( isQualityBadgeFilterActive( { quality_badge: '1' }, {} ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'is inactive without the param', () => {
+		expect(
+			isQualityBadgeFilterActive( {}, contextWithBadge.iamSettings )
+		).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #67457. The marketplace search requests appended `quality_badge=1` based on the URL alone, while the toggle that clears the filter hides whenever the API reports the badge disabled or the IAM settings fetch fails. With the badge enabled server-side and settings unavailable client-side (failed fetch, expired cache plus one bad request), the extensions listing stayed silently filtered with no visible control to clear it.

The param now counts only under the toggle's own visibility conditions: a shared `isQualityBadgeFilterActive( query, iamSettings )` predicate gates all three request sites in `content.tsx`, so the request and the UI derive from the same state and cannot diverge.

Found by the AI regression review: [WOOAIRR-46](https://linear.app/a8c/issue/WOOAIRR-46/ai-regression-reviewtrunk-stale-quality-badge1-url-param-keeps)

### How to test the changes in this Pull Request:

1. Point the marketplace at a WooCommerce.com environment with the badge enabled (or use production, the badge is live). On the Extensions tab, enable the "Show only" toggle so the URL carries `quality_badge=1`.
2. In DevTools, block the `wccom-extensions/1.0/iam-settings` request and remove the `wc_iam_settings` localStorage key, then reload with the param still in the URL. The listing shows the full unfiltered results, no toggle, and the outgoing search request does not carry `quality_badge` (previously: filtered results with no way to clear them).
3. Unblock the request and reload: the toggle renders checked and the listing is filtered again.

### Changelog entry

Changelog file is committed in the PR (`plugins/woocommerce/changelog/fix-iam-settings-quality-badge-fix`, significance: patch, type: fix).

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Use of AI Tools

Implemented with Claude Code (AI-authored, human-reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
