### PR TITLE
Improve release handle rotation and Product DRI instructions

### DIFF
--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -386,6 +386,8 @@ jobs:
         if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}
         id: create-tracking-issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PREVIOUS_RELEASE_LEAD: ${{ steps.get-previous-tracking-issue.outputs.mention }}
         with:
           script: |
             const { LinearClient } = require( '@linear/sdk' );
@@ -439,7 +441,7 @@ jobs:
               '{date_beta2}': '${{ needs.check-upcoming-release-events.outputs.beta-2-release-date }}',
               '{date_rc1}': '${{ needs.check-upcoming-release-events.outputs.rc-1-release-date }}',
               '{date_stable}': '${{ needs.check-upcoming-release-events.outputs.final-release-date }}',
-              '{previous_release_lead}': '${{ steps.get-previous-tracking-issue.outputs.mention }}'
+              '{previous_release_lead}': process.env.PREVIOUS_RELEASE_LEAD || ''
             };
 
             // Apply replacements.

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -377,9 +377,10 @@ jobs:
 
             console.log( 'Found release lead from two cycles back' );
             const organizationUrlKey = '${{ steps.get-linear-data.outputs.organizationUrlKey }}';
-            core.setOutput( 'mention', assignee.username
-              ? `https://linear.app/${ organizationUrlKey }/profiles/${ assignee.username }`
-              : assignee.displayName );
+            const label = assignee.username
+              ? `[${ assignee.displayName }](https://linear.app/${ organizationUrlKey }/profiles/${ assignee.username })`
+              : assignee.displayName;
+            core.setOutput( 'mention', `${ label } (release lead from the ${ twoCyclesBackVersion } cycle)` );
 
       - name: Process template and create release tracking issue
         if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -367,20 +367,20 @@ jobs:
               }
             } );
 
+            const previousIssueUrl = issues.nodes[ 0 ]?.url;
+            const cycleRef = previousIssueUrl ? `[the ${ twoCyclesBackVersion } cycle](${ previousIssueUrl })` : `the ${ twoCyclesBackVersion } cycle`;
+
             const assignee = await issues.nodes[ 0 ]?.assignee;
 
             if ( ! assignee ) {
               console.log( 'No assignee found for the tracking issue two cycles back' );
-              core.setOutput( 'mention', `the release lead from the ${ twoCyclesBackVersion } cycle` );
+              core.setOutput( 'mention', `the release lead from ${ cycleRef }` );
               return;
             }
 
             console.log( 'Found release lead from two cycles back' );
-            const organizationUrlKey = '${{ steps.get-linear-data.outputs.organizationUrlKey }}';
-            const label = assignee.username
-              ? `[${ assignee.displayName }](https://linear.app/${ organizationUrlKey }/profiles/${ assignee.username })`
-              : assignee.displayName;
-            core.setOutput( 'mention', `${ label } (release lead from the ${ twoCyclesBackVersion } cycle)` );
+            const name = assignee.username || assignee.displayName;
+            core.setOutput( 'mention', `**${ name }** (release lead from ${ cycleRef })` );
 
       - name: Process template and create release tracking issue
         if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -355,32 +355,38 @@ jobs:
 
             const releaseMainVersion = '${{ needs.check-upcoming-release-events.outputs.version }}';
             const twoCyclesBackVersion = ( releaseMainVersion - 0.2 ).toFixed( 1 );
+            const fallbackMention = `the release lead from the ${ twoCyclesBackVersion } cycle`;
 
-            const previousTitle = `[${ twoCyclesBackVersion }] Release tracking`;
-            console.log( `Looking for tracking issue two cycles back: "${ previousTitle }"` );
+            try {
+              const previousTitle = `[${ twoCyclesBackVersion }] Release tracking`;
+              console.log( `Looking for tracking issue two cycles back: "${ previousTitle }"` );
 
-            const issues = await linearClient.issues( {
-              includeArchived: true,
-              filter: {
-                team: { id: { eq: '${{ secrets.LINEAR_TEAM_ID }}' } },
-                title: { eq: previousTitle }
+              const issues = await linearClient.issues( {
+                includeArchived: true,
+                filter: {
+                  team: { id: { eq: '${{ secrets.LINEAR_TEAM_ID }}' } },
+                  title: { eq: previousTitle }
+                }
+              } );
+
+              const previousIssueUrl = issues.nodes[ 0 ]?.url;
+              const cycleRef = previousIssueUrl ? `[the ${ twoCyclesBackVersion } cycle](${ previousIssueUrl })` : `the ${ twoCyclesBackVersion } cycle`;
+
+              const assignee = await issues.nodes[ 0 ]?.assignee;
+
+              if ( ! assignee ) {
+                console.log( 'No assignee found for the tracking issue two cycles back' );
+                core.setOutput( 'mention', `the release lead from ${ cycleRef }` );
+                return;
               }
-            } );
 
-            const previousIssueUrl = issues.nodes[ 0 ]?.url;
-            const cycleRef = previousIssueUrl ? `[the ${ twoCyclesBackVersion } cycle](${ previousIssueUrl })` : `the ${ twoCyclesBackVersion } cycle`;
-
-            const assignee = await issues.nodes[ 0 ]?.assignee;
-
-            if ( ! assignee ) {
-              console.log( 'No assignee found for the tracking issue two cycles back' );
-              core.setOutput( 'mention', `the release lead from ${ cycleRef }` );
-              return;
+              console.log( 'Found release lead from two cycles back' );
+              const name = assignee.displayName;
+              core.setOutput( 'mention', `**${ name }** (release lead from ${ cycleRef })` );
+            } catch ( error ) {
+              core.warning( `Failed to look up the release lead from two cycles back, falling back to a generic mention: ${ error.message }` );
+              core.setOutput( 'mention', fallbackMention );
             }
-
-            console.log( 'Found release lead from two cycles back' );
-            const name = assignee.username || assignee.displayName;
-            core.setOutput( 'mention', `**${ name }** (release lead from ${ cycleRef })` );
 
       - name: Process template and create release tracking issue
         if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}

--- a/.github/workflows/release-assignment.yml
+++ b/.github/workflows/release-assignment.yml
@@ -342,6 +342,45 @@ jobs:
             core.setOutput( 'assignee-display-name', displayName || '' );
             core.setOutput( 'assignee-username', username || '' );
 
+      - name: Get release lead from two cycles ago
+        if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}
+        id: get-previous-tracking-issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { LinearClient } = require( '@linear/sdk' );
+            const linearClient = new LinearClient( {
+              apiKey: '${{ secrets.LINEAR_OAUTH_TOKEN }}'
+            } );
+
+            const releaseMainVersion = '${{ needs.check-upcoming-release-events.outputs.version }}';
+            const twoCyclesBackVersion = ( releaseMainVersion - 0.2 ).toFixed( 1 );
+
+            const previousTitle = `[${ twoCyclesBackVersion }] Release tracking`;
+            console.log( `Looking for tracking issue two cycles back: "${ previousTitle }"` );
+
+            const issues = await linearClient.issues( {
+              includeArchived: true,
+              filter: {
+                team: { id: { eq: '${{ secrets.LINEAR_TEAM_ID }}' } },
+                title: { eq: previousTitle }
+              }
+            } );
+
+            const assignee = await issues.nodes[ 0 ]?.assignee;
+
+            if ( ! assignee ) {
+              console.log( 'No assignee found for the tracking issue two cycles back' );
+              core.setOutput( 'mention', `the release lead from the ${ twoCyclesBackVersion } cycle` );
+              return;
+            }
+
+            console.log( 'Found release lead from two cycles back' );
+            const organizationUrlKey = '${{ steps.get-linear-data.outputs.organizationUrlKey }}';
+            core.setOutput( 'mention', assignee.username
+              ? `https://linear.app/${ organizationUrlKey }/profiles/${ assignee.username }`
+              : assignee.displayName );
+
       - name: Process template and create release tracking issue
         if: ${{ steps.check-existing-issue.outputs.exists != 'true' }}
         id: create-tracking-issue
@@ -398,7 +437,8 @@ jobs:
               '{date_beta1}': '${{ needs.check-upcoming-release-events.outputs.beta-1-release-date }}',
               '{date_beta2}': '${{ needs.check-upcoming-release-events.outputs.beta-2-release-date }}',
               '{date_rc1}': '${{ needs.check-upcoming-release-events.outputs.rc-1-release-date }}',
-              '{date_stable}': '${{ needs.check-upcoming-release-events.outputs.final-release-date }}'
+              '{date_stable}': '${{ needs.check-upcoming-release-events.outputs.final-release-date }}',
+              '{previous_release_lead}': '${{ steps.get-previous-tracking-issue.outputs.mention }}'
             };
 
             // Apply replacements.

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           script: |
             const nextTrunkMainVersion = '${{ needs.prepare-for-feature-freeze.outputs.nextTrunkMainVersion }}'; // e.g. '10.5'
-            const minVersionToKeep     = Number( nextTrunkMainVersion ) - 0.2; // e.g. 10.3
+            const minVersionToKeep     = Number( ( nextTrunkMainVersion - 0.2 ).toFixed( 1 ) ); // e.g. 10.3
 
             const { data: latestMilestones } = await github.rest.issues.listMilestones( {
               owner: context.repo.owner,

--- a/.linear/release-kickoff-patch.md
+++ b/.linear/release-kickoff-patch.md
@@ -12,13 +12,13 @@ Keep the _[Release Troubleshooting & Recovery](https://developer.woocommerce.com
 
 ### 1. Go/no-go
 
-For scheduled stable releases, hold this 24-48 hours before the release date, with the Product DRI (named on the parent tracking issue). Bring in QualityOps and the Atomic contact when staging or monitoring left open questions. See the [readiness guide](https://developer.woocommerce.com/docs/contribution/releases/readiness/) for details.
+For scheduled stable releases, hold this 24-48 hours before the release date with the Product DRIs named on the parent tracking issue - ping `@woo-core-release` in Slack if you need to reach them or aren't sure who's available. Bring in QualityOps and the Atomic contact when staging or monitoring left open questions. See the [readiness guide](https://developer.woocommerce.com/docs/contribution/releases/readiness/) for details.
 
 - [ ] The readiness review is complete and its verdicts still hold.
 - [ ] No new blocking findings since the readiness review (check `#woo-core-releases` threads and the [newest issues]({repository_url}/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc)).
 - [ ] Decision recorded as a comment on this issue - **go**, **no-go**, or **go with conditions** - with the names behind it.
 
-For scheduled releases, the readiness review is the one in the RC sub-issue. Point releases have no RC: run the [readiness criteria](https://developer.woocommerce.com/docs/contribution/releases/readiness/) over the changes being shipped as part of this go/no-go. For unscheduled point releases shipping an urgent fix, a quick go/no-go with the Product DRI in `#woo-core-releases` is enough - record the outcome here all the same.
+For scheduled releases, the readiness review is the one in the RC sub-issue. Point releases have no RC: run the [readiness criteria](https://developer.woocommerce.com/docs/contribution/releases/readiness/) over the changes being shipped as part of this go/no-go. For unscheduled point releases shipping an urgent fix, a quick go/no-go with `@woo-core-release` in `#woo-core-releases` is enough - record the outcome here all the same.
 
 
 ### 2. Pre-build checks

--- a/.linear/release-kickoff-rc.md
+++ b/.linear/release-kickoff-rc.md
@@ -12,7 +12,7 @@ Keep the _[Release Troubleshooting & Recovery](https://developer.woocommerce.com
 
 ### 1. Release readiness review
 
-Go through this with the Product DRI (named on the parent tracking issue) before starting the build. The goal is a deliberate "this RC is ready to go out" call, with the evidence in one place. See the [readiness guide](https://developer.woocommerce.com/docs/contribution/releases/readiness/) for details on each item.
+Go through this checklist together with the Product DRIs named on the parent tracking issue before starting the build - ping `@woo-core-release` in Slack if you need to reach them or aren't sure who's available. The goal is a deliberate "this RC is ready to go out" call, with the evidence in one place. See the [readiness guide](https://developer.woocommerce.com/docs/contribution/releases/readiness/) for details on each item.
 
 - [ ] Review the QIT compatibility regression sweep report for this prerelease. Every introduced issue has a verdict: blocking or not.
 - [ ] Every open finding against this release (bug reports, testing threads, monitoring alerts) has a linked issue and a verdict: release-blocking / fix in a point release / not a bug.

--- a/.linear/release-kickoff.md
+++ b/.linear/release-kickoff.md
@@ -6,7 +6,7 @@ This issue provides visibility on the progress of the release process of WooComm
 - **Milestone:** [{release_milestone}]({repository_url}/issues?q=is:open+milestone:{release_milestone})
 - **Release branch:** [`{release_branch}`]({repository_url}/tree/{release_branch})
 - **Release lead:** {lead_user} ({lead_team})
-- **Product DRI:** _to be confirmed - see [release roles](https://developer.woocommerce.com/docs/contribution/releases/readiness/#release-roles)_
+- **Product DRI:** James Kemp, Warren Holmes (reachable via `@woo-core-release` in Slack)
 - **Relevant dates:** ([release calendar](https://developer.woocommerce.com/release-calendar/))
   - **Feature Freeze:** {date_feature_freeze}
   - **Beta 1:** {date_beta1}
@@ -16,11 +16,17 @@ This issue provides visibility on the progress of the release process of WooComm
 
 ---
 
-⚠ Dear release lead:
+⚠ Complete the setup steps below to get started, and keep the rest of this section handy as reference throughout the release cycle.
 
-- Please read this issue carefully and familiarize yourself with the [release process documentation](https://developer.woocommerce.com/docs/contribution/releases/).
-- Confirm the Product DRI for this cycle: ask `@woo-core-release` in `#woo-core-releases` to confirm the product-side owner for this release, then edit the line above with their name. The readiness review (RC sub-issue) and the go/no-go (stable sub-issue) need both of you.
-- Join the release channels in Slack (`#woo-core-releases`, `#woo-core-releases-notifications`), where discussions happen and notifications are sent.
+##### Setup
+
+- [ ] Read this issue carefully and familiarize yourself with the [release process documentation](https://developer.woocommerce.com/docs/contribution/releases/).
+- [ ] Update `@woo-core-release` membership in Slack: add yourself, and give {previous_release_lead} a heads-up before removing them from the handle. Leave everyone else alone.
+- [ ] Join the release channels in Slack (`#woo-core-releases`, `#woo-core-releases-notifications`), where discussions happen and notifications are sent.
+
+##### Good to know
+
+- When in doubt at any step, ping `@woo-core-release` in Slack. In particular, you'll need to loop in the Product DRIs listed above via the handle for the readiness review and the go/no-go during the RC and stable releases.
 - For every release in the cycle, there's a corresponding sub-issue. On the date of each release (see schedule above), open the relevant issue and follow the instructions in it.
 - Any additional point/patch releases after the first stable must be tracked as well. Run the **[Release: Create Tracking Issue]({repository_url}/actions/workflows/release-create-tracking-issue.yml)** workflow with the version (e.g., `{release_main_version}.1`) to create the sub-issue.
 

--- a/.linear/release-kickoff.md
+++ b/.linear/release-kickoff.md
@@ -21,7 +21,7 @@ This issue provides visibility on the progress of the release process of WooComm
 ##### Setup
 
 - [ ] Read this issue carefully and familiarize yourself with the [release process documentation](https://developer.woocommerce.com/docs/contribution/releases/).
-- [ ] Update `@woo-core-release` membership in Slack: add yourself, and give {previous_release_lead} a heads-up before removing them from the handle. Leave everyone else alone.
+- [ ] On feature freeze ({date_feature_freeze}), update `@woo-core-release` membership in Slack: add yourself, give {previous_release_lead} a heads-up, then remove them. The previous cycle's lead stays for point releases. Leave everyone else alone.
 - [ ] Join the release channels in Slack (`#woo-core-releases`, `#woo-core-releases-notifications`), where discussions happen and notifications are sent.
 
 ##### Good to know

--- a/docs/contribution/releases/README.md
+++ b/docs/contribution/releases/README.md
@@ -5,7 +5,7 @@ sidebar_label: Releases
 
 # Releasing WooCommerce
 
-The WooCommerce release process is managed by a rotating release lead, paired with a per-cycle Product DRI (see [release roles](/docs/contribution/releases/readiness#release-roles)).  The documentation below outlines the process for managing releases.  To get started with a new release, see [Building and Publishing WooCommerce](/docs/contribution/releases/building-and-publishing).
+The WooCommerce release process is managed by a rotating release lead, alongside two standing Product DRI seats in `@woo-core-release` (see [release roles](/docs/contribution/releases/readiness#release-roles)).  The documentation below outlines the process for managing releases.  To get started with a new release, see [Building and Publishing WooCommerce](/docs/contribution/releases/building-and-publishing).
 
 ## Process Overview
 

--- a/docs/contribution/releases/readiness.md
+++ b/docs/contribution/releases/readiness.md
@@ -15,7 +15,7 @@ Each cycle has two named owners, listed on the parent tracking issue:
 * **Release lead** (engineering) - runs the release process end to end: builds, publishes, monitors, and executes the run-books.
 * **Product DRI** - the product-side counterpart. Joins the readiness review at RC and the go/no-go before stable, and owns the product read on open findings: what blocks the release, what waits for a point release, and what ships with a known-issues note.
 
-The release lead is assigned by rotation via the [Release: Assignment workflow](/docs/contribution/releases/workflows). The Product DRI is confirmed per cycle on the tracking issue: the release lead asks `@woo-core-release` in `#woo-core-releases`, and the group confirms the product-side owner for the release.
+The release lead is assigned by rotation via the [Release: Assignment workflow](/docs/contribution/releases/workflows). The Product DRI role is covered by two standing Product seats in Slack's `@woo-core-release` group. Their names are on the tracking issue. If you're unsure who to loop in, ping the handle.
 
 ## Readiness review (at RC)
 

--- a/docs/contribution/releases/readiness.md
+++ b/docs/contribution/releases/readiness.md
@@ -17,6 +17,8 @@ Each cycle has two named owners, listed on the parent tracking issue:
 
 The release lead is assigned by rotation via the [Release: Assignment workflow](/docs/contribution/releases/workflows). The Product DRI role is covered by two standing Product seats in Slack's `@woo-core-release` group. Their names are on the tracking issue. If you're unsure who to loop in, ping the handle.
 
+The handle also holds a standing set of engineering members and the current and previous release leads, who rotate at each feature freeze.
+
 ## Readiness review (at RC)
 
 The RC is the last point where finding a problem is cheap: nothing has shipped, and delaying costs a day, not a revert. The review runs before the RC build starts and answers one question - is there anything we know about that should stop this release?


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This implements a few improvements to the `@woo-core-release` Slack handle rotation and Product DRI involvement:

- The kickoff issue now tells the incoming lead who led two cycles ago (found automatically), so they know who to give a heads-up to before removing them from the handle. It also asks the new DRI to add themselves to the Slack handle.
- The release templates list the two standing Product DRIs directly, instead of asking the lead to ping the handle each cycle to confirm who's covering it.
- The kickoff issue is split into setup tasks to do right away and notes to keep in mind throughout the release, so it's clearer what needs doing when.

This PR also fixes a small rounding bug in the feature-freeze workflow.

Closes [ARC-1860](https://linear.app/a8c/issue/ARC-1860/adopt-woo-core-release-team-as-the-official-release-process-contact).

### Screenshots

_Product DRIs mention in tracking issue:_
<img width="500" alt="Screenshot 2026-08-14 at 11 03 06" src="https://github.com/user-attachments/assets/36be639b-8790-43c0-b6a0-69068811b4e3" />

_New tracking instructions, including how to rotate release DRIs:_
<img width="500" alt="Screenshot 2026-08-14 at 11 03 14" src="https://github.com/user-attachments/assets/3e623577-a804-4543-9570-e1ab06e5a25d" />


### How to test the changes in this Pull Request:

1. Review the updated templates (`.linear/release-kickoff.md`, `release-kickoff-rc.md`, `release-kickoff-patch.md`) for wording and structure.
2. Run the `Release: Assignment` workflow from a fork pointed at a test Linear instance and test calendar, and confirm the created tracking issues render as expected, including the new "previous release lead" lookup.
3. To confirm the milestone-cleanup fix directly: on a fork, set the `Version:` header in `plugins/woocommerce/woocommerce.php` on `trunk` to `10.8.0-dev`, pre-create open milestones titled `10.6.0` and `10.7.0` with no open issues, then manually run `Release: Enforce Feature Freeze`. Confirm `10.7.0` stays open and `10.6.0` gets closed.


### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal release-process tooling and documentation; not shipped to merchants.

</details>