### PR TITLE
Fix: skip unnecessary geolocation API requests for private/reserved IPs

### DIFF
--- a/plugins/woocommerce/changelog/52360-fix-geolocation-private-ips
+++ b/plugins/woocommerce/changelog/52360-fix-geolocation-private-ips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip the geolocation API lookup for private, reserved, and loopback IP addresses (e.g. 127.0.0.1, 0.0.0.0, 192.168.0.1), since they can never be geolocated.

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -280,10 +280,17 @@ class WC_Geolocation {
 	 * If APIs are defined, one will be chosen at random to fulfil the request. After completing, the result
 	 * will be cached in a transient.
 	 *
+	 * Private, reserved, and otherwise non-public IP addresses (e.g. 127.0.0.1, 0.0.0.0, 192.168.0.1) are
+	 * skipped, since they can never be geolocated and querying an external API for them is pointless.
+	 *
 	 * @param  string $ip_address IP address.
 	 * @return string
 	 */
 	private static function geolocate_via_api( $ip_address ) {
+		if ( ! filter_var( $ip_address, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return '';
+		}
+
 		$country_code = get_transient( 'geoip_' . $ip_address );
 
 		if ( false === $country_code ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -132,4 +132,57 @@ class WC_Tests_Geolocation extends WC_Unit_Test_Case {
 		$this->assertEquals( 'US', $geolocation['country'], 'The country code from the API response should be returned' );
 		$this->assertStringStartsWith( 'https://', $requested_url, 'The geolocation request must be made over HTTPS' );
 	}
+
+	/**
+	 * @testdox Geolocating via the API should be skipped for private, reserved, and otherwise non-public IP addresses.
+	 * @dataProvider non_public_ip_address_provider
+	 * @param string $ip_address A private, reserved, loopback, or invalid IP address.
+	 */
+	public function test_geolocate_via_api_skips_non_public_ip_addresses( $ip_address ) {
+		$request_made = false;
+
+		delete_transient( 'geoip_' . $ip_address );
+
+		// Force the database lookup to return nothing so the API fallback runs.
+		$force_empty_geolocation = function ( $data ) {
+			$data['country'] = '';
+			return $data;
+		};
+		add_filter( 'woocommerce_get_geolocation', $force_empty_geolocation, 999 );
+
+		$intercept_request = function () use ( &$request_made ) {
+			$request_made = true;
+			return array(
+				'body'     => wp_json_encode( array( 'country' => 'US' ) ),
+				'response' => array( 'code' => 200 ),
+			);
+		};
+		add_filter( 'pre_http_request', $intercept_request );
+
+		$geolocation = WC_Geolocation::geolocate_ip( $ip_address, false, true );
+
+		remove_filter( 'pre_http_request', $intercept_request, 10 );
+		remove_filter( 'woocommerce_get_geolocation', $force_empty_geolocation, 999 );
+		delete_transient( 'geoip_' . $ip_address );
+
+		$this->assertFalse( $request_made, "No geolocation API request should be made for non-public IP address {$ip_address}" );
+		$this->assertSame( '', $geolocation['country'], "No country should be returned for non-public IP address {$ip_address}" );
+	}
+
+	/**
+	 * Data provider of private, reserved, loopback, and invalid IP addresses.
+	 *
+	 * @return array
+	 */
+	public function non_public_ip_address_provider() {
+		return array(
+			'IPv4 unspecified'         => array( '0.0.0.0' ),
+			'IPv4 loopback'            => array( '127.0.0.1' ),
+			'IPv4 link-local'          => array( '169.254.1.1' ),
+			'IPv4 private (class A)'   => array( '10.0.0.5' ),
+			'IPv4 private (class C)'   => array( '192.168.0.1' ),
+			'IPv6 loopback'            => array( '::1' ),
+			'Not an IP address at all' => array( 'not-an-ip' ),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Geolocation::geolocate_via_api()` queried a third-party GeoIP service unconditionally whenever it was reached, even for IP addresses that can never be geolocated, such as loopback (`127.0.0.1`, `::1`), unspecified (`0.0.0.0`), private ranges (`192.168.x.x`, `10.x.x.x`), and link-local addresses. This wastes an API request and sends local network details to a third party without any benefit.

This PR adds a guard at the top of `geolocate_via_api()` to skip the API call when the given IP address is not a genuine public, routable address, using `filter_var()` with `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`. Real visitor IPs are always public and routable, so this has no effect on normal geolocation behavior.

Closes #52360, closes WOOPLUG-2681

### Screenshots or screen recordings:

No visual changes.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

### How to test the changes in this Pull Request:

1. Start the local environment from the repo root:

   ```bash
   pnpm wc:env
   ```

2. Run the geolocation unit tests:

   ```bash
   cd plugins/woocommerce
   pnpm run test:php:env -- --filter WC_Tests_Geolocation
   ```

   All tests should pass, including `test_geolocate_via_api_skips_non_public_ip_addresses`, which covers loopback, unspecified, private class A/C, link-local, IPv6 loopback, and invalid IP addresses.

3. To verify the behavior directly, create `plugins/woocommerce/tmp-test.php` with:

   ```php
   <?php
   $log = array();
   add_filter(
       'pre_http_request',
       function ( $pre, $args, $url ) use ( &$log ) {
           $log[] = $url;
           return array(
               'body'     => '{}',
               'response' => array( 'code' => 200 ),
           );
       },
       10,
       3
   );

   foreach ( array( '127.0.0.1', '0.0.0.0', '192.168.0.1', '10.0.0.5', '169.254.1.1', '::1', 'not-an-ip', '8.8.8.8' ) as $ip ) {
       delete_transient( 'geoip_' . $ip );
       $log    = array();
       $result = WC_Geolocation::geolocate_ip( $ip, false, true );
       printf(
           "IP %-15s -> country=%-6s API requests attempted=%d %s\n",
           $ip,
           var_export( $result['country'], true ),
           count( $log ),
           $log ? '(' . implode( ', ', $log ) . ')' : ''
       );
   }
   ```

   Then run it inside the dev container:

   ```bash
   cd plugins/woocommerce
   pnpm wp-env run cli wp eval-file wp-content/plugins/woocommerce/tmp-test.php
   ```

   The private IP (`127.0.0.1`) should show `API requests attempted=0`, while the public IP (`8.8.8.8`) should show `1` or more.


### Testing that has already taken place:

Confirmed the compiled behavior by hooking into `pre_http_request` to intercept outbound requests and testing `WC_Geolocation::geolocate_ip()` with `127.0.0.1`, `0.0.0.0`, `192.168.0.1`, `10.0.0.5`, `169.254.1.1`, `::1`, an invalid string, and a real public IP (`8.8.8.8`). All non-public addresses made zero API requests, while the public IP triggered the expected lookup. Also confirmed that the new unit test fails when the fix is temporarily reverted and passes again once the fix is restored.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

This PR was developed with the assistance of Claude Code.
