### PR TITLE
Move test hook-comment phpcs suppressions into the ruleset

### DIFF
--- a/plugins/woocommerce/changelog/dev-phpcs-test-hook-sniff-exclusions
+++ b/plugins/woocommerce/changelog/dev-phpcs-test-hook-sniff-exclusions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Exclude the hook comment and hyphenated hook name phpcs sniffs for tests and remove the redundant inline ignores.

--- a/plugins/woocommerce/phpcs.xml
+++ b/plugins/woocommerce/phpcs.xml
@@ -206,6 +206,18 @@
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
+	<!-- Hook comments document firing points for extension developers; tests fire hooks to
+	     exercise callbacks, they don't declare API surface. -->
+	<rule ref="WooCommerce.Commenting.CommentHooks">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<!-- Tests fire legacy hyphenated core hooks (e.g. woocommerce_settings-{page_id}) that
+	     can't be renamed. -->
+	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
 	<rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine">
 		<exclude-pattern>tests/e2e-tests/</exclude-pattern>
 	</rule>

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-rest-unit-test-case.php
@@ -111,7 +111,6 @@ class WC_Lazy_REST_Server extends WP_Test_Spy_REST_Server {
 			WC_Unit_Test_Case::with_rest_route_context(
 				$route,
 				static function () {
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					do_action( 'rest_api_init' );
 				}
 			);

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -223,7 +223,6 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 		}
 
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'rest_api_init' );
 		} finally {
 			if ( null === $rest_api_init_hook ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/account/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/account/functions.php
@@ -16,7 +16,6 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_lostpassword_url() {
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'login_form_login' ); // Simulate admin login screen.
 
 		// Admin URL is expected.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -730,7 +730,6 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Fire the personal-data eraser hook the analytics anonymizer is attached to.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks -- the test fires an existing core hook, it does not introduce one.
 		do_action( 'woocommerce_privacy_remove_order_personal_data', $order );
 
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/is-woo-express-rule-processor.php
@@ -27,7 +27,7 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_IsWooExpressRuleProcessor extend
 			 * Fake function wc_calypso_bridge_is_woo_express_plan so that we can test the processor.
 			 */
 			function wc_calypso_bridge_is_woo_express_plan() {
-				return apply_filters( 'test_wc_calypso_bridge_is_woo_express_plan', true ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				return apply_filters( 'test_wc_calypso_bridge_is_woo_express_plan', true );
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-reports-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-reports-test.php
@@ -22,7 +22,7 @@ final class WC_Admin_Reports_Test extends WC_Unit_Test_Case {
 
 		// Verify the purge-workflow.
 		set_transient( 'wc_admin_report', 'Verify deletion' );
-		do_action( 'woocommerce_delete_legacy_report_transients', 0, false ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'woocommerce_delete_legacy_report_transients', 0, false );
 		$this->assertFalse( get_transient( 'wc_admin_report' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -148,7 +148,6 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 	 */
 	public function test_integrates_akismet_excluded_comment_types(): void {
 		$this->assertTrue( has_filter( 'akismet_excluded_comment_types' ) );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertSame( array( 'order_note' ), apply_filters( 'akismet_excluded_comment_types', array() ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -18,7 +18,6 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 		// 10 is expected priority of the hook.
 		$this->assertEquals( 10, has_action( 'woocommerce_email_header', array( $email_object, 'email_header' ) ) );
 		ob_start();
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_email_header', 'header' );
 		$content = ob_get_contents();
 		ob_end_clean();
@@ -34,7 +33,6 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 		// 10 is expected priority of the hook.
 		$this->assertEquals( 10, has_action( 'woocommerce_email_footer', array( $email_object, 'email_footer' ) ) );
 		ob_start();
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_email_footer' );
 		$content = ob_get_contents();
 		ob_end_clean();

--- a/plugins/woocommerce/tests/php/includes/class-wc-importer-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-importer-tracking-test.php
@@ -47,7 +47,6 @@ class WC_Importer_Tracking_Test extends \WC_Unit_Test_Case {
 		$_REQUEST['step']     = 'done';
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'woocommerce-csv-importer' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'product_page_product_importer' );
 
 		$this->assertRecordedTracksEvent( 'wcadmin_product_import_complete' );
@@ -66,7 +65,6 @@ class WC_Importer_Tracking_Test extends \WC_Unit_Test_Case {
 		$_GET['products-failed']              = '1';
 		$_GET['products-skipped']             = '4';
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'product_page_product_importer' );
 
 		$events = $this->get_tracks_events( 'wcadmin_product_import_complete' );
@@ -85,7 +83,6 @@ class WC_Importer_Tracking_Test extends \WC_Unit_Test_Case {
 	public function test_import_complete_not_recorded_without_nonce() {
 		$_REQUEST['step'] = 'done';
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'product_page_product_importer' );
 
 		$this->assertNotRecordedTracksEvent( 'wcadmin_product_import_complete' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -47,7 +47,7 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		$this->current_screen_backup = $GLOBALS['current_screen'] ?? null;
 		$GLOBALS['current_screen']   = $this->get_screen_mock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		if ( ! did_action( 'current_screen' ) ) {
-			do_action( 'current_screen', $GLOBALS['current_screen'] ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'current_screen', $GLOBALS['current_screen'] );
 		}
 
 		$orders_tracking = new WC_Orders_Tracking();
@@ -93,7 +93,6 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		$order = wc_create_order();
 		$order->save();
 
-		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_order_status_changed', $order->get_id(), OrderStatus::PENDING, 'finished', $order );
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_edit_status_change' );
 		$this->assertTracksEventHasRequestTimestampAndNoCache( 'wcadmin_orders_edit_status_change' );
@@ -111,8 +110,6 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		$this->toggle_cot_authoritative( $hpos_enabled );
 		$this->setup_screen( 'list' );
 
-		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 		do_action( $hpos_enabled ? 'load-woocommerce_page_wc-orders' : 'load-edit.php' );
 
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_view' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
@@ -104,8 +104,6 @@ class WC_Products_Tracking_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_products_view(): void {
 		$_GET['post_type'] = 'product';
-		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'load-edit.php' );
 		$this->assertRecordedTracksEvent( 'wcadmin_products_view' );
 	}
@@ -116,7 +114,6 @@ class WC_Products_Tracking_Test extends \WC_Unit_Test_Case {
 	public function test_products_search(): void {
 		$_GET['post_type'] = 'product';
 		$_GET['s']         = 'test';
-		/* phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'load-edit.php' );
 		$this->assertRecordedTracksEvent( 'wcadmin_products_search' );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -37,7 +37,6 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 		$this->clear_scheduled_actions();
 
 		// Ensure recurring actions are scheduled.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'action_scheduler_ensure_recurring_actions' );
 
 		$this->assertTrue(
@@ -97,7 +96,6 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 			'Tracker send event wrapper should not be scheduled'
 		);
 		// Validate the wrapper is not scheduled when ensure_recurring_actions is called with tracking disabled.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'action_scheduler_ensure_recurring_actions' );
 		$this->assertFalse(
 			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-settings-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-settings-tracking-test.php
@@ -33,7 +33,6 @@ class WC_Settings_Tracking_Test extends \WC_Unit_Test_Case {
 	 * Test wcadmin_settings_view tracks event
 	 */
 	public function test_settings_view() {
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_settings_page_init' );
 		$this->assertRecordedTracksEvent( 'wcadmin_settings_view' );
 	}
@@ -41,11 +40,8 @@ class WC_Settings_Tracking_Test extends \WC_Unit_Test_Case {
 	 * Test wcadmin_settings_change tracks event
 	 */
 	public function test_settings_change() {
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_update_option', array( 'id' => 'some_option' ) );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'update_option', 'some_option', 'old_value', 'new_value' );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_update_options' );
 		$this->assertRecordedTracksEvent( 'wcadmin_settings_change' );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -198,9 +198,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 
 		try {
 			$this->assertTrue( is_admin(), 'New post editor load action should run in an admin context.' );
-			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment, WordPress.NamingConventions.ValidHookName.UseUnderscores
 			do_action( 'load-post-new.php' );
-			// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingHookComment, WordPress.NamingConventions.ValidHookName.UseUnderscores
 			$query_after_action = WC()->query;
 		} finally {
 			WC()->query                = $original_query;

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -1007,7 +1007,6 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		};
 		add_action( 'wc_product_start_scheduled_sale', $writer, 1, 1 );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'wc_product_start_scheduled_sale', $product->get_id() );
 
 		remove_action( 'wc_product_start_scheduled_sale', $writer, 1 );
@@ -1029,7 +1028,6 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		};
 		add_action( 'wc_product_end_scheduled_sale', $writer, 1, 1 );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'wc_product_end_scheduled_sale', $product->get_id() );
 
 		remove_action( 'wc_product_end_scheduled_sale', $writer, 1 );

--- a/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/ActivityPanelCountsTest.php
@@ -192,7 +192,6 @@ class ActivityPanelCountsTest extends WC_REST_Unit_Test_Case {
 	private function reregister_routes() {
 		$this->server              = new WP_REST_Server();
 		$GLOBALS['wp_rest_server'] = $this->server;
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Re-firing a core hook to re-register routes in the test, not defining one.
 		do_action( 'rest_api_init' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/PageControllerTest.php
@@ -80,7 +80,7 @@ class PageControllerTest extends WC_Unit_Test_Case {
 		$this->current_screen_backup = $GLOBALS['current_screen'] ?? null;
 		$GLOBALS['current_screen']   = $this->get_screen_mock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		if ( ! did_action( 'current_screen' ) ) {
-			do_action( 'current_screen', $GLOBALS['current_screen'] ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'current_screen', $GLOBALS['current_screen'] );
 		}
 
 		parent::setUp();

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockHooksTests.php
@@ -37,7 +37,6 @@ class BlockHooksTests extends WP_UnitTestCase {
 	public function test_mocked_block_gets_hooked_with_correct_version(): void {
 		new BlockHooksTestBlock();
 		update_option( self::$option_name, '8.4.0', false );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );
 		$this->assertContains(
 			'woocommerce/test-block',
@@ -53,7 +52,6 @@ class BlockHooksTests extends WP_UnitTestCase {
 	public function test_mocked_block_does_not_get_hooked(): void {
 		new BlockHooksNoVersionTestBlock();
 		delete_option( self::$option_name );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );
 		$this->assertNotContains(
 			'woocommerce/test-block',
@@ -68,7 +66,6 @@ class BlockHooksTests extends WP_UnitTestCase {
 	public function test_mocked_block_does_not_get_hooked_with_lower_version(): void {
 		new BlockHooksLowerVersionTestBlock();
 		update_option( self::$option_name, '8.3.0', false );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'after', 'core/navigation', array( 'mock-context' ) );
 		$this->assertNotContains(
 			'woocommerce/test-block',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
@@ -30,7 +30,6 @@ class Totals extends \WP_UnitTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'rest_api_init', $wp_rest_server );
 
 		wp_set_current_user( 0 );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductDetails/ProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductDetails/ProductDetails.php
@@ -212,11 +212,9 @@ class ProductDetails extends \WP_UnitTestCase {
 		// Next, we apply the `hooked_block_types` and `hooked_block_{$slug}` filters.
 		// We pretend that we're in the `last_child` position of the `woocommerce/accordion-group` block.
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', $accordion_group_name, null );
 		$this->assertSame( array( $test_block['slug'] ), $hooked_block_types );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_custom_info = apply_filters(
 			'hooked_block_' . $test_block['slug'],
 			array(

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/BootstrapTest.php
@@ -130,7 +130,6 @@ class BootstrapTest extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $this->registered_woo_blocks, 'The test bootstrap should have registered WooCommerce blocks to snapshot.' );
 		$this->assertFalse( $registry->is_registered( self::SAMPLE_BLOCK ), 'WooCommerce blocks should start unregistered for this test.' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', 'Intro <!-- wp:woocommerce/product-price /--> outro' );
 
 		$this->assertTrue(
@@ -164,7 +163,6 @@ class BootstrapTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $registry->is_registered( 'woocommerce/accordion-group' ), 'WooCommerce blocks should start unregistered for this test.' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', $markup );
 
 		$this->assertTrue(
@@ -183,7 +181,6 @@ class BootstrapTest extends WC_Unit_Test_Case {
 
 		// The referenced pattern's content cannot be inspected without fetching it, so a wp:block reference
 		// must register the block types in case the pattern contains a WooCommerce block at any depth.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', '<!-- wp:block {"ref":129} /-->' );
 
 		$this->assertTrue(
@@ -201,7 +198,6 @@ class BootstrapTest extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $this->registered_woo_blocks, 'The test bootstrap should have registered WooCommerce blocks to snapshot.' );
 		$this->assertFalse( $registry->is_registered( self::SAMPLE_BLOCK ), 'WooCommerce blocks should start unregistered for this test.' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', 'Just plain text with no blocks, or only a core <!-- wp:paragraph -->.' );
 
 		$this->assertFalse(
@@ -211,7 +207,6 @@ class BootstrapTest extends WC_Unit_Test_Case {
 
 		// Without whitespace after the comment opener this is not a block per the parser grammar (`<!--\s+wp:`),
 		// so do_blocks would leave it untouched and registration would be wasted.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', '<!--wp:woocommerce/product-price /-->' );
 
 		$this->assertFalse(
@@ -340,7 +335,6 @@ HTML;
 
 		// Firing the filter must not call register_blocks() again — doing so would re-register already-registered
 		// block types and trigger a doing_it_wrong failure, which WC_Unit_Test_Case turns into a test failure.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing an existing core filter to exercise its callbacks, not declaring a new hook.
 		apply_filters( 'woocommerce_short_description', 'Intro <!-- wp:woocommerce/product-price /--> outro' );
 
 		$this->assertTrue(

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -16,7 +16,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
  * AdditionalFields Controller Tests.
  *
  *
- * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r, WooCommerce.Commenting.CommentHooks.MissingHookComment
+ * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
  */
 class AdditionalFields extends \WP_Test_REST_TestCase {
 	use MockeryPHPUnitIntegration;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -24,7 +24,7 @@ use WC_Gateway_BACS;
 /**
  * Checkout Controller Tests.
  *
- * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r, WooCommerce.Commenting.CommentHooks.MissingHookComment
+ * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
  */
 class Checkout extends \WP_Test_REST_TestCase {
 	use MockeryPHPUnitIntegration;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/StoreApiRestTestCaseTrait.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/StoreApiRestTestCaseTrait.php
@@ -71,7 +71,6 @@ trait StoreApiRestTestCaseTrait {
 		\WC_Unit_Test_Case::with_rest_route_context(
 			'/wc/store/v1',
 			static function () use ( $wp_rest_server ) {
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				do_action( 'rest_api_init', $wp_rest_server );
 			}
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/AbilitiesLoaderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/AbilitiesLoaderTest.php
@@ -474,7 +474,7 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		add_action( 'wp_abilities_api_init', array( AbilitiesLoader::class, 'register_abilities' ), 10 );
 
 		try {
-			do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+			do_action( 'wp_abilities_api_init' );
 		} finally {
 			remove_filter( 'woocommerce_logging_class', $logger_filter );
 			remove_action( 'wp_abilities_api_init', $shadow_callback, 5 );
@@ -569,7 +569,7 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_categories_init', $callback );
-		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Exercise category registration on its required lifecycle hook.
+		do_action( 'wp_abilities_api_categories_init' );
 		remove_action( 'wp_abilities_api_categories_init', $callback );
 
 		$this->assertTrue( wp_has_ability_category( 'woocommerce' ) );
@@ -2233,7 +2233,7 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_categories_init', $callback );
-		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_categories_init' );
 		remove_action( 'wp_abilities_api_categories_init', $callback );
 
 		$this->registered_category_ids[] = 'woocommerce';
@@ -2246,7 +2246,7 @@ class AbilitiesLoaderTest extends \WC_Unit_Test_Case {
 		$callback = array( AbilitiesLoader::class, 'register_abilities' );
 
 		add_action( 'wp_abilities_api_init', $callback );
-		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_init' );
 		remove_action( 'wp_abilities_api_init', $callback );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Abilities/REST/RestAbilityFactoryTest.php
@@ -162,7 +162,7 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_categories_init', $callback );
-		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_categories_init' );
 		remove_action( 'wp_abilities_api_categories_init', $callback );
 
 		if ( null !== $category ) {
@@ -271,7 +271,7 @@ class RestAbilityFactoryTest extends WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_init', $callback );
-		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_init' );
 		remove_action( 'wp_abilities_api_init', $callback );
 
 		$ability = wp_get_ability( $ability_id );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Agentic/AgenticWebhookManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Agentic/AgenticWebhookManagerTest.php
@@ -311,7 +311,6 @@ class AgenticWebhookManagerTest extends \WC_Unit_Test_Case {
 				'body'    => $test['payload'],
 			);
 
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			$modified_args = apply_filters(
 				'woocommerce_webhook_http_args',
 				$args,
@@ -346,7 +345,6 @@ class AgenticWebhookManagerTest extends \WC_Unit_Test_Case {
 			'body'    => '{"test":"data"}',
 		);
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$modified_args = apply_filters(
 			'woocommerce_webhook_http_args',
 			$args,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/EditLockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/EditLockTest.php
@@ -128,7 +128,7 @@ class EditLockTest extends \WC_Unit_Test_Case {
 		$this->sut->lock( $this->order );
 
 		// Simulate a heartbeat, which for user 1 should result in a renewed lock.
-		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' );
 		$this->assertArrayHasKey( 'wc-refresh-order-lock', $response );
 		$this->assertArrayHasKey( 'lock', $response['wc-refresh-order-lock'] );
 
@@ -141,7 +141,7 @@ class EditLockTest extends \WC_Unit_Test_Case {
 
 		// user1 now gets the "taken over" message when the heartbeat attempts to renew the lock.
 		wp_set_current_user( $this->user1 );
-		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' );
 		$this->assertArrayHasKey( 'wc-refresh-order-lock', $response );
 		$this->assertArrayHasKey( 'error', $response['wc-refresh-order-lock'] );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TaxSettingsRecommendationsTest.php
@@ -28,7 +28,6 @@ class TaxSettingsRecommendationsTest extends WC_Unit_Test_Case {
 		$this->sut->init();
 
 		// Routes must register on rest_api_init; firing it runs init()'s callback.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'rest_api_init' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -172,7 +172,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 		$this->sut->enqueue_processor( get_class( $second_processor ) );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
@@ -196,7 +195,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	public function test_remove_processor_when_no_others_remain_enqueued() {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
@@ -561,7 +559,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
@@ -582,7 +579,7 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 			}
 		);
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
-		do_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->test_process ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->test_process ) );
 
 		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
 		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
@@ -609,7 +606,7 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 			}
 		);
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
-		do_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->test_process ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->test_process ) );
 
 		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
 		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
@@ -624,7 +621,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 		$this->sut->enqueue_processor( get_class( $second_processor ) );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
@@ -655,7 +651,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 			false
 		);
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_scheduled( 'Processor\\A' ), 'A valid processor should be scheduled by the watchdog.' );
@@ -685,7 +680,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 	public function test_remove_processor_sweeps_ghost_actions_when_queue_empties(): void {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		// A leftover single-batch action for a processor that is no longer enqueued, e.g. from the historical corruption bug.
@@ -729,7 +723,6 @@ class BatchProcessingControllerTests extends \WC_Unit_Test_Case {
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 		$this->sut->enqueue_processor( get_class( $second_processor ) );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( $this->sut::WATCHDOG_ACTION_NAME );
 
 		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/OrdersVersionStringInvalidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/OrdersVersionStringInvalidatorTest.php
@@ -372,7 +372,6 @@ class OrdersVersionStringInvalidatorTest extends WC_Unit_Test_Case {
 		$this->assertNotNull( $order_refunds_version_before, 'Order refunds list version string should exist before deletion' );
 
 		$refund->delete( true );
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test code.
 		do_action( 'woocommerce_refund_deleted', $refund_id, $order_id );
 
 		$order_version_after         = $this->version_generator->get_version( "order_{$order_id}", false );

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/ProductVersionStringInvalidatorTest.php
@@ -415,7 +415,6 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before stock update' );
 
 		// Trigger stock update hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_updated_product_stock', $product_id );
 
 		$version_after = $this->version_generator->get_version( "product_{$product_id}", false );
@@ -436,7 +435,6 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before price update' );
 
 		// Trigger price update hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_updated_product_price', $product_id );
 
 		$version_after = $this->version_generator->get_version( "product_{$product_id}", false );
@@ -457,7 +455,6 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before sales update' );
 
 		// Trigger sales update hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_updated_product_sales', $product_id );
 
 		$version_after = $this->version_generator->get_version( "product_{$product_id}", false );
@@ -503,7 +500,6 @@ class ProductVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before attribute term update' );
 
 		// Trigger edited_term hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'edited_term', $red_term['term_id'], $red_term['term_taxonomy_id'], 'pa_test_color' );
 
 		$version_after = $this->version_generator->get_version( "product_{$product->get_id()}", false );

--- a/plugins/woocommerce/tests/php/src/Internal/Caches/TaxRateVersionStringInvalidatorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Caches/TaxRateVersionStringInvalidatorTest.php
@@ -150,7 +150,6 @@ class TaxRateVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before hook fires' );
 
 		// Trigger the hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_tax_rate_added', $tax_rate_id );
 
 		$version_after = $this->version_generator->get_version( "tax_rate_{$tax_rate_id}", false );
@@ -170,7 +169,6 @@ class TaxRateVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before update' );
 
 		// Trigger the hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_tax_rate_updated', $tax_rate_id );
 
 		$version_after = $this->version_generator->get_version( "tax_rate_{$tax_rate_id}", false );
@@ -190,7 +188,6 @@ class TaxRateVersionStringInvalidatorTest extends \WC_Unit_Test_Case {
 		$this->assertNotNull( $version_before, 'Version string should exist before deletion' );
 
 		// Trigger the hook.
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_tax_rate_deleted', $tax_rate_id );
 
 		$version_after = $this->version_generator->get_version( "tax_rate_{$tax_rate_id}", false );

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/ImplicitVerificationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/ImplicitVerificationTest.php
@@ -42,7 +42,6 @@ class ImplicitVerificationTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->sut->is_verified( $user_id ), 'New customers should not be verified by default' );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Firing a core WordPress hook to exercise the listener, not defining a new hook.
 		do_action( 'after_password_reset', $user, 'newpassword123' );
 
 		$this->assertTrue( $this->sut->is_verified( $user_id ), 'Customer should be verified after a password reset' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -637,7 +637,7 @@ class DataSynchronizerTests extends \HposTestCase {
 		$order3->save();
 
 		// Run WP's auto-draft delete.
-		do_action( 'wp_scheduled_auto_draft_delete' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		do_action( 'wp_scheduled_auto_draft_delete' );
 
 		$orders = wc_get_orders(
 			array(
@@ -673,7 +673,7 @@ class DataSynchronizerTests extends \HposTestCase {
 		$order->save();
 
 		// Run scheduled deletion.
-		do_action( 'wp_scheduled_delete' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		do_action( 'wp_scheduled_delete' );
 
 		// Refresh order and ensure it's *not* gone.
 		$order = wc_get_order( $order->get_id() );
@@ -689,7 +689,7 @@ class DataSynchronizerTests extends \HposTestCase {
 		);
 
 		// Run scheduled deletion.
-		do_action( 'wp_scheduled_delete' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		do_action( 'wp_scheduled_delete' );
 
 		// Ensure the placeholder post is gone.
 		$placeholder = get_post( $order->get_id() );
@@ -750,7 +750,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		$this->disable_cot_sync();
 		OrderHelper::create_order();
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$features = apply_filters( 'woocommerce_get_settings_advanced', array(), 'features' );
 
 		$cot_setting = array_filter(
@@ -822,7 +821,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		wc_get_container()->get( BatchProcessingController::class )->remove_processor( DataSynchronizer::class );
 		$this->assertFalse( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK );
 		$this->assertFalse( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 
@@ -830,7 +828,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		$this->direct_delete_cot_order( $cot_order->get_id() );
 		$this->assertEquals( 1, $this->sut->get_total_pending_count() );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK );
 		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 
@@ -858,7 +855,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		update_option( $this->sut::BACKGROUND_SYNC_MODE_OPTION, $this->sut::BACKGROUND_SYNC_MODE_INTERVAL );
 		$this->assertTrue( as_has_scheduled_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK ) );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK );
 		$this->assertFalse( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 
@@ -868,7 +864,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		$this->direct_delete_cot_order( $cot_order->get_id() );
 		$this->assertEquals( 1, $this->sut->get_total_pending_count() );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK );
 		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 
@@ -899,7 +894,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 		$this->assertFalse( as_has_scheduled_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK ) );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( wc_get_container()->get( BatchProcessingController::class )::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->sut ) );
 		$this->assertFalse( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 		$handler_method->invoke( $this->sut );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataCleanupTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/LegacyDataCleanupTests.php
@@ -101,7 +101,7 @@ class LegacyDataCleanupTests extends \WC_Unit_Test_Case {
 		$this->assertNotEquals( 0, $this->sut->get_total_pending_count() );
 
 		// Let the batch processing controller process the rest and confirm.
-		do_action( $batch_processing::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->sut ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle -- this is a test
+		do_action( $batch_processing::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->sut ) );
 		$this->assertEquals( 0, $this->sut->get_total_pending_count() );
 		$this->assertFalse( $batch_processing->is_enqueued( get_class( $this->sut ) ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/DeferredEmailQueueTest.php
@@ -193,7 +193,6 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 
 		$this->set_wc_emails_deferred_queue( $this->sut );
 
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.MissingSinceComment -- Test-only hooks.
 		add_action( 'woocommerce_deferred_email_test_unknown_object', array( \WC_Emails::class, 'queue_transactional_email' ) );
 		add_action(
 			'woocommerce_deferred_email_test_unknown_object_notification',
@@ -203,7 +202,6 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		);
 
 		do_action( 'woocommerce_deferred_email_test_unknown_object', $object );
-		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		$this->sut->dispatch();
 
@@ -222,7 +220,6 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 
 		$this->set_wc_emails_deferred_queue( $this->sut );
 
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.MissingSinceComment -- Test-only hooks.
 		add_action( 'woocommerce_deferred_email_test_unsaved_product', array( \WC_Emails::class, 'queue_transactional_email' ) );
 		add_action(
 			'woocommerce_deferred_email_test_unsaved_product_notification',
@@ -232,7 +229,6 @@ class DeferredEmailQueueTest extends WC_Unit_Test_Case {
 		);
 
 		do_action( 'woocommerce_deferred_email_test_unsaved_product', $product );
-		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		$this->sut->dispatch();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -529,7 +529,6 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected, $result );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'deactivated_plugin', 'the_plugin' );
 		$this->fake_plugin_util->set_active_plugins( array( 'the_plugin_2', 'the_plugin_3', 'the_plugin_4' ) );
 
@@ -984,11 +983,9 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected, $result );
 
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'deactivated_plugin', 'the_plugin_2' );
 		do_action( 'deactivated_plugin', 'the_plugin_4' );
 		do_action( 'deactivated_plugin', 'the_plugin_6' );
-		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		$this->fake_plugin_util->set_active_plugins( array( 'the_plugin', 'the_plugin_3', 'the_plugin_5' ) );
 		$result             = $this->sut->get_compatible_plugins_for_feature( 'mature1', $active_only );
@@ -1455,7 +1452,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Simulate deactivation: set flag (for mock callback) and trigger action (to unset compatibility).
 		$deactivated = true;
-		do_action( 'deactivated_plugin', 'plugin/plugin.php' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'deactivated_plugin', 'plugin/plugin.php' );
 
 		// Check after: compatibility unset, so moves to 'uncertain' (still in aware list when ! active_only).
 		$compat_after = $this->sut->get_compatible_plugins_for_feature( 'mature1' );

--- a/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/MCP/MCPAdapterProviderTest.php
@@ -475,7 +475,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_init', $callback );
-		do_action( 'wp_abilities_api_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_init' );
 		remove_action( 'wp_abilities_api_init', $callback );
 
 		$this->assertNotWPError( $ability, 'Test ability should register successfully.' );
@@ -517,7 +517,7 @@ class MCPAdapterProviderTest extends \WC_Unit_Test_Case {
 		};
 
 		add_action( 'wp_abilities_api_categories_init', $callback );
-		do_action( 'wp_abilities_api_categories_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Test bootstrap for Abilities API registration.
+		do_action( 'wp_abilities_api_categories_init' );
 		remove_action( 'wp_abilities_api_categories_init', $callback );
 
 		if ( null !== $category ) {

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SchedulerTest.php
@@ -134,7 +134,6 @@ class SchedulerTest extends WC_Unit_Test_Case {
 		$order->update_status( 'completed' );
 		$first = (int) wc_get_order( $order->get_id() )->get_meta( Scheduler::SCHEDULED_META_KEY );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Existing core hook, fired here only to simulate a second completed-notification (e.g. status toggled back and forth).
 		do_action( 'woocommerce_order_status_completed', $order->get_id() );
 		$second = (int) wc_get_order( $order->get_id() )->get_meta( Scheduler::SCHEDULED_META_KEY );
 

--- a/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerRoutingTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/OrderReviews/SubmissionHandlerRoutingTest.php
@@ -120,7 +120,7 @@ class SubmissionHandlerRoutingTest extends WC_Unit_Test_Case {
 
 		ob_start();
 		try {
-			do_action( 'wp_ajax_nopriv_' . SubmissionHandler::ACTION ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'wp_ajax_nopriv_' . SubmissionHandler::ACTION );
 		} catch ( WPAjaxDieContinueException $e ) {
 			// Expected: wp_send_json_* always calls wp_die().
 			unset( $e );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -196,7 +196,6 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_attribute_lookup_processed_count', 7 );
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( array( 1, 2, 3 ), $this->lookup_data_store->passed_products );
@@ -254,7 +253,6 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		remove_all_filters( ' woocommerce_attribute_lookup_regeneration_step_size' );
@@ -288,7 +286,6 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
@@ -315,7 +312,6 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 			update_option( 'woocommerce_attribute_lookup_enabled', $previous_option_value );
 		}
 
-		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_installed' );
 
 		$actual_final_option_value = get_option( 'woocommerce_attribute_lookup_enabled' );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -434,11 +434,9 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		switch ( $deletion_mechanism ) {
 			case 'wp_trash_post':
-                // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				do_action( 'wp_trash_post', $product );
 				break;
 			case 'delete_post':
-                // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				do_action( 'delete_post', $product->get_id() );
 				break;
 			case 'delete_method_in_product':

--- a/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/PushNotifications/Controllers/NotificationPreferencesRestControllerTest.php
@@ -577,7 +577,6 @@ class NotificationPreferencesRestControllerTest extends WC_Unit_Test_Case {
 		$preferences_controller->register();
 		$push_token_controller->register();
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- Triggering an existing filter from RestApiControllerBase, not defining one.
 		$namespaces = apply_filters( 'woocommerce_rest_api_get_rest_namespaces', array( 'wc/v3' => array() ) );
 
 		$this->assertArrayHasKey( 'wc/v3', $namespaces );

--- a/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/TransientFiles/TransientFilesEngineTest.php
@@ -746,7 +746,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		);
 
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'woocommerce_expired_transient_files_cleanup' );
 		} finally {
 			remove_all_filters( 'woocommerce_expired_transient_files_cleanup' );
@@ -776,7 +775,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		add_filter( 'woocommerce_delete_expired_transient_files_interval', fn( $interval ) => HOUR_IN_SECONDS );
 
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'woocommerce_expired_transient_files_cleanup' );
 		} finally {
 			remove_all_filters( 'woocommerce_expired_transient_files_cleanup' );
@@ -819,7 +817,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		$today = '2023-12-03';
 
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'woocommerce_expired_transient_files_cleanup' );
 		} finally {
 			remove_all_filters( 'woocommerce_expired_transient_files_cleanup' );
@@ -893,7 +890,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		$_GET['wc-transient-file-name'] = $file_name;
 		$_SERVER['REQUEST_METHOD']      = 'GET';
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'parse_request' );
 		} catch ( \LogicException $ex ) {
 			$response_body = ob_get_clean();
@@ -946,7 +942,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		$_GET['wc-transient-file-name'] = 'NOT_EXISTING';
 		$_SERVER['REQUEST_METHOD']      = 'GET';
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'parse_request' );
 		} catch ( \LogicException $ex ) {
 			$response_body = ob_get_clean();
@@ -1001,7 +996,6 @@ class TransientFilesEngineTest extends \WC_REST_Unit_Test_Case {
 		$_GET['wc-transient-file-name'] = $file_name;
 		$_SERVER['REQUEST_METHOD']      = 'GET';
 		try {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'parse_request' );
 		} catch ( \LogicException $ex ) {
 			$response_body = ob_get_clean();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `WooCommerce.Commenting.CommentHooks` sniff requires a doc comment on every `do_action`/`apply_filters` call site. That documents hooks for extension developers, but tests fire hooks to exercise callbacks, so about 110 inline `phpcs:ignore` suppressions had accumulated across the test suite.

- Exclude `WooCommerce.Commenting.CommentHooks` for `tests/` in `phpcs.xml`, matching the existing test exclusions for `Generic.Commenting` and `Squiz.Commenting`.
- Exclude `WordPress.NamingConventions.ValidHookName.UseUnderscores` for `tests/` as well, since tests fire legacy hyphenated core hooks (`woocommerce_settings-{page_id}`) that can't be renamed.
- Delete the redundant inline ignores across 45 test files.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run `./vendor/bin/phpcs tests/php/includes/class-wc-settings-tracking-test.php` and confirm there are no `CommentHooks` or `ValidHookName` findings.
2. Run `grep -rn "CommentHooks\|ValidHookName.UseUnderscores" tests/` and confirm nothing remains outside `tests/Tools/`, which holds the sniff infrastructure itself.
3. Add an uncommented `do_action( 'some_test_hook' );` to a test file and run phpcs on it: no finding. Add the same line to a file in `src/`: `MissingHookComment` is still reported, so the exclusion only covers tests.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Full phpcs over all 45 swept files: 43 are clean, and the two with findings report a set identical to trunk (pre-existing violations on unchanged lines).
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passes.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Developed with Claude Code. I directed the approach and reviewed the changes.
