### PR TITLE
Fix missing tax rates in Analytics orders advanced filter

### DIFF
--- a/packages/js/components/changelog/fix-wooplug-1941-tax-rate-filter-options
+++ b/packages/js/components/changelog/fix-wooplug-1941-tax-rate-filter-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show all applicable tax rates in the Analytics advanced filter by requesting the full page of results instead of only the first 10.

--- a/packages/js/components/src/search/autocompleters/taxes.tsx
+++ b/packages/js/components/src/search/autocompleters/taxes.tsx
@@ -17,12 +17,14 @@ const completer: AutoCompleter = {
 	name: 'taxes',
 	className: 'woocommerce-search__tax-result',
 	options( search ) {
-		const query = search
-			? {
-					search,
-					per_page: 10,
-			  }
-			: {};
+		// Request the full page (up to the `/wc-analytics/taxes` endpoint's
+		// `per_page` maximum) instead of the default of 10. The dropdown has no
+		// "load more" control, so a low page size hid most of the configured tax
+		// rates from the advanced filter.
+		const query = {
+			per_page: 100,
+			...( search ? { search } : {} ),
+		};
 		return apiFetch( {
 			path: addQueryArgs( '/wc-analytics/taxes', query ),
 		} );

--- a/packages/js/components/src/search/autocompleters/test/taxes.tsx
+++ b/packages/js/components/src/search/autocompleters/test/taxes.tsx
@@ -43,13 +43,6 @@ describe( 'taxes autocompleter', () => {
 		expect( getQueryArg( path, 'search' ) ).toBeUndefined();
 	} );
 
-	test( 'never caps results at the previous limit of 10', () => {
-		taxes.options( 'US' );
-
-		const path = getRequestedPath();
-		expect( getQueryArg( path, 'per_page' ) ).not.toBe( '10' );
-	} );
-
 	test( 'queries the analytics taxes endpoint', () => {
 		taxes.options( '' );
 

--- a/packages/js/components/src/search/autocompleters/test/taxes.tsx
+++ b/packages/js/components/src/search/autocompleters/test/taxes.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { getQueryArg } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import taxes from '../taxes';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'taxes autocompleter', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+		mockedApiFetch.mockResolvedValue( [] );
+	} );
+
+	const getRequestedPath = () => mockedApiFetch.mock.calls[ 0 ][ 0 ].path;
+
+	test( 'requests the full page so every applicable tax rate can be filtered (empty search)', () => {
+		taxes.options( '' );
+
+		const path = getRequestedPath();
+		expect( getQueryArg( path, 'per_page' ) ).toBe( '100' );
+	} );
+
+	test( 'requests the full page and forwards the search term', () => {
+		taxes.options( 'US' );
+
+		const path = getRequestedPath();
+		expect( getQueryArg( path, 'per_page' ) ).toBe( '100' );
+		expect( getQueryArg( path, 'search' ) ).toBe( 'US' );
+	} );
+
+	test( 'omits the search param when no term is provided', () => {
+		taxes.options( '' );
+
+		const path = getRequestedPath();
+		expect( getQueryArg( path, 'search' ) ).toBeUndefined();
+	} );
+
+	test( 'never caps results at the previous limit of 10', () => {
+		taxes.options( 'US' );
+
+		const path = getRequestedPath();
+		expect( getQueryArg( path, 'per_page' ) ).not.toBe( '10' );
+	} );
+
+	test( 'queries the analytics taxes endpoint', () => {
+		taxes.options( '' );
+
+		expect( getRequestedPath() ).toContain( '/wc-analytics/taxes' );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The **Tax Rate** advanced filter in Analytics → Orders fetched its suggestions from the `/wc-analytics/taxes` endpoint with `per_page: 10` and no pagination or "load more" control. On stores with more than 10 configured tax rates, only the first 10 (ordered by tax rate ID) were ever returned, so the remaining rates were impossible to discover in the filter — which is exactly what the linked issue reports.

This requests the endpoint's full page size (`per_page: 100`, the endpoint maximum) in both the empty and search branches, so every configured tax rate is available in the filter. The endpoint reads directly from the tax rates table and already supports server-side `search`, so no backend change is needed.

Closes #44338.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| With 15+ configured tax rates, the Tax Rate filter only ever suggested the first 10; the rest could not be found. <img width="750" height="764" alt="image-1786604074594" src="https://github.com/user-attachments/assets/322b26bf-ade7-425f-b652-9a1e5adbe475" />| The filter suggests every matching configured tax rate (verified with 15 seeded rates — all 15 appear). <img width="750" height="979" alt="image-1786604079850" src="https://github.com/user-attachments/assets/13b0e293-fbbc-4ee3-af89-5890e554eda4" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. In **WooCommerce → Settings → Tax → Standard rates**, add more than 10 tax rates (e.g. 12–15 rates with distinct names).
2. Go to **Analytics → Orders**.
3. In **Show**, choose **Advanced filters**.
4. Click **Add a filter** and select **Tax rate**.
5. Click into the Tax rate search field and type part of a rate name shared by all of them.
6. Confirm that **all** matching configured tax rates are offered as suggestions — not just the first 10. (On `trunk` without this change, at most 10 appear.)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

Verified locally on `wp-env` (WooCommerce `trunk`, WP admin analytics client). Seeded 15 US tax rates, each applied to a completed order:

- **Endpoint:** `GET /wc-analytics/taxes?per_page=10` returned 10 rows; `per_page=100` returned all 16 configured rates.
- **Live admin:** opening the Tax rate advanced filter now issues `GET /wc-analytics/taxes?per_page=100&search=…` (previously `per_page=10`), and the dropdown lists all 15 seeded rates.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changelog entry added manually in `packages/js/components/changelog/`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude (Anthropic) was used to help investigate the root cause, draft the one-line fix, and run local verification. All changes were reviewed by the author.
