### PR TITLE
Fix fatal error from a Single Product block that recursively embeds i…

### DIFF
--- a/plugins/woocommerce/changelog/67750-fix-single-product-recursive-embed
+++ b/plugins/woocommerce/changelog/67750-fix-single-product-recursive-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error when a product's description embeds a Single Product block that references itself (directly, or through a chain of other products), which previously exhausted PHP's memory limit and crashed the front end.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\SharedStores\ProductsStore;
 use Automattic\WooCommerce\Blocks\Utils\ProductDataUtils;
 use Automattic\WooCommerce\Enums\ProductType;
 
@@ -33,6 +34,19 @@ class SingleProduct extends AbstractBlock {
 	 * @var array
 	 */
 	protected $single_product_inner_blocks_names = [];
+
+	/**
+	 * Product IDs currently being rendered by this block on the current
+	 * call stack, keyed by product ID.
+	 *
+	 * Guards against a product's description (or a chain of products'
+	 * descriptions) embedding a Single Product block that points back at
+	 * a product already mid-render. Without this, rendering recurses
+	 * until PHP's memory limit is exhausted.
+	 *
+	 * @var array<int, true>
+	 */
+	protected $rendering_product_ids = [];
 
 	/**
 	 * Initialize the block and Hook into the `render_block_context` filter
@@ -81,6 +95,29 @@ class SingleProduct extends AbstractBlock {
 	 * @return array Updated block context.
 	 */
 	public function update_context( $context, $block, $parent_block ) {
+		// A product's description can itself contain WooCommerce block
+		// markup (e.g. a Single Product block left behind by copy-pasting
+		// page content into the description). Rendering that markup
+		// happens as a side effect of ProductsStore::load_product()
+		// formatting the description for hydration. WordPress core seeds
+		// render_block_context with the *page's* queried post (global
+		// $post) by default, so left alone, embedded blocks (e.g. Add to
+		// Cart Form) inherit the page's product as their context even
+		// though there's no real Single Product Template render behind
+		// them, which can fatal. Strip that ambient context so embedded
+		// blocks fall back to their own "no product context" guards
+		// instead.
+		// @see https://github.com/woocommerce/woocommerce/issues/67750.
+		if ( ProductsStore::is_hydrating() ) {
+			// Set (rather than unset) so direct `$context['postId']` reads
+			// elsewhere (e.g. Add to Cart Form) don't emit "undefined
+			// array key" notices; isset() still resolves to false either
+			// way, so guards depending on it behave the same.
+			$context['postId']   = null;
+			$context['postType'] = null;
+			return $context;
+		}
+
 		if ( 'woocommerce/single-product' === $block['blockName']
 			&& isset( $block['attrs']['productId'] ) ) {
 				$this->product_id = $block['attrs']['productId'];
@@ -193,44 +230,60 @@ class SingleProduct extends AbstractBlock {
 
 		$product_id = $product->get_id();
 
-		if ( post_password_required( $product_id ) ) {
-			$password_form = get_the_password_form( $product_id );
-			$html          = new \WP_HTML_Tag_Processor( $password_form );
-			$current_url   = home_url( add_query_arg( null, null ) );
+		// Guard against re-entrant rendering: a product's description (or a
+		// chain of products' descriptions) may embed a Single Product block
+		// that points back at a product already being rendered on the
+		// current call stack. Rendering it again would recurse until PHP's
+		// memory limit is exhausted.
+		// @see https://github.com/woocommerce/woocommerce/issues/67750.
+		if ( isset( $this->rendering_product_ids[ $product_id ] ) ) {
+			return '';
+		}
 
-			while ( $html->next_tag( array( 'tag_name' => 'input' ) ) ) {
-				if ( 'redirect_to' !== $html->get_attribute( 'name' ) ) {
-					continue;
+		$this->rendering_product_ids[ $product_id ] = true;
+
+		try {
+			if ( post_password_required( $product_id ) ) {
+				$password_form = get_the_password_form( $product_id );
+				$html          = new \WP_HTML_Tag_Processor( $password_form );
+				$current_url   = home_url( add_query_arg( null, null ) );
+
+				while ( $html->next_tag( array( 'tag_name' => 'input' ) ) ) {
+					if ( 'redirect_to' !== $html->get_attribute( 'name' ) ) {
+						continue;
+					}
+
+					$html->set_attribute( 'value', $current_url );
+					break;
 				}
 
-				$html->set_attribute( 'value', $current_url );
-				break;
+				return $html->get_updated_html();
 			}
 
-			return $html->get_updated_html();
+			// Load product into the shared products store.
+			wc_interactivity_api_load_product(
+				'I acknowledge that using experimental APIs means my theme or plugin will inevitably break in the next version of WooCommerce',
+				$product_id
+			);
+
+			$interactivity_context = array(
+				'productId'   => $product_id,
+				'variationId' => null,
+			);
+
+			$html = new \WP_HTML_Tag_Processor( $content );
+
+			if ( $html->next_tag( array( 'tag_name' => 'div' ) ) ) {
+				$html->set_attribute( 'data-wp-interactive', $this->get_full_block_name() );
+				$html->set_attribute( 'data-wp-context', 'woocommerce/products::' . wp_json_encode( $interactivity_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) );
+			}
+
+			$updated_html = $html->get_updated_html();
+
+			return parent::render( $attributes, $updated_html, $block );
+		} finally {
+			unset( $this->rendering_product_ids[ $product_id ] );
 		}
-
-		// Load product into the shared products store.
-		wc_interactivity_api_load_product(
-			'I acknowledge that using experimental APIs means my theme or plugin will inevitably break in the next version of WooCommerce',
-			$product_id
-		);
-
-		$interactivity_context = array(
-			'productId'   => $product_id,
-			'variationId' => null,
-		);
-
-		$html = new \WP_HTML_Tag_Processor( $content );
-
-		if ( $html->next_tag( array( 'tag_name' => 'div' ) ) ) {
-			$html->set_attribute( 'data-wp-interactive', $this->get_full_block_name() );
-			$html->set_attribute( 'data-wp-context', 'woocommerce/products::' . wp_json_encode( $interactivity_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) );
-		}
-
-		$updated_html = $html->get_updated_html();
-
-		return parent::render( $attributes, $updated_html, $block );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
@@ -68,6 +68,24 @@ class ProductsStore {
 	private static array $loaded_variation_parents = array();
 
 	/**
+	 * Parent product IDs whose purchasable-child-products fetch is
+	 * currently in flight. Guards load_purchasable_child_products() against
+	 * the same re-entrancy cycle described on $hydration_depth below.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $loading_child_parents = array();
+
+	/**
+	 * Parent product IDs whose variations fetch is currently in flight.
+	 * Guards load_variations() against the same re-entrancy cycle
+	 * described on $hydration_depth below.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $loading_variation_parents = array();
+
+	/**
 	 * Whether the derived-state getters have been registered.
 	 *
 	 * @var bool
@@ -75,7 +93,8 @@ class ProductsStore {
 	private static bool $getters_registered = false;
 
 	/**
-	 * Depth counter for in-flight load_product() calls.
+	 * Depth counter for in-flight load_product() / load_variations() /
+	 * load_purchasable_child_products() calls.
 	 *
 	 * A product's description can itself contain block markup, including a
 	 * Single Product block. Rendering that markup happens as a side effect
@@ -251,7 +270,22 @@ class ProductsStore {
 		);
 		$query_string   = implode( '&', $include_params );
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
+		// Bail on a re-entrant load of a parent whose fetch is still in
+		// flight (e.g. a child product's description embeds a block that
+		// loads this same parent's children again). Recursing would
+		// exhaust memory. @see https://github.com/woocommerce/woocommerce/issues/67750.
+		if ( isset( self::$loading_child_parents[ $parent_id ] ) ) {
+			return array();
+		}
+
+		self::$loading_child_parents[ $parent_id ] = true;
+		++self::$hydration_depth;
+		try {
+			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
+		} finally {
+			--self::$hydration_depth;
+			unset( self::$loading_child_parents[ $parent_id ] );
+		}
 
 		if ( empty( $response['body'] ) ) {
 			return array();
@@ -295,7 +329,22 @@ class ProductsStore {
 			);
 		}
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
+		// Bail on a re-entrant load of a parent whose fetch is still in
+		// flight (e.g. a variation's description embeds a block that loads
+		// this same parent's variations again). Recursing would exhaust
+		// memory. @see https://github.com/woocommerce/woocommerce/issues/67750.
+		if ( isset( self::$loading_variation_parents[ $parent_id ] ) ) {
+			return array();
+		}
+
+		self::$loading_variation_parents[ $parent_id ] = true;
+		++self::$hydration_depth;
+		try {
+			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
+		} finally {
+			--self::$hydration_depth;
+			unset( self::$loading_variation_parents[ $parent_id ] );
+		}
 
 		self::$loaded_variation_parents[ $parent_id ] = true;
 

--- a/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
@@ -75,6 +75,22 @@ class ProductsStore {
 	private static bool $getters_registered = false;
 
 	/**
+	 * Depth counter for in-flight load_product() calls.
+	 *
+	 * A product's description can itself contain block markup, including a
+	 * Single Product block. Rendering that markup happens as a side effect
+	 * of formatting the description for hydration below, which means it
+	 * has no page-level Single Product Template context. Consumers use
+	 * is_hydrating() to detect this "detached" render and avoid wiring up
+	 * behaviour (e.g. block context) that assumes a normal page render.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 *
+	 * @var int
+	 */
+	private static int $hydration_depth = 0;
+
+	/**
 	 * Check that the consent statement was passed.
 	 *
 	 * @param string $consent_statement The consent statement string.
@@ -172,9 +188,15 @@ class ProductsStore {
 			return self::$products[ $product_id ];
 		}
 
-		$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
+		++self::$hydration_depth;
+		try {
+			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
 
-		self::$products[ $product_id ] = $response['body'] ?? array();
+			self::$products[ $product_id ] = $response['body'] ?? array();
+		} finally {
+			--self::$hydration_depth;
+		}
+
 		self::register_getters();
 		wp_interactivity_state(
 			self::$store_namespace,
@@ -182,6 +204,19 @@ class ProductsStore {
 		);
 
 		return self::$products[ $product_id ];
+	}
+
+	/**
+	 * Whether a product's content is currently being formatted for
+	 * hydration (i.e. we're inside load_product()). Used to detect
+	 * "detached" block renders triggered by that formatting.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 *
+	 * @return bool
+	 */
+	public static function is_hydrating(): bool {
+		return self::$hydration_depth > 0;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/src/Blocks/SharedStores/ProductsStore.php
@@ -192,6 +192,46 @@ class ProductsStore {
 	}
 
 	/**
+	 * Fetch a Store API response while `woocommerce/single-product` blocks
+	 * are short-circuited and the hydration depth counter is held.
+	 *
+	 * The Store API formats a product's description with `do_blocks()`. A
+	 * `woocommerce/single-product` block stored inside a description
+	 * (commonly left behind by copy-pasting product page blocks) would
+	 * render detached from any Single Product Template context: its inner
+	 * blocks can fatal without a resolvable product (e.g. Add to Cart
+	 * Form), and loading its product into this store mid-fetch can recurse
+	 * indefinitely when it references a product already being fetched.
+	 * Skipping the block outright for the duration of the fetch prevents
+	 * both, regardless of whether the block's own inner blocks happen to
+	 * guard against a missing product context. This is on top of, not a
+	 * replacement for, the per-ID re-entrancy guards below.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 *
+	 * @param string $path The Store API path to fetch.
+	 * @return array The response data.
+	 */
+	private static function fetch_rest_api_response_data( string $path ): array {
+		$skip_single_product_block = static function ( $pre_render, $parsed_block ) {
+			if ( isset( $parsed_block['blockName'] ) && 'woocommerce/single-product' === $parsed_block['blockName'] ) {
+				return '';
+			}
+
+			return $pre_render;
+		};
+
+		add_filter( 'pre_render_block', $skip_single_product_block, 10, 2 );
+		++self::$hydration_depth;
+		try {
+			return Package::container()->get( Hydration::class )->get_rest_api_response_data( $path );
+		} finally {
+			--self::$hydration_depth;
+			remove_filter( 'pre_render_block', $skip_single_product_block, 10 );
+		}
+	}
+
+	/**
 	 * Load a product into state.
 	 *
 	 * @param string $consent_statement The consent statement string.
@@ -207,14 +247,9 @@ class ProductsStore {
 			return self::$products[ $product_id ];
 		}
 
-		++self::$hydration_depth;
-		try {
-			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
+		$response = self::fetch_rest_api_response_data( '/wc/store/v1/products/' . $product_id );
 
-			self::$products[ $product_id ] = $response['body'] ?? array();
-		} finally {
-			--self::$hydration_depth;
-		}
+		self::$products[ $product_id ] = $response['body'] ?? array();
 
 		self::register_getters();
 		wp_interactivity_state(
@@ -279,11 +314,9 @@ class ProductsStore {
 		}
 
 		self::$loading_child_parents[ $parent_id ] = true;
-		++self::$hydration_depth;
 		try {
-			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
+			$response = self::fetch_rest_api_response_data( '/wc/store/v1/products?' . $query_string );
 		} finally {
-			--self::$hydration_depth;
 			unset( self::$loading_child_parents[ $parent_id ] );
 		}
 
@@ -338,11 +371,9 @@ class ProductsStore {
 		}
 
 		self::$loading_variation_parents[ $parent_id ] = true;
-		++self::$hydration_depth;
 		try {
-			$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
+			$response = self::fetch_rest_api_response_data( '/wc/store/v1/products?parent[]=' . $parent_id . '&type=variation' );
 		} finally {
-			--self::$hydration_depth;
 			unset( self::$loading_variation_parents[ $parent_id ] );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -179,6 +179,95 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox load_product() short-circuits single-product blocks rendered while the fetch is in flight and restores rendering afterwards.
+	 *
+	 * The per-ID re-entrancy guard above stops a self-referencing block
+	 * from recursing, but a Single Product block embedded in a
+	 * description is never a legitimate render regardless of which
+	 * product it points at — it has no page-level Single Product Template
+	 * context. This blanket short-circuit means inner blocks (e.g. Add to
+	 * Cart Form) are never touched at all, rather than relying on them to
+	 * individually guard against a missing product context.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 */
+	public function test_load_product_short_circuits_single_product_blocks_during_fetch(): void {
+		$product      = WC_Helper_Product::create_simple_product();
+		$other        = WC_Helper_Product::create_simple_product();
+		$block_markup = '<!-- wp:woocommerce/single-product {"productId":' . $other->get_id() . '} -->' .
+			'<div class="wp-block-woocommerce-single-product woocommerce"><p>Embedded</p></div>' .
+			'<!-- /wp:woocommerce/single-product -->';
+
+		$fake_hydration = new class( $product->get_id(), $block_markup ) {
+			/**
+			 * The product ID for the canned response.
+			 *
+			 * @var int
+			 */
+			private int $product_id;
+
+			/**
+			 * Block markup to render mid-fetch.
+			 *
+			 * @var string
+			 */
+			private string $block_markup;
+
+			/**
+			 * What do_blocks() produced while the fetch was in flight.
+			 *
+			 * @var string|null
+			 */
+			public ?string $rendered_during_fetch = null;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $product_id   The product ID.
+			 * @param string $block_markup Block markup to render mid-fetch.
+			 */
+			public function __construct( int $product_id, string $block_markup ) {
+				$this->product_id   = $product_id;
+				$this->block_markup = $block_markup;
+			}
+
+			/**
+			 * Mimic Hydration::get_rest_api_response_data, rendering block
+			 * markup mid-fetch like description formatting would.
+			 *
+			 * @param string $path The REST path (ignored).
+			 * @return array The canned response.
+			 */
+			public function get_rest_api_response_data( string $path ): array {
+				// Avoid parameter not used PHPCS errors.
+				unset( $path );
+				$this->rendered_during_fetch = do_blocks( $this->block_markup );
+
+				return array(
+					'body' => array(
+						'id'   => $this->product_id,
+						'name' => 'Fake Product',
+					),
+				);
+			}
+		};
+		$this->inject_hydration( $fake_hydration );
+
+		global $wp_filter;
+		$callbacks_before = isset( $wp_filter['pre_render_block'] ) ? count( $wp_filter['pre_render_block']->callbacks[10] ?? array() ) : 0;
+
+		TestedProductsStore::load_product( $this->consent, $product->get_id() );
+
+		$callbacks_after = isset( $wp_filter['pre_render_block'] ) ? count( $wp_filter['pre_render_block']->callbacks[10] ?? array() ) : 0;
+
+		$this->assertSame( '', $fake_hydration->rendered_during_fetch, 'single-product blocks should not render while a product fetch is in flight, regardless of which product they point at.' );
+		$this->assertSame( $callbacks_before, $callbacks_after, 'The pre_render_block short-circuit should be removed after the fetch.' );
+
+		$product->delete( true );
+		$other->delete( true );
+	}
+
+	/**
 	 * @testdox load_variations() hydrates interactivity state with every child variation.
 	 */
 	public function test_load_variations_populates_state(): void {

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -116,6 +116,69 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox load_product() does not fatal when a product's own description embeds a Single Product block pointing at itself.
+	 *
+	 * Regression test for a description that embeds a Single Product block
+	 * referencing its own product (e.g. left behind by copy-pasting page
+	 * blocks into the description). Rendering the description for
+	 * hydration used to recurse into load_product() for the same ID until
+	 * PHP's memory limit was exhausted, and even once that recursion was
+	 * blocked, inner blocks like Add to Cart Form would fatal because they
+	 * inherited the page's product as ambient block context.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 */
+	public function test_load_product_handles_self_referencing_single_product_block(): void {
+		$product    = WC_Helper_Product::create_simple_product();
+		$product_id = $product->get_id();
+
+		$product->set_description(
+			'<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} -->' .
+			'<div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div>' .
+			'<!-- /wp:woocommerce/single-product -->'
+		);
+		$product->save();
+
+		$result = TestedProductsStore::load_product( $this->consent, $product_id );
+
+		$this->assertSame( $product->get_name(), $result['name'], 'The product should still load and hydrate normally.' );
+
+		$product->delete( true );
+	}
+
+	/**
+	 * @testdox load_product() does not fatal on an indirect two-product description cycle.
+	 *
+	 * Same failure mode as the self-referencing case, but via a chain of
+	 * two products whose descriptions embed each other.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 */
+	public function test_load_product_handles_indirect_description_cycle(): void {
+		$product_a = WC_Helper_Product::create_simple_product();
+		$product_b = WC_Helper_Product::create_simple_product();
+
+		$block_for = static function ( $id ) {
+			return '<!-- wp:woocommerce/single-product {"productId":' . $id . '} -->' .
+				'<div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div>' .
+				'<!-- /wp:woocommerce/single-product -->';
+		};
+
+		$product_a->set_description( $block_for( $product_b->get_id() ) );
+		$product_a->save();
+
+		$product_b->set_description( $block_for( $product_a->get_id() ) );
+		$product_b->save();
+
+		$result = TestedProductsStore::load_product( $this->consent, $product_a->get_id() );
+
+		$this->assertSame( $product_a->get_name(), $result['name'], 'The product should still load and hydrate normally.' );
+
+		$product_a->delete( true );
+		$product_b->delete( true );
+	}
+
+	/**
 	 * @testdox load_variations() hydrates interactivity state with every child variation.
 	 */
 	public function test_load_variations_populates_state(): void {
@@ -515,6 +578,10 @@ class ProductsStore extends \WC_Unit_Test_Case {
 		$flag = $reflection->getProperty( 'getters_registered' );
 		$flag->setAccessible( true );
 		$flag->setValue( null, false );
+
+		$depth = $reflection->getProperty( 'hydration_depth' );
+		$depth->setAccessible( true );
+		$depth->setValue( null, 0 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/SharedStores/ProductsStore.php
@@ -242,6 +242,94 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox load_variations() breaks a re-entrant load of a parent whose fetch is still in flight instead of recursing.
+	 *
+	 * Same failure mode as load_product()'s self-reference: a variation's
+	 * description can embed a block that re-triggers load_variations() for
+	 * the same parent while the first fetch is still on the stack.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 */
+	public function test_load_variations_breaks_reentrant_load_of_same_parent(): void {
+		$product   = WC_Helper_Product::create_variation_product();
+		$parent_id = $product->get_id();
+
+		$fake_hydration = new class( $parent_id, $this->consent ) {
+			/**
+			 * The parent ID to re-enter the store with.
+			 *
+			 * @var int
+			 */
+			private int $parent_id;
+
+			/**
+			 * The consent string.
+			 *
+			 * @var string
+			 */
+			private string $consent;
+
+			/**
+			 * How many times get_rest_api_response_data was called.
+			 *
+			 * @var int
+			 */
+			public int $call_count = 0;
+
+			/**
+			 * The result of the re-entrant load_variations() call.
+			 *
+			 * @var array|null
+			 */
+			public ?array $inner_result = null;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $parent_id The parent product ID.
+			 * @param string $consent   The consent string.
+			 */
+			public function __construct( int $parent_id, string $consent ) {
+				$this->parent_id = $parent_id;
+				$this->consent   = $consent;
+			}
+
+			/**
+			 * Mimic Hydration::get_rest_api_response_data, re-entering the
+			 * store mid-fetch like a block in a variation's description would.
+			 *
+			 * @param string $path The REST path (ignored).
+			 * @return array The canned response.
+			 */
+			public function get_rest_api_response_data( string $path ): array {
+				// Avoid parameter not used PHPCS errors.
+				unset( $path );
+				++$this->call_count;
+				$this->inner_result = TestedProductsStore::load_variations( $this->consent, $this->parent_id );
+
+				return array(
+					'body' => array(
+						array(
+							'id'     => 999,
+							'parent' => $this->parent_id,
+							'name'   => 'Self Referencing Variation',
+						),
+					),
+				);
+			}
+		};
+		$this->inject_hydration( $fake_hydration );
+
+		$result = TestedProductsStore::load_variations( $this->consent, $parent_id );
+
+		$this->assertSame( 1, $fake_hydration->call_count, 'The re-entrant call should not trigger a second fetch.' );
+		$this->assertSame( array(), $fake_hydration->inner_result, 'The re-entrant call should return an empty array.' );
+		$this->assertArrayHasKey( 999, $result, 'The outer call should still return the fetched variation.' );
+
+		$product->delete( true );
+	}
+
+	/**
 	 * @testdox load_variations() returns only the variations belonging to the requested parent.
 	 */
 	public function test_load_variations_second_call_filters_by_parent(): void {
@@ -300,6 +388,102 @@ class ProductsStore extends \WC_Unit_Test_Case {
 		$this->assertSame( array(), $result );
 
 		$grouped->delete( true );
+	}
+
+	/**
+	 * @testdox load_purchasable_child_products() breaks a re-entrant load of a parent whose fetch is still in flight instead of recursing.
+	 *
+	 * Same failure mode as load_product()'s self-reference: a child
+	 * product's description can embed a block that re-triggers
+	 * load_purchasable_child_products() for the same parent while the
+	 * first fetch is still on the stack.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/67750
+	 */
+	public function test_load_purchasable_child_products_breaks_reentrant_load_of_same_parent(): void {
+		$child = WC_Helper_Product::create_simple_product();
+
+		$grouped = new WC_Product_Grouped();
+		$grouped->set_name( 'Reentrant Grouped Parent' );
+		$grouped->set_children( array( $child->get_id() ) );
+		$grouped->save();
+		$parent_id = $grouped->get_id();
+
+		$fake_hydration = new class( $parent_id, $this->consent ) {
+			/**
+			 * The parent ID to re-enter the store with.
+			 *
+			 * @var int
+			 */
+			private int $parent_id;
+
+			/**
+			 * The consent string.
+			 *
+			 * @var string
+			 */
+			private string $consent;
+
+			/**
+			 * How many times get_rest_api_response_data was called.
+			 *
+			 * @var int
+			 */
+			public int $call_count = 0;
+
+			/**
+			 * The result of the re-entrant load_purchasable_child_products() call.
+			 *
+			 * @var array|null
+			 */
+			public ?array $inner_result = null;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $parent_id The parent product ID.
+			 * @param string $consent   The consent string.
+			 */
+			public function __construct( int $parent_id, string $consent ) {
+				$this->parent_id = $parent_id;
+				$this->consent   = $consent;
+			}
+
+			/**
+			 * Mimic Hydration::get_rest_api_response_data, re-entering the
+			 * store mid-fetch like a block in a child product's description
+			 * would.
+			 *
+			 * @param string $path The REST path (ignored).
+			 * @return array The canned response.
+			 */
+			public function get_rest_api_response_data( string $path ): array {
+				// Avoid parameter not used PHPCS errors.
+				unset( $path );
+				++$this->call_count;
+				$this->inner_result = TestedProductsStore::load_purchasable_child_products( $this->consent, $this->parent_id );
+
+				return array(
+					'body' => array(
+						array(
+							'id'             => 999,
+							'is_purchasable' => true,
+							'name'           => 'Self Referencing Child',
+						),
+					),
+				);
+			}
+		};
+		$this->inject_hydration( $fake_hydration );
+
+		$result = TestedProductsStore::load_purchasable_child_products( $this->consent, $parent_id );
+
+		$this->assertSame( 1, $fake_hydration->call_count, 'The re-entrant call should not trigger a second fetch.' );
+		$this->assertSame( array(), $fake_hydration->inner_result, 'The re-entrant call should return an empty array.' );
+		$this->assertArrayHasKey( 999, $result, 'The outer call should still return the fetched child.' );
+
+		$grouped->delete( true );
+		$child->delete( true );
 	}
 
 	/**
@@ -569,7 +753,7 @@ class ProductsStore extends \WC_Unit_Test_Case {
 	private function reset_products_store_static_state(): void {
 		$reflection = new \ReflectionClass( TestedProductsStore::class );
 
-		foreach ( array( 'products', 'product_variations', 'loaded_variation_parents' ) as $name ) {
+		foreach ( array( 'products', 'product_variations', 'loaded_variation_parents', 'loading_child_parents', 'loading_variation_parents' ) as $name ) {
 			$property = $reflection->getProperty( $name );
 			$property->setAccessible( true );
 			$property->setValue( null, array() );


### PR DESCRIPTION
…tself

A product's description can end up containing a Single Product block that points back at the same product (or at another product with the same issue), e.g. from copy-pasting page blocks into the description. Rendering that block while the product's own content is being formatted for hydration used to recurse until PHP's memory limit was exhausted, crashing the front end.

- ProductsStore::load_product() now tracks whether a hydration request is currently in flight, and bails on a re-entrant load of a product whose fetch is still on the stack.
- ProductsStore::load_variations() and load_purchasable_child_products() are guarded the same way, since a variation's or grouped-product child's description can trigger the identical re-entrancy cycle through those two fetch paths.
- All three fetches now also short-circuit any `woocommerce/single-product` block via a scoped `pre_render_block` filter, since such a block is never a legitimate render regardless of which product it points at — it has no page-level Single Product Template context. This means inner blocks (e.g. Add to Cart Form) are never touched at all during a detached render, rather than relying on them to each individually guard against a missing product context.
- SingleProduct::update_context() additionally clears the ambient postId/postType block context while any of the three fetches above are in flight, as defense-in-depth for any other block that ends up rendering during hydration.
- SingleProduct::render() also guards against re-rendering a product that is already mid-render on the current call stack, covering indirect cycles between two or more products.

Fixes #67750

**Related:** #67789 also addresses this issue, opened independently around the same time, with a very similar approach (per-ID re-entrancy guards on all three ProductsStore fetch paths, plus a `pre_render_block` short-circuit for `woocommerce/single-product` blocks). Flagging for visibility in case the maintainers prefer to consolidate on one PR.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #67750.

(For Bug Fixes) Bug introduced in PR # . Not confirmed — the issue notes this likely landed in WooCommerce 10.8.0 when Store API/iAPI hydration was added to the Single Product Template, but the originating PR wasn't identified.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A — this is a backend fatal-error fix with no visual UI change.

| Before | After |
| ------ | ----- |
| Visiting a product page whose description embeds a Single Product block pointing at itself (directly, or via a chain of other products) fatals with "Allowed memory size exhausted." | The same page loads normally (HTTP 200). The embedded Single Product block renders nothing (WooCommerce blocks aren't supported inside product content), and the rest of the page renders as usual. |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create a product (Product A), note its ID, and set its description to: `<!-- wp:woocommerce/single-product {"productId":<A's ID>} --><div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div><!-- /wp:woocommerce/single-product -->`. Use a block theme (e.g. Twenty Twenty-Five) with the block-based Single Product Template active.
2. Visit Product A's page on the front end. Before this fix, this fatals with "Allowed memory size exhausted." After the fix, the page loads normally (200) and the embedded block renders nothing.
3. Regression check: embed a Single Product block pointing at a *different*, unrelated product inside a normal page (not a product description) — it should still render fully (image, price, Add to Cart, etc.), confirming legitimate embeds are unaffected.
4. Indirect cycle check: Product A's description embeds Product B, and Product B's description embeds Product A — both product pages should load without crashing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Manually reproduced the crash and verified the fix on a local WordPress/WooCommerce install (Twenty Twenty-Five block theme, block-based Single Product Template): self-reference, an indirect two-product cycle, and a legitimate non-recursive embed (regression check, confirming the `pre_render_block` short-circuit is scoped to the fetch and doesn't affect a normal page-level embed) — all confirmed via direct HTTP requests and `debug.log` inspection (no fatals, no warnings in any case). PHPCS is clean on all changed files. PHPUnit tests were added covering the self-reference and indirect-cycle scenarios, plus the `pre_render_block` short-circuit and its removal after the fetch; they were not run locally (no Docker/wp-env available in this environment) but will run in CI.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->



