### PR TITLE
Fix memory-exhausting recursion when a Single Product block is embedded in a product description

### DIFF
--- a/plugins/woocommerce/changelog/67750-fix-single-product-block-recursion-in-description
+++ b/plugins/woocommerce/changelog/67750-fix-single-product-block-recursion-in-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a memory-exhausting recursion when a product description contains a Single Product block that references the product being loaded into the shared products store.

--- a/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
@@ -68,6 +68,41 @@ class ProductsStore {
 	private static array $loaded_variation_parents = array();
 
 	/**
+	 * Product IDs whose Store API fetch is currently in flight.
+	 *
+	 * Formatting a Store API product response runs the product description
+	 * through `do_blocks()`, so a description containing a block that loads
+	 * products (e.g. `woocommerce/single-product`) can re-enter
+	 * `load_product()` for the ID being fetched before it is memoized in
+	 * `$products`. This map breaks that cycle. See
+	 * https://github.com/woocommerce/woocommerce/issues/67750.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $loading_products = array();
+
+	/**
+	 * Parent product IDs whose variations fetch is currently in flight.
+	 *
+	 * Guards `load_variations()` against the same re-entrancy cycle as
+	 * `$loading_products` guards `load_product()`.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $loading_variation_parents = array();
+
+	/**
+	 * Parent product IDs whose purchasable child products fetch is
+	 * currently in flight.
+	 *
+	 * Guards `load_purchasable_child_products()` against the same
+	 * re-entrancy cycle as `$loading_products` guards `load_product()`.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $loading_child_parents = array();
+
+	/**
 	 * Whether the derived-state getters have been registered.
 	 *
 	 * @var bool
@@ -157,6 +192,40 @@ class ProductsStore {
 	}
 
 	/**
+	 * Fetch a Store API response while `woocommerce/single-product` blocks
+	 * are short-circuited.
+	 *
+	 * The Store API formats product descriptions with `do_blocks()`. A
+	 * `woocommerce/single-product` block stored inside a description
+	 * (commonly left behind by copy-pasting product page blocks) would
+	 * render detached from any Single Product Template context: its inner
+	 * blocks can fatal without a resolvable product, and loading its
+	 * product into this store mid-fetch can recurse indefinitely when it
+	 * references the product being fetched. Skipping the block for the
+	 * duration of the fetch prevents both.
+	 *
+	 * @param string $path The Store API path to fetch.
+	 * @return array The response data.
+	 */
+	private static function fetch_rest_api_response_data( string $path ): array {
+		$skip_single_product_block = static function ( $pre_render, $parsed_block ) {
+			if ( isset( $parsed_block['blockName'] ) && 'woocommerce/single-product' === $parsed_block['blockName'] ) {
+				return '';
+			}
+
+			return $pre_render;
+		};
+
+		add_filter( 'pre_render_block', $skip_single_product_block, 10, 2 );
+
+		try {
+			return Package::container()->get( Hydration::class )->get_rest_api_response_data( $path );
+		} finally {
+			remove_filter( 'pre_render_block', $skip_single_product_block, 10 );
+		}
+	}
+
+	/**
 	 * Load a product into state.
 	 *
 	 * @param string $consent_statement The consent statement string.
@@ -172,7 +241,21 @@ class ProductsStore {
 			return self::$products[ $product_id ];
 		}
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
+		// Bail on a re-entrant load: rendering block markup stored in this
+		// product's description (or in the description of another product
+		// fetched further up the stack) triggered a load of a product whose
+		// fetch is still in flight. Recursing would exhaust memory.
+		if ( isset( self::$loading_products[ $product_id ] ) ) {
+			return array();
+		}
+
+		self::$loading_products[ $product_id ] = true;
+
+		try {
+			$response = self::fetch_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
+		} finally {
+			unset( self::$loading_products[ $product_id ] );
+		}
 
 		self::$products[ $product_id ] = $response['body'] ?? array();
 		self::register_getters();
@@ -216,7 +299,18 @@ class ProductsStore {
 		);
 		$query_string   = implode( '&', $include_params );
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
+		// Bail on a re-entrant load of a parent whose fetch is in flight.
+		if ( isset( self::$loading_child_parents[ $parent_id ] ) ) {
+			return array();
+		}
+
+		self::$loading_child_parents[ $parent_id ] = true;
+
+		try {
+			$response = self::fetch_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
+		} finally {
+			unset( self::$loading_child_parents[ $parent_id ] );
+		}
 
 		if ( empty( $response['body'] ) ) {
 			return array();
@@ -260,7 +354,18 @@ class ProductsStore {
 			);
 		}
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
+		// Bail on a re-entrant load of a parent whose fetch is in flight.
+		if ( isset( self::$loading_variation_parents[ $parent_id ] ) ) {
+			return array();
+		}
+
+		self::$loading_variation_parents[ $parent_id ] = true;
+
+		try {
+			$response = self::fetch_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
+		} finally {
+			unset( self::$loading_variation_parents[ $parent_id ] );
+		}
 
 		self::$loaded_variation_parents[ $parent_id ] = true;
 

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -285,9 +285,10 @@ class ProductsStore extends \WC_Unit_Test_Case {
 
 		$this->assertIsArray( $result );
 		$this->assertSame( $product->get_id(), $result['id'] ?? null, 'The product should load despite the self-referencing description.' );
+		$this->assertArrayHasKey( 'description', $result, 'The response should include the formatted description.' );
 		$this->assertStringNotContainsString(
 			'wp-block-woocommerce-single-product',
-			$result['description'] ?? '',
+			$result['description'],
 			'The embedded single-product block should not be rendered into the description.'
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -116,6 +116,185 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox load_product() breaks a re-entrant load of a product whose fetch is still in flight instead of recursing.
+	 */
+	public function test_load_product_breaks_reentrant_load_of_same_product(): void {
+		$product    = WC_Helper_Product::create_simple_product();
+		$product_id = $product->get_id();
+
+		$fake_hydration = new class( $product_id, $this->consent ) {
+			/**
+			 * The product ID to re-enter the store with.
+			 *
+			 * @var int
+			 */
+			private int $product_id;
+
+			/**
+			 * The consent string.
+			 *
+			 * @var string
+			 */
+			private string $consent;
+
+			/**
+			 * How many times get_rest_api_response_data was called.
+			 *
+			 * @var int
+			 */
+			public int $call_count = 0;
+
+			/**
+			 * The result of the re-entrant load_product() call.
+			 *
+			 * @var array|null
+			 */
+			public ?array $inner_result = null;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $product_id The product ID.
+			 * @param string $consent    The consent string.
+			 */
+			public function __construct( int $product_id, string $consent ) {
+				$this->product_id = $product_id;
+				$this->consent    = $consent;
+			}
+
+			/**
+			 * Mimic Hydration::get_rest_api_response_data, re-entering the
+			 * store mid-fetch like a block in the product description would.
+			 *
+			 * @param string $path The REST path (ignored).
+			 * @return array The canned response.
+			 */
+			public function get_rest_api_response_data( string $path ): array {
+				// Avoid parameter not used PHPCS errors.
+				unset( $path );
+				++$this->call_count;
+				$this->inner_result = TestedProductsStore::load_product( $this->consent, $this->product_id );
+
+				return array(
+					'body' => array(
+						'id'   => $this->product_id,
+						'name' => 'Self Referencing Product',
+					),
+				);
+			}
+		};
+		$this->inject_hydration( $fake_hydration );
+
+		$result = TestedProductsStore::load_product( $this->consent, $product_id );
+
+		$this->assertSame( 1, $fake_hydration->call_count, 'The re-entrant call should not trigger a second fetch.' );
+		$this->assertSame( array(), $fake_hydration->inner_result, 'The re-entrant call should return an empty array.' );
+		$this->assertSame( 'Self Referencing Product', $result['name'], 'The outer call should still return the fetched product.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox load_product() skips single-product blocks rendered while the fetch is in flight and restores rendering afterwards.
+	 */
+	public function test_load_product_short_circuits_single_product_blocks_during_fetch(): void {
+		$product    = WC_Helper_Product::create_simple_product();
+		$product_id = $product->get_id();
+
+		$block_markup = '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><div class="wp-block-woocommerce-single-product woocommerce"><p>Embedded</p></div><!-- /wp:woocommerce/single-product -->';
+
+		$fake_hydration = new class( $product_id, $block_markup ) {
+			/**
+			 * The product ID for the canned response.
+			 *
+			 * @var int
+			 */
+			private int $product_id;
+
+			/**
+			 * Block markup to render mid-fetch.
+			 *
+			 * @var string
+			 */
+			private string $block_markup;
+
+			/**
+			 * What do_blocks() produced while the fetch was in flight.
+			 *
+			 * @var string|null
+			 */
+			public ?string $rendered_during_fetch = null;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $product_id   The product ID.
+			 * @param string $block_markup Block markup to render mid-fetch.
+			 */
+			public function __construct( int $product_id, string $block_markup ) {
+				$this->product_id   = $product_id;
+				$this->block_markup = $block_markup;
+			}
+
+			/**
+			 * Mimic Hydration::get_rest_api_response_data, rendering block
+			 * markup mid-fetch like description formatting would.
+			 *
+			 * @param string $path The REST path (ignored).
+			 * @return array The canned response.
+			 */
+			public function get_rest_api_response_data( string $path ): array {
+				// Avoid parameter not used PHPCS errors.
+				unset( $path );
+				$this->rendered_during_fetch = do_blocks( $this->block_markup );
+
+				return array(
+					'body' => array(
+						'id'   => $this->product_id,
+						'name' => 'Fake Product',
+					),
+				);
+			}
+		};
+		$this->inject_hydration( $fake_hydration );
+
+		global $wp_filter;
+		$callbacks_before = isset( $wp_filter['pre_render_block'] ) ? count( $wp_filter['pre_render_block']->callbacks[10] ?? array() ) : 0;
+
+		TestedProductsStore::load_product( $this->consent, $product_id );
+
+		$callbacks_after = isset( $wp_filter['pre_render_block'] ) ? count( $wp_filter['pre_render_block']->callbacks[10] ?? array() ) : 0;
+
+		$this->assertSame( '', $fake_hydration->rendered_during_fetch, 'single-product blocks should not render while a product fetch is in flight.' );
+		$this->assertSame( $callbacks_before, $callbacks_after, 'The pre_render_block short-circuit should be removed after the fetch.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox load_product() survives a product whose description embeds a single-product block referencing itself.
+	 */
+	public function test_load_product_with_self_referencing_description_block(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description(
+			'<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div><!-- /wp:woocommerce/single-product -->'
+		);
+		$product->save();
+
+		$result = TestedProductsStore::load_product( $this->consent, $product->get_id() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $product->get_id(), $result['id'] ?? null, 'The product should load despite the self-referencing description.' );
+		$this->assertStringNotContainsString(
+			'wp-block-woocommerce-single-product',
+			$result['description'] ?? '',
+			'The embedded single-product block should not be rendered into the description.'
+		);
+
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox load_variations() hydrates interactivity state with every child variation.
 	 */
 	public function test_load_variations_populates_state(): void {
@@ -506,7 +685,7 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	private function reset_products_store_static_state(): void {
 		$reflection = new \ReflectionClass( TestedProductsStore::class );
 
-		foreach ( array( 'products', 'product_variations', 'loaded_variation_parents' ) as $name ) {
+		foreach ( array( 'products', 'product_variations', 'loaded_variation_parents', 'loading_products', 'loading_variation_parents', 'loading_child_parents' ) as $name ) {
 			$property = $reflection->getProperty( $name );
 			$property->setAccessible( true );
 			$property->setValue( null, array() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Visiting a product page on the block Single Product Template fatals with `Allowed memory size exhausted` when the product's description contains a `woocommerce/single-product` block whose `productId` points back at that product (commonly left behind by copy-pasting product page blocks into the description).

The cycle: `SingleProductTemplate` (or `SingleProduct::render()`) calls `ProductsStore::load_product()`, which fetches the product from the Store API. The Store API formats the description with `wc_format_content()`, whose `woocommerce_short_description` filter chain runs `do_blocks()`. That renders the embedded `single-product` block, whose render callback calls `wc_interactivity_api_load_product()` for the same ID. Because `load_product()` memoizes only after the fetch returns, the re-entrant call fetches again, reformats the same description, and recurses until memory is exhausted. Any product-loading block in a description (`add-to-cart-with-options`, `product-template`, `product-query`) can trigger the same cycle.

Two guards, both in `ProductsStore`:

1. `load_product()` now tracks in-flight product IDs and returns an empty array on a re-entrant load of an ID whose fetch is still on the stack, breaking the recursion at its root regardless of which block triggers it.
2. All three Store API fetches (`load_product`, `load_purchasable_child_products`, `load_variations`) short-circuit `woocommerce/single-product` blocks via `pre_render_block` for the duration of the fetch. A `single-product` block inside product content renders detached from any template context there, so skipping it also prevents the secondary `get_id()` on null TypeError from its inner blocks and keeps the rendered block markup out of the hydrated description payload.

Closes #67750.

(For Bug Fixes) Bug introduced in PR #63662 (template-level `ProductsStore::load_product()` hydration; the block-side load path came from #62167).

### Screenshots or screen recordings:

Captured on a local wp-env site (WordPress latest, Twenty Twenty-Five, plain permalinks) with a simple product whose description contains the self-referencing Single Product block from the reproduction steps below.

Before:

<img width="1280" height="900" alt="before-fix-critical-error" src="https://github.com/user-attachments/assets/654c1cc7-fc86-49ee-96c8-2c1f54a63ee0" />


After fix:

<img width="1280" height="2069" alt="after-fix-product-page" src="https://github.com/user-attachments/assets/fef7d57d-de13-4ac4-a436-a9c69ae7e13c" />

On trunk, the same request 500s during the hydration fetch. The fatal on this repro is the secondary symptom from the issue report:

```text
PHP Fatal error: Uncaught Error: Call to a member function get_id() on string
  in .../src/Blocks/BlockTypes/AddToCartForm.php:181
  ... do_blocks() <- wc_format_content() <- ProductSchema->get_item_response()
  <- Hydration->get_rest_api_response_data() <- ProductsStore::load_product()
  <- SingleProductTemplate->render_block_template()
```

The memory-exhaustion variant is proven by the new unit tests: running them against trunk code ends with the container stopped at its memory limit (exit code 137), while this branch passes.

### How to test the changes in this Pull Request:

1. Use a block theme (Twenty Twenty-Five) so the block Single Product Template renders.
2. Create a simple product and note its ID. Edit the product, switch the description editor to code view, and set the description to (replace `123` with the product's own ID):
   ```html
   <!-- wp:woocommerce/single-product {"productId":123} -->
   <div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div>
   <!-- /wp:woocommerce/single-product -->
   ```
3. On trunk, visit the product page on the front end: the request crashes with a memory-exhaustion fatal (or a WSOD/500).
4. With this branch, visit the product page again: it renders normally, and the embedded Single Product block is not rendered inside the description.
5. Confirm a regular product (no block markup in the description) still renders, and a legitimate Single Product block in a post or page still works.

### Testing that has already taken place:

- Manual before/after on a local wp-env site (WordPress latest, PHP 8.1, Twenty Twenty-Five block theme, WooCommerce from this branch, no other plugins): created a simple product with the self-referencing description markup, loaded the product page. Trunk code: HTTP 500 with the `get_id()` on string fatal above. This branch: HTTP 200, full product page renders, and the embedded block degrades to a harmless inline add-to-cart form inside the description. Screenshots above.
- New unit tests in `tests/php/src/Blocks/SharedStores/ProductsStore.php`: a re-entrant `load_product()` call mid-fetch returns an empty array and triggers no second fetch; `woocommerce/single-product` blocks rendered during a fetch are short-circuited and the filter is removed afterwards; a product whose description embeds a self-referencing Single Product block (the reporter's exact markup) loads without recursing and without the block rendered into the description payload.
- Full `ProductsStore` test class run against the wp-env test environment.
- `lint:php:changes`, `lint:changes:branch`, and PHPStan on the modified file: clean.

Backward compatibility: no public signatures, hooks, or hook timings change. The `pre_render_block` short-circuit is scoped to the duration of the store's Store API fetch, which only occurs inside this experimental hydration path; `woocommerce/single-product` blocks rendered anywhere else are unaffected. Descriptions containing an embedded Single Product block no longer include that block's rendered markup in the hydrated payload, which is the intended behavior since WooCommerce blocks are unsupported inside product content.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Changelog entry created manually in `plugins/woocommerce/changelog/67750-fix-single-product-block-recursion-in-description`.

-   [ ] Automatically create a changelog entry from the details below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
