### PR TITLE
e2e tests: Fix create-post e2e test against Gutenberg nightly

### DIFF
--- a/plugins/woocommerce/changelog/fix-gb-nightly-create-post-appender
+++ b/plugins/woocommerce/changelog/fix-gb-nightly-create-post-appender
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the create-post e2e test against Gutenberg nightly, where the default block appender no longer exposes the button role.

--- a/plugins/woocommerce/tests/e2e/tests/wp-core/create-post.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/wp-core/create-post.spec.ts
@@ -29,9 +29,7 @@ test.describe(
 
 			const canvas = await getCanvas( page );
 
-			await canvas
-				.getByRole( 'button', { name: 'Add default block' } )
-				.click();
+			await canvas.getByLabel( /Add default block|Empty block/ ).click();
 
 			await canvas
 				.getByRole( 'document', {


### PR DESCRIPTION

### Changes proposed in this Pull Request:

The nightly Gutenberg e2e job has [failed](https://github.com/woocommerce/woocommerce/actions/runs/32094948595) on `create-post.spec.ts` since 12 August. Gutenberg [WordPress/gutenberg#81231](https://github.com/WordPress/gutenberg/pull/81231) replaced the default block appender with a real empty paragraph block. The element keeps the accessible name `Add default block`, but its role changed from `button` to `document`. The test asked for the button role, so its locator matched nothing and timed out.

The test now matches by label:

```ts
await canvas.getByLabel( /Add default block|Empty block/ ).click();
```

`create-page.spec.ts` and `products.block_theme.spec.ts` already do this, after an earlier appender change in #53100. `create-post.spec.ts` was the last one still asking for the button role.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Build the plugin: `pnpm --filter=@woocommerce/plugin-woocommerce build`.
3. Start the e2e environment: `pnpm --filter=@woocommerce/plugin-woocommerce env:e2e`.
4. Run against Gutenberg nightly: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:gb-nightly tests/wp-core/create-post.spec.ts`. It passes. On `trunk` it fails at `create-post.spec.ts:33` with `TimeoutError: locator.click: Timeout 20000ms exceeded`.
5. Run against Gutenberg stable: `pnpm --filter=@woocommerce/plugin-woocommerce test:e2e:gb-stable tests/wp-core/create-post.spec.ts`. It still passes.

Tested: https://github.com/woocommerce/woocommerce/actions/runs/32123269803

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
