### PR TITLE
[Email Editor] Fix locale-sensitive pill padding

### DIFF
--- a/packages/php/email-editor/changelog/fix-pill-shape-padding-locale
+++ b/packages/php/email-editor/changelog/fix-pill-shape-padding-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure pill-shaped social link padding uses locale-independent decimal formatting in rendered emails.

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
@@ -168,7 +168,7 @@ class Social_Links extends Abstract_Block_Renderer {
 		);
 
 		if ( $is_pill_shape ) {
-			$pill_shape_horizontal_padding         = round( $font_size_value * 2 / 3, 2 ) . 'px';
+			$pill_shape_horizontal_padding         = rtrim( rtrim( number_format( $font_size_value * 2 / 3, 2, '.', '' ), '0' ), '.' ) . 'px';
 			$row_container_styles['padding-left']  = $pill_shape_horizontal_padding;
 			$row_container_styles['padding-right'] = $pill_shape_horizontal_padding;
 		}

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -161,8 +161,8 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 		$original_locale      = setlocale( LC_NUMERIC, '0' );
 		$comma_decimal_locale = setlocale( LC_NUMERIC, 'de_DE.UTF-8', 'de_DE.utf8', 'fr_FR.UTF-8', 'fr_FR.utf8' );
 
-		if ( false === $comma_decimal_locale ) {
-			$this->markTestSkipped( 'A locale with a comma decimal separator is not available.' );
+		if ( false === $comma_decimal_locale || ',' !== localeconv()['decimal_point'] ) {
+			$this->markTestSkipped( 'A working locale with a comma decimal separator is not available.' );
 		}
 
 		try {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -153,6 +153,39 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test locale-independent pill shape padding.
+	 *
+	 * @testdox Should render locale-independent pill shape padding.
+	 */
+	public function test_it_renders_locale_independent_pill_shape_padding(): void {
+		$original_locale      = setlocale( LC_NUMERIC, '0' );
+		$comma_decimal_locale = setlocale( LC_NUMERIC, 'de_DE.UTF-8', 'de_DE.utf8', 'fr_FR.UTF-8', 'fr_FR.utf8' );
+
+		if ( false === $comma_decimal_locale ) {
+			$this->markTestSkipped( 'A locale with a comma decimal separator is not available.' );
+		}
+
+		try {
+			$parsed_social_links                       = $this->parsed_social_links;
+			$parsed_social_links['attrs']['className'] = 'is-style-pill-shape';
+			$parsed_social_links['attrs']['size']      = 'has-small-icon-size';
+
+			$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
+			$this->checkValidHTML( $rendered );
+			$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
+
+			foreach ( $link_wrappers as $link_wrapper ) {
+				$this->assertStringContainsString( 'padding-left:10.67px;', $link_wrapper );
+				$this->assertStringContainsString( 'padding-right:10.67px;', $link_wrapper );
+			}
+		} finally {
+			if ( false !== $original_locale ) {
+				setlocale( LC_NUMERIC, $original_locale );
+			}
+		}
+	}
+
+	/**
 	 * Test it renders a gap between social link items.
 	 */
 	public function testItRendersGapBetweenSocialLinkItems(): void {

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Social_Links_Test.php
@@ -153,39 +153,6 @@ class Social_Links_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
-	 * Test locale-independent pill shape padding.
-	 *
-	 * @testdox Should render locale-independent pill shape padding.
-	 */
-	public function test_it_renders_locale_independent_pill_shape_padding(): void {
-		$original_locale      = setlocale( LC_NUMERIC, '0' );
-		$comma_decimal_locale = setlocale( LC_NUMERIC, 'de_DE.UTF-8', 'de_DE.utf8', 'fr_FR.UTF-8', 'fr_FR.utf8' );
-
-		if ( false === $comma_decimal_locale || ',' !== localeconv()['decimal_point'] ) {
-			$this->markTestSkipped( 'A working locale with a comma decimal separator is not available.' );
-		}
-
-		try {
-			$parsed_social_links                       = $this->parsed_social_links;
-			$parsed_social_links['attrs']['className'] = 'is-style-pill-shape';
-			$parsed_social_links['attrs']['size']      = 'has-small-icon-size';
-
-			$rendered = $this->social_links_renderer->render( '', $parsed_social_links, $this->rendering_context );
-			$this->checkValidHTML( $rendered );
-			$link_wrappers = $this->getRenderedSocialLinkWrappers( $rendered );
-
-			foreach ( $link_wrappers as $link_wrapper ) {
-				$this->assertStringContainsString( 'padding-left:10.67px;', $link_wrapper );
-				$this->assertStringContainsString( 'padding-right:10.67px;', $link_wrapper );
-			}
-		} finally {
-			if ( false !== $original_locale ) {
-				setlocale( LC_NUMERIC, $original_locale );
-			}
-		}
-	}
-
-	/**
 	 * Test it renders a gap between social link items.
 	 */
 	public function testItRendersGapBetweenSocialLinkItems(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Pill-shaped Social Links calculate horizontal padding from the selected icon size. On PHP 7.4, converting the resulting decimal to a string can follow `LC_NUMERIC` and emit invalid CSS such as `10,67px` when a comma-decimal locale is active.

Format the padding with an explicit decimal separator while preserving the existing `10.67px`, `16px`, `24px`, and `32px` output, and add integration coverage that renders the block under a comma-decimal locale.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #67642.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Use a PHP 7.4 environment with a comma-decimal `LC_NUMERIC` locale available, such as `de_DE.UTF-8`.
2. Run the `Social_Links_Test::test_it_renders_locale_independent_pill_shape_padding` Email Editor integration test.
3. Confirm the rendered small pill-shaped links contain `padding-left:10.67px` and `padding-right:10.67px`, never `10,67px`.
4. Run the full `Social_Links_Test` class and confirm all icon-size padding values remain unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Reproduced the invalid `10,67px` output with PHP 7.4.33 and `de_DE.UTF-8` before the fix.
- Verified the focused regression test failed before the production change and passed afterward: 1 test, 6 assertions.
- Full `Social_Links_Test` on PHP 7.4.33: 13 tests, 82 assertions.
- Full `Social_Links_Test` on the standard PHP 8.1 wp-env: 13 tests, 82 assertions.
- `pnpm --filter=@woocommerce/email-editor-config lint:lang:php`
- `pnpm --filter=@woocommerce/email-editor-config phpstan:php7`
- `pnpm --filter=@woocommerce/email-editor-config phpstan:php8`
- `composer exec -- changelogger validate`

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to investigate the regression report, reproduce the PHP 7.4 locale behavior, implement the fix and test, and run local verification. The generated code and rendered output were reviewed against the reported failure.
