### PR TITLE
Fix non-scalar classic cart item data (redux)

### DIFF
--- a/plugins/woocommerce/changelog/65484-fix-cart-item-data-non-scalar
+++ b/plugins/woocommerce/changelog/65484-fix-cart-item-data-non-scalar
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent classic cart item data rendering from fataling when extensions provide non-scalar item data.
+Prevent non-scalar cart item data provided by extensions from causing a fatal error when rendering the classic cart.

--- a/plugins/woocommerce/changelog/65484-fix-cart-item-data-non-scalar
+++ b/plugins/woocommerce/changelog/65484-fix-cart-item-data-non-scalar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent classic cart item data rendering from fataling when extensions provide non-scalar item data.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4549,21 +4549,20 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 				unset( $item_data[ $key ] );
 				continue;
 			}
-			// Resolve the label and display value that will actually be rendered.
-			// Only these two values are escaped during output, so guard against
-			// non-scalar values here to prevent fatals while preserving rows whose
-			// non-rendered fields (or a non-scalar `value` with a scalar `display`)
-			// would still render correctly.
+			// Only the label and display value are rendered; drop rows whose rendered values cannot be cast to a string.
 			$label   = ! empty( $data['key'] ) ? $data['key'] : ( $data['name'] ?? '' );
 			$display = ! empty( $data['display'] ) ? $data['display'] : ( $data['value'] ?? '' );
 
-			if ( ! is_scalar( $label ) || ! is_scalar( $display ) ) {
+			$label_is_renderable   = is_scalar( $label ) || ( is_object( $label ) && method_exists( $label, '__toString' ) );
+			$display_is_renderable = is_scalar( $display ) || ( is_object( $display ) && method_exists( $display, '__toString' ) );
+
+			if ( ! $label_is_renderable || ! $display_is_renderable ) {
 				unset( $item_data[ $key ] );
 				continue;
 			}
 
-			$item_data[ $key ]['key']     = $label;
-			$item_data[ $key ]['display'] = $display;
+			$item_data[ $key ]['key']     = (string) $label;
+			$item_data[ $key ]['display'] = (string) $display;
 		}
 
 		// Output flat or in list format.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4549,7 +4549,6 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 				unset( $item_data[ $key ] );
 				continue;
 			}
-			// Only the label and display value are rendered; drop rows whose rendered values cannot be cast to a string.
 			$label   = ! empty( $data['key'] ) ? $data['key'] : ( $data['name'] ?? '' );
 			$display = ! empty( $data['display'] ) ? $data['display'] : ( $data['value'] ?? '' );
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4549,14 +4549,21 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 				unset( $item_data[ $key ] );
 				continue;
 			}
-			foreach ( $data as $data_value ) {
-				if ( ! is_scalar( $data_value ) ) {
-					unset( $item_data[ $key ] );
-					continue 2;
-				}
+			// Resolve the label and display value that will actually be rendered.
+			// Only these two values are escaped during output, so guard against
+			// non-scalar values here to prevent fatals while preserving rows whose
+			// non-rendered fields (or a non-scalar `value` with a scalar `display`)
+			// would still render correctly.
+			$label   = ! empty( $data['key'] ) ? $data['key'] : ( $data['name'] ?? '' );
+			$display = ! empty( $data['display'] ) ? $data['display'] : ( $data['value'] ?? '' );
+
+			if ( ! is_scalar( $label ) || ! is_scalar( $display ) ) {
+				unset( $item_data[ $key ] );
+				continue;
 			}
-			$item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
-			$item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];
+
+			$item_data[ $key ]['key']     = $label;
+			$item_data[ $key ]['display'] = $display;
 		}
 
 		// Output flat or in list format.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4540,10 +4540,20 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
 	if ( is_array( $item_data ) ) {
 		// Format item data ready to display.
 		foreach ( $item_data as $key => $data ) {
+			if ( ! is_array( $data ) ) {
+				unset( $item_data[ $key ] );
+				continue;
+			}
 			// Set hidden to true to not display meta on cart.
 			if ( ! empty( $data['hidden'] ) ) {
 				unset( $item_data[ $key ] );
 				continue;
+			}
+			foreach ( $data as $data_value ) {
+				if ( ! is_scalar( $data_value ) ) {
+					unset( $item_data[ $key ] );
+					continue 2;
+				}
 			}
 			$item_data[ $key ]['key']     = ! empty( $data['key'] ) ? $data['key'] : $data['name'];
 			$item_data[ $key ]['display'] = ! empty( $data['display'] ) ? $data['display'] : $data['value'];

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -310,6 +310,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 				'value'   => 'Details',
 				'display' => new stdClass(),
 			);
+			$item_data[] = 'Malformed item data';
 
 			return $item_data;
 		};
@@ -333,6 +334,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( 'file-a.pdf', $html );
 		$this->assertStringNotContainsString( 'Extra', $html );
 		$this->assertStringNotContainsString( 'Details', $html );
+		$this->assertStringNotContainsString( 'Malformed item data', $html );
 	}
 
 	/**
@@ -348,6 +350,12 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 				'key'   => 'Attachments',
 				'value' => array( 'file-a.pdf', 'file-b.pdf' ),
 			);
+			$item_data[] = array(
+				'key'     => 'Extra',
+				'value'   => 'Details',
+				'display' => new stdClass(),
+			);
+			$item_data[] = 'Malformed item data';
 
 			return $item_data;
 		};
@@ -367,6 +375,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		}
 
 		$this->assertSame( "Gift wrap: Included\n", $output );
+		$this->assertStringNotContainsString( 'Malformed item data', $output );
 	}
 
 	public function test_hidden_field() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -300,7 +300,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	 * @param array $item_data Existing item data.
 	 * @return array
 	 */
-	private function get_cart_item_data_fixture( $item_data ) {
+	public function get_cart_item_data_fixture( $item_data ) {
 		$item_data[] = array(
 			'key'   => 'Gift wrap',
 			'value' => 'Included',

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -378,6 +378,90 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( 'Malformed item data', $output );
 	}
 
+	/**
+	 * Test wc_get_formatted_cart_item_data renders rows when only the non-rendered
+	 * fields are non-scalar, since the classic cart renders just the label and display.
+	 */
+	public function test_wc_get_formatted_cart_item_data_renders_scalar_display_with_non_scalar_value() {
+		$filter = function ( $item_data ) {
+			// Non-scalar `value`, but a scalar `display` — should render using `display`.
+			$item_data[] = array(
+				'key'     => 'Attachments',
+				'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
+				'display' => '2 files',
+			);
+			// Scalar rendered fields alongside a non-scalar field that is never rendered.
+			$item_data[] = array(
+				'key'      => 'Custom',
+				'value'    => 'Shown',
+				'display'  => 'Shown',
+				'_private' => array( 'internal' => 'data' ),
+			);
+
+			return $item_data;
+		};
+
+		add_filter( 'woocommerce_get_item_data', $filter );
+
+		try {
+			$html = wc_get_formatted_cart_item_data(
+				array(
+					'data'      => new WC_Product_Simple(),
+					'variation' => array(),
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_get_item_data', $filter );
+		}
+
+		// Both rows render, using their scalar display values.
+		$this->assertStringContainsString( 'Attachments', $html );
+		$this->assertStringContainsString( '2 files', $html );
+		$this->assertStringContainsString( 'Custom', $html );
+		$this->assertStringContainsString( 'Shown', $html );
+		// The non-scalar value must not leak into the output.
+		$this->assertStringNotContainsString( 'file-a.pdf', $html );
+	}
+
+	/**
+	 * Test wc_get_formatted_cart_item_data renders rows when only the non-rendered
+	 * fields are non-scalar, in flat output.
+	 */
+	public function test_wc_get_formatted_cart_item_data_renders_scalar_display_with_non_scalar_value_in_flat_output() {
+		$filter = function ( $item_data ) {
+			$item_data[] = array(
+				'key'     => 'Attachments',
+				'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
+				'display' => '2 files',
+			);
+			$item_data[] = array(
+				'key'      => 'Custom',
+				'value'    => 'Shown',
+				'display'  => 'Shown',
+				'_private' => array( 'internal' => 'data' ),
+			);
+
+			return $item_data;
+		};
+
+		add_filter( 'woocommerce_get_item_data', $filter );
+
+		try {
+			$output = wc_get_formatted_cart_item_data(
+				array(
+					'data'      => new WC_Product_Simple(),
+					'variation' => array(),
+				),
+				true
+			);
+		} finally {
+			remove_filter( 'woocommerce_get_item_data', $filter );
+		}
+
+		$this->assertSame( "Attachments: 2 files\nCustom: Shown\n", $output );
+		$this->assertStringNotContainsString( 'file-a.pdf', $output );
+	}
+
 	public function test_hidden_field() {
 		$actual_html   = woocommerce_form_field(
 			'test',

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -301,25 +301,21 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	 * @return array
 	 */
 	private function get_cart_item_data_fixture( $item_data ) {
-		// Renders: plain scalar row.
 		$item_data[] = array(
 			'key'   => 'Gift wrap',
 			'value' => 'Included',
 		);
-		// Renders: non-scalar `value` but scalar `display`.
 		$item_data[] = array(
 			'key'     => 'Attachments',
 			'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
 			'display' => '2 files',
 		);
-		// Renders: non-scalar field that is never rendered.
 		$item_data[] = array(
 			'key'      => 'Custom',
 			'value'    => 'Hidden value',
 			'display'  => 'Shown',
 			'_private' => array( 'internal' => 'data' ),
 		);
-		// Renders: object implementing __toString as `display`.
 		$item_data[] = array(
 			'key'     => 'Note',
 			'display' => new class() {
@@ -328,18 +324,15 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 				}
 			},
 		);
-		// Dropped: non-scalar `value` without a `display`.
 		$item_data[] = array(
 			'key'   => 'Files',
 			'value' => array( 'file-c.pdf' ),
 		);
-		// Dropped: non-stringable object as `display`.
 		$item_data[] = array(
 			'key'     => 'Extra',
 			'value'   => 'Details',
 			'display' => new stdClass(),
 		);
-		// Dropped: not an array.
 		$item_data[] = 'Malformed item data';
 
 		return $item_data;
@@ -384,7 +377,6 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'Shown', $html );
 		$this->assertStringContainsString( 'Note', $html );
 		$this->assertStringContainsString( 'From object', $html );
-		// `display` is preferred over `value`, and non-renderable rows are dropped.
 		$this->assertStringNotContainsString( 'Hidden value', $html );
 		$this->assertStringNotContainsString( 'file-a.pdf', $html );
 		$this->assertStringNotContainsString( 'Files', $html );

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -293,173 +293,112 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data skips non-scalar item data.
+	 * Item data used by the wc_get_formatted_cart_item_data tests, mixing rows
+	 * that should render (scalar or stringable rendered fields) with rows that
+	 * should be dropped (non-scalar rendered fields or malformed entries).
+	 *
+	 * @param array $item_data Existing item data.
+	 * @return array
 	 */
-	public function test_wc_get_formatted_cart_item_data_skips_non_scalar_item_data() {
-		$filter = function ( $item_data ) {
-			$item_data[] = array(
-				'key'   => 'Gift wrap',
-				'value' => 'Included',
-			);
-			$item_data[] = array(
-				'key'   => 'Attachments',
-				'value' => array( 'file-a.pdf', 'file-b.pdf' ),
-			);
-			$item_data[] = array(
-				'key'     => 'Extra',
-				'value'   => 'Details',
-				'display' => new stdClass(),
-			);
-			$item_data[] = 'Malformed item data';
+	private function get_cart_item_data_fixture( $item_data ) {
+		// Renders: plain scalar row.
+		$item_data[] = array(
+			'key'   => 'Gift wrap',
+			'value' => 'Included',
+		);
+		// Renders: non-scalar `value` but scalar `display`.
+		$item_data[] = array(
+			'key'     => 'Attachments',
+			'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
+			'display' => '2 files',
+		);
+		// Renders: non-scalar field that is never rendered.
+		$item_data[] = array(
+			'key'      => 'Custom',
+			'value'    => 'Hidden value',
+			'display'  => 'Shown',
+			'_private' => array( 'internal' => 'data' ),
+		);
+		// Renders: object implementing __toString as `display`.
+		$item_data[] = array(
+			'key'     => 'Note',
+			'display' => new class() {
+				public function __toString() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+					return 'From object';
+				}
+			},
+		);
+		// Dropped: non-scalar `value` without a `display`.
+		$item_data[] = array(
+			'key'   => 'Files',
+			'value' => array( 'file-c.pdf' ),
+		);
+		// Dropped: non-stringable object as `display`.
+		$item_data[] = array(
+			'key'     => 'Extra',
+			'value'   => 'Details',
+			'display' => new stdClass(),
+		);
+		// Dropped: not an array.
+		$item_data[] = 'Malformed item data';
 
-			return $item_data;
-		};
-
-		add_filter( 'woocommerce_get_item_data', $filter );
-
-		try {
-			$html = wc_get_formatted_cart_item_data(
-				array(
-					'data'      => new WC_Product_Simple(),
-					'variation' => array(),
-				)
-			);
-		} finally {
-			remove_filter( 'woocommerce_get_item_data', $filter );
-		}
-
-		$this->assertStringContainsString( 'Gift wrap', $html );
-		$this->assertStringContainsString( 'Included', $html );
-		$this->assertStringNotContainsString( 'Attachments', $html );
-		$this->assertStringNotContainsString( 'file-a.pdf', $html );
-		$this->assertStringNotContainsString( 'Extra', $html );
-		$this->assertStringNotContainsString( 'Details', $html );
-		$this->assertStringNotContainsString( 'Malformed item data', $html );
+		return $item_data;
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data skips non-scalar item data in flat output.
+	 * Calls wc_get_formatted_cart_item_data with the shared fixture hooked into
+	 * the woocommerce_get_item_data filter.
+	 *
+	 * @param bool $flat Whether to request flat output.
+	 * @return string
 	 */
-	public function test_wc_get_formatted_cart_item_data_skips_non_scalar_item_data_in_flat_output() {
-		$filter = function ( $item_data ) {
-			$item_data[] = array(
-				'key'   => 'Gift wrap',
-				'value' => 'Included',
-			);
-			$item_data[] = array(
-				'key'   => 'Attachments',
-				'value' => array( 'file-a.pdf', 'file-b.pdf' ),
-			);
-			$item_data[] = array(
-				'key'     => 'Extra',
-				'value'   => 'Details',
-				'display' => new stdClass(),
-			);
-			$item_data[] = 'Malformed item data';
-
-			return $item_data;
-		};
-
+	private function get_formatted_cart_item_data_with_fixture( $flat ) {
+		$filter = array( $this, 'get_cart_item_data_fixture' );
 		add_filter( 'woocommerce_get_item_data', $filter );
 
 		try {
-			$output = wc_get_formatted_cart_item_data(
+			return wc_get_formatted_cart_item_data(
 				array(
 					'data'      => new WC_Product_Simple(),
 					'variation' => array(),
 				),
-				true
+				$flat
 			);
 		} finally {
 			remove_filter( 'woocommerce_get_item_data', $filter );
 		}
-
-		$this->assertSame( "Gift wrap: Included\n", $output );
-		$this->assertStringNotContainsString( 'Malformed item data', $output );
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data renders rows when only the non-rendered
-	 * fields are non-scalar, since the classic cart renders just the label and display.
+	 * Test wc_get_formatted_cart_item_data renders rows whose label and display
+	 * value are stringable and drops the rest.
 	 */
-	public function test_wc_get_formatted_cart_item_data_renders_scalar_display_with_non_scalar_value() {
-		$filter = function ( $item_data ) {
-			// Non-scalar `value`, but a scalar `display` — should render using `display`.
-			$item_data[] = array(
-				'key'     => 'Attachments',
-				'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
-				'display' => '2 files',
-			);
-			// Scalar rendered fields alongside a non-scalar field that is never rendered.
-			$item_data[] = array(
-				'key'      => 'Custom',
-				'value'    => 'Shown',
-				'display'  => 'Shown',
-				'_private' => array( 'internal' => 'data' ),
-			);
+	public function test_wc_get_formatted_cart_item_data_skips_non_renderable_item_data() {
+		$html = $this->get_formatted_cart_item_data_with_fixture( false );
 
-			return $item_data;
-		};
-
-		add_filter( 'woocommerce_get_item_data', $filter );
-
-		try {
-			$html = wc_get_formatted_cart_item_data(
-				array(
-					'data'      => new WC_Product_Simple(),
-					'variation' => array(),
-				)
-			);
-		} finally {
-			remove_filter( 'woocommerce_get_item_data', $filter );
-		}
-
-		// Both rows render, using their scalar display values.
+		$this->assertStringContainsString( 'Gift wrap', $html );
+		$this->assertStringContainsString( 'Included', $html );
 		$this->assertStringContainsString( 'Attachments', $html );
 		$this->assertStringContainsString( '2 files', $html );
 		$this->assertStringContainsString( 'Custom', $html );
 		$this->assertStringContainsString( 'Shown', $html );
-		// The non-scalar value must not leak into the output.
+		$this->assertStringContainsString( 'Note', $html );
+		$this->assertStringContainsString( 'From object', $html );
+		// `display` is preferred over `value`, and non-renderable rows are dropped.
+		$this->assertStringNotContainsString( 'Hidden value', $html );
 		$this->assertStringNotContainsString( 'file-a.pdf', $html );
+		$this->assertStringNotContainsString( 'Files', $html );
+		$this->assertStringNotContainsString( 'Extra', $html );
+		$this->assertStringNotContainsString( 'Malformed item data', $html );
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data renders rows when only the non-rendered
-	 * fields are non-scalar, in flat output.
+	 * Test wc_get_formatted_cart_item_data renders the same rows in flat output.
 	 */
-	public function test_wc_get_formatted_cart_item_data_renders_scalar_display_with_non_scalar_value_in_flat_output() {
-		$filter = function ( $item_data ) {
-			$item_data[] = array(
-				'key'     => 'Attachments',
-				'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
-				'display' => '2 files',
-			);
-			$item_data[] = array(
-				'key'      => 'Custom',
-				'value'    => 'Shown',
-				'display'  => 'Shown',
-				'_private' => array( 'internal' => 'data' ),
-			);
+	public function test_wc_get_formatted_cart_item_data_skips_non_renderable_item_data_in_flat_output() {
+		$output = $this->get_formatted_cart_item_data_with_fixture( true );
 
-			return $item_data;
-		};
-
-		add_filter( 'woocommerce_get_item_data', $filter );
-
-		try {
-			$output = wc_get_formatted_cart_item_data(
-				array(
-					'data'      => new WC_Product_Simple(),
-					'variation' => array(),
-				),
-				true
-			);
-		} finally {
-			remove_filter( 'woocommerce_get_item_data', $filter );
-		}
-
-		$this->assertSame( "Attachments: 2 files\nCustom: Shown\n", $output );
-		$this->assertStringNotContainsString( 'file-a.pdf', $output );
+		$this->assertSame( "Gift wrap: Included\nAttachments: 2 files\nCustom: Shown\nNote: From object\n", $output );
 	}
 
 	public function test_hidden_field() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -292,6 +292,83 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_html, $actual_html );
 	}
 
+	/**
+	 * Test wc_get_formatted_cart_item_data skips non-scalar item data.
+	 */
+	public function test_wc_get_formatted_cart_item_data_skips_non_scalar_item_data() {
+		$filter = function ( $item_data ) {
+			$item_data[] = array(
+				'key'   => 'Gift wrap',
+				'value' => 'Included',
+			);
+			$item_data[] = array(
+				'key'   => 'Attachments',
+				'value' => array( 'file-a.pdf', 'file-b.pdf' ),
+			);
+			$item_data[] = array(
+				'key'     => 'Extra',
+				'value'   => 'Details',
+				'display' => new stdClass(),
+			);
+
+			return $item_data;
+		};
+
+		add_filter( 'woocommerce_get_item_data', $filter );
+
+		try {
+			$html = wc_get_formatted_cart_item_data(
+				array(
+					'data'      => new WC_Product_Simple(),
+					'variation' => array(),
+				)
+			);
+		} finally {
+			remove_filter( 'woocommerce_get_item_data', $filter );
+		}
+
+		$this->assertStringContainsString( 'Gift wrap', $html );
+		$this->assertStringContainsString( 'Included', $html );
+		$this->assertStringNotContainsString( 'Attachments', $html );
+		$this->assertStringNotContainsString( 'file-a.pdf', $html );
+		$this->assertStringNotContainsString( 'Extra', $html );
+		$this->assertStringNotContainsString( 'Details', $html );
+	}
+
+	/**
+	 * Test wc_get_formatted_cart_item_data skips non-scalar item data in flat output.
+	 */
+	public function test_wc_get_formatted_cart_item_data_skips_non_scalar_item_data_in_flat_output() {
+		$filter = function ( $item_data ) {
+			$item_data[] = array(
+				'key'   => 'Gift wrap',
+				'value' => 'Included',
+			);
+			$item_data[] = array(
+				'key'   => 'Attachments',
+				'value' => array( 'file-a.pdf', 'file-b.pdf' ),
+			);
+
+			return $item_data;
+		};
+
+		add_filter( 'woocommerce_get_item_data', $filter );
+
+		try {
+			$output = wc_get_formatted_cart_item_data(
+				array(
+					'data'      => new WC_Product_Simple(),
+					'variation' => array(),
+				),
+				true
+			);
+		} finally {
+			remove_filter( 'woocommerce_get_item_data', $filter );
+		}
+
+		$this->assertSame( "Gift wrap: Included\n", $output );
+	}
+
 	public function test_hidden_field() {
 		$actual_html   = woocommerce_form_field(
 			'test',

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -363,8 +363,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data renders rows whose label and display
-	 * value are stringable and drops the rest.
+	 * @testdox 'wc_get_formatted_cart_item_data' renders rows whose label and display value are stringable and drops the rest.
 	 */
 	public function test_wc_get_formatted_cart_item_data_skips_non_renderable_item_data() {
 		$html = $this->get_formatted_cart_item_data_with_fixture( false );
@@ -385,7 +384,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_get_formatted_cart_item_data renders the same rows in flat output.
+	 * @testdox 'wc_get_formatted_cart_item_data' renders the same rows in flat output.
 	 */
 	public function test_wc_get_formatted_cart_item_data_skips_non_renderable_item_data_in_flat_output() {
 		$output = $this->get_formatted_cart_item_data_with_fixture( true );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This is a redux of #65837 by @sawirricardo, reopened from a fresh branch so CI can run again (the original run is too old to re-run and the fork does not allow maintainer pushes). All commits from that PR are preserved with their original authorship. The only addition is a small commit adding `@testdox` annotations to the two new tests, which was the last outstanding review item.

From the original PR:

> Root cause: `wc_get_formatted_cart_item_data()` copied `value` into `display` without validating the field type. When an extension returned an array or object, that non-scalar value reached template output helpers such as `wpautop()`.

With this fix, the classic cart drops a `woocommerce_get_item_data` row before rendering when the row is not an array, or when a rendered field (the label, or the display value with `display` preferred over `value`) is not a scalar or an object implementing `__toString()`. Non-scalar data in fields that are not rendered does not cause a row to be dropped.

Replaces #65837.

Closes #65484.

### How to test the changes in this Pull Request:

1. Use a WooCommerce site running PHP 8.1+ with the classic cart page available.
2. Add this temporary snippet through a small test plugin, mu-plugin, or code snippet tool:

```php
add_filter(
    'woocommerce_get_item_data',
    function ( $item_data ) {
        $item_data[] = array(
            'key'   => 'Gift wrap',
            'value' => 'Included',
        );
        $item_data[] = array(
            'key'     => 'Attachments',
            'value'   => array( 'file-a.pdf', 'file-b.pdf' ),
            'display' => '2 files',
        );
        $item_data[] = array(
            'key'   => 'Files',
            'value' => array( 'file-c.pdf' ),
        );
        $item_data[] = array(
            'key'     => 'Extra',
            'value'   => 'Details',
            'display' => new stdClass(),
        );
        $item_data[] = 'Malformed item data';

        return $item_data;
    }
);
```

3. Add any product to the cart.
4. Visit the classic cart page and confirm the page does not fatal.
5. Confirm the cart item data shows `Gift wrap: Included` and `Attachments: 2 files`.
6. Confirm `Files`, `file-a.pdf`, `Extra`, `Details`, and `Malformed item data` are not shown.
7. Visit checkout and any mini-cart location using the classic template path, then confirm the same behavior.
8. Optional flat-output check: call `wc_get_formatted_cart_item_data( $cart_item, true )` for an item in the cart and confirm the returned string is `Gift wrap: Included\nAttachments: 2 files\n`.

Before this fix, the same snippet can trigger a PHP 8+ fatal when the non-scalar value reaches classic template output.

### Testing that has already taken place:

Unit tests in `plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php` cover both the HTML and flat output paths. The same commits (through 70410bcda39) passed all required CI checks on #65837, where the code was reviewed over several rounds.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

https://claude.ai/code/session_01B2TdqXCihgNvbvmSHMuD4y