### PR TITLE
Fix `has_orders_pending_sync()` false negative after a full sync

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-sync-pending-null-count
+++ b/plugins/woocommerce/changelog/fix-hpos-sync-pending-null-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix has_orders_pending_sync() incorrectly returning false when an order changes after a full HPOS backfill

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -592,7 +592,7 @@ $limit_clause",
 		$sql = $wpdb->prepare(
 			"
 SELECT(
-	($missing_orders_count_sql)
+	COALESCE(($missing_orders_count_sql), 0)
 	+
 	(SELECT COUNT(1) FROM (
 		SELECT orders.id FROM $orders_table orders

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -151,9 +151,7 @@ class DataSynchronizerTests extends \HposTestCase {
 	}
 
 	/**
-	 * An order backfilled to a real post has no "missing" orders, but can still go stale afterwards
-	 * (post record not touched because sync is disabled). has_orders_pending_sync() must still catch
-	 * that case instead of letting the empty "missing orders" count null out the whole sum.
+	 * @testDox An order edited after a full backfill is still detected as pending sync.
 	 */
 	public function test_has_orders_pending_sync_detects_stale_order_after_backfill_with_no_missing_orders() {
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -151,6 +151,27 @@ class DataSynchronizerTests extends \HposTestCase {
 	}
 
 	/**
+	 * An order backfilled to a real post has no "missing" orders, but can still go stale afterwards
+	 * (post record not touched because sync is disabled). has_orders_pending_sync() must still catch
+	 * that case instead of letting the empty "missing orders" count null out the whole sum.
+	 */
+	public function test_has_orders_pending_sync_detects_stale_order_after_backfill_with_no_missing_orders() {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
+
+		$order = OrderHelper::create_complex_data_store_order();
+		$this->sut->process_batch( array( $order->get_id() ) );
+		$this->assertFalse( $this->sut->has_orders_pending_sync(), 'No orders should be pending sync right after a full backfill.' );
+
+		// The order changes after the backfill; with sync disabled its post record is not updated to match.
+		$order->set_date_modified( time() + 1000 );
+		$order->save();
+
+		$this->assertTrue( $this->sut->has_orders_pending_sync() );
+		$this->assertEquals( 1, $this->sut->get_current_orders_pending_sync_count() );
+	}
+
+	/**
 	 * When the CPT data store is authoritative, and an order is updated, we should propagate those changes to
 	 * the COT store immediately (rather than wait for sync to catch up). This guards against a situation where
 	 * the corresponding COT record is temporarily inaccurate.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -161,7 +161,6 @@ class DataSynchronizerTests extends \HposTestCase {
 		$this->sut->process_batch( array( $order->get_id() ) );
 		$this->assertFalse( $this->sut->has_orders_pending_sync(), 'No orders should be pending sync right after a full backfill.' );
 
-		// The order changes after the backfill; with sync disabled its post record is not updated to match.
 		$order->set_date_modified( time() + 1000 );
 		$order->save();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(Found this while working on #67817)

`has_orders_pending_sync()` is used to determine whether HPOS/CPT datastores are in sync. To do that, two numbers are added internally: orders missing from the table + orders where update date differs.

In PR #56186 an optimization was introduced for the first count that changed the underlying query from `COUNT(1)` to a `SELECT 1`, introducing a subtle bug: while `COUNT(1)` used to return `0` when it found nothing, `SELECT 1` returns `NULL`. In SQL, adding `NULL` to a number produces `NULL`, so the combined count came back as 0 even when the second one was not 0.

This is the situation after a _full sync_: there are no missing orders (so `NULL` is returned by the first query), so even if the existing orders now differ (say, after updates or payment), the code would treat the datastores as still being in sync.

This PR fixes this by ensuring NULL is treated as 0 in the first query.


### How to test the changes in this Pull Request:

1. Start with HPOS enabled and compatibility mode off in **WC > Settings > Advanced > Features**. Run `wp wc hpos sync` if a sync is needed to enable HPOS.
1. Go to **WC > Orders** and create a new order.
1. Confirm that the HPOS UI in **WC > Settings > Advanced > Features** indicates a sync is needed to switch datastores.
1. Perform the sync either through that screen or via `wp wc hpos sync`.
1. Go to **WC > Orders** and change the status on any order.
1. Go back to the settings screen and confirm that the UI once again indicates a sync is needed to switch datastores.
1. (Optional) Check out `trunk` and repeat the steps above. You'll notice that the UI on the settings screen correctly detects unsynced orders when you create a new one (steps 1-3) but not after making changes to existing ones (4-6).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.