### PR TITLE
Name the conflicting product in SKU uniqueness errors

### DIFF
--- a/plugins/woocommerce/changelog/fix-54073-sku-conflict-error-detail
+++ b/plugins/woocommerce/changelog/fix-54073-sku-conflict-error-detail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Name the specific product a SKU conflict is with, and whether it's in the Trash, a draft, or published, instead of a generic "already in use" message.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -186,6 +186,70 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		return (bool) $result;
 	}
 
+	/**
+	 * Build a message explaining which existing product is holding a SKU, so a
+	 * merchant knows where to look instead of only seeing a generic conflict.
+	 *
+	 * The regular SKU uniqueness check (@see wc_product_has_unique_sku) excludes
+	 * trashed products, so a SKU held by a trashed product can still block a new
+	 * product here without ever surfacing in that check. This looks up the
+	 * conflicting product regardless of status to explain that case specifically.
+	 *
+	 * @param string $sku The SKU that could not be locked.
+	 * @return string
+	 */
+	private function get_sku_conflict_message( $sku ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
+		$conflict = $wpdb->get_row(
+			$wpdb->prepare(
+				"
+				SELECT posts.ID, posts.post_status
+				FROM {$wpdb->posts} as posts
+				INNER JOIN {$wpdb->wc_product_meta_lookup} AS lookup ON posts.ID = lookup.product_id
+				WHERE
+				posts.post_type IN ( 'product', 'product_variation' )
+				AND lookup.sku = %s
+				LIMIT 1
+				",
+				$sku
+			)
+		);
+
+		if ( ! $conflict ) {
+			// translators: %s: SKU.
+			return sprintf( __( 'The SKU (%s) you are trying to insert is already in use and could not be verified further.', 'woocommerce' ), $sku );
+		}
+
+		$conflict_id = (int) $conflict->ID;
+
+		if ( ProductStatus::TRASH === $conflict->post_status ) {
+			return sprintf(
+				// translators: 1: SKU, 2: conflicting product ID.
+				__( 'The SKU (%1$s) conflicts with product #%2$d, which is in the Trash. Use a different SKU, or restore or permanently delete that product to free it up.', 'woocommerce' ),
+				$sku,
+				$conflict_id
+			);
+		}
+
+		if ( in_array( $conflict->post_status, array( ProductStatus::DRAFT, ProductStatus::AUTO_DRAFT, ProductStatus::PENDING ), true ) ) {
+			return sprintf(
+				// translators: 1: SKU, 2: conflicting product ID.
+				__( 'The SKU (%1$s) is already assigned to draft product #%2$d. Use a different SKU, or update the existing draft.', 'woocommerce' ),
+				$sku,
+				$conflict_id
+			);
+		}
+
+		return sprintf(
+			// translators: 1: SKU, 2: conflicting product ID.
+			__( 'The SKU (%1$s) is already in use by product #%2$d. Use a different SKU.', 'woocommerce' ),
+			$sku,
+			$conflict_id
+		);
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD Methods
@@ -239,8 +303,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			 */
 			if ( ! empty( $sku ) && WC()->is_rest_api_request() && ! $this->obtain_lock_on_sku_for_concurrent_requests( $product ) ) {
 				$product->delete( true );
-				// translators: 1: SKU.
-				throw new Exception( esc_html( sprintf( __( 'The product with SKU (%1$s) you are trying to insert is already present in the lookup table', 'woocommerce' ), $sku ) ) );
+				throw new Exception( esc_html( $this->get_sku_conflict_message( $sku ) ) );
 			}
 
 			// get the post object so that we can set the status

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -242,6 +242,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			);
 		}
 
+		if ( ProductStatus::PUBLISH === $conflict->post_status ) {
+			return sprintf(
+				// translators: 1: SKU, 2: conflicting product ID.
+				__( 'The SKU (%1$s) is already in use by published product #%2$d. Use a different SKU.', 'woocommerce' ),
+				$sku,
+				$conflict_id
+			);
+		}
+
+		// Any other status - private, scheduled, or one added by an extension.
 		return sprintf(
 			// translators: 1: SKU, 2: conflicting product ID.
 			__( 'The SKU (%1$s) is already in use by product #%2$d. Use a different SKU.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -260,7 +260,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * Method to create a new product in the database.
 	 *
 	 * @param WC_Product $product Product object.
-	 * @throws Exception If SKU is already under processing.
+	 * @throws Exception If the SKU could not be locked (see get_sku_conflict_message()).
 	 * @return void
 	 */
 	public function create( &$product ) {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -387,7 +387,7 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->expectException( 'Exception' );
 		$this->expectExceptionMessage(
 			sprintf(
-				'The SKU (DUMMY SKU) is already in use by product #%d. Use a different SKU.',
+				'The SKU (DUMMY SKU) is already in use by published product #%d. Use a different SKU.',
 				$product1->get_id()
 			)
 		);
@@ -477,6 +477,50 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 			sprintf(
 				'The SKU (DRAFT SKU) is already assigned to draft product #%d. Use a different SKU, or update the existing draft.',
 				$draft_product->get_id()
+			)
+		);
+
+		$conflicting_product->save();
+	}
+
+	/**
+	 * Test that a status with no dedicated message - private here, but equally
+	 * a scheduled product or a status added by an extension - still falls back
+	 * to naming the conflicting product rather than saying nothing useful.
+	 *
+	 * @return void
+	 */
+	public function test_create_product_with_sku_conflicting_with_other_status_product() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
+
+		$private_product = new WC_Product_Simple();
+		$private_product->set_props(
+			array(
+				'name'          => 'Private Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'PRIVATE SKU',
+				'status'        => 'private',
+			)
+		);
+
+		$conflicting_product = new WC_Product_Simple();
+		$conflicting_product->set_props(
+			array(
+				'name'          => 'Conflicting Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'PRIVATE SKU',
+			)
+		);
+
+		$private_product->save();
+
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage(
+			sprintf(
+				'The SKU (PRIVATE SKU) is already in use by product #%d. Use a different SKU.',
+				$private_product->get_id()
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -356,50 +356,87 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 	/**
 	 * Test that only one product is created with a unique SKU
-	 * during concurrent requests and when request is initiated via REST API.
-	 *
-	 * Throw error when two concurrent requests try to create a product with the same SKU.
+	 * during concurrent requests and when request is initiated via REST API,
+	 * and that the resulting error names the conflicting published product.
 	 *
 	 * @return void
 	 */
 	public function test_create_product_with_unique_sku_on_concurrent_requests() {
-		$this->expectException(
-			'Exception',
-		);
-		$this->expectExceptionMessage(
-			'The product with SKU (DUMMY SKU) you are trying to insert is already present in the lookup table'
-		);
-
 		// exception is only thrown during the REST API request.
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
-		$this->create_products_concurrently();
-	}
 
-	/**
-	 * Helper function to create products concurrently with same SKU
-	 *
-	 * @return void
-	 */
-	private static function create_products_concurrently() {
-		$default_props =
+		$existing_product = new WC_Product_Simple();
+		$existing_product->set_props(
 			array(
 				'name'          => 'Dummy Product',
 				'regular_price' => 10,
 				'price'         => 10,
 				'sku'           => 'DUMMY SKU',
-			);
+			)
+		);
+		$existing_product->save();
 
-		$product1 = new WC_Product_Simple();
-		$product2 = new WC_Product_Simple();
-		$product3 = new WC_Product_Simple();
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage(
+			sprintf(
+				'The SKU (DUMMY SKU) is already in use by product #%d. Use a different SKU.',
+				$existing_product->get_id()
+			)
+		);
 
-		$product1->set_props( $default_props );
-		$product2->set_props( $default_props );
-		$product3->set_props( $default_props );
+		$conflicting_product = new WC_Product_Simple();
+		$conflicting_product->set_props(
+			array(
+				'name'          => 'Dummy Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DUMMY SKU',
+			)
+		);
+		$conflicting_product->save();
+	}
 
-		$product1->save();
-		$product2->save();
-		$product3->save();
+	/**
+	 * Test that creating a product with a SKU already held by a trashed
+	 * product names the trashed product specifically, since the regular
+	 * uniqueness check (wc_product_has_unique_sku) excludes trashed products
+	 * and would otherwise let this conflict through with no explanation.
+	 *
+	 * @return void
+	 */
+	public function test_create_product_with_sku_conflicting_with_trashed_product() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
+
+		$trashed_product = new WC_Product_Simple();
+		$trashed_product->set_props(
+			array(
+				'name'          => 'Trashed Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'TRASHED SKU',
+			)
+		);
+		$trashed_product->save();
+		wp_trash_post( $trashed_product->get_id() );
+
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage(
+			sprintf(
+				'The SKU (TRASHED SKU) conflicts with product #%d, which is in the Trash. Use a different SKU, or restore or permanently delete that product to free it up.',
+				$trashed_product->get_id()
+			)
+		);
+
+		$new_product = new WC_Product_Simple();
+		$new_product->set_props(
+			array(
+				'name'          => 'New Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'TRASHED SKU',
+			)
+		);
+		$new_product->save();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -439,6 +439,51 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that a concurrent-creation conflict with a draft product names it
+	 * as a draft. Props are set on both before either is saved, same as the
+	 * published-conflict test, since a draft is still caught by the regular
+	 * uniqueness check once saved - only the race case reaches this code.
+	 *
+	 * @return void
+	 */
+	public function test_create_product_with_sku_conflicting_with_draft_product() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
+
+		$draft_product = new WC_Product_Simple();
+		$draft_product->set_props(
+			array(
+				'name'          => 'Draft Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DRAFT SKU',
+				'status'        => 'draft',
+			)
+		);
+
+		$conflicting_product = new WC_Product_Simple();
+		$conflicting_product->set_props(
+			array(
+				'name'          => 'Conflicting Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DRAFT SKU',
+			)
+		);
+
+		$draft_product->save();
+
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage(
+			sprintf(
+				'The SKU (DRAFT SKU) is already assigned to draft product #%d. Use a different SKU, or update the existing draft.',
+				$draft_product->get_id()
+			)
+		);
+
+		$conflicting_product->save();
+	}
+
+	/**
 	 * @testDox Test that meta cache key is changed on direct post meta add.
 	 */
 	public function test_get_meta_data_is_busted_on_post_meta_add() {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -365,35 +365,34 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		// exception is only thrown during the REST API request.
 		$_SERVER['REQUEST_URI'] = '/wp-json/wc/v3/products';
 
-		$existing_product = new WC_Product_Simple();
-		$existing_product->set_props(
-			array(
-				'name'          => 'Dummy Product',
-				'regular_price' => 10,
-				'price'         => 10,
-				'sku'           => 'DUMMY SKU',
-			)
+		$default_props = array(
+			'name'          => 'Dummy Product',
+			'regular_price' => 10,
+			'price'         => 10,
+			'sku'           => 'DUMMY SKU',
 		);
-		$existing_product->save();
+
+		// Set props on both before either is saved, so neither exists in the
+		// database yet when the SKU is assigned - the regular uniqueness check
+		// (wc_product_has_unique_sku) can't catch this, only the DB-level lock
+		// obtained during create() can, which is what this test targets.
+		$product1 = new WC_Product_Simple();
+		$product1->set_props( $default_props );
+
+		$product2 = new WC_Product_Simple();
+		$product2->set_props( $default_props );
+
+		$product1->save();
 
 		$this->expectException( 'Exception' );
 		$this->expectExceptionMessage(
 			sprintf(
 				'The SKU (DUMMY SKU) is already in use by product #%d. Use a different SKU.',
-				$existing_product->get_id()
+				$product1->get_id()
 			)
 		);
 
-		$conflicting_product = new WC_Product_Simple();
-		$conflicting_product->set_props(
-			array(
-				'name'          => 'Dummy Product',
-				'regular_price' => 10,
-				'price'         => 10,
-				'sku'           => 'DUMMY SKU',
-			)
-		);
-		$conflicting_product->save();
+		$product2->save();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

When a product can't be created because its SKU is already in use, the REST API returned a single generic message regardless of why: "The product with SKU (X) you are trying to insert is already present in the lookup table." That's the message a real support case (9115515-zd-a8c) was filed over — a merchant's product feed sync tool (Inventory Source) hit it repeatedly with no way to tell what was actually wrong.

The real cause in that case was a SKU still held by a trashed product. That's a genuinely confusing situation: WooCommerce's regular uniqueness check intentionally excludes trashed products, so merchants can freely reuse a trashed product's SKU through the normal product editor - but this REST-only lock, used to prevent two concurrent requests from creating the same SKU twice, does not exclude trash. A SKU stays reserved in the lookup table until the trashed product is permanently deleted, so a sync tool retrying a create looks stuck for a reason nothing in the UI would explain.

This looks up which product actually holds the conflicting SKU and says so, with a next step:

| Conflicting product is... | Message |
| --- | --- |
| In the Trash | "The SKU (X) conflicts with product #123, which is in the Trash. Use a different SKU, or restore or permanently delete that product to free it up." |
| A draft or pending | "The SKU (X) is already assigned to draft product #123. Use a different SKU, or update the existing draft." |
| Published | "The SKU (X) is already in use by product #123. Use a different SKU." |

Closes #54073.

### How to test the changes in this Pull Request:

This only fires through the REST API - specifically the concurrent-creation lock in `WC_Product_Data_Store_CPT::create()`, which is the code the issue links to. It does not appear in the classic product editor or CSV import, since neither goes through this lock; that's expected, not a gap, since the real support case was a REST-API-based sync tool.

1. Create a product via the REST API with a known SKU, then trash it (`wp_trash_post`, not permanent delete).
2. POST a new product with the same SKU. You should get a 400 naming the trashed product and its ID, not the old generic message.
3. Repeat with a draft and with a published product holding the SKU, to see the other two message variants.

### Testing that has already taken place:

Verified with real REST API calls (not just the test suite) against a local install: created a product, trashed it, then POSTed a new one with the same SKU. Response:

```json
{"code":"woocommerce_rest_product_not_created","message":"The SKU (X) conflicts with product #103, which is in the Trash. Use a different SKU, or restore or permanently delete that product to free it up.","data":{"status":400}}
```

Also checked what does *not* go through this code: a SKU conflict with an already-published product hits a separate, older check (`set_sku()`'s generic "Invalid or duplicated SKU.", with a suggested unique SKU in the response's `data` field) rather than this one, unless it's a genuine concurrent-creation race. This PR doesn't touch that path - it wasn't referenced by the issue and carries its own structured data already.

Three PHPUnit tests cover the three message branches (trash, draft, published) with the real conflicting product ID, plus the original concurrent-creation test rewritten to actually exercise the DB-level lock rather than the regular per-property check (a bug I found and fixed in the process - the original ordering let `set_props()` silently swallow the conflict instead of reaching this code at all). All pass: `OK (31 tests, 84 assertions)`. PHPCS clean on the branch diff.

Worth flagging for review: the message text itself changed, twice over in this PR's history (once before I started, and again here). The real support case involved a third party matching against this exact string, so any integration doing the same against the old wording will need to update. I don't see a way around that if the message is going to say anything more specific than before.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->

- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Written with Claude Code, which diagnosed the cause, made the PHP change, and ran the checks - real REST API calls and the PHPUnit suite, not just reasoning about the code. I walked through the flows, reviewed the result, and take responsibility for it.
