### PR TITLE
Fix disabled buttons not looking disabled in cart and checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-47008-disabled-button-state
+++ b/plugins/woocommerce/changelog/fix-47008-disabled-button-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fade the whole button rather than only its label when a cart or checkout button is disabled, and stop disabled outlined buttons from taking on the dark hover styling.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
@@ -28,15 +28,18 @@
 	&.text {
 		color: $gray-900;
 
-		&:hover {
+		&:hover:not(:disabled):not([aria-disabled="true"]) {
 			opacity: 0.9;
 		}
 	}
 
-	&:disabled {
-		.wc-block-components-button__text {
-			opacity: 0.5;
-		}
+	// Fade the whole button, not just its label, so the fill and border read as
+	// unavailable too. Some buttons stay focusable and use aria-disabled rather
+	// than the disabled attribute, so both need covering.
+	&:disabled,
+	&[aria-disabled="true"] {
+		cursor: not-allowed;
+		opacity: 0.5;
 	}
 
 	&.outlined,
@@ -48,18 +51,15 @@
 			box-shadow: inset 0 0 0 1px currentColor;
 		}
 
-		&:disabled,
-		&:hover,
-		&:focus,
-		&:active {
-			background-color: $gray-900;
-			color: $white;
-		}
-
-		&:hover {
-			background-color: $gray-900;
-			color: $white;
-			opacity: 1;
+		// Interaction states must not apply while disabled, or the button
+		// would fill in dark and read as more prominent than at rest.
+		&:not(:disabled):not([aria-disabled="true"]) {
+			&:hover,
+			&:focus,
+			&:active {
+				background-color: $gray-900;
+				color: $white;
+			}
 		}
 	}
 }
@@ -77,7 +77,7 @@ body:not(.woocommerce-block-theme-has-button-styles)
 	&.text {
 		color: $gray-900;
 
-		&:hover {
+		&:hover:not(:disabled):not([aria-disabled="true"]) {
 			opacity: 0.9;
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -18,12 +18,6 @@
 		}
 	}
 }
-.wc-block-cart__submit-button[aria-disabled="true"] {
-	.wc-block-components-button__text {
-		opacity: 0.5;
-	}
-}
-
 .wc-block-cart {
 	.wc-block-cart__submit-container {
 		padding: 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Disabled buttons in cart and checkout only faded their label. The fill stayed at full strength, so a disabled "Apply" sat next to "Proceed to Checkout" looking just as clickable — the washed-out text read as a broken label rather than an unavailable button.

Outlined buttons had the opposite problem. Their disabled state shared a rule with hover, focus and active, so disabling one filled it in near-black and made it the most prominent thing on screen.

Now the whole button fades when disabled, with a not-allowed cursor, and outlined buttons keep their light treatment. This follows the disabled state in the approved button designs, and lands in the shared button component as the issue suggested — which also let the cart submit button drop its own copy of the old label-only rule.

Closes #47008. Kudos to @yjailin for designs.

### Screenshots or screen recordings:

Before | After
--|--
<img width="822" height="680" alt="47008-before" src="https://github.com/user-attachments/assets/950ffd30-7dc4-4122-8953-53b83a9a7f67" /> | <img width="822" height="680" alt="47008-after" src="https://github.com/user-attachments/assets/4b55b6dc-d7d1-43ae-9106-b78e864c6866" />


### How to test the changes in this Pull Request:

1. Add a product to the cart and go to the Cart page.
2. Expand **Add coupons** and leave the field empty — "Apply" is disabled.
3. The whole button should look faded, not just its label, and the cursor should be not-allowed on hover.
4. Compare against "Proceed to Checkout" below it: the disabled button should clearly read as unavailable next to an active one.
5. Type a code so "Apply" becomes enabled, and confirm it returns to full strength with normal hover behavior.

### Testing that has already taken place:

Tested on wp-env with the Cart block and a block theme, comparing against trunk:

- Contained disabled: was full-strength fill with a 50% label, now a 50% button with a not-allowed cursor.
- Outlined disabled: was a near-black fill with white text, now stays light and faded.
- Outlined enabled: unchanged. Hover, focus and active still apply — the new scoping only excludes disabled buttons.
- The cart's "Proceed to Checkout" link is disabled via `aria-disabled` rather than the disabled attribute, and is covered by the shared rule now that its own style has been removed.

stylelint passes. No unit tests were added or run — the change is CSS only.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Comment required below)

#### Comment
Created manually.

### Use of AI Tools

Written with Claude Code, which diagnosed the cause, made the CSS change, and ran the browser checks. I walked through the flows, reviewed the result, and take responsibility for it.