### PR TITLE
Move role column to end of customers report CSV export

### DIFF
--- a/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
+++ b/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Amends unreleased #67653 (CSV Role column order); its changelog entry already describes the shipped behavior.
+
+

--- a/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
+++ b/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move the Role column to the end of the Analytics > Customers CSV export so pre-existing columns keep their positions.

--- a/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
+++ b/plugins/woocommerce/changelog/move-customers-csv-role-column-to-end
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Move the Role column to the end of the Analytics > Customers CSV export so pre-existing columns keep their positions.

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -754,7 +754,6 @@ class Controller extends GenericController implements ExportableInterface {
 		$export_columns = array(
 			'name'            => __( 'Name', 'woocommerce' ),
 			'username'        => __( 'Username', 'woocommerce' ),
-			'role'            => __( 'Role', 'woocommerce' ),
 			'last_active'     => __( 'Last Active', 'woocommerce' ),
 			'registered'      => __( 'Sign Up', 'woocommerce' ),
 			'email'           => __( 'Email', 'woocommerce' ),
@@ -767,6 +766,7 @@ class Controller extends GenericController implements ExportableInterface {
 			'postcode'        => __( 'Postal Code', 'woocommerce' ),
 			'billing_phone'   => __( 'Billing Phone', 'woocommerce' ),
 			'shipping_phone'  => __( 'Shipping Phone', 'woocommerce' ),
+			'role'            => __( 'Role', 'woocommerce' ),
 		);
 
 		/**
@@ -791,7 +791,6 @@ class Controller extends GenericController implements ExportableInterface {
 		$export_item = array(
 			'name'            => $item['name'],
 			'username'        => $item['username'],
-			'role'            => $item['role'] ?? '',
 			'last_active'     => $item['date_last_active'],
 			'registered'      => $item['date_registered'],
 			'email'           => $item['email'],
@@ -804,6 +803,7 @@ class Controller extends GenericController implements ExportableInterface {
 			'postcode'        => $item['postcode'],
 			'billing_phone'   => $item['billing_phone'] ?? '',
 			'shipping_phone'  => $item['shipping_phone'] ?? '',
+			'role'            => $item['role'] ?? '',
 		);
 
 		/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -263,6 +263,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		foreach ( $reports as $report ) {
 			$export_item = $controller->prepare_item_for_export( $report );
 			$export_roles_by_user_id[ (int) $report['user_id'] ] = $export_item['role'];
+			$this->assertSame( 'role', array_key_last( $export_item ), 'Role must stay the last column in prepared export rows, matching the header order' );
 		}
 
 		$this->assertEquals( 'Editor, Shop manager', $export_roles_by_user_id[ $editor_id ], 'CSV export should carry the role value' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -257,6 +257,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$export_columns = $controller->get_export_columns();
 		$this->assertArrayHasKey( 'role', $export_columns, 'CSV export should include a role column' );
 		$this->assertEquals( 'Role', $export_columns['role'] );
+		$this->assertSame( 'role', array_key_last( $export_columns ), 'Role must stay the last CSV column so positional consumers of the pre-existing columns are unaffected' );
 
 		$export_roles_by_user_id = array();
 		foreach ( $reports as $report ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves the Role column added in #67653 to the end of the Analytics > Customers CSV export, so all pre-existing columns keep their positions and integrations that parse the export positionally are unaffected. This matches how the billing/shipping phone columns were appended, and only touches the CSV export order - the on-screen table keeps Role next to Username. Flagged by the AI regression review (WOOAIRR-95); #67653 has not shipped in a release yet, so this is the free window to reorder.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Analytics > Customers and click Download.
2. Verify the CSV header ends with `Role` and the columns before it match the pre-#67653 order (Name, Username, Last Active, ... Billing Phone, Shipping Phone).

### Testing that has already taken place:

-   `WC_Admin_Tests_API_Reports_Customers` (32 tests) passes in wp-env, including a new assertion pinning `role` as the last export column.
-   phpcs and PHPStan clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Comment-only changelog entry included (`plugins/woocommerce/changelog/move-customers-csv-role-column-to-end`) - satisfies the changelog CI without adding a release-notes line, since the entry from #67653 in the same unreleased cycle already describes the shipped behavior.

### Use of AI Tools

Authored with the assistance of Claude Code; reviewed and tested by me.


