### PR TITLE
Add translator context to the Orders list Status column

### DIFF
--- a/plugins/woocommerce/changelog/fix-45770-order-status-translator-context
+++ b/plugins/woocommerce/changelog/fix-45770-order-status-translator-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add translator context to the Orders list table "Status" column so it can be translated independently of the unrelated "Status" strings elsewhere in the admin.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -123,7 +123,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$show_columns['cb']               = $columns['cb'];
 		$show_columns['order_number']     = __( 'Order', 'woocommerce' );
 		$show_columns['order_date']       = __( 'Date', 'woocommerce' );
-		$show_columns['order_status']     = __( 'Status', 'woocommerce' );
+		$show_columns['order_status']     = _x( 'Status', 'Order status', 'woocommerce' );
 		$show_columns['billing_address']  = __( 'Billing', 'woocommerce' );
 		$show_columns['shipping_address'] = __( 'Ship to', 'woocommerce' );
 		$show_columns['order_total']      = __( 'Total', 'woocommerce' );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1041,7 +1041,7 @@ class ListTable extends WP_List_Table {
 				'cb'               => '<input type="checkbox" />',
 				'order_number'     => esc_html__( 'Order', 'woocommerce' ),
 				'order_date'       => esc_html__( 'Date', 'woocommerce' ),
-				'order_status'     => esc_html__( 'Status', 'woocommerce' ),
+				'order_status'     => esc_html_x( 'Status', 'Order status', 'woocommerce' ),
 				'billing_address'  => esc_html__( 'Billing', 'woocommerce' ),
 				'shipping_address' => esc_html__( 'Ship to', 'woocommerce' ),
 				'order_total'      => esc_html__( 'Total', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

"Status" is a single translatable string shared by thirteen call sites — the Orders list column, the WooCommerce > Status menu, webhook status, stock status and more. Translators get one entry covering all of them, so they can only choose a word that works everywhere rather than the right word for each. In Japanese that means the Orders column is stuck with the generic ステータス and can never say 注文ステータス ("order status"), which is what the reporter asked for.

This wraps the Orders list column in `_x()` with the `Order status` context already used for order status values elsewhere in the codebase, so it becomes its own entry and can carry the more specific meaning. Same English text, no visual change. Applied to both the HPOS and legacy posts list tables so the two storage modes keep the same header.

Approach agreed on the issue by @coreymckrill, @naokomc and @shoheitanaka. There's existing precedent for it too — `Internal/StockNotifications/Admin/ListTable.php` already uses `_x()` for its own list table columns.

The issue also suggested rewording the bulk actions ("Change status to processing" → "Change order status to processing"). I've left those alone: they're unique strings with enough sentence context for translators to disambiguate already (Japanese renders them as 注文状況を処理中に変更), so changing the English would discard existing translations without fixing anything.

Closes #45770.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Orders and confirm the Status column header is unchanged.
2. Confirm the same with HPOS disabled, so the legacy list table renders.

### Testing that has already taken place:

Confirmed the column renders unchanged in English on both list tables, and that the column and the WooCommerce > Status menu item now resolve through separate translation lookups so they can take different translations. PHPCS clean on the branch.

Worth noting for reviewers: this is a new translatable string, so it will show untranslated until it's picked up in GlotPress. That's expected whenever context is added.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->

### Use of AI Tools

Written with Claude Code, which made the change and ran the checks. I walked through the flows, reviewed the result, and take responsibility for it.
