### PR TITLE
Exclude WordPress notes from the comment count cache

### DIFF
--- a/plugins/woocommerce/changelog/67610-fix-note-comment-count
+++ b/plugins/woocommerce/changelog/67610-fix-note-comment-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude WordPress editorial notes from the WooCommerce comment count cache, so adding a note no longer inflates the pending comment count shown in wp-admin.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -324,9 +324,6 @@ class WC_Comments {
 	 * Determines whether the given comment should be included in the core WP comment counts that are displayed in the
 	 * WordPress admin.
 	 *
-	 * The 'note' type covers the editorial notes introduced in WordPress 7.1, which core itself excludes from the
-	 * comment counts.
-	 *
 	 * @param WP_Comment $comment Comment object.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -324,12 +324,15 @@ class WC_Comments {
 	 * Determines whether the given comment should be included in the core WP comment counts that are displayed in the
 	 * WordPress admin.
 	 *
+	 * The 'note' type covers the editorial notes introduced in WordPress 7.1, which core itself excludes from the
+	 * comment counts.
+	 *
 	 * @param WP_Comment $comment Comment object.
 	 *
 	 * @return bool
 	 */
 	private static function is_comment_excluded_from_wp_comment_counts( $comment ) {
-		return in_array( $comment->comment_type, array( 'action_log', 'order_note', 'webhook_delivery' ), true )
+		return in_array( $comment->comment_type, array( 'action_log', 'note', 'order_note', 'webhook_delivery' ), true )
 			|| get_post_type( $comment->comment_post_ID ) === 'product';
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -154,9 +154,6 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 	/**
 	 * @testdox Should not increment the cached comment count for comment types excluded from the counts.
 	 *
-	 * The 'note' type is the editorial note introduced in WordPress 7.1. Core excludes it from the comment counts, so
-	 * incrementing the cached count for it makes wp-admin report pending comments that the moderation table cannot show.
-	 *
 	 * @testWith ["action_log"]
 	 *           ["note"]
 	 *           ["order_note"]
@@ -185,7 +182,7 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 
 		$this->assertSame(
 			0,
-			(int) wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
+			wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
 			"Inserting a '{$comment_type}' comment should leave the cached unapproved count untouched"
 		);
 
@@ -220,7 +217,7 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 
 		$this->assertSame(
 			1,
-			(int) wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
+			wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
 			'A regular comment should increment the cached unapproved count'
 		);
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -150,4 +150,82 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		$this->assertTrue( has_filter( 'akismet_excluded_comment_types' ) );
 		$this->assertSame( array( 'order_note' ), apply_filters( 'akismet_excluded_comment_types', array() ) );
 	}
+
+	/**
+	 * @testdox Should not increment the cached comment count for comment types excluded from the counts.
+	 *
+	 * The 'note' type is the editorial note introduced in WordPress 7.1. Core excludes it from the comment counts, so
+	 * incrementing the cached count for it makes wp-admin report pending comments that the moderation table cannot show.
+	 *
+	 * @testWith ["action_log"]
+	 *           ["note"]
+	 *           ["order_note"]
+	 *           ["webhook_delivery"]
+	 *
+	 * @param string $comment_type Comment type that should be excluded from the counts.
+	 */
+	public function test_excluded_comment_types_do_not_increment_the_count_cache( string $comment_type ): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'A post that is not a product',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		wp_cache_set( 'wc_count_comments_unapproved', 0, 'wc_comment_counts' );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => $comment_type,
+				'comment_approved' => '0',
+			)
+		);
+
+		$this->assertSame(
+			0,
+			(int) wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
+			"Inserting a '{$comment_type}' comment should leave the cached unapproved count untouched"
+		);
+
+		// Clean up.
+		wp_delete_comment( $comment_id, true );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * @testdox Should still increment the cached comment count for a regular comment.
+	 *
+	 * Guards the test above: without this, the exclusion assertions could pass for the wrong reason.
+	 */
+	public function test_regular_comments_still_increment_the_count_cache(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'A post that is not a product',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		wp_cache_set( 'wc_count_comments_unapproved', 0, 'wc_comment_counts' );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'comment',
+				'comment_approved' => '0',
+			)
+		);
+
+		$this->assertSame(
+			1,
+			(int) wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' ),
+			'A regular comment should increment the cached unapproved count'
+		);
+
+		// Clean up.
+		wp_delete_comment( $comment_id, true );
+		wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

WordPress 7.1 stores editorial Notes as comments with `comment_type = 'note'`, and core excludes them from the comment counts (see [`comment.php`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/comment.php#L3138), which filters with `AND comment_type != 'note'`).

WooCommerce counts comments two ways, and they currently disagree:

- `WC_Comments::wp_count_comments()` recomputes via `get_comments()`, which core filters to exclude notes. Correct.
- `increment_comments_count_cache_on_wp_insert_comment()` is gated on `is_comment_excluded_from_wp_comment_counts()`, which listed only `action_log`, `order_note` and `webhook_delivery`. `note` was missing.

On a site with a persistent object cache, every note added increments the cached pending count, so **wp-admin → Comments shows pending comments that the moderation table cannot display and that cannot be cleared** — core's list query correctly excludes them.

This adds `'note'` to the excluded types, which is the same one-line fix previously applied for product reviews (#11499), `webhook_delivery` (#12344) and `action_log` (#24071).

It also adds test coverage for **all four** excluded types — there was none for any of them — plus a guard test asserting that a regular comment still *does* increment the cache, so the exclusion assertions cannot pass for the wrong reason.

Closes #67610.

### How to test the changes in this Pull Request:

Requires a site running WordPress 7.1+ (for Notes) with a persistent object cache enabled.

1. Go to **wp-admin → Comments** and note the counts, e.g. `All (0) | Pending (0) | Approved (0)`.
2. Add an editorial Note to any post.
3. Return to **wp-admin → Comments**.
4. **Before this change:** the count reads `Pending (1)` while the moderation table shows "No comments found." Deleting the note decrements it again.
5. **After this change:** the counts are unchanged by adding or deleting a note.

It can also be verified directly, without the admin UI:

```php
wp_cache_set( 'wc_count_comments_unapproved', 0, 'wc_comment_counts' );
wp_insert_comment( array(
	'comment_post_ID'  => 1,
	'comment_type'     => 'note',
	'comment_approved' => 0,
) );
wp_cache_get( 'wc_count_comments_unapproved', 'wc_comment_counts' );
// before: 1   after: 0
```

### Testing that has already taken place:

Ran `WC_Comments_Tests` against PHP 8.3 / MySQL 8.0 / WordPress latest: **12 tests, 18 assertions, all passing.**

To confirm the new tests actually cover the reported bug, the one-line fix was reverted while keeping the tests, and the suite was re-run:

```
 ✘ Excluded comment types do not increment the count cache with data set #1
   │ Failed asserting that 1 is identical to 0.
FAILURES!  Tests: 12, Assertions: 18, Failures: 1.
```

Only data set #1 (`note`) failed, and it failed with exactly the reported symptom. The other three exclusions stayed green, confirming the test is specific to this bug. Restoring the fix returns the suite to green.

`phpcs` reports no violations on the test file, and none on the changed lines of `class-wc-comments.php`.

### Note for reviewers

In the issue discussion, @Ninodevo suggested a more durable alternative: have the increment callbacks fall back to `delete_comments_count_cache()` for any comment type WooCommerce does not explicitly track, so the cache self-corrects instead of drifting each time a new comment type appears. That seems worthwhile, but it is a broader behavioural change than this bug needs, so I have kept this PR to the minimal fix matching the three precedents above. Happy to open a follow-up issue for the general approach if you would like.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
