### PR TITLE
Stop a shopper being blocked by their own stale stock reservation

### DIFF
--- a/plugins/woocommerce/changelog/fix-67354-own-reserved-stock-grace-window
+++ b/plugins/woocommerce/changelog/fix-67354-own-reserved-stock-grace-window
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Stop a shopper being blocked by their own abandoned stock reservation. A hold placed by the same shopper is discounted once it is older than a grace window, filterable via woocommerce_own_reserved_stock_grace_minutes and defaulting to 10 minutes. Holds belonging to other shoppers are unaffected.
+Stop a shopper being blocked by their own abandoned stock reservation. A hold placed by the same shopper is excluded once it is older than a threshold, filterable via woocommerce_own_stock_hold_exclusion_threshold_minutes and defaulting to 10 minutes. Holds belonging to other shoppers are unaffected.

--- a/plugins/woocommerce/changelog/fix-67354-own-reserved-stock-grace-window
+++ b/plugins/woocommerce/changelog/fix-67354-own-reserved-stock-grace-window
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Stop a shopper being blocked by their own abandoned stock reservation. A hold placed by the same shopper is discounted once it is older than a grace window, filterable via woocommerce_own_reserved_stock_grace_minutes and defaulting to 10 minutes. Holds belonging to other shoppers are unaffected.

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -27,8 +27,11 @@ final class ReserveStock {
 	private const OWN_ORDERS_SESSION_KEY = 'stock_holding_orders';
 
 	/**
-	 * Most of the current shopper's own orders to consider when discounting their
-	 * own stale holds. Keeps the generated IN clause bounded.
+	 * Upper bound on own orders considered when excluding a shopper's stale holds.
+	 *
+	 * Keeps the generated IN clause bounded. A shopper who exceeds it loses the
+	 * oldest ids from the list, and those holds simply block again until they
+	 * expire — the failure direction is blocking, never overselling.
 	 */
 	private const MAX_OWN_ORDERS = 10;
 
@@ -40,15 +43,14 @@ final class ReserveStock {
 	private $enabled = true;
 
 	/**
-	 * Request scoped memo of a signed in customer's unpaid order ids.
+	 * Request scoped memo of a signed in customer's potential stock-holding order ids.
 	 *
 	 * A new ReserveStock is constructed for each wc_get_held_stock_quantity()
-	 * call, and the cart makes one per stock managed item, so the memo cannot
-	 * live on the instance.
+	 * call, so the memo cannot live on the instance.
 	 *
 	 * @var array<int, int[]>
 	 */
-	private static $unpaid_order_ids_by_customer = array();
+	private static $potential_order_ids_by_customer = array();
 
 	/**
 	 * Constructor
@@ -321,7 +323,7 @@ final class ReserveStock {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		$query .= $this->get_clause_to_discount_stale_own_holds( $exclude_order_id );
+		$query .= $this->get_stale_own_holds_exclusion_clause( $product_id, $exclude_order_id );
 
 		/**
 		 * Filter: woocommerce_query_for_reserved_stock
@@ -336,42 +338,38 @@ final class ReserveStock {
 	}
 
 	/**
-	 * Returns a clause discounting holds the current shopper placed themselves and
-	 * then left unpaid for longer than a grace window.
+	 * Builds a SQL clause excluding the current shopper's stale stock holds.
 	 *
-	 * Only one order is excluded by $exclude_order_id, so a shopper who abandons a
-	 * checkout and starts another is blocked by their own earlier hold for the
-	 * whole of woocommerce_hold_stock_minutes, which stores accepting slow payment
-	 * methods set to days. Inside the window their hold still counts, so a genuine
-	 * in flight payment is protected across a bank app switch or a one time code.
-	 * Past it, that shopper stops being blocked by their own abandoned attempt.
-	 * Holds belonging to anybody else are unaffected either way.
-	 *
+	 * @param int $product_id       Product whose reserved stock is being counted.
 	 * @param int $exclude_order_id Order already excluded by the caller.
-	 * @return string Clause to append, or an empty string when nothing qualifies.
+	 * @return string SQL clause, or an empty string when no holds qualify.
 	 */
-	private function get_clause_to_discount_stale_own_holds( $exclude_order_id ): string {
+	private function get_stale_own_holds_exclusion_clause( $product_id, $exclude_order_id ): string {
 		global $wpdb;
 
 		/**
-		 * Filters how long a shopper's own unpaid hold keeps blocking that same shopper.
+		 * Filters how many minutes must pass before a shopper's own unpaid stock hold
+		 * stops blocking that same shopper.
 		 *
-		 * The hold is only ever discounted for the shopper who placed it, and only
-		 * once it is older than this. Return 0 to keep such holds blocking for the
-		 * full reservation window, which is how WooCommerce behaved before this
-		 * filter existed.
+		 * Only the shopper who placed the hold is affected. Return 0 to exclude own
+		 * holds immediately, or false to disable the exclusion and keep own holds
+		 * blocking for the full reservation window.
 		 *
 		 * @since 11.2.0
 		 *
-		 * @param int $minutes Grace window in minutes.
+		 * @param int|false $threshold_minutes Threshold in minutes, or false to disable.
+		 * @param int       $product_id        Product whose reserved stock is being counted.
+		 * @param int       $exclude_order_id  Order already excluded by the caller.
 		 */
-		$grace_minutes = (int) apply_filters( 'woocommerce_own_reserved_stock_grace_minutes', 10 );
+		$threshold_minutes = apply_filters( 'woocommerce_own_stock_hold_exclusion_threshold_minutes', 10, $product_id, $exclude_order_id );
 
-		if ( $grace_minutes < 1 ) {
+		if ( false === $threshold_minutes ) {
 			return '';
 		}
 
-		$order_ids = array_values( array_diff( $this->get_current_shopper_order_ids(), array( absint( $exclude_order_id ) ) ) );
+		$threshold_minutes = max( 0, (int) $threshold_minutes );
+
+		$order_ids = array_values( array_diff( $this->get_current_shopper_stock_holding_order_ids(), array( absint( $exclude_order_id ) ) ) );
 
 		if ( empty( $order_ids ) ) {
 			return '';
@@ -379,10 +377,9 @@ final class ReserveStock {
 
 		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
 
-		// The `timestamp` column records when the hold was first placed and is not
-		// touched by the ON DUPLICATE KEY UPDATE in reserve_stock_for_product(), so
-		// it measures the age of the shopper's attempt rather than of the last write.
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// The `timestamp` column records when the hold was first placed, so it
+		// measures the age of the shopper's attempt rather than of the last write.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- The interpolated value contains only generated %d placeholders.
 		return $wpdb->prepare(
 			"
 			AND NOT (
@@ -390,120 +387,88 @@ final class ReserveStock {
 				AND stock_table.`timestamp` < ( NOW() - INTERVAL %d MINUTE )
 			)
 			",
-			array_merge( $order_ids, array( $grace_minutes ) )
+			array_merge( $order_ids, array( $threshold_minutes ) )
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
-	 * Returns order ids that demonstrably belong to the shopper making this request.
+	 * Returns stock-holding order ids associated with the current shopper.
 	 *
-	 * Two sources. The list this class records as it takes holds, which is bound to
-	 * the session that recorded it, and the account when the shopper is signed in.
-	 * Ownership is never taken from anything a shopper can type: an unauthenticated
-	 * field such as the billing email would let one shopper claim another's in
-	 * flight hold, which is the oversell the grace window exists to bound.
-	 *
-	 * order_awaiting_payment and store_api_draft_order are deliberately NOT read
-	 * here. Session contents are not by themselves a proof of identity, because
-	 * core hands them to a different shopper in two places: clone_session_data()
-	 * copies everything except `customer` into a freshly minted session when a cart
-	 * token is presented, and migrate_guest_session_to_user_session() moves a guest
-	 * session wholesale onto whichever account next signs in on that browser. Those
-	 * two keys carry no record of who wrote them, so they cannot be checked. They
-	 * also add nothing: an order can only hold stock by passing through
-	 * reserve_stock_for_order(), which is where the bound list is written.
-	 *
-	 * This runs inside get_query_for_reserved_stock(), which wc_get_held_stock_quantity()
-	 * also reaches from the admin, WP-CLI and cron. There is no shopper in those
-	 * contexts and WC()->session is not initialised, so there is no ownership and
-	 * the query is returned unchanged.
+	 * Includes orders recorded by the current session and unpaid orders belonging
+	 * to the signed-in customer. Ownership is never inferred from anything a
+	 * shopper can type, such as the billing email.
 	 *
 	 * @return int[]
 	 */
-	private function get_current_shopper_order_ids(): array {
-		$session = $this->get_shopper_session();
+	private function get_current_shopper_stock_holding_order_ids(): array {
+		$session = WC()->session;
 
+		// In the admin, WP-CLI and cron there is no shopper and WC()->session is
+		// not initialised, so nothing is ever treated as the requester's own hold.
 		if ( ! $session instanceof \WC_Session ) {
 			return array();
 		}
 
-		$order_ids = $this->get_remembered_order_ids( $session );
+		$order_ids = $this->get_session_stock_holding_order_ids( $session );
 
 		$customer_id = get_current_user_id();
 
 		if ( $customer_id ) {
-			$order_ids = array_merge( $order_ids, $this->get_unpaid_order_ids_for_customer( $customer_id ) );
+			$order_ids = array_merge( $order_ids, $this->get_potential_stock_holding_order_ids_for_customer( $customer_id ) );
 		}
 
 		return array_values( array_filter( array_unique( $order_ids ) ) );
 	}
 
 	/**
-	 * Returns the recorded order ids, but only if this is still the session that
-	 * recorded them.
+	 * Returns the stock-holding order ids recorded against the current session.
 	 *
-	 * The customer id is stamped alongside the ids when they are written, and both
-	 * of the ways core moves session data between shoppers change it first:
-	 * init_session_from_request() mints a new customer id before cloning, and
-	 * migrate_guest_session_to_user_session() swaps the guest id for the account id.
-	 * A mismatch therefore means the data arrived from somebody else's session, and
-	 * the list is ignored rather than trusted.
+	 * The list is only trusted if it was written under this session's customer id.
 	 *
 	 * @param \WC_Session $session Session of the shopper making this request.
 	 * @return int[]
 	 */
-	private function get_remembered_order_ids( \WC_Session $session ): array {
+	private function get_session_stock_holding_order_ids( \WC_Session $session ): array {
 		$remembered = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
 
-		if ( ! is_array( $remembered ) || ! isset( $remembered['customer'], $remembered['order_ids'] ) || ! is_array( $remembered['order_ids'] ) ) {
+		if ( ! is_array( $remembered ) ) {
 			return array();
 		}
 
+		if ( ! isset( $remembered['customer'], $remembered['order_ids'] ) || ! is_array( $remembered['order_ids'] ) ) {
+			return array();
+		}
+
+		// Core hands session data to a different shopper in two places (cart token
+		// cloning and guest-to-user migration), and both change the session
+		// customer id first. A mismatch means the list arrived from somebody
+		// else's session, so it confers no ownership.
 		if ( (string) $remembered['customer'] !== (string) $session->get_customer_id() ) {
 			return array();
 		}
 
-		return array_map( 'absint', $remembered['order_ids'] );
+		return array_slice( array_map( 'absint', $remembered['order_ids'] ), 0, self::MAX_OWN_ORDERS );
 	}
 
 	/**
-	 * Returns the session of the shopper making this request, if there is one.
+	 * Records a stock-holding order against the current customer session.
 	 *
-	 * @return \WC_Session|null
-	 */
-	private function get_shopper_session() {
-		$session = function_exists( 'WC' ) && WC() ? WC()->session : null;
-
-		return $session instanceof \WC_Session ? $session : null;
-	}
-
-	/**
-	 * Records an order against the shopper's session so that a later request can
-	 * still recognise the hold as theirs.
-	 *
-	 * Neither existing pointer survives an abandoned attempt. The Store API
-	 * repoints store_api_draft_order at a new draft as soon as the previous one
-	 * leaves checkout-draft, and order_awaiting_payment is only ever written by the
-	 * classic checkout. This list keeps the ids for the life of the session.
-	 *
-	 * The session's customer id is stamped alongside them so that the list can be
+	 * The session's customer id is stamped alongside the ids so the list can be
 	 * discarded if it later turns up in somebody else's session. See
-	 * get_remembered_order_ids().
-	 *
-	 * Skipped entirely where there is no session, which is how an order created in
-	 * the admin or over WP-CLI leaves nothing behind.
+	 * get_session_stock_holding_order_ids().
 	 *
 	 * @param \WC_Order $order Order that now holds stock.
 	 */
-	private function remember_order_for_shopper( $order ): void {
-		$session = $this->get_shopper_session();
+	private function remember_order_for_shopper( \WC_Order $order ): void {
+		$session = WC()->session;
 
+		// An order created in the admin or over WP-CLI has no session to record against.
 		if ( ! $session instanceof \WC_Session ) {
 			return;
 		}
 
-		$order_ids = $this->get_remembered_order_ids( $session );
+		$order_ids = $this->get_session_stock_holding_order_ids( $session );
 
 		array_unshift( $order_ids, $order->get_id() );
 
@@ -519,29 +484,21 @@ final class ReserveStock {
 	}
 
 	/**
-	 * Returns unpaid order ids belonging to a signed in customer, newest first.
+	 * Returns order ids of a signed-in customer that could be holding stock, newest first.
 	 *
-	 * Session pointers are lost when the shopper switches device, clears cookies or
-	 * lets the session lapse, which is when they come back and meet their own hold.
-	 * The account covers that case for shoppers who are signed in.
-	 *
-	 * The statuses match the ones the reserved stock query counts, so an order that
-	 * cannot be holding stock is never fetched.
+	 * Covers a shopper whose session pointers were lost (new device, cleared
+	 * cookies, lapsed session). The statuses match the ones the reserved stock
+	 * query counts.
 	 *
 	 * @param int $customer_id Customer ID.
 	 * @return int[]
 	 */
-	private function get_unpaid_order_ids_for_customer( int $customer_id ): array {
-		if ( isset( self::$unpaid_order_ids_by_customer[ $customer_id ] ) ) {
-			return self::$unpaid_order_ids_by_customer[ $customer_id ];
+	private function get_potential_stock_holding_order_ids_for_customer( int $customer_id ): array {
+		if ( isset( self::$potential_order_ids_by_customer[ $customer_id ] ) ) {
+			return self::$potential_order_ids_by_customer[ $customer_id ];
 		}
 
-		/**
-		 * The 'ids' return yields plain ints, but wc_get_orders() is documented as
-		 * returning objects, so both shapes are accepted rather than assumed.
-		 *
-		 * @var array<int|\WC_Order> $order_ids
-		 */
+		/** @var int[] $order_ids */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		$order_ids = wc_get_orders(
 			array(
 				'customer' => $customer_id,
@@ -553,14 +510,10 @@ final class ReserveStock {
 			)
 		);
 
-		$ids = array();
+		$order_ids = array_map( 'absint', $order_ids );
 
-		foreach ( $order_ids as $order_id ) {
-			$ids[] = $order_id instanceof \WC_Order ? $order_id->get_id() : absint( $order_id );
-		}
+		self::$potential_order_ids_by_customer[ $customer_id ] = $order_ids;
 
-		self::$unpaid_order_ids_by_customer[ $customer_id ] = $ids;
-
-		return $ids;
+		return $order_ids;
 	}
 }

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -20,6 +20,9 @@ final class ReserveStock {
 
 	/**
 	 * Session key listing orders this shopper has taken a stock hold for.
+	 *
+	 * Holds array( 'customer' => string, 'order_ids' => int[] ), where `customer`
+	 * is the session customer id that recorded them.
 	 */
 	private const OWN_ORDERS_SESSION_KEY = 'stock_holding_orders';
 
@@ -395,12 +398,21 @@ final class ReserveStock {
 	/**
 	 * Returns order ids that demonstrably belong to the shopper making this request.
 	 *
-	 * Three sources, all of them authenticated: the two session pointers, the list
-	 * this class records as it takes holds, and the account when the shopper is
-	 * signed in. Ownership is never taken from anything a shopper can type. An
-	 * unauthenticated field such as the billing email would let one shopper claim
-	 * another's in flight hold, which is the oversell the grace window exists to
-	 * bound.
+	 * Two sources. The list this class records as it takes holds, which is bound to
+	 * the session that recorded it, and the account when the shopper is signed in.
+	 * Ownership is never taken from anything a shopper can type: an unauthenticated
+	 * field such as the billing email would let one shopper claim another's in
+	 * flight hold, which is the oversell the grace window exists to bound.
+	 *
+	 * order_awaiting_payment and store_api_draft_order are deliberately NOT read
+	 * here. Session contents are not by themselves a proof of identity, because
+	 * core hands them to a different shopper in two places: clone_session_data()
+	 * copies everything except `customer` into a freshly minted session when a cart
+	 * token is presented, and migrate_guest_session_to_user_session() moves a guest
+	 * session wholesale onto whichever account next signs in on that browser. Those
+	 * two keys carry no record of who wrote them, so they cannot be checked. They
+	 * also add nothing: an order can only hold stock by passing through
+	 * reserve_stock_for_order(), which is where the bound list is written.
 	 *
 	 * This runs inside get_query_for_reserved_stock(), which wc_get_held_stock_quantity()
 	 * also reaches from the admin, WP-CLI and cron. There is no shopper in those
@@ -416,24 +428,7 @@ final class ReserveStock {
 			return array();
 		}
 
-		$order_ids = array();
-
-		// Read through get() rather than the magic property: WC_Session::__isset()
-		// is true for a stored `false`, which is what payment_complete() leaves in
-		// order_awaiting_payment.
-		foreach ( array( 'order_awaiting_payment', 'store_api_draft_order' ) as $session_key ) {
-			$order_id = absint( $session->get( $session_key, 0 ) );
-
-			if ( $order_id ) {
-				$order_ids[] = $order_id;
-			}
-		}
-
-		$remembered = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
-
-		if ( is_array( $remembered ) ) {
-			$order_ids = array_merge( $order_ids, array_map( 'absint', $remembered ) );
-		}
+		$order_ids = $this->get_remembered_order_ids( $session );
 
 		$customer_id = get_current_user_id();
 
@@ -442,6 +437,34 @@ final class ReserveStock {
 		}
 
 		return array_values( array_filter( array_unique( $order_ids ) ) );
+	}
+
+	/**
+	 * Returns the recorded order ids, but only if this is still the session that
+	 * recorded them.
+	 *
+	 * The customer id is stamped alongside the ids when they are written, and both
+	 * of the ways core moves session data between shoppers change it first:
+	 * init_session_from_request() mints a new customer id before cloning, and
+	 * migrate_guest_session_to_user_session() swaps the guest id for the account id.
+	 * A mismatch therefore means the data arrived from somebody else's session, and
+	 * the list is ignored rather than trusted.
+	 *
+	 * @param \WC_Session $session Session of the shopper making this request.
+	 * @return int[]
+	 */
+	private function get_remembered_order_ids( \WC_Session $session ): array {
+		$remembered = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
+
+		if ( ! is_array( $remembered ) || ! isset( $remembered['customer'], $remembered['order_ids'] ) || ! is_array( $remembered['order_ids'] ) ) {
+			return array();
+		}
+
+		if ( (string) $remembered['customer'] !== (string) $session->get_customer_id() ) {
+			return array();
+		}
+
+		return array_map( 'absint', $remembered['order_ids'] );
 	}
 
 	/**
@@ -462,29 +485,37 @@ final class ReserveStock {
 	 * Neither existing pointer survives an abandoned attempt. The Store API
 	 * repoints store_api_draft_order at a new draft as soon as the previous one
 	 * leaves checkout-draft, and order_awaiting_payment is only ever written by the
-	 * classic checkout. This list keeps the ids for the life of the session, which
-	 * is the same trust boundary as the pointers themselves.
+	 * classic checkout. This list keeps the ids for the life of the session.
+	 *
+	 * The session's customer id is stamped alongside them so that the list can be
+	 * discarded if it later turns up in somebody else's session. See
+	 * get_remembered_order_ids().
 	 *
 	 * Skipped entirely where there is no session, which is how an order created in
 	 * the admin or over WP-CLI leaves nothing behind.
 	 *
 	 * @param \WC_Order $order Order that now holds stock.
 	 */
-	private function remember_order_for_shopper( $order ) {
+	private function remember_order_for_shopper( $order ): void {
 		$session = $this->get_shopper_session();
 
 		if ( ! $session instanceof \WC_Session ) {
 			return;
 		}
 
-		$order_ids = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
-		$order_ids = is_array( $order_ids ) ? $order_ids : array();
+		$order_ids = $this->get_remembered_order_ids( $session );
 
 		array_unshift( $order_ids, $order->get_id() );
 
 		$order_ids = array_slice( array_values( array_unique( array_map( 'absint', $order_ids ) ) ), 0, self::MAX_OWN_ORDERS );
 
-		$session->set( self::OWN_ORDERS_SESSION_KEY, $order_ids );
+		$session->set(
+			self::OWN_ORDERS_SESSION_KEY,
+			array(
+				'customer'  => (string) $session->get_customer_id(),
+				'order_ids' => $order_ids,
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -536,6 +536,12 @@ final class ReserveStock {
 			return self::$unpaid_order_ids_by_customer[ $customer_id ];
 		}
 
+		/**
+		 * The 'ids' return yields plain ints, but wc_get_orders() is documented as
+		 * returning objects, so both shapes are accepted rather than assumed.
+		 *
+		 * @var array<int|\WC_Order> $order_ids
+		 */
 		$order_ids = wc_get_orders(
 			array(
 				'customer' => $customer_id,
@@ -547,8 +553,14 @@ final class ReserveStock {
 			)
 		);
 
-		self::$unpaid_order_ids_by_customer[ $customer_id ] = is_array( $order_ids ) ? array_map( 'absint', $order_ids ) : array();
+		$ids = array();
 
-		return self::$unpaid_order_ids_by_customer[ $customer_id ];
+		foreach ( $order_ids as $order_id ) {
+			$ids[] = $order_id instanceof \WC_Order ? $order_id->get_id() : absint( $order_id );
+		}
+
+		self::$unpaid_order_ids_by_customer[ $customer_id ] = $ids;
+
+		return $ids;
 	}
 }

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Checkout\Helpers;
 
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Enums\OrderItemType;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\Orders\OrderNoteGroup;
 
@@ -18,11 +19,33 @@ defined( 'ABSPATH' ) || exit;
 final class ReserveStock {
 
 	/**
+	 * Session key listing orders this shopper has taken a stock hold for.
+	 */
+	private const OWN_ORDERS_SESSION_KEY = 'stock_holding_orders';
+
+	/**
+	 * Most of the current shopper's own orders to consider when discounting their
+	 * own stale holds. Keeps the generated IN clause bounded.
+	 */
+	private const MAX_OWN_ORDERS = 10;
+
+	/**
 	 * Is stock reservation enabled?
 	 *
 	 * @var boolean
 	 */
 	private $enabled = true;
+
+	/**
+	 * Request scoped memo of a signed in customer's unpaid order ids.
+	 *
+	 * A new ReserveStock is constructed for each wc_get_held_stock_quantity()
+	 * call, and the cart makes one per stock managed item, so the memo cannot
+	 * live on the instance.
+	 *
+	 * @var array<int, int[]>
+	 */
+	private static $unpaid_order_ids_by_customer = array();
 
 	/**
 	 * Constructor
@@ -149,6 +172,8 @@ final class ReserveStock {
 				foreach ( $rows as $product_id => $quantity ) {
 					$this->reserve_stock_for_product( $product_id, $quantity, $order, $minutes );
 				}
+
+				$this->remember_order_for_shopper( $order );
 			}
 		} catch ( ReserveStockException $e ) {
 			$this->release_stock_for_order( $order );
@@ -293,6 +318,8 @@ final class ReserveStock {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+		$query .= $this->get_clause_to_discount_stale_own_holds( $exclude_order_id );
+
 		/**
 		 * Filter: woocommerce_query_for_reserved_stock
 		 * Allows to filter the query for getting reserved stock of a product.
@@ -303,5 +330,194 @@ final class ReserveStock {
 		 * @param int    $exclude_order_id Order to exclude from the results.
 		 */
 		return apply_filters( 'woocommerce_query_for_reserved_stock', $query, $product_id, $exclude_order_id );
+	}
+
+	/**
+	 * Returns a clause discounting holds the current shopper placed themselves and
+	 * then left unpaid for longer than a grace window.
+	 *
+	 * Only one order is excluded by $exclude_order_id, so a shopper who abandons a
+	 * checkout and starts another is blocked by their own earlier hold for the
+	 * whole of woocommerce_hold_stock_minutes, which stores accepting slow payment
+	 * methods set to days. Inside the window their hold still counts, so a genuine
+	 * in flight payment is protected across a bank app switch or a one time code.
+	 * Past it, that shopper stops being blocked by their own abandoned attempt.
+	 * Holds belonging to anybody else are unaffected either way.
+	 *
+	 * @param int $exclude_order_id Order already excluded by the caller.
+	 * @return string Clause to append, or an empty string when nothing qualifies.
+	 */
+	private function get_clause_to_discount_stale_own_holds( $exclude_order_id ): string {
+		global $wpdb;
+
+		/**
+		 * Filters how long a shopper's own unpaid hold keeps blocking that same shopper.
+		 *
+		 * The hold is only ever discounted for the shopper who placed it, and only
+		 * once it is older than this. Return 0 to keep such holds blocking for the
+		 * full reservation window, which is how WooCommerce behaved before this
+		 * filter existed.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param int $minutes Grace window in minutes.
+		 */
+		$grace_minutes = (int) apply_filters( 'woocommerce_own_reserved_stock_grace_minutes', 10 );
+
+		if ( $grace_minutes < 1 ) {
+			return '';
+		}
+
+		$order_ids = array_values( array_diff( $this->get_current_shopper_order_ids(), array( absint( $exclude_order_id ) ) ) );
+
+		if ( empty( $order_ids ) ) {
+			return '';
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+
+		// The `timestamp` column records when the hold was first placed and is not
+		// touched by the ON DUPLICATE KEY UPDATE in reserve_stock_for_product(), so
+		// it measures the age of the shopper's attempt rather than of the last write.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $wpdb->prepare(
+			"
+			AND NOT (
+				stock_table.`order_id` IN ( $placeholders )
+				AND stock_table.`timestamp` < ( NOW() - INTERVAL %d MINUTE )
+			)
+			",
+			array_merge( $order_ids, array( $grace_minutes ) )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Returns order ids that demonstrably belong to the shopper making this request.
+	 *
+	 * Three sources, all of them authenticated: the two session pointers, the list
+	 * this class records as it takes holds, and the account when the shopper is
+	 * signed in. Ownership is never taken from anything a shopper can type. An
+	 * unauthenticated field such as the billing email would let one shopper claim
+	 * another's in flight hold, which is the oversell the grace window exists to
+	 * bound.
+	 *
+	 * This runs inside get_query_for_reserved_stock(), which wc_get_held_stock_quantity()
+	 * also reaches from the admin, WP-CLI and cron. There is no shopper in those
+	 * contexts and WC()->session is not initialised, so there is no ownership and
+	 * the query is returned unchanged.
+	 *
+	 * @return int[]
+	 */
+	private function get_current_shopper_order_ids(): array {
+		$session = $this->get_shopper_session();
+
+		if ( ! $session instanceof \WC_Session ) {
+			return array();
+		}
+
+		$order_ids = array();
+
+		// Read through get() rather than the magic property: WC_Session::__isset()
+		// is true for a stored `false`, which is what payment_complete() leaves in
+		// order_awaiting_payment.
+		foreach ( array( 'order_awaiting_payment', 'store_api_draft_order' ) as $session_key ) {
+			$order_id = absint( $session->get( $session_key, 0 ) );
+
+			if ( $order_id ) {
+				$order_ids[] = $order_id;
+			}
+		}
+
+		$remembered = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
+
+		if ( is_array( $remembered ) ) {
+			$order_ids = array_merge( $order_ids, array_map( 'absint', $remembered ) );
+		}
+
+		$customer_id = get_current_user_id();
+
+		if ( $customer_id ) {
+			$order_ids = array_merge( $order_ids, $this->get_unpaid_order_ids_for_customer( $customer_id ) );
+		}
+
+		return array_values( array_filter( array_unique( $order_ids ) ) );
+	}
+
+	/**
+	 * Returns the session of the shopper making this request, if there is one.
+	 *
+	 * @return \WC_Session|null
+	 */
+	private function get_shopper_session() {
+		$session = function_exists( 'WC' ) && WC() ? WC()->session : null;
+
+		return $session instanceof \WC_Session ? $session : null;
+	}
+
+	/**
+	 * Records an order against the shopper's session so that a later request can
+	 * still recognise the hold as theirs.
+	 *
+	 * Neither existing pointer survives an abandoned attempt. The Store API
+	 * repoints store_api_draft_order at a new draft as soon as the previous one
+	 * leaves checkout-draft, and order_awaiting_payment is only ever written by the
+	 * classic checkout. This list keeps the ids for the life of the session, which
+	 * is the same trust boundary as the pointers themselves.
+	 *
+	 * Skipped entirely where there is no session, which is how an order created in
+	 * the admin or over WP-CLI leaves nothing behind.
+	 *
+	 * @param \WC_Order $order Order that now holds stock.
+	 */
+	private function remember_order_for_shopper( $order ) {
+		$session = $this->get_shopper_session();
+
+		if ( ! $session instanceof \WC_Session ) {
+			return;
+		}
+
+		$order_ids = $session->get( self::OWN_ORDERS_SESSION_KEY, array() );
+		$order_ids = is_array( $order_ids ) ? $order_ids : array();
+
+		array_unshift( $order_ids, $order->get_id() );
+
+		$order_ids = array_slice( array_values( array_unique( array_map( 'absint', $order_ids ) ) ), 0, self::MAX_OWN_ORDERS );
+
+		$session->set( self::OWN_ORDERS_SESSION_KEY, $order_ids );
+	}
+
+	/**
+	 * Returns unpaid order ids belonging to a signed in customer, newest first.
+	 *
+	 * Session pointers are lost when the shopper switches device, clears cookies or
+	 * lets the session lapse, which is when they come back and meet their own hold.
+	 * The account covers that case for shoppers who are signed in.
+	 *
+	 * The statuses match the ones the reserved stock query counts, so an order that
+	 * cannot be holding stock is never fetched.
+	 *
+	 * @param int $customer_id Customer ID.
+	 * @return int[]
+	 */
+	private function get_unpaid_order_ids_for_customer( int $customer_id ): array {
+		if ( isset( self::$unpaid_order_ids_by_customer[ $customer_id ] ) ) {
+			return self::$unpaid_order_ids_by_customer[ $customer_id ];
+		}
+
+		$order_ids = wc_get_orders(
+			array(
+				'customer' => $customer_id,
+				'status'   => array( OrderStatus::CHECKOUT_DRAFT, OrderStatus::PENDING ),
+				'limit'    => self::MAX_OWN_ORDERS,
+				'orderby'  => 'date',
+				'order'    => 'DESC',
+				'return'   => 'ids',
+			)
+		);
+
+		self::$unpaid_order_ids_by_customer[ $customer_id ] = is_array( $order_ids ) ? array_map( 'absint', $order_ids ) : array();
+
+		return self::$unpaid_order_ids_by_customer[ $customer_id ];
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -369,6 +369,10 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	 * for 4 units of a 1-unit product and throw ReserveStockException. Same approach
 	 * as create_order_holding_stock() in class-wc-cart-test.php.
 	 *
+	 * The save() between removing and adding is required, not cosmetic: without it
+	 * the replacement line item never reaches wc_order_items, so the order reloads
+	 * with no items and reserves nothing.
+	 *
 	 * @param int               $customer_id Customer ID, 0 for a guest.
 	 * @param WC_Product_Simple $product     Product to add.
 	 * @return int Order ID.
@@ -376,6 +380,7 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	private function create_unpaid_order_for( int $customer_id, WC_Product_Simple $product ): int {
 		$order = WC_Helper_Order::create_order( $customer_id );
 		$order->remove_order_items();
+		$order->save();
 		$order->add_product( wc_get_product( $product->get_id() ), 1 );
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -59,6 +59,13 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	private $original_customer;
 
 	/**
+	 * $_COOKIE as it was before the test, put back in tearDown.
+	 *
+	 * @var array
+	 */
+	private $original_cookies;
+
+	/**
 	 * Set up a shopper session and a store that manages stock.
 	 */
 	public function setUp(): void {
@@ -70,6 +77,15 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
 		$this->original_session  = WC()->session;
 		$this->original_customer = WC()->customer;
+
+		// Earlier suites can leave a valid session cookie in $_COOKIE (the test
+		// framework never resets it), and WC_Session_Handler::init() would then
+		// give every session in these tests that cookie's customer id instead of
+		// minting distinct ones.
+		$this->original_cookies = $_COOKIE;
+
+		/** This filter is documented in includes/class-wc-session-handler.php */
+		unset( $_COOKIE[ (string) apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH ) ] );
 
 		WC()->session = new WC_Session_Handler();
 		WC()->session->init();
@@ -88,6 +104,7 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
 		wp_set_current_user( 0 );
 
+		$_COOKIE       = $this->original_cookies;
 		WC()->session  = $this->original_session;
 		WC()->customer = $this->original_customer;
 

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -1,25 +1,6 @@
 <?php
 /**
- * Tests for discounting a shopper's own stale stock holds.
- *
- * Intended location:
- *   plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
- *
- * The contract under test, in order of importance:
- *
- *   1. A hold belonging to ANOTHER shopper always blocks, however old it is.
- *      That is the oversell invariant and every other case is a refinement of it.
- *   2. The shopper's OWN hold blocks inside the grace window and is discounted
- *      after it.
- *   3. Ownership never comes from anything the shopper can type.
- *   4. With no session — admin, WP-CLI, cron — nothing is discounted and the
- *      current user is never consulted.
- *   5. The woocommerce_query_for_reserved_stock signature is unchanged.
- *
- * Holds are written straight into wc_reserved_stock rather than through
- * reserve_stock_for_order() so that `timestamp` can be aged exactly, and so that
- * a hold can be created without also entering the session list. The one test
- * that exercises the session list calls wc_reserve_stock_for_order() for real.
+ * Tests for excluding a shopper's own stale stock holds.
  */
 
 declare(strict_types=1);
@@ -37,13 +18,23 @@ use WC_Unit_Test_Case;
 /**
  * Class ReserveStockOwnHoldsTest.
  *
- * Exercises the grace window that stops a shopper being blocked by their own
- * stale, unpaid stock hold. The full contract is in the file docblock above.
+ * Exercises the threshold that stops a shopper being blocked by their own
+ * stale, unpaid stock hold:
+ *
+ *   1. A hold belonging to another shopper always blocks, however old it is.
+ *   2. The shopper's own hold blocks inside the threshold and is excluded past it.
+ *   3. Ownership never comes from anything the shopper can type.
+ *   4. With no session (admin, WP-CLI, cron) nothing is excluded.
+ *   5. The woocommerce_query_for_reserved_stock signature is unchanged.
+ *
+ * Holds are written straight into wc_reserved_stock so `timestamp` can be aged
+ * exactly. Tests exercising the session list call wc_reserve_stock_for_order()
+ * for real.
  */
 class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
 	/**
-	 * How long the reservation itself lasts, well beyond any grace window used here.
+	 * How long the reservation itself lasts, well beyond any threshold used here.
 	 */
 	private const HOLD_MINUTES = 2880;
 
@@ -119,25 +110,10 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	// ---------------------------------------------------------------------
 
 	/**
-	 * Another shopper's hold blocks however stale it is.
+	 * A stale hold on an order the shopper does not own keeps blocking, even
+	 * while the shopper's own stale hold is excluded.
 	 */
-	public function test_another_shoppers_stale_hold_still_blocks() {
-		$product = $this->create_stock_managed_product( 1 );
-
-		// Signed in, with a session, and owning nothing that holds stock.
-		$this->create_signed_in_shopper();
-		$other = $this->create_shopper_with_unpaid_order( $product );
-
-		$this->hold_stock( $other, $product->get_id(), 1, 120 );
-
-		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
-	}
-
-	/**
-	 * A stale hold on an order the shopper does not own is not discounted just
-	 * because the shopper's own list happens to be non empty.
-	 */
-	public function test_own_stale_hold_does_not_release_another_shoppers_hold() {
+	public function test_own_stale_hold_does_not_exclude_another_shoppers_hold() {
 		$product = $this->create_stock_managed_product( 2 );
 		$shopper = $this->create_signed_in_shopper();
 		$mine    = $this->create_unpaid_order_for( $shopper, $product );
@@ -150,11 +126,11 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	}
 
 	// ---------------------------------------------------------------------
-	// 2. The grace window.
+	// 2. The exclusion threshold.
 	// ---------------------------------------------------------------------
 
 	/**
-	 * The shopper's own hold still blocks inside the default 10 minute window.
+	 * The shopper's own hold still blocks inside the default 10 minute threshold.
 	 */
 	public function test_own_fresh_hold_still_blocks() {
 		$product = $this->create_stock_managed_product( 1 );
@@ -167,9 +143,9 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Past the window the shopper stops being blocked by their own attempt.
+	 * Past the threshold the shopper stops being blocked by their own attempt.
 	 */
-	public function test_own_stale_hold_is_discounted() {
+	public function test_own_stale_hold_is_excluded() {
 		$product = $this->create_stock_managed_product( 1 );
 		$shopper = $this->create_signed_in_shopper();
 		$order   = $this->create_unpaid_order_for( $shopper, $product );
@@ -180,23 +156,44 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A grace window of zero restores the behaviour from before this change.
+	 * A false threshold disables the exclusion and restores the behaviour from
+	 * before this change.
 	 */
-	public function test_zero_grace_window_keeps_own_hold_blocking() {
+	public function test_false_threshold_keeps_own_hold_blocking() {
 		$product = $this->create_stock_managed_product( 1 );
 		$shopper = $this->create_signed_in_shopper();
 		$order   = $this->create_unpaid_order_for( $shopper, $product );
 
 		$this->hold_stock( $order, $product->get_id(), 1, 2000 );
 
-		add_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+		add_filter( 'woocommerce_own_stock_hold_exclusion_threshold_minutes', '__return_false' );
 		try {
 			$held = wc_get_held_stock_quantity( $product, 0 );
 		} finally {
-			remove_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+			remove_filter( 'woocommerce_own_stock_hold_exclusion_threshold_minutes', '__return_false' );
 		}
 
 		$this->assertSame( 1, $held );
+	}
+
+	/**
+	 * A threshold of zero excludes the shopper's own hold immediately.
+	 */
+	public function test_zero_threshold_excludes_own_hold_immediately() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 5 );
+
+		add_filter( 'woocommerce_own_stock_hold_exclusion_threshold_minutes', '__return_zero' );
+		try {
+			$held = wc_get_held_stock_quantity( $product, 0 );
+		} finally {
+			remove_filter( 'woocommerce_own_stock_hold_exclusion_threshold_minutes', '__return_zero' );
+		}
+
+		$this->assertSame( 0, $held );
 	}
 
 	// ---------------------------------------------------------------------
@@ -205,7 +202,7 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
 	/**
 	 * The reported flow: a guest on the block checkout whose draft pointer has
-	 * already moved on to a new order.
+	 * already moved on to a new draft order.
 	 */
 	public function test_session_list_covers_a_guest_whose_draft_pointer_moved_on() {
 		$product = $this->create_stock_managed_product( 1 );
@@ -215,23 +212,18 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		wc_reserve_stock_for_order( wc_get_order( $order ) );
 		$this->age_hold( $order, 11 );
 
-		// The Store API mints a new draft and repoints the session at it.
-		WC()->session->set( 'store_api_draft_order', $this->create_unpaid_order_for( 0, $product ) );
+		// The Store API has since minted a new draft and repointed the session at it.
+		$new_draft = $this->create_unpaid_order_for( 0, $product, OrderStatus::CHECKOUT_DRAFT );
+		WC()->session->set( 'store_api_draft_order', $new_draft );
 
-		$remembered = WC()->session->get( 'stock_holding_orders', array() );
-
-		$this->assertContains( $order, $remembered['order_ids'] );
-		$this->assertSame( 0, wc_get_held_stock_quantity( $product, 0 ) );
+		$this->assertSame( 0, wc_get_held_stock_quantity( $product, $new_draft ) );
 	}
 
 	/**
 	 * A session list that arrived from somebody else's session confers nothing.
 	 *
-	 * WC_Session_Handler hands one shopper's session data to another in two places:
-	 * clone_session_data() copies everything but `customer` into a freshly minted
-	 * session when a cart token is presented, and
-	 * migrate_guest_session_to_user_session() moves a guest session onto whichever
-	 * account next signs in on that browser. Both change the session customer id
+	 * Core hands session data to a different shopper in two places (cart token
+	 * cloning and guest-to-user migration); both change the session customer id
 	 * first, which is what the stamp detects.
 	 */
 	public function test_borrowed_session_list_confers_no_ownership() {
@@ -242,8 +234,6 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		$this->age_hold( $order, 11 );
 
 		$borrowed = WC()->session->get( 'stock_holding_orders', array() );
-
-		$this->assertContains( $order, $borrowed['order_ids'], 'Precondition: the owner recorded the hold.' );
 
 		// A second shopper, whose session carries the first shopper's list verbatim
 		// but under their own, different customer id.
@@ -285,12 +275,31 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
 	}
 
+	/**
+	 * A guest who exceeds the session list limit loses the oldest entry, and that
+	 * hold blocks again: the failure direction is blocking, never overselling.
+	 */
+	public function test_own_holds_beyond_the_session_list_limit_block_again() {
+		$product = $this->create_stock_managed_product( 20 );
+
+		// One more attempt than the list keeps.
+		for ( $i = 0; $i < 11; $i++ ) {
+			$order = $this->create_unpaid_order_for( 0, $product );
+			wc_reserve_stock_for_order( wc_get_order( $order ) );
+			$this->age_hold( $order, 11 );
+		}
+
+		// The list keeps the ten newest ids, so the first order's hold counts
+		// again while the remembered ten are excluded.
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
 	// ---------------------------------------------------------------------
 	// 4. Contexts with no shopper.
 	// ---------------------------------------------------------------------
 
 	/**
-	 * With no session — the admin, WP-CLI, cron — nothing is discounted, even for
+	 * With no session — the admin, WP-CLI, cron — nothing is excluded, even for
 	 * a signed in user who happens to have unpaid orders of their own.
 	 */
 	public function test_no_session_leaves_the_total_unchanged() {
@@ -311,7 +320,7 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
 	/**
 	 * woocommerce_query_for_reserved_stock still receives a scalar order id, and
-	 * still receives the complete core query.
+	 * still receives the complete core query, exclusion clause included.
 	 */
 	public function test_filter_signature_is_unchanged() {
 		$product = $this->create_stock_managed_product( 1 );
@@ -389,26 +398,21 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	/**
 	 * An unpaid order for a customer, holding one unit of the product.
 	 *
-	 * The line item is rebuilt rather than left as WC_Helper_Order::create_order()
-	 * makes it, because that helper hard-codes a quantity of 4
-	 * (class-wc-helper-order.php:73). A test that then reserves for real would ask
-	 * for 4 units of a 1-unit product and throw ReserveStockException. Same approach
-	 * as create_order_holding_stock() in class-wc-cart-test.php.
-	 *
-	 * The save() between removing and adding is required, not cosmetic: without it
-	 * the replacement line item never reaches wc_order_items, so the order reloads
-	 * with no items and reserves nothing.
+	 * WC_Helper_Order::create_order() hard-codes a line quantity of 4, so the
+	 * line item is rebuilt — with a save() between remove and add, without which
+	 * the order reloads with no items and reserves nothing.
 	 *
 	 * @param int               $customer_id Customer ID, 0 for a guest.
 	 * @param WC_Product_Simple $product     Product to add.
+	 * @param string            $status      Order status, unpaid pending by default.
 	 * @return int Order ID.
 	 */
-	private function create_unpaid_order_for( int $customer_id, WC_Product_Simple $product ): int {
+	private function create_unpaid_order_for( int $customer_id, WC_Product_Simple $product, string $status = OrderStatus::PENDING ): int {
 		$order = WC_Helper_Order::create_order( $customer_id );
 		$order->remove_order_items();
 		$order->save();
 		$order->add_product( wc_get_product( $product->get_id() ), 1 );
-		$order->set_status( OrderStatus::PENDING );
+		$order->set_status( $status );
 		$order->save();
 
 		return $order->get_id();

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Tests for discounting a shopper's own stale stock holds.
+ *
+ * Intended location:
+ *   plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+ *
+ * The contract under test, in order of importance:
+ *
+ *   1. A hold belonging to ANOTHER shopper always blocks, however old it is.
+ *      That is the oversell invariant and every other case is a refinement of it.
+ *   2. The shopper's OWN hold blocks inside the grace window and is discounted
+ *      after it.
+ *   3. Ownership never comes from anything the shopper can type.
+ *   4. With no session — admin, WP-CLI, cron — nothing is discounted and the
+ *      current user is never consulted.
+ *   5. The woocommerce_query_for_reserved_stock signature is unchanged.
+ *
+ * Holds are written straight into wc_reserved_stock rather than through
+ * reserve_stock_for_order() so that `timestamp` can be aged exactly, and so that
+ * a hold can be created without also entering the session list. The one test
+ * that exercises the session list calls wc_reserve_stock_for_order() for real.
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Checkout\Helpers;
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use WC_Customer;
+use WC_Helper_Order;
+use WC_Helper_Product;
+use WC_Product_Simple;
+use WC_Session_Handler;
+use WC_Unit_Test_Case;
+
+/**
+ * Class ReserveStockOwnHoldsTest
+ */
+class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * How long the reservation itself lasts, well beyond any grace window used here.
+	 */
+	private const HOLD_MINUTES = 2880;
+
+	/**
+	 * Set up a shopper session and a store that manages stock.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		update_option( 'woocommerce_schema_version', 430 );
+		update_option( 'woocommerce_hold_stock_minutes', self::HOLD_MINUTES );
+
+		WC()->session = new WC_Session_Handler();
+		WC()->session->init();
+	}
+
+	/**
+	 * Leave no session, user or reservation behind.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->wc_reserved_stock}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		wp_set_current_user( 0 );
+		WC()->session = null;
+
+		parent::tearDown();
+	}
+
+	// ---------------------------------------------------------------------
+	// 1. The oversell invariant.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Another shopper's hold blocks however stale it is.
+	 */
+	public function test_another_shoppers_stale_hold_still_blocks() {
+		$product = $this->create_stock_managed_product( 1 );
+
+		// Signed in, with a session, and owning nothing that holds stock.
+		$this->create_signed_in_shopper();
+		$other = $this->create_shopper_with_unpaid_order( $product );
+
+		$this->hold_stock( $other, $product->get_id(), 1, 120 );
+
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	/**
+	 * A stale hold on an order the shopper does not own is not discounted just
+	 * because the shopper's own list happens to be non empty.
+	 */
+	public function test_own_stale_hold_does_not_release_another_shoppers_hold() {
+		$product = $this->create_stock_managed_product( 2 );
+		$shopper = $this->create_signed_in_shopper();
+		$mine    = $this->create_unpaid_order_for( $shopper, $product );
+		$theirs  = $this->create_shopper_with_unpaid_order( $product );
+
+		$this->hold_stock( $mine, $product->get_id(), 1, 120 );
+		$this->hold_stock( $theirs, $product->get_id(), 1, 120 );
+
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. The grace window.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * The shopper's own hold still blocks inside the default 10 minute window.
+	 */
+	public function test_own_fresh_hold_still_blocks() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 9 );
+
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	/**
+	 * Past the window the shopper stops being blocked by their own attempt.
+	 */
+	public function test_own_stale_hold_is_discounted() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 11 );
+
+		$this->assertSame( 0, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	/**
+	 * A grace window of zero restores the behaviour from before this change.
+	 */
+	public function test_zero_grace_window_keeps_own_hold_blocking() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 2000 );
+
+		add_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+		$held = wc_get_held_stock_quantity( $product, 0 );
+		remove_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+
+		$this->assertSame( 1, $held );
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. Ownership sources.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * The reported flow: a guest on the block checkout whose draft pointer has
+	 * already moved on to a new order.
+	 */
+	public function test_session_list_covers_a_guest_whose_draft_pointer_moved_on() {
+		$product = $this->create_stock_managed_product( 1 );
+		$order   = $this->create_unpaid_order_for( 0, $product );
+
+		// The real reservation path, which is what records the order in the session.
+		wc_reserve_stock_for_order( wc_get_order( $order ) );
+		$this->age_hold( $order, 11 );
+
+		// The Store API mints a new draft and repoints the session at it.
+		WC()->session->set( 'store_api_draft_order', $this->create_unpaid_order_for( 0, $product ) );
+
+		$this->assertContains( $order, WC()->session->get( 'stock_holding_orders', array() ) );
+		$this->assertSame( 0, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	/**
+	 * A billing email is not an ownership claim.
+	 *
+	 * The attacker types the victim's address into their own checkout. The
+	 * victim's in-flight hold must keep blocking.
+	 */
+	public function test_billing_email_confers_no_ownership() {
+		$product      = $this->create_stock_managed_product( 1 );
+		$victim       = $this->create_signed_in_shopper( 'victim@example.com' );
+		$order        = $this->create_unpaid_order_for( $victim, $product );
+		$victim_order = wc_get_order( $order );
+		$victim_order->set_billing_email( 'victim@example.com' );
+		$victim_order->save();
+
+		$this->hold_stock( $order, $product->get_id(), 1, 120 );
+
+		// Now a different, unrelated shopper claiming the same address.
+		wp_set_current_user( 0 );
+		WC()->session = new WC_Session_Handler();
+		WC()->session->init();
+		WC()->customer = new WC_Customer();
+		WC()->customer->set_billing_email( 'victim@example.com' );
+
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. Contexts with no shopper.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * With no session — the admin, WP-CLI, cron — nothing is discounted, even for
+	 * a signed in user who happens to have unpaid orders of their own.
+	 */
+	public function test_no_session_leaves_the_total_unchanged() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 120 );
+
+		WC()->session = null;
+
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. The public filter contract.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * woocommerce_query_for_reserved_stock still receives a scalar order id, and
+	 * still receives the complete core query.
+	 */
+	public function test_filter_signature_is_unchanged() {
+		$product = $this->create_stock_managed_product( 1 );
+		$shopper = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $shopper, $product );
+
+		$this->hold_stock( $order, $product->get_id(), 1, 120 );
+
+		$seen = array();
+
+		$capture = function ( $query, $product_id, $exclude_order_id ) use ( &$seen ) {
+			$seen = array(
+				'query'            => $query,
+				'product_id'       => $product_id,
+				'exclude_order_id' => $exclude_order_id,
+			);
+
+			return $query;
+		};
+
+		add_filter( 'woocommerce_query_for_reserved_stock', $capture, 10, 3 );
+		wc_get_held_stock_quantity( $product, 4242 );
+		remove_filter( 'woocommerce_query_for_reserved_stock', $capture, 10 );
+
+		$this->assertIsInt( $seen['exclude_order_id'] );
+		$this->assertSame( 4242, $seen['exclude_order_id'] );
+		$this->assertSame( $product->get_id(), $seen['product_id'] );
+		$this->assertStringContainsString( 'AND NOT (', $seen['query'], 'The filter sees the complete core query.' );
+	}
+
+	// ---------------------------------------------------------------------
+	// Helpers.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * A simple product managing a fixed quantity of stock.
+	 *
+	 * @param int $quantity Stock quantity.
+	 * @return WC_Product_Simple
+	 */
+	private function create_stock_managed_product( int $quantity ): WC_Product_Simple {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( $quantity );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * A signed in shopper. A fresh user per test, because the customer lookup is
+	 * memoised for the life of the request.
+	 *
+	 * @param string $email Optional email.
+	 * @return int User ID.
+	 */
+	private function create_signed_in_shopper( string $email = '' ): int {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => uniqid( 'shopper_' ),
+				'user_pass'  => wp_generate_password(),
+				'user_email' => '' !== $email ? $email : uniqid( 'shopper_' ) . '@example.com',
+				'role'       => 'customer',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		return (int) $user_id;
+	}
+
+	/**
+	 * An unpaid order for a customer, containing the product.
+	 *
+	 * @param int               $customer_id Customer ID, 0 for a guest.
+	 * @param WC_Product_Simple $product     Product to add.
+	 * @return int Order ID.
+	 */
+	private function create_unpaid_order_for( int $customer_id, WC_Product_Simple $product ): int {
+		$order = WC_Helper_Order::create_order( $customer_id, $product );
+		$order->set_status( OrderStatus::PENDING );
+		$order->save();
+
+		return $order->get_id();
+	}
+
+	/**
+	 * An unpaid order belonging to somebody who is not the current user, and whose
+	 * id never enters the current session.
+	 *
+	 * @param WC_Product_Simple $product Product to add.
+	 * @return int Order ID.
+	 */
+	private function create_shopper_with_unpaid_order( WC_Product_Simple $product ): int {
+		$current = get_current_user_id();
+		$other   = $this->create_signed_in_shopper();
+		$order   = $this->create_unpaid_order_for( $other, $product );
+
+		wp_set_current_user( $current );
+
+		return $order;
+	}
+
+	/**
+	 * Write a hold directly, with an exact age.
+	 *
+	 * @param int $order_id    Order holding the stock.
+	 * @param int $product_id  Product held.
+	 * @param int $quantity    Quantity held.
+	 * @param int $age_minutes How long ago the hold was placed.
+	 */
+	private function hold_stock( int $order_id, int $product_id, int $quantity, int $age_minutes ): void {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				"
+				INSERT INTO {$wpdb->wc_reserved_stock} ( `order_id`, `product_id`, `stock_quantity`, `timestamp`, `expires` )
+				VALUES ( %d, %d, %d, ( NOW() - INTERVAL %d MINUTE ), ( NOW() + INTERVAL %d MINUTE ) )
+				",
+				$order_id,
+				$product_id,
+				$quantity,
+				$age_minutes,
+				self::HOLD_MINUTES
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Backdate a hold that was created by the real reservation path.
+	 *
+	 * @param int $order_id    Order holding the stock.
+	 * @param int $age_minutes How long ago the hold should read as placed.
+	 */
+	private function age_hold( int $order_id, int $age_minutes ): void {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->wc_reserved_stock} SET `timestamp` = ( NOW() - INTERVAL %d MINUTE ) WHERE `order_id` = %d",
+				$age_minutes,
+				$order_id
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -35,7 +35,10 @@ use WC_Session_Handler;
 use WC_Unit_Test_Case;
 
 /**
- * Class ReserveStockOwnHoldsTest
+ * Class ReserveStockOwnHoldsTest.
+ *
+ * Exercises the grace window that stops a shopper being blocked by their own
+ * stale, unpaid stock hold. The full contract is in the file docblock above.
  */
 class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 
@@ -187,8 +190,11 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		$this->hold_stock( $order, $product->get_id(), 1, 2000 );
 
 		add_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
-		$held = wc_get_held_stock_quantity( $product, 0 );
-		remove_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+		try {
+			$held = wc_get_held_stock_quantity( $product, 0 );
+		} finally {
+			remove_filter( 'woocommerce_own_reserved_stock_grace_minutes', '__return_zero' );
+		}
 
 		$this->assertSame( 1, $held );
 	}
@@ -327,8 +333,11 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		};
 
 		add_filter( 'woocommerce_query_for_reserved_stock', $capture, 10, 3 );
-		wc_get_held_stock_quantity( $product, 4242 );
-		remove_filter( 'woocommerce_query_for_reserved_stock', $capture, 10 );
+		try {
+			wc_get_held_stock_quantity( $product, 4242 );
+		} finally {
+			remove_filter( 'woocommerce_query_for_reserved_stock', $capture, 10 );
+		}
 
 		$this->assertIsInt( $seen['exclude_order_id'] );
 		$this->assertSame( 4242, $seen['exclude_order_id'] );

--- a/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php
@@ -45,6 +45,20 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	private const HOLD_MINUTES = 2880;
 
 	/**
+	 * The session the bootstrap set up, put back in tearDown.
+	 *
+	 * @var \WC_Session|null
+	 */
+	private $original_session;
+
+	/**
+	 * The customer the bootstrap set up, put back in tearDown.
+	 *
+	 * @var WC_Customer|null
+	 */
+	private $original_customer;
+
+	/**
 	 * Set up a shopper session and a store that manages stock.
 	 */
 	public function setUp(): void {
@@ -54,12 +68,18 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_schema_version', 430 );
 		update_option( 'woocommerce_hold_stock_minutes', self::HOLD_MINUTES );
 
+		$this->original_session  = WC()->session;
+		$this->original_customer = WC()->customer;
+
 		WC()->session = new WC_Session_Handler();
 		WC()->session->init();
 	}
 
 	/**
 	 * Leave no session, user or reservation behind.
+	 *
+	 * The session and customer singletons are restored rather than nulled: this
+	 * suite runs in one process, and a null WC()->session fatals later classes.
 	 */
 	public function tearDown(): void {
 		global $wpdb;
@@ -67,7 +87,9 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->wc_reserved_stock}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		wp_set_current_user( 0 );
-		WC()->session = null;
+
+		WC()->session  = $this->original_session;
+		WC()->customer = $this->original_customer;
 
 		parent::tearDown();
 	}
@@ -173,8 +195,45 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 		// The Store API mints a new draft and repoints the session at it.
 		WC()->session->set( 'store_api_draft_order', $this->create_unpaid_order_for( 0, $product ) );
 
-		$this->assertContains( $order, WC()->session->get( 'stock_holding_orders', array() ) );
+		$remembered = WC()->session->get( 'stock_holding_orders', array() );
+
+		$this->assertContains( $order, $remembered['order_ids'] );
 		$this->assertSame( 0, wc_get_held_stock_quantity( $product, 0 ) );
+	}
+
+	/**
+	 * A session list that arrived from somebody else's session confers nothing.
+	 *
+	 * WC_Session_Handler hands one shopper's session data to another in two places:
+	 * clone_session_data() copies everything but `customer` into a freshly minted
+	 * session when a cart token is presented, and
+	 * migrate_guest_session_to_user_session() moves a guest session onto whichever
+	 * account next signs in on that browser. Both change the session customer id
+	 * first, which is what the stamp detects.
+	 */
+	public function test_borrowed_session_list_confers_no_ownership() {
+		$product = $this->create_stock_managed_product( 1 );
+		$order   = $this->create_unpaid_order_for( 0, $product );
+
+		wc_reserve_stock_for_order( wc_get_order( $order ) );
+		$this->age_hold( $order, 11 );
+
+		$borrowed = WC()->session->get( 'stock_holding_orders', array() );
+
+		$this->assertContains( $order, $borrowed['order_ids'], 'Precondition: the owner recorded the hold.' );
+
+		// A second shopper, whose session carries the first shopper's list verbatim
+		// but under their own, different customer id.
+		WC()->session = new WC_Session_Handler();
+		WC()->session->init();
+		WC()->session->set( 'stock_holding_orders', $borrowed );
+
+		$this->assertNotSame(
+			$borrowed['customer'],
+			(string) WC()->session->get_customer_id(),
+			'Precondition: the borrowing session has a different customer id.'
+		);
+		$this->assertSame( 1, wc_get_held_stock_quantity( $product, 0 ) );
 	}
 
 	/**
@@ -302,14 +361,22 @@ class ReserveStockOwnHoldsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * An unpaid order for a customer, containing the product.
+	 * An unpaid order for a customer, holding one unit of the product.
+	 *
+	 * The line item is rebuilt rather than left as WC_Helper_Order::create_order()
+	 * makes it, because that helper hard-codes a quantity of 4
+	 * (class-wc-helper-order.php:73). A test that then reserves for real would ask
+	 * for 4 units of a 1-unit product and throw ReserveStockException. Same approach
+	 * as create_order_holding_stock() in class-wc-cart-test.php.
 	 *
 	 * @param int               $customer_id Customer ID, 0 for a guest.
 	 * @param WC_Product_Simple $product     Product to add.
 	 * @return int Order ID.
 	 */
 	private function create_unpaid_order_for( int $customer_id, WC_Product_Simple $product ): int {
-		$order = WC_Helper_Order::create_order( $customer_id, $product );
+		$order = WC_Helper_Order::create_order( $customer_id );
+		$order->remove_order_items();
+		$order->add_product( wc_get_product( $product->get_id() ), 1 );
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();
 


### PR DESCRIPTION
# Exclude a shopper's own stale stock hold

Part of #67354. Shape agreed with @opr and @jamesckemp on the issue.

#67471 has since landed, so `check_cart_item_stock()` now reads
`order_awaiting_payment` with `get()` and treats a stored `false` as "no order".
That closes the falsy-pointer half. This PR is the other half: the exclusion is
still a **single** order id, so a shopper with more than one unpaid order holding
the same product is blocked by their own earlier attempt.

### What

`ReserveStock::get_query_for_reserved_stock()` gains a clause that excludes a
hold when all three of these are true:

1. the hold belongs to the shopper making the request,
2. its order is unpaid — the existing status join already restricts the query to
   `wc-checkout-draft` and `wc-pending`,
3. the hold is older than a threshold, filterable via
   `woocommerce_own_stock_hold_exclusion_threshold_minutes`, default **10 minutes**.
   `0` excludes own holds immediately; `false` disables the exclusion. The filter
   also receives `$product_id` and `$exclude_order_id`, so a store can vary the
   threshold per product.

Inside the threshold nothing changes, so a genuine in-flight payment still blocks
across a bank app switch or a one-time code. Past it the shopper stops being
blocked by their own abandoned attempt. A hold belonging to any other shopper is
untouched in both cases.

Because `reserve_stock_for_product()` and `check_cart_item_stock()` share this
query, the checkout submit stops failing as well as the cart message.

### Why a threshold rather than excluding outright

The oversell risk is not eliminated, it is bounded. Today a shopper who abandons
a card attempt is locked out for the full `woocommerce_hold_stock_minutes` —
2880 minutes on the store this was reported from, because that option also
decides when `wc_cancel_unpaid_orders()` runs and stores accepting bank transfer
set it high on purpose. The worst case becomes one shopper double-booking their
own attempt inside a window the store chooses.

### Ownership

Two sources, both authenticated:

| source | covers |
|---|---|
| `stock_holding_orders`, a session list written inside `reserve_stock_for_order()` and stamped with the session customer id | the shopper's own attempts for the life of the session, including one whose draft pointer has since moved on |
| unpaid orders for `get_current_user_id()` | a signed-in shopper who lost the session |

Nothing a shopper can type is consulted. The billing email was in our earlier
sketch and is deliberately not here: it is unauthenticated, so it would let one
shopper have another's in-flight hold excluded for them.

**`order_awaiting_payment` and `store_api_draft_order` are deliberately not read.**
Session contents are not by themselves proof of identity. Core hands them to a
different shopper in two places: `clone_session_data()` copies everything except
`customer` into a freshly minted session when a cart token is presented, and
`migrate_guest_session_to_user_session()` moves a guest session wholesale onto
whichever account next signs in on that browser. Those two keys carry no record of
who wrote them, so they cannot be checked. They also add nothing, because an order
can only hold stock by passing through `reserve_stock_for_order()`, which is where
the stamped list is written.

That distinction matters here specifically because the exclusion reaches the
**reservation gate**, not only the display checks. Before this PR the sole
session-derived exclusion was the scalar `$exclude_order_id` used by
`check_cart_item_stock()`, `CartController` and `QuantityLimits`, none of which can
mint stock; `reserve_stock_for_product()` always passed its own order id. Widening
a session-derived set into that gate would otherwise turn a cosmetic leak into a
real oversell. The stamp catches both paths above, since each changes the session
customer id before the data moves. A test pins it.

### What this does not fix

**An anonymous shopper whose session is gone.** Cleared cookies, a different
browser, a different device. There is no authenticated durable identity for a
guest, so ownership cannot reach that case at all without consulting something
they type, which is the thing we are not doing.

It is a narrower slice than it first looks: a guest session lasts
`2 * DAY_IN_SECONDS` by default, so on the reported store the session and the
2880-minute hold expired together. What is left is switching device or clearing
cookies, not waiting too long.

The lever for that case is not ownership but the length of the hold itself.
`woocommerce_hold_stock_minutes` decides three unrelated things — how long stock
is reserved, when `wc_cancel_unpaid_orders()` cancels, and how long a coupon is
held — so a store cannot shorten the reservation without also cancelling the slow
payments it set the option high for. `woocommerce_order_hold_stock_minutes`
(8.8.0) already separates them. Happy to raise that as its own issue rather than
widen this PR.

### Contexts with no shopper

`wc_get_held_stock_quantity()` also reaches this query from the admin, WP-CLI and
cron. The whole ownership lookup returns early unless `WC()->session` is a
`WC_Session`, so those contexts get the query unchanged — and never consult
`get_current_user_id()`, which in the admin is the store manager rather than a
shopper.

### Public API

`$exclude_order_id` stays scalar, and the clause is appended **before**
`woocommerce_query_for_reserved_stock` fires, so the signature documented since
4.5.0 is unchanged and existing callbacks still receive the complete core query.
A test pins both.

### Cost

One `wc_get_orders()` call per request, only for signed-in shoppers with a
session, memoised per request because a fresh `ReserveStock` is constructed for
every `wc_get_held_stock_quantity()` call and the cart makes one per stock-managed
item. Guests and unauthenticated contexts add no query at all.

### Tests

`plugins/woocommerce/tests/php/src/Checkout/Helpers/ReserveStockOwnHoldsTest.php`,
led by the oversell invariant:

- a shopper's own stale hold does not exclude another shopper's stale hold
- own hold blocks at 9 minutes, is excluded at 11
- a `false` threshold disables the exclusion; a threshold of `0` excludes immediately
- the session list covers a guest whose draft pointer has moved on
- an 11th attempt drops the oldest id from the session list and that hold blocks again
- a session list arriving from somebody else's session confers no ownership
- a billing email confers no ownership
- with no session the total is unchanged
- `woocommerce_query_for_reserved_stock` still receives a scalar order id and the complete query

Run locally against this branch:

| | |
|---|---|
| PHPUnit, default HPOS leg | OK (11 tests, 15 assertions) |
| PHPUnit, `DISABLE_HPOS=1` | OK (11 tests, 15 assertions) |
| PHPStan level 8 | No errors |
| PHPCS | no new errors against unmodified trunk |

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->



