### PR TITLE
Add product name CSS class to improved emails

### DIFF
--- a/plugins/woocommerce/changelog/29386-product-name-css-class
+++ b/plugins/woocommerce/changelog/29386-product-name-css-class
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Add a reusable CSS class to product names in classic checkout and order emails.
+Add a reusable CSS class to product names in improved order emails.

--- a/plugins/woocommerce/changelog/29386-product-name-css-class
+++ b/plugins/woocommerce/changelog/29386-product-name-css-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add a reusable CSS class to product names in classic checkout and order emails.

--- a/plugins/woocommerce/templates/checkout/review-order.php
+++ b/plugins/woocommerce/templates/checkout/review-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.2.0
+ * @version 11.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 				?>
 				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
 					<td class="product-name">
-						<span class="wc-product-name"><?php echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) ); ?></span>&nbsp;
+						<?php echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) ) . '&nbsp;'; ?>
 						<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times;&nbsp;%s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						<?php echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</td>

--- a/plugins/woocommerce/templates/checkout/review-order.php
+++ b/plugins/woocommerce/templates/checkout/review-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 11.0.0
+ * @version 11.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 				?>
 				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
 					<td class="product-name">
-						<?php echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) ) . '&nbsp;'; ?>
+						<span class="wc-product-name"><?php echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) ); ?></span>&nbsp;
 						<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times;&nbsp;%s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						<?php echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</td>

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -173,7 +173,7 @@ foreach ( $items as $item_id => $item ) :
 				 * @param WC_Order_Item_Product $item      The item being displayed.
 				 * @since 2.1.0
 				 */
-				echo '<span class="wc-product-name">' . wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) ) . '</span>';
+				echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
 
 				// SKU.
 				if ( $show_sku && $sku ) {

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 11.0.0
+ * @version 11.2.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -90,7 +90,7 @@ foreach ( $items as $item_id => $item ) :
 							 * @since 2.1.0
 							 */
 							$order_item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
-							echo wp_kses_post( "<h3 style='font-size: inherit;font-weight: inherit;'>{$order_item_name}</h3>" );
+							echo wp_kses_post( "<h3 class='wc-product-name' style='font-size: inherit;font-weight: inherit;'>{$order_item_name}</h3>" );
 
 							// SKU.
 							if ( $show_sku && $sku ) {
@@ -173,7 +173,7 @@ foreach ( $items as $item_id => $item ) :
 				 * @param WC_Order_Item_Product $item      The item being displayed.
 				 * @since 2.1.0
 				 */
-				echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+				echo '<span class="wc-product-name">' . wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) ) . '</span>';
 
 				// SKU.
 				if ( $show_sku && $sku ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The improved HTML email layout already renders each product name in its own `h3` element. This PR adds the reusable `wc-product-name` class to that existing element so email styles can target the product name independently.

The broader request in #29386 also proposed wrapping product-name filter output in checkout and legacy emails. That approach was dropped after reviewing ecosystem usage: `woocommerce_cart_item_name` and `woocommerce_order_item_name` callbacks may return structured or block-level HTML, so adding a generic wrapper could change existing markup. Checkout and legacy-email output therefore remain unchanged.

The compatibility impact is limited to an additive class on an existing improved-email element. The element hierarchy, rendered content, hooks, and filter arguments are unchanged.

Related: #29386.

### Screenshots or screen recordings:

No visual change is expected without custom email CSS.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable WooCommerce's email improvements feature.
2. Place an order and generate an HTML order email containing at least one product.
3. Inspect the email HTML and confirm the product-name `h3` has the `wc-product-name` class.
4. Disable email improvements and confirm the legacy email markup remains unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

- `php -l` passes for `templates/emails/email-order-items.php` using PHP 8.4.23.
- Changed-line PHPCS passes for the modified template.
- `git diff --check` passes.
- Ecosystem usage of the affected product-name filters was reviewed across WooCommerce and Automattic repositories. The wrapper changes were removed after finding callbacks that return structured and block-level markup.
- Runtime email rendering has not been tested locally.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually set the milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

A changelog entry was created manually at `plugins/woocommerce/changelog/29386-product-name-css-class`.

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

ChatGPT was used by the original contributor to help triage the issue, inspect templates, prepare the initial implementation, run static validation, and draft the pull request. Pi was used during maintainer review to inspect ecosystem compatibility, reduce the implementation to the safe additive change, and update the pull request description. The final diff was reviewed by a human maintainer.
