### PR TITLE
Fix POS catalog download URLs after site URL changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-pos-catalog-response-url
+++ b/plugins/woocommerce/changelog/fix-pos-catalog-response-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure POS catalog download URLs reflect the current site URL.

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/ApiController.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/ApiController.php
@@ -114,9 +114,9 @@ class ApiController {
 					? (string) $response['file_name']
 					: wp_basename( (string) ( $response['path'] ?? '' ) );
 
-				if ( '' !== $file_name && wp_basename( $file_name ) === $file_name ) {
-					$upload_dir      = wp_upload_dir( null, false, true );
-					$response['url'] = trailingslashit( $upload_dir['baseurl'] ) . JsonFileFeed::UPLOAD_DIR . '/' . rawurlencode( $file_name );
+				$file_url = JsonFileFeed::get_file_url_for_identifier( $file_name );
+				if ( null !== $file_url ) {
+					$response['url'] = $file_url;
 				}
 			}
 

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/ApiController.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/ApiController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Internal\ProductFeed\Integrations\POSCatalog;
 
 use Automattic\WooCommerce\Container;
+use Automattic\WooCommerce\Internal\ProductFeed\Storage\JsonFileFeed;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -105,6 +106,19 @@ class ApiController {
 			$response = $request->get_param( 'force' )
 				? $generator->force_regeneration( $params )
 				: $generator->get_status( $params );
+
+			// Build the download URL from the current site configuration instead of persisting it with the feed status.
+			unset( $response['url'] );
+			if ( AsyncGenerator::STATE_COMPLETED === ( $response['state'] ?? '' ) ) {
+				$file_name = ! empty( $response['file_name'] )
+					? (string) $response['file_name']
+					: wp_basename( (string) ( $response['path'] ?? '' ) );
+
+				if ( '' !== $file_name && wp_basename( $file_name ) === $file_name ) {
+					$upload_dir      = wp_upload_dir( null, false, true );
+					$response['url'] = trailingslashit( $upload_dir['baseurl'] ) . JsonFileFeed::UPLOAD_DIR . '/' . rawurlencode( $file_name );
+				}
+			}
 
 			// Use the right datetime format.
 			if ( isset( $response['scheduled_at'] ) ) {

--- a/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGenerator.php
@@ -269,7 +269,6 @@ class AsyncGenerator {
 
 				$status['state']        = self::STATE_COMPLETED;
 				$status['progress']     = 100;
-				$status['url']          = $feed->get_file_url();
 				$status['path']         = $feed->get_file_path();
 				$status['completed_at'] = time();
 				update_option( $option_key, $status );

--- a/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
+++ b/plugins/woocommerce/src/Internal/ProductFeed/Storage/JsonFileFeed.php
@@ -128,7 +128,7 @@ class JsonFileFeed implements ResumableFeedInterface {
 		$this->file_url       = null;
 
 		if ( null !== $resume_identifier ) {
-			if ( ! $this->is_valid_feed_identifier( $resume_identifier ) ) {
+			if ( ! self::is_valid_feed_identifier( $resume_identifier ) ) {
 				throw new Exception(
 					esc_html(
 						sprintf(
@@ -258,7 +258,7 @@ class JsonFileFeed implements ResumableFeedInterface {
 	 */
 	public function delete( string $identifier ): void {
 		// Never turn an identifier that is actually a path into a delete outside the feed directory.
-		if ( ! $this->is_valid_feed_identifier( $identifier ) ) {
+		if ( ! self::is_valid_feed_identifier( $identifier ) ) {
 			return;
 		}
 
@@ -278,7 +278,7 @@ class JsonFileFeed implements ResumableFeedInterface {
 	 * @param string $identifier The feed file identifier to check.
 	 * @return bool True if the identifier is a safe, plain `.json` file name.
 	 */
-	private function is_valid_feed_identifier( string $identifier ): bool {
+	private static function is_valid_feed_identifier( string $identifier ): bool {
 		return '' !== $identifier
 			&& wp_basename( $identifier ) === $identifier
 			&& 'json' === strtolower( (string) pathinfo( $identifier, PATHINFO_EXTENSION ) );
@@ -413,9 +413,48 @@ class JsonFileFeed implements ResumableFeedInterface {
 
 		// Resolve the upload directory (also refreshes its .htaccess for file access) and build the URL.
 		$upload_dir     = $this->get_upload_dir();
-		$this->file_url = $upload_dir['url'] . $this->file_name;
+		$this->file_url = self::build_file_url( $upload_dir['url'], $this->file_name );
 
 		return $this->file_url;
+	}
+
+	/**
+	 * Builds the current URL for a feed identifier.
+	 *
+	 * @param string $identifier The feed file identifier.
+	 * @return string|null The feed URL, or null if the identifier is invalid.
+	 *
+	 * @since 11.2.0
+	 */
+	public static function get_file_url_for_identifier( string $identifier ): ?string {
+		if ( ! self::is_valid_feed_identifier( $identifier ) ) {
+			return null;
+		}
+
+		$upload_dir    = wp_upload_dir( null, false, true );
+		$directory_url = self::build_directory_url( untrailingslashit( $upload_dir['baseurl'] ) );
+		return self::build_file_url( $directory_url, rawurlencode( $identifier ) );
+	}
+
+	/**
+	 * Builds the feed directory URL from an uploads base URL.
+	 *
+	 * @param string $uploads_base_url The uploads base URL.
+	 * @return string The feed directory URL with a trailing slash.
+	 */
+	private static function build_directory_url( string $uploads_base_url ): string {
+		return $uploads_base_url . '/' . self::UPLOAD_DIR . '/';
+	}
+
+	/**
+	 * Appends a feed identifier to its directory URL.
+	 *
+	 * @param string $directory_url The feed directory URL with a trailing slash.
+	 * @param string $identifier    The feed file identifier.
+	 * @return string The feed file URL.
+	 */
+	private static function build_file_url( string $directory_url, string $identifier ): string {
+		return $directory_url . $identifier;
 	}
 
 	/**
@@ -461,7 +500,7 @@ class JsonFileFeed implements ResumableFeedInterface {
 			);
 		}
 
-		$directory_url = $upload_dir['baseurl'] . '/' . self::UPLOAD_DIR . '/';
+		$directory_url = self::build_directory_url( $upload_dir['baseurl'] );
 
 		// Follow the format, returned by `wp_upload_dir()`.
 		$this->prepared_upload_dir = array(

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/ApiControllerTest.php
@@ -69,13 +69,13 @@ class ApiControllerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the generate_feed endpoint method.
+	 * @testdox Should prepare the feed status using the current uploads URL.
 	 *
 	 * @dataProvider provider_generate_feed
 	 * @param bool        $force_regeneration Whether to force regeneration of the feed.
 	 * @param string|null $fields The fields to include in the feed.
 	 */
-	public function test_generate_feed( bool $force_regeneration, ?string $fields = null ) {
+	public function test_generate_feed( bool $force_regeneration, ?string $fields = null ): void {
 		$request = new WP_REST_Request( 'POST', '/wc/pos/v1/catalog/create' );
 
 		if ( $force_regeneration ) {
@@ -90,17 +90,29 @@ class ApiControllerTest extends \WC_Unit_Test_Case {
 			->with( $fields ? array( '_product_fields' => $fields ) : array() )
 			->willReturn(
 				array(
+					'state'           => AsyncGenerator::STATE_COMPLETED,
 					'action_id'       => 6789,
 					'path'            => '/tmp/random_path.json',
 					'file_name'       => 'pos-catalog-feed.json',
 					'page'            => 3,
 					'entries_written' => 250,
 					'updated_at'      => time(),
-					'url'             => 'https://example.com/feed.json',
+					'url'             => 'https://old.example/uploads/product-feeds/pos-catalog-feed.json',
 				)
 			);
 
-		$response      = $this->sut->generate_feed( $request );
+		$upload_dir_filter = function ( array $upload_dir ): array {
+			$upload_dir['baseurl'] = 'https://current.example/uploads';
+			return $upload_dir;
+		};
+		add_filter( 'upload_dir', $upload_dir_filter );
+
+		try {
+			$response = $this->sut->generate_feed( $request );
+		} finally {
+			remove_filter( 'upload_dir', $upload_dir_filter );
+		}
+
 		$response_data = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -111,6 +123,42 @@ class ApiControllerTest extends \WC_Unit_Test_Case {
 		}
 
 		$this->assertArrayHasKey( 'url', $response_data );
-		$this->assertEquals( 'https://example.com/feed.json', $response_data['url'] );
+		$this->assertEquals( 'https://current.example/uploads/product-feeds/pos-catalog-feed.json', $response_data['url'] );
+	}
+
+	/**
+	 * @testdox Should replace a legacy serialized download URL without duplicating it.
+	 */
+	public function test_generate_feed_replaces_legacy_serialized_url(): void {
+		$request = new WP_REST_Request( 'POST', '/wc/pos/v1/catalog/create' );
+
+		$this->mock_async_generator->expects( $this->once() )
+			->method( 'get_status' )
+			->with( array() )
+			->willReturn(
+				array(
+					'state' => AsyncGenerator::STATE_COMPLETED,
+					'path'  => '/tmp/pos-catalog-feed.json',
+					'url'   => 'https://old.example/uploads/product-feeds/pos-catalog-feed.json',
+				)
+			);
+
+		$upload_dir_filter = function ( array $upload_dir ): array {
+			$upload_dir['baseurl'] = 'https://current.example/uploads';
+			return $upload_dir;
+		};
+		add_filter( 'upload_dir', $upload_dir_filter );
+
+		try {
+			$response = $this->sut->generate_feed( $request );
+		} finally {
+			remove_filter( 'upload_dir', $upload_dir_filter );
+		}
+
+		$this->assertSame(
+			'https://current.example/uploads/product-feeds/pos-catalog-feed.json',
+			$response->get_data()['url'],
+			'A legacy absolute URL should be replaced with one URL based on the current site configuration.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Integrations/POSCatalog/AsyncGeneratorTest.php
@@ -75,9 +75,9 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that feed generation action forwards arguments to mapper.
+	 * @testdox Should forward arguments to the mapper without persisting a download URL.
 	 */
-	public function test_feed_generation_action_forwards_args() {
+	public function test_feed_generation_action_forwards_args(): void {
 		// Make sure at least one product is present. We will not check it here.
 		WC_Helper_Product::create_simple_product();
 
@@ -119,6 +119,7 @@ class AsyncGeneratorTest extends \WC_Unit_Test_Case {
 		// Check the final status.
 		$updated_status = get_option( self::OPTION_KEY );
 		$this->assertEquals( AsyncGenerator::STATE_COMPLETED, $updated_status['state'] );
+		$this->assertArrayNotHasKey( 'url', $updated_status );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFeed/Storage/JsonFileFeedTest.php
@@ -303,6 +303,68 @@ class JsonFileFeedTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should build an encoded feed URL using the current uploads URL.
+	 */
+	public function test_get_file_url_for_identifier_uses_current_uploads_url(): void {
+		$upload_dir_filter = function ( array $upload_dir ): array {
+			$upload_dir['baseurl'] = 'https://current.example/uploads';
+			return $upload_dir;
+		};
+		add_filter( 'upload_dir', $upload_dir_filter );
+
+		try {
+			$this->assertSame(
+				'https://current.example/uploads/product-feeds/feed%20name.json',
+				JsonFileFeed::get_file_url_for_identifier( 'feed name.json' )
+			);
+		} finally {
+			remove_filter( 'upload_dir', $upload_dir_filter );
+		}
+	}
+
+	/**
+	 * @testdox Should not build a feed URL for an invalid identifier.
+	 */
+	public function test_get_file_url_for_identifier_rejects_invalid_identifier(): void {
+		$this->assertNull( JsonFileFeed::get_file_url_for_identifier( '../feed.json' ) );
+		$this->assertNull( JsonFileFeed::get_file_url_for_identifier( 'feed.csv' ) );
+	}
+
+	/**
+	 * @testdox Should preserve the upload URL resolved when an existing feed was opened.
+	 */
+	public function test_get_file_url_preserves_cached_upload_url(): void {
+		$generation_upload_dir_filter = function ( array $upload_dir ): array {
+			$upload_dir['baseurl'] = 'https://generation.example/uploads';
+			return $upload_dir;
+		};
+		add_filter( 'upload_dir', $generation_upload_dir_filter );
+
+		try {
+			$feed = new JsonFileFeed( 'test-feed' );
+			$feed->start();
+			$feed->end();
+		} finally {
+			remove_filter( 'upload_dir', $generation_upload_dir_filter );
+		}
+
+		$response_upload_dir_filter = function ( array $upload_dir ): array {
+			$upload_dir['baseurl'] = 'https://response.example/uploads';
+			return $upload_dir;
+		};
+		add_filter( 'upload_dir', $response_upload_dir_filter );
+
+		try {
+			$this->assertStringStartsWith(
+				'https://generation.example/uploads/product-feeds/',
+				(string) $feed->get_file_url()
+			);
+		} finally {
+			remove_filter( 'upload_dir', $response_upload_dir_filter );
+		}
+	}
+
+	/**
 	 * Test that add_entry before start is a no-op (does not throw).
 	 */
 	public function test_add_entry_before_start_is_noop() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

POS catalog generation persisted an absolute download URL, so changing a site's URL left saved catalogs pointing at the old location. Where a URL was `http`, this would lead to issues downloading the catalog and opening the POS on iOS, which could last until the next natural regeneration, up to 24h later.

This PR changes to build the URL when preparing the REST response from the current site configuration, while retaining compatibility with saved catalogs that have an absolute URL but no `file_name`.

The REST response shape and externally exposed PHP signatures remain unchanged. Existing serialized catalogs are supported by deriving the filename from their stored path. URL construction uses the current site's `wp_upload_dir()` result, just as it used to do at generation time.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #62313.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable; there are no UI changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. On a test store running a WooCommerce version without this fix, temporarily filter `upload_dir` so its `baseurl` uses HTTP, then generate the POS catalog to completion.
2. Remove the filter without regenerating the catalog and update to this branch.
3. Request the completed POS catalog status, without forcing, and confirm its download URL uses the store's current HTTPS uploads URL.
4. Force a new catalog generation and confirm the fresh completed response also uses the current uploads URL.

You can use this snippet to change `upload_dir` while you do the first generation:
```
add_filter(
	'upload_dir',
	static function ( array $uploads ): array {
		$uploads['baseurl'] = set_url_scheme( $uploads['baseurl'], 'http' );
		$uploads['url']     = set_url_scheme( $uploads['url'], 'http' );

		return $uploads;
	},
	PHP_INT_MAX
);
```

Request for catalog is:
```
POST https://respective-hamster.jurassic.ninja/wp-json/wc/pos/v1/catalog/create
{
  "_variation_fields": "id,parent_id,attributes,image,price,description,sku,global_unique_id,type,downloadable,manage_stock,stock_quantity,stock_status",
  "_product_fields": "id,name,type,description,short_description,sku,global_unique_id,price,downloadable,parent_id,images,attributes,manage_stock,stock_quantity,stock_status,status,variations"
}
```

You can add `"force": true` in the request for step 4.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHPUnit tests passed under PHP 8.1: 54 tests, 235 assertions.
- Changed-file PHP lint and full committed branch lint passed without errors or warnings.
- PHPStan passed for both modified production classes.
- The packaged change was manually verified on a Jurassic Ninja test store.
- Multisite was not tested.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex assisted with implementation, tests, repository history research, and PR drafting. The resulting change was reviewed and manually tested on a test store.
