### PR TITLE
Restore Taxes report orders_count filter string, fix cache gap

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-48-taxes-report-columns-bc
+++ b/plugins/woocommerce/changelog/fix-wooairr-48-taxes-report-columns-bc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Analytics: restore the released unqualified parent_id form of the Taxes orders_count column carried by the woocommerce_admin_report_columns filter, and invalidate report caches on the first-ever save of the analytics date type.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -87,8 +87,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		global $wpdb;
-		$table_name        = self::get_db_table_name();
-		$order_stats_table = $wpdb->prefix . 'wc_order_stats';
+		$table_name = self::get_db_table_name();
 
 		// Using wp_woocommerce_tax_rates table limits the result to only the existing tax rates and
 		// omits the historical records which differs from the purpose of wp_wc_order_tax_lookup table.
@@ -108,8 +107,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'total_tax'    => 'SUM(total_tax) as total_tax',
 			'order_tax'    => 'SUM(order_tax) as order_tax',
 			'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
-			// parent_id is qualified to wc_order_stats to stay unambiguous now that the join is always present.
-			'orders_count' => "COUNT( DISTINCT ( CASE WHEN {$order_stats_table}.parent_id = 0 THEN {$table_name}.order_id END ) ) as orders_count",
+			// parent_id stays unqualified: wc_order_stats is the only joined table carrying it, and
+			// this string is carried by the public woocommerce_admin_report_columns filter, so it must
+			// match the released form for extension callbacks that inspect or rewrite it.
+			'orders_count' => "COUNT( DISTINCT ( CASE WHEN parent_id = 0 THEN {$table_name}.order_id END ) ) as orders_count",
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -81,16 +81,16 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @override ReportsDataStore::assign_report_columns()
 	 */
 	protected function assign_report_columns() {
-		global $wpdb;
 		$table_name           = self::get_db_table_name();
-		$order_stats_table    = $wpdb->prefix . 'wc_order_stats';
 		$this->report_columns = array(
 			'tax_codes'    => 'COUNT(DISTINCT tax_rate_id) as tax_codes',
 			'total_tax'    => 'SUM(total_tax) AS total_tax',
 			'order_tax'    => 'SUM(order_tax) as order_tax',
 			'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
-			// parent_id is qualified to wc_order_stats to stay unambiguous now that the join is always present.
-			'orders_count' => "COUNT( DISTINCT ( CASE WHEN {$order_stats_table}.parent_id = 0 THEN {$table_name}.order_id END ) ) as orders_count",
+			// parent_id stays unqualified: wc_order_stats is the only joined table carrying it, and
+			// this string is carried by the public woocommerce_admin_report_columns filter, so it must
+			// match the released form for extension callbacks that inspect or rewrite it.
+			'orders_count' => "COUNT( DISTINCT ( CASE WHEN parent_id = 0 THEN {$table_name}.order_id END ) ) as orders_count",
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/ReportsSync.php
+++ b/plugins/woocommerce/src/Admin/ReportsSync.php
@@ -30,6 +30,8 @@ class ReportsSync {
 		add_action( 'update_option_woocommerce_notify_no_stock_amount', array( __CLASS__, 'clear_stock_count_cache' ) );
 		// Invalidate report caches when the analytics date type changes, so all report families
 		// (Orders, Revenue, Taxes) reflect the new date basis immediately instead of after the cache TTL.
+		// The very first save of the option takes the add_option path, so hook both.
+		add_action( 'add_option_woocommerce_date_type', array( ReportsCache::class, 'invalidate' ) );
 		add_action( 'update_option_woocommerce_date_type', array( ReportsCache::class, 'invalidate' ) );
 		add_action( 'trashed_post', array( __CLASS__, 'maybe_clear_stock_count_cache_for_post' ) );
 		add_action( 'untrashed_post', array( __CLASS__, 'maybe_clear_stock_count_cache_for_post' ) );

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Taxes/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Taxes/DataStoreTest.php
@@ -290,6 +290,10 @@ class DataStoreTest extends WC_Unit_Test_Case {
 			has_action( 'update_option_woocommerce_date_type', array( ReportsCache::class, 'invalidate' ) ),
 			'Changing the analytics date type should invalidate the report cache so all report families reflect the new basis immediately.'
 		);
+		$this->assertNotFalse(
+			has_action( 'add_option_woocommerce_date_type', array( ReportsCache::class, 'invalidate' ) ),
+			'The very first save of the date type takes the add_option path and should invalidate the report cache too.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #67553, addressing two findings from an internal regression review of that merge:

1. **Restore the released `orders_count` column expression carried by the public `woocommerce_admin_report_columns` filter.** #67553 qualified `parent_id` to `wc_order_stats.parent_id` in the Taxes report column expressions. That array flows through the public `woocommerce_admin_report_columns` filter, so the released unqualified `parent_id = 0` string is a contract for extension callbacks that inspect or rewrite it — a callback string-matching the released form would silently stop matching. This reverts to the unqualified form, which is unambiguous on every query path: `wc_order_stats` is the only joined table carrying `parent_id`, and the join is now unconditional (the pre-#67553 edge case where the join could be absent no longer exists). The produced SQL is semantically identical; only the filter-carried string returns to its released form.

2. **Invalidate report caches on the first-ever save of the analytics date type.** #67553 hooked `update_option_woocommerce_date_type` into `ReportsCache::invalidate()`, but on a store where the option row does not yet exist the first save takes the `add_option` path, where that hook never fires — reports could serve old-basis cached numbers until the cache TTL. This adds the matching `add_option_woocommerce_date_type` hook.

No report output changes: order counts, tax totals, and the Taxes/Orders reconciliation delivered by #67553 are unaffected (covered by the existing test suite, which passes unchanged).

Bug introduced in PR #67553.

### How to test the changes in this Pull Request:

1. Confirm the Taxes report still reconciles with Orders (regression check for #67553): with taxes enabled, a tax rate configured, and Analytics → Settings → Date type at its default (Date paid), create a taxed paid order, open Analytics → Taxes for the period, click the tax code to drill down into Analytics → Orders, and confirm both screens show the same order count.
2. Filter contract: hook `woocommerce_admin_report_columns` and inspect `$columns['orders_count']` for the `taxes`/`taxes_stats` contexts — it again contains the released, unqualified `CASE WHEN parent_id = 0 …` form.
3. Cache gap: on a site where `woocommerce_date_type` has never been saved (`wp option delete woocommerce_date_type`), save Analytics → Settings → Date type for the first time and confirm report caches invalidate immediately (report numbers reflect the new basis without waiting for the cache TTL).

### Testing that has already taken place:

- Full Taxes report suites pass unchanged (`Tests\Admin\API\Reports\Taxes\DataStoreTest`, `WC_Admin_Tests_API_Reports_Taxes`, `WC_Admin_Tests_API_Reports_Taxes_Stats`) plus a new assertion covering the `add_option_woocommerce_date_type` hook wiring.
- Behaviourally verified the `add_option` path on wp-env: with the option deleted and the cache version seeded with a sentinel, the first save of the option invalidates the report cache.
- Manually verified end to end on wp-env that the Taxes report and the Orders drill-down still reconcile after the revert (same counts, no SQL errors).
- `phpcs-changed` clean; PHPStan reports no new errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Analytics: restore the released unqualified parent_id form of the Taxes orders_count column carried by the woocommerce_admin_report_columns filter, and invalidate report caches on the first-ever save of the analytics date type.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This pull request was authored with the assistance of Claude Code, reviewed and verified by the author.