### PR TITLE
Fix EllipsisMenu label wrapping and focus styles

### DIFF
--- a/packages/js/components/changelog/fix-wooplug-1016-ellipsis-menu-labels
+++ b/packages/js/components/changelog/fix-wooplug-1016-ellipsis-menu-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep EllipsisMenu labels on one line and show focus styles only for keyboard navigation.

--- a/packages/js/components/src/ellipsis-menu/style.scss
+++ b/packages/js/components/src/ellipsis-menu/style.scss
@@ -22,7 +22,10 @@
 	}
 
 	.components-popover__content {
-		width: 182px;
+		inline-size: max-content;
+		// Leave room on either side because Popover flips but does not shift.
+		min-inline-size: min(182px, calc(50vw - $gap-smaller));
+		max-inline-size: min(320px, calc(50vw - $gap-smaller));
 		padding: 2px;
 	}
 
@@ -48,6 +51,11 @@
 			box-shadow: inset 0 0 0 1px #6c7781, inset 0 0 0 2px $studio-white;
 			outline: 2px solid transparent;
 			outline-offset: -2px;
+		}
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+			outline: none;
 		}
 
 		.components-form-toggle {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes WOOPLUG-1016

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

EllipsisMenu popovers used a fixed width that wrapped longer Analytics labels, and menu items kept a keyboard-style focus ring after pointer clicks. Size the popover to its content within viewport-safe limits and show item focus styles only when `:focus-visible` matches.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in [woocommerce-admin#40](https://github.com/woocommerce/woocommerce-admin/pull/40).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="203" height="731" alt="Screenshot 2026-08-13 at 13 53 59" src="https://github.com/user-attachments/assets/518638ee-e1a0-4041-b302-4f806e8bb585" /> | <img width="216" height="698" alt="Screenshot 2026-08-13 at 13 12 44" src="https://github.com/user-attachments/assets/1f44d26a-6be9-48e1-8871-911ff0615881" /> |
| <img width="224" height="547" alt="Screenshot 2026-08-13 at 13 54 06" src="https://github.com/user-attachments/assets/e9d0112f-e70f-4d87-8cab-dc088876a95c" /> | <img width="285" height="478" alt="Screenshot 2026-08-13 at 13 13 03" src="https://github.com/user-attachments/assets/db039947-4d51-4078-962d-2c805aae8bf7" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open **WooCommerce > Analytics > Overview** with Store performance and Leaderboards visible.
2. Open their ellipsis menus at desktop width. Confirm labels stay on one line when they fit and the menu remains between 182px and 320px wide.
3. Click a menu item. Confirm pointer focus does not leave a focus ring.
4. Reopen the menu with Enter or Space. Use Tab or Arrow keys and confirm the focused item has a visible ring and activates with Enter or Space.
5. Resize the viewport to 320px. Confirm the popover stays inside the viewport and labels wrap only when needed.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

The focused EllipsisMenu Jest suite passed. The components package and WooCommerce Admin production bundles compiled, and the package changelog validated. Codex and Claude CLI independently reviewed the final diff for correctness, accessibility, browser support, and backwards compatibility.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `packages/js/components/changelog/fix-wooplug-1016-ellipsis-menu-labels`.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex helped implement and test the change, review the diff, and draft this description. Claude CLI supplied an independent code review. I reviewed the resulting changes.
