### PR TITLE
Fix oversized gap between core profiler buttons on mobile

### DIFF
--- a/plugins/woocommerce/changelog/fix-52385-core-profiler-mobile-button-spacing
+++ b/plugins/woocommerce/changelog/fix-52385-core-profiler-mobile-button-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the oversized gap between the two buttons on the core profiler welcome screen at mobile widths.

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -212,7 +212,12 @@
 
 		@include breakpoint("<782px") {
 			width: 100%;
-			margin-top: auto;
+
+			// Only the first button pushes the group down. Applying this to
+			// every button splits the free space between them instead.
+			&:first-of-type {
+				margin-top: auto;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the core profiler welcome screen, "Set up my store" and "Skip guided setup" drift far apart on mobile. There are 54px between the two buttons, while the pair sits just 16px above the opt-in checkbox. The two elements that belong together end up three times further apart than the two that don't, so the buttons stop reading as a group and the checkbox looks attached to the wrong thing.

Both buttons were being told to push themselves to the bottom of the screen, so the free space got split between them instead of collecting above the pair. Now only the first one does that, and the gap falls back to the 16px the buttons
already carried — no new spacing value introduced.

Closes #52385.

### Screenshots or screen recordings:

Before | After
--|--
<img width="780" height="1688" alt="52385-before-390" src="https://github.com/user-attachments/assets/fe79559a-1915-4bb4-bc40-850076330881" /> | <img width="780" height="1688" alt="52385-after-390" src="https://github.com/user-attachments/assets/65b0f085-a877-4bda-9263-f22ea1747322" />

### How to test the changes in this Pull Request:

1. On a fresh store (or after resetting onboarding), go to **WooCommerce → Home** and start the setup wizard, or visit
   `/wp-admin/admin.php?page=wc-admin&path=/setup-wizard`.
2. Set the viewport to 782px wide or narrower.
3. Check the welcome screen: "Set up my store" and "Skip guided setup" should sit 16px apart as a single group at the bottom of the screen, matching the 16px between the group and the opt-in checkbox.
4. Widen past 782px and confirm the desktop layout is unchanged.

### Testing that has already taken place:

Checked on wp-env with WooCommerce trunk and the default theme:

- 390×844 — gap between buttons goes from 54px to 16px.
- 1440×900 — desktop unchanged; the fix is scoped to the mobile breakpoint.
- 782×900 — breakpoint edge behaves correctly.
- 375×667 — short screens have no free space to distribute, so behavior is unchanged from before.

stylelint passes, and the 10 existing `intro-opt-in` unit tests still pass.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

#### Comment
Created manually.

### Use of AI Tools

Written with Claude Code, which diagnosed the cause, made the CSS change, and ran the browser checks. I walked through the flow, reviewed the result, and take responsibility for it.