### PR TITLE
Export the global email styles panel from @woocommerce/email-editor

### DIFF
--- a/packages/js/email-editor/changelog/add-export-styles-panel
+++ b/packages/js/email-editor/changelog/add-export-styles-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Export the global email styles UI: StylesSidebar for editors that provide the interface skeleton, StylesPanel for consumers that own their own container, and useCanEditEmailStyles to gate it

--- a/packages/js/email-editor/src/components/styles-sidebar/hooks.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/hooks.ts
@@ -23,6 +23,21 @@ const TEXT_BACKGROUND_PROBE_SETTINGS = {
 };
 
 /**
+ * Whether the current user may edit the global email styles record.
+ *
+ * `StylesSidebar` uses this to decide whether to register itself at all.
+ * Consumers rendering `StylesPanel` inside their own container use it to gate
+ * that container, so an unprivileged user doesn't get an empty panel.
+ */
+export function useCanEditEmailStyles(): boolean {
+	return useSelect(
+		( select ) =>
+			select( storeName ).canUserEditGlobalEmailStyles().canEdit,
+		[]
+	);
+}
+
+/**
  * Whether the text color control belongs in the typography panel rather than
  * the Colors screen in the running WordPress version.
  */

--- a/packages/js/email-editor/src/components/styles-sidebar/index.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/index.ts
@@ -1,1 +1,3 @@
 export * from './styles-sidebar';
+export * from './styles-panel';
+export { useCanEditEmailStyles } from './hooks';

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-panel.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-panel.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { memo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ScreenTypography,
+	ScreenTypographyElement,
+	ScreenLayout,
+	ScreenRoot,
+	ScreenColors,
+	ScreenBackground,
+} from './screens';
+import { Navigator } from './navigator';
+
+/**
+ * The global email styles UI, without any surrounding editor chrome.
+ *
+ * `StylesSidebar` renders this inside a `PluginSidebar`, which is what the
+ * email editor itself wants. Consumers that already own their container —
+ * their own sidebar, a modal, a settings screen — render this directly
+ * instead, and gate it themselves with `useCanEditEmailStyles`.
+ *
+ * The panel reads and writes through the `email-editor/editor` store, so the
+ * store must be registered with `createStore()` and configured with
+ * `setEditorConfig()` before this renders.
+ */
+export function RawStylesPanel(): JSX.Element {
+	return (
+		<div className="woocommerce-email-editor-styles-panel">
+			<Navigator initialPath="/">
+				<Navigator.Screen path="/">
+					<ScreenRoot />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/typography">
+					<ScreenTypography />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/typography/text">
+					<ScreenTypographyElement element="text" />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/typography/link">
+					<ScreenTypographyElement element="link" />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/typography/heading">
+					<ScreenTypographyElement element="heading" />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/typography/button">
+					<ScreenTypographyElement element="button" />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/colors">
+					<ScreenColors />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/background">
+					<ScreenBackground />
+				</Navigator.Screen>
+
+				<Navigator.Screen path="/layout">
+					<ScreenLayout />
+				</Navigator.Screen>
+			</Navigator>
+		</div>
+	);
+}
+
+export const StylesPanel = memo( RawStylesPanel );

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -3,31 +3,17 @@
  */
 import { memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import { styles } from '@wordpress/icons';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import { storeName } from '../../store';
-import {
-	ScreenTypography,
-	ScreenTypographyElement,
-	ScreenLayout,
-	ScreenRoot,
-	ScreenColors,
-	ScreenBackground,
-} from './screens';
-import { Navigator } from './navigator';
+import { StylesPanel } from './styles-panel';
+import { useCanEditEmailStyles } from './hooks';
 
 export function RawStylesSidebar(): JSX.Element {
-	const { userCanEditGlobalStyles } = useSelect( ( select ) => {
-		const { canEdit } = select( storeName ).canUserEditGlobalEmailStyles();
-		return {
-			userCanEditGlobalStyles: canEdit,
-		};
-	}, [] );
+	const userCanEditGlobalStyles = useCanEditEmailStyles();
 
 	return (
 		userCanEditGlobalStyles && (
@@ -44,43 +30,7 @@ export function RawStylesSidebar(): JSX.Element {
 					title={ __( 'Styles', __i18n_text_domain__ ) }
 					className="woocommerce-email-editor-styles-panel"
 				>
-					<Navigator initialPath="/">
-						<Navigator.Screen path="/">
-							<ScreenRoot />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/typography">
-							<ScreenTypography />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/typography/text">
-							<ScreenTypographyElement element="text" />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/typography/link">
-							<ScreenTypographyElement element="link" />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/typography/heading">
-							<ScreenTypographyElement element="heading" />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/typography/button">
-							<ScreenTypographyElement element="button" />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/colors">
-							<ScreenColors />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/background">
-							<ScreenBackground />
-						</Navigator.Screen>
-
-						<Navigator.Screen path="/layout">
-							<ScreenLayout />
-						</Navigator.Screen>
-					</Navigator>
+					<StylesPanel />
 				</PluginSidebar>
 			</>
 		)

--- a/packages/js/email-editor/src/components/styles-sidebar/test/styles-panel.spec.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/test/styles-panel.spec.tsx
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { StylesPanel } from '../styles-panel';
+import { StylesSidebar } from '../styles-sidebar';
+import { useCanEditEmailStyles } from '../hooks';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+
+// Importing the package store loads `@wordpress/core-data`, and the private
+// APIs load `@wordpress/block-editor`; both drag in untransformable ESM under
+// the test runner. Only the store's name and the panel gates are needed here.
+jest.mock( '../../../store', () => ( {
+	storeName: 'email-editor/editor',
+} ) );
+
+jest.mock( '../../../private-apis', () => ( {
+	useHasStylesColorPanel: () => true,
+	useHasStylesBackgroundPanel: () => true,
+} ) );
+
+// The screens pull in the block editor's private APIs, which need a running
+// editor. This suite is about how the panel and the sidebar compose, so stand
+// them in for markers we can assert on.
+jest.mock( '../screens', () => ( {
+	ScreenRoot: () => <div data-testid="screen-root" />,
+	ScreenTypography: () => <div data-testid="screen-typography" />,
+	ScreenTypographyElement: () => (
+		<div data-testid="screen-typography-element" />
+	),
+	ScreenColors: () => <div data-testid="screen-colors" />,
+	ScreenBackground: () => <div data-testid="screen-background" />,
+	ScreenLayout: () => <div data-testid="screen-layout" />,
+} ) );
+
+jest.mock( '../navigator', () => {
+	const Navigator = ( { children } ) => <div>{ children }</div>;
+	Navigator.Screen = ( { path, children } ) =>
+		path === '/' ? <div>{ children }</div> : null;
+	Navigator.BackButton = () => null;
+	return { Navigator };
+} );
+
+jest.mock( '@wordpress/editor', () => ( {
+	PluginSidebar: ( { children, name } ) => (
+		<div data-testid="plugin-sidebar" data-name={ name }>
+			{ children }
+		</div>
+	),
+	PluginSidebarMoreMenuItem: () => <div data-testid="more-menu-item" />,
+} ) );
+
+const mockedUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+
+/**
+ * Drive `canUserEditGlobalEmailStyles()` through the mocked `useSelect`.
+ *
+ * @param canEdit What the selector should report.
+ */
+function mockCanEdit( canEdit: boolean ) {
+	mockedUseSelect.mockImplementation( ( mapSelect: ( s ) => unknown ) =>
+		mapSelect( () => ( {
+			canUserEditGlobalEmailStyles: () => ( { canEdit, postId: 42 } ),
+		} ) )
+	);
+}
+
+describe( 'StylesPanel', () => {
+	beforeEach( () => {
+		mockedUseSelect.mockReset();
+	} );
+
+	it( 'renders the styles screens without any editor chrome', () => {
+		render( <StylesPanel /> );
+
+		expect( screen.getByTestId( 'screen-root' ) ).toBeInTheDocument();
+		// The point of the split: no PluginSidebar, so no complementary area
+		// and no dependency on the editor's interface skeleton.
+		expect(
+			screen.queryByTestId( 'plugin-sidebar' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'more-menu-item' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'carries the class the panel stylesheet is scoped to', () => {
+		const { container } = render( <StylesPanel /> );
+
+		expect(
+			container.querySelector( '.woocommerce-email-editor-styles-panel' )
+		).not.toBeNull();
+	} );
+
+	it( 'renders regardless of edit permission, leaving the gate to the consumer', () => {
+		mockCanEdit( false );
+
+		render( <StylesPanel /> );
+
+		expect( screen.getByTestId( 'screen-root' ) ).toBeInTheDocument();
+		expect( mockedUseSelect ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'StylesSidebar', () => {
+	beforeEach( () => {
+		mockedUseSelect.mockReset();
+	} );
+
+	it( 'registers a plugin sidebar containing the panel when the user may edit', () => {
+		mockCanEdit( true );
+
+		render( <StylesSidebar /> );
+
+		const sidebar = screen.getByTestId( 'plugin-sidebar' );
+		expect( sidebar ).toHaveAttribute(
+			'data-name',
+			'email-styles-sidebar'
+		);
+		expect( sidebar ).toContainElement(
+			screen.getByTestId( 'screen-root' )
+		);
+		expect( screen.getByTestId( 'more-menu-item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the user may not edit global email styles', () => {
+		mockCanEdit( false );
+
+		render( <StylesSidebar /> );
+
+		expect(
+			screen.queryByTestId( 'plugin-sidebar' )
+		).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'screen-root' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'useCanEditEmailStyles', () => {
+	beforeEach( () => {
+		mockedUseSelect.mockReset();
+	} );
+
+	it( 'reports what canUserEditGlobalEmailStyles resolves to', () => {
+		mockCanEdit( true );
+		let result: boolean | undefined;
+		const Probe = () => {
+			result = useCanEditEmailStyles();
+			return null;
+		};
+
+		render( <Probe /> );
+
+		expect( result ).toBe( true );
+	} );
+} );

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -183,11 +183,55 @@ export function initializeEditor( htmlId: string ) {
 export { ExperimentalEmailEditor } from './editor';
 
 export type {
+	EmailEditorConfig,
 	EmailEditorSettings,
 	EmailTheme,
 	EmailEditorUrls,
 	PostWithPermissions,
 } from './store/types';
+
+/**
+ * The global email styles UI.
+ *
+ * `StylesSidebar` is what the email editor mounts: it gates on the user's
+ * permission and registers itself as a `PluginSidebar`. Use it when you are
+ * inside an editor that provides the interface skeleton.
+ *
+ * `StylesPanel` is the same UI without any chrome, for consumers that already
+ * own their container — their own sidebar, a modal, a settings screen. Pair it
+ * with `useCanEditEmailStyles` to gate that container yourself.
+ *
+ * Both read and write through the `email-editor/editor` store rather than
+ * props, so register it with `createStore()` and configure it with
+ * `dispatch( storeName ).setEditorConfig( config )` first. `globalStylesPostId`
+ * on that config decides which `wp_global_styles` record the panel edits.
+ *
+ * The panel also needs the block editor's settings in the block-editor store
+ * (font sizes, spacing units, color origins) and the package's
+ * `build-style/style.css` enqueued.
+ *
+ * @example
+ * ```jsx
+ * import {
+ *   createStore, storeName, StylesPanel, useCanEditEmailStyles,
+ * } from '@woocommerce/email-editor';
+ *
+ * createStore();
+ * dispatch( storeName ).setEditorConfig( config );
+ *
+ * function MySidebar() {
+ *   if ( ! useCanEditEmailStyles() ) {
+ *     return null;
+ *   }
+ *   return <MyContainer><StylesPanel /></MyContainer>;
+ * }
+ * ```
+ */
+export {
+	StylesPanel,
+	StylesSidebar,
+	useCanEditEmailStyles,
+} from './components/styles-sidebar';
 
 /**
  * The registerEntityAction and unregisterEntityAction are used to register and unregister entity actions.


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md).
- [x] I have added tests to cover my change.

<!-- MARKING A CHECKBOX AS COMPLETE INDICATES YOU HAVE READ AND FOLLOWED THE GUIDELINE -->

### Changes proposed in this Pull Request:

Draft — opened to share an export shape for discussion, not to merge as-is.

Splits the chrome-free part of the global email styles UI out of `StylesSidebar` and exports it, so consumers that already have an editor shell can mount the styles UI without the email editor around it.

- `StylesPanel` — the navigator and all nine screens, no `PluginSidebar`, no permission gate. New.
- `StylesSidebar` — unchanged externally. Now composes `StylesPanel` inside its `PluginSidebar`.
- `useCanEditEmailStyles()` — the permission check on its own, so a consumer can decide where to apply it.

No behaviour change inside the email editor: the sidebar renders the same tree it did before.

#### Why

We are looking at reusing this UI for Jetpack newsletters. The email styles are a genuinely shared concern — MailPoet, WooCommerce and CIAB all present the same controls — and today the only way to get them is to run the whole email editor.

#### Open question for maintainers

`StylesPanel` requires the consumer to register the store and dispatch `setEditorConfig` before rendering, whereas `ExperimentalEmailEditor` takes the same configuration as a `config` prop and does that internally. The package currently answers "props or store?" both ways depending on which export you use.

I have deliberately not changed that here — the panel follows the existing store-based convention. If the preference is for the panel to take the styles record and settings as props, matching `ExperimentalEmailEditor`, I am happy to rework it that way.

### How to test the changes in this Pull Request:

1. Open the WooCommerce email editor and the Styles sidebar.
2. Confirm the styles screens, navigation and permission gating behave exactly as before.
3. `pnpm --filter=@woocommerce/email-editor test:js` — 13 tests covering the split.

### Testing that has already taken place:

Unit tests pass. The exported panel has also been mounted outside the email editor in a Jetpack proof of concept — in the newsletter sidebar of the post editor — where it renders without the editor shell and writes to `wp-global-styles-woocommerce-email` rather than the site's global styles.

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (Changelog entry added manually.)
