### PR TITLE
Fix duplicate Analytics customers for manual orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-4518-duplicate-manual-order-customers
+++ b/plugins/woocommerce/changelog/fix-wooplug-4518-duplicate-manual-order-customers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplicate customer entries in Analytics after manually creating guest orders without an email address.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomerHistory.php
@@ -3,8 +3,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 use Automattic\WooCommerce\Admin\API\Reports\Customers\Query as CustomersQuery;
-use Automattic\WooCommerce\Admin\Overrides\Order as AdminOrder;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
@@ -230,9 +230,7 @@ class CustomerHistory {
 			return 0;
 		}
 
-		$report_order = $order instanceof AdminOrder ? $order : new AdminOrder( $order->get_id() );
-
-		return (int) $report_order->get_report_customer_id();
+		return (int) CustomersDataStore::get_existing_customer_id_from_order( $order );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/CustomerHistoryTest.php
@@ -3,8 +3,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Orders\MetaBoxes;
 
+use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use Automattic\WooCommerce\Admin\Overrides\Order as AdminOrder;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomerHistory;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\Utilities\OrderUtil;
@@ -678,6 +680,61 @@ class CustomerHistoryTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'order-attribution-total-orders', $output, 'Should render the metabox template' );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-orders">\s*1\s*</', $output, 'Should show 1 order from analytics data' );
 		$this->assertMatchesRegularExpression( '/order-attribution-total-spend">\s*.*100\.00/', $output, 'Should show total spend of 100' );
+	}
+
+	/**
+	 * @testdox CPT fallback should not duplicate a guest customer without an email address.
+	 */
+	public function test_cpt_fallback_does_not_duplicate_guest_without_email(): void {
+		global $wpdb;
+
+		$this->use_cpt_orders();
+		$this->assertFalse( OrderUtil::custom_orders_table_usage_is_enabled(), 'Test should use CPT order storage.' );
+
+		$order = WC_Helper_Order::create_order( 0 );
+		$order->set_billing_first_name( 'Guest' );
+		$order->set_billing_last_name( 'Customer' );
+		$order->set_billing_email( '' );
+		$order->set_status( OrderStatus::COMPLETED );
+		$order->set_total( 100 );
+		$order->save();
+
+		$this->assertSame( '', $order->get_billing_email( 'edit' ), 'Test order should not have a billing email.' );
+		\WC_Helper_Reports::reset_stats_dbs();
+
+		$new_customer_fired = 0;
+		$callback           = static function () use ( &$new_customer_fired ) {
+			++$new_customer_fired;
+		};
+		add_action( 'woocommerce_analytics_new_customer', $callback );
+
+		try {
+			ob_start();
+			try {
+				$this->sut->output( $order );
+				$output = (string) ob_get_contents();
+			} finally {
+				ob_end_clean();
+			}
+
+			$customer_lookup_table = CustomersDataStore::get_db_table_name();
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is provided by the data store.
+			$customers_after_render     = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$customer_lookup_table}" );
+			$new_customers_after_render = $new_customer_fired;
+
+			OrdersStatsDataStore::update( new AdminOrder( $order->get_id() ) );
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is provided by the data store.
+			$customers_after_import = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$customer_lookup_table}" );
+		} finally {
+			remove_action( 'woocommerce_analytics_new_customer', $callback );
+		}
+
+		$this->assertStringContainsString( 'order-attribution-total-orders', $output, 'Should render the metabox template.' );
+		$this->assertSame( 0, $customers_after_render, 'Rendering customer history should not create an analytics customer.' );
+		$this->assertSame( 0, $new_customers_after_render, 'Rendering customer history should not fire the new-customer action.' );
+		$this->assertSame( 1, $customers_after_import, 'Importing the order should create one analytics customer.' );
+		$this->assertSame( 1, $new_customer_fired, 'Importing the order should fire the new-customer action once.' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #58564, closes WOOPLUG-4518

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

- Use the read-only customer lookup when rendering manual-order customer history under CPT storage.
- Avoid creating a second blank Analytics customer merely by viewing the order.
- Cover the regression with customer-history tests while retaining HPOS behavior.

Compatibility: no public signatures or schema change. Rendering no longer fires the erroneous early `woocommerce_analytics_new_customer` action caused by creating the duplicate row; the action still fires when an Analytics import legitimately creates a customer. This PR does not remove or merge duplicate rows that already exist: it only prevents new blank `wc_customer_lookup` rows from being created when viewing email-less manual orders under CPT storage. Blank rows already created on existing sites remain until they are deleted or Analytics is re-imported.

Bug introduced in PR #44318.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Disable HPOS and create a manual guest order without billing identity fields.
2. Open the order and view its customer history.
3. Confirm no duplicate blank Analytics customer is created.
4. Run the `CustomerHistoryTest` PHPUnit class.

<!-- End testing instructions -->

### Testing that has already taken place:

- `CustomerHistoryTest`: 22 tests, 62 assertions.
- The focused CPT regression test passed with 5 assertions.
- Branch PHP lint, PHPStan, syntax, and diff checks passed.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry.

A manual patch changelog entry is included in this branch.

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

### Use of AI Tools

Codex authored the implementation and tests and ran `neo-review`. Claude independently ran `neo-review`; both reviews found the final diff ready to ship. Cursor Agent was also asked to run `neo-review`, but the account quota prevented the review from starting. Every available finding was checked before push.

