### PR TITLE
Localize the Analytics date range calendar header and aria-labels

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-2024-rtl-custom-range
+++ b/plugins/woocommerce/changelog/fix-wooplug-2024-rtl-custom-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Localize the Analytics date range calendar: override the PHP-style moment date formats WordPress injects (fixing literal 'F j, Y' in day aria-labels) and load localized weekday names for the calendar header.

--- a/plugins/woocommerce/client/admin/client/embed.tsx
+++ b/plugins/woocommerce/client/admin/client/embed.tsx
@@ -2,8 +2,12 @@
  * Internal dependencies
  */
 import { initRemoteLogging } from './lib/init-remote-logging';
+import { initDateLocale } from './lib/date-locale';
 // Initialize remote logging early to log any errors that occur during initialization.
 initRemoteLogging();
+// Replace the PHP-style moment date formats WordPress core injects with
+// moment-style formats and localized weekday names.
+initDateLocale();
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/index.tsx
+++ b/plugins/woocommerce/client/admin/client/index.tsx
@@ -11,8 +11,12 @@ import {
  * Internal dependencies
  */
 import { initRemoteLogging } from './lib/init-remote-logging';
+import { initDateLocale } from './lib/date-locale';
 // Initialize remote logging early to log any errors that occur during initialization.
 initRemoteLogging();
+// Replace the PHP-style moment date formats WordPress core injects with
+// moment-style formats and localized weekday names.
+initDateLocale();
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/lib/date-locale/index.ts
+++ b/plugins/woocommerce/client/admin/client/lib/date-locale/index.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import { loadLocaleData } from '@woocommerce/date';
+import { getSetting } from '@woocommerce/settings';
+
+/**
+ * WordPress core loads moment with PHP-style long date formats (e.g.
+ * `LL: "F j, Y"`) and without localized minimal weekday names, which
+ * breaks components that format dates through moment tokens, such as
+ * the react-dates calendar. Re-apply moment-style formats and localized
+ * weekday names on top of the WordPress-provided locale.
+ *
+ * The locale setting must name the moment locale WordPress activated:
+ * when `wcSettings.locale` is absent the settings package substitutes
+ * en_US defaults, and applying those would switch the whole admin to
+ * English on a localized site.
+ */
+export function initDateLocale() {
+	const { userLocale, weekdaysShort } = getSetting< {
+		userLocale?: string;
+		weekdaysShort?: string[];
+	} >( 'locale', {} );
+	if ( userLocale === moment.locale() ) {
+		loadLocaleData( { userLocale, weekdaysShort } );
+	}
+}

--- a/plugins/woocommerce/client/admin/client/lib/date-locale/test/index.ts
+++ b/plugins/woocommerce/client/admin/client/lib/date-locale/test/index.ts
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { initDateLocale } from '..';
+
+describe( 'initDateLocale', () => {
+	const HEBREW_WEEKDAYS_SHORT = [ 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ש' ];
+
+	beforeEach( () => {
+		// Simulate WordPress core's inline moment setup for a non-English
+		// locale: PHP-style long date formats and no weekdaysMin.
+		moment.updateLocale( 'he_IL', {
+			longDateFormat: {
+				LL: 'F j, Y',
+			},
+			weekdaysShort: HEBREW_WEEKDAYS_SHORT,
+		} );
+		global.wcSettings = {
+			...global.wcSettings,
+			locale: {
+				siteLocale: 'he_IL',
+				userLocale: 'he_IL',
+				weekdaysShort: HEBREW_WEEKDAYS_SHORT,
+			},
+		};
+	} );
+
+	afterEach( () => {
+		moment.locale( 'en' );
+		moment.updateLocale( 'he_IL', null );
+		delete global.wcSettings.locale;
+	} );
+
+	it( 'overrides the PHP-style long date format WordPress injects into moment', () => {
+		expect( moment( '2026-08-02' ).format( 'LL' ) ).toBe( 'F j, 2026' );
+
+		initDateLocale();
+
+		expect( moment( '2026-08-02' ).format( 'LL' ) ).toBe(
+			'August 2, 2026'
+		);
+	} );
+
+	it( 'does nothing when the locale setting does not match the active moment locale', () => {
+		// A missing wcSettings.locale entry resolves to en_US defaults in the
+		// settings package; applying those on a non-English site would switch
+		// the whole admin to English.
+		global.wcSettings = {
+			...global.wcSettings,
+			locale: {
+				siteLocale: 'en_US',
+				userLocale: 'en_US',
+				weekdaysShort: [
+					'Sun',
+					'Mon',
+					'Tue',
+					'Wed',
+					'Thu',
+					'Fri',
+					'Sat',
+				],
+			},
+		};
+
+		initDateLocale();
+
+		expect( moment.locale() ).toBe( 'he_IL' );
+		expect( moment( '2026-08-02' ).format( 'LL' ) ).toBe( 'F j, 2026' );
+	} );
+
+	it( 'loads localized minimal weekday names used by calendar week headers', () => {
+		expect( moment.localeData().weekdaysMin() ).toEqual( [
+			'Su',
+			'Mo',
+			'Tu',
+			'We',
+			'Th',
+			'Fr',
+			'Sa',
+		] );
+
+		initDateLocale();
+
+		expect( moment.localeData().weekdaysMin() ).toEqual(
+			HEBREW_WEEKDAYS_SHORT
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

WordPress core loads the shared moment instance with PHP-style long date formats (e.g. `LL: "F j, Y"`) and no localized minimal weekday names. The react-dates calendar in Analytics formats day aria-labels with `LL` and week headers with `dd`, so screen readers heard the literal string "F j, 2026" instead of a date and the weekday header always rendered in English ("Sa Fr Th…"), in every locale.

`loadLocaleData()` in `@woocommerce/date` was built to fix exactly this, but its only call site was removed in [woocommerce-admin#3362](https://github.com/woocommerce/woocommerce-admin/pull/3362) (2019) on the assumption that `@wordpress/date` handles it — it configures its own formatter only, not moment. This PR restores the call at bootstrap of both admin entries (`app` and `embed`) via a small `initDateLocale()` module, guarded so it only runs when `wcSettings.locale` names the moment locale WordPress actually activated (when the setting is absent, the settings package substitutes `en_US` defaults, and applying those would switch a localized admin to English).

Related: the "blank dates" half of the linked issue was already fixed by #61028 (WooCommerce 10.3.0); this addresses the remaining localization defects observed while verifying that fix across he_IL, ar, and fa_IR.

**Backward-compatibility note (for extension developers):** on wc-admin pages this changes the global `window.moment` locale's `longDateFormat` (`L`, `LL`, `LLL`, `LLLL`, `LT`) from raw PHP format strings (which moment rendered as garbage tokens) to valid moment-style formats, and sets `weekdaysMin` to the site's localized weekday abbreviations. Third-party admin scripts consuming these tokens on wc-admin screens will see corrected (changed) output.

Closes #45265.

Bug introduced in [woocommerce-admin#3362](https://github.com/woocommerce/woocommerce-admin/pull/3362).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|        |       |

<!-- Annotated before/after screenshots (Hebrew locale) to be attached: English weekday header + literal "F j, 2026" aria-label vs localized header + real date. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Set Settings → General → Site Language to עברית (Hebrew) and let WordPress install the language packs (with WP-CLI: `wp site switch-language he_IL && wp language plugin install woocommerce he_IL`).
2. Go to WooCommerce → Analytics → Overview, open the **Date range** dropdown, and switch to the **Custom** tab.
3. Confirm the calendar's weekday header row shows Hebrew letters (א ב ג ד ה ו ש) instead of English "Su Mo Tu…".
4. Inspect any day cell in the browser dev tools and confirm its `aria-label` contains a real localized date (e.g. "…יום רביעי, יולי 2026") rather than the literal text "F j, 2026".
5. Switch back to English (US) and confirm the calendar still renders correctly (weekday header shows the site's weekday abbreviations, dates format normally).

<!-- End testing instructions -->

### Testing that has already taken place:

- Jest: 3 new tests in `client/lib/date-locale/test/` (format override, localized weekday names, and the locale-mismatch guard), written test-first; full `client/lib` scope green (64 tests).
- Browser verification on local wp-env (WP 7.0.3, PHP 8.2) in he_IL, ar, fa_IR, and en_US with core + WooCommerce language packs installed: weekday headers localize, day aria-labels contain real dates, custom range selection and Update work end-to-end, and the calendar honors the site's "Week Starts On" setting.
- `ts:check` and per-file ESLint clean. No PHP changes.
- Known residual (translation data, not code): the Hebrew GlotPress translation of `MMMM D, YYYY` is "MMMM YYYY" (missing the day token), so Hebrew aria-labels lack the day number until the translation is corrected upstream.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This PR was authored with the assistance of AI tooling (Claude Code); the changes, tests, and verification were reviewed by the submitting developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)