### PR TITLE
Fix docblock of woocommerce_blocks_product_grid_is_cacheable filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-grid-is-cacheable-docblock
+++ b/plugins/woocommerce/changelog/fix-product-grid-is-cacheable-docblock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Documentation-only: fix the copy-pasted param description and wrong return type in the woocommerce_blocks_product_grid_is_cacheable filter docblock and its generated hook reference.
+
+Fix the docblock for the woocommerce_blocks_product_grid_is_cacheable filter and its generated hook documentation.

--- a/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
+++ b/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md
@@ -527,13 +527,13 @@ apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', boolean $is_cache
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| $is_cacheable | boolean | The list of script dependencies. |
+| $is_cacheable | boolean | Whether the product grid is cacheable. True to enable cache, false to disable. |
 | $query_args | array | Query args for the products query passed to BlocksWpQuery. |
 
 ### Returns
 
 
-`array` True to enable cache, false to disable cache.
+`boolean` True to enable cache, false to disable cache.
 
 ### Source
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php
@@ -349,9 +349,9 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		/**
 		 * Filters whether or not the product grid is cacheable.
 		 *
-		 * @param boolean $is_cacheable The list of script dependencies.
+		 * @param boolean $is_cacheable Whether the product grid is cacheable. True to enable cache, false to disable.
 		 * @param array $query_args Query args for the products query passed to BlocksWpQuery.
-		 * @return array True to enable cache, false to disable cache.
+		 * @return boolean True to enable cache, false to disable cache.
 		 *
 		 * @since 2.5.0
 		 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The docblock of the `woocommerce_blocks_product_grid_is_cacheable` filter in `AbstractProductGrid.php` has two copy-paste errors: the `$is_cacheable` param is described as "The list of script dependencies", and the `@return` type says `array` while the filtered value is cast to `(bool)`. This PR fixes the description and the return type; the filter call, its arguments, and `@since` are untouched.

The generated hook reference (`plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md`) reproduces the same errors, so I updated that section by hand to mirror the corrected docblock. The `build:docs` regeneration pipeline in `client/blocks/package.json` has been broken since the blocks merge; repairing it is tracked as separate work.

Surfaced during review of #45489; the issue is pre-existing on trunk, so we deferred it out of that PR. See https://github.com/woocommerce/woocommerce/pull/45489#discussion_r3811707091.

**Backward compatibility:** none. This is a documentation-only change; no signature, hook firing, or runtime behavior changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Open `plugins/woocommerce/src/Blocks/BlockTypes/AbstractProductGrid.php` and find the `woocommerce_blocks_product_grid_is_cacheable` docblock in `get_products()`; confirm the `$is_cacheable` description matches the filter's purpose and `@return` says `boolean`.
2. Open `plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/hooks/filters.md` and find the `woocommerce_blocks_product_grid_is_cacheable` section; confirm the parameter table and the Returns line mirror the docblock, and that no other section changed.

<!-- End testing instructions -->

### Testing that has already taken place:

- `phpcs-changed` reports no issues on the modified lines.
- PHPStan output for `AbstractProductGrid.php` is identical to trunk; no new errors.
- Documentation-only change; no runtime testing applies.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was authored with Claude Code; I reviewed the changes.