### PR TITLE
Fix Recently Viewed Products widget query cap

### DIFF
--- a/plugins/woocommerce/changelog/fix-recently-viewed-widget-query-cap
+++ b/plugins/woocommerce/changelog/fix-recently-viewed-widget-query-cap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Limit Recently Viewed Products widget query IDs.

--- a/plugins/woocommerce/changelog/fix-recently-viewed-widget-query-cap
+++ b/plugins/woocommerce/changelog/fix-recently-viewed-widget-query-cap
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Limit Recently Viewed Products widget query IDs.
+Limit the Recently Viewed Products widget query to the 15 most recent product IDs from the cookie. This prevents oversized cookies from increasing query workload while preserving normal browsing behavior.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-recently-viewed.php
@@ -51,7 +51,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$viewed_products = ! empty( $_COOKIE['woocommerce_recently_viewed'] ) ? (array) explode( '|', wp_unslash( $_COOKIE['woocommerce_recently_viewed'] ) ) : array(); // @codingStandardsIgnoreLine
-		$viewed_products = array_reverse( array_filter( array_map( 'absint', $viewed_products ) ) );
+		$viewed_products = array_slice( array_reverse( array_filter( array_map( 'absint', $viewed_products ) ) ), 0, 15 );
 
 		if ( empty( $viewed_products ) ) {
 			return;
@@ -71,14 +71,14 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$query_args['tax_query'] = array(
+			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Recently viewed product IDs are capped at 15.
 				array(
 					'taxonomy' => 'product_visibility',
 					'field'    => 'name',
 					'terms'    => ProductStockStatus::OUT_OF_STOCK,
 					'operator' => 'NOT IN',
 				),
-			); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query -- The taxonomy filter is bounded to the non-empty recently viewed product ID list.
+			);
 		}
 
 		$r = new WP_Query( apply_filters( 'woocommerce_recently_viewed_products_widget_query_args', $query_args ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
@@ -64,4 +64,42 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 		$dummy_widget = $wp_widget_factory->widgets['Dummy_Widget'];
 		$this->assertEmpty( $dummy_widget->form( array( 'widget_id' => $dummy_widget->widget_id ) ) );
 	}
+
+	/**
+	 * @testdox Should limit recently viewed widget queries from oversized cookies.
+	 */
+	public function test_recently_viewed_widget_query_limits_oversized_cookie(): void {
+		$viewed_product_ids = range( 1, 20 );
+		$query_args         = array();
+		$query_args_filter  = static function ( $args ) use ( &$query_args ) {
+			$query_args = $args;
+
+			return $args;
+		};
+		$cookies            = $_COOKIE; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Preserve global test cookie state.
+
+		$_COOKIE['woocommerce_recently_viewed'] = implode( '|', $viewed_product_ids );
+		add_filter( 'woocommerce_recently_viewed_products_widget_query_args', $query_args_filter );
+
+		try {
+			$widget = new WC_Widget_Recently_Viewed();
+
+			ob_start();
+			try {
+				$widget->widget( array(), array() );
+			} finally {
+				ob_end_clean();
+			}
+
+			$this->assertSame(
+				array_slice( array_reverse( $viewed_product_ids ), 0, 15 ),
+				$query_args['post__in'],
+				'An oversized recently viewed cookie should only send the 15 newest product IDs to the query.'
+			);
+		} finally {
+			remove_filter( 'woocommerce_recently_viewed_products_widget_query_args', $query_args_filter );
+
+			$_COOKIE = $cookies;
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Oversized or manually altered `woocommerce_recently_viewed` cookies could make the Recently Viewed Products widget pass an unbounded ID list into `WP_Query`. This caps the parsed and sanitized list at 15 IDs before the query, preserving newest-first order, and places the slow-query suppression on the `tax_query` assignment it covers.

Closes #67821.

Compatibility: the cookie's public shape and ordering remain unchanged; the normal cookie writer already retains at most 15 IDs. Only query workload from cookies containing more than 15 valid IDs is capped. Saved widget instances clamp their configured `number` to 1–15, and the widget query renders at most that configured count. The `woocommerce_recently_viewed_products_widget_query_args` filter's signature and execution point remain unchanged; for oversized cookies, its `post__in` value now contains only the newest 15 IDs. This has no multisite or install-layout implications: it does not change stored site/network data or derive filesystem paths or URLs.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/):

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Widget::test_recently_viewed_widget_query_limits_oversized_cookie`.
2. Confirm it passes; it supplies a manually altered 20-ID cookie and asserts that the widget query receives exactly the 15 newest IDs in newest-first order.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused Docker PHPUnit regression passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.
- Targeted PHPCS passed normally. With annotations ignored, direct PHPCS reports the expected `WordPress.DB.SlowDBQuery.slow_db_query_tax_query` warning at the suppressed assignment; the branch-aware changed-lines runner reports no unrelated diagnostics.
- PHP syntax and diff checks passed. PHPStan passed for the production widget. The repository PHPStan configuration cannot resolve the legacy PHPUnit bootstrap for `tests/legacy`, so that test file is not statically analyzable in this configuration.

#### Storefront user testing

Tested in a disposable `wp-env` storefront with PHP 8.1, the Twenty Twenty-Five theme, 20 published products, and the Recently Viewed Products widget configured to show 10 products:

- Visiting all 20 product pages through the browser left the normal WooCommerce-managed cookie at 15 IDs. The filter received those 15 newest IDs, and the widget rendered its configured 10 products.
- With a simulated oversized 20-ID cookie, the filter received only the newest 15 IDs and the widget still rendered its configured 10 products.
- A test callback that changed `posts_per_page` to 20 still received only 15 IDs in `post__in`, so the widget rendered 15 products. This confirms that the cap is applied before the public query-arguments filter.
- After viewing another product with the oversized cookie, the cookie decreased from 20 IDs to 19 rather than being immediately normalized to 15; the widget query remained capped at 15 IDs.

This confirms that the normal WooCommerce browsing path is unchanged. The compatibility impact is limited to callbacks that rely on IDs beyond the newest 15 when an oversized cookie is present.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI tooling assisted with implementation, test creation, and validation. The changes and PR content were reviewed before submission.
