### PR TITLE
Fix RTL currency symbol position in block-rendered prices

### DIFF
--- a/plugins/woocommerce/changelog/fix-67688-rtl-currency-symbol-blocks
+++ b/plugins/woocommerce/changelog/fix-67688-rtl-currency-symbol-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor the currency position setting for RTL-script currency symbols in block-rendered prices by wrapping them in first-strong isolate characters in FormattedMonetaryAmount.

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/formatted-monetary-amount/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/formatted-monetary-amount/index.tsx
@@ -30,10 +30,31 @@ export interface FormattedMonetaryAmountProps
 	renderText?: ( value: string ) => JSX.Element;
 }
 
+// Matches characters from strong RTL scripts (Hebrew, Arabic, Syriac, Thaana,
+// NKo, and their presentation forms).
+const RTL_SCRIPT_REGEX = /[\u0591-\u08FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
+
+/**
+ * Wraps an RTL-script currency symbol in first-strong isolate characters
+ * (U+2068 FSI … U+2069 PDI) — the plain-text equivalent of `dir="auto"` — so
+ * the bidi algorithm cannot move it to the wrong side of the amount.
+ * Surrounding whitespace stays outside the isolate. LTR symbols are returned
+ * unchanged so rendered text is identical for LTR currencies.
+ */
+const isolateRtlSymbol = ( affix: string ): string => {
+	if ( ! RTL_SCRIPT_REGEX.test( affix ) ) {
+		return affix;
+	}
+	return affix.replace( /^(\s*)(.*?)(\s*)$/, '$1\u2068$2\u2069$3' );
+};
+
 /**
  * Formats currency data into the expected format for NumberFormat.
  */
-const currencyToNumberFormat = ( currency: Currency ) => {
+const currencyToNumberFormat = (
+	currency: Currency,
+	displayType: NumberFormatProps[ 'displayType' ]
+) => {
 	const { prefix, suffix, thousandSeparator, decimalSeparator } = currency;
 	// Decode HTML entities in separators
 	const decodedThousandSeparator = decodeHtmlEntities( thousandSeparator );
@@ -47,14 +68,24 @@ const currencyToNumberFormat = ( currency: Currency ) => {
 			'Thousand separator and decimal separator are the same. This may cause formatting issues.'
 		);
 	}
+
+	const decodedPrefix = decodeHtmlEntities( prefix );
+	const decodedSuffix = decodeHtmlEntities( suffix );
+	// Isolate characters are invisible control characters; they must not leak
+	// into editable input values, so only display text gets them.
+	const isDisplayText = displayType === 'text';
 	return {
 		thousandSeparator: hasDuplicateSeparator
 			? ''
 			: decodedThousandSeparator,
 		decimalSeparator: decodedDecimalSeparator,
 		fixedDecimalScale: true,
-		prefix: decodeHtmlEntities( prefix ),
-		suffix: decodeHtmlEntities( suffix ),
+		prefix: isDisplayText
+			? isolateRtlSymbol( decodedPrefix )
+			: decodedPrefix,
+		suffix: isDisplayText
+			? isolateRtlSymbol( decodedSuffix )
+			: decodedSuffix,
 		isNumericString: true,
 	};
 };
@@ -102,7 +133,7 @@ const FormattedMonetaryAmount = ( {
 	const decimalScale = props.decimalScale ?? currency?.minorUnit;
 	const numberFormatProps = {
 		...props,
-		...currencyToNumberFormat( currency ),
+		...currencyToNumberFormat( currency, displayType ),
 		decimalScale,
 		value: undefined,
 		currency: undefined,

--- a/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/formatted-monetary-amount/test/index.js
+++ b/plugins/woocommerce/client/blocks/packages/public-api/blocks-components/formatted-monetary-amount/test/index.js
@@ -123,6 +123,87 @@ describe( 'FormattedMonetaryAmount', () => {
 		} );
 	} );
 
+	describe( 'RTL-script currency symbols', () => {
+		// Lebanese Pound (LBP) — an RTL-script symbol reordered by the bidi
+		// algorithm when composed into a plain-text string with the amount.
+		const FSI = '\u2068';
+		const PDI = '\u2069';
+		/** @type {import('@woocommerce/types').Currency} */
+		const lbpCurrency = {
+			code: 'LBP',
+			symbol: 'ل.ل',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			minorUnit: 2,
+			prefix: '',
+			suffix: ' ل.ل',
+		};
+
+		test( 'wraps an RTL-script suffix in first-strong isolate characters', () => {
+			const { container } = render(
+				<FormattedMonetaryAmount
+					value="156345"
+					currency={ lbpCurrency }
+				/>
+			);
+
+			expect( container.textContent ).toBe(
+				`1,563.45 ${ FSI }ل.ل${ PDI }`
+			);
+		} );
+
+		test( 'wraps an RTL-script prefix in first-strong isolate characters', () => {
+			const { container } = render(
+				<FormattedMonetaryAmount
+					value="156345"
+					currency={ {
+						...lbpCurrency,
+						prefix: 'ل.ل ',
+						suffix: '',
+					} }
+				/>
+			);
+
+			expect( container.textContent ).toBe(
+				`${ FSI }ل.ل${ PDI } 1,563.45`
+			);
+		} );
+
+		test( 'does not add isolate characters to LTR currency symbols', () => {
+			const { container } = render(
+				<FormattedMonetaryAmount
+					value="156345"
+					currency={ {
+						code: 'EUR',
+						symbol: '€',
+						thousandSeparator: '.',
+						decimalSeparator: ',',
+						minorUnit: 2,
+						prefix: '',
+						suffix: ' €',
+					} }
+				/>
+			);
+
+			expect( container.textContent ).toBe( '1.563,45 €' );
+		} );
+
+		test( 'does not add isolate characters to editable input values', () => {
+			render(
+				<FormattedMonetaryAmount
+					displayType="input"
+					value="156345"
+					currency={ lbpCurrency }
+					onValueChange={ () => void 0 }
+				/>
+			);
+
+			expect( screen.getByRole( 'textbox' ) ).toHaveValue(
+				'1,563.45 ل.ل'
+			);
+		} );
+	} );
+
 	describe( 'supports different value types', () => {
 		test( 'should support numbers', () => {
 			render(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up to #67686, which fixed RTL-script currency symbols in server-rendered prices by adding `dir="auto"` in `wc_price()`. Block-rendered prices (Cart, Checkout, Mini-Cart) are formatted client-side in `FormattedMonetaryAmount` as one plain-text string; the Unicode bidi algorithm moves RTL-script symbols such as the Lebanese Pound (ل.ل) to the wrong side of the amount, ignoring the currency position setting.

This PR wraps RTL-script currency prefixes/suffixes in first-strong isolate characters (U+2068 FSI … U+2069 PDI), the plain-text equivalent of `dir="auto"`. The wrapping applies only in display mode, so the invisible characters cannot leak into editable inputs such as the price filter; symbols without RTL-script characters render byte-identical output.

A previous CSS attempt (#58134, `unicode-bidi: bidi-override`) reversed digits on RTL sites (#60986) and was reverted in #61003; isolate characters cannot reorder characters within a run, and the unit tests assert the digit order stays intact.

**Design decisions:**

-   **Isolation applies only in display mode (`displayType: 'text'`).** The component also renders editable inputs (the Price Filter min/max fields), where the affixes become part of the input value; invisible control characters there would leak into the clipboard, caret positioning, and validation. The accepted limitation: those inputs still show RTL-script symbols on the wrong side of the number. Fixing that requires moving the symbol outside the input, which is a markup change to the Price Filter and out of scope here.
-   **Isolation is conditional on the affix containing RTL-script characters, while #67686 applies `dir="auto"` unconditionally.** This is deliberate, not an inconsistency: `dir="auto"` is an attribute, so the server change leaves text output identical for every currency; FSI/PDI are text, so applying them unconditionally would change the text content of every price in every store and break text assertions for LTR currencies too. The tradeoff is that symbols outside the detected ranges, such as the Israeli new shekel (₪, U+20AA), are isolated on the server but not here. I'll verify ₪ on an RTL site during the screenshot pass; if it renders on the wrong side, I'll extend the detection for it rather than make the isolation unconditional.

**Backward compatibility:** `FormattedMonetaryAmount` is public API (`wc.blocksComponents`). Rendered text changes only for currencies whose symbol uses an RTL script, where two invisible isolate characters now surround the symbol; no markup, class, or prop changes. Prices formatted through `@woocommerce/price-format` are out of scope here and still lack bidi isolation.

Closes #67688.

### Screenshots or screen recordings:

None yet; the visual result needs an RTL-configured site. I'll add before/after screenshots after verifying there, including a check of the Israeli new shekel (₪) per the design decisions above, before marking the PR ready for review.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In WooCommerce → Settings → General, set the currency to Lebanese pound (ل.ل) and the currency position to "Right with space".
2. Add a product to the cart and open the Cart block page. Confirm all prices show the symbol after the amount (e.g. 1,563.45 ل.ل), including the Mini-Cart and the Checkout block.
3. Switch the currency position to "Left with space" and confirm the symbol renders before the amount.
4. Add the Price Filter block to a page with products. Confirm the editable min/max price inputs work normally and contain no stray characters.
5. Optional regression check for #60986: switch the site language to Arabic or Hebrew and confirm digits in prices are not reversed. While there, set the currency to Israeli new shekel (₪) and confirm the symbol respects the currency position setting.

<!-- End testing instructions -->

### Testing that has already taken place:

Jest: four new unit tests for `FormattedMonetaryAmount` (RTL suffix, RTL prefix, LTR output unchanged, input mode free of isolate characters); the blocks-components, cart, checkout, totals, product-price, and price-slider suites pass locally. Not yet verified visually on an RTL site; I'll do that before marking the PR ready for review.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

I used Claude Code to write the fix and the tests; I reviewed the changes and ran the test suites locally.
