### PR TITLE
Fix #67456: Order/refund hydration fatals with "Cannot use object of type stdClass as array" when a postmeta entry is malformed (read_order_data)

### DIFF
--- a/plugins/woocommerce/changelog/fix-67456-order-refund-hydration-malformed-postmeta
+++ b/plugins/woocommerce/changelog/fix-67456-order-refund-hydration-malformed-postmeta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error when reading an order or refund whose postmeta entry is malformed.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -57,6 +57,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected $internal_data_store_key_getters = array();
 
 	/**
+	 * Validated postmeta read during a single hydration, keyed by post ID, so
+	 * the same malformed entry is not re-read and re-logged more than once.
+	 *
+	 * @var array
+	 */
+	private $validated_order_meta = array();
+
+	/**
 	 * Return internal key getters name.
 	 *
 	 * @return string[]
@@ -427,39 +435,116 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	}
 
 	/**
-	 * Read a single value from the raw postmeta array returned by get_post_meta().
+	 * Read the postmeta for an order or refund, self-healing a corrupted object
+	 * cache entry when possible.
 	 *
-	 * Postmeta values are normally arrays of values, the first of which is the
-	 * stored value. When an entry is malformed (for example a corrupted object
-	 * cache entry that leaves a stdClass where the array should be), it is
-	 * treated as missing and the provided default is returned instead of
-	 * fatalling on the illegal array access.
+	 * The values returned by get_post_meta() are normally arrays of values, the
+	 * first of which is the stored value. A corrupted persistent object cache
+	 * entry can leave a non-array (for example a stdClass) where the array
+	 * should be, which fatals on PHP 8 when the entry is dereferenced as an
+	 * array. When that happens this method clears the cached postmeta and
+	 * re-reads it from the database so the real values are used instead of
+	 * falling back to defaults.
 	 *
 	 * @since 11.1.0
-	 * @param array  $meta_data     The full postmeta array for a post.
+	 * @param int $id The post ID.
+	 * @return array The validated postmeta array.
+	 */
+	protected function get_validated_order_meta( int $id ): array {
+		if ( isset( $this->validated_order_meta[ $id ] ) ) {
+			return $this->validated_order_meta[ $id ];
+		}
+
+		$meta_data = get_post_meta( $id );
+
+		if ( ! $this->is_valid_order_meta( $meta_data ) ) {
+			// The cached postmeta is malformed. Clear it and re-read from the database.
+			wp_cache_delete( $id, 'post_meta' );
+			$meta_data = get_post_meta( $id );
+		}
+
+		if ( ! $this->is_valid_order_meta( $meta_data ) ) {
+			$this->log_malformed_order_meta( $id, $meta_data );
+		}
+
+		$meta_data = is_array( $meta_data ) ? $meta_data : array();
+		$this->validated_order_meta[ $id ] = $meta_data;
+
+		return $meta_data;
+	}
+
+	/**
+	 * Whether the raw postmeta array returned by get_post_meta() is well-formed.
+	 *
+	 * @param mixed $meta_data The postmeta to validate.
+	 * @return bool True when every entry is an array containing a value at index 0.
+	 */
+	private function is_valid_order_meta( $meta_data ): bool {
+		if ( ! is_array( $meta_data ) ) {
+			return false;
+		}
+
+		foreach ( $meta_data as $value ) {
+			if ( ! is_array( $value ) || ! array_key_exists( 0, $value ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Log a single warning describing the malformed postmeta entries for a post.
+	 *
+	 * @param int   $id        The post ID.
+	 * @param mixed $meta_data The malformed postmeta.
+	 */
+	private function log_malformed_order_meta( int $id, $meta_data ): void {
+		$malformed = array();
+
+		if ( ! is_array( $meta_data ) ) {
+			$malformed[] = sprintf( 'entire postmeta (got %s, expected array)', gettype( $meta_data ) );
+		} else {
+			foreach ( $meta_data as $key => $value ) {
+				if ( ! is_array( $value ) || ! array_key_exists( 0, $value ) ) {
+					$malformed[] = sprintf(
+						'"%1$s" (got %2$s, expected array)',
+						$key,
+						is_array( $value ) ? 'array without index 0' : gettype( $value )
+					);
+				}
+			}
+		}
+
+		wc_get_logger()->warning(
+			sprintf(
+				'Malformed postmeta data detected for order ID %1$d: %2$s. The affected values will be read with their defaults. This usually indicates corrupted postmeta in the database.',
+				$id,
+				implode( ', ', $malformed )
+			),
+			array(
+				'source'  => 'woocommerce-order-data-store',
+				'post_id' => $id,
+			)
+		);
+	}
+
+	/**
+	 * Read a single value from the validated postmeta array.
+	 *
+	 * Postmeta values are arrays of values, the first of which is the stored
+	 * value. Returns the provided default when the key is missing or the entry
+	 * is malformed.
+	 *
+	 * @since 11.1.0
+	 * @param mixed  $meta_data     The postmeta array for a post.
 	 * @param string $key           The meta key to read.
-	 * @param int    $post_id       The post ID, used for logging when a malformed entry is skipped.
 	 * @param mixed  $default_value The value to return when the key is missing or malformed.
 	 * @return mixed The stored value for the key, or the default value when the key is missing or malformed.
 	 */
-	protected function get_order_meta_value( $meta_data, string $key, int $post_id = 0, $default_value = '' ) {
+	protected function get_order_meta_value( $meta_data, string $key, $default_value = '' ) {
 		if ( is_array( $meta_data ) && isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && array_key_exists( 0, $meta_data[ $key ] ) ) {
 			return $meta_data[ $key ][0];
-		}
-
-		if ( is_array( $meta_data ) && isset( $meta_data[ $key ] ) ) {
-			wc_get_logger()->warning(
-				sprintf(
-					'Skipping malformed postmeta entry "%1$s" for post ID %2$d while reading order data.',
-					$key,
-					$post_id
-				),
-				array(
-					'source'  => 'woocommerce-order-data-store',
-					'meta'    => $key,
-					'post_id' => $post_id,
-				)
-			);
 		}
 
 		return $default_value;
@@ -475,21 +560,21 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function read_order_data( &$order, $post_object ) {
 		$id = $order->get_id();
 
-		$meta_data = get_post_meta( $id );
+		$meta_data = $this->get_validated_order_meta( $id );
 
-		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', $id, null );
+		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', null );
 
 		$this->set_order_props(
 			$order,
 			array(
-				'currency'           => $this->get_order_meta_value( $meta_data, '_order_currency', $id ),
-				'discount_total'     => $this->get_order_meta_value( $meta_data, '_cart_discount', $id ),
-				'discount_tax'       => $this->get_order_meta_value( $meta_data, '_cart_discount_tax', $id ),
-				'shipping_total'     => $this->get_order_meta_value( $meta_data, '_order_shipping', $id ),
-				'shipping_tax'       => $this->get_order_meta_value( $meta_data, '_order_shipping_tax', $id ),
-				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax', $id ),
-				'total'              => $this->get_order_meta_value( $meta_data, '_order_total', $id ),
-				'version'            => $this->get_order_meta_value( $meta_data, '_order_version', $id ),
+				'currency'           => $this->get_order_meta_value( $meta_data, '_order_currency' ),
+				'discount_total'     => $this->get_order_meta_value( $meta_data, '_cart_discount' ),
+				'discount_tax'       => $this->get_order_meta_value( $meta_data, '_cart_discount_tax' ),
+				'shipping_total'     => $this->get_order_meta_value( $meta_data, '_order_shipping' ),
+				'shipping_tax'       => $this->get_order_meta_value( $meta_data, '_order_shipping_tax' ),
+				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax' ),
+				'total'              => $this->get_order_meta_value( $meta_data, '_order_total' ),
+				'version'            => $this->get_order_meta_value( $meta_data, '_order_version' ),
 				'prices_include_tax' => null !== $prices_include_tax ? 'yes' === $prices_include_tax : 'yes' === get_option( 'woocommerce_prices_include_tax' ),
 			)
 		);
@@ -498,7 +583,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $order->get_extra_data_keys() as $key ) {
 			$function = 'set_' . $key;
 			if ( is_callable( array( $order, $function ) ) ) {
-				$order->{$function}( $this->get_order_meta_value( $meta_data, '_' . $key, $id ) );
+				$order->{$function}( $this->get_order_meta_value( $meta_data, '_' . $key ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -435,25 +435,29 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * treated as missing and the provided default is returned instead of
 	 * fatalling on the illegal array access.
 	 *
-	 * @param array  $meta_data The full postmeta array for a post.
-	 * @param string $key       The meta key to read.
-	 * @param mixed  $default_value The value to return when the key is missing or malformed.
-	 * @param int    $post_id       The post ID, used for logging when a malformed entry is skipped.
-	 * @return mixed
 	 * @since 11.1.0
+	 * @param array  $meta_data     The full postmeta array for a post.
+	 * @param string $key           The meta key to read.
+	 * @param int    $post_id       The post ID, used for logging when a malformed entry is skipped.
+	 * @param mixed  $default_value The value to return when the key is missing or malformed.
+	 * @return mixed The stored value for the key, or the default value when the key is missing or malformed.
 	 */
-	protected function get_order_meta_value( array $meta_data, string $key, $default_value = '', int $post_id = 0 ) {
-		if ( isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && array_key_exists( 0, $meta_data[ $key ] ) ) {
+	protected function get_order_meta_value( $meta_data, string $key, int $post_id = 0, $default_value = '' ) {
+		if ( is_array( $meta_data ) && isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && array_key_exists( 0, $meta_data[ $key ] ) ) {
 			return $meta_data[ $key ][0];
 		}
 
-		if ( isset( $meta_data[ $key ] ) ) {
+		if ( is_array( $meta_data ) && isset( $meta_data[ $key ] ) ) {
 			wc_get_logger()->warning(
 				sprintf(
-					/* translators: 1: postmeta key, 2: post ID */
 					'Skipping malformed postmeta entry "%1$s" for post ID %2$d while reading order data.',
 					$key,
 					$post_id
+				),
+				array(
+					'source'  => 'woocommerce-order-data-store',
+					'meta'    => $key,
+					'post_id' => $post_id,
 				)
 			);
 		}
@@ -473,19 +477,19 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		$meta_data = get_post_meta( $id );
 
-		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', null, $id );
+		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', $id, null );
 
 		$this->set_order_props(
 			$order,
 			array(
-				'currency'           => $this->get_order_meta_value( $meta_data, '_order_currency', '', $id ),
-				'discount_total'     => $this->get_order_meta_value( $meta_data, '_cart_discount', '', $id ),
-				'discount_tax'       => $this->get_order_meta_value( $meta_data, '_cart_discount_tax', '', $id ),
-				'shipping_total'     => $this->get_order_meta_value( $meta_data, '_order_shipping', '', $id ),
-				'shipping_tax'       => $this->get_order_meta_value( $meta_data, '_order_shipping_tax', '', $id ),
-				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax', '', $id ),
-				'total'              => $this->get_order_meta_value( $meta_data, '_order_total', '', $id ),
-				'version'            => $this->get_order_meta_value( $meta_data, '_order_version', '', $id ),
+				'currency'           => $this->get_order_meta_value( $meta_data, '_order_currency', $id ),
+				'discount_total'     => $this->get_order_meta_value( $meta_data, '_cart_discount', $id ),
+				'discount_tax'       => $this->get_order_meta_value( $meta_data, '_cart_discount_tax', $id ),
+				'shipping_total'     => $this->get_order_meta_value( $meta_data, '_order_shipping', $id ),
+				'shipping_tax'       => $this->get_order_meta_value( $meta_data, '_order_shipping_tax', $id ),
+				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax', $id ),
+				'total'              => $this->get_order_meta_value( $meta_data, '_order_total', $id ),
+				'version'            => $this->get_order_meta_value( $meta_data, '_order_version', $id ),
 				'prices_include_tax' => null !== $prices_include_tax ? 'yes' === $prices_include_tax : 'yes' === get_option( 'woocommerce_prices_include_tax' ),
 			)
 		);
@@ -494,7 +498,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $order->get_extra_data_keys() as $key ) {
 			$function = 'set_' . $key;
 			if ( is_callable( array( $order, $function ) ) ) {
-				$order->{$function}( $this->get_order_meta_value( $meta_data, '_' . $key, '', $id ) );
+				$order->{$function}( $this->get_order_meta_value( $meta_data, '_' . $key, $id ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -427,6 +427,41 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	}
 
 	/**
+	 * Read a single value from the raw postmeta array returned by get_post_meta().
+	 *
+	 * Postmeta values are normally arrays of values, the first of which is the
+	 * stored value. When an entry is malformed (for example a corrupted object
+	 * cache entry that leaves a stdClass where the array should be), it is
+	 * treated as missing and the provided default is returned instead of
+	 * fatalling on the illegal array access.
+	 *
+	 * @param array  $meta_data The full postmeta array for a post.
+	 * @param string $key       The meta key to read.
+	 * @param mixed  $default_value The value to return when the key is missing or malformed.
+	 * @param int    $post_id       The post ID, used for logging when a malformed entry is skipped.
+	 * @return mixed
+	 * @since 11.1.0
+	 */
+	protected function get_order_meta_value( array $meta_data, string $key, $default_value = '', int $post_id = 0 ) {
+		if ( isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && ! empty( $meta_data[ $key ] ) ) {
+			return $meta_data[ $key ][0];
+		}
+
+		if ( isset( $meta_data[ $key ] ) ) {
+			wc_get_logger()->warning(
+				sprintf(
+					/* translators: 1: postmeta key, 2: post ID */
+					'Skipping malformed postmeta entry "%1$s" for post ID %2$d while reading order data.',
+					$key,
+					$post_id
+				)
+			);
+		}
+
+		return $default_value;
+	}
+
+	/**
 	 * Read order data. Can be overridden by child classes to load other props.
 	 *
 	 * @param WC_Order $order Order object.
@@ -438,19 +473,19 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		$meta_data = get_post_meta( $id );
 
-		$prices_include_tax = $meta_data['_prices_include_tax'][0] ?? '';
+		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', '', $id );
 
 		$this->set_order_props(
 			$order,
 			array(
-				'currency'           => $meta_data['_order_currency'][0] ?? '',
-				'discount_total'     => $meta_data['_cart_discount'][0] ?? '',
-				'discount_tax'       => $meta_data['_cart_discount_tax'][0] ?? '',
-				'shipping_total'     => $meta_data['_order_shipping'][0] ?? '',
-				'shipping_tax'       => $meta_data['_order_shipping_tax'][0] ?? '',
-				'cart_tax'           => $meta_data['_order_tax'][0] ?? '',
-				'total'              => $meta_data['_order_total'][0] ?? '',
-				'version'            => $meta_data['_order_version'][0] ?? '',
+				'currency'           => $this->get_order_meta_value( $meta_data, '_order_currency', '', $id ),
+				'discount_total'     => $this->get_order_meta_value( $meta_data, '_cart_discount', '', $id ),
+				'discount_tax'       => $this->get_order_meta_value( $meta_data, '_cart_discount_tax', '', $id ),
+				'shipping_total'     => $this->get_order_meta_value( $meta_data, '_order_shipping', '', $id ),
+				'shipping_tax'       => $this->get_order_meta_value( $meta_data, '_order_shipping_tax', '', $id ),
+				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax', '', $id ),
+				'total'              => $this->get_order_meta_value( $meta_data, '_order_total', '', $id ),
+				'version'            => $this->get_order_meta_value( $meta_data, '_order_version', '', $id ),
 				'prices_include_tax' => metadata_exists( 'post', $id, '_prices_include_tax' ) ? 'yes' === $prices_include_tax : 'yes' === get_option( 'woocommerce_prices_include_tax' ),
 			)
 		);
@@ -459,7 +494,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $order->get_extra_data_keys() as $key ) {
 			$function = 'set_' . $key;
 			if ( is_callable( array( $order, $function ) ) ) {
-				$order->{$function}( $meta_data[ '_' . $key ][0] ?? '' );
+				$order->{$function}( $this->get_order_meta_value( $meta_data, '_' . $key, '', $id ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -443,7 +443,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @since 11.1.0
 	 */
 	protected function get_order_meta_value( array $meta_data, string $key, $default_value = '', int $post_id = 0 ) {
-		if ( isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && ! empty( $meta_data[ $key ] ) ) {
+		if ( isset( $meta_data[ $key ] ) && is_array( $meta_data[ $key ] ) && array_key_exists( 0, $meta_data[ $key ] ) ) {
 			return $meta_data[ $key ][0];
 		}
 
@@ -473,7 +473,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		$meta_data = get_post_meta( $id );
 
-		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', '', $id );
+		$prices_include_tax = $this->get_order_meta_value( $meta_data, '_prices_include_tax', null, $id );
 
 		$this->set_order_props(
 			$order,
@@ -486,7 +486,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				'cart_tax'           => $this->get_order_meta_value( $meta_data, '_order_tax', '', $id ),
 				'total'              => $this->get_order_meta_value( $meta_data, '_order_total', '', $id ),
 				'version'            => $this->get_order_meta_value( $meta_data, '_order_version', '', $id ),
-				'prices_include_tax' => metadata_exists( 'post', $id, '_prices_include_tax' ) ? 'yes' === $prices_include_tax : 'yes' === get_option( 'woocommerce_prices_include_tax' ),
+				'prices_include_tax' => null !== $prices_include_tax ? 'yes' === $prices_include_tax : 'yes' === get_option( 'woocommerce_prices_include_tax' ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -151,6 +151,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @throws Exception If passed order is invalid.
 	 */
 	public function read( &$order ) {
+		$this->validated_order_meta = array();
 		$order->set_defaults();
 		$post_object = get_post( $order->get_id() );
 		if ( ! $order->get_id() || ! $post_object || ! in_array( $post_object->post_type, wc_get_order_types(), true ) ) {
@@ -446,7 +447,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * re-reads it from the database so the real values are used instead of
 	 * falling back to defaults.
 	 *
-	 * @since 11.1.0
+	 * @since 11.2.0
 	 * @param int $id The post ID.
 	 * @return array The validated postmeta array.
 	 */
@@ -467,7 +468,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			$this->log_malformed_order_meta( $id, $meta_data );
 		}
 
-		$meta_data = is_array( $meta_data ) ? $meta_data : array();
+		$meta_data                         = is_array( $meta_data ) ? $meta_data : array();
 		$this->validated_order_meta[ $id ] = $meta_data;
 
 		return $meta_data;
@@ -536,7 +537,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * value. Returns the provided default when the key is missing or the entry
 	 * is malformed.
 	 *
-	 * @since 11.1.0
+	 * @since 11.2.0
 	 * @param mixed  $meta_data     The postmeta array for a post.
 	 * @param string $key           The meta key to read.
 	 * @param mixed  $default_value The value to return when the key is missing or malformed.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1364,7 +1364,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @param array    $post_meta The post meta data array.
 	 */
 	private function read_cogs_data( $order, $post_meta ) {
-		$cogs_value = isset( $post_meta['_cogs_total_value'][0] ) ? (float) $post_meta['_cogs_total_value'][0] : 0;
+		$cogs_value = (float) $this->get_order_meta_value( $post_meta, '_cogs_total_value', 0, $order->get_id() );
 
 		/**
 		 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -130,59 +130,59 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		$post_meta = get_post_meta( $id );
 
-		$date_completed = $this->get_order_meta_value( $post_meta, '_date_completed', '', $id );
-		$date_paid      = $this->get_order_meta_value( $post_meta, '_date_paid', '', $id );
+		$date_completed = $this->get_order_meta_value( $post_meta, '_date_completed', $id );
+		$date_paid      = $this->get_order_meta_value( $post_meta, '_date_paid', $id );
 
 		if ( ! $date_completed ) {
-			$date_completed = $this->get_order_meta_value( $post_meta, '_completed_date', '', $id );
+			$date_completed = $this->get_order_meta_value( $post_meta, '_completed_date', $id );
 		}
 
 		if ( ! $date_paid ) {
-			$date_paid = $this->get_order_meta_value( $post_meta, '_paid_date', '', $id );
+			$date_paid = $this->get_order_meta_value( $post_meta, '_paid_date', $id );
 		}
 
 		$order->set_props(
 			array(
-				'order_key'                    => $this->get_order_meta_value( $post_meta, '_order_key', '', $id ),
-				'customer_id'                  => $this->get_order_meta_value( $post_meta, '_customer_user', '', $id ),
-				'billing_first_name'           => $this->get_order_meta_value( $post_meta, '_billing_first_name', '', $id ),
-				'billing_last_name'            => $this->get_order_meta_value( $post_meta, '_billing_last_name', '', $id ),
-				'billing_company'              => $this->get_order_meta_value( $post_meta, '_billing_company', '', $id ),
-				'billing_address_1'            => $this->get_order_meta_value( $post_meta, '_billing_address_1', '', $id ),
-				'billing_address_2'            => $this->get_order_meta_value( $post_meta, '_billing_address_2', '', $id ),
-				'billing_city'                 => $this->get_order_meta_value( $post_meta, '_billing_city', '', $id ),
-				'billing_state'                => $this->get_order_meta_value( $post_meta, '_billing_state', '', $id ),
-				'billing_postcode'             => $this->get_order_meta_value( $post_meta, '_billing_postcode', '', $id ),
-				'billing_country'              => $this->get_order_meta_value( $post_meta, '_billing_country', '', $id ),
-				'billing_email'                => $this->get_order_meta_value( $post_meta, '_billing_email', '', $id ),
-				'billing_phone'                => $this->get_order_meta_value( $post_meta, '_billing_phone', '', $id ),
-				'shipping_first_name'          => $this->get_order_meta_value( $post_meta, '_shipping_first_name', '', $id ),
-				'shipping_last_name'           => $this->get_order_meta_value( $post_meta, '_shipping_last_name', '', $id ),
-				'shipping_company'             => $this->get_order_meta_value( $post_meta, '_shipping_company', '', $id ),
-				'shipping_address_1'           => $this->get_order_meta_value( $post_meta, '_shipping_address_1', '', $id ),
-				'shipping_address_2'           => $this->get_order_meta_value( $post_meta, '_shipping_address_2', '', $id ),
-				'shipping_city'                => $this->get_order_meta_value( $post_meta, '_shipping_city', '', $id ),
-				'shipping_state'               => $this->get_order_meta_value( $post_meta, '_shipping_state', '', $id ),
-				'shipping_postcode'            => $this->get_order_meta_value( $post_meta, '_shipping_postcode', '', $id ),
-				'shipping_country'             => $this->get_order_meta_value( $post_meta, '_shipping_country', '', $id ),
-				'shipping_phone'               => $this->get_order_meta_value( $post_meta, '_shipping_phone', '', $id ),
-				'payment_method'               => $this->get_order_meta_value( $post_meta, '_payment_method', '', $id ),
-				'payment_method_title'         => $this->get_order_meta_value( $post_meta, '_payment_method_title', '', $id ),
-				'transaction_id'               => $this->get_order_meta_value( $post_meta, '_transaction_id', '', $id ),
-				'customer_ip_address'          => $this->get_order_meta_value( $post_meta, '_customer_ip_address', '', $id ),
-				'customer_user_agent'          => $this->get_order_meta_value( $post_meta, '_customer_user_agent', '', $id ),
-				'created_via'                  => $this->get_order_meta_value( $post_meta, '_created_via', '', $id ),
+				'order_key'                    => $this->get_order_meta_value( $post_meta, '_order_key', $id ),
+				'customer_id'                  => $this->get_order_meta_value( $post_meta, '_customer_user', $id ),
+				'billing_first_name'           => $this->get_order_meta_value( $post_meta, '_billing_first_name', $id ),
+				'billing_last_name'            => $this->get_order_meta_value( $post_meta, '_billing_last_name', $id ),
+				'billing_company'              => $this->get_order_meta_value( $post_meta, '_billing_company', $id ),
+				'billing_address_1'            => $this->get_order_meta_value( $post_meta, '_billing_address_1', $id ),
+				'billing_address_2'            => $this->get_order_meta_value( $post_meta, '_billing_address_2', $id ),
+				'billing_city'                 => $this->get_order_meta_value( $post_meta, '_billing_city', $id ),
+				'billing_state'                => $this->get_order_meta_value( $post_meta, '_billing_state', $id ),
+				'billing_postcode'             => $this->get_order_meta_value( $post_meta, '_billing_postcode', $id ),
+				'billing_country'              => $this->get_order_meta_value( $post_meta, '_billing_country', $id ),
+				'billing_email'                => $this->get_order_meta_value( $post_meta, '_billing_email', $id ),
+				'billing_phone'                => $this->get_order_meta_value( $post_meta, '_billing_phone', $id ),
+				'shipping_first_name'          => $this->get_order_meta_value( $post_meta, '_shipping_first_name', $id ),
+				'shipping_last_name'           => $this->get_order_meta_value( $post_meta, '_shipping_last_name', $id ),
+				'shipping_company'             => $this->get_order_meta_value( $post_meta, '_shipping_company', $id ),
+				'shipping_address_1'           => $this->get_order_meta_value( $post_meta, '_shipping_address_1', $id ),
+				'shipping_address_2'           => $this->get_order_meta_value( $post_meta, '_shipping_address_2', $id ),
+				'shipping_city'                => $this->get_order_meta_value( $post_meta, '_shipping_city', $id ),
+				'shipping_state'               => $this->get_order_meta_value( $post_meta, '_shipping_state', $id ),
+				'shipping_postcode'            => $this->get_order_meta_value( $post_meta, '_shipping_postcode', $id ),
+				'shipping_country'             => $this->get_order_meta_value( $post_meta, '_shipping_country', $id ),
+				'shipping_phone'               => $this->get_order_meta_value( $post_meta, '_shipping_phone', $id ),
+				'payment_method'               => $this->get_order_meta_value( $post_meta, '_payment_method', $id ),
+				'payment_method_title'         => $this->get_order_meta_value( $post_meta, '_payment_method_title', $id ),
+				'transaction_id'               => $this->get_order_meta_value( $post_meta, '_transaction_id', $id ),
+				'customer_ip_address'          => $this->get_order_meta_value( $post_meta, '_customer_ip_address', $id ),
+				'customer_user_agent'          => $this->get_order_meta_value( $post_meta, '_customer_user_agent', $id ),
+				'created_via'                  => $this->get_order_meta_value( $post_meta, '_created_via', $id ),
 				'date_completed'               => $date_completed,
 				'date_paid'                    => $date_paid,
-				'cart_hash'                    => $this->get_order_meta_value( $post_meta, '_cart_hash', '', $id ),
+				'cart_hash'                    => $this->get_order_meta_value( $post_meta, '_cart_hash', $id ),
 				'customer_note'                => $post_object->post_excerpt,
 
 				// Operational data props.
-				'order_stock_reduced'          => $this->get_order_meta_value( $post_meta, '_order_stock_reduced', '', $id ),
-				'download_permissions_granted' => $this->get_order_meta_value( $post_meta, '_download_permissions_granted', '', $id ),
-				'new_order_email_sent'         => $this->get_order_meta_value( $post_meta, '_new_order_email_sent', '', $id ),
-				'recorded_sales'               => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_recorded_sales', '', $id ) ),
-				'recorded_coupon_usage_counts' => $this->get_order_meta_value( $post_meta, '_recorded_coupon_usage_counts', '', $id ),
+				'order_stock_reduced'          => $this->get_order_meta_value( $post_meta, '_order_stock_reduced', $id ),
+				'download_permissions_granted' => $this->get_order_meta_value( $post_meta, '_download_permissions_granted', $id ),
+				'new_order_email_sent'         => $this->get_order_meta_value( $post_meta, '_new_order_email_sent', $id ),
+				'recorded_sales'               => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_recorded_sales', $id ) ),
+				'recorded_coupon_usage_counts' => $this->get_order_meta_value( $post_meta, '_recorded_coupon_usage_counts', $id ),
 			)
 		);
 
@@ -1364,7 +1364,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @param array    $post_meta The post meta data array.
 	 */
 	private function read_cogs_data( $order, $post_meta ) {
-		$cogs_value = (float) $this->get_order_meta_value( $post_meta, '_cogs_total_value', 0, $order->get_id() );
+		$cogs_value = (float) $this->get_order_meta_value( $post_meta, '_cogs_total_value', $order->get_id(), 0 );
 
 		/**
 		 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -130,59 +130,59 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		$post_meta = get_post_meta( $id );
 
-		$date_completed = $post_meta['_date_completed'][0] ?? '';
-		$date_paid      = $post_meta['_date_paid'][0] ?? '';
+		$date_completed = $this->get_order_meta_value( $post_meta, '_date_completed', '', $id );
+		$date_paid      = $this->get_order_meta_value( $post_meta, '_date_paid', '', $id );
 
 		if ( ! $date_completed ) {
-			$date_completed = $post_meta['_completed_date'][0] ?? '';
+			$date_completed = $this->get_order_meta_value( $post_meta, '_completed_date', '', $id );
 		}
 
 		if ( ! $date_paid ) {
-			$date_paid = $post_meta['_paid_date'][0] ?? '';
+			$date_paid = $this->get_order_meta_value( $post_meta, '_paid_date', '', $id );
 		}
 
 		$order->set_props(
 			array(
-				'order_key'                    => $post_meta['_order_key'][0] ?? '',
-				'customer_id'                  => $post_meta['_customer_user'][0] ?? '',
-				'billing_first_name'           => $post_meta['_billing_first_name'][0] ?? '',
-				'billing_last_name'            => $post_meta['_billing_last_name'][0] ?? '',
-				'billing_company'              => $post_meta['_billing_company'][0] ?? '',
-				'billing_address_1'            => $post_meta['_billing_address_1'][0] ?? '',
-				'billing_address_2'            => $post_meta['_billing_address_2'][0] ?? '',
-				'billing_city'                 => $post_meta['_billing_city'][0] ?? '',
-				'billing_state'                => $post_meta['_billing_state'][0] ?? '',
-				'billing_postcode'             => $post_meta['_billing_postcode'][0] ?? '',
-				'billing_country'              => $post_meta['_billing_country'][0] ?? '',
-				'billing_email'                => $post_meta['_billing_email'][0] ?? '',
-				'billing_phone'                => $post_meta['_billing_phone'][0] ?? '',
-				'shipping_first_name'          => $post_meta['_shipping_first_name'][0] ?? '',
-				'shipping_last_name'           => $post_meta['_shipping_last_name'][0] ?? '',
-				'shipping_company'             => $post_meta['_shipping_company'][0] ?? '',
-				'shipping_address_1'           => $post_meta['_shipping_address_1'][0] ?? '',
-				'shipping_address_2'           => $post_meta['_shipping_address_2'][0] ?? '',
-				'shipping_city'                => $post_meta['_shipping_city'][0] ?? '',
-				'shipping_state'               => $post_meta['_shipping_state'][0] ?? '',
-				'shipping_postcode'            => $post_meta['_shipping_postcode'][0] ?? '',
-				'shipping_country'             => $post_meta['_shipping_country'][0] ?? '',
-				'shipping_phone'               => $post_meta['_shipping_phone'][0] ?? '',
-				'payment_method'               => $post_meta['_payment_method'][0] ?? '',
-				'payment_method_title'         => $post_meta['_payment_method_title'][0] ?? '',
-				'transaction_id'               => $post_meta['_transaction_id'][0] ?? '',
-				'customer_ip_address'          => $post_meta['_customer_ip_address'][0] ?? '',
-				'customer_user_agent'          => $post_meta['_customer_user_agent'][0] ?? '',
-				'created_via'                  => $post_meta['_created_via'][0] ?? '',
+				'order_key'                    => $this->get_order_meta_value( $post_meta, '_order_key', '', $id ),
+				'customer_id'                  => $this->get_order_meta_value( $post_meta, '_customer_user', '', $id ),
+				'billing_first_name'           => $this->get_order_meta_value( $post_meta, '_billing_first_name', '', $id ),
+				'billing_last_name'            => $this->get_order_meta_value( $post_meta, '_billing_last_name', '', $id ),
+				'billing_company'              => $this->get_order_meta_value( $post_meta, '_billing_company', '', $id ),
+				'billing_address_1'            => $this->get_order_meta_value( $post_meta, '_billing_address_1', '', $id ),
+				'billing_address_2'            => $this->get_order_meta_value( $post_meta, '_billing_address_2', '', $id ),
+				'billing_city'                 => $this->get_order_meta_value( $post_meta, '_billing_city', '', $id ),
+				'billing_state'                => $this->get_order_meta_value( $post_meta, '_billing_state', '', $id ),
+				'billing_postcode'             => $this->get_order_meta_value( $post_meta, '_billing_postcode', '', $id ),
+				'billing_country'              => $this->get_order_meta_value( $post_meta, '_billing_country', '', $id ),
+				'billing_email'                => $this->get_order_meta_value( $post_meta, '_billing_email', '', $id ),
+				'billing_phone'                => $this->get_order_meta_value( $post_meta, '_billing_phone', '', $id ),
+				'shipping_first_name'          => $this->get_order_meta_value( $post_meta, '_shipping_first_name', '', $id ),
+				'shipping_last_name'           => $this->get_order_meta_value( $post_meta, '_shipping_last_name', '', $id ),
+				'shipping_company'             => $this->get_order_meta_value( $post_meta, '_shipping_company', '', $id ),
+				'shipping_address_1'           => $this->get_order_meta_value( $post_meta, '_shipping_address_1', '', $id ),
+				'shipping_address_2'           => $this->get_order_meta_value( $post_meta, '_shipping_address_2', '', $id ),
+				'shipping_city'                => $this->get_order_meta_value( $post_meta, '_shipping_city', '', $id ),
+				'shipping_state'               => $this->get_order_meta_value( $post_meta, '_shipping_state', '', $id ),
+				'shipping_postcode'            => $this->get_order_meta_value( $post_meta, '_shipping_postcode', '', $id ),
+				'shipping_country'             => $this->get_order_meta_value( $post_meta, '_shipping_country', '', $id ),
+				'shipping_phone'               => $this->get_order_meta_value( $post_meta, '_shipping_phone', '', $id ),
+				'payment_method'               => $this->get_order_meta_value( $post_meta, '_payment_method', '', $id ),
+				'payment_method_title'         => $this->get_order_meta_value( $post_meta, '_payment_method_title', '', $id ),
+				'transaction_id'               => $this->get_order_meta_value( $post_meta, '_transaction_id', '', $id ),
+				'customer_ip_address'          => $this->get_order_meta_value( $post_meta, '_customer_ip_address', '', $id ),
+				'customer_user_agent'          => $this->get_order_meta_value( $post_meta, '_customer_user_agent', '', $id ),
+				'created_via'                  => $this->get_order_meta_value( $post_meta, '_created_via', '', $id ),
 				'date_completed'               => $date_completed,
 				'date_paid'                    => $date_paid,
-				'cart_hash'                    => $post_meta['_cart_hash'][0] ?? '',
+				'cart_hash'                    => $this->get_order_meta_value( $post_meta, '_cart_hash', '', $id ),
 				'customer_note'                => $post_object->post_excerpt,
 
 				// Operational data props.
-				'order_stock_reduced'          => $post_meta['_order_stock_reduced'][0] ?? '',
-				'download_permissions_granted' => $post_meta['_download_permissions_granted'][0] ?? '',
-				'new_order_email_sent'         => $post_meta['_new_order_email_sent'][0] ?? '',
-				'recorded_sales'               => wc_string_to_bool( $post_meta['_recorded_sales'][0] ?? '' ),
-				'recorded_coupon_usage_counts' => $post_meta['_recorded_coupon_usage_counts'][0] ?? '',
+				'order_stock_reduced'          => $this->get_order_meta_value( $post_meta, '_order_stock_reduced', '', $id ),
+				'download_permissions_granted' => $this->get_order_meta_value( $post_meta, '_download_permissions_granted', '', $id ),
+				'new_order_email_sent'         => $this->get_order_meta_value( $post_meta, '_new_order_email_sent', '', $id ),
+				'recorded_sales'               => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_recorded_sales', '', $id ) ),
+				'recorded_coupon_usage_counts' => $this->get_order_meta_value( $post_meta, '_recorded_coupon_usage_counts', '', $id ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -128,61 +128,61 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		parent::read_order_data( $order, $post_object );
 		$id = $order->get_id();
 
-		$post_meta = get_post_meta( $id );
+		$post_meta = $this->get_validated_order_meta( $id );
 
-		$date_completed = $this->get_order_meta_value( $post_meta, '_date_completed', $id );
-		$date_paid      = $this->get_order_meta_value( $post_meta, '_date_paid', $id );
+		$date_completed = $this->get_order_meta_value( $post_meta, '_date_completed' );
+		$date_paid      = $this->get_order_meta_value( $post_meta, '_date_paid' );
 
 		if ( ! $date_completed ) {
-			$date_completed = $this->get_order_meta_value( $post_meta, '_completed_date', $id );
+			$date_completed = $this->get_order_meta_value( $post_meta, '_completed_date' );
 		}
 
 		if ( ! $date_paid ) {
-			$date_paid = $this->get_order_meta_value( $post_meta, '_paid_date', $id );
+			$date_paid = $this->get_order_meta_value( $post_meta, '_paid_date' );
 		}
 
 		$order->set_props(
 			array(
-				'order_key'                    => $this->get_order_meta_value( $post_meta, '_order_key', $id ),
-				'customer_id'                  => $this->get_order_meta_value( $post_meta, '_customer_user', $id ),
-				'billing_first_name'           => $this->get_order_meta_value( $post_meta, '_billing_first_name', $id ),
-				'billing_last_name'            => $this->get_order_meta_value( $post_meta, '_billing_last_name', $id ),
-				'billing_company'              => $this->get_order_meta_value( $post_meta, '_billing_company', $id ),
-				'billing_address_1'            => $this->get_order_meta_value( $post_meta, '_billing_address_1', $id ),
-				'billing_address_2'            => $this->get_order_meta_value( $post_meta, '_billing_address_2', $id ),
-				'billing_city'                 => $this->get_order_meta_value( $post_meta, '_billing_city', $id ),
-				'billing_state'                => $this->get_order_meta_value( $post_meta, '_billing_state', $id ),
-				'billing_postcode'             => $this->get_order_meta_value( $post_meta, '_billing_postcode', $id ),
-				'billing_country'              => $this->get_order_meta_value( $post_meta, '_billing_country', $id ),
-				'billing_email'                => $this->get_order_meta_value( $post_meta, '_billing_email', $id ),
-				'billing_phone'                => $this->get_order_meta_value( $post_meta, '_billing_phone', $id ),
-				'shipping_first_name'          => $this->get_order_meta_value( $post_meta, '_shipping_first_name', $id ),
-				'shipping_last_name'           => $this->get_order_meta_value( $post_meta, '_shipping_last_name', $id ),
-				'shipping_company'             => $this->get_order_meta_value( $post_meta, '_shipping_company', $id ),
-				'shipping_address_1'           => $this->get_order_meta_value( $post_meta, '_shipping_address_1', $id ),
-				'shipping_address_2'           => $this->get_order_meta_value( $post_meta, '_shipping_address_2', $id ),
-				'shipping_city'                => $this->get_order_meta_value( $post_meta, '_shipping_city', $id ),
-				'shipping_state'               => $this->get_order_meta_value( $post_meta, '_shipping_state', $id ),
-				'shipping_postcode'            => $this->get_order_meta_value( $post_meta, '_shipping_postcode', $id ),
-				'shipping_country'             => $this->get_order_meta_value( $post_meta, '_shipping_country', $id ),
-				'shipping_phone'               => $this->get_order_meta_value( $post_meta, '_shipping_phone', $id ),
-				'payment_method'               => $this->get_order_meta_value( $post_meta, '_payment_method', $id ),
-				'payment_method_title'         => $this->get_order_meta_value( $post_meta, '_payment_method_title', $id ),
-				'transaction_id'               => $this->get_order_meta_value( $post_meta, '_transaction_id', $id ),
-				'customer_ip_address'          => $this->get_order_meta_value( $post_meta, '_customer_ip_address', $id ),
-				'customer_user_agent'          => $this->get_order_meta_value( $post_meta, '_customer_user_agent', $id ),
-				'created_via'                  => $this->get_order_meta_value( $post_meta, '_created_via', $id ),
+				'order_key'                    => $this->get_order_meta_value( $post_meta, '_order_key' ),
+				'customer_id'                  => $this->get_order_meta_value( $post_meta, '_customer_user' ),
+				'billing_first_name'           => $this->get_order_meta_value( $post_meta, '_billing_first_name' ),
+				'billing_last_name'            => $this->get_order_meta_value( $post_meta, '_billing_last_name' ),
+				'billing_company'              => $this->get_order_meta_value( $post_meta, '_billing_company' ),
+				'billing_address_1'            => $this->get_order_meta_value( $post_meta, '_billing_address_1' ),
+				'billing_address_2'            => $this->get_order_meta_value( $post_meta, '_billing_address_2' ),
+				'billing_city'                 => $this->get_order_meta_value( $post_meta, '_billing_city' ),
+				'billing_state'                => $this->get_order_meta_value( $post_meta, '_billing_state' ),
+				'billing_postcode'             => $this->get_order_meta_value( $post_meta, '_billing_postcode' ),
+				'billing_country'              => $this->get_order_meta_value( $post_meta, '_billing_country' ),
+				'billing_email'                => $this->get_order_meta_value( $post_meta, '_billing_email' ),
+				'billing_phone'                => $this->get_order_meta_value( $post_meta, '_billing_phone' ),
+				'shipping_first_name'          => $this->get_order_meta_value( $post_meta, '_shipping_first_name' ),
+				'shipping_last_name'           => $this->get_order_meta_value( $post_meta, '_shipping_last_name' ),
+				'shipping_company'             => $this->get_order_meta_value( $post_meta, '_shipping_company' ),
+				'shipping_address_1'           => $this->get_order_meta_value( $post_meta, '_shipping_address_1' ),
+				'shipping_address_2'           => $this->get_order_meta_value( $post_meta, '_shipping_address_2' ),
+				'shipping_city'                => $this->get_order_meta_value( $post_meta, '_shipping_city' ),
+				'shipping_state'               => $this->get_order_meta_value( $post_meta, '_shipping_state' ),
+				'shipping_postcode'            => $this->get_order_meta_value( $post_meta, '_shipping_postcode' ),
+				'shipping_country'             => $this->get_order_meta_value( $post_meta, '_shipping_country' ),
+				'shipping_phone'               => $this->get_order_meta_value( $post_meta, '_shipping_phone' ),
+				'payment_method'               => $this->get_order_meta_value( $post_meta, '_payment_method' ),
+				'payment_method_title'         => $this->get_order_meta_value( $post_meta, '_payment_method_title' ),
+				'transaction_id'               => $this->get_order_meta_value( $post_meta, '_transaction_id' ),
+				'customer_ip_address'          => $this->get_order_meta_value( $post_meta, '_customer_ip_address' ),
+				'customer_user_agent'          => $this->get_order_meta_value( $post_meta, '_customer_user_agent' ),
+				'created_via'                  => $this->get_order_meta_value( $post_meta, '_created_via' ),
 				'date_completed'               => $date_completed,
 				'date_paid'                    => $date_paid,
-				'cart_hash'                    => $this->get_order_meta_value( $post_meta, '_cart_hash', $id ),
+				'cart_hash'                    => $this->get_order_meta_value( $post_meta, '_cart_hash' ),
 				'customer_note'                => $post_object->post_excerpt,
 
 				// Operational data props.
-				'order_stock_reduced'          => $this->get_order_meta_value( $post_meta, '_order_stock_reduced', $id ),
-				'download_permissions_granted' => $this->get_order_meta_value( $post_meta, '_download_permissions_granted', $id ),
-				'new_order_email_sent'         => $this->get_order_meta_value( $post_meta, '_new_order_email_sent', $id ),
-				'recorded_sales'               => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_recorded_sales', $id ) ),
-				'recorded_coupon_usage_counts' => $this->get_order_meta_value( $post_meta, '_recorded_coupon_usage_counts', $id ),
+				'order_stock_reduced'          => $this->get_order_meta_value( $post_meta, '_order_stock_reduced' ),
+				'download_permissions_granted' => $this->get_order_meta_value( $post_meta, '_download_permissions_granted' ),
+				'new_order_email_sent'         => $this->get_order_meta_value( $post_meta, '_new_order_email_sent' ),
+				'recorded_sales'               => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_recorded_sales' ) ),
+				'recorded_coupon_usage_counts' => $this->get_order_meta_value( $post_meta, '_recorded_coupon_usage_counts' ),
 			)
 		);
 
@@ -1364,7 +1364,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @param array    $post_meta The post meta data array.
 	 */
 	private function read_cogs_data( $order, $post_meta ) {
-		$cogs_value = (float) $this->get_order_meta_value( $post_meta, '_cogs_total_value', $order->get_id(), 0 );
+		$cogs_value = (float) $this->get_order_meta_value( $post_meta, '_cogs_total_value', 0 );
 
 		/**
 		 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -80,14 +80,14 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 
 		$post_meta = get_post_meta( $id );
 
-		$refunded_by = $post_meta['_refunded_by'][0] ?? null;
-		$reason      = $post_meta['_refund_reason'][0] ?? '';
+		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', null, $id );
+		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', '', $id );
 
 		$refund->set_props(
 			array(
-				'amount'           => $post_meta['_refund_amount'][0] ?? 0,
+				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', 0, $id ),
 				'refunded_by'      => metadata_exists( 'post', $id, '_refunded_by' ) ? $refunded_by : absint( $post_object->post_author ),
-				'refunded_payment' => wc_string_to_bool( $post_meta['_refunded_payment'][0] ?? false ),
+				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', false, $id ) ),
 				'reason'           => metadata_exists( 'post', $id, '_refund_reason' ) ? $reason : $post_object->post_excerpt,
 			)
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -81,14 +81,14 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 		$post_meta = get_post_meta( $id );
 
 		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', null, $id );
-		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', '', $id );
+		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', null, $id );
 
 		$refund->set_props(
 			array(
 				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', 0, $id ),
-				'refunded_by'      => metadata_exists( 'post', $id, '_refunded_by' ) ? $refunded_by : absint( $post_object->post_author ),
+				'refunded_by'      => null !== $refunded_by ? $refunded_by : absint( $post_object->post_author ),
 				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', false, $id ) ),
-				'reason'           => metadata_exists( 'post', $id, '_refund_reason' ) ? $reason : $post_object->post_excerpt,
+				'reason'           => null !== $reason ? $reason : $post_object->post_excerpt,
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -80,14 +80,14 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 
 		$post_meta = get_post_meta( $id );
 
-		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', null, $id );
-		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', null, $id );
+		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', $id, null );
+		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', $id, null );
 
 		$refund->set_props(
 			array(
-				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', 0, $id ),
+				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', $id, 0 ),
 				'refunded_by'      => null !== $refunded_by ? $refunded_by : absint( $post_object->post_author ),
-				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', false, $id ) ),
+				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', $id, false ) ),
 				'reason'           => null !== $reason ? $reason : $post_object->post_excerpt,
 			)
 		);

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -78,16 +78,16 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 		parent::read_order_data( $refund, $post_object );
 		$id = $refund->get_id();
 
-		$post_meta = get_post_meta( $id );
+		$post_meta = $this->get_validated_order_meta( $id );
 
-		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', $id, null );
-		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', $id, null );
+		$refunded_by = $this->get_order_meta_value( $post_meta, '_refunded_by', null );
+		$reason      = $this->get_order_meta_value( $post_meta, '_refund_reason', null );
 
 		$refund->set_props(
 			array(
-				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', $id, 0 ),
+				'amount'           => $this->get_order_meta_value( $post_meta, '_refund_amount', 0 ),
 				'refunded_by'      => null !== $refunded_by ? $refunded_by : absint( $post_object->post_author ),
-				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', $id, false ) ),
+				'refunded_payment' => wc_string_to_bool( $this->get_order_meta_value( $post_meta, '_refunded_payment', false ) ),
 				'reason'           => null !== $reason ? $reason : $post_object->post_excerpt,
 			)
 		);

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1534,9 +1534,9 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Reading an order does not fatal when a postmeta entry is malformed (e.g. a stdClass from a corrupted cache).
+	 * @testdox Reading an order recovers the real value from the database when a corrupted cache entry leaves malformed postmeta.
 	 */
-	public function test_reading_order_does_not_fatal_on_malformed_postmeta(): void {
+	public function test_reading_order_self_heals_malformed_postmeta_cache(): void {
 		$order = WC_Helper_Order::create_order();
 		$order->set_currency( 'EUR' );
 		$order->save();
@@ -1548,13 +1548,13 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$read_order = wc_get_order( $order_id );
 
 		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on malformed postmeta' );
-		$this->assertEquals( get_woocommerce_currency(), $read_order->get_currency(), 'Malformed currency meta should fall back to the store currency' );
+		$this->assertEquals( 'EUR', $read_order->get_currency(), 'The corrupted cache entry should be discarded and the real currency re-read from the database' );
 	}
 
 	/**
-	 * @testdox Reading a refund does not fatal when a postmeta entry is malformed (e.g. a stdClass from a corrupted cache).
+	 * @testdox Reading a refund recovers the real value from the database when a corrupted cache entry leaves malformed postmeta.
 	 */
-	public function test_reading_refund_does_not_fatal_on_malformed_postmeta(): void {
+	public function test_reading_refund_self_heals_malformed_postmeta_cache(): void {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
@@ -1571,41 +1571,52 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$read_refund = wc_get_order( $refund_id );
 
 		$this->assertInstanceOf( WC_Order_Refund::class, $read_refund, 'Refund should hydrate without fataling on malformed postmeta' );
-		$this->assertEquals( 0, $read_refund->get_amount(), 'Malformed refund amount meta should fall back to the default of zero' );
+		$this->assertEquals( 10, $read_refund->get_amount(), 'The corrupted cache entry should be discarded and the real amount re-read from the database' );
 	}
 
 	/**
-	 * @testdox Reading a refund with malformed _refunded_by/_refund_reason meta falls back to the post author and excerpt.
+	 * @testdox Reading an order falls back to defaults and logs a single warning when the postmeta is persistently malformed.
 	 */
-	public function test_reading_refund_falls_back_on_malformed_refunded_by_and_reason(): void {
+	public function test_reading_order_falls_back_and_logs_once_when_postmeta_is_persistently_malformed(): void {
 		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'EUR' );
 		$order->save();
+		$order_id = $order->get_id();
 
-		$refund = new WC_Order_Refund();
-		$refund->set_parent_id( $order->get_id() );
-		$refund->set_amount( 10 );
-		$refund->set_reason( 'test' );
-		$refund->save();
-		$refund_id = $refund->get_id();
-
-		$expected_author  = (int) get_post_field( 'post_author', $refund_id );
-		$expected_excerpt = (string) get_post_field( 'post_excerpt', $refund_id );
-
-		wp_cache_flush();
-		wp_cache_set(
-			$refund_id,
-			array(
-				'_refunded_by'   => (object) array( 'corrupt' ),
-				'_refund_reason' => (object) array( 'corrupt' ),
-			),
-			'post_meta'
+		$fake_logger = $this->create_fake_logger();
+		add_filter(
+			'woocommerce_logging_class',
+			function () use ( $fake_logger ) {
+				return $fake_logger;
+			}
 		);
 
-		$read_refund = wc_get_order( $refund_id );
+		// Force every "read all postmeta" lookup to return a malformed entry, so the
+		// self-heal re-read also fails and the default fallback + warning path is taken.
+		$malformed_meta_filter = function ( $value, $object_id, $meta_key ) use ( $order_id ) {
+			if ( $order_id === $object_id && '' === $meta_key ) {
+				return array( '_order_currency' => (object) array( 'corrupt' ) );
+			}
+			return $value;
+		};
+		add_filter( 'get_post_metadata', $malformed_meta_filter, 10, 3 );
 
-		$this->assertInstanceOf( WC_Order_Refund::class, $read_refund, 'Refund should hydrate without fataling on malformed postmeta' );
-		$this->assertEquals( $expected_author, $read_refund->get_refunded_by(), 'Malformed _refunded_by meta should fall back to the post author' );
-		$this->assertEquals( $expected_excerpt, $read_refund->get_reason(), 'Malformed _refund_reason meta should fall back to the post excerpt' );
+		$read_order = wc_get_order( $order_id );
+
+		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on persistently malformed postmeta' );
+		$this->assertEquals( get_woocommerce_currency(), $read_order->get_currency(), 'Persistently malformed currency meta should fall back to the store currency' );
+
+		$warnings = array_filter(
+			$fake_logger->warning_calls,
+			function ( $call ) {
+				return 'woocommerce-order-data-store' === ( $call['context']['source'] ?? '' );
+			}
+		);
+		$this->assertCount( 1, $warnings, 'A single warning should be logged per hydration for malformed postmeta' );
+		$this->assertStringContainsString( '_order_currency', $warnings[ array_key_first( $warnings ) ]['message'] ?? '' );
+
+		remove_filter( 'get_post_metadata', $malformed_meta_filter, 10 );
+		remove_all_filters( 'woocommerce_logging_class' );
 	}
 
 	/**
@@ -1626,4 +1637,61 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on malformed COGS postmeta' );
 		$this->assertEquals( 0, $read_order->get_cogs_total_value(), 'Malformed COGS meta should fall back to zero' );
 	}
+
+	/**
+	 * Create a fake logger that records warning calls for assertion.
+	 *
+	 * @return WC_Logger_Interface Fake logger.
+	 */
+	// phpcs:disable Squiz.Commenting
+	private function create_fake_logger(): WC_Logger_Interface {
+		return new class() implements WC_Logger_Interface {
+			public $warning_calls = array();
+
+			public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
+				unset( $handle, $message, $level ); // Avoid parameter not used PHPCS errors.
+				return true;
+			}
+
+			public function log( $level, $message, $context = array() ) {
+				unset( $level, $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function emergency( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function alert( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function critical( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function error( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function warning( $message, $context = array() ) {
+				$this->warning_calls[] = array(
+					'message' => $message,
+					'context' => $context,
+				);
+			}
+
+			public function notice( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function info( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+
+			public function debug( $message, $context = array() ) {
+				unset( $message, $context ); // Avoid parameter not used PHPCS errors.
+			}
+		};
+	}
+	// phpcs:enable Squiz.Commenting
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1532,4 +1532,45 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			$this->assertGreaterThan( 0, $item->get_product_id(), 'Item should have a product ID from cached meta' );
 		}
 	}
+
+	/**
+	 * @testdox Reading an order does not fatal when a postmeta entry is malformed (e.g. a stdClass from a corrupted cache).
+	 */
+	public function test_reading_order_does_not_fatal_on_malformed_postmeta(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'EUR' );
+		$order->save();
+		$order_id = $order->get_id();
+
+		wp_cache_flush();
+		wp_cache_set( $order_id, array( '_order_currency' => (object) array( 'corrupt' ) ), 'post_meta' );
+
+		$read_order = wc_get_order( $order_id );
+
+		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on malformed postmeta' );
+		$this->assertEquals( get_woocommerce_currency(), $read_order->get_currency(), 'Malformed currency meta should fall back to the store currency' );
+	}
+
+	/**
+	 * @testdox Reading a refund does not fatal when a postmeta entry is malformed (e.g. a stdClass from a corrupted cache).
+	 */
+	public function test_reading_refund_does_not_fatal_on_malformed_postmeta(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$refund = new WC_Order_Refund();
+		$refund->set_parent_id( $order->get_id() );
+		$refund->set_amount( 10 );
+		$refund->set_reason( 'test' );
+		$refund->save();
+		$refund_id = $refund->get_id();
+
+		wp_cache_flush();
+		wp_cache_set( $refund_id, array( '_refund_amount' => (object) array( 'corrupt' ) ), 'post_meta' );
+
+		$read_refund = wc_get_order( $refund_id );
+
+		$this->assertInstanceOf( WC_Order_Refund::class, $read_refund, 'Refund should hydrate without fataling on malformed postmeta' );
+		$this->assertEquals( 0, $read_refund->get_amount(), 'Malformed refund amount meta should fall back to the default of zero' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1573,4 +1573,57 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( WC_Order_Refund::class, $read_refund, 'Refund should hydrate without fataling on malformed postmeta' );
 		$this->assertEquals( 0, $read_refund->get_amount(), 'Malformed refund amount meta should fall back to the default of zero' );
 	}
+
+	/**
+	 * @testdox Reading a refund with malformed _refunded_by/_refund_reason meta falls back to the post author and excerpt.
+	 */
+	public function test_reading_refund_falls_back_on_malformed_refunded_by_and_reason(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$refund = new WC_Order_Refund();
+		$refund->set_parent_id( $order->get_id() );
+		$refund->set_amount( 10 );
+		$refund->set_reason( 'test' );
+		$refund->save();
+		$refund_id = $refund->get_id();
+
+		$expected_author  = (int) get_post_field( 'post_author', $refund_id );
+		$expected_excerpt = (string) get_post_field( 'post_excerpt', $refund_id );
+
+		wp_cache_flush();
+		wp_cache_set(
+			$refund_id,
+			array(
+				'_refunded_by'   => (object) array( 'corrupt' ),
+				'_refund_reason' => (object) array( 'corrupt' ),
+			),
+			'post_meta'
+		);
+
+		$read_refund = wc_get_order( $refund_id );
+
+		$this->assertInstanceOf( WC_Order_Refund::class, $read_refund, 'Refund should hydrate without fataling on malformed postmeta' );
+		$this->assertEquals( $expected_author, $read_refund->get_refunded_by(), 'Malformed _refunded_by meta should fall back to the post author' );
+		$this->assertEquals( $expected_excerpt, $read_refund->get_reason(), 'Malformed _refund_reason meta should fall back to the post excerpt' );
+	}
+
+	/**
+	 * @testdox Reading a COGS-enabled order does not fatal when the COGS postmeta entry is malformed.
+	 */
+	public function test_reading_order_does_not_fatal_on_malformed_cogs_postmeta(): void {
+		$this->enable_cogs_feature();
+
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+		$order_id = $order->get_id();
+
+		wp_cache_flush();
+		wp_cache_set( $order_id, array( '_cogs_total_value' => (object) array( 'corrupt' ) ), 'post_meta' );
+
+		$read_order = wc_get_order( $order_id );
+
+		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on malformed COGS postmeta' );
+		$this->assertEquals( 0, $read_order->get_cogs_total_value(), 'Malformed COGS meta should fall back to zero' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1583,13 +1583,11 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$order->save();
 		$order_id = $order->get_id();
 
-		$fake_logger = $this->create_fake_logger();
-		add_filter(
-			'woocommerce_logging_class',
-			function () use ( $fake_logger ) {
-				return $fake_logger;
-			}
-		);
+		$fake_logger   = $this->create_fake_logger();
+		$logger_filter = function () use ( $fake_logger ) {
+			return $fake_logger;
+		};
+		add_filter( 'woocommerce_logging_class', $logger_filter );
 
 		// Force every "read all postmeta" lookup to return a malformed entry, so the
 		// self-heal re-read also fails and the default fallback + warning path is taken.
@@ -1601,22 +1599,64 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		};
 		add_filter( 'get_post_metadata', $malformed_meta_filter, 10, 3 );
 
-		$read_order = wc_get_order( $order_id );
+		try {
+			$read_order = wc_get_order( $order_id );
 
-		$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on persistently malformed postmeta' );
-		$this->assertEquals( get_woocommerce_currency(), $read_order->get_currency(), 'Persistently malformed currency meta should fall back to the store currency' );
+			$this->assertInstanceOf( WC_Order::class, $read_order, 'Order should hydrate without fataling on persistently malformed postmeta' );
+			$this->assertEquals( get_woocommerce_currency(), $read_order->get_currency(), 'Persistently malformed currency meta should fall back to the store currency' );
 
-		$warnings = array_filter(
-			$fake_logger->warning_calls,
-			function ( $call ) {
-				return 'woocommerce-order-data-store' === ( $call['context']['source'] ?? '' );
-			}
-		);
-		$this->assertCount( 1, $warnings, 'A single warning should be logged per hydration for malformed postmeta' );
-		$this->assertStringContainsString( '_order_currency', $warnings[ array_key_first( $warnings ) ]['message'] ?? '' );
+			$warnings = array_filter(
+				$fake_logger->warning_calls,
+				function ( $call ) {
+					return 'woocommerce-order-data-store' === ( $call['context']['source'] ?? '' );
+				}
+			);
+			$this->assertCount( 1, $warnings, 'A single warning should be logged per hydration for malformed postmeta' );
+			$this->assertStringContainsString( '_order_currency', $warnings[ array_key_first( $warnings ) ]['message'] ?? '' );
+		} finally {
+			remove_filter( 'get_post_metadata', $malformed_meta_filter, 10 );
+			remove_filter( 'woocommerce_logging_class', $logger_filter );
+		}
+	}
 
-		remove_filter( 'get_post_metadata', $malformed_meta_filter, 10 );
-		remove_all_filters( 'woocommerce_logging_class' );
+	/**
+	 * @testdox Reusing an order data store reads updated metadata on each hydration.
+	 */
+	public function test_reading_order_refreshes_metadata_when_data_store_is_reused(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'EUR' );
+		$order->set_billing_first_name( 'Alice' );
+		$order->save();
+
+		$sut = new WC_Order_Data_Store_CPT();
+		$sut->read( $order );
+		$this->assertSame( 'EUR', $order->get_currency(), 'The first read should load the stored currency' );
+		$this->assertSame( 'Alice', $order->get_billing_first_name(), 'The first read should load the stored billing name' );
+
+		update_post_meta( $order->get_id(), '_order_currency', 'GBP' );
+		update_post_meta( $order->get_id(), '_billing_first_name', 'Bob' );
+		$sut->read( $order );
+
+		$this->assertSame( 'GBP', $order->get_currency(), 'The second read should reload the shared order metadata' );
+		$this->assertSame( 'Bob', $order->get_billing_first_name(), 'The second read should reload the order-specific metadata' );
+	}
+
+	/**
+	 * @testdox Reusing a refund data store reads updated metadata on each hydration.
+	 */
+	public function test_reading_refund_refreshes_metadata_when_data_store_is_reused(): void {
+		$refund = new WC_Order_Refund();
+		$refund->set_amount( 10 );
+		$refund->save();
+
+		$sut = new WC_Order_Refund_Data_Store_CPT();
+		$sut->read( $refund );
+		$this->assertEquals( 10, $refund->get_amount(), 'The first read should load the stored refund amount' );
+
+		update_post_meta( $refund->get_id(), '_refund_amount', '20' );
+		$sut->read( $refund );
+
+		$this->assertEquals( 20, $refund->get_amount(), 'The second read should reload the refund metadata' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Malformed postmeta cache entries can make order/refund hydration throw `Cannot use object of type stdClass as array`, aborting reads and batch order queries.

The CPT data stores validate the postmeta shape and evict/reload a malformed cache entry once so stored order values can be recovered. If metadata remains malformed, guarded reads use defaults and log one warning per hydration. Order, refund, and COGS metadata reads use the guarded path.

The latest revision resets the validated metadata at the start of every `read()`, preventing stale values when a data-store instance is reused. It adds regression tests for repeated order and refund reads and removes the malformed-metadata and logger test filters in a `finally` block. Version annotations are updated to 11.2.0.

Closes #67456.

Bug-introducing PR: unknown; the issue concerns a long-standing unguarded read pattern in the legacy CPT data stores.

### How to test the changes in this Pull Request:

On a development store using legacy post-based order storage:

1. Create an order with currency EUR and a refund with amount 10; retain their IDs.
2. Poison the refund's postmeta cache: `wp_cache_set( $refund_id, array( '_refund_amount' => (object) array( 'corrupt' ) ), 'post_meta' );`.
3. Call `wc_get_order( $refund_id )`. Verify hydration succeeds and the refund amount is recovered as 10 from the database.
4. Repeat with the order's `_order_currency` cache entry. Verify its currency remains EUR.
5. Read the order using one `WC_Order_Data_Store_CPT` instance. Update `_order_currency` to GBP through `update_post_meta()`, then call `read()` again on that same instance. Verify GBP is returned. Repeat for the refund with `WC_Order_Refund_Data_Store_CPT` and a changed `_refund_amount`.
6. Run the data-store regression suite, including persistent malformed metadata, one warning per hydration, COGS, and reused data-store instances:

```sh
pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter=WC_Order_Data_Store_CPT_Test
```

### Testing that has already taken place:

For this revision, on macOS without Docker:

- PHP syntax checks passed for both modified PHP files.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch upstream/trunk` passed. The explicit upstream ref is needed because this fork checkout has no `origin/trunk`.
- PHPStan passed for `includes/data-stores/abstract-wc-order-data-store-cpt.php`.
- `git diff --check` passed.
- PHPUnit and runtime/manual store testing were **not run locally for this revision**, by request. The new regression tests require execution in CI; earlier test counts do not validate this revision.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

A changelog entry has already been added manually to this branch (`plugins/woocommerce/changelog/fix-67456-order-refund-hydration-malformed-postmeta`).

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Prevent a fatal error when reading an order or refund whose postmeta entry is malformed.

</details>

### Use of AI Tools

The original implementation used OpenCode through the wp-contrib workflow. Codex reviewed the issue and feedback, authored this follow-up change and regression tests, ran the checks listed above, and updated this description.

### Backward compatibility

Existing data-store method signatures and hooks are unchanged. Well-formed metadata follows the existing read path. Corrupted metadata now triggers a cache eviction and retry; persistent malformed values fall back to defaults instead of causing a fatal error. This is an intentional behavior change and can differ from the actual stored values when recovery fails.

The new protected helpers `get_validated_order_meta()` and `get_order_meta_value()` still carry a potential name/signature collision risk for third-party subclasses. The review suggestion to move helpers into a utility class remains open; this follow-up addresses the latest stale-cache and test-cleanup findings.

Postmeta cache APIs use the current site's scope. Multisite behavior has not been tested.
