### PR TITLE
Fix Store API fatal when the cart session fails to load

### DIFF
--- a/plugins/woocommerce/changelog/67124-fix-store-api-cart-session-error-boundary
+++ b/plugins/woocommerce/changelog/67124-fix-store-api-cart-session-error-boundary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Return a Store API error response instead of a fatal error when the cart cannot be loaded from the session.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -104,6 +104,37 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	}
 
 	/**
+	 * Convert a failure during cart session loading into a client-safe error response.
+	 *
+	 * The original error is logged rather than returned, so nothing internal reaches the client.
+	 *
+	 * @param  \Throwable $error The error that occurred while loading the cart session.
+	 * @return \WP_REST_Response The error response to return to the client.
+	 */
+	protected function get_cart_session_error_response( \Throwable $error ) {
+		wc_get_logger()->error(
+			sprintf(
+				'Store API could not load the cart session: %1$s in %2$s:%3$d',
+				$error->getMessage(),
+				$error->getFile(),
+				$error->getLine()
+			),
+			array(
+				'source'    => 'store-api',
+				'exception' => $error,
+			)
+		);
+
+		return $this->error_to_response(
+			$this->get_route_error_response(
+				'woocommerce_rest_unknown_server_error',
+				__( 'The cart could not be loaded. Please try again.', 'woocommerce' ),
+				500
+			)
+		);
+	}
+
+	/**
 	 * Get the route response based on the type of request.
 	 *
 	 * @param \WP_REST_Request $request Request object.
@@ -111,7 +142,11 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->load_cart_session( $request );
+		try {
+			$this->load_cart_session( $request );
+		} catch ( \Throwable $error ) {
+			return $this->add_response_headers( $this->get_cart_session_error_response( $error ) );
+		}
 
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
@@ -156,9 +191,12 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		$response->header( 'Nonce', $nonce );
 		$response->header( 'Nonce-Timestamp', time() );
 		$response->header( 'User-ID', get_current_user_id() );
-		$response->header( 'Cart-Token', $this->get_cart_token() );
-		$response->header( 'Cart-Hash', WC()->cart->get_cart_hash() );
 		$response->header( 'Cache-Control', 'no-store' );
+
+		if ( WC()->cart instanceof \WC_Cart ) {
+			$response->header( 'Cart-Token', $this->get_cart_token() );
+			$response->header( 'Cart-Hash', WC()->cart->get_cart_hash() );
+		}
 
 		return $response;
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -150,7 +150,11 @@ class Checkout extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->load_cart_session( $request );
+		try {
+			$this->load_cart_session( $request );
+		} catch ( \Throwable $error ) {
+			return $this->add_response_headers( $this->get_cart_session_error_response( $error ) );
+		}
 
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -34,6 +34,13 @@ class Cart extends ControllerTestCase {
 	private static $coupon_id;
 
 	/**
+	 * Cart instance removed to mimic a REST request, restored on teardown.
+	 *
+	 * @var \WC_Cart|null
+	 */
+	private $cart_backup = null;
+
+	/**
 	 * Create immutable catalog rows shared by all test methods.
 	 */
 	public static function wpSetUpBeforeClass(): void {
@@ -1549,5 +1556,65 @@ class Cart extends ControllerTestCase {
 
 		remove_action( 'internal_woocommerce_cart_item_added_from_user_request', $callback );
 		remove_filter( 'woocommerce_store_api_add_to_cart_data', $add_to_cart_data_callback );
+	}
+
+	/**
+	 * @testdox Should return an error response when restoring the cart session throws.
+	 */
+	public function test_cart_session_failure_returns_error_response() {
+		wc()->session->set( 'cart', wc()->cart->get_cart_for_session() );
+
+		// The route restores the cart only when this action has not run yet, so reset
+		// the counter to put the process back into the state a REST request starts in.
+		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+
+		add_filter(
+			'woocommerce_get_cart_item_from_session',
+			static function () {
+				throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+			}
+		);
+
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
+
+		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
+		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @testdox Should return an error response when the cart session fails before it is restored.
+	 */
+	public function test_cart_session_failure_before_restore_returns_error_response() {
+		// This filter runs before `get_cart_from_session()` fires its action, so nothing
+		// stops the response headers attempting a second load of the failed cart.
+		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+
+		// A REST request never runs `initialize_cart()`, so the route starts with no
+		// cart at all. The test bootstrap leaves one behind.
+		$this->cart_backup = WC()->cart;
+		WC()->cart         = null;
+
+		add_filter(
+			'woocommerce_session_handler',
+			static function () {
+				throw new \RuntimeException( 'Synthetic session handler failure.' );
+			}
+		);
+
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
+
+		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
+	}
+
+	/**
+	 * Restore the cart instance removed by the cart session failure tests.
+	 */
+	public function tearDown(): void {
+		if ( $this->cart_backup instanceof \WC_Cart ) {
+			WC()->cart         = $this->cart_backup;
+			$this->cart_backup = null;
+		}
+
+		parent::tearDown();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -2929,4 +2929,27 @@ class Checkout extends \WP_Test_REST_TestCase {
 		$this->assertNull( $result, 'No payment method on a zero-total order should resolve to a null gateway.' );
 		$this->assertSame( 0, $gateway_resolution_count, 'Available payment gateways must not be resolved when no payment method is supplied.' );
 	}
+
+	/**
+	 * @testdox Should return an error response when restoring the cart session throws.
+	 */
+	public function test_cart_session_failure_returns_error_response() {
+		wc()->session->set( 'cart', wc()->cart->get_cart_for_session() );
+
+		// The route restores the cart only when this action has not run yet, so reset
+		// the counter to put the process back into the state a REST request starts in.
+		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+
+		add_filter(
+			'woocommerce_get_cart_item_from_session',
+			static function () {
+				throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+			}
+		);
+
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' ) );
+
+		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
+		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

- Wrapped `AbstractCartRoute::get_response()`'s and `Checkout::get_response()`'s calls to `load_cart_session()` in a  `try/catch` block, so any `Throwable` raised while WooCommerce restores the cart from the session is caught.
- I also added a check in `add_response_headers` to make sure the cart exists before trying to generate headers based off it.
- Created `get_cart_session_error_response` to log the error, this is shared between `Checkout` and `AbstracrCartRoute`.

**Backward compatibility:** `add_response_headers()` now omits `Cart-Token` and `Cart-Hash` when no cart is available. This only occurs on a path that previously fataled, and the method is still invoked on every path, so subclass overrides continue to fire. `get_cart_session_error_response()` is a new `protected` method on a class extensions subclass — additive, though a subclass that already declares that exact name would collide. No signatures, hooks or script handles changed.

Closes #67124.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a simple product, add it to the cart, and keep that browser session open.
2. Add a temporary mu-plugin or code snippet that makes cart restoration fail on REST requests:

```php
add_filter(
	'woocommerce_get_cart_item_from_session',
	static function ( $session_data ) {
		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
		}
		return $session_data;
	}
);
```

3. In the same browser session, visit `/wp-json/wc/store/v1/cart`.
4. **Before this change:** HTTP 500 `internal_server_error` from WordPress's fatal handler, with no `Nonce` header.
   **After this change:** HTTP 500 with a Store API JSON body — `{"code":"woocommerce_rest_unknown_server_error","message":"The cart could not be loaded. Please try again.","data":{"status":500}}` — and `Nonce`, `Nonce-Timestamp`, `User-ID` and `Cache-Control` headers present.
5. Repeat with `/wp-json/wc/store/v1/checkout` to exercise Checkout's separate `get_response()` implementation.
6. Confirm the original exception, with file and line, is recorded in **WooCommerce → Status → Logs** under the `store-api` source.
7. Remove the mu-plugin, then reload Cart and Checkout and confirm both work normally.

<!-- End testing instructions -->

### Testing that has already taken place:

Three regression tests were added to the existing Store API route test classes — two in `tests/php/src/Blocks/StoreApi/Routes/Cart.php`, one in `tests/php/src/Blocks/StoreApi/Routes/Checkout.php`:

- Cart route converts a cart-session `Throwable` into a Store API error response.
- Checkout route does the same through its own `get_response()`.
- A failure raised *before* the session restore — thrown from `woocommerce_session_handler`, so nothing short-circuits a second load attempt — no longer fatals during response-header generation.

Each of the three was confirmed to fail against `trunk` and to pass with this change. The full `Cart` and `Checkout` route suites pass: 93 tests, 394 assertions.

Also run clean: `lint:php:changes`, `lint:changes:branch`, and PHPStan across `src/StoreApi` (132 files).

Not tested under multisite. The change reads no site-scoped state, builds no paths or URLs, and adds no new global dependencies, so multisite behaviour is expected to be unaffected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Claude Code was used throughout: to reproduce the reported issue as a failing PHPUnit test, to investigate the cause and the follow-on failure in response-header generation, and to draft parts of the fix and these testing instructions. The final implementation was written and reviewed by hand, and every claim above is backed by a test or command run locally.
