### PR TITLE
Fix Import historical data action buttons misalignment in Analytics settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-67170-historical-data-actions-alignment
+++ b/plugins/woocommerce/changelog/fix-67170-historical-data-actions-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Left-align the Import historical data action buttons in Analytics settings with the rest of the section on wide viewports.

--- a/plugins/woocommerce/changelog/fix-67170-historical-data-actions-alignment
+++ b/plugins/woocommerce/changelog/fix-67170-historical-data-actions-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Left-align the Import historical data action buttons in Analytics settings with the rest of the section on wide viewports.
+Left-align the action buttons on the Analytics settings page (Import historical data, and Reset defaults / Save settings) with the rest of the page content on wide viewports.

--- a/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/layout.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/layout.js
@@ -90,16 +90,16 @@ class HistoricalDataLayout extends Component {
 							<FailedOrdersNotice />
 						</div>
 					</div>
+					<HistoricalDataActions
+						clearStatusAndTotalsCache={ clearStatusAndTotalsCache }
+						dateFormat={ dateFormat }
+						importDate={ importDate }
+						lastImportStartTimestamp={ lastImportStartTimestamp }
+						onImportStarted={ onImportStarted }
+						stopImport={ stopImport }
+						status={ status }
+					/>
 				</div>
-				<HistoricalDataActions
-					clearStatusAndTotalsCache={ clearStatusAndTotalsCache }
-					dateFormat={ dateFormat }
-					importDate={ importDate }
-					lastImportStartTimestamp={ lastImportStartTimestamp }
-					onImportStarted={ onImportStarted }
-					stopImport={ stopImport }
-					status={ status }
-				/>
 			</Fragment>
 		);
 	}

--- a/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/style.scss
@@ -110,14 +110,6 @@
 .woocommerce-settings-historical-data__actions {
 	align-items: center;
 	display: flex;
-
-	@include breakpoint( ">782px" ) {
-		padding: 0 ($gap - 3);
-	}
-
-	@include breakpoint( ">1280px" ) {
-		margin-left: 0;
-	}
 }
 
 .woocommerce-settings-historical-data__failed-orders {

--- a/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/style.scss
@@ -110,6 +110,14 @@
 .woocommerce-settings-historical-data__actions {
 	align-items: center;
 	display: flex;
+
+	@include breakpoint( ">782px" ) {
+		padding: 0 ($gap - 3);
+	}
+
+	@include breakpoint( ">1280px" ) {
+		margin-left: 0;
+	}
 }
 
 .woocommerce-settings-historical-data__failed-orders {

--- a/plugins/woocommerce/client/admin/client/analytics/settings/index.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/index.scss
@@ -9,10 +9,6 @@
 .woocommerce-settings__actions {
 	margin-bottom: $gap-largest;
 
-	@include breakpoint( ">1280px" ) {
-		margin-left: 15%;
-	}
-
 	button {
 		margin-right: $gap;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### What changed

In **Analytics → Settings**, the action buttons in the **Import historical data** section were not aligned with the rest of the section.

`HistoricalDataActions` uses the shared `woocommerce-settings__actions` class. That shared class still had a `margin-left: 15%` rule at wide viewports, which originally existed to align action buttons with inputs when Analytics settings used a 15% label column.

The current Analytics settings layout no longer uses that label column in the same way. The main settings content is wrapped in `.woocommerce-settings__wrapper`, but the historical data actions were rendered outside that wrapper. As a result, the old shared margin and missing wrapper padding caused the historical data action buttons to appear indented.

This PR removes the obsolete wide-viewport `margin-left` from the shared Analytics settings actions class and moves `HistoricalDataActions` inside the settings wrapper. This aligns both the main **Reset defaults / Save settings** actions and the **Start** actions flush left with the section content, matching the standard WooCommerce settings page convention.

Closes #67170.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1470" height="836" alt="Before" src="https://github.com/user-attachments/assets/71eb7935-c08f-4049-a0c0-626bbdec40b3" /> | <img width="1470" height="833" alt="Screenshot 2026-08-14 at 5 18 46 PM" src="https://github.com/user-attachments/assets/87b45381-823b-452f-a3fe-345177e72444" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to **WooCommerce → Analytics → Settings**.
2. Widen the browser window to above 1280px.
3. Confirm the **Reset defaults / Save settings** row is flush left with the Analytics settings section content.
4. Scroll to the **Import historical data** section.
5. Confirm the **Start** button is flush left with the historical data section content.
6. Resize the window across the 782px and 1280px breakpoints and confirm both action rows remain consistently aligned.

<!-- End testing instructions -->

### Testing that has already taken place:

Verified locally with a wp-env test site. Confirmed the historical data action buttons were indented above 1280px before the fix, and align flush left with the section content after applying the change.

Also confirmed the main **Reset defaults / Save settings** action row now aligns flush left with the Analytics settings section content, matching the intended shared action alignment.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This PR was developed with the assistance of Claude Code.
