### PR TITLE
Remove formatting shipping zone modal prices

### DIFF
--- a/plugins/woocommerce/changelog/67793-master
+++ b/plugins/woocommerce/changelog/67793-master
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Select the release communication labels this PR needs:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.  - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.  - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  Selected labels are applied when the pull request is merged.
+
+

--- a/plugins/woocommerce/changelog/67793-master
+++ b/plugins/woocommerce/changelog/67793-master
@@ -1,5 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Select the release communication labels this PR needs:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.  - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.  - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  Selected labels are applied when the pull request is merged.
 
-
+Preserve the exact shipping cost entered in the shipping zone method modal instead of reformatting it to the store's number of decimals on blur.

--- a/plugins/woocommerce/changelog/67793-master
+++ b/plugins/woocommerce/changelog/67793-master
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
+Comment: Select the release communication labels this PR needs:  - [ ] **Feature Highlight** - For user-facing features (what changed, user impact) - [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)  <details> <summary>When to use each?</summary>  **Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.  - Example: "New bulk editing for products", "Improved checkout performance"  **Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.  - Example: "Hook signature change", "Deprecated filter", "REST API field removed"  Selected labels are applied when the pull request is merged.
 
-Preserve the exact shipping cost entered in the shipping zone method modal instead of reformatting it to the store's number of decimals on blur.
+

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -705,12 +705,6 @@
 									modal.find( '.wc-shipping-method-add-class-costs').hide();
 								}
 							});
-
-							$('.wc-shipping-modal-price').on('blur', function() {
-								const value = $(this).val();
-								const formattedValue = window.wc.currency.localiseMonetaryValue( config, value );
-								$(this).val( formattedValue );
-							});
 						}
 					}
 				},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Completely remove formatting prices in shipping modal on price input (blur). Currently this does automatic rounding as per "number of decimals" setting, but that setting is for display purposes. Rounding itself has different setting (rounding precision 6 by default). Also, this makes impossible to enter exact prices as needed.

Furthermore, it is inconsistent:
If I add the shipping method in a new tab (not modal), then I can easily add three decimals places and validation occours on backend. Price stays 3.145 and frontend shows correctly as per decimals setting.

Shipping price entering is not displaying price, it is raw price.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Preserve the exact shipping cost entered in the shipping zone method modal instead of reformatting it to the store's number of decimals on blur.</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
