### PR TITLE
Reword HPOS out-of-sync message and add a sync confirmation

### DIFF
--- a/plugins/woocommerce/changelog/fix-65735-hpos-out-of-sync-warning
+++ b/plugins/woocommerce/changelog/fix-65735-hpos-out-of-sync-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clarify the misleading HPOS "orders out of sync" message and warn before running a full order sync

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -391,6 +391,15 @@
 				) {
 					event.stopPropagation();
 				}
+			} )
+
+			// Confirm before running the HPOS "Sync orders now" action.
+			.on( 'click', '.wc-hpos-sync-now', function ( event ) {
+				var message = $( this ).data( 'confirm-message' );
+
+				if ( message && ! window.confirm( message ) ) {
+					event.preventDefault();
+				}
 			} );
 
 		// Tooltips

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -758,13 +758,14 @@ class CustomOrdersTableController {
 
 				if ( ! $is_dangerous ) {
 					$sync_message[] = wp_kses_data(
-						__( "You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There are currently orders out of sync.", 'woocommerce' ),
+						__( "If you'd like to switch order data storage, run a one-time sync below first. That option becomes available once the sync finishes.", 'woocommerce' ),
 					);
 				}
 
 				$sync_message[] = sprintf(
-					'<a href="%1$s" class="button-link">%2$s</a>',
+					'<a href="%1$s" class="button-link wc-hpos-sync-now" data-confirm-message="%2$s">%3$s</a>',
 					esc_url( $sync_now_url ),
+					esc_attr__( 'This syncs all pending orders into the other storage table. Continue?', 'woocommerce' ),
 					__( 'Sync orders now', 'woocommerce' )
 				);
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -762,10 +762,20 @@ class CustomOrdersTableController {
 					);
 				}
 
+				$sync_target = $this->data_synchronizer->custom_orders_table_is_authoritative()
+					? __( 'WordPress posts storage', 'woocommerce' )
+					: __( 'High-performance order storage', 'woocommerce' );
+
 				$sync_message[] = sprintf(
 					'<a href="%1$s" class="button-link wc-hpos-sync-now" data-confirm-message="%2$s">%3$s</a>',
 					esc_url( $sync_now_url ),
-					esc_attr__( 'This syncs all pending orders into the other storage table. Continue?', 'woocommerce' ),
+					esc_attr(
+						sprintf(
+							/* translators: %s: name of the order storage system orders will be copied into. */
+							__( 'This syncs any orders that still need syncing into %s. Continue?', 'woocommerce' ),
+							$sync_target
+						)
+					),
 					__( 'Sync orders now', 'woocommerce' )
 				);
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -783,6 +783,34 @@ class DataSynchronizerTests extends \HposTestCase {
 	}
 
 	/**
+	 * @testDox The "Sync orders now" confirmation names the correct destination storage system.
+	 *
+	 * @testWith [true, "WordPress posts storage"]
+	 *           [false, "High-performance order storage"]
+	 *
+	 * @param bool   $cot_is_authoritative Whether the custom orders table is the authoritative source.
+	 * @param string $expected_sync_target The storage system the confirmation message should name.
+	 */
+	public function test_sync_now_link_names_the_correct_target_storage( $cot_is_authoritative, $expected_sync_target ) {
+		$this->toggle_cot_authoritative( $cot_is_authoritative );
+		$this->disable_cot_sync();
+		OrderHelper::create_order();
+
+		$features = apply_filters( 'woocommerce_get_settings_advanced', array(), 'features' );
+
+		$sync_setting = array_filter(
+			$features,
+			function ( $feature ) {
+				return DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $feature['id'];
+			}
+		);
+		$sync_setting = array_values( $sync_setting )[0];
+
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], 'wc-hpos-sync-now' ) );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], $expected_sync_target ) );
+	}
+
+	/**
 	 * Delete an order directly from the wc_orders table so that the usual hooks and filters don't run.
 	 *
 	 * @param int $order_id The ID of the order to delete.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -770,13 +770,13 @@ class DataSynchronizerTests extends \HposTestCase {
 		);
 		$sync_setting = array_values( $sync_setting )[0];
 		$this->assertEquals( $sync_setting['value'], 'no' );
-		$this->assertTrue( str_contains( $sync_setting['desc_tip'], $auth_table_change_allowed_with_sync_pending ? "There are orders pending sync" : "There are currently orders out of sync" ) );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], $auth_table_change_allowed_with_sync_pending ? 'There are orders pending sync' : "If you'd like to switch order data storage" ) );
 		$this->assertTrue(
 			str_contains(
 				$sync_setting['desc_tip'],
 				$auth_table_change_allowed_with_sync_pending ?
 				'Switching data storage while sync is incomplete is dangerous' :
-				'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>'
+				'run a one-time sync below first'
 			)
 		);
 		$this->assertEquals( $auth_table_change_allowed_with_sync_pending, $sync_setting['description_is_error'] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce always shows "There are currently orders out of sync" message on the features screen, which can cause confusion as it seems to indicate the sync is _necessary_. This has led some site owners to click "Sync orders now" without intending to switch data storage, bloating their database tables.

This PR rewords the message to explain what's actually needed to switch storage without sounding like an alarm. I also adds a confirmation before "Sync orders now" runs so people know what it does before it starts running a potentially expensive operation.

Closes #65735.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1085" height="204" alt="Screenshot 2026-08-18 at 15 21 31" src="https://github.com/user-attachments/assets/f4fbb01a-79e6-4cc3-8f31-30c0744aadd4" /> | <img width="1070" height="202" alt="Screenshot 2026-08-18 at 15 11 33" src="https://github.com/user-attachments/assets/bff93424-d017-4a0f-9d4f-2d3e5451de85" /> |
| | <img width="502" height="185" alt="Screenshot 2026-08-18 at 17 48 27" src="https://github.com/user-attachments/assets/b9ff4521-bab9-4f52-aa43-3605e4caca9c" />|



### How to test the changes in this Pull Request:

1. On a site running HPOS with compatibility mode off, create at least one order, then go to **WooCommerce > Settings > Advanced > Features**.
2. Confirm the message under **Enable compatibility mode** matches the screenshot above.
3. Click **Sync orders now** and confirm the browser confirmation dialog matches the screenshot above. Canceling it should not trigger the sync.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.