### PR TITLE
Match truncated order statuses in the Customer History metabox

### DIFF
--- a/plugins/woocommerce/changelog/fix-67697-customer-history-excluded-long-statuses
+++ b/plugins/woocommerce/changelog/fix-67697-customer-history-excluded-long-statuses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect excluded order statuses in the Customer History metabox when a custom status slug exceeds the 20-character storage limit

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -283,7 +283,10 @@ class CustomerHistory {
 		$prefixed = array_map(
 			function ( $status ) {
 				$status = sanitize_title( $status );
-				return 'auto-draft' === $status || 'trash' === $status ? $status : 'wc-' . $status;
+				$status = 'auto-draft' === $status || 'trash' === $status ? $status : 'wc-' . $status;
+				// Status columns are varchar(20) and longer values are silently truncated
+				// on write, so truncate the same way or comparisons never match long slugs.
+				return mb_substr( $status, 0, 20 );
 			},
 			$excluded_statuses
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -31,6 +31,13 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 	private bool $restore_hpos_after_test = false;
 
 	/**
+	 * Callback registering the long custom status, kept for removal in tearDown.
+	 *
+	 * @var callable|null
+	 */
+	private $add_long_status_callback = null;
+
+	/**
 	 * Previous HPOS state.
 	 *
 	 * @var bool
@@ -87,6 +94,11 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		}
 
 		delete_option( 'woocommerce_excluded_report_order_statuses' );
+		if ( null !== $this->add_long_status_callback ) {
+			remove_filter( 'wc_order_statuses', $this->add_long_status_callback );
+			unset( $GLOBALS['wp_post_statuses']['wc-competition-completed'] );
+			$this->add_long_status_callback = null;
+		}
 		remove_filter( 'woocommerce_order_class', array( AdminOrder::class, 'order_class_name' ) );
 		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		parent::tearDown();
@@ -227,6 +239,69 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*0\s*</', $output, 'Should show 0 orders when all are excluded' );
+	}
+
+	/**
+	 * @testdox Should not count orders in an excluded custom status whose slug exceeds the 20-char storage limit (HPOS).
+	 */
+	public function test_excluded_long_custom_status_not_counted(): void {
+		list( $order_good, $long_status ) = $this->create_orders_with_long_custom_status();
+
+		update_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled', $long_status ) );
+
+		ob_start();
+		$this->sut->output( $order_good );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should only count the completed order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should only sum spend from the completed order' );
+	}
+
+	/**
+	 * @testdox Should count orders in a non-excluded custom status whose slug exceeds the 20-char storage limit (HPOS).
+	 */
+	public function test_non_excluded_long_custom_status_counted(): void {
+		list( $order_good ) = $this->create_orders_with_long_custom_status();
+
+		ob_start();
+		$this->sut->output( $order_good );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should count both orders' );
+		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*150\.00/', $output, 'Should sum spend from both orders' );
+	}
+
+	/**
+	 * Creates a completed order and an order in a custom status whose slug is stored truncated.
+	 *
+	 * @return array{0: \WC_Order, 1: string} The completed order and the custom status slug.
+	 */
+	private function create_orders_with_long_custom_status(): array {
+		// Core warns when saving a status longer than the 20-char column; that
+		// truncated storage is the exact scenario under test.
+		$this->setExpectedIncorrectUsage( 'Abstract_WC_Order_Data_Store_CPT::get_post_status' );
+
+		$long_status = 'competition-completed';
+		register_post_status( 'wc-' . $long_status, array( 'public' => true ) );
+		$this->add_long_status_callback = function ( $statuses ) use ( $long_status ) {
+			$statuses[ 'wc-' . $long_status ] = 'Competition Completed';
+			return $statuses;
+		};
+		add_filter( 'wc_order_statuses', $this->add_long_status_callback );
+
+		$customer_id = $this->factory->user->create();
+
+		$order_good = WC_Helper_Order::create_order( $customer_id );
+		$order_good->set_status( 'completed' );
+		$order_good->set_total( 100 );
+		$order_good->save();
+
+		$order_custom = WC_Helper_Order::create_order( $customer_id );
+		$order_custom->set_status( $long_status );
+		$order_custom->set_total( 50 );
+		$order_custom->save();
+
+		return array( $order_good, $long_status );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -255,6 +255,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should only count the completed order' );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should only sum spend from the completed order' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*100\.00/', $output, 'Should show average order value of 100' );
 	}
 
 	/**
@@ -269,6 +270,7 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*2\s*</', $output, 'Should count both orders' );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*150\.00/', $output, 'Should sum spend from both orders' );
+		$this->assertMatchesRegularExpression( '/order-attribution-average-order-value">\s*.*75\.00/', $output, 'Should show average order value of 75' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Order status columns are varchar(20), so a custom status whose `wc-`-prefixed slug exceeds 20 characters is stored truncated, while the Customer History metabox builds its excluded-statuses SQL from the full registered slugs - the `NOT IN` comparison never matches and orders in such an excluded status keep being counted in the metabox's orders count, total spend, and average order value. The excluded-statuses SQL now truncates slugs to the same 20-character limit so comparisons match what is actually stored, mirroring the `normalize_order_status()` fix in #67694.

Note: this PR fixes the HPOS query path. On non-HPOS stores the metabox falls back to the Analytics Customers report, which gets the same fix from #67694 - with only this PR applied, CPT stores still overcount until that lands.

Closes #67697.

### Screenshots or screen recordings:

Two orders for the same customer: one Completed ($100) and one in the excluded long-slug status Competition Completed ($50).

| Before (excluded order still counted: 2 orders / $150) | After (excluded order now excluded: 1 order / $100) |
| --- | --- |
| <img width="1280" height="1527" alt="before-customer-history" src="https://github.com/user-attachments/assets/62f91495-7b73-47fd-bce9-345815c277af" /> | <img width="1280" height="1527" alt="after-customer-history" src="https://github.com/user-attachments/assets/be4fc9b9-b6e7-44b4-b4c7-c32faae8d982" /> |

### How to test the changes in this Pull Request:

1. Register a custom order status with a slug longer than 17 characters, e.g. add to a snippet plugin: `register_post_status( 'wc-competition-completed', array( 'public' => true ) );` and `add_filter( 'wc_order_statuses', function( $s ) { $s['wc-competition-completed'] = 'Competition Completed'; return $s; } );` (make sure HPOS is enabled).
2. Create two orders for the same customer: one Completed, one moved to Competition Completed.
3. Go to Analytics > Settings, add Competition Completed to "Excluded statuses", and save.
4. Open the Completed order's edit screen and check the Customer History metabox. Before this fix the Competition Completed order is included in the orders count and total spend; after the fix it is excluded. A short-slug custom status behaves the same before and after (control).

### Testing that has already taken place:

-   New unit tests in `CustomerHistoryTest` (fail before the fix, pass after); full `CustomerHistoryTest` suite passes (21 tests).
-   Independent adversarial code review pass over the diff (verdict: ship; varchar(20) truncation semantics verified against wpdb behavior).

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually in the branch (`plugins/woocommerce/changelog/fix-67697-customer-history-excluded-long-statuses`).

### Use of AI Tools

Authored with Claude Code (Claude Fable 5); investigation, fix, and tests reviewed and verified by the contributor.

