### PR TITLE
Remove stale changelog checkout note from troubleshooting guide

### DIFF
--- a/docs/contribution/releases/troubleshooting.md
+++ b/docs/contribution/releases/troubleshooting.md
@@ -24,10 +24,6 @@ This page provides guidance for troubleshooting and recovering from issues that 
 
 ⚠️ _Do not re-run any workflows until you understand the cause of the failure._ Re-running without fixing the root issue can make things more complicated.
 
-### The changelog workflow fails with "Your local changes would be overwritten"
-
-Backport the updated `tools/monorepo-utils/dist/index.js` from `trunk` to the release branch and re-run the workflow. This happens on the rare occasions that file (a committed build artifact) is updated on `trunk`, making the two branches diverge during the workflow's checkout.
-
 ### CI is failing on a release-related PR
 
 During the release process, you may encounter CI test failures on release-related PRs. These failures sometimes occur because test fixes were merged to trunk but not backported to the release branch before it was cut.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The troubleshooting guide has a note saying the changelog workflow can fail with "Your local changes would be overwritten" when `tools/monorepo-utils/dist/index.js` diverges between trunk and the release branch, with a backport workaround. That was true prior to #62077, which removed the in-place branch checkout in the workflow that caused it. The failure mode described no longer applies, so removing the stale note.

Closes #67383.

### How to test the changes in this Pull Request:

1. Read the updated `docs/contribution/releases/troubleshooting.md` and confirm the removed section is gone and the rest of the doc still reads correctly.

### Milestone

<!-- milestone-target-selection -->
- [X] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Docs-only change, not shipped to merchants.

</details>

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**