### PR TITLE
Fix Revenue analytics counting refunds of never-paid orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-1113-revenue-tax-refunded-orders
+++ b/plugins/woocommerce/changelog/fix-wooplug-1113-revenue-tax-refunded-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude lump-sum refunds of never-paid orders from date_paid-based Revenue analytics so manually refunded failed orders no longer produce phantom returns, negative net sales and uncollected tax amounts.

--- a/plugins/woocommerce/changelog/fix-wooplug-1113-revenue-tax-refunded-orders
+++ b/plugins/woocommerce/changelog/fix-wooplug-1113-revenue-tax-refunded-orders
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Exclude lump-sum refunds of never-paid orders from date_paid-based Revenue analytics so manually refunded failed orders no longer produce phantom returns, negative net sales and uncollected tax amounts.
+Exclude refunds of never-paid or never-completed orders from Revenue analytics filtered by paid or completed date, so manually refunded failed orders no longer produce phantom returns, negative net sales and uncollected tax amounts. Applies to refunds synced after this fix; previously imported rows update on re-sync or historical data re-import.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -633,11 +633,16 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				}
 			}
 			/**
-			 * Set date_completed and date_paid the same as date_created to avoid problems
-			 * when they are being used to sort the data, as refunds don't have them filled
-			*/
-			$data['date_completed'] = $data['date_created'];
-			$data['date_paid']      = $data['date_created'];
+			 * Refunds don't have date_completed and date_paid filled, so backfill each from
+			 * date_created for sorting — but only when the parent order has that date itself.
+			 * A refund of a never-paid order (e.g. a failed order manually set to "refunded")
+			 * moves no money; backfilling its dates would include the refund row in reports
+			 * filtered by that date while the parent row (NULL date) stays excluded, counting
+			 * a one-sided negative. Mirroring the parent keeps the pair excluded together.
+			 */
+			$parent_is_order        = $parent_order instanceof WC_Order;
+			$data['date_completed'] = $parent_is_order && ! $parent_order->get_date_completed() ? null : $data['date_created'];
+			$data['date_paid']      = $parent_is_order && ! $parent_order->get_date_paid() ? null : $data['date_created'];
 		}
 
 		// Update or add the information to the DB.

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
@@ -276,6 +276,43 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A refund of a paid-but-never-completed order backfills only the paid date and keeps the completed date empty.
+	 */
+	public function test_refund_of_paid_uncompleted_order_backfills_only_date_paid(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_date_paid( time() );
+		$order->set_status( 'processing' );
+		$order->save();
+		$this->assertNotNull( $order->get_date_paid(), 'Fixture order must have been paid.' );
+		$this->assertNull( $order->get_date_completed(), 'Fixture order must never have been completed.' );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => (float) wc_format_decimal( $order->get_total() - $order->get_total_refunded() ),
+				'line_items' => array(),
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $refund );
+
+		OrdersStatsDataStore::sync_order( $refund->get_id() );
+
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT date_paid, date_completed, date_created FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d",
+				$refund->get_id()
+			)
+		);
+
+		$this->assertNotNull( $row, 'The refund should have a stats row.' );
+		$this->assertSame( $row->date_created, $row->date_paid, 'A refund of a paid order should keep its creation date as the paid date.' );
+		$this->assertNull( $row->date_completed, 'A refund of a never-completed order should carry no completed date.' );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
 	 * @testdox Deleting a refund removes its analytics rows while keeping the parent order's rows.
 	 *
 	 * Regression test for HPOS refund deletion leaving orphaned analytics rows:

--- a/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/Reports/Orders/Stats/DataStoreTest.php
@@ -199,6 +199,83 @@ class DataStoreTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A lump-sum refund of a never-paid order stores no paid or completed date, so date-filtered reports exclude it with its parent.
+	 *
+	 * Regression test for https://github.com/woocommerce/woocommerce/issues/37065: a failed
+	 * (never-paid) order manually set to "refunded" produced a refund stats row with
+	 * date_paid and date_completed backfilled from its own creation date. The parent row
+	 * (both dates NULL) was excluded from date-filtered Revenue reports while the refund row
+	 * was included, so the pair no longer cancelled out: Returns, Net sales and Taxes all
+	 * showed amounts for money that was never collected.
+	 */
+	public function test_refund_of_never_paid_order_has_null_date_paid(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'failed' );
+		$order->save();
+		$this->assertNull( $order->get_date_paid(), 'Fixture order must never have been paid.' );
+
+		// Setting the status to "refunded" fires wc_order_fully_refunded(), creating the lump-sum refund.
+		$order->update_status( 'refunded' );
+		$refunds = $order->get_refunds();
+		$this->assertCount( 1, $refunds, 'Marking the order refunded should create one lump-sum refund.' );
+		$refund = reset( $refunds );
+
+		OrdersStatsDataStore::sync_order( $order->get_id() );
+		OrdersStatsDataStore::sync_order( $refund->get_id() );
+
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT order_id, date_paid, date_completed FROM {$wpdb->prefix}wc_order_stats WHERE order_id IN (%d, %d)",
+				$order->get_id(),
+				$refund->get_id()
+			),
+			OBJECT_K
+		);
+
+		$this->assertCount( 2, $rows, 'Both the order and its refund should have stats rows.' );
+		$this->assertNull( $rows[ $order->get_id() ]->date_paid, 'A never-paid order should carry no paid date.' );
+		$this->assertNull( $rows[ $refund->get_id() ]->date_paid, 'A refund of a never-paid order should carry no paid date.' );
+		$this->assertNull( $rows[ $refund->get_id() ]->date_completed, 'A refund of a never-completed order should carry no completed date.' );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * @testdox A refund of a paid order keeps its own creation date as the stats row paid and completed dates.
+	 */
+	public function test_refund_of_paid_order_keeps_own_date_paid(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->update_status( 'completed' );
+		$this->assertNotNull( $order->get_date_paid(), 'Fixture order must have been paid.' );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => (float) wc_format_decimal( $order->get_total() - $order->get_total_refunded() ),
+				'line_items' => array(),
+			)
+		);
+		$this->assertNotInstanceOf( WP_Error::class, $refund );
+
+		OrdersStatsDataStore::sync_order( $refund->get_id() );
+
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT date_paid, date_completed, date_created FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d",
+				$refund->get_id()
+			)
+		);
+
+		$this->assertNotNull( $row, 'The refund should have a stats row.' );
+		$this->assertSame( $row->date_created, $row->date_paid, 'A refund of a paid order should keep its creation date as the paid date.' );
+		$this->assertSame( $row->date_created, $row->date_completed, 'A refund of a completed order should keep its creation date as the completed date.' );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
 	 * @testdox Deleting a refund removes its analytics rows while keeping the parent order's rows.
 	 *
 	 * Regression test for HPOS refund deletion leaving orphaned analytics rows:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Marking a failed (never-paid) order as "Refunded" auto-creates a lump-sum refund via `wc_order_fully_refunded()`. The analytics sync backfilled that refund's stats-row `date_paid`/`date_completed` from the refund's own creation date, while the parent row stores NULL for both. Reports filtered by `date_paid` (the Analytics default) or `date_completed` therefore excluded the parent's positive row but included the refund's negative row, so the pair no longer cancelled out: the Revenue report showed phantom Returns, negative Net sales and negative Taxes for money that was never collected.

The fix mirrors the parent order when backfilling a refund row's paired dates: `date_paid`/`date_completed` are backfilled from `date_created` only when the parent order has that date itself, and stay NULL otherwise — so both rows of the pair are excluded from date-filtered reports together. Refunds of genuinely paid/completed orders are unaffected and still report in the period the refund was issued.

**Backward-compatibility impact:** No signatures, hooks, or schema change. The only change is the value written to the existing nullable `wc_order_stats.date_paid`/`date_completed` columns for refunds of orders lacking the corresponding date; NULL is already an established value in those columns (unpaid parent rows have always stored it) and all report queries filter on the same column they sort/group by, so NULL rows are uniformly excluded rather than mis-sorted. The `woocommerce_analytics_update_order_stats_data` filter continues to fire unchanged; the post-filter date override follows the pre-existing backfill pattern. Deliberate trade-offs: (1) orders imported by migration tools without `_date_paid` meta are treated as never-paid, so their refunds drop out of `date_paid`-filtered reports together with the parent's sale — internally consistent, but a visible change for such stores; (2) already-synced refund rows keep their backfilled dates until the order is re-synced or historical analytics data is re-imported (Analytics → Settings → Delete and re-import historical data).

Closes #37065 .

### Screenshots or screen recordings:

Revenue report, "Today" range containing only a failed order (€100 + €1.50 tax) manually set to Refunded:

| Field | Before | After |
| ------ | ----- | ----- |
| Gross sales | €0.00 | €0.00 |
| Returns | €101.50 | €0.00 |
| Net sales | −€100.00 | €0.00 |
| Taxes | −€1.50 | €0.00 |
| Total sales | −€101.50 | €0.00 |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Enable taxes (WooCommerce → Settings → General → Enable tax rates) and add a standard tax rate (e.g. 10%) for your store country. Create a simple taxable product.
2. Create an order that fails before payment: either check out with a failing payment method, or create the order programmatically and set its status to **Failed** (the order must have no *Paid* date — verify on the order edit screen).
3. Open the order in WooCommerce → Orders and change its status to **Refunded** (do not click the Refund button — just change the status and save). A lump-sum refund is created automatically.
4. Trigger the analytics sync (wait for Action Scheduler, or run `wp wc cot sync`/re-save the order), then open **Analytics → Revenue** with a date range covering the order.
5. Verify Returns, Taxes, Net sales and Total sales do **not** include any amounts from this order (before this fix, Returns shows the order total and Taxes/Net sales go negative).
6. Regression check: create a normal order, mark it Completed, then refund it via the **Refund** button. Verify it still appears in Returns for the day the refund was issued.

<!-- End testing instructions -->

### Testing that has already taken place:

- New PHPUnit regression tests (`DataStoreTest::test_refund_of_never_paid_order_has_null_date_paid`, `::test_refund_of_paid_order_keeps_own_date_paid`), written test-first and watched fail against trunk.
- Full modern Reports suites (36 tests) and legacy `WC_Admin_Tests_Reports` suites (82 tests) pass in wp-env (PHP 8.1, PHPUnit 9.6).
- Manually reproduced and verified in wp-env in the browser: before the fix the Revenue report showed the phantom values in the table above; after the fix all fields read €0.00 for the affected day. The `date_created` date type was also checked: totals cancel to zero there both before and after.
- `lint:php:changes`, `lint:changes:branch` and PHPStan on the changed file are clean.
- Not tested under multisite; the change touches only per-site analytics lookup tables and reads no site-level options, so no multisite-specific behavior is expected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

This PR was developed with assistance from Claude Code (Anthropic): reproduction, root-cause analysis, implementation, tests and this description were AI-generated under human direction and review; all changes were verified by a human-supervised session against a local wp-env environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)