### PR TITLE
[Backport to release/11.1] Fix Product Gallery variation image lag

### DIFF
--- a/plugins/woocommerce/changelog/codex-fix-product-gallery-variation-lag
+++ b/plugins/woocommerce/changelog/codex-fix-product-gallery-variation-lag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Product Gallery showing the previously selected variation's image when used with the classic Add to Cart Form.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -718,53 +718,59 @@ const productGallery = {
 			}
 
 			const productImageSet = getProductImageSet( context.productId );
-			const syncFormVariationGallery = withScope( () => {
-				if ( ! productImageSet ) {
+			const syncFormVariationGallery = withScope(
+				( variationId?: number, featuredImageId?: number ) => {
+					if ( ! productImageSet ) {
+						actions.resetImageData();
+						return;
+					}
+
+					const $variationIdInput = $form.querySelector(
+						SELECTORS.legacyVariationIdInput
+					) as HTMLInputElement | null;
+					const hasVariationIdInput = !! $variationIdInput;
+					const currentVariationId =
+						variationId ??
+						Number.parseInt( $variationIdInput?.value || '0', 10 );
+
+					// When the form exposes a variation_id input but it's empty,
+					// the merchant cleared the variation — restore the parent
+					// gallery instead of guessing from `current-image`.
+					if ( hasVariationIdInput && ! currentVariationId ) {
+						actions.resetImageData();
+						return;
+					}
+
+					const currentImageId =
+						featuredImageId ??
+						Number.parseInt(
+							$form.getAttribute( 'current-image' ) || '0',
+							10
+						);
+					const variationImageSet = currentVariationId
+						? productImageSet.variations?.[ currentVariationId ]
+						: getVariationImageSetByCurrentImage(
+								productImageSet,
+								currentImageId
+						  );
+
+					if ( variationImageSet?.image_ids?.length ) {
+						actions.setImageData(
+							variationImageSet.image_ids,
+							currentImageId || variationImageSet.image_id
+						);
+						return;
+					}
+
 					actions.resetImageData();
-					return;
 				}
-
-				const $variationIdInput = $form.querySelector(
-					SELECTORS.legacyVariationIdInput
-				) as HTMLInputElement | null;
-				const hasVariationIdInput = !! $variationIdInput;
-				const currentVariationId = Number.parseInt(
-					$variationIdInput?.value || '0',
-					10
-				);
-
-				// When the form exposes a variation_id input but it's empty,
-				// the merchant cleared the variation — restore the parent
-				// gallery instead of guessing from `current-image`.
-				if ( hasVariationIdInput && ! currentVariationId ) {
-					actions.resetImageData();
-					return;
-				}
-
-				const currentImageId = Number.parseInt(
-					$form.getAttribute( 'current-image' ) || '0',
-					10
-				);
-				const variationImageSet = hasVariationIdInput
-					? productImageSet.variations?.[ currentVariationId ]
-					: getVariationImageSetByCurrentImage(
-							productImageSet,
-							currentImageId
-					  );
-
-				if ( variationImageSet?.image_ids?.length ) {
-					actions.setImageData(
-						variationImageSet.image_ids,
-						currentImageId || variationImageSet.image_id
-					);
-					return;
-				}
-
-				actions.resetImageData();
-			} );
+			);
 
 			const teardownJQuery = subscribeLegacyJQueryFormVariations( $form, {
-				onVariationFound: () => syncFormVariationGallery(),
+				// `found_variation` fires before the classic form updates its DOM.
+				// Pass its fresh IDs into the config-based gallery sync.
+				onVariationFound: ( variationId, featuredImageId ) =>
+					syncFormVariationGallery( variationId, featuredImageId ),
 				onVariationReset: () => actions.resetImageData(),
 			} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/legacy-jquery-form.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/legacy-jquery-form.ts
@@ -26,28 +26,9 @@ import type {
 	LegacyVariationPayload,
 } from './types';
 
-/** A WP attachment ID that's safe to use as a gallery slot. */
-const isValidImageId = ( id: unknown ): id is number =>
+/** A positive integer ID from the variation event payload. */
+const isValidId = ( id: unknown ): id is number =>
 	typeof id === 'number' && Number.isInteger( id ) && id > 0;
-
-/**
- * Coerce the variation event payload's IDs into a deduped list of
- * positive integers, with the optional featured image at position 0.
- */
-const normalizeImageData = (
-	imageIds: unknown,
-	featuredImageId?: number
-): number[] => {
-	const featured = isValidImageId( featuredImageId )
-		? [ featuredImageId ]
-		: [];
-	const others = Array.isArray( imageIds )
-		? imageIds
-				.map( ( id ) => Number.parseInt( String( id ), 10 ) )
-				.filter( isValidImageId )
-		: [];
-	return Array.from( new Set( [ ...featured, ...others ] ) );
-};
 
 /**
  * Subscribe to the legacy classic Add to Cart form's jQuery variation
@@ -67,13 +48,14 @@ export const subscribeLegacyJQueryFormVariations = (
 
 	const handleFound = withScope(
 		( _event?: unknown, variation?: LegacyVariationPayload ) => {
-			const imageData = normalizeImageData(
-				variation?.gallery_image_ids,
-				variation?.image_id
-			);
-
-			if ( imageData.length ) {
-				handlers.onVariationFound( imageData, variation?.image_id );
+			if (
+				isValidId( variation?.variation_id ) &&
+				isValidId( variation?.image_id )
+			) {
+				handlers.onVariationFound(
+					variation.variation_id,
+					variation.image_id
+				);
 				return;
 			}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/types.ts
@@ -29,8 +29,8 @@ export type ProductGalleryConfig = WooCommerceConfig & {
 };
 
 export type LegacyVariationPayload = {
+	variation_id?: number;
 	image_id?: number;
-	gallery_image_ids?: number[];
 };
 
 export type LegacyJQueryInstance = {
@@ -46,7 +46,10 @@ export type LegacyJQueryWindow = Window & {
 };
 
 export type LegacyJQueryFormHandlers = {
-	onVariationFound: ( imageIds: number[], featuredImageId?: number ) => void;
+	onVariationFound: (
+		variationId?: number,
+		featuredImageId?: number
+	) => void;
 	onVariationReset: () => void;
 };
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -168,7 +168,7 @@ test.describe( `${ blockData.name }`, () => {
 		pageObject,
 	} ) => {
 		await pageObject.addProductGalleryBlock( { cleanContent: true } );
-		await pageObject.addAddToCartWithOptionsBlock();
+		await pageObject.addClassicAddToCartFormBlock();
 
 		const viewerBlock = await pageObject.getViewerBlock( {
 			page: 'editor',
@@ -185,7 +185,7 @@ test.describe( `${ blockData.name }`, () => {
 		const featuredImageId = await pageObject.getViewerImageId();
 		expect( featuredImageId ).not.toBeNull();
 
-		const cartForm = await pageObject.getAddToCartWithOptionsBlock( {
+		const cartForm = await pageObject.getClassicAddToCartFormBlock( {
 			page: 'frontend',
 		} );
 		const colorSelect = cartForm.getByLabel( 'Color' );
@@ -206,6 +206,91 @@ test.describe( `${ blockData.name }`, () => {
 		await expect( async () => {
 			const afterClearImageId = await pageObject.getViewerImageId();
 			expect( afterClearImageId ).toEqual( featuredImageId );
+		} ).toPass( { timeout: 5_000 } );
+	} );
+
+	test( 'Variable product gallery: classic Add to Cart Form preserves the parent gallery between variations', async ( {
+		page,
+		editor,
+		pageObject,
+	} ) => {
+		await pageObject.addProductGalleryBlock( { cleanContent: true } );
+		await pageObject.addClassicAddToCartFormBlock();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( blockData.productPage );
+		const featuredImageId = await pageObject.getViewerImageId();
+		expect( featuredImageId ).not.toBeNull();
+		const parentImageIds = await pageObject.getVisibleViewerImageIds();
+		const parentGalleryImageIds = parentImageIds.slice( 1 );
+		expect( parentGalleryImageIds.length ).toBeGreaterThan( 0 );
+
+		const addToCartForm = await pageObject.getClassicAddToCartFormBlock( {
+			page: 'frontend',
+		} );
+		await expect(
+			addToCartForm.locator( 'form.variations_form' )
+		).toBeVisible();
+
+		const colorSelect = addToCartForm.getByLabel( 'Color' );
+		const logoSelect = addToCartForm.getByLabel( 'Logo' );
+
+		await colorSelect.selectOption( 'Blue' );
+		await logoSelect.selectOption( 'Yes' );
+
+		await expect( async () => {
+			const variationImageId = await pageObject.getViewerImageId();
+			expect( variationImageId ).not.toEqual( featuredImageId );
+		} ).toPass( { timeout: 5_000 } );
+
+		const firstVariationImageId = await pageObject.getViewerImageId();
+		const firstVariationImageIds = Array.from(
+			new Set( [ firstVariationImageId, ...parentGalleryImageIds ] )
+		);
+		// Product Gallery blocks update reactively and may not be ready
+		// instantly hence expect().toPass with custom timeout since it's 0 by default.
+		await expect( async () => {
+			const variationImageIds =
+				await pageObject.getVisibleViewerImageIds();
+			const thumbnailImageIds =
+				await pageObject.getVisibleThumbnailImageIds();
+			const activeThumbnailImageId =
+				await pageObject.getActiveThumbnailImageId();
+
+			expect( variationImageIds ).toEqual( firstVariationImageIds );
+			expect( thumbnailImageIds ).toEqual( firstVariationImageIds );
+			expect( activeThumbnailImageId ).toEqual( firstVariationImageId );
+		} ).toPass( { timeout: 5_000 } );
+
+		await logoSelect.selectOption( 'No' );
+
+		// Product Gallery blocks update reactively and may not be ready
+		// instantly hence expect().toPass with custom timeout since it's 0 by default.
+		await expect( async () => {
+			const nextVariationImageId = await pageObject.getViewerImageId();
+			expect( nextVariationImageId ).not.toEqual( firstVariationImageId );
+		} ).toPass( { timeout: 5_000 } );
+
+		const nextVariationImageId = await pageObject.getViewerImageId();
+		const nextVariationImageIds = Array.from(
+			new Set( [ nextVariationImageId, ...parentGalleryImageIds ] )
+		);
+		// Product Gallery blocks update reactively and may not be ready
+		// instantly hence expect().toPass with custom timeout since it's 0 by default.
+		await expect( async () => {
+			const variationImageIds =
+				await pageObject.getVisibleViewerImageIds();
+			const thumbnailImageIds =
+				await pageObject.getVisibleThumbnailImageIds();
+			const activeThumbnailImageId =
+				await pageObject.getActiveThumbnailImageId();
+
+			expect( variationImageIds ).toEqual( nextVariationImageIds );
+			expect( thumbnailImageIds ).toEqual( nextVariationImageIds );
+			expect( activeThumbnailImageId ).toEqual( nextVariationImageId );
 		} ).toPass( { timeout: 5_000 } );
 	} );
 

--- a/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.page.ts
+++ b/plugins/woocommerce/tests/e2e/tests/blocks/product-gallery/product-gallery.page.ts
@@ -41,7 +41,7 @@ export class ProductGalleryPage {
 		} );
 	}
 
-	async addAddToCartWithOptionsBlock() {
+	async addClassicAddToCartFormBlock() {
 		await this.editor.insertBlock( {
 			name: 'woocommerce/add-to-cart-form',
 		} );
@@ -153,6 +153,33 @@ export class ProductGalleryPage {
 		return null;
 	}
 
+	async getVisibleViewerImageIds() {
+		const viewerBlockLocator = await this.getViewerBlock( {
+			page: 'frontend',
+		} );
+
+		return viewerBlockLocator
+			.locator(
+				'.wc-block-product-gallery-large-image__wrapper:not([hidden]) img[data-image-id]'
+			)
+			.evaluateAll( ( images ) =>
+				images
+					.map( ( image ) => ( {
+						id: image.getAttribute( 'data-image-id' ) || '',
+						order: Number.parseInt(
+							(
+								image.closest(
+									'.wc-block-product-gallery-large-image__wrapper'
+								) as HTMLElement
+							 )?.style.order || '0',
+							10
+						),
+					} ) )
+					.sort( ( first, second ) => first.order - second.order )
+					.map( ( image ) => image.id )
+			);
+	}
+
 	async getThumbnailsBlock( { page }: { page: 'frontend' | 'editor' } ) {
 		const blockName = 'woocommerce/product-gallery-thumbnails';
 		if ( page === 'frontend' ) {
@@ -163,6 +190,45 @@ export class ProductGalleryPage {
 			} );
 		}
 		return this.editor.getBlockByName( blockName );
+	}
+
+	async getVisibleThumbnailImageIds() {
+		const thumbnailsBlockLocator = await this.getThumbnailsBlock( {
+			page: 'frontend',
+		} );
+
+		return thumbnailsBlockLocator
+			.locator(
+				'.wc-block-product-gallery-thumbnails__thumbnail:not([hidden]) [data-image-id]'
+			)
+			.evaluateAll( ( thumbnails ) =>
+				thumbnails
+					.map( ( thumbnail ) => ( {
+						id: thumbnail.getAttribute( 'data-image-id' ) || '',
+						order: Number.parseInt(
+							(
+								thumbnail.closest(
+									'.wc-block-product-gallery-thumbnails__thumbnail'
+								) as HTMLElement
+							 )?.style.order || '0',
+							10
+						),
+					} ) )
+					.sort( ( first, second ) => first.order - second.order )
+					.map( ( thumbnail ) => thumbnail.id )
+			);
+	}
+
+	async getActiveThumbnailImageId() {
+		const thumbnailsBlockLocator = await this.getThumbnailsBlock( {
+			page: 'frontend',
+		} );
+
+		return thumbnailsBlockLocator
+			.locator(
+				'.wc-block-product-gallery-thumbnails__thumbnail__image--is-active[data-image-id]'
+			)
+			.getAttribute( 'data-image-id' );
 	}
 
 	async getNextPreviousButtonsBlock( {
@@ -210,7 +276,7 @@ export class ProductGalleryPage {
 		return this.editor.getBlockByName( blockName );
 	}
 
-	async getAddToCartWithOptionsBlock( {
+	async getClassicAddToCartFormBlock( {
 		page,
 	}: {
 		page: 'frontend' | 'editor';


### PR DESCRIPTION
<!-- cherry-pick-source-branch: trunk -->
This PR is a cherry-pick of #67480 to `release/11.1`.

> [!NOTE]
> This is opened manually due to GitHub issue at the moment of merging original PR.
> I attempted to merge the PR and it failed so I tried again. In the background it actually merged the PR both times:
> - merge commit: https://github.com/woocommerce/woocommerce/commit/fe9ef76a33d93b5161c0a0ebd9580d9eacb4c43a
> - empty commit: https://github.com/woocommerce/woocommerce/commit/eb3b07386b4a709a3c690413551ddd7d3d2c61eb
>
> but kept the original PR opened so no automation has been triggered. So opening PR manually.

## Original PR Description

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The classic Add to Cart Form fires `found_variation` before its `variation_id` and `current-image` DOM values are updated, so Product Gallery could read the previous variation and lag one selection behind. This passes the event's fresh variation and featured-image IDs into the existing configuration-based gallery sync, preserving variation galleries and parent-gallery fallbacks.

Reported in https://github.com/woocommerce/woocommerce/discussions/54809#discussioncomment-17908740.

Bug introduced in PR #64524.

### Videos

Before | After
-- | --
https://github.com/user-attachments/assets/87ec6415-d1ec-4664-a476-5fda4869d85c | https://github.com/user-attachments/assets/869b0920-9717-4139-82ff-43490127264b

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Edit the Single Product template to use Product Gallery with the classic Add to Cart Form.
2. Open a variable product with a parent gallery and variations with different featured images.
3. Switch directly between variations and verify the large image and thumbnails immediately match the selected variation, while retaining the parent gallery when the variation has no gallery.
4. If Variation Gallery is enabled, verify a variation with its own gallery uses those images instead of the parent gallery.
5. Clear the selection and verify the parent gallery is restored.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified parent-gallery fallback and variation-owned galleries on a Local by Flywheel block-theme site.
- Verified consecutive variation changes update the large image, thumbnail order, and active thumbnail without console errors.
- Added and ran the focused Playwright regression test: 2 passed.
- Ran the WooCommerce Blocks build successfully.
- Ran Blocks and changed-file lint with zero errors; existing warnings remain.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the event-ordering bug, implement and test the fix, and draft this Pull Request. The resulting code and PR content were reviewed during the development workflow.