### PR TITLE
Fix Store API order-pay stripping a coupon because of the order's own hold

### DIFF
--- a/plugins/woocommerce/changelog/fix-67677-store-api-coupon-own-hold
+++ b/plugins/woocommerce/changelog/fix-67677-store-api-coupon-own-hold
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude an order's own tentative coupon hold when Store API order-pay validates usage limits.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -570,6 +570,11 @@ class OrderController {
 			return;
 		}
 
+		// Once this order recorded usage, its `_used_by` row is this order's own use.
+		if ( $order->get_recorded_coupon_usage_counts() ) {
+			return;
+		}
+
 		// First, we check a logged in customer usage count, which happens against their user id, billing email, and account email.
 		if ( $order->get_customer_id() ) {
 			// We get usage per user id and associated emails.
@@ -608,6 +613,8 @@ class OrderController {
 			);
 		}
 
+		$usage_count -= $this->count_active_order_coupon_hold( $order, (int) $coupon->get_id(), '_maybe_used_by_' );
+
 		if ( $usage_count >= $coupon_usage_limit ) {
 			throw new Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED ) );
 		}
@@ -629,11 +636,13 @@ class OrderController {
 			return;
 		}
 
-		// Include tentative holds, matching WC_Discounts::validate_coupon_usage_limit().
+		// Include tentative holds from other checkouts, but not this order's own hold.
 		$data_store      = $coupon->get_data_store();
 		$tentative_usage = is_callable( array( $data_store, 'get_tentative_usage_count' ) )
 			? (int) $data_store->get_tentative_usage_count( $coupon->get_id() )
 			: 0;
+
+		$tentative_usage -= $this->count_active_order_coupon_hold( $order, (int) $coupon->get_id(), '_coupon_held_' );
 
 		if ( $coupon->get_usage_count() + $tentative_usage >= $usage_limit ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
@@ -676,6 +685,49 @@ class OrderController {
 		// Coupons can be held for an x amount of time before being applied to an order, so we need to check if it's already being held in (maybe via another flow).
 		$tentative_usage_count = $data_store->get_tentative_usages_for_user( $coupon->get_id(), $aliases );
 		return $tentative_usage_count + $usage_count;
+	}
+
+	/**
+	 * Count this order's still-active tentative hold for a coupon.
+	 *
+	 * Only the key currently recorded on the order is considered. Expired or
+	 * released holds are already omitted from tentative usage queries and must
+	 * not be subtracted. Re-holding overwrites the order map and can orphan an
+	 * earlier key; that orphan is not recorded, so it is not excluded.
+	 *
+	 * @param \WC_Order $order     Order being paid.
+	 * @param int       $coupon_id Coupon ID.
+	 * @param string    $prefix    Hold meta key prefix (`_coupon_held_` or `_maybe_used_by_`).
+	 * @return int 0 or 1.
+	 */
+	private function count_active_order_coupon_hold( \WC_Order $order, int $coupon_id, string $prefix ): int {
+		$order_data_store = $order->get_data_store();
+		if ( ! $order_data_store ) {
+			return 0;
+		}
+
+		$held_key = '_coupon_held_' === $prefix
+			? ( is_callable( array( $order_data_store, 'get_coupon_held_keys' ) )
+				? $order_data_store->get_coupon_held_keys( $order, $coupon_id )
+				: null )
+			: ( is_callable( array( $order_data_store, 'get_coupon_held_keys_for_users' ) )
+				? $order_data_store->get_coupon_held_keys_for_users( $order, $coupon_id )
+				: null );
+
+		if ( ! is_string( $held_key ) || '' === $held_key ) {
+			return 0;
+		}
+
+		if ( ! metadata_exists( 'post', $coupon_id, $held_key ) ) {
+			return 0;
+		}
+
+		// Same expiry comparison as WC_Coupon_Data_Store_CPT tentative queries.
+		if ( $held_key <= $prefix . time() ) {
+			return 0;
+		}
+
+		return 1;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -205,6 +205,75 @@ class OrderControllerTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Order-pay keeps a usage-limited coupon when the only tentative hold belongs to this order.
+	 */
+	public function test_validate_existing_order_before_payment_keeps_coupon_with_own_global_hold() {
+		$coupon = CouponHelper::create_coupon( 'own-hold-limit1', 'publish', array( 'usage_limit' => 1 ) );
+		$order  = $this->create_pending_order_with_coupon( $coupon );
+		$this->hold_coupon_for_order( $order, $coupon );
+
+		$this->assertSame( 1, (int) $coupon->get_data_store()->get_tentative_usage_count( $coupon->get_id() ) );
+		$this->assertNull( $this->sut->validate_existing_order_before_payment( $order ) );
+		$this->assertEquals( array( 'own-hold-limit1' ), $order->get_coupon_codes() );
+	}
+
+	/**
+	 * @testdox Order-pay still rejects a coupon when another checkout's hold consumes the last remaining use.
+	 */
+	public function test_validate_existing_order_before_payment_strips_coupon_when_other_hold_exists() {
+		$coupon = CouponHelper::create_coupon( 'other-hold-limit1', 'publish', array( 'usage_limit' => 1 ) );
+		$order  = $this->create_pending_order_with_coupon( $coupon );
+
+		$other_hold = $coupon->get_data_store()->check_and_hold_coupon( $coupon );
+		$this->assertNotEmpty( $other_hold );
+
+		try {
+			$this->sut->validate_existing_order_before_payment( $order );
+			$this->fail( 'Expected a RouteException when another order holds the last coupon use.' );
+		} catch ( RouteException $e ) {
+			$this->assertEquals( 409, $e->getCode() );
+		}
+
+		$this->assertEmpty( $order->get_coupon_codes() );
+	}
+
+	/**
+	 * @testdox An expired or released hold recorded on the order is not subtracted from the tentative count.
+	 */
+	public function test_validate_existing_order_before_payment_does_not_subtract_released_hold() {
+		$coupon = CouponHelper::create_coupon( 'released-hold-limit1', 'publish', array( 'usage_limit' => 1 ) );
+		$order  = $this->create_pending_order_with_coupon( $coupon );
+
+		$active_other_hold = $coupon->get_data_store()->check_and_hold_coupon( $coupon );
+		$this->assertNotEmpty( $active_other_hold );
+
+		$released_key = '_coupon_held_' . ( time() + HOUR_IN_SECONDS ) . '_dead01';
+		$order->get_data_store()->set_coupon_held_keys( $order, array( $coupon->get_id() => $released_key ), array() );
+		$order->save();
+
+		try {
+			$this->sut->validate_existing_order_before_payment( $order );
+			$this->fail( 'Expected a RouteException; a missing recorded hold must not hide another active hold.' );
+		} catch ( RouteException $e ) {
+			$this->assertEquals( 409, $e->getCode() );
+		}
+
+		$this->assertEmpty( $order->get_coupon_codes() );
+	}
+
+	/**
+	 * @testdox Order-pay keeps a per-user limited coupon when the only tentative hold belongs to this order.
+	 */
+	public function test_validate_existing_order_before_payment_keeps_coupon_with_own_per_user_hold() {
+		$coupon = CouponHelper::create_coupon( 'own-user-limit1', 'publish', array( 'usage_limit_per_user' => 1 ) );
+		$order  = $this->create_pending_order_with_coupon( $coupon );
+		$this->hold_coupon_for_user_on_order( $order, $coupon );
+
+		$this->assertNull( $this->sut->validate_existing_order_before_payment( $order ) );
+		$this->assertEquals( array( 'own-user-limit1' ), $order->get_coupon_codes() );
+	}
+
+	/**
 	 * test_validate_order_before_payment_invalid_email.
 	 */
 	public function test_validate_order_before_payment_invalid_email() {
@@ -434,6 +503,52 @@ class OrderControllerTests extends \WC_Unit_Test_Case {
 			has_filter( $hook ),
 			'create_order_from_cart() must remove its woocommerce_default_order_status filter; the chain must not grow across repeated calls.'
 		);
+	}
+
+	/**
+	 * Create a pending order that looks like classic checkout: coupon applied, usage not recorded.
+	 *
+	 * @param \WC_Coupon $coupon Coupon to attach.
+	 * @return \WC_Order
+	 */
+	private function create_pending_order_with_coupon( \WC_Coupon $coupon ): \WC_Order {
+		$order = WC_Helper_Order::create_order();
+		$this->set_shipping_address( $order );
+		$item = new \WC_Order_Item_Coupon();
+		$item->set_code( $coupon->get_code() );
+		$order->add_item( $item );
+		$order->set_status( OrderStatus::PENDING );
+		$order->set_recorded_coupon_usage_counts( false );
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Place a global tentative hold and record it on the order, matching WC_Checkout::hold_applied_coupons().
+	 *
+	 * @param \WC_Order  $order  Order object.
+	 * @param \WC_Coupon $coupon Coupon object.
+	 */
+	private function hold_coupon_for_order( \WC_Order $order, \WC_Coupon $coupon ): void {
+		$held_key = $coupon->get_data_store()->check_and_hold_coupon( $coupon );
+		$this->assertNotEmpty( $held_key, 'Expected check_and_hold_coupon() to reserve a global hold.' );
+		$order->get_data_store()->set_coupon_held_keys( $order, array( $coupon->get_id() => $held_key ), array() );
+		$order->save();
+	}
+
+	/**
+	 * Place a per-user tentative hold and record it on the order.
+	 *
+	 * @param \WC_Order  $order  Order object.
+	 * @param \WC_Coupon $coupon Coupon object.
+	 */
+	private function hold_coupon_for_user_on_order( \WC_Order $order, \WC_Coupon $coupon ): void {
+		$email    = $order->get_billing_email();
+		$held_key = $coupon->get_data_store()->check_and_hold_coupon_for_user( $coupon, array( $email ), $email );
+		$this->assertNotEmpty( $held_key, 'Expected check_and_hold_coupon_for_user() to reserve a per-user hold.' );
+		$order->get_data_store()->set_coupon_held_keys( $order, array(), array( $coupon->get_id() => $held_key ) );
+		$order->save();
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Classic checkout can place a tentative coupon hold (`_coupon_held_*` / `_maybe_used_by_*`) on a pending order without firing `woocommerce_order_status_pending`, so `recorded_coupon_usage_counts` stays false.

Paying that order through `POST /wc/store/v1/checkout/{order_id}` then runs Store API usage-limit checks. Those checks count every tentative hold, including the paying order's own still-active hold. With `usage_limit=1` (or `usage_limit_per_user=1`) the coupon looks exhausted, Store API returns 409, and the coupon is removed from the order.

This change excludes only the paying order's currently recorded hold, and only while that hold is still present and unexpired on the coupon. Expired, released, or orphaned keys (for example after a re-hold overwrites the order map) stay in the tentative count.

`validate_coupon_usage_limit()` now also returns early when the order has already recorded coupon usage, matching the global-limit guard.

Fixes #67677

### How to test the changes in this Pull Request:

1. Create a coupon with **Usage limit per coupon** set to `1`.
2. Place an order through classic checkout using that coupon and leave the order pending (do not complete payment).
3. Confirm the coupon still has a tentative hold and `recorded_coupon_usage_counts` is not set on the order.
4. Pay the same order through Store API: `POST /wc/store/v1/checkout/{order_id}`.
5. Confirm the request succeeds and the coupon remains on the order.
6. Repeat with a second pending checkout that holds the same `usage_limit=1` coupon, then try to pay the first order. Confirm Store API still returns 409 and strips the coupon.
7. Repeat steps 1–5 with **Usage limit per user** set to `1` instead of a global limit.

### Testing that has already taken place:

Added PHPUnit coverage in `OrderControllerTests`:

- Own global hold + `usage_limit=1` keeps the coupon.
- Another order's hold + `usage_limit=1` still returns 409 and strips the coupon.
- A released/missing recorded key is not subtracted, so another active hold is still enforced.
- Own per-user hold + `usage_limit_per_user=1` keeps the coupon.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

A changelog file is already included: `plugins/woocommerce/changelog/fix-67677-store-api-coupon-own-hold`.
