### PR TITLE
Remove stale PHPStan baseline entries for TransientFilesEngine

### DIFF
--- a/plugins/woocommerce/changelog/fix-phpstan-baseline-transient-files
+++ b/plugins/woocommerce/changelog/fix-phpstan-baseline-transient-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove two stale PHPStan baseline entries for TransientFilesEngine that no longer match any reported error.

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -67789,18 +67789,6 @@ parameters:
 			path: src/Internal/TransientFiles/TransientFilesEngine.php
 
 		-
-			message: '#^Parameter \#1 \$input of function array_slice expects array, list\<string\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/TransientFiles/TransientFilesEngine.php
-
-		-
-			message: '#^Parameter \#1 \$var of function count expects array\|Countable, list\<string\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Internal/TransientFiles/TransientFilesEngine.php
-
-		-
 			message: '#^Parameter \#2 \$timestamp of function gmdate expects int, int\|string given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Removes two entries from `phpstan-baseline.neon` that no longer match any reported error, which is currently failing the **PHPStan Analysis** job on trunk and on every PR that touches WooCommerce PHP.

Both baselined errors originated in `TransientFilesEngine::delete_expired_files()`, where `glob()` returns `list<string>|false` and that union reached `count()` and `array_slice()`:

```
Parameter #1 $input of function array_slice expects array, list<string>|false given.
Parameter #1 $var of function count expects array|Countable, list<string>|false given.
```

PR #67592 replaced both `glob()` calls with `scandir()` plus an explicit `false === $entries` check that throws, so by the time `$files_to_delete` reaches `count()` and `array_slice()` it is a plain `list<string>`. That resolved both errors but left the baseline entries in place, so PHPStan now reports the patterns as unmatched and exits non-zero. This deletes them.

The baseline only shrinks here: 12 lines removed, nothing added.

Bug introduced in PR #67592.

**Backport note:** this does not need a separate cherry-pick to `release/11.1`. The same two entries have already been removed on the backport branch in PR #67670, which was red for this exact reason.

### How to test the changes in this Pull Request:

1. Check out `trunk` and run `cd plugins/woocommerce && composer run-script phpstan`. It fails with `[ERROR] Found 2 errors`, both of the form "Ignored error pattern ... was not matched in reported errors" for `src/Internal/TransientFiles/TransientFilesEngine.php`.
2. Check out this branch and run the same command. It passes.
3. Confirm nothing was added to the baseline: `git diff trunk -- plugins/woocommerce/phpstan-baseline.neon` shows deletions only.

### Testing that has already taken place:

-   The failure is reproduced by CI rather than locally: the PHPStan Analysis job on PR #67670 (run 31613339647) reports exactly these two unmatched patterns and nothing else, so removing them is the complete fix. The same job on PR #67592 failed the same way before merge, which is how the stale entries reached trunk.
-   I have not run PHPStan locally on this branch — the plugin's Composer dependencies are not installed in this checkout. CI on this PR is the verification.
-   No source files are touched, so there is no runtime behavior change and no backward-compatibility impact.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] ~~Automatically create a changelog entry from the details below.~~

The changelog entry was added manually: `plugins/woocommerce/changelog/fix-phpstan-baseline-transient-files`.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Remove two stale PHPStan baseline entries for TransientFilesEngine that no longer match any reported error.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Claude Code diagnosed the CI failure, removed the baseline entries, and drafted this description. I reviewed the change and take responsibility for it.
