### PR TITLE
Fix Analytics ignoring category and product filters with no overlap

### DIFF
--- a/plugins/woocommerce/changelog/fix-analytics-disjoint-category-product-filters
+++ b/plugins/woocommerce/changelog/fix-analytics-disjoint-category-product-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Report nothing instead of everything in Analytics when the category and product filters have no product in common. An empty intersection was indistinguishable from an absent product filter, so both filters were dropped.

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1227,6 +1227,13 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 				if ( 'AND' === $operator ) {
 					// AND results in an intersection between products from selected categories and manually included products.
 					$included_products = array_intersect( $included_products, $query_args['product_includes'] );
+
+					// Nothing satisfies both filters. Force an empty set the same way an empty
+					// category does, since callers cannot tell an empty list apart from an
+					// absent product filter and would drop both filters instead.
+					if ( empty( $included_products ) ) {
+						$included_products = array( '-1' );
+					}
 				} elseif ( 'OR' === $operator ) {
 					// OR results in a union of products from selected categories and manually included products.
 					$included_products = array_merge( $included_products, $query_args['product_includes'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -779,6 +779,93 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should report nothing when the category and product filters have no product in common.
+	 *
+	 * An empty intersection used to be indistinguishable from an absent product filter, so both
+	 * filters were dropped and the report covered every product instead of none.
+	 */
+	public function test_disjoint_category_and_product_filters() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$in_category = new WC_Product_Simple();
+		$in_category->set_name( 'In Category' );
+		$in_category->set_regular_price( 25 );
+		$in_category->save();
+
+		$outside = new WC_Product_Simple();
+		$outside->set_name( 'Outside Category' );
+		$outside->set_regular_price( 25 );
+		$outside->save();
+
+		$term = wp_insert_term( 'Filtered Category', 'product_cat' );
+		wp_set_object_terms( $in_category->get_id(), array( $term['term_id'] ), 'product_cat' );
+
+		foreach ( array( $in_category, $outside ) as $product ) {
+			$order = WC_Helper_Order::create_order( 1, $product );
+			$order->set_status( OrderStatus::COMPLETED );
+			$order->set_total( 100 );
+			$order->save();
+		}
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$data_store = new ProductsDataStore();
+		$args       = array(
+			'after'             => '2000-01-01 00:00:00',
+			'before'            => '2100-01-01 00:00:00',
+			'category_includes' => array( $term['term_id'] ),
+			'product_includes'  => array( $outside->get_id() ),
+		);
+
+		$data = $data_store->get_data( $args );
+
+		$this->assertEquals( 0, $data->total, 'A product filter that excludes every product in the category should report nothing' );
+		$this->assertSame( array(), $data->data );
+
+		// The same pair of filters still reports the product they do have in common.
+		$args['product_includes'] = array( $in_category->get_id() );
+
+		$data = $data_store->get_data( $args );
+
+		$this->assertEquals( 1, $data->total );
+		$this->assertEquals( $in_category->get_id(), $data->data[0]['product_id'] );
+	}
+
+	/**
+	 * @testdox Should report nothing when a product filter is combined with an empty category.
+	 */
+	public function test_product_filter_with_an_empty_category() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Uncategorized Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->set_total( 100 );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+
+		$term = wp_insert_term( 'Empty Category', 'product_cat' );
+
+		$data_store = new ProductsDataStore();
+		$data       = $data_store->get_data(
+			array(
+				'after'             => '2000-01-01 00:00:00',
+				'before'            => '2100-01-01 00:00:00',
+				'category_includes' => array( $term['term_id'] ),
+				'product_includes'  => array( $product->get_id() ),
+			)
+		);
+
+		$this->assertEquals( 0, $data->total, 'An empty category should keep forcing an empty set once a product filter is added' );
+		$this->assertSame( array(), $data->data );
+	}
+
+	/**
 	 * Tests the data stored in the wc_order_product_lookup table when a full refund is made.
 	 *
 	 * The full refunds here are the ones that change the order status to refunded.


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Filtering an Analytics products report by a category and by products with nothing in common reports every product in the store, instead of none.

`get_included_products_array()` intersects the two filters under `match=all`. An empty intersection ends up as an empty string further down, and callers read that as "no product filter" rather than "no products", so both filters get dropped. This forces an empty set with the same `-1` sentinel the empty category branch above already uses.

Affects `reports/products` and `reports/products/stats`, the only two routes that expose both filters.

#### Backward compatibility

Those two routes now return nothing instead of everything for this filter combination. The old result was wrong, but it is a visible change to a public REST surface.

### Screenshots or screen recordings:

Single category view, searching for a product that is not in the category. The summary at the top is the part that moves, boxed in red. Note that on trunk it contradicts everything below it, which already read 0.

| Before | After |
| ------ | ----- |
| <img width="1440" height="1552" alt="pr67682-before-outside-search" src="https://github.com/user-attachments/assets/263b99a9-4887-491a-b650-8dc4bb0933e6" /> | <img width="1440" height="1552" alt="pr67682-after-outside-search" src="https://github.com/user-attachments/assets/21f2cdb5-0b44-4bdd-83e4-83e2ca031933" /> |
| 145 items sold, 13 480,00 € net sales, 5 orders, which is the whole store | 0 items sold, 0,00 € net sales, 0 orders |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Everything to watch is in the summary numbers at the top of the page.

1. On a store with a few products that have completed orders, create a category and put one of those products in it. Leave another product that has orders out of the category.

    ```sh
    wp term create product_cat "Test Cat" --porcelain          # note the ID
    wp post term add <PRODUCT_WITH_ORDERS> product_cat <CAT_ID> --by=id
    ```

2. Open `/wp-admin/admin.php?page=wc-admin&path=/analytics/categories&filter=single_category&categories=<CAT_ID>` and set the date range to cover the orders. The summary shows the category's totals.
3. Add `&search=<PRODUCT_OUTSIDE_THE_CATEGORY>` to the link. The summary should read 0 items sold, 0,00 net sales, 0 orders. On trunk it jumps to the whole store's totals.
4. Change the search to a product that **is** in the category. The summary should show that product's numbers.

Run `wp transient delete --all` whenever you switch between trunk and this branch, otherwise you read a cached report.

The products table below the summary lists the searched products with zero sales in all three cases, on trunk and here alike. Its own request carries only the product filter, so this fix does not touch it.

<!-- End testing instructions -->

### Testing that has already taken place:

WordPress 7.0.4, PHP 8.4.23, WooCommerce 11.1.0-dev, Storefront, single site, HPOS on, 215 products with 12 carrying sales.

Number of products the `wc-analytics/reports/products` route reports over the same date range:

| Filters | Trunk | This PR |
| ------- | ----- | ------- |
| category alone | 4 | 4 |
| product list alone | 2 | 2 |
| **category + products, no overlap** | **12** | **0** |
| category + products, overlapping | 1 | 1 |
| empty category alone | 0 | 0 |
| **empty category + products** | **12** | **0** |
| category + products, `match=any` | 5 | 5 |
| no filters | 12 | 12 |

`12` is every product with sales, which is what "both filters dropped" produces. `reports/products/stats` was checked over the same matrix and its totals agree row for row.

Through the admin, following the steps above, the summary numbers in the single category view went from `145 items sold / 13 480,00 € / 5 orders`, which is the whole store, to `0 / 0,00 € / 0`. A search matching a product inside the category still reports that product, and clearing the search still reports the category.

`phpcs` and PHPStan are clean on the changed files. The two new unit tests have not run locally, since this machine has no Docker for the PHPUnit environment, so CI will be their first run.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually, in `plugins/woocommerce/changelog/fix-analytics-disjoint-category-product-filters`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

I used Claude Code to find the bug, write the fix and the tests, and verify the behaviour against a local install.
