### PR TITLE
Fix receipt fatal when a filter sets a non-string payment method

### DIFF
--- a/plugins/woocommerce/changelog/fix-receipt-payment-method-non-string
+++ b/plugins/woocommerce/changelog/fix-receipt-payment-method-non-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cast the payment method title to string on printed order receipts so a non-string value from the woocommerce_printable_order_receipt_data filter no longer fatals receipt generation.

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
@@ -22,7 +22,7 @@
 	<h3 id="payment_status_section_title"><?php echo strtoupper( $data['texts']['payment_status_section_title'] ); ?></h3>
 	<p><?php echo $data['texts']['payment_status']; ?></p>
 
-	<?php if ( isset( $data['payment_method'] ) && ( '' !== trim( $data['payment_method'] ) || ! $data['show_payment_method_title'] ) ) { ?>
+	<?php if ( isset( $data['payment_method'] ) && ( '' !== trim( (string) $data['payment_method'] ) || ! $data['show_payment_method_title'] ) ) { ?>
 		<h3 id="payment_method_section_title"><?php echo strtoupper( $data['texts']['payment_method_section_title'] ); ?></h3>
 		<p>
 			<?php if ( $data['show_payment_method_title'] ) { ?>

--- a/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
+++ b/plugins/woocommerce/src/Internal/ReceiptRendering/Templates/order-receipt.php
@@ -22,7 +22,7 @@
 	<h3 id="payment_status_section_title"><?php echo strtoupper( $data['texts']['payment_status_section_title'] ); ?></h3>
 	<p><?php echo $data['texts']['payment_status']; ?></p>
 
-	<?php if ( isset( $data['payment_method'] ) && ( '' !== trim( (string) $data['payment_method'] ) || ! $data['show_payment_method_title'] ) ) { ?>
+	<?php if ( isset( $data['payment_method'] ) && ( ! $data['show_payment_method_title'] || '' !== trim( (string) $data['payment_method'] ) ) ) { ?>
 		<h3 id="payment_method_section_title"><?php echo strtoupper( $data['texts']['payment_method_section_title'] ); ?></h3>
 		<p>
 			<?php if ( $data['show_payment_method_title'] ) { ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

@albarin after I merged a PR WOOAIRR-70 was created. It's a small fix to that

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`$data` reaches the receipt template through the public `woocommerce_printable_order_receipt_data` filter, so a callback can set `payment_method` to a non-string. `trim()` then throws a `TypeError` and fatals receipt generation, where before it only emitted a non-fatal warning.

Cast to string before trimming, per the AGENTS.md rule to coerce hook data before passing it to strictly typed code. In-tree the value is always a string (`get_payment_method_title()`), so only stores with such an extension are affected.

(For Bug Fixes) Bug introduced in PR #67661.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add to a plugin or snippet: `add_filter( 'woocommerce_printable_order_receipt_data', fn( $d ) => array_merge( $d, array( 'payment_method' => array() ) ) );`
2. Generate a printable receipt for any order (WooCommerce > Orders, or `POST /wc/v3/orders/<id>/receipt`).
3. On trunk the request fatals with `trim(): Argument #1 must be of type string, array given`. With this branch the receipt renders (a PHP notice about array-to-string conversion remains, as before the regression).
4. Remove the filter and confirm normal receipts are unchanged: the payment method section shows for orders with a title and stays hidden for orders without one.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->

- `lint:php:changes` and `lint:changes:branch` clean.
- PHPStan clean on the modified template (baseline unchanged).
- PHPUnit was not run locally (no Docker on this machine); relying on CI. No test added: the fix turns a fatal into a PHP warning, and PHPUnit converts warnings to exceptions, so the non-fatal outcome is not expressible as a unit test.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Claude Code (Claude Opus 5) verified the report this fixes, wrote the one-line change, the changelog entry, and this description.
