### PR TITLE
Add product sorting usage tracking

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-7525-track-product-sorting-usage
+++ b/plugins/woocommerce/changelog/wooplug-7525-track-product-sorting-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tracking for product sorting views and manual reordering.

--- a/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
@@ -60,6 +60,14 @@ jQuery( function( $ ) {
 					ui.item.find( '.check-column input' ).show().siblings( 'img' ).remove();
 					$( 'table.widefat tbody th, table.widefat tbody td' ).css( 'cursor', 'move' );
 					$( 'table.widefat tbody' ).sortable( 'enable' );
+					if (
+						response &&
+						'object' === typeof response &&
+						window.wcTracks &&
+						window.wcTracks.recordEvent
+					) {
+						window.wcTracks.recordEvent( 'products_sorting_reordered' );
+					}
 				}
 			);
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -52,12 +52,11 @@ class WC_Products_Tracking {
 	 * Send a Tracks event when the Products page is viewed.
 	 */
 	public function track_products_view() {
-		// Only record Tracks events when `_wp_http_referer` is absent. Product searches
-		// first request this page with the argument, then WordPress redirects to the same
-		// URL without it. Tracking both requests would duplicate the view and search events.
+		// We only record Tracks event when no `_wp_http_referer` query arg is set, since
+		// when searching, the request gets sent from the browser twice,
+		// once with the `_wp_http_referer` and once without it.
 		//
-		// Sorting mode records `products_sorting_view` instead of `products_view` so the
-		// two view events remain mutually exclusive.
+		// Otherwise, we would double-record the view and search events.
 
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 		if (
@@ -65,18 +64,16 @@ class WC_Products_Tracking {
 			&& 'product' === wp_unslash( $_GET['post_type'] )
 			&& ! isset( $_GET['_wp_http_referer'] )
 		) {
-			// phpcs:enable
 
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			WC_Tracks::record_event( 'products_view' );
+
+			// Track sorting mode.
 			if (
 				isset( $_GET['orderby'] )
 				&& 'menu_order title' === wc_clean( wp_unslash( $_GET['orderby'] ) )
 			) {
 				WC_Tracks::record_event( 'products_sorting_view' );
-			} else {
-				WC_Tracks::record_event( 'products_view' );
 			}
-			// phpcs:enable
 
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 			if (

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -52,11 +52,8 @@ class WC_Products_Tracking {
 	 * Send a Tracks event when the Products page is viewed.
 	 */
 	public function track_products_view() {
-		// We only record Tracks event when no `_wp_http_referer` query arg is set, since
-		// when searching, the request gets sent from the browser twice,
-		// once with the `_wp_http_referer` and once without it.
-		//
-		// Otherwise, we would double-record the view and search events.
+		// Product searches trigger an initial request with `_wp_http_referer`, followed
+		// by a request without it. Track only the latter to avoid duplicate events.
 
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 		if (
@@ -66,7 +63,16 @@ class WC_Products_Tracking {
 		) {
 			// phpcs:enable
 
-			WC_Tracks::record_event( 'products_view' );
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if (
+				isset( $_GET['orderby'] )
+				&& 'menu_order title' === wc_clean( wp_unslash( $_GET['orderby'] ) )
+			) {
+				WC_Tracks::record_event( 'products_sorting_view' );
+			} else {
+				WC_Tracks::record_event( 'products_view' );
+			}
+			// phpcs:enable
 
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 			if (

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -52,8 +52,12 @@ class WC_Products_Tracking {
 	 * Send a Tracks event when the Products page is viewed.
 	 */
 	public function track_products_view() {
-		// Product searches trigger an initial request with `_wp_http_referer`, followed
-		// by a request without it. Track only the latter to avoid duplicate events.
+		// Only record Tracks events when `_wp_http_referer` is absent. Product searches
+		// first request this page with the argument, then WordPress redirects to the same
+		// URL without it. Tracking both requests would duplicate the view and search events.
+		//
+		// Sorting mode records `products_sorting_view` instead of `products_view` so the
+		// two view events remain mutually exclusive.
 
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 		if (

--- a/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
@@ -27,6 +27,7 @@ class WC_Products_Tracking_Test extends \WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function tearDown(): void {
+		unset( $_GET['post_type'], $_GET['orderby'], $_GET['_wp_http_referer'], $_GET['s'], $_POST['action'] );
 		update_option( 'woocommerce_allow_tracking', 'no' );
 		parent::tearDown();
 	}
@@ -100,12 +101,24 @@ class WC_Products_Tracking_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wcadmin_products_view tracks event
+	 * @testdox Should record a products view without a sorting view for the standard Products list.
 	 */
 	public function test_products_view(): void {
 		$_GET['post_type'] = 'product';
 		do_action( 'load-edit.php' );
 		$this->assertRecordedTracksEvent( 'wcadmin_products_view' );
+		$this->assertNotRecordedTracksEvent( 'wcadmin_products_sorting_view' );
+	}
+
+	/**
+	 * @testdox Should record only the sorting view event when the Products list is in sorting mode.
+	 */
+	public function test_products_sorting_view(): void {
+		$_GET['post_type'] = 'product';
+		$_GET['orderby']   = 'menu_order title';
+		do_action( 'load-edit.php' );
+		$this->assertNotRecordedTracksEvent( 'wcadmin_products_view' );
+		$this->assertRecordedTracksEvent( 'wcadmin_products_sorting_view' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-products-tracking-test.php
@@ -117,7 +117,7 @@ class WC_Products_Tracking_Test extends \WC_Unit_Test_Case {
 		$_GET['post_type'] = 'product';
 		$_GET['orderby']   = 'menu_order title';
 		do_action( 'load-edit.php' );
-		$this->assertNotRecordedTracksEvent( 'wcadmin_products_view' );
+		$this->assertRecordedTracksEvent( 'wcadmin_products_view' );
 		$this->assertRecordedTracksEvent( 'wcadmin_products_sorting_view' );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds the tracking for the Sorting mode in the All Products page. This adds a dedicated `products_sorting_view` event in place of `products_view` for Sorting-mode requests and records `products_sorting_reordered` after a successful reorder response. 

Closes #67725.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Ensure the store has at least two products, then enable usage tracking under WooCommerce > Settings > Advanced > WooCommerce.com.
2. Open the browser developer tools, select the Network tab, and filter requests by `t.gif`.
3. Visit Products > All Products. Confirm a request has `_en=wcadmin_products_view` and no request has `_en=wcadmin_products_sorting_view`.
4. Clear the Network log and select Sorting. Confirm a request has `_en=wcadmin_products_sorting_view` and no request has `_en=wcadmin_products_view`.
5. Clear the Network log and drag a product to a new position. Confirm the new order persists and a request has `_en=wcadmin_products_sorting_reordered`.

<!-- End testing instructions -->



### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to implement the tracking changes, add tests, run validation, and draft this pull request. The resulting changes and validation output were reviewed.
