### PR TITLE
Trace connect attempts when wp-env start retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,11 @@ jobs:
               exit 1
             fi
             echo "::warning::wp-env-start-retry reason=${reason} attempt=${attempt}/${max_attempts} -- retrying in $((attempt * 15))s"
+            # The AggregateError wp-env surfaces names neither the host nor the address that
+            # failed, so `reason=wordpress` is as far as the log gets us. Trace the retries:
+            # a repeat failure then records every connect attempt with its address and errno.
+            # Healthy first attempts stay untraced, so this costs nothing on a green job.
+            export NODE_DEBUG=net
             sleep "$((attempt * 15))"
             attempt=$((attempt + 1))
           done


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of TESTOPS-262

`wp-env start` fails in CI when a wordpress.org download dies at ~255 ms with `ETIMEDOUT` from `internalConnectMultiple`. The retry loop tags that `reason=wordpress`, and that is the end of what the logs tell us: the AggregateError names neither the host nor the address that failed, so we cannot say which of the ten downloads died, on which address family, or with which errno.

This sets `NODE_DEBUG=net` before each retry in the `Start Test Environment: start` step. A first attempt that works stays untraced, so a green job logs nothing extra. A repeat failure records every connect attempt with its address and error. The retry logic does not change.

### How to test the changes in this Pull Request:

Nothing to see on a green run — that is the point. To confirm the tracing works, force a failure in the step locally (or watch the next `reason=wordpress` retry in the nightly) and check the log shows `NET:` lines naming each address tried.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


