### PR TITLE
Fix raw HTML entity shown when price separator is stored as an entity

### DIFF
--- a/plugins/woocommerce/changelog/fix-41577-nbsp-separator-entities
+++ b/plugins/woocommerce/changelog/fix-41577-nbsp-separator-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display the real character instead of the raw HTML entity when the price thousand or decimal separator is stored as an entity such as &nbsp; in Analytics, admin screens, and blocks.

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -119,8 +119,8 @@ class AssetDataRegistry {
 			'precision'         => wc_get_price_decimals(),
 			'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $currency ) ),
 			'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-			'decimalSeparator'  => wc_get_price_decimal_separator(),
-			'thousandSeparator' => wc_get_price_thousand_separator(),
+			'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+			'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 			'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 		];
 	}

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Internal\Logging\RemoteLogger;
+use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
 use Exception;
 use InvalidArgumentException;
 
@@ -119,8 +120,8 @@ class AssetDataRegistry {
 			'precision'         => wc_get_price_decimals(),
 			'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $currency ) ),
 			'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-			'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-			'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+			'decimalSeparator'  => PriceSeparators::get_decimal(),
+			'thousandSeparator' => PriceSeparators::get_thousand(),
 			'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 		];
 	}

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Blocks\Utils;
 use InvalidArgumentException;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
+use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
 
 /**
  * Manages the registration of interactivity config and state that is commonly shared by WooCommerce blocks.
@@ -143,8 +144,8 @@ class BlocksSharedState {
 				'precision'         => wc_get_price_decimals(),
 				'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $currency ) ),
 				'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-				'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-				'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'decimalSeparator'  => PriceSeparators::get_decimal(),
+				'thousandSeparator' => PriceSeparators::get_thousand(),
 				'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 			),
 		);

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -143,8 +143,8 @@ class BlocksSharedState {
 				'precision'         => wc_get_price_decimals(),
 				'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $currency ) ),
 				'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-				'decimalSeparator'  => wc_get_price_decimal_separator(),
-				'thousandSeparator' => wc_get_price_thousand_separator(),
+				'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 				'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 			),
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\Settings\SettingsUIRequestContext;
+use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Marketplace_Suggestions;
@@ -105,8 +106,8 @@ class Settings {
 				'precision'         => wc_get_price_decimals(),
 				'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
 				'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-				'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-				'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'decimalSeparator'  => PriceSeparators::get_decimal(),
+				'thousandSeparator' => PriceSeparators::get_thousand(),
 				'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -105,8 +105,8 @@ class Settings {
 				'precision'         => wc_get_price_decimals(),
 				'symbol'            => html_entity_decode( get_woocommerce_currency_symbol( $code ) ),
 				'symbolPosition'    => get_option( 'woocommerce_currency_pos' ),
-				'decimalSeparator'  => wc_get_price_decimal_separator(),
-				'thousandSeparator' => wc_get_price_thousand_separator(),
+				'decimalSeparator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'thousandSeparator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 				'priceFormat'       => html_entity_decode( get_woocommerce_price_format() ),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Utilities/PriceSeparators.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PriceSeparators.php
@@ -1,0 +1,34 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+/**
+ * Provides the price separators decoded for non-HTML consumers (client settings payloads, APIs).
+ *
+ * Merchants may store a separator as an HTML entity such as `&nbsp;` or `&apos;`, which renders
+ * correctly in HTML output but shows up as literal text when the raw value reaches JavaScript or
+ * API responses. ENT_HTML5 matches how browsers parse the entity in HTML output.
+ *
+ * @since 11.2.0
+ */
+class PriceSeparators {
+
+	/**
+	 * Get the decimal separator with HTML entities decoded.
+	 *
+	 * @return string
+	 */
+	public static function get_decimal(): string {
+		return html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5 );
+	}
+
+	/**
+	 * Get the thousand separator with HTML entities decoded.
+	 *
+	 * @return string
+	 */
+	public static function get_thousand(): string {
+		return html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5 );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Formatters/CurrencyFormatter.php
+++ b/plugins/woocommerce/src/StoreApi/Formatters/CurrencyFormatter.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\StoreApi\Formatters;
 
 use Automattic\WooCommerce\Enums\CurrencyPosition;
+use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
 
 /**
  * Currency Formatter.
@@ -43,8 +44,8 @@ class CurrencyFormatter implements FormatterInterface {
 				'currency_code'               => get_woocommerce_currency(),
 				'currency_symbol'             => $symbol,
 				'currency_minor_unit'         => wc_get_price_decimals(),
-				'currency_decimal_separator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-				'currency_thousand_separator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'currency_decimal_separator'  => PriceSeparators::get_decimal(),
+				'currency_thousand_separator' => PriceSeparators::get_thousand(),
 				'currency_prefix'             => $prefix,
 				'currency_suffix'             => $suffix,
 			]

--- a/plugins/woocommerce/src/StoreApi/Formatters/CurrencyFormatter.php
+++ b/plugins/woocommerce/src/StoreApi/Formatters/CurrencyFormatter.php
@@ -43,8 +43,8 @@ class CurrencyFormatter implements FormatterInterface {
 				'currency_code'               => get_woocommerce_currency(),
 				'currency_symbol'             => $symbol,
 				'currency_minor_unit'         => wc_get_price_decimals(),
-				'currency_decimal_separator'  => wc_get_price_decimal_separator(),
-				'currency_thousand_separator' => wc_get_price_thousand_separator(),
+				'currency_decimal_separator'  => html_entity_decode( wc_get_price_decimal_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+				'currency_thousand_separator' => html_entity_decode( wc_get_price_thousand_separator(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 				'currency_prefix'             => $prefix,
 				'currency_suffix'             => $suffix,
 			]

--- a/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Assets/AssetDataRegistry.php
@@ -28,6 +28,21 @@ class AssetDataRegistry extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->registry->get() );
 	}
 
+	/**
+	 * @testdox Currency data decodes HTML entities in the price separators.
+	 */
+	public function test_currency_data_decodes_separator_entities() {
+		update_option( 'woocommerce_price_thousand_sep', '&nbsp;' );
+		update_option( 'woocommerce_price_decimal_sep', '&#44;' );
+
+		$method = new \ReflectionMethod( $this->registry, 'get_currency_data' );
+		$method->setAccessible( true );
+		$currency_data = $method->invoke( $this->registry );
+
+		$this->assertSame( "\u{00A0}", $currency_data['thousandSeparator'] );
+		$this->assertSame( ',', $currency_data['decimalSeparator'] );
+	}
+
 	public function test_add_data() {
 		$this->registry->add( 'test', 'foo' );
 		$this->assertEquals( [ 'test' => 'foo' ], $this->registry->get() );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Formatters/TestCurrencyFormatter.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Formatters/TestCurrencyFormatter.php
@@ -36,4 +36,17 @@ class TestCurrencyFormatter extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'currency_prefix', $value );
 		$this->assertArrayHasKey( 'currency_suffix', $value );
 	}
+
+	/**
+	 * @testdox Formatted currency data decodes HTML entities in the price separators.
+	 */
+	public function test_format_decodes_separator_entities() {
+		update_option( 'woocommerce_price_thousand_sep', '&nbsp;' );
+		update_option( 'woocommerce_price_decimal_sep', '&#44;' );
+
+		$value = $this->mock_formatter->format( [] );
+
+		$this->assertSame( "\u{00A0}", $value['currency_thousand_separator'] );
+		$this->assertSame( ',', $value['currency_decimal_separator'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlocksSharedStateTest.php
@@ -60,6 +60,21 @@ class BlocksSharedStateTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Currency data decodes HTML entities in the price separators.
+	 */
+	public function test_currency_data_decodes_separator_entities(): void {
+		update_option( 'woocommerce_price_thousand_sep', '&nbsp;' );
+		update_option( 'woocommerce_price_decimal_sep', '&#44;' );
+
+		$method = new \ReflectionMethod( BlocksSharedState::class, 'get_currency_data' );
+		$method->setAccessible( true );
+		$currency_data = $method->invoke( null );
+
+		$this->assertSame( "\u{00A0}", $currency_data['currency']['thousandSeparator'] );
+		$this->assertSame( ',', $currency_data['currency']['decimalSeparator'] );
+	}
+
+	/**
 	 * @testdox nonOptimisticProperties is empty when no filter is registered.
 	 */
 	public function test_no_filter_returns_empty_non_optimistic_properties(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/SettingsTest.php
@@ -49,6 +49,19 @@ class SettingsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should decode HTML entities in the currency separators exposed to the client.
+	 */
+	public function test_currency_settings_decode_separator_entities(): void {
+		update_option( 'woocommerce_price_thousand_sep', '&nbsp;' );
+		update_option( 'woocommerce_price_decimal_sep', '&#44;' );
+
+		$currency_settings = Settings::get_currency_settings();
+
+		$this->assertSame( "\u{00A0}", $currency_settings['thousandSeparator'], 'A thousand separator stored as an HTML entity should be decoded to the real character' );
+		$this->assertSame( ',', $currency_settings['decimalSeparator'], 'A decimal separator stored as an HTML entity should be decoded to the real character' );
+	}
+
+	/**
 	 * Get the resolved wc_admin group settings via the REST settings controller.
 	 *
 	 * @return array

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/PriceSeparatorsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/PriceSeparatorsTest.php
@@ -1,0 +1,55 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\PriceSeparators;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the PriceSeparators class.
+ */
+class PriceSeparatorsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Should decode HTML entities stored as separators, including HTML5-only entities.
+	 * @dataProvider separator_entity_data
+	 *
+	 * @param string $stored   The raw option value.
+	 * @param string $expected The expected decoded separator.
+	 */
+	public function test_separators_are_decoded( string $stored, string $expected ): void {
+		update_option( 'woocommerce_price_thousand_sep', $stored );
+		update_option( 'woocommerce_price_decimal_sep', $stored );
+
+		$this->assertSame( $expected, PriceSeparators::get_thousand(), "Thousand separator stored as '{$stored}' should decode to '{$expected}'" );
+		$this->assertSame( $expected, PriceSeparators::get_decimal(), "Decimal separator stored as '{$stored}' should decode to '{$expected}'" );
+	}
+
+	/**
+	 * Data provider of stored separator values and their expected decoded forms.
+	 *
+	 * @return array
+	 */
+	public function separator_entity_data(): array {
+		return array(
+			'plain comma'             => array( ',', ',' ),
+			'plain space'             => array( ' ', ' ' ),
+			'non-breaking space char' => array( "\u{00A0}", "\u{00A0}" ),
+			'named entity nbsp'       => array( '&nbsp;', "\u{00A0}" ),
+			'numeric entity comma'    => array( '&#44;', ',' ),
+			'HTML5-only entity apos'  => array( '&apos;', "'" ),
+		);
+	}
+
+	/**
+	 * @testdox Should preserve the core getters' fallbacks when the options are empty.
+	 */
+	public function test_empty_options_preserve_getter_fallbacks(): void {
+		update_option( 'woocommerce_price_thousand_sep', '' );
+		update_option( 'woocommerce_price_decimal_sep', '' );
+
+		$this->assertSame( '', PriceSeparators::get_thousand(), 'An empty thousand separator should stay empty' );
+		$this->assertSame( '.', PriceSeparators::get_decimal(), 'An empty decimal separator should fall back to a period, matching wc_get_price_decimal_separator()' );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Merchants sometimes store the price thousand/decimal separator as an HTML entity such as `&nbsp;` (it renders fine in the classic frontend because `wc_price()` outputs HTML), but the currency settings handed to JavaScript decode `symbol` and `priceFormat` while leaving the separators raw, so admin Analytics/Customers screens and blocks render the literal entity text in every number. This decodes the separators with `html_entity_decode()` in the four currency payloads exposed to clients: wc-admin settings, `wcSettings.currency`, the Interactivity API shared state, and the Store API currency formatter.

Backwards compatibility: Store API responses now return the decoded character (e.g. a real non-breaking space) instead of the entity string in `currency_thousand_separator`/`currency_decimal_separator`. This only changes output on stores that have an entity stored, and matches the already-decoded `currency_symbol` in the same response.

Closes #41577 .

### Screenshots or screen recordings:

| Revenue Before | Revenue After |
| ------ | ----- |
| <img width="1060" height="260" alt="wooplug-1677-revenue-before" src="https://github.com/user-attachments/assets/2d456091-96c2-4815-bb38-0a3c2260f6c0" /> | <img width="1060" height="260" alt="wooplug-1677-revenue-after" src="https://github.com/user-attachments/assets/34ecfabd-1d45-49c5-a5de-b227754bb38e" /> |

| Customers Before | Customers After |
| ------ | ----- |
| <img width="1080" height="240" alt="wooplug-1677-customers-before" src="https://github.com/user-attachments/assets/6b16712c-8d17-459e-9fb0-3eee447b29db" /> |  <img width="1080" height="240" alt="wooplug-1677-customers-after" src="https://github.com/user-attachments/assets/e4f77a0c-2d72-41d1-af57-f55666a68091" /> |

### How to test the changes in this Pull Request:

1. In WooCommerce > Settings > General, set Thousand separator to `&nbsp;` (or run `wp option update woocommerce_price_thousand_sep '&nbsp;'`).
2. Create and complete an order with a total of at least 1,000 so it shows up in Analytics.
3. Go to Analytics > Revenue and WooCommerce > Customers.
4. Without this PR the numbers show the literal text `$2&nbsp;469&nbsp;000.00`; with this PR they show `$2 469 000.00` with a non-breaking space.

### Testing that has already taken place:

- Reproduced and verified the fix on a local site (trunk vs this branch) on the Analytics > Revenue and Customers screens.
- New unit tests for the four touched classes; ran the full test classes involved (81 tests passing), plus PHPCS and PHPStan on the changed files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This PR was developed with AI assistance (Claude Code): investigation, implementation, tests, and verification were AI-generated and human-reviewed.