### PR TITLE
Fix Product Filters when Shop is the static front page

### DIFF
--- a/plugins/woocommerce/changelog/wc-67498-front-page-filters-design
+++ b/plugins/woocommerce/changelog/wc-67498-front-page-filters-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Product Filters on a Shop page set as the static front page.

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer;
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
 
@@ -315,6 +316,7 @@ class WC_Query {
 	private function is_query_var_valid_on_front_page( $query_var ) {
 		return in_array( $query_var, array( 'preview', 'page', 'paged', 'cpage', 'orderby' ), true )
 			|| in_array( $query_var, array( 'min_price', 'max_price', 'rating_filter' ), true )
+			|| in_array( $query_var, wc_get_container()->get( Params::class )->get_param_keys(), true )
 			|| 0 === strpos( $query_var, 'filter_' )
 			|| 0 === strpos( $query_var, 'query_type_' );
 	}

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -315,7 +315,6 @@ class WC_Query {
 	 */
 	private function is_query_var_valid_on_front_page( $query_var ) {
 		return in_array( $query_var, array( 'preview', 'page', 'paged', 'cpage', 'orderby' ), true )
-			|| in_array( $query_var, array( 'min_price', 'max_price', 'rating_filter' ), true )
 			|| in_array( $query_var, wc_get_container()->get( Params::class )->get_param_keys(), true )
 			|| 0 === strpos( $query_var, 'filter_' )
 			|| 0 === strpos( $query_var, 'query_type_' );

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -579,7 +579,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		}
 
 		foreach ( $this->params->get_param( 'taxonomy' ) as $taxonomy => $param ) {
-			if ( isset( $query_vars[ $param ] ) && ! empty( trim( $query_vars[ $param ] ) ) ) {
+			if ( isset( $query_vars[ $param ] ) && is_string( $query_vars[ $param ] ) && ! empty( trim( $query_vars[ $param ] ) ) ) {
 				$chosen_taxonomies[ $taxonomy ] = array_filter( array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) ) );
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -73,6 +73,15 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( defined( 'SHOP_IS_ON_FRONT' ) && SHOP_IS_ON_FRONT );
 		$this->assert_shop_page_queried_object( $query, $shop_page_id );
 
+		foreach ( array( 'categories', 'tags', 'brands' ) as $query_var ) {
+			$query        = new WP_Query();
+			$wp_the_query = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$query->query( array( $query_var => 'filter-term' ) );
+
+			$this->assertSame( 'product_query', $query->get( 'wc_query' ), "{$query_var} should preserve the product query." );
+			$this->assert_shop_page_queried_object( $query, $shop_page_id );
+		}
+
 		// Reset main query, options and delete the page we created.
 		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		update_option( 'woocommerce_shop_page_id', $default_woocommerce_shop_page_id );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
@@ -241,6 +241,17 @@ class QueryClausesTest extends AbstractProductFiltersTest {
 	}
 
 	/**
+	 * @testdox Non-string taxonomy filter values are ignored.
+	 */
+	public function test_non_string_taxonomy_filter_values_are_ignored(): void {
+		$query                           = new \WP_Query();
+		$query->query_vars['categories'] = array( 'cat-1' );
+		$clauses                         = array( 'where' => '' );
+
+		$this->assertSame( $clauses, $this->sut->add_query_clauses( $clauses, $query ) );
+	}
+
+	/**
 	 * @testdox A hierarchical category filter must match products in descendant categories without a child_of query per chosen term.
 	 *
 	 * @testWith [["hcat-parent"], ["In Parent", "In Child", "In Grandchild"]]


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR add supports for taxonomy filtering for the Product Filters block on the static homepage.

Closes #67498.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/cc839f8a-54d4-40ea-bf78-4a206375f3e4

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Use a block theme. Set the WooCommerce Shop page as the static homepage.
2. Create products using unique category, tag, and brand slugs.
3. Visit `/?categories=<category-slug>`, `/?tags=<tag-slug>`, and `/?brands=<brand-slug>`.
4. For each URL, confirm the Product Catalog remains visible, only matching products appear, and the blog homepage does not replace the catalog.
5. Visit `/?categories[]=<category-slug>`. Confirm the catalog loads without a PHP error and the malformed filter is ignored.
6. Visit the homepage. Confirm the unfiltered Product Catalog still loads.

<details>
<summary>Detailed instructions</summary>

1. Activate a block theme, such as Twenty Twenty-Five. In **Settings → Reading**, select **A static page** and choose **Shop** as the homepage.
2. Create and publish these simple, in-stock products and taxonomy terms. Keep each taxonomy slug unique and assign only the listed term to each matching product:

   | Product | Assignment | Slug |
   | --- | --- | --- |
   | WC 67498 Category Match | Product category: WC 67498 Category | `wc-67498-category` |
   | WC 67498 Tag Match | Product tag: WC 67498 Tag | `wc-67498-tag` |
   | WC 67498 Brand Match | Product brand: WC 67498 Brand | `wc-67498-brand` |
   | WC 67498 Control | No category, tag, or brand term above | — |

3. Visit `/?categories=wc-67498-category`. Confirm the Product Catalog and filters remain visible, **WC 67498 Category Match** is the only product shown, and blog-home content does not replace the catalog.
4. Repeat with `/?tags=wc-67498-tag` and `/?brands=wc-67498-brand`. Confirm each URL shows only its corresponding matching product while preserving the Product Catalog.
5. Visit `/?categories[]=wc-67498-category`. Confirm the Product Catalog loads without a PHP error and the visible product set matches the unfiltered catalog because the array value is ignored.
6. Remove the query string and visit the homepage. Confirm the unfiltered Product Catalog still loads and includes the four test products.

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

- `openai-codex/gpt-5.6-sol` — investigated the issue and reviewed the design and compatibility risks; implemented the PHP fix and focused tests; ran automated and browser testing, recorded evidence, and drafted the PR description.
