### PR TITLE
Fix inline tag alignment in single-select controls

### DIFF
--- a/packages/js/components/changelog/fix-select-control-inline-tag-alignment
+++ b/packages/js/components/changelog/fix-select-control-inline-tag-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Align inline tags in single-select controls.

--- a/packages/js/components/src/select-control/index.tsx
+++ b/packages/js/components/src/select-control/index.tsx
@@ -299,6 +299,15 @@ export class SelectControl extends Component< Props, State > {
 		return Boolean( selected );
 	}
 
+	hasTags() {
+		const selected = this.getSelected();
+
+		return (
+			Array.isArray( selected ) &&
+			selected.some( ( item ) => Boolean( item.label ) )
+		);
+	}
+
 	getSelected(): Selected | undefined {
 		const { multiple, options, selected } = this.props;
 
@@ -565,6 +574,7 @@ export class SelectControl extends Component< Props, State > {
 		const { isExpanded, isFocused, selectedIndex } = this.state;
 
 		const hasMultiple = this.hasMultiple();
+		const hasTags = this.hasTags();
 		const { key: selectedKey = '' } =
 			( isNumber( selectedIndex ) && options[ selectedIndex ] ) || {};
 		const listboxId = isExpanded
@@ -577,7 +587,7 @@ export class SelectControl extends Component< Props, State > {
 		return (
 			<div
 				className={ clsx( 'woocommerce-select-control', className, {
-					'has-inline-tags': hasMultiple && inlineTags,
+					'has-inline-tags': hasTags && inlineTags,
 					'is-focused': isFocused,
 					'is-searchable': isSearchable,
 				} ) }
@@ -611,7 +621,7 @@ export class SelectControl extends Component< Props, State > {
 					activeId={ activeId }
 					className={ controlClassName }
 					disabled={ disabled }
-					hasTags={ hasMultiple }
+					hasTags={ hasTags }
 					isExpanded={ isExpanded }
 					listboxId={ listboxId }
 					onSearch={ this.search }

--- a/packages/js/components/src/select-control/stories/select-control.story.tsx
+++ b/packages/js/components/src/select-control/stories/select-control.story.tsx
@@ -248,6 +248,23 @@ const SelectControlExample = () => {
 
 export const Basic = () => <SelectControlExample />;
 
+export const SingleSelectWithInlineTag = () => {
+	const [ selected, setSelected ] = useState( [ options[ 0 ] ] );
+
+	return (
+		<SelectControl
+			label="Single value with inline tag"
+			isSearchable
+			inlineTags
+			multiple={ false }
+			onChange={ setSelected }
+			options={ options }
+			placeholder="Start typing to filter options..."
+			selected={ selected }
+		/>
+	);
+};
+
 export default {
 	title: 'Components/SelectControl',
 	component: SelectControl,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Inline chips in single-select `SelectControl` instances were treated as non-inline because tag presence was derived from the `multiple` prop. This caused Product Attribute chips to inherit the non-inline top margin and appear vertically misaligned.

This PR fixes this beavhiour.


<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #54375.

### Screenshots or screen recordings:


<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/92498f23-48bf-4d96-a262-84f8ee5ce821" /> | <video src="https://github.com/user-attachments/assets/298f29f4-9b95-4504-8e91-ff966ee029be" /> |
| <video src="https://github.com/user-attachments/assets/c8b53189-0b75-4071-baa1-bf2d3481ea57" /> | <video src="https://github.com/user-attachments/assets/5d27b0ab-363a-4284-a884-10399c412265" /> | 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/storybook watch:build:storybook`.
2. Open **Components → SelectControl → Single Select With Inline Tag**.
3. Verify the selected "Apple" chip is vertically centered in the control.
4. Remove the chip, select another option, and verify the replacement chip remains centered.
5. Ensure you have at least one product with an attribute (e.g. "Size" with terms "Small"/"Large") used in a variation or order.
6. Go to **Analytics > Variations** (or **Analytics > Orders**).
7. Under **Show**, select **Advanced filters**.
8. Click **Add a filter** and choose **Product attribute**.
9. In the "Attribute name" search box, search for and select an attribute (e.g. "Size").
10. In the "Attribute value" box, select a term (e.g. "Large").
11.  Confirm both the "Size" and "Large" tags render vertically centered in their input boxes, in line with the search icon and the "=" separator and not pushed down.
12. Repeat on **Analytics > Orders**.


### `inlineTags` / single-select usage audit

I audited all `inlineTags` usages across the monorepo to determine whether this issue affects scenarios beyond the Analytics Product Attribute filter.

#### Findings

Two production controls combine `inlineTags` with `multiple={ false }`:

| Control | Component | Location |
| --- | --- | --- |
| Attribute name, e.g. “Color” | `Search` | `packages/js/components/src/advanced-filters/attribute-filter.js` |
| Attribute value, e.g. “Blue” | `SelectControl` | `packages/js/components/src/advanced-filters/attribute-filter.js` |

Both belong to the Product Attribute advanced filter used on the Analytics Orders and Variations pages. Therefore, the issue can affect both sides of an attribute expression such as `Color = Blue`. 



<!-- End testing instructions -->


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to diagnose the styling issue, implement the fix and Storybook story, and run verification checks.
