### PR TITLE
Match truncated order statuses in Analytics status filters

### DIFF
--- a/plugins/woocommerce/changelog/fix-44554-analytics-excluded-long-custom-statuses
+++ b/plugins/woocommerce/changelog/fix-44554-analytics-excluded-long-custom-statuses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect excluded order statuses in Analytics reports when a custom status slug exceeds the 20-character storage limit

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -876,7 +876,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$excluded_statuses           = array_map( array( __CLASS__, 'normalize_order_status' ), self::get_excluded_report_order_statuses() );
 		$excluded_statuses_condition = '';
 		if ( ! empty( $excluded_statuses ) ) {
-			$excluded_statuses_str       = implode( "','", $excluded_statuses );
+			$excluded_statuses_str       = implode( "','", array_map( 'esc_sql', $excluded_statuses ) );
 			$excluded_statuses_condition = "AND status NOT IN ('{$excluded_statuses_str}')";
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -855,7 +855,9 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 	 */
 	protected static function normalize_order_status( $status ) {
 		$status = trim( $status );
-		return 'wc-' . $status;
+		// Status columns are varchar(20) and longer values are silently truncated
+		// on write, so truncate the same way or comparisons never match long slugs.
+		return mb_substr( 'wc-' . $status, 0, 20 );
 	}
 
 	/**
@@ -1386,7 +1388,9 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 		$subqueries        = array();
 		$excluded_statuses = array();
 		if ( isset( $query_args['status_is'] ) && is_array( $query_args['status_is'] ) && count( $query_args['status_is'] ) > 0 ) {
-			$allowed_statuses = array_map( array( $this, 'normalize_order_status' ), esc_sql( $query_args['status_is'] ) );
+			// Escape after normalizing: truncation could otherwise cut an escape
+			// sequence in half and leave a dangling backslash in the SQL literal.
+			$allowed_statuses = array_map( 'esc_sql', array_map( array( $this, 'normalize_order_status' ), $query_args['status_is'] ) );
 			if ( $allowed_statuses ) {
 				$subqueries[] = "{$wpdb->prefix}wc_order_stats.status IN ( '" . implode( "','", $allowed_statuses ) . "' )";
 			}
@@ -1403,7 +1407,7 @@ class DataStore extends SqlQuery implements DataStoreInterface {
 		}
 
 		if ( $excluded_statuses ) {
-			$subqueries[] = "{$wpdb->prefix}wc_order_stats.status NOT IN ( '" . implode( "','", $excluded_statuses ) . "' )";
+			$subqueries[] = "{$wpdb->prefix}wc_order_stats.status NOT IN ( '" . implode( "','", array_map( 'esc_sql', $excluded_statuses ) ) . "' )";
 		}
 
 		return implode( " $operator ", $subqueries );

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -869,11 +869,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$first_order       = $oldest_orders[0];
 		$second_order      = isset( $oldest_orders[1] ) ? $oldest_orders[1] : false;
-		$excluded_statuses = self::get_excluded_report_order_statuses();
+		$excluded_statuses = array_map( array( __CLASS__, 'normalize_order_status' ), self::get_excluded_report_order_statuses() );
+		$order_status      = self::normalize_order_status( $order->get_status() );
 
 		// Order is older than previous first order.
 		if ( $order->get_date_created() < wc_string_to_datetime( $first_order->date_created ) &&
-			! in_array( $order->get_status(), $excluded_statuses, true )
+			! in_array( $order_status, $excluded_statuses, true )
 		) {
 			self::set_customer_first_order( $customer_id, $order->get_id() );
 			return false;
@@ -887,7 +888,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			wc_string_to_datetime( $second_order->date_created ) < $order->get_date_created();
 		// Status has changed to an excluded status and next oldest order is now the first order.
 		$status_change = $second_order &&
-			in_array( $order->get_status(), $excluded_statuses, true );
+			in_array( $order_status, $excluded_statuses, true );
 		if ( $is_first_order && ( $date_change || $status_change ) ) {
 			self::set_customer_first_order( $customer_id, $second_order->order_id );
 			return true;

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
@@ -449,4 +449,65 @@ class DataStoreTest extends WC_Unit_Test_Case {
 
 		WC_Helper_Order::delete_order( $order_id );
 	}
+
+	/**
+	 * @testdox Changing the first order to an excluded custom status longer than the 20-char storage limit reassigns the first-order role and marks the customer as returning.
+	 */
+	public function test_returning_customer_recalculated_for_long_excluded_status(): void {
+		global $wpdb;
+
+		$long_status = 'competition-completed';
+		register_post_status( 'wc-' . $long_status, array( 'public' => true ) );
+		$add_status = function ( $statuses ) use ( $long_status ) {
+			$statuses[ 'wc-' . $long_status ] = 'Competition Completed';
+			return $statuses;
+		};
+		add_filter( 'wc_order_statuses', $add_status );
+		update_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled', $long_status ) );
+
+		$customer = \WC_Helper_Customer::create_customer( 'cust_long_status', 'pwd', 'long_status_customer@mail.com' );
+
+		$order_1 = WC_Helper_Order::create_order( $customer->get_id() );
+		$order_1->set_date_created( time() - 2 * HOUR_IN_SECONDS );
+		$order_1->set_status( 'processing' );
+		$order_1->save();
+
+		$order_2 = WC_Helper_Order::create_order( $customer->get_id() );
+		$order_2->set_date_created( time() - HOUR_IN_SECONDS );
+		$order_2->set_status( 'processing' );
+		$order_2->save();
+
+		OrdersStatsDataStore::sync_order( $order_1->get_id() );
+		OrdersStatsDataStore::sync_order( $order_2->get_id() );
+
+		$returning_flag = static function ( $id ) use ( $wpdb ) {
+			return $wpdb->get_var(
+				$wpdb->prepare( "SELECT returning_customer FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $id )
+			);
+		};
+		$this->assertSame( '0', $returning_flag( $order_1->get_id() ), 'Oldest order should start as the non-returning first order.' );
+		$this->assertSame( '1', $returning_flag( $order_2->get_id() ), 'Second order should start as returning.' );
+
+		// Core warns when saving a status longer than the 20-char column; that
+		// truncated storage is the exact scenario under test.
+		$this->setExpectedIncorrectUsage( 'Abstract_WC_Order_Data_Store_CPT::get_post_status' );
+		$order_1->set_status( $long_status );
+		$order_1->save();
+
+		// Reload so the order reports the truncated status actually stored in the database.
+		$order_1 = wc_get_order( $order_1->get_id() );
+
+		$this->assertTrue(
+			OrdersStatsDataStore::is_returning_customer( $order_1 ),
+			'An order moved to an excluded long custom status should be reported as returning.'
+		);
+		$this->assertSame(
+			'0',
+			$returning_flag( $order_2->get_id() ),
+			'The next oldest order should be reassigned as the customer\'s first order.'
+		);
+
+		remove_filter( 'wc_order_statuses', $add_status );
+		unset( $GLOBALS['wp_post_statuses'][ 'wc-' . $long_status ] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Products/DataStoreTest.php
@@ -1,0 +1,122 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\API\Reports\Products;
+
+use Automattic\WooCommerce\Admin\API\Reports\Cache;
+use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
+use Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
+use WC_Helper_Product;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for Products report DataStore.
+ */
+class DataStoreTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Custom status slug that exceeds the 20-char status column once 'wc-' prefixed.
+	 *
+	 * @var string
+	 */
+	private $long_status = 'competition-completed';
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		register_post_status( 'wc-' . $this->long_status, array( 'public' => true ) );
+		add_filter( 'wc_order_statuses', array( $this, 'add_custom_status' ) );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wc_order_statuses', array( $this, 'add_custom_status' ) );
+		delete_option( 'woocommerce_excluded_report_order_statuses' );
+		unset( $GLOBALS['wp_post_statuses'][ 'wc-' . $this->long_status ] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Register the custom status with WooCommerce.
+	 *
+	 * @param array $statuses Registered order statuses.
+	 * @return array
+	 */
+	public function add_custom_status( $statuses ) {
+		$statuses[ 'wc-' . $this->long_status ] = 'Competition Completed';
+		return $statuses;
+	}
+
+	/**
+	 * Create a synced order with one product in the custom status.
+	 *
+	 * @return int Product ID.
+	 */
+	private function create_synced_custom_status_order() {
+		// Core warns when saving a status longer than the 20-char column; that
+		// truncated storage is the exact scenario under test.
+		$this->setExpectedIncorrectUsage( 'Abstract_WC_Order_Data_Store_CPT::get_post_status' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$order   = wc_create_order();
+		$order->add_product( $product, 2 );
+		$order->calculate_totals();
+		$order->set_status( $this->long_status );
+		$order->save();
+
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+		ProductsDataStore::sync_order_products( $order->get_id() );
+
+		return $product->get_id();
+	}
+
+	/**
+	 * Query the products report for a single product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return object Report data.
+	 */
+	private function get_product_report_data( $product_id ) {
+		Cache::invalidate();
+		$data_store = new ProductsDataStore();
+		return $data_store->get_data(
+			array(
+				'after'    => gmdate( 'Y-m-d', strtotime( '-1 day' ) ) . 'T00:00:00',
+				'before'   => gmdate( 'Y-m-d', strtotime( '+1 day' ) ) . 'T23:59:59',
+				'products' => array( $product_id ),
+			)
+		);
+	}
+
+	/**
+	 * @testdox Products report should exclude orders whose custom status is excluded, even when the status slug exceeds the 20-char storage limit.
+	 */
+	public function test_excluded_long_custom_status_is_not_counted(): void {
+		$product_id = $this->create_synced_custom_status_order();
+
+		update_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled', $this->long_status ) );
+
+		$data       = $this->get_product_report_data( $product_id );
+		$items_sold = array_sum( array_map( 'absint', array_column( $data->data, 'items_sold' ) ) );
+
+		$this->assertSame( 0, $items_sold, 'Orders in an excluded custom status should not be counted in the products report' );
+	}
+
+	/**
+	 * @testdox Products report should count orders in a long custom status when it is not excluded.
+	 */
+	public function test_non_excluded_long_custom_status_is_counted(): void {
+		$product_id = $this->create_synced_custom_status_order();
+
+		update_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
+
+		$data       = $this->get_product_report_data( $product_id );
+		$items_sold = array_sum( array_map( 'absint', array_column( $data->data, 'items_sold' ) ) );
+
+		$this->assertSame( 2, $items_sold, 'Orders in a non-excluded custom status should be counted in the products report' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Order status columns are varchar(20), so a custom status whose `wc-`-prefixed slug exceeds 20 characters is silently truncated when stored, while the Analytics status filters (excluded statuses setting, `status_is`, `status_is_not`) compare the full registered slug - the comparison never matches and excluded orders keep being counted. This is most visible in the Products report because Revenue/Orders default to filtering by `date_paid`, which such orders usually lack. `normalize_order_status()` now truncates to the same 20-character limit so comparisons match what is actually stored, and `is_returning_customer()` normalizes both sides of its excluded-status check.

BC impact: `normalize_order_status()` output changes only for inputs longer than 20 characters once prefixed, which previously could never match any stored value. Status values in the `IN`/`NOT IN` clauses are now escaped after truncation (`status_is_not` values were previously interpolated unescaped, relying on REST sanitization).

The Customer History metabox has the same truncation mismatch in its HPOS query path; that is fixed separately in #67700 (this PR covers its non-HPOS fallback, which goes through the Analytics Customers report).

Closes #44554, closes WOOPLUG-1966

### Screenshots or screen recordings:

Analytics > Products with an order in the custom status `competition-completed`, which is selected under Analytics > Settings > Excluded statuses:

| Before | After |
| ------ | ----- |
| <img width="1280" height="1202" alt="wooplug-1966-before" src="https://github.com/user-attachments/assets/3cdb9107-fc32-4087-b326-d65dd4cfbf20" /> |  <img width="1280" height="1166" alt="wooplug-1966-after" src="https://github.com/user-attachments/assets/7baf2c25-d750-45aa-b726-041302ca638f" /> |

### How to test the changes in this Pull Request:

1. Register a custom order status with a slug longer than 17 characters, e.g. add to a snippet plugin: `register_post_status( 'wc-competition-completed', array( 'public' => true ) );` and `add_filter( 'wc_order_statuses', function( $s ) { $s['wc-competition-completed'] = 'Competition Completed'; return $s; } );` (make sure HPOS is enabled; the CPT order store refuses to save over-length statuses altogether).
2. Create an order containing a product and move it to the Competition Completed status.
3. Go to Analytics > Settings, add Competition Completed to "Excluded statuses", and save.
4. Open Analytics > Products with a date range covering the order. Before this fix the order's items are counted; after the fix they are excluded. A short-slug custom status behaves the same before and after (control).

### Testing that has already taken place:

-   New unit tests in `tests/php/src/Admin/API/Reports/Products/DataStoreTest.php` (fail before the fix, pass after); modern + legacy Analytics report suites and `CustomerHistoryTest` all pass.
-   Reproduced end to end on a local site (HPOS): stored status `wc-competition-compl` vs excluded `wc-competition-completed`; the Products report counted the order before the fix and excludes it after (screenshots above).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually in the branch (`plugins/woocommerce/changelog/fix-44554-analytics-excluded-long-custom-statuses`).

### Use of AI Tools

Authored with Claude Code (Claude Fable 5); investigation, fix, and tests reviewed and verified by the contributor.

