### PR TITLE
Declare UUID dependency for WooCommerce Admin builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,13 @@
 		"wp-textdomain": "1.0.1"
 	},
 	"pnpm": {
+		"packageExtensions": {
+			"@wordpress/dataviews@10.1.7": {
+				"dependencies": {
+					"uuid": "^9.0.1"
+				}
+			}
+		},
 		"overrides": {
 			"@types/react": "18.3.x",
 			"@wordpress/data-controls>@wordpress/api-fetch": "catalog:wp-min",

--- a/plugins/woocommerce/changelog/fix-admin-dataviews-uuid-dependency
+++ b/plugins/woocommerce/changelog/fix-admin-dataviews-uuid-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Declare the UUID dependency required by WooCommerce Admin builds.

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -126,6 +126,7 @@
 		"react-transition-group": "^4.4.5",
 		"react-visibility-sensor": "^5.1.1",
 		"redux": "^4.2.1",
+		"uuid": "^9.0.1",
 		"xstate": "4.37.1",
 		"xstate5": "npm:xstate@^5.13.1",
 		"zod": "^3.22.4"

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -126,7 +126,6 @@
 		"react-transition-group": "^4.4.5",
 		"react-visibility-sensor": "^5.1.1",
 		"redux": "^4.2.1",
-		"uuid": "^9.0.1",
 		"xstate": "4.37.1",
 		"xstate5": "npm:xstate@^5.13.1",
 		"zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3104,6 +3104,9 @@ importers:
       redux:
         specifier: ^4.2.1
         version: 4.2.1
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       xstate:
         specifier: 4.37.1
         version: 4.37.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,8 @@ overrides:
   react-resize-aware: 3.1.1
   sass: 1.69.5
 
+packageExtensionsChecksum: sha256-Bd7QxlEbzBKxNWC7ENjsz13HMrXMdmoBe/wU8Vnmv+Q=
+
 pnpmfileChecksum: sha256-7lEtYKkj9MKUQ1wDfOySWQ01OX5tYIUQTnfpMq5epMI=
 
 patchedDependencies:
@@ -3104,9 +3106,6 @@ importers:
       redux:
         specifier: ^4.2.1
         version: 4.2.1
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       xstate:
         specifier: 4.37.1
         version: 4.37.1
@@ -33148,6 +33147,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       remove-accents: 0.5.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`@wordpress/dataviews@10.1.7` imports `uuid` without declaring it. As a result, filtered installs of the WooCommerce plugin can fail to build Admin when no unrelated workspace package hoists `uuid`.

Patch `@wordpress/dataviews@10.1.7` with the current monorepo-aligned `uuid` range through a version-scoped pnpm package extension. This gives the dependency to the package that imports it without affecting other DataViews versions or relying on hoisting. PR #67777 should update this package extension to the patched `^11.1.1` range after rebasing.

Relates to #67777.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm install --filter='@woocommerce/plugin-woocommerce...' --filter='compare-perf...' --frozen-lockfile`.
2. Run `pnpm --filter=@woocommerce/admin-library build`.
3. Confirm the Admin webpack build succeeds without a `Can't resolve 'uuid'` error from `@wordpress/dataviews`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

The filtered frozen install, Syncpack validation, changelog validation, and WooCommerce Admin production build passed locally.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually at `plugins/woocommerce/changelog/fix-admin-dataviews-uuid-dependency`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to investigate the CI failure, prepare the dependency change, run local validation, and draft this PR.

