### PR TITLE
Fix: allow items to be added to a existing order with negative quantity

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1765,13 +1765,19 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function add_product( $product, $qty = 1, $args = array() ) {
 		if ( $product ) {
 			$order = ArrayUtil::get_value_or_default( $args, 'order' );
-			$total = wc_get_price_excluding_tax(
+			// wc_get_price_excluding_tax() clamps qty to >= 0, so pass the absolute
+			// value and re-sign the resulting line total to support negative quantities.
+			$abs_qty = abs( (float) $qty );
+			$total   = wc_get_price_excluding_tax(
 				$product,
 				array(
-					'qty'   => $qty,
+					'qty'   => $abs_qty,
 					'order' => $order,
 				)
 			);
+			if ( '' !== $total && (float) $qty < 0 ) {
+				$total = -1 * (float) $total;
+			}
 
 			$default_args = array(
 				'name'         => $product->get_name(),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -121,7 +121,7 @@ $item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $i
 			* @param   WC_Product  $product The product that is being edited.
 			* @param   string      $context The context in which the quantity editor is shown, 'edit' or 'refund'.
 			*/
-			$min_edit   = apply_filters( 'woocommerce_quantity_input_min_admin', '0', $product, 'edit' );
+			$min_edit   = apply_filters( 'woocommerce_quantity_input_min_admin', '-9999', $product, 'edit' );
 			$min_refund = apply_filters( 'woocommerce_quantity_input_min_admin', '0', $product, 'refund' );
 		?>
 		<div class="edit" style="display: none;">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -438,7 +438,7 @@ if ( wc_tax_enabled() ) {
 							<?php
 								$row = '
 									<td><select class="wc-product-search" name="item_id" data-allow_clear="true" data-display_stock="true" data-exclude_type="variable" data-placeholder="' . esc_attr__( 'Search for a product&hellip;', 'woocommerce' ) . '"></select></td>
-									<td><input type="number" step="1" min="0" max="9999" autocomplete="off" name="item_qty" placeholder="1" size="4" class="quantity" /></td>';
+									<td><input type="number" step="1" min="-9999" max="9999" autocomplete="off" name="item_qty" placeholder="1" size="4" class="quantity" /></td>';
 							?>
 							<tbody data-row="<?php echo esc_attr( $row ); ?>">
 								<tr>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

It is currently not possible to add products to existing orders with a negative quantity, due to a front-end restriction in the quantity field. This PR allows for that.

Closes #31068.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Edit an existing order.
2. Select **Add Item(s)**.
3. Select **Add Product(s)**.
4. Find any product, change the quantity to anything less than 0.
5. **Update** the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>
- Allows adding products to existing orders with negative quantity
<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

- Claude for help with calculating amounts for products in [abstract-wc-order.php](https://github.com/woocommerce/woocommerce/compare/trunk...fix/31068-adding-products-with-negative-qty?expand=1#diff-8261b720d84fcccf0d768b1a4114051cd1d52a4661b320a28b5144abefaf41c8)
