### PR TITLE
Let themes size the Order Confirmation section headings

### DIFF
--- a/plugins/woocommerce/changelog/fix-50587-order-confirmation-heading-sizes
+++ b/plugins/woocommerce/changelog/fix-50587-order-confirmation-heading-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Let themes size the Order Confirmation section headings, so they no longer render smaller than body text on narrow screens.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -208,7 +208,7 @@ final class BlockTypesController {
 			array(
 				'title'    => '',
 				'inserter' => false,
-				'content'  => '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"24px"}}} --><h2 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Order details', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
+				'content'  => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">' . esc_html__( 'Order details', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
 			)
 		);
 		register_block_pattern(
@@ -216,7 +216,7 @@ final class BlockTypesController {
 			array(
 				'title'    => '',
 				'inserter' => false,
-				'content'  => '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"24px"}}} --><h2 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Downloads', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
+				'content'  => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">' . esc_html__( 'Downloads', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
 			)
 		);
 		register_block_pattern(
@@ -224,7 +224,7 @@ final class BlockTypesController {
 			array(
 				'title'    => '',
 				'inserter' => false,
-				'content'  => '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"24px"}}} --><h2 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Shipping address', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
+				'content'  => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">' . esc_html__( 'Shipping address', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
 			)
 		);
 		register_block_pattern(
@@ -232,7 +232,7 @@ final class BlockTypesController {
 			array(
 				'title'    => '',
 				'inserter' => false,
-				'content'  => '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"24px"}}} --><h2 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Billing address', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
+				'content'  => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">' . esc_html__( 'Billing address', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
 			)
 		);
 		register_block_pattern(
@@ -240,7 +240,7 @@ final class BlockTypesController {
 			array(
 				'title'    => '',
 				'inserter' => false,
-				'content'  => '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"24px"}}} --><h2 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Additional information', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
+				'content'  => '<!-- wp:heading {"level":2} --><h2 class="wp-block-heading">' . esc_html__( 'Additional information', 'woocommerce' ) . '</h2><!-- /wp:heading -->',
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

On the Order Confirmation page, the section headings — Order details, Shipping address, Billing address and the rest — render *smaller* than the text beneath them on narrow screens. They end up the quietest thing on the page, quieter than "Product" or "Note:".

The cause is that we hardcode `font-size: 24px` on those five headings. WordPress fluid typography rewrites a bare pixel value into a clamp with a floor around 65% of it, so on a phone our 24px collapses to roughly 16px — below the theme's own body size. Measured at 390px: 16.35px against 16.8px body in Twenty Twenty-Four, and 16.31px against 18.27px in Twenty Twenty-Five.

This removes the size and lets each theme style its own `h2`. That fixes the hierarchy by construction, because a theme sizes its headings against its own body text. Picking a preset like `large` instead wouldn't be safe — in Twenty Twenty-Five it resolves to exactly the body size.

It also puts these headings back in line with our own contributor guidelines, which say font sizes "must" be theme-relative so blocks "fit better within different themes". These were the only hardcoded pixel font size left in any shop-facing template or pattern, and the value looks accidental rather than chosen: it arrived with the original blockified template and has only been touched once since, by an accessibility pass that changed the heading level and left it alone.

There's precedent for exactly this edit in #10227, which stripped hardcoded sizes out of the Minimal Header pattern under the title "Remove opinionated styles".

Closes #50587.

### Screenshots or screen recordings:

Before on the left, after on the right, same scroll position.

| Theme | Mobile (390px) | Desktop (1280px) |
| ----- | -------------- | ---------------- |
| Twenty Twenty-Four | <img width="1568" height="1692" alt="50587-tt4-390" src="https://github.com/user-attachments/assets/c7f8df14-723d-4f19-bea3-94353e33f5d3" /> | <img width="2568" height="904" alt="50587-tt4-1280" src="https://github.com/user-attachments/assets/b43c884b-e123-40ec-b83e-2ff5d42748f9" /> |
| Twenty Twenty-Five | <img width="1568" height="1692" alt="50587-tt5-390" src="https://github.com/user-attachments/assets/818ad8a4-440f-4b68-98e4-cfe0f475a981" /> | <img width="2568" height="904" alt="50587-tt5-1280" src="https://github.com/user-attachments/assets/040783b9-d0af-407d-b400-6ddb4e04faa7" /> |

### How to test the changes in this Pull Request:

1. Activate a default block theme (Twenty Twenty-Four or Twenty Twenty-Five).
2. Place an order so you land on the Order Confirmation page, or open an existing order's received URL.
3. Narrow the viewport to around 390px.
4. Check the section headings — Order details, Shipping address, Billing address. They should read as headings, comfortably larger than the body text and table labels around them. Before this change they render smaller.
5. Widen to desktop and confirm the headings still read as headings. They now follow the theme's own `h2` size, so they will be larger than the previous fixed 24px.

### Testing that has already taken place:

Tested on wp-env against Twenty Twenty-Four and Twenty Twenty-Five at 390px and 1280px, comparing each against trunk.

Heading size versus body copy at 390px:

| Theme | Before | After | Body |
| ----- | ------ | ----- | ---- |
| Twenty Twenty-Four | 16.35px | 30.36px | 16.8px |
| Twenty Twenty-Five | 16.31px | 28.27px | 18.27px |

Worth flagging for review: on desktop in Twenty Twenty-Four these headings go from 24px to 40px, since that is the theme's own `h2` size. That is the intended consequence of handing sizing back to the theme, but it is a visible change and reviewers may want to weigh in.

Also worth knowing: themes that ship their own Order Confirmation template are unaffected, because they never use these patterns. Ollie is one, and its own pattern contains four copies of `font-size:24px` copied from ours — so this value has been propagating into third-party themes. Fixing the source stops that spreading further, though themes that already forked it will need their own fix.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)

### Use of AI Tools

Written with Claude Code, which diagnosed the cause, made the pattern change, and ran the browser checks. I walked through the flows, reviewed the result, and take responsibility for it.
