### PR TITLE
Calculate coupon discounts from manually edited order line item totals

### DIFF
--- a/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
+++ b/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Calculate coupon discounts from manually edited order line item totals instead of the original prices, and stop coupon application from discarding those manual edits.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1548,7 +1548,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Only called when the order has no coupons applied, since applied coupons make the
 	 * subtotal/total difference ambiguous (coupon discount vs manual adjustment).
 	 *
-	 * @return array Original subtotal and subtotal tax of the changed items, keyed by item ID.
+	 * @return array Original tax and subtotal values of the changed items, keyed by item ID.
 	 */
 	private function sync_subtotals_with_manually_edited_totals() {
 		$original_subtotals = array();
@@ -1562,13 +1562,26 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				continue;
 			}
 
+			$taxes = $item->get_taxes( 'edit' );
+
 			$original_subtotals[ $item_id ] = array(
 				'subtotal'     => $item->get_subtotal( 'edit' ),
 				'subtotal_tax' => $item->get_subtotal_tax( 'edit' ),
+				'total_tax'    => $item->get_total_tax( 'edit' ),
+				'taxes'        => $taxes,
 			);
 
 			$item->set_subtotal( $item->get_total( 'edit' ) );
-			$item->set_subtotal_tax( $item->get_total_tax( 'edit' ) );
+
+			// set_taxes() keeps the per-rate tax array and the subtotal_tax/total_tax totals in
+			// sync, so consumers see the same value whichever one they read. It is skipped when
+			// there is no per-rate data, since it would then zero out the stored tax totals.
+			if ( ! empty( $taxes['total'] ) ) {
+				$taxes['subtotal'] = $taxes['total'];
+				$item->set_taxes( $taxes );
+			} else {
+				$item->set_subtotal_tax( $item->get_total_tax( 'edit' ) );
+			}
 		}
 
 		return $original_subtotals;
@@ -1578,17 +1591,26 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Restore item subtotals changed by sync_subtotals_with_manually_edited_totals(), so
 	 * that a failed coupon application leaves the in-memory order unchanged.
 	 *
-	 * @param array $original_subtotals Original subtotal and subtotal tax, keyed by item ID.
+	 * @param array $original_subtotals Original tax and subtotal values, keyed by item ID.
 	 * @return void
 	 */
 	private function restore_item_subtotals( array $original_subtotals ) {
 		foreach ( $original_subtotals as $item_id => $original ) {
 			$item = $this->get_item( $item_id, false );
 
-			if ( $item instanceof WC_Order_Item_Product ) {
-				$item->set_subtotal( $original['subtotal'] );
-				$item->set_subtotal_tax( $original['subtotal_tax'] );
+			if ( ! $item instanceof WC_Order_Item_Product ) {
+				continue;
 			}
+
+			// Restoring the per-rate taxes recomputes both tax totals, so it runs before the
+			// stored totals are put back.
+			if ( ! empty( $original['taxes']['total'] ) ) {
+				$item->set_taxes( $original['taxes'] );
+			}
+
+			$item->set_subtotal( $original['subtotal'] );
+			$item->set_subtotal_tax( $original['subtotal_tax'] );
+			$item->set_total_tax( $original['total_tax'] );
 		}
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1558,17 +1558,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				continue;
 			}
 
-			if ( (float) $item->get_subtotal() === (float) $item->get_total() && (float) $item->get_subtotal_tax() === (float) $item->get_total_tax() ) {
+			if ( (float) $item->get_subtotal( 'edit' ) === (float) $item->get_total( 'edit' ) && (float) $item->get_subtotal_tax( 'edit' ) === (float) $item->get_total_tax( 'edit' ) ) {
 				continue;
 			}
 
 			$original_subtotals[ $item_id ] = array(
-				'subtotal'     => $item->get_subtotal(),
-				'subtotal_tax' => $item->get_subtotal_tax(),
+				'subtotal'     => $item->get_subtotal( 'edit' ),
+				'subtotal_tax' => $item->get_subtotal_tax( 'edit' ),
 			);
 
-			$item->set_subtotal( $item->get_total() );
-			$item->set_subtotal_tax( $item->get_total_tax() );
+			$item->set_subtotal( $item->get_total( 'edit' ) );
+			$item->set_subtotal_tax( $item->get_total_tax( 'edit' ) );
 		}
 
 		return $original_subtotals;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1441,6 +1441,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Apply a coupon to the order and recalculate totals.
 	 *
 	 * @since 3.2.0
+	 * @since 11.2.0 When no coupons are applied yet, line items whose totals were manually
+	 *               edited have their subtotals synced to those totals first, so discounts
+	 *               are calculated from the edited prices rather than the original ones.
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
 	 * @return true|WP_Error True if applied, error if not.
 	 */
@@ -1473,10 +1476,18 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
+		// With no coupons applied, a line total differing from its subtotal is a manual price
+		// adjustment. Adopt it as the new pre-discount price, otherwise discounts would be
+		// calculated from the original price and recalculations would discard the adjustment.
+		// With coupons already applied this is skipped: the difference also contains their
+		// discounts and the manual portion cannot be separated out.
+		$original_subtotals = empty( $applied_coupons ) ? $this->sync_subtotals_with_manually_edited_totals() : array();
+
 		$discounts = new WC_Discounts( $this );
 		$applied   = $discounts->apply_coupon( $coupon );
 
 		if ( is_wp_error( $applied ) ) {
+			$this->restore_item_subtotals( $original_subtotals );
 			return $applied;
 		}
 
@@ -1486,6 +1497,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( $data_store && 0 === $this->get_customer_id() ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
+				$this->restore_item_subtotals( $original_subtotals );
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),
@@ -1527,6 +1539,59 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		wc_update_coupon_usage_counts( $this->get_id() );
 
 		return true;
+	}
+
+	/**
+	 * Sync the subtotal of line items whose total was manually edited, adopting the edited
+	 * total as the new pre-discount price that discounts are calculated from.
+	 *
+	 * Only called when the order has no coupons applied, since applied coupons make the
+	 * subtotal/total difference ambiguous (coupon discount vs manual adjustment).
+	 *
+	 * @since 11.2.0
+	 * @return array Original subtotal and subtotal tax of the changed items, keyed by item ID.
+	 */
+	private function sync_subtotals_with_manually_edited_totals() {
+		$original_subtotals = array();
+
+		foreach ( $this->get_items() as $item_id => $item ) {
+			if ( ! $item instanceof WC_Order_Item_Product ) {
+				continue;
+			}
+
+			if ( (float) $item->get_subtotal() === (float) $item->get_total() && (float) $item->get_subtotal_tax() === (float) $item->get_total_tax() ) {
+				continue;
+			}
+
+			$original_subtotals[ $item_id ] = array(
+				'subtotal'     => $item->get_subtotal(),
+				'subtotal_tax' => $item->get_subtotal_tax(),
+			);
+
+			$item->set_subtotal( $item->get_total() );
+			$item->set_subtotal_tax( $item->get_total_tax() );
+		}
+
+		return $original_subtotals;
+	}
+
+	/**
+	 * Restore item subtotals changed by sync_subtotals_with_manually_edited_totals(), so
+	 * that a failed coupon application leaves the in-memory order unchanged.
+	 *
+	 * @since 11.2.0
+	 * @param array $original_subtotals Original subtotal and subtotal tax, keyed by item ID.
+	 * @return void
+	 */
+	private function restore_item_subtotals( array $original_subtotals ) {
+		foreach ( $original_subtotals as $item_id => $original ) {
+			$item = $this->get_item( $item_id, false );
+
+			if ( $item instanceof WC_Order_Item_Product ) {
+				$item->set_subtotal( $original['subtotal'] );
+				$item->set_subtotal_tax( $original['subtotal_tax'] );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1548,7 +1548,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Only called when the order has no coupons applied, since applied coupons make the
 	 * subtotal/total difference ambiguous (coupon discount vs manual adjustment).
 	 *
-	 * @since 11.2.0
 	 * @return array Original subtotal and subtotal tax of the changed items, keyed by item ID.
 	 */
 	private function sync_subtotals_with_manually_edited_totals() {
@@ -1579,7 +1578,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Restore item subtotals changed by sync_subtotals_with_manually_edited_totals(), so
 	 * that a failed coupon application leaves the in-memory order unchanged.
 	 *
-	 * @since 11.2.0
 	 * @param array $original_subtotals Original subtotal and subtotal tax, keyed by item ID.
 	 * @return void
 	 */

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -320,6 +320,96 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Create a pending order with one $100 product whose line total was manually edited to $50.
+	 *
+	 * @return WC_Order
+	 */
+	private function create_order_with_manually_edited_total() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->set_status( OrderStatus::PENDING );
+		$order->calculate_totals();
+
+		foreach ( $order->get_items() as $item ) {
+			$item->set_total( 50 );
+			$item->save();
+		}
+		$order->calculate_totals();
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * @testdox Applying a coupon calculates the discount from a manually edited line total instead of the original price.
+	 */
+	public function test_apply_coupon_uses_manually_edited_line_total() {
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'percent_coupon_28591',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+		$order  = $this->create_order_with_manually_edited_total();
+
+		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 50, $item->get_subtotal(), 'Edited line total should become the new pre-discount price' );
+		$this->assertEquals( 45, $item->get_total(), 'Discount should be taken off the edited price' );
+		$this->assertEquals( 5, $order->get_discount_total(), 'Discount should be 10% of the edited price' );
+		$this->assertEquals( 45, $order->get_total() );
+	}
+
+	/**
+	 * @testdox A failed coupon application leaves manually edited line items unchanged.
+	 */
+	public function test_apply_coupon_failure_keeps_manually_edited_line_items() {
+		WC_Helper_Coupon::create_coupon(
+			'expired_coupon_28591',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+				'expiry_date'   => gmdate( 'Y-m-d', time() - 2 * DAY_IN_SECONDS ),
+			)
+		);
+		$order = $this->create_order_with_manually_edited_total();
+
+		$this->assertWPError( $order->apply_coupon( 'expired_coupon_28591' ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 100, $item->get_subtotal(), 'Failed coupon application should not change the subtotal' );
+		$this->assertEquals( 50, $item->get_total(), 'Failed coupon application should not change the total' );
+	}
+
+	/**
+	 * @testdox Removing a coupon restores the manually edited line total, not the original price.
+	 */
+	public function test_remove_coupon_restores_manually_edited_line_total() {
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'percent_coupon_28591_remove',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+		$order  = $this->create_order_with_manually_edited_total();
+
+		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+		$this->assertTrue( $order->remove_coupon( $coupon->get_code() ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 50, $item->get_subtotal() );
+		$this->assertEquals( 50, $item->get_total(), 'Removing the coupon should restore the edited price, not the original one' );
+		$this->assertEquals( 50, $order->get_total() );
+	}
+
+	/**
 	 * Test for get_discount_to_display which must return a value
 	 * with and without tax whatever the setting of the options.
 	 *

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -466,6 +466,95 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Create a pending order with a 10% tax rate and one $100 product whose line total was
+	 * manually edited to $50.
+	 *
+	 * @return WC_Order
+	 */
+	private function create_taxed_order_with_manually_edited_total() {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => '1',
+				'tax_rate_order'    => '1',
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->set_status( OrderStatus::PENDING );
+		$order->calculate_totals( true );
+
+		foreach ( $order->get_items() as $item ) {
+			$item->set_total( 50 );
+			$item->save();
+		}
+		$order->calculate_totals( true );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * @testdox Applying a coupon syncs the per-rate subtotal taxes with the manually edited total.
+	 */
+	public function test_apply_coupon_syncs_line_item_taxes_with_manually_edited_total() {
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'percent_coupon_28591_tax',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+		$order  = $this->create_taxed_order_with_manually_edited_total();
+
+		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+
+		$item  = current( $order->get_items() );
+		$taxes = $item->get_taxes();
+		$this->assertEquals( 50, $item->get_subtotal() );
+		$this->assertEquals( 5, $item->get_subtotal_tax(), 'Subtotal tax should follow the edited price' );
+		$this->assertEquals( 5, array_sum( $taxes['subtotal'] ), 'Per-rate subtotal taxes should match the subtotal tax total' );
+		$this->assertEquals( 45, $item->get_total() );
+		$this->assertEquals( 4.5, $item->get_total_tax() );
+		$this->assertEquals( 49.5, $order->get_total() );
+	}
+
+	/**
+	 * @testdox A failed coupon application restores the per-rate taxes of manually edited line items.
+	 */
+	public function test_apply_coupon_failure_keeps_manually_edited_line_item_taxes() {
+		WC_Helper_Coupon::create_coupon(
+			'expired_coupon_28591_tax',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+				'expiry_date'   => gmdate( 'Y-m-d', time() - 2 * DAY_IN_SECONDS ),
+			)
+		);
+		$order = $this->create_taxed_order_with_manually_edited_total();
+
+		$original_taxes = current( $order->get_items() )->get_taxes();
+
+		$this->assertWPError( $order->apply_coupon( 'expired_coupon_28591_tax' ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 100, $item->get_subtotal() );
+		$this->assertEquals( 10, $item->get_subtotal_tax(), 'Failed coupon application should not change the subtotal tax' );
+		$this->assertEquals( 50, $item->get_total() );
+		$this->assertEquals( 5, $item->get_total_tax(), 'Failed coupon application should not change the total tax' );
+		$this->assertEquals( $original_taxes, $item->get_taxes(), 'Failed coupon application should restore the per-rate taxes' );
+	}
+
+	/**
 	 * Test for get_discount_to_display which must return a value
 	 * with and without tax whatever the setting of the options.
 	 *

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -410,6 +410,62 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A guest usage-limit rejection leaves manually edited line items unchanged.
+	 */
+	public function test_apply_coupon_usage_limit_rejection_keeps_manually_edited_line_items() {
+		$guest_email = 'guest28591@example.com';
+		$coupon      = WC_Helper_Coupon::create_coupon(
+			'limited_coupon_28591',
+			array(
+				'discount_type'        => 'percent',
+				'coupon_amount'        => '10',
+				'usage_limit_per_user' => '1',
+			)
+		);
+		$coupon->increase_usage_count( $guest_email );
+
+		$order = $this->create_order_with_manually_edited_total();
+		$order->set_billing_email( $guest_email );
+		$order->save();
+
+		$this->assertWPError( $order->apply_coupon( $coupon->get_code() ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 100, $item->get_subtotal(), 'Usage-limit rejection should not change the subtotal' );
+		$this->assertEquals( 50, $item->get_total(), 'Usage-limit rejection should not change the total' );
+	}
+
+	/**
+	 * @testdox A second coupon stacks on the manually edited price without re-syncing subtotals.
+	 */
+	public function test_apply_second_coupon_stacks_on_manually_edited_line_total() {
+		$percent_coupon = WC_Helper_Coupon::create_coupon(
+			'percent_coupon_28591_stack',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+		$fixed_coupon   = WC_Helper_Coupon::create_coupon(
+			'fixed_coupon_28591_stack',
+			array(
+				'discount_type' => 'fixed_cart',
+				'coupon_amount' => '5',
+			)
+		);
+		$order          = $this->create_order_with_manually_edited_total();
+
+		$this->assertTrue( $order->apply_coupon( $percent_coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon( $fixed_coupon->get_code() ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 50, $item->get_subtotal(), 'Second coupon application should not re-sync the subtotal' );
+		$this->assertEquals( 40, $item->get_total(), 'Both discounts should be taken off the edited price' );
+		$this->assertEquals( 10, $order->get_discount_total() );
+		$this->assertEquals( 40, $order->get_total() );
+	}
+
+	/**
 	 * Test for get_discount_to_display which must return a value
 	 * with and without tax whatever the setting of the options.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a coupon is applied to an order that has no coupons yet, line items whose totals were manually edited now have their subtotals synced to those edited totals first. Discounts are then calculated from the edited price instead of the original one, and coupon recalculation no longer resets the item back to its original price (previously the order total could even go *up* when applying a coupon, since the manual reduction was discarded).

If a coupon application fails (invalid coupon, usage limit), the original subtotals are restored so the in-memory order is left untouched.

**Backward compatibility:** `WC_Abstract_Order::apply_coupon()` is a public method used by the admin order screen, REST API and CLI. For orders with manually edited line totals and no coupons, applying a coupon now (1) persists the edited total as the item's new subtotal, so the admin "before discount" value and reports treat the edited price as the base price, and (2) computes the discount from that edited price. Orders without manual edits (subtotal == total) are unaffected. A manual edit made *after* a coupon is already applied still cannot be separated from the coupon discount and keeps the previous behavior. Code listening to `woocommerce_order_applied_coupon` now observes the synced subtotals.

Closes #28591, closes WOOPLUG-292

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1207" height="353" alt="28591-before-items" src="https://github.com/user-attachments/assets/62d76188-1c50-4f8d-a97f-4c8e830b6abb" /> | <img width="1207" height="353" alt="28591-after-items" src="https://github.com/user-attachments/assets/a1140aa4-7952-44bf-be86-ce271e2c31f3" /> |

### How to test the changes in this Pull Request:

1. Create a simple product priced at $100 and a "Percentage discount" coupon of 10%.
2. Create a new order (WooCommerce > Orders > Add order), add the product, and set the order status to "Pending payment". Save.
3. Edit the line item and change its Total from 100 to 50. Save the order.
4. Apply the 10% coupon to the order.
5. Verify the discount is $5 (10% of the edited $50 price) and the order total is $45. Before this change, the discount was $10 (10% of the original $100) and the order total *increased* to $90.
6. Remove the coupon and verify the item price returns to $50, not $100.

### Testing that has already taken place:

- New unit tests in `WC_Abstract_Order_Test` covering discount from edited totals, failed coupon application leaving items untouched, and coupon removal restoring the edited price; existing coupon/discount/order suites pass (`WC_Tests_Order_Coupons`, `WC_Tests_Discounts`, `WC_Tests_CRUD_Orders`).
- Verified the full flow (apply, failed apply, remove, stacked second coupon) against a local site running this branch.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry added manually in this branch (`fix-28591-coupon-discount-on-edited-order-totals`).

### Use of AI Tools

Authored with Claude Code (Claude Fable 5); reviewed and tested by a human.
