### PR TITLE
Fix Analytics date range label in locales with digits in month names

### DIFF
--- a/packages/js/date/changelog/fix-53303-day-range-in-localized-format
+++ b/packages/js/date/changelog/fix-53303-day-range-in-localized-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Build the same-month range label by substituting the day token in the date format, so month names that contain digits are no longer corrupted (#53303).

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -141,23 +141,29 @@ export function toMoment( format: string, str: unknown ) {
  * "10月", where replacing the day "1" lands on the month instead, and locales
  * with non-Latin digits never match a Latin day number at all.
  *
- * @param {string} format      - localized date string format
- * @param {string} replacement - literal text to render in place of the day
+ * @param {string}   format      - localized date string format
+ * @param {Function} replacement - builds the literal text to render in place of
+ *                               the day, from the token it replaces
  * @return {string|null} - format string, or null when it holds no day token
  */
-function replaceDayToken( format: string, replacement: string ) {
+function replaceDayToken(
+	format: string,
+	replacement: ( dayToken: string ) => string
+) {
 	let replaced = false;
 	// Bracketed sections are moment's escaped literals, so a "D" inside one is text.
 	const dayRangeFormat = format.replace( /\[[^\]]*\]|D+o?/g, ( token ) => {
 		// Runs longer than "DD" are day of year tokens, not day of month.
-		const isDayOfMonth = token.replace( /o$/, '' ).length <= 2;
+		const dayDigits = token.endsWith( 'o' )
+			? token.length - 1
+			: token.length;
 
-		if ( replaced || token.startsWith( '[' ) || ! isDayOfMonth ) {
+		if ( replaced || token.startsWith( '[' ) || dayDigits > 2 ) {
 			return token;
 		}
 
 		replaced = true;
-		return `[${ replacement }]`;
+		return `[${ replacement( token ) }]`;
 	} );
 
 	return replaced ? dayRangeFormat : null;
@@ -180,13 +186,18 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 	if ( isSameDay ) {
 		return after.format( fullDateFormat );
 	} else if ( isSameMonth ) {
+		// Formatting each day through the token it replaces keeps whatever the
+		// format asked for, such as the zero padding of "DD" or the ordinal of "Do".
 		const dayRangeFormat = replaceDayToken(
 			fullDateFormat,
-			`${ after.date() } - ${ before.date() }`
+			( dayToken ) =>
+				`${ after.format( dayToken ) } - ${ before.format( dayToken ) }`
 		);
 
-		// A translated format without a day token cannot express days at all,
-		// so the shared month is as much of the range as it can carry.
+		// No day of month token to swap: the format either omits the day, or
+		// renders one through an aggregate token such as "LL" that is not
+		// scanned. Either way the shared month is as much of the range as this
+		// format can carry.
 		if ( dayRangeFormat === null ) {
 			return after.format( fullDateFormat );
 		}

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -134,6 +134,36 @@ export function toMoment( format: string, str: unknown ) {
 }
 
 /**
+ * Swaps the day of month token of a moment format string for an escaped literal.
+ *
+ * Substituting in the format instead of in the formatted date keeps the value
+ * away from the rest of the localized output: Japanese renders October as
+ * "10月", where replacing the day "1" lands on the month instead, and locales
+ * with non-Latin digits never match a Latin day number at all.
+ *
+ * @param {string} format      - localized date string format
+ * @param {string} replacement - literal text to render in place of the day
+ * @return {string|null} - format string, or null when it holds no day token
+ */
+function replaceDayToken( format: string, replacement: string ) {
+	let replaced = false;
+	// Bracketed sections are moment's escaped literals, so a "D" inside one is text.
+	const dayRangeFormat = format.replace( /\[[^\]]*\]|D+o?/g, ( token ) => {
+		// Runs longer than "DD" are day of year tokens, not day of month.
+		const isDayOfMonth = token.replace( /o$/, '' ).length <= 2;
+
+		if ( replaced || token.startsWith( '[' ) || ! isDayOfMonth ) {
+			return token;
+		}
+
+		replaced = true;
+		return `[${ replacement }]`;
+	} );
+
+	return replaced ? dayRangeFormat : null;
+}
+
+/**
  * Given two dates, derive a string representation
  *
  * @param {moment.Moment} after  - start date
@@ -150,13 +180,18 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 	if ( isSameDay ) {
 		return after.format( fullDateFormat );
 	} else if ( isSameMonth ) {
-		const afterDate = after.date();
-		return after
-			.format( fullDateFormat )
-			.replace(
-				String( afterDate ),
-				`${ afterDate } - ${ before.date() }`
-			);
+		const dayRangeFormat = replaceDayToken(
+			fullDateFormat,
+			`${ after.date() } - ${ before.date() }`
+		);
+
+		// A translated format without a day token cannot express days at all,
+		// so the shared month is as much of the range as it can carry.
+		if ( dayRangeFormat === null ) {
+			return after.format( fullDateFormat );
+		}
+
+		return after.format( dayRangeFormat );
 	} else if ( isSameYear ) {
 		const monthDayFormat = __( 'MMM D', 'woocommerce' );
 		return `${ after.format( monthDayFormat ) } - ${ before.format(

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -151,20 +151,29 @@ function replaceDayToken(
 	replacement: ( dayToken: string ) => string
 ) {
 	let replaced = false;
-	// Bracketed sections are moment's escaped literals, so a "D" inside one is text.
-	const dayRangeFormat = format.replace( /\[[^\]]*\]|D+o?/g, ( token ) => {
-		// Runs longer than "DD" are day of year tokens, not day of month.
-		const dayDigits = token.endsWith( 'o' )
-			? token.length - 1
-			: token.length;
+	// Backslash escapes and bracketed sections are moment's literals, so a "D"
+	// inside one is text.
+	const dayRangeFormat = format.replace(
+		/\\.|\[[^\]]*\]|D+o?/g,
+		( token ) => {
+			// Runs longer than "DD" are day of year tokens, not day of month.
+			const dayDigits = token.endsWith( 'o' )
+				? token.length - 1
+				: token.length;
 
-		if ( replaced || token.startsWith( '[' ) || dayDigits > 2 ) {
-			return token;
+			if (
+				replaced ||
+				token.startsWith( '[' ) ||
+				token.startsWith( '\\' ) ||
+				dayDigits > 2
+			) {
+				return token;
+			}
+
+			replaced = true;
+			return `[${ replacement( token ) }]`;
 		}
-
-		replaced = true;
-		return `[${ replacement( token ) }]`;
-	} );
+	);
 
 	return replaced ? dayRangeFormat : null;
 }

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -937,6 +937,70 @@ describe( 'getRangeLabel', () => {
 		} );
 	} );
 
+	describe( 'with a locale that renders non-Latin digits', () => {
+		// Mirrors moment's Arabic locale, which maps digits when formatting.
+		const arabicDigits = [
+			'٠',
+			'١',
+			'٢',
+			'٣',
+			'٤',
+			'٥',
+			'٦',
+			'٧',
+			'٨',
+			'٩',
+		];
+		const monthNames = [
+			'يناير',
+			'فبراير',
+			'مارس',
+			'أبريل',
+			'مايو',
+			'يونيو',
+			'يوليو',
+			'أغسطس',
+			'سبتمبر',
+			'أكتوبر',
+			'نوفمبر',
+			'ديسمبر',
+		];
+		let originalLocale: string;
+
+		beforeAll( () => {
+			originalLocale = moment.locale();
+			moment.defineLocale( 'non-latin-digits', {
+				months: monthNames,
+				monthsShort: monthNames,
+				postformat: ( value: string ) =>
+					value.replace(
+						/\d/g,
+						( digit ) => arabicDigits[ Number( digit ) ]
+					),
+			} );
+			moment.locale( 'non-latin-digits' );
+		} );
+
+		afterAll( () => {
+			moment.locale( originalLocale );
+		} );
+
+		it( 'should keep both ends of the range', () => {
+			const label = getRangeLabel(
+				moment( '2024-10-01' ),
+				moment( '2024-10-31' )
+			);
+			expect( label ).toBe( 'أكتوبر ١ - ٣١, ٢٠٢٤' );
+		} );
+
+		it( 'should leave a single day label alone', () => {
+			const label = getRangeLabel(
+				moment( '2024-10-01' ),
+				moment( '2024-10-01' )
+			);
+			expect( label ).toBe( 'أكتوبر ١, ٢٠٢٤' );
+		} );
+	} );
 } );
 
 describe( 'loadLocaleData', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -839,6 +839,54 @@ describe( 'getRangeLabel', () => {
 		expect( label ).toBe( '2024年10月' );
 	} );
 
+	it( 'should keep the zero padding a "DD" format asks for', () => {
+		// Mirrors the Serbian translation of the format.
+		( __ as jest.Mock ).mockReturnValueOnce( 'DD. MMM YYYY.' );
+
+		const label = getRangeLabel(
+			moment( '2018-04-01' ),
+			moment( '2018-04-15' )
+		);
+
+		expect( label ).toBe( '01 - 15. Apr 2018.' );
+	} );
+
+	it( 'should keep the ordinal a "Do" format asks for', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'MMM Do, YYYY' );
+
+		const label = getRangeLabel(
+			moment( '2018-04-01' ),
+			moment( '2018-04-15' )
+		);
+
+		expect( label ).toBe( 'Apr 1st - 15th, 2018' );
+	} );
+
+	it( 'should leave a bracketed day literal alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '[Day] MMM D, YYYY' );
+
+		const label = getRangeLabel(
+			moment( '2018-04-01' ),
+			moment( '2018-04-15' )
+		);
+
+		expect( label ).toBe( 'Day Apr 1 - 15, 2018' );
+	} );
+
+	it( 'should not mistake day of year tokens for the day of month', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'DDDD, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2018-04-01' ), moment( '2018-04-15' ) )
+		).toBe( '091, 2018' );
+
+		( __ as jest.Mock ).mockReturnValueOnce( 'DDDo, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2018-04-01' ), moment( '2018-04-15' ) )
+		).toBe( '91st, 2018' );
+	} );
+
 	describe( 'with a locale whose month names contain digits', () => {
 		// Mirrors moment's Japanese locale, which renders October as "10月".
 		const monthNames = Array.from(
@@ -888,6 +936,7 @@ describe( 'getRangeLabel', () => {
 			).toBe( '10月 1, 2023 - 12月 31, 2024' );
 		} );
 	} );
+
 } );
 
 describe( 'loadLocaleData', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -2,12 +2,19 @@
  * External dependencies
  */
 import moment from 'moment';
+import { __ } from '@wordpress/i18n';
 import {
 	format as formatDate,
 	getSettings as getDateSettings,
 	setSettings as setDateSettings,
 } from '@wordpress/date';
 import { timeFormat as d3TimeFormat } from 'd3-time-format';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	__: jest.fn( ( text: string ) => text ),
+} ) );
+
 /**
  * Internal dependencies
  */
@@ -819,6 +826,67 @@ describe( 'getRangeLabel', () => {
 			moment( '2018-05-15' )
 		);
 		expect( label ).toBe( 'Apr 1, 2017 - May 15, 2018' );
+	} );
+
+	it( 'should fall back to the shared month when the format holds no day token', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'YYYY年M月' );
+
+		const label = getRangeLabel(
+			moment( '2024-10-01' ),
+			moment( '2024-10-31' )
+		);
+
+		expect( label ).toBe( '2024年10月' );
+	} );
+
+	describe( 'with a locale whose month names contain digits', () => {
+		// Mirrors moment's Japanese locale, which renders October as "10月".
+		const monthNames = Array.from(
+			{ length: 12 },
+			( _, index ) => `${ index + 1 }月`
+		);
+		let originalLocale: string;
+
+		beforeAll( () => {
+			originalLocale = moment.locale();
+			moment.defineLocale( 'digit-months', {
+				months: monthNames,
+				monthsShort: monthNames,
+			} );
+			moment.locale( 'digit-months' );
+		} );
+
+		afterAll( () => {
+			moment.locale( originalLocale );
+		} );
+
+		it( 'should not expand the day range inside the month name', () => {
+			const label = getRangeLabel(
+				moment( '2024-10-01' ),
+				moment( '2024-10-31' )
+			);
+			expect( label ).toBe( '10月 1 - 31, 2024' );
+		} );
+
+		it( 'should not expand the day range inside a month name sharing the day digits', () => {
+			const label = getRangeLabel(
+				moment( '2024-12-12' ),
+				moment( '2024-12-31' )
+			);
+			expect( label ).toBe( '12月 12 - 31, 2024' );
+		} );
+
+		it( 'should leave single day, cross month and cross year labels alone', () => {
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-01' ) )
+			).toBe( '10月 1, 2024' );
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-12-31' ) )
+			).toBe( '10月 1 - 12月 31, 2024' );
+			expect(
+				getRangeLabel( moment( '2023-10-01' ), moment( '2024-12-31' ) )
+			).toBe( '10月 1, 2023 - 12月 31, 2024' );
+		} );
 	} );
 } );
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -873,6 +873,17 @@ describe( 'getRangeLabel', () => {
 		expect( label ).toBe( 'Day Apr 1 - 15, 2018' );
 	} );
 
+	it( 'should leave a backslash escaped day literal alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '\\D MMM D, YYYY' );
+
+		const label = getRangeLabel(
+			moment( '2018-04-01' ),
+			moment( '2018-04-15' )
+		);
+
+		expect( label ).toBe( 'D Apr 1 - 15, 2018' );
+	} );
+
 	it( 'should not mistake day of year tokens for the day of month', () => {
 		( __ as jest.Mock ).mockReturnValueOnce( 'DDDD, YYYY' );
 

--- a/plugins/woocommerce/changelog/fix-53303-day-range-in-localized-format
+++ b/plugins/woocommerce/changelog/fix-53303-day-range-in-localized-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Analytics date range label showing a garbled date in languages whose month names contain digits, such as Japanese.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`getRangeLabel()` builds the same-month Analytics label ("Oct 1 - 31, 2024") by string-replacing the start day inside the already formatted date, so the substitution lands on the first matching digits anywhere in the localized output. Japanese short month names are themselves numbers - October formats as `10月 1, 2024` - so replacing `1` hits the month and the label reads `1 - 310月 1, 2024`. This swaps the day token in the date format instead and formats once, which keeps the value away from the rest of the string.

The same root cause covers two more cases the issue does not mention: months whose digits collide with the day (`12月 12, 2024`), and locales with non-Latin digits (`ar-sa` formats October 1st as `أكتوبر ١، ٢٠٢٤`, where `String( 1 )` matched nothing and the end of the range was silently dropped).

English output is byte-identical. `getRangeLabel` is a public `@woocommerce/date` export; its signature is unchanged and only the previously mangled locale output changes. The buggy line predates the wc-admin merge into core, so there is no single bug-introducing PR to link.

Closes #53303 .

### Screenshots or screen recordings:

Analytics > Overview date range picker, site language Japanese, custom range Oct 1 - 31 2024.

| Before (JA) | After (JA) | After (EN) |
| ------ | ----- | - |
| <img width="620" height="100" alt="wooplug-2814-ja-before" src="https://github.com/user-attachments/assets/1eab9580-be82-4d67-b889-fabf63d17510" /> | <img width="620" height="100" alt="wooplug-2814-ja-after" src="https://github.com/user-attachments/assets/f1e5f2ee-afc2-4a82-ab87-3fa4fde89073" /> | <img width="620" height="100" alt="wooplug-2814-en-after-unchanged" src="https://github.com/user-attachments/assets/cad968a2-3ead-4945-a5d1-2d3a428a953d" /> |

### How to test the changes in this Pull Request:

1. Set the site language to Japanese (Settings > General > Site Language, or `wp language core install ja && wp site switch-language ja && wp language plugin install woocommerce ja`).
2. Go to Analytics > Overview and pick a custom date range inside October, for example Oct 1 2024 to Oct 31 2024.
3. Without this PR the date range picker reads `カスタム (1 - 310月 1, 2024)`; with this PR it reads `カスタム (10月 1 - 31, 2024)`. The chart legend rows below show the same label.
4. Repeat with December 12 to December 31: before it reads `12 - 31月 12, 2024`, after `12月 12 - 31, 2024`.
5. Switch the language back to English and confirm the same range still reads `Custom (Oct 1 - 31, 2024)`.

### Testing that has already taken place:

- Reproduced on trunk and verified the fix on a local Japanese site (Analytics > Overview), plus an English pass confirming the label is unchanged.
- `@woocommerce/date` suite green (104 tests) with new cases for month names containing digits and for a translated format with no day token; eslint and tsc clean on the package.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually, for both `plugins/woocommerce` and `packages/js/date`.

</details>

### Release Communication

<!-- release-communication-section -->

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This PR was developed with AI assistance (Claude Code): investigation, implementation, tests, and verification were AI-generated and human-reviewed.
