### PR TITLE
Flip pagination arrow icons in RTL locales

### DIFF
--- a/packages/js/components/changelog/fix-55817-rtl-pagination-arrows
+++ b/packages/js/components/changelog/fix-55817-rtl-pagination-arrows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Flip the pagination previous/next arrow icons in RTL locales so they point in the direction they navigate.

--- a/packages/js/components/src/pagination/page-arrows-with-picker.tsx
+++ b/packages/js/components/src/pagination/page-arrows-with-picker.tsx
@@ -4,7 +4,7 @@
 import { Button } from '@wordpress/components';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, isRTL } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { uniqueId } from 'lodash';
 
@@ -92,7 +92,7 @@ export function PageArrowsWithPicker( {
 		<div className="woocommerce-pagination__page-arrows">
 			<Button
 				className={ previousLinkClass }
-				icon={ chevronLeft }
+				icon={ isRTL() ? chevronRight : chevronLeft }
 				disabled={ ! ( currentPage > 1 ) }
 				onClick={ previousPage }
 				label={ __( 'Previous Page', 'woocommerce' ) }
@@ -115,7 +115,7 @@ export function PageArrowsWithPicker( {
 			) }
 			<Button
 				className={ nextLinkClass }
-				icon={ chevronRight }
+				icon={ isRTL() ? chevronLeft : chevronRight }
 				disabled={ ! ( currentPage < pageCount ) }
 				onClick={ nextPage }
 				label={ __( 'Next Page', 'woocommerce' ) }

--- a/packages/js/components/src/pagination/page-arrows.tsx
+++ b/packages/js/components/src/pagination/page-arrows.tsx
@@ -4,7 +4,7 @@
 import { Button, Icon } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, isRTL } from '@wordpress/i18n';
 import clsx from 'clsx';
 
 type PageArrowsProps = {
@@ -74,7 +74,7 @@ export function PageArrows( {
 					onClick={ previousPage }
 					label={ __( 'Previous Page', 'woocommerce' ) }
 				>
-					<Icon icon={ chevronLeft } />
+					<Icon icon={ isRTL() ? chevronRight : chevronLeft } />
 				</Button>
 				<Button
 					className={ nextLinkClass }
@@ -82,7 +82,7 @@ export function PageArrows( {
 					onClick={ nextPage }
 					label={ __( 'Next Page', 'woocommerce' ) }
 				>
-					<Icon icon={ chevronRight } />
+					<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 				</Button>
 			</div>
 		</div>

--- a/packages/js/components/src/pagination/test/page-arrows.test.tsx
+++ b/packages/js/components/src/pagination/test/page-arrows.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PageArrows } from '../page-arrows';
+import { PageArrowsWithPicker } from '../page-arrows-with-picker';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	isRTL: jest.fn( () => false ),
+} ) );
+
+const mockedIsRTL = isRTL as jest.MockedFunction< typeof isRTL >;
+
+// chevronLeft points left (path starts moving toward smaller x), chevronRight
+// the opposite; compare the rendered SVG path data to tell them apart.
+function getArrowPaths( container: HTMLElement ) {
+	const buttons = container.querySelectorAll(
+		'.woocommerce-pagination__link'
+	);
+	return Array.from( buttons ).map(
+		( button ) => button.querySelector( 'path' )?.getAttribute( 'd' )
+	);
+}
+
+const CHEVRON_LEFT_D = 'M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z';
+const CHEVRON_RIGHT_D = 'M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z';
+
+describe( 'PageArrows', () => {
+	afterEach( () => {
+		mockedIsRTL.mockReturnValue( false );
+	} );
+
+	it( 'points previous left and next right in LTR', () => {
+		const { container } = render(
+			<PageArrows
+				currentPage={ 2 }
+				pageCount={ 3 }
+				setCurrentPage={ () => {} }
+			/>
+		);
+		expect( getArrowPaths( container ) ).toEqual( [
+			CHEVRON_LEFT_D,
+			CHEVRON_RIGHT_D,
+		] );
+	} );
+
+	it( 'points previous right and next left in RTL', () => {
+		mockedIsRTL.mockReturnValue( true );
+		const { container } = render(
+			<PageArrows
+				currentPage={ 2 }
+				pageCount={ 3 }
+				setCurrentPage={ () => {} }
+			/>
+		);
+		expect( getArrowPaths( container ) ).toEqual( [
+			CHEVRON_RIGHT_D,
+			CHEVRON_LEFT_D,
+		] );
+	} );
+} );
+
+describe( 'PageArrowsWithPicker', () => {
+	afterEach( () => {
+		mockedIsRTL.mockReturnValue( false );
+	} );
+
+	it( 'points previous left and next right in LTR', () => {
+		const { container } = render(
+			<PageArrowsWithPicker
+				currentPage={ 2 }
+				pageCount={ 3 }
+				setCurrentPage={ () => {} }
+			/>
+		);
+		expect( getArrowPaths( container ) ).toEqual( [
+			CHEVRON_LEFT_D,
+			CHEVRON_RIGHT_D,
+		] );
+	} );
+
+	it( 'points previous right and next left in RTL', () => {
+		mockedIsRTL.mockReturnValue( true );
+		const { container } = render(
+			<PageArrowsWithPicker
+				currentPage={ 2 }
+				pageCount={ 3 }
+				setCurrentPage={ () => {} }
+			/>
+		);
+		expect( getArrowPaths( container ) ).toEqual( [
+			CHEVRON_RIGHT_D,
+			CHEVRON_LEFT_D,
+		] );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-55817-rtl-pagination-arrows
+++ b/plugins/woocommerce/changelog/fix-55817-rtl-pagination-arrows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix reversed pagination arrows on Analytics report tables in RTL locales


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In RTL admin locales the pagination controls on Analytics report tables mirror position but keep their LTR glyphs, so Previous points left and Next points right - each arrow points away from the direction it navigates. Both pagination variants (`PageArrows`, used by every Analytics report table, and the exported `PageArrowsWithPicker`) now swap chevrons under `isRTL()`, following the same pattern already used elsewhere in the admin client. LTR behavior is unchanged; a jest test covers both directions for both variants.

Closes #55817.

### Screenshots or screen recordings:

| RTL before | RTL after | LTR after (unchanged) |
| ---------- | --------- | --------------------- |
|  <img width="700" height="90" alt="wooplug-3239-rtl-before" src="https://github.com/user-attachments/assets/588854d0-417a-4d20-bbd1-03aace2b419c" /> |  <img width="700" height="90" alt="wooplug-3239-rtl-after" src="https://github.com/user-attachments/assets/ffa2f1a5-660e-4936-abe2-97061794eded" /> |  <img width="700" height="90" alt="wooplug-3239-ltr-after-unchanged" src="https://github.com/user-attachments/assets/91c6c235-4add-4cec-a419-826a26fd4313" /> |

### How to test the changes in this Pull Request:

1. On a store with more than 25 completed orders, set the site language to an RTL locale (e.g. Hebrew) under Settings > General, and install the WooCommerce translation pack (Dashboard > Updates > Update translations).
2. Go to WooCommerce > Analytics > Orders and look at the pagination controls below the table: the Next arrow (enabled on page 1) should point left and the Previous arrow should point right, following the reading direction.
3. Switch back to English and confirm the arrows still point left (Previous) / right (Next).

### Testing that has already taken place:

- Verified on a local trunk site with Hebrew locale + WooCommerce he_IL translations: baseline shows reversed arrows, fixed build shows them following the reading direction; English LTR verified unchanged (screenshots above).
- New jest tests (4) pass: `pnpm test:js --testPathPattern=pagination` in `packages/js/components`.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entries created manually and included in the branch for `@woocommerce/components` and `@woocommerce/plugin-woocommerce`.

### Use of AI Tools

Authored with AI assistance (Claude Code); reviewed and tested by a human.
