### PR TITLE
Keep the "+N more" badge on the same line to even out Analytics rows

### DIFF
--- a/plugins/woocommerce/changelog/fix-37999-analytics-row-height-view-more-badge
+++ b/plugins/woocommerce/changelog/fix-37999-analytics-row-height-view-more-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep a cell's first item on the same line as its "+N more" badge in Analytics report tables, so rows carrying a badge are no longer taller than rows without one.

--- a/plugins/woocommerce/client/admin/client/analytics/report/orders/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/orders/table.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { map } from 'lodash';
 import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { formatValue } from '@woocommerce/number';
@@ -315,12 +315,12 @@ class OrdersReportTable extends Component {
 
 	renderList( visibleItems, popoverItems ) {
 		return (
-			<Fragment>
+			<div className="woocommerce-analytics__inline-list">
 				{ this.renderLinks( visibleItems ) }
 				{ popoverItems.length > 1 && (
 					<ViewMoreList items={ this.renderLinks( popoverItems ) } />
 				) }
-			</Fragment>
+			</div>
 		);
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/report/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/report/style.scss
@@ -22,9 +22,18 @@
 	align-items: center;
 	max-width: 80ch;
 
-	// Enough room that the name beside a badge doesn't shred into three lines.
-	// Scoped so the Coupons cell — same class, usually empty — is left alone.
-	&:has(.woocommerce-view-more-list) {
+	// A name with no spaces has a min-content width of the whole name, which
+	// would otherwise set the column's floor and widen the table. Allowing a
+	// break anywhere lets it wrap inside the bounds here instead.
+	> a {
+		overflow-wrap: anywhere;
+	}
+
+	// Enough room that the name beside a badge doesn't shred into short lines.
+	// On the link rather than the wrapper, so the badge's fixed width isn't
+	// taken out of the name's share. Scoped so the Coupons cell — same class,
+	// usually empty — is left alone.
+	&:has(.woocommerce-view-more-list) > a {
 		min-width: 20ch;
 	}
 

--- a/plugins/woocommerce/client/admin/client/analytics/report/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/report/style.scss
@@ -14,10 +14,23 @@
 
 // Keeps a cell's first item on the same line as its "+N more" badge. The badge
 // is a button, so once it wraps onto its own line it adds that full height and
-// rows carrying one end up taller than rows without.
+// rows carrying one end up taller than rows without. Flex alone (no wrap) is
+// enough for that; the name itself is still allowed to wrap onto multiple
+// lines within the bounds below, so a long name doesn't force one endless row.
 .woocommerce-analytics__inline-list {
 	display: inline-flex;
 	align-items: center;
-	gap: $gap-smaller;
-	white-space: nowrap;
+	max-width: 80ch;
+
+	// Enough room that the name beside a badge doesn't shred into three lines.
+	// Scoped so the Coupons cell — same class, usually empty — is left alone.
+	&:has(.woocommerce-view-more-list) {
+		min-width: 20ch;
+	}
+
+	// The badge carries overflow: hidden and text-overflow: ellipsis, so it
+	// renders as "+…" if flex is allowed to shrink it.
+	> .woocommerce-view-more-list {
+		flex-shrink: 0;
+	}
 }

--- a/plugins/woocommerce/client/admin/client/analytics/report/style.scss
+++ b/plugins/woocommerce/client/admin/client/analytics/report/style.scss
@@ -11,3 +11,13 @@
 		}
 	}
 }
+
+// Keeps a cell's first item on the same line as its "+N more" badge. The badge
+// is a button, so once it wraps onto its own line it adds that full height and
+// rows carrying one end up taller than rows without.
+.woocommerce-analytics__inline-list {
+	display: inline-flex;
+	align-items: center;
+	gap: $gap-smaller;
+	white-space: nowrap;
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

In Analytics report tables, a row whose Products cell carries a "+N more" badge is taller than a row without one. The badge is a button, and in a narrow column it can't fit beside the product name, so it wraps onto its own line and adds that full height.

`renderList()` returned the first item's link and the `ViewMoreList` badge as adjacent fragment children. This wraps them in a scoped `inline-flex` container that keeps them on one line, so every row matches. Following @vladolaru's recommendation on the issue, the fix lives in the Orders report rather than in the shared `Tag` component, so no other consumer of `Tag` is affected.

Closes #37999.
Closes WOOPLUG-1222

**There is a trade-off, and it needs a call from a reviewer.** Keeping the two on one line means the Products cell claims its natural width instead of wrapping. That widens the column and pushes the table into its existing horizontal scroll. This is caused by the change — reverting it returns the overflow to zero on the same data.

### Screenshots or screen recordings:

Before | After
--|--
<img width="1440" height="400" alt="37999-repro" src="https://github.com/user-attachments/assets/0990d3cd-a711-4328-ac9c-c6d196e24c41" /> | <img width="1440" height="400" alt="37999-after" src="https://github.com/user-attachments/assets/9152fadd-d4c1-4408-a109-ac8c81bd3db4" />


### How to test the changes in this Pull Request:

1. Create two completed orders: one with a single product, one with three or more products. Optionally add a third with a very long product name.
2. Make sure they are imported into Analytics (Analytics → Settings → Import historical data, if needed).
3. Go to **Analytics → Orders** and set the date range so all orders appear.
4. Every row should be the same height. On trunk, the rows with a "+N more" badge are visibly taller.
5. Click a "+N more" badge and confirm the popover still opens and lists all products.
6. Narrow the window and confirm the table's horizontal scroll still behaves.

### Testing that has already taken place:

Tested on wp-env at 1440px and 768px, comparing against trunk on the same three orders.

Row heights at 1440px:

| Row | Before | After |
| --- | ------ | ----- |
| 82-character product name + `+2 more` | 232.8px | 87.6px |
| Typical product name + `+2 more` | 105.4px | 87.6px |
| Single product, no badge | 87.1px | 87.1px |

The 105.4px figure matches the measurement @vladolaru recorded on the issue.

The popover still opens at 288px and lists every product, so the #65414 popover-width behaviour is unaffected. Both `renderList()` call sites are covered, so the Coupons column benefits too. stylelint passes; `eslint` reports two `i18n-no-flanking-whitespace` warnings on line 276 that are already present on trunk.

**The width trade-off, measured.** Products column width and how far the table overflows its card, with the 82-character product name present:

| | Products column | Table overflow |
| --- | --------------- | -------------- |
| Trunk (uneven rows) | 125px | 0px |
| This PR | 655px | 522px |
| This PR + an 18ch ellipsis cap on the link | 275px | 143px |
| This PR + an explicit 200px column | 200px | 68px |

With ordinary product names and no pathological case, this PR alone gives a 232px column and 100px of overflow. The 522px figure comes from a deliberately extreme name.

Some horizontal growth is unavoidable if the name and badge share a line: the badge is around 70px wide plus an 8px gap, so the column cannot stay at 125px and still show a useful amount of the name. I also tried letting the link shrink to fit rather than the column grow, but in an auto-layout table the cell's natural width still drives the column, so it has no effect. Equalising vertically instead does not work either, because a row's height can only grow, so the tall row stays tall.

Worth knowing the table already scrolls horizontally by design — its accessible name is "Orders (scroll to see more)" — so this makes an existing affordance fire more often rather than introducing one.

I have left the patch as the plain fix. If a reviewer would rather bound the column, the ellipsis cap is three lines in the same scoped block and the full product name remains available in the popover and the CSV export.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->

### Use of AI Tools

Written with Claude Code, which diagnosed the cause, made the layout change, and ran the browser checks. I walked through the flows, reviewed the result, and take responsibility for it.
