### PR TITLE
Recover from an unusable cached shipping class term

### DIFF
--- a/plugins/woocommerce/changelog/67520-fix-wooplug-7470-shipping-class-term-cache-fatal
+++ b/plugins/woocommerce/changelog/67520-fix-wooplug-7470-shipping-class-term-cache-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error on add-to-cart when the product shipping class terms cannot be read, by clearing the cached terms and reading them again.

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -234,16 +234,72 @@ class WC_Shipping {
 	 */
 	public function get_shipping_classes() {
 		if ( empty( $this->shipping_classes ) ) {
-			$classes                = get_terms(
-				'product_shipping_class',
-				array(
-					'hide_empty' => '0',
-					'orderby'    => 'name',
-				)
-			);
+			try {
+				$classes = $this->query_shipping_class_terms();
+			} catch ( TypeError $e ) {
+				/*
+				 * One way this happens is a cached term that is no longer a term object, for example when a
+				 * persistent object cache holds a value that no longer unserializes and the drop-in falls back to
+				 * the raw bytes. WP_Term::get_instance() only goes back to the database when the cached value is
+				 * falsy or belongs to another taxonomy, and WP_Term_Query::populate_terms() looks terms up without
+				 * naming one, so such a value reaches WP_Term::__construct() and throws. Nothing repairs it on its
+				 * own either, because _get_non_cached_ids() treats any non-false value as a cache hit.
+				 *
+				 * Shipping methods read these terms on every shipping calculation, so leaving this unhandled means
+				 * add-to-cart fails on every request. Clear the cached terms and read again, which recovers from
+				 * that case and is harmless otherwise. The cause is not necessarily the cache, so report what
+				 * happened rather than diagnosing it, and let the retry throw if the problem lies elsewhere.
+				 */
+				wc_get_logger()->warning(
+					'Could not read the product_shipping_class terms. Cleared the cached terms and retried. Original error: ' . $e->getMessage(),
+					array( 'source' => 'shipping' )
+				);
+
+				$this->clean_shipping_class_term_cache();
+
+				$classes = $this->query_shipping_class_terms();
+			}
+
 			$this->shipping_classes = ! is_wp_error( $classes ) ? $classes : array();
 		}
 		return apply_filters( 'woocommerce_get_shipping_classes', $this->shipping_classes );
+	}
+
+	/**
+	 * Read the shipping class terms.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function query_shipping_class_terms() {
+		return get_terms(
+			'product_shipping_class',
+			array(
+				'hide_empty' => '0',
+				'orderby'    => 'name',
+			)
+		);
+	}
+
+	/**
+	 * Drop the cached shipping class terms.
+	 *
+	 * Reads the term IDs straight from the term_taxonomy table, so a cache holding unusable values is never
+	 * consulted to build the list. clean_term_cache() then deletes the individual `terms` entries and bumps the
+	 * terms `last_changed` value, which also invalidates any cached get_terms() results.
+	 *
+	 * @return void
+	 */
+	private function clean_shipping_class_term_cache() {
+		global $wpdb;
+
+		$term_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT term_id FROM {$wpdb->term_taxonomy} WHERE taxonomy = %s",
+				'product_shipping_class'
+			)
+		);
+
+		clean_term_cache( array_map( 'intval', $term_ids ), 'product_shipping_class' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -274,7 +274,7 @@ class WC_Shipping {
 		return get_terms(
 			array(
 				'taxonomy'   => 'product_shipping_class',
-				'hide_empty' => '0',
+				'hide_empty' => false,
 				'orderby'    => 'name',
 			)
 		);

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -272,8 +272,8 @@ class WC_Shipping {
 	 */
 	private function query_shipping_class_terms() {
 		return get_terms(
-			'product_shipping_class',
 			array(
+				'taxonomy'   => 'product_shipping_class',
 				'hide_empty' => '0',
 				'orderby'    => 'name',
 			)

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -15012,11 +15012,6 @@ parameters:
 			count: 1
 			path: includes/class-wc-shipping.php
 
-		-
-			message: '#^Parameter \#1 \$args of function get_terms expects array\{taxonomy\?\: array\<string\>\|string, object_ids\?\: array\<int\>\|int, orderby\?\: string, order\?\: string, hide_empty\?\: bool\|int, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, exclude_tree\?\: array\<int\>\|string, \.\.\.\}, ''product_shipping…'' given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wc-shipping.php
 
 		-
 			message: '#^@param bool \$force_rendering does not accept actual type of parameter\: null\.$#'

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -410,6 +410,10 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 	 * @testdox get_shipping_classes() recovers when a cached shipping class term is not a term object.
 	 */
 	public function test_get_shipping_classes_recovers_from_unusable_cached_term(): void {
+		if ( PHP_VERSION_ID < 80000 ) {
+			$this->markTestSkipped( 'Internal functions only throw for argument type mismatches from PHP 8.0 onwards; on PHP 7.4 get_object_vars() raises a warning instead, so there is no failure here to recover from.' );
+		}
+
 		$term    = wp_insert_term( 'Fragile', 'product_shipping_class' );
 		$term_id = $term['term_id'];
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shipping-test.php
@@ -405,4 +405,39 @@ class WC_Shipping_Test extends WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * @testdox get_shipping_classes() recovers when a cached shipping class term is not a term object.
+	 */
+	public function test_get_shipping_classes_recovers_from_unusable_cached_term(): void {
+		$term    = wp_insert_term( 'Fragile', 'product_shipping_class' );
+		$term_id = $term['term_id'];
+
+		/*
+		 * What a persistent object cache hands back when a stored value no longer unserializes: the raw bytes
+		 * instead of the term object, truncated here the way a partial write leaves them. Left alone this reaches
+		 * WP_Term::__construct() and throws a TypeError, taking down every shipping calculation, and nothing
+		 * repairs the entry on its own.
+		 */
+		$unusable_value = 'O:7:"WP_Term":11:{s:7:"term_id";i:';
+		wp_cache_set( $term_id, $unusable_value, 'terms' );
+
+		$classes = $this->sut->get_shipping_classes();
+
+		$this->assertContains( 'Fragile', wp_list_pluck( $classes, 'name' ) );
+		$this->assertContainsOnlyInstancesOf( WP_Term::class, $classes );
+
+		/*
+		 * The cached value has to be gone, not just worked around. Every other reader of this taxonomy, such as
+		 * WC_Product::get_shipping_class(), goes through the same cache and would keep failing if it survived.
+		 */
+		$this->assertNotSame(
+			$unusable_value,
+			wp_cache_get( $term_id, 'terms' ),
+			'The unusable cached term should have been cleared, not left in place.'
+		);
+		$this->assertInstanceOf( WP_Term::class, get_term( $term_id ), 'Reading the term directly should work again.' );
+
+		wp_delete_term( $term_id, 'product_shipping_class' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A persistent object cache can return something other than a term object for a cached term — for example when a stored value no longer unserializes and the drop-in falls back to the raw bytes. When that happens for `product_shipping_class`, **every add-to-cart returns a fatal error** until the entry is deleted.

This makes the shipping class lookup recover on its own instead of taking the store down.

#### Root cause

Three things combine, none of them a WooCommerce regression:

1. [`WP_Term::get_instance()`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-term.php) only goes back to the database when the cached value is falsy **or** belongs to another taxonomy. A non-empty string is truthy, so the first test passes.
2. `WP_Term_Query::populate_terms()` calls `get_term( $term_id )` **without naming a taxonomy**, so the second test short-circuits too. The unusable value reaches `WP_Term::__construct()`, and `get_object_vars()` throws a `TypeError`.
3. `_get_non_cached_ids()` treats any non-`false` value as a cache hit, so nothing ever repairs the entry. It is permanent until something deletes it.

Shipping methods read these terms on every shipping calculation — [`settings-flat-rate.php:46`](plugins/woocommerce/includes/shipping/flat-rate/includes/settings-flat-rate.php#L46) calls [`WC_Shipping::get_shipping_classes()`](plugins/woocommerce/includes/class-wc-shipping.php#L235) — so one bad cache entry means an indefinite store-wide outage.

#### What this changes

1. `get_shipping_classes()` catches the failure, drops the cached terms for the taxonomy, and reads again from the database.
2. The recovery is logged at `warning` level rather than silently swallowed, so the underlying cache problem stays visible.
3. New `wc_clean_product_shipping_class_cache()` reads term IDs straight from `term_taxonomy`, so the unusable cache is never consulted to build the list.
4. Regression test covering the recovery.

#### Notes on the original report

The issue theorised that 11.0's `product_shipping_class` `'public' => false` change caused this. **That turned out not to be the case** — see "Testing that has already taken place" below. The taxonomy's registration args play no part in the `terms` cache key, and 10.9.3 fails identically. The reporter's rollback appeared to fix it because the plugin operation flushed the object cache.

Consequently this PR does **not** add an upgrade routine — there is no stale-data migration to perform, and a one-time flush would not help if the cache produces another bad entry later. The recovery is cause-agnostic and handles a recurrence.

Closes # .

(For Bug Fixes) Bug introduced in PR # . <!-- Not a regression; latent for as long as this code has read the taxonomy. -->

Related: https://linear.app/a8c/issue/WOOPLUG-7470/fatal-error-in-wp-term-construct-on-add-to-cart-after-updating-to
GitHub issue: https://github.com/woocommerce/woocommerce/issues/67520

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You need a **persistent** object cache — WordPress's default in-memory cache is per-request, so a bad entry cannot survive to the next request and the bug will not appear.

**Setup**

1. Point your store at a persistent object cache (Redis/Memcached drop-in) and confirm it is genuinely active:
   - `wp cache type` reports something other than `Default`, and
   - `wp eval 'wp_cache_set("probe","hello","probe-group");'` followed by `wp eval 'var_dump( wp_cache_get("probe","probe-group") );'` in a **separate** command returns `string(5) "hello"`. If it returns `bool(false)` the cache is not persistent and the rest will not reproduce.

   <details>
   <summary>Don't have one? Redis setup in three steps</summary>

   ```sh
   docker run -d --name wc-redis -p 6379:6379 redis:7-alpine
   wp plugin install redis-cache --activate
   wp redis enable
   ```

   `wp redis enable` is what installs `wp-content/object-cache.php`; activating the plugin alone does nothing. It refuses to install the drop-in while it cannot connect, so fix any connection error first.

   If WordPress runs in a container (wp-env, Docker), `127.0.0.1` is the container itself, so add these to `wp-config.php` and re-run `wp redis enable`:

   ```php
   define( 'WP_REDIS_HOST', 'host.docker.internal' ); // or 172.17.0.1
   define( 'WP_REDIS_CLIENT', 'predis' );             // only if the phpredis extension is missing
   ```

   </details>
2. Go to **WooCommerce → Settings → Shipping → Classes** and add a shipping class, e.g. `Fragile`.
3. Add a shipping zone with the **Flat rate** method, and make sure you have a publishable, non-virtual product.

**Reproduce the failure on `trunk`**

4. On `trunk` (without this branch), corrupt the cached term the way a failed unserialize would:
   ```
   wp eval '$t = get_term_by("name","Fragile","product_shipping_class"); $s = serialize($t); wp_cache_set($t->term_id, substr($s,0,intdiv(strlen($s),2)), "terms"); echo "poisoned #{$t->term_id}\n";'
   ```
5. Visit the shop and add the product to the cart (`/?add-to-cart=<product_id>`).
   - **Expected on trunk:** an HTTP 500 / critical error, with `get_object_vars(): Argument #1 ($object) must be of type object, string given` at `wp-includes/class-wp-term.php`.
6. Reload a few times — it fails every time and never recovers on its own.

**Verify the fix**

7. Check out this branch. **Do not flush the cache** — the bad entry must still be in place.
8. Add the product to the cart again.
   - **Expected:** the page loads normally (HTTP 200) and the product is added.
9. Confirm the entry repaired itself:
   ```
   wp eval '$t = get_term_by("name","Fragile","product_shipping_class"); echo gettype( wp_cache_get($t->term_id,"terms") ), "\n";'
   ```
   - **Expected:** `object` (it was `string` before step 8).
10. Check **WooCommerce → Status → Logs**, `shipping` source.
    - **Expected:** one `WARNING Recovered from an unusable product_shipping_class term cache entry: get_object_vars(): ...`. The problem is surfaced, not hidden.
11. Confirm normal operation is unaffected: flush the cache, then check that **Settings → Shipping → Classes** still lists your class and that a flat-rate cost per shipping class still applies correctly at checkout.

<!-- End testing instructions -->

### Testing that has already taken place:

Reproduced and verified end to end on wp-env with a **real Redis persistent object cache** (Redis Object Cache 2.8.0, Predis 2.4.0 client), WordPress with `product_shipping_class` in use, Flat Rate shipping, PHP 8.1.

- **Reproduced the reported crash exactly.** Poisoning the cached term produced `GET /?add-to-cart=31` → **HTTP 500**, with frames #0–#9 matching the issue's stack trace (`class-wp-term.php:198` → `taxonomy.php:996` → `class-wp-term-query.php` → `taxonomy.php:1357` → `class-wc-shipping.php` → `settings-flat-rate.php:46` → `class-wc-shipping-flat-rate.php:61`).
- **Verified the fix against the same poisoned entry.** Without flushing the cache, the identical request returned **HTTP 200**, the cached value went from `string` to `object`, and the recovery warning was logged.
- **Disproved the `'public' => false` theory.** Two taxonomies registered identically apart from `public` both fail the same way, and `WP_Term::get_instance()` was observed being called as `get_instance(28, '')` — the cache key is the bare term ID, so registration args are not involved.
- **Confirmed this is not a regression.** **WooCommerce 10.9.3 fatals identically** with the same poisoned entry, so the reporter's successful rollback is explained by the plugin operation flushing the object cache rather than by a code difference.
- **Confirmed the entry never self-heals** — `_prime_term_caches()` leaves it in place, which is why the reporter saw it "100% reproducible" over two days.
- **Confirmed WooCommerce is not the writer.** The only writers to the `terms` cache group are two spots in WP core, both of which can only write objects; WooCommerce writes to that group nowhere.
- **Mutation-tested the new test** — with the recovery disabled it fails with the real `TypeError`, so it is not passing vacuously.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry is already included in the branch (`plugins/woocommerce/changelog/67520-fix-wooplug-7470-shipping-class-term-cache-fatal`, significance `patch`, type `fix`), so the automated job is not needed.
