### PR TITLE
Add a DataForm adapter for the Settings UI schema

### DIFF
--- a/packages/js/settings-ui/changelog/add-wooprd-3595-dataform-adapter
+++ b/packages/js/settings-ui/changelog/add-wooprd-3595-dataform-adapter
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: add
 
 Add a DataForm adapter that maps the Settings UI schema to a single DataForm field list and form configuration.

--- a/packages/js/settings-ui/changelog/add-wooprd-3595-dataform-adapter
+++ b/packages/js/settings-ui/changelog/add-wooprd-3595-dataform-adapter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a DataForm adapter that maps the Settings UI schema to a single DataForm field list and form configuration.

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -117,34 +117,36 @@ const runVisibilityPredicate = (
 	}
 };
 
+// Predicates resolve on every evaluation, so an extension that registers a
+// predicate after the adapter is built still takes effect.
 const createIsVisible = (
 	settingsField: SettingsUIField,
 	options: DataFormAdapterOptions
 ): Field< SettingsValues >[ 'isVisible' ] => {
-	const predicate = resolveFieldVisibilityPredicate(
-		settingsField.id,
-		options.context
-	);
+	return ( item ) => {
+		const predicate = resolveFieldVisibilityPredicate(
+			settingsField.id,
+			options.context
+		);
 
-	if ( predicate ) {
-		return ( item ) =>
-			runVisibilityPredicate(
+		if ( predicate ) {
+			return runVisibilityPredicate(
 				predicate,
 				'field',
 				settingsField.id,
 				item,
 				options
 			);
-	}
+		}
 
-	const visibility = settingsField.visibility;
-	return visibility
-		? ( item ) =>
-				valueMatchesVisibilityRule(
+		const visibility = settingsField.visibility;
+		return visibility
+			? valueMatchesVisibilityRule(
 					item[ visibility.controller ],
 					visibility.value
-				)
-		: undefined;
+			  )
+			: true;
+	};
 };
 
 const createInfoRender = (
@@ -236,12 +238,6 @@ export const createDataFormAdapter = (
 	const fieldsById = new Map(
 		fields.map( ( field ) => [ field.id, field ] )
 	);
-	const groupPredicates = new Map(
-		groups.map( ( group ) => [
-			group.id,
-			resolveGroupVisibilityPredicate( group.id, options.context ),
-		] )
-	);
 
 	const isFieldVisible = ( fieldId: string, values: SettingsValues ) =>
 		fieldsById.get( fieldId )?.isVisible?.( values ) !== false;
@@ -250,7 +246,10 @@ export const createDataFormAdapter = (
 		group: SettingsUIGroup,
 		values: SettingsValues
 	) => {
-		const predicate = groupPredicates.get( group.id );
+		const predicate = resolveGroupVisibilityPredicate(
+			group.id,
+			options.context
+		);
 		if (
 			predicate &&
 			! runVisibilityPredicate(

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -169,6 +169,10 @@ export const buildDataFormField = (
 		placeholder: settingsField.placeholder,
 		type: descriptor?.type,
 		elements: settingsField.options,
+		// DataForm turns on its closed elements rule whenever elements are
+		// set, but stored settings values can predate the current options
+		// (deleted pages, uninstalled gateways) and must not block saving.
+		isValid: { elements: false },
 		isVisible: createIsVisible( settingsField, options ),
 		isDisabled: isFieldDisabled( settingsField ),
 	};

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, RawHTML } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import type {
 	Field,
 	FieldTypeName,
@@ -14,7 +14,7 @@ import type {
  * Internal dependencies
  */
 import { error, warn } from './diagnostics';
-import { createSettingsHelpElement, sanitizeSettingsHtml } from './html';
+import { createSettingsHelpElement } from './html';
 import {
 	resolveFieldVisibilityPredicate,
 	resolveGroupVisibilityPredicate,
@@ -132,18 +132,6 @@ const createIsVisible = (
 	};
 };
 
-// DataForm renders the label for read-only fields itself, so the info
-// renderer paints only the sanitized description.
-const createInfoRender = ( settingsField: SettingsUIField ) => {
-	return function InfoSettingsField() {
-		return settingsField.description ? (
-			<RawHTML className="wc-settings-ui__info">
-				{ sanitizeSettingsHtml( settingsField.description ) }
-			</RawHTML>
-		) : null;
-	};
-};
-
 // HTML boolean attributes use presence semantics: disabled="false" still
 // disables, while a boolean false stays unset.
 const isAttributeSet = ( value: string | number | boolean | undefined ) =>
@@ -258,7 +246,15 @@ export const buildDataFormField = (
 		// control even when read-only, so info keeps the text type.
 		field.type = 'text';
 		field.readOnly = true;
-		field.render = createInfoRender( settingsField );
+		// DataForm paints the label for a read-only field and drops its
+		// description, so info shows the sanitized element the field already
+		// carries rather than sanitizing the same string again per render.
+		field.render = ( { field: normalizedField } ) =>
+			normalizedField.description ? (
+				<div className="wc-settings-ui__info">
+					{ normalizedField.description }
+				</div>
+			) : null;
 		return field;
 	}
 

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -192,6 +192,8 @@ export const buildDataFormField = (
 	return field;
 };
 
+// Group descriptions and actions are HTML chrome that stays with the
+// renderer; FormField.description only accepts a plain string.
 const buildGroupFormField = ( group: SettingsUIGroup ): FormField => ( {
 	id: group.id,
 	label: group.title || undefined,

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -12,7 +12,7 @@ import type {
 /**
  * Internal dependencies
  */
-import { warn } from './diagnostics';
+import { error, warn } from './diagnostics';
 import { NativeSettingsField } from './native-fields';
 import {
 	resolveFieldVisibilityPredicate,
@@ -93,7 +93,8 @@ const settingsTypeDescriptors: Record< string, SettingsTypeDescriptor > = {
 };
 
 // Predicates fail open: a broken visibility callback renders the field or
-// group rather than hiding it.
+// group rather than hiding it. The failure logs unconditionally because
+// failing open can expose a field that was meant to stay hidden.
 const runVisibilityPredicate = (
 	predicate: SettingsVisibilityPredicate,
 	kind: 'field' | 'group',
@@ -109,7 +110,7 @@ const runVisibilityPredicate = (
 			schema: options.schema,
 		} );
 	} catch ( predicateError ) {
-		warn(
+		error(
 			`Visibility predicate for ${ kind } "${ id }" failed. Rendering it visible.`,
 			{ error: predicateError, context: options.context }
 		);

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -13,6 +13,7 @@ import type {
  * Internal dependencies
  */
 import { error, warn } from './diagnostics';
+import { createSettingsHelpElement } from './html';
 import { NativeSettingsField } from './native-fields';
 import {
 	resolveFieldVisibilityPredicate,
@@ -166,7 +167,7 @@ export const buildDataFormField = (
 	const field: Field< SettingsValues > = {
 		id: settingsField.id,
 		label: settingsField.label,
-		description: settingsField.description,
+		description: createSettingsHelpElement( settingsField.description ),
 		placeholder: settingsField.placeholder,
 		type: descriptor?.type ?? 'text',
 		elements: settingsField.options,

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -23,10 +23,10 @@ import type {
 	SettingsUIField,
 	SettingsUIGroup,
 	SettingsUISchema,
-	SettingsValue,
 	SettingsValues,
 	SettingsVisibilityPredicate,
 } from './types';
+import { valueMatchesVisibilityRule } from './values';
 
 // The adapter assumes the canonical value vocabulary from the PHP schema
 // builder and how extension components attach is a renderer concern, so
@@ -41,32 +41,6 @@ export type DataFormAdapterOptions = {
 export type DataFormAdapter = {
 	fields: Field< SettingsValues >[];
 	getForm: ( values: SettingsValues ) => Form;
-};
-
-const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
-	if ( Array.isArray( a ) || Array.isArray( b ) ) {
-		return (
-			Array.isArray( a ) &&
-			Array.isArray( b ) &&
-			a.length === b.length &&
-			a.every( ( value, index ) => value === b[ index ] )
-		);
-	}
-
-	return a === b;
-};
-
-const valueMatchesVisibilityRule = (
-	value: SettingsValue,
-	expected: SettingsValue | SettingsValue[] | undefined
-) => {
-	const expectedValues = Array.isArray( expected )
-		? expected
-		: [ expected ?? true ];
-
-	return expectedValues.some( ( expectedValue ) =>
-		areValuesEqual( value, expectedValue )
-	);
 };
 
 type SettingsTypeDescriptor = {

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -54,7 +54,9 @@ const settingsTypeDescriptors: Record< string, SettingsTypeDescriptor > = {
 	radio: { type: 'text', edit: 'radio' },
 	textarea: { type: 'text', edit: 'textarea' },
 	number: { type: 'number', edit: 'number' },
-	array: { type: 'array', edit: 'array' },
+	// The select control renders as a closed multi-select for array fields,
+	// matching the `select multiple` the native renderer uses.
+	array: { type: 'array', edit: 'select' },
 	text: { type: 'text', edit: 'text' },
 	password: { type: 'password', edit: 'password' },
 	'datetime-local': { type: 'datetime', edit: 'datetime' },

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -1,0 +1,266 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import type {
+	Field,
+	FieldTypeName,
+	Form,
+	FormField,
+} from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { warn } from './diagnostics';
+import { NativeSettingsField } from './native-fields';
+import {
+	resolveFieldVisibilityPredicate,
+	resolveGroupVisibilityPredicate,
+} from './registry';
+import type {
+	SettingsFieldContext,
+	SettingsUIField,
+	SettingsUIGroup,
+	SettingsUISchema,
+	SettingsValue,
+	SettingsValues,
+	SettingsVisibilityPredicate,
+} from './types';
+
+// The adapter assumes the canonical value vocabulary from the PHP schema
+// builder and how extension components attach is a renderer concern, so
+// neither value coercion nor component registry resolution happens here.
+
+export type DataFormAdapterOptions = {
+	schema: SettingsUISchema;
+	context: SettingsFieldContext;
+	initialValues: SettingsValues;
+};
+
+export type DataFormAdapter = {
+	fields: Field< SettingsValues >[];
+	getForm: ( values: SettingsValues ) => Form;
+};
+
+const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
+	if ( Array.isArray( a ) || Array.isArray( b ) ) {
+		return (
+			Array.isArray( a ) &&
+			Array.isArray( b ) &&
+			a.length === b.length &&
+			a.every( ( value, index ) => value === b[ index ] )
+		);
+	}
+
+	return a === b;
+};
+
+const valueMatchesVisibilityRule = (
+	value: SettingsValue,
+	expected: SettingsValue | SettingsValue[] | undefined
+) => {
+	const expectedValues = Array.isArray( expected )
+		? expected
+		: [ expected ?? true ];
+
+	return expectedValues.some( ( expectedValue ) =>
+		areValuesEqual( value, expectedValue )
+	);
+};
+
+type SettingsTypeDescriptor = {
+	type: FieldTypeName;
+	edit: string;
+};
+
+const settingsTypeDescriptors: Record< string, SettingsTypeDescriptor > = {
+	checkbox: { type: 'boolean', edit: 'checkbox' },
+	select: { type: 'text', edit: 'select' },
+	radio: { type: 'text', edit: 'radio' },
+	textarea: { type: 'text', edit: 'textarea' },
+	number: { type: 'number', edit: 'number' },
+	array: { type: 'array', edit: 'array' },
+	text: { type: 'text', edit: 'text' },
+	password: { type: 'password', edit: 'password' },
+	'datetime-local': { type: 'datetime', edit: 'datetime' },
+	date: { type: 'date', edit: 'date' },
+	// DataForm has no time control; the plain text control carries the value.
+	time: { type: 'text', edit: 'text' },
+	email: { type: 'email', edit: 'email' },
+	url: { type: 'url', edit: 'url' },
+	tel: { type: 'telephone', edit: 'telephone' },
+};
+
+// Predicates fail open: a broken visibility callback renders the field or
+// group rather than hiding it.
+const runVisibilityPredicate = (
+	predicate: SettingsVisibilityPredicate,
+	kind: 'field' | 'group',
+	id: string,
+	values: SettingsValues,
+	options: DataFormAdapterOptions
+) => {
+	try {
+		return predicate( {
+			values,
+			initialValues: options.initialValues,
+			context: options.context,
+			schema: options.schema,
+		} );
+	} catch ( predicateError ) {
+		warn(
+			`Visibility predicate for ${ kind } "${ id }" failed. Rendering it visible.`,
+			{ error: predicateError, context: options.context }
+		);
+		return true;
+	}
+};
+
+const createIsVisible = (
+	settingsField: SettingsUIField,
+	options: DataFormAdapterOptions
+): Field< SettingsValues >[ 'isVisible' ] => {
+	const predicate = resolveFieldVisibilityPredicate(
+		settingsField.id,
+		options.context
+	);
+
+	if ( predicate ) {
+		return ( item ) =>
+			runVisibilityPredicate(
+				predicate,
+				'field',
+				settingsField.id,
+				item,
+				options
+			);
+	}
+
+	const visibility = settingsField.visibility;
+	return visibility
+		? ( item ) =>
+				valueMatchesVisibilityRule(
+					item[ visibility.controller ],
+					visibility.value
+				)
+		: undefined;
+};
+
+const createInfoRender = (
+	settingsField: SettingsUIField,
+	options: DataFormAdapterOptions
+) => {
+	return function InfoSettingsField( { item }: { item: SettingsValues } ) {
+		return (
+			<NativeSettingsField
+				field={ settingsField }
+				value={ item[ settingsField.id ] ?? null }
+				onChange={ () => undefined }
+				values={ item }
+				initialValues={ options.initialValues }
+				setValue={ () => undefined }
+				setValues={ () => undefined }
+				context={ options.context }
+			/>
+		);
+	};
+};
+
+export const buildDataFormField = (
+	settingsField: SettingsUIField,
+	options: DataFormAdapterOptions
+): Field< SettingsValues > => {
+	const descriptor = settingsTypeDescriptors[ settingsField.type ];
+
+	const field: Field< SettingsValues > = {
+		id: settingsField.id,
+		label: settingsField.label,
+		description: settingsField.description,
+		placeholder: settingsField.placeholder,
+		type: descriptor?.type ?? 'text',
+		elements: settingsField.options,
+		isVisible: createIsVisible( settingsField, options ),
+		isDisabled: Boolean( settingsField.disabled ),
+	};
+
+	if ( settingsField.type === 'info' ) {
+		field.readOnly = true;
+		field.render = createInfoRender( settingsField, options );
+		return field;
+	}
+
+	if ( ! descriptor ) {
+		warn( `Field type "${ settingsField.type }" is not supported.`, {
+			field: settingsField,
+		} );
+		field.readOnly = true;
+		field.render = () => null;
+		return field;
+	}
+
+	field.Edit = descriptor.edit;
+
+	return field;
+};
+
+const buildGroupFormField = ( group: SettingsUIGroup ): FormField => ( {
+	id: group.id,
+	label: group.title || undefined,
+	layout: group.title
+		? { type: 'card', isCollapsible: false }
+		: { type: 'card', withHeader: false },
+	children: group.fields.map( ( field ) => field.id ),
+} );
+
+export const createDataFormAdapter = (
+	options: DataFormAdapterOptions
+): DataFormAdapter => {
+	const groups = Object.values( options.schema.groups );
+	const fields = groups.flatMap( ( group ) =>
+		group.fields.map( ( field ) => buildDataFormField( field, options ) )
+	);
+	const fieldsById = new Map(
+		fields.map( ( field ) => [ field.id, field ] )
+	);
+	const groupPredicates = new Map(
+		groups.map( ( group ) => [
+			group.id,
+			resolveGroupVisibilityPredicate( group.id, options.context ),
+		] )
+	);
+
+	const isFieldVisible = ( fieldId: string, values: SettingsValues ) =>
+		fieldsById.get( fieldId )?.isVisible?.( values ) !== false;
+
+	const isGroupVisible = (
+		group: SettingsUIGroup,
+		values: SettingsValues
+	) => {
+		const predicate = groupPredicates.get( group.id );
+		if (
+			predicate &&
+			! runVisibilityPredicate(
+				predicate,
+				'group',
+				group.id,
+				values,
+				options
+			)
+		) {
+			return false;
+		}
+
+		return group.fields.some( ( field ) =>
+			isFieldVisible( field.id, values )
+		);
+	};
+
+	const getForm = ( values: SettingsValues ): Form => ( {
+		fields: groups
+			.filter( ( group ) => isGroupVisible( group, values ) )
+			.map( buildGroupFormField ),
+	} );
+
+	return { fields, getForm };
+};

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -79,12 +79,17 @@ const runVisibilityPredicate = (
 	options: DataFormAdapterOptions
 ) => {
 	try {
-		return predicate( {
-			values,
-			initialValues: options.initialValues,
-			context: options.context,
-			schema: options.schema,
-		} );
+		// Coerce with the truthiness DataForm's layout applies, so a loose
+		// predicate result cannot make the form filter and the layout
+		// disagree about a field.
+		return Boolean(
+			predicate( {
+				values,
+				initialValues: options.initialValues,
+				context: options.context,
+				schema: options.schema,
+			} )
+		);
 	} catch ( predicateError ) {
 		error(
 			`Visibility predicate for ${ kind } "${ id }" failed. Rendering it visible.`,
@@ -214,8 +219,9 @@ export const createDataFormAdapter = (
 		fields.map( ( field ) => [ field.id, field ] )
 	);
 
+	// A field without an isVisible callback is shown, matching DataForm.
 	const isFieldVisible = ( fieldId: string, values: SettingsValues ) =>
-		fieldsById.get( fieldId )?.isVisible?.( values ) !== false;
+		Boolean( fieldsById.get( fieldId )?.isVisible?.( values ) ?? true );
 
 	const isGroupVisible = (
 		group: SettingsUIGroup,

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -167,6 +167,19 @@ const createInfoRender = (
 	};
 };
 
+// Classic settings disable fields through custom_attributes with HTML
+// presence semantics, so any defined value except boolean false disables.
+const isFieldDisabled = ( settingsField: SettingsUIField ) => {
+	if ( settingsField.disabled ) {
+		return true;
+	}
+
+	const disabledAttribute = settingsField.customAttributes?.disabled;
+	return (
+		typeof disabledAttribute !== 'undefined' && disabledAttribute !== false
+	);
+};
+
 export const buildDataFormField = (
 	settingsField: SettingsUIField,
 	options: DataFormAdapterOptions
@@ -181,7 +194,7 @@ export const buildDataFormField = (
 		type: descriptor?.type ?? 'text',
 		elements: settingsField.options,
 		isVisible: createIsVisible( settingsField, options ),
-		isDisabled: Boolean( settingsField.disabled ),
+		isDisabled: isFieldDisabled( settingsField ),
 	};
 
 	if ( settingsField.type === 'info' ) {

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -237,7 +237,12 @@ export const buildDataFormField = (
 	settingsField: SettingsUIField,
 	options: DataFormAdapterOptions
 ): Field< SettingsValues > => {
-	const descriptor = settingsTypeDescriptors[ settingsField.type ];
+	const descriptor = Object.prototype.hasOwnProperty.call(
+		settingsTypeDescriptors,
+		settingsField.type
+	)
+		? settingsTypeDescriptors[ settingsField.type ]
+		: undefined;
 
 	const field: Field< SettingsValues > = {
 		id: settingsField.id,

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -46,27 +46,37 @@ export type DataFormAdapter = {
 
 type SettingsTypeDescriptor = {
 	type: FieldTypeName;
-	edit: string;
+	// Only named where the type alone resolves the wrong control. DataForm
+	// derives the control from the field type otherwise, so naming one here
+	// would restate its own default.
+	edit?: string;
 };
 
 const settingsTypeDescriptors: Record< string, SettingsTypeDescriptor > = {
-	checkbox: { type: 'boolean', edit: 'checkbox' },
-	select: { type: 'text', edit: 'select' },
-	radio: { type: 'text', edit: 'radio' },
+	text: { type: 'text' },
+	password: { type: 'password' },
+	number: { type: 'number' },
+	checkbox: { type: 'boolean' },
+	email: { type: 'email' },
+	url: { type: 'url' },
+	tel: { type: 'telephone' },
+	date: { type: 'date' },
+	'datetime-local': { type: 'datetime' },
+	// DataForm has no time type, so the value rides in a text control.
+	time: { type: 'text' },
+	// Read-only display text. The type is here so DataForm resolves a control
+	// and keeps the field; the renderer paints the description over it.
+	info: { type: 'text' },
+	// DataForm has no textarea or radio type, so these name the control the
+	// schema asked for.
 	textarea: { type: 'text', edit: 'textarea' },
-	number: { type: 'number', edit: 'number' },
-	// The select control renders as a closed multi-select for array fields,
-	// matching the `select multiple` the native renderer uses.
+	radio: { type: 'text', edit: 'radio' },
+	// Closed lists name their control because DataForm only infers a select
+	// from a non-empty elements list, and these types keep their meaning when
+	// the list comes back empty. Array also has to be named because DataForm
+	// defaults it to a free-text token field.
+	select: { type: 'text', edit: 'select' },
 	array: { type: 'array', edit: 'select' },
-	text: { type: 'text', edit: 'text' },
-	password: { type: 'password', edit: 'password' },
-	'datetime-local': { type: 'datetime', edit: 'datetime' },
-	date: { type: 'date', edit: 'date' },
-	// DataForm has no time control; the plain text control carries the value.
-	time: { type: 'text', edit: 'text' },
-	email: { type: 'email', edit: 'email' },
-	url: { type: 'url', edit: 'url' },
-	tel: { type: 'telephone', edit: 'telephone' },
 };
 
 // Predicates fail open: a broken visibility callback renders the field or
@@ -242,9 +252,6 @@ export const buildDataFormField = (
 	};
 
 	if ( settingsField.type === 'info' ) {
-		// DataForm's regular layout skips fields whose type resolves no Edit
-		// control even when read-only, so info keeps the text type.
-		field.type = 'text';
 		field.readOnly = true;
 		// DataForm paints the label for a read-only field and drops its
 		// description, so info shows the sanitized element the field already
@@ -268,7 +275,9 @@ export const buildDataFormField = (
 		return field;
 	}
 
-	field.Edit = descriptor.edit;
+	if ( descriptor.edit ) {
+		field.Edit = descriptor.edit;
+	}
 
 	return field;
 };

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -192,15 +192,14 @@ const toLengthConstraint = ( value: string | number | boolean | undefined ) => {
 };
 
 // Classic settings express constraints as HTML custom_attributes; map the
-// ones with DataForm rule slots. The closed elements rule stays off because
-// stored values can predate the current options, and step stays unmapped
-// because DataForm derives it from format.decimals rather than a rule.
+// ones with DataForm rule slots. Step stays unmapped because DataForm derives
+// it from format.decimals rather than a rule.
 const buildValidationRules = (
 	settingsField: SettingsUIField,
 	descriptor: SettingsTypeDescriptor | undefined
 ): Rules< SettingsValues > => {
 	const attributes = settingsField.customAttributes ?? {};
-	const rules: Rules< SettingsValues > = { elements: false };
+	const rules: Rules< SettingsValues > = {};
 
 	if ( isAttributeSet( attributes.required ) ) {
 		rules.required = true;

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import { createElement, RawHTML } from '@wordpress/element';
 import type {
 	Field,
 	FieldTypeName,
@@ -13,8 +13,7 @@ import type {
  * Internal dependencies
  */
 import { error, warn } from './diagnostics';
-import { createSettingsHelpElement } from './html';
-import { NativeSettingsField } from './native-fields';
+import { createSettingsHelpElement, sanitizeSettingsHtml } from './html';
 import {
 	resolveFieldVisibilityPredicate,
 	resolveGroupVisibilityPredicate,
@@ -125,23 +124,15 @@ const createIsVisible = (
 	};
 };
 
-const createInfoRender = (
-	settingsField: SettingsUIField,
-	options: DataFormAdapterOptions
-) => {
-	return function InfoSettingsField( { item }: { item: SettingsValues } ) {
-		return (
-			<NativeSettingsField
-				field={ settingsField }
-				value={ item[ settingsField.id ] ?? null }
-				onChange={ () => undefined }
-				values={ item }
-				initialValues={ options.initialValues }
-				setValue={ () => undefined }
-				setValues={ () => undefined }
-				context={ options.context }
-			/>
-		);
+// DataForm renders the label for read-only fields itself, so the info
+// renderer paints only the sanitized description.
+const createInfoRender = ( settingsField: SettingsUIField ) => {
+	return function InfoSettingsField() {
+		return settingsField.description ? (
+			<RawHTML className="wc-settings-ui__info">
+				{ sanitizeSettingsHtml( settingsField.description ) }
+			</RawHTML>
+		) : null;
 	};
 };
 
@@ -177,7 +168,7 @@ export const buildDataFormField = (
 
 	if ( settingsField.type === 'info' ) {
 		field.readOnly = true;
-		field.render = createInfoRender( settingsField, options );
+		field.render = createInfoRender( settingsField );
 		return field;
 	}
 

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -162,24 +162,28 @@ export const buildDataFormField = (
 		label: settingsField.label,
 		description: createSettingsHelpElement( settingsField.description ),
 		placeholder: settingsField.placeholder,
-		type: descriptor?.type ?? 'text',
+		type: descriptor?.type,
 		elements: settingsField.options,
 		isVisible: createIsVisible( settingsField, options ),
 		isDisabled: isFieldDisabled( settingsField ),
 	};
 
 	if ( settingsField.type === 'info' ) {
+		// DataForm's regular layout skips fields whose type resolves no Edit
+		// control even when read-only, so info keeps the text type.
+		field.type = 'text';
 		field.readOnly = true;
 		field.render = createInfoRender( settingsField );
 		return field;
 	}
 
 	if ( ! descriptor ) {
+		// The renderer resolves registered type renderers before failing, so
+		// unknown types keep Edit and render unset rather than a baked
+		// fallback the adapter cannot decide on.
 		warn( `Field type "${ settingsField.type }" is not supported.`, {
 			field: settingsField,
 		} );
-		field.readOnly = true;
-		field.render = () => null;
 		return field;
 	}
 

--- a/packages/js/settings-ui/src/dataform-adapter.tsx
+++ b/packages/js/settings-ui/src/dataform-adapter.tsx
@@ -7,6 +7,7 @@ import type {
 	FieldTypeName,
 	Form,
 	FormField,
+	Rules,
 } from '@wordpress/dataviews';
 
 /**
@@ -143,17 +144,95 @@ const createInfoRender = ( settingsField: SettingsUIField ) => {
 	};
 };
 
-// Classic settings disable fields through custom_attributes with HTML
-// presence semantics, so any defined value except boolean false disables.
-const isFieldDisabled = ( settingsField: SettingsUIField ) => {
-	if ( settingsField.disabled ) {
-		return true;
+// HTML boolean attributes use presence semantics: disabled="false" still
+// disables, while a boolean false stays unset.
+const isAttributeSet = ( value: string | number | boolean | undefined ) =>
+	typeof value !== 'undefined' && value !== false;
+
+const isFieldDisabled = ( settingsField: SettingsUIField ) =>
+	Boolean( settingsField.disabled ) ||
+	isAttributeSet( settingsField.customAttributes?.disabled );
+
+// Range constraints only validate against matching value types: numbers for
+// number fields, date strings for date fields. Other types have no range
+// rule slot in DataForm.
+const toRangeConstraint = (
+	value: string | number | boolean | undefined,
+	type: FieldTypeName | undefined
+) => {
+	if (
+		typeof value === 'boolean' ||
+		typeof value === 'undefined' ||
+		value === ''
+	) {
+		return undefined;
 	}
 
-	const disabledAttribute = settingsField.customAttributes?.disabled;
-	return (
-		typeof disabledAttribute !== 'undefined' && disabledAttribute !== false
-	);
+	if ( type === 'number' ) {
+		const numeric = Number( value );
+		return Number.isFinite( numeric ) ? numeric : undefined;
+	}
+
+	if ( type === 'date' || type === 'datetime' ) {
+		return String( value );
+	}
+
+	return undefined;
+};
+
+const toLengthConstraint = ( value: string | number | boolean | undefined ) => {
+	if (
+		typeof value === 'boolean' ||
+		typeof value === 'undefined' ||
+		value === ''
+	) {
+		return undefined;
+	}
+
+	const numeric = Number( value );
+	return Number.isFinite( numeric ) ? numeric : undefined;
+};
+
+// Classic settings express constraints as HTML custom_attributes; map the
+// ones with DataForm rule slots. The closed elements rule stays off because
+// stored values can predate the current options, and step stays unmapped
+// because DataForm derives it from format.decimals rather than a rule.
+const buildValidationRules = (
+	settingsField: SettingsUIField,
+	descriptor: SettingsTypeDescriptor | undefined
+): Rules< SettingsValues > => {
+	const attributes = settingsField.customAttributes ?? {};
+	const rules: Rules< SettingsValues > = { elements: false };
+
+	if ( isAttributeSet( attributes.required ) ) {
+		rules.required = true;
+	}
+
+	const min = toRangeConstraint( attributes.min, descriptor?.type );
+	if ( typeof min !== 'undefined' ) {
+		rules.min = min;
+	}
+
+	const max = toRangeConstraint( attributes.max, descriptor?.type );
+	if ( typeof max !== 'undefined' ) {
+		rules.max = max;
+	}
+
+	const minLength = toLengthConstraint( attributes.minlength );
+	if ( typeof minLength !== 'undefined' ) {
+		rules.minLength = minLength;
+	}
+
+	const maxLength = toLengthConstraint( attributes.maxlength );
+	if ( typeof maxLength !== 'undefined' ) {
+		rules.maxLength = maxLength;
+	}
+
+	if ( typeof attributes.pattern === 'string' && attributes.pattern !== '' ) {
+		rules.pattern = attributes.pattern;
+	}
+
+	return rules;
 };
 
 export const buildDataFormField = (
@@ -169,10 +248,7 @@ export const buildDataFormField = (
 		placeholder: settingsField.placeholder,
 		type: descriptor?.type,
 		elements: settingsField.options,
-		// DataForm turns on its closed elements rule whenever elements are
-		// set, but stored settings values can predate the current options
-		// (deleted pages, uninstalled gateways) and must not block saving.
-		isValid: { elements: false },
+		isValid: buildValidationRules( settingsField, descriptor ),
 		isVisible: createIsVisible( settingsField, options ),
 		isDisabled: isFieldDisabled( settingsField ),
 	};

--- a/packages/js/settings-ui/src/html.ts
+++ b/packages/js/settings-ui/src/html.ts
@@ -2,5 +2,17 @@
  * External dependencies
  */
 import { sanitizeHTML } from '@woocommerce/sanitize';
+import { createElement } from '@wordpress/element';
 
 export const sanitizeSettingsHtml = ( html?: string ) => sanitizeHTML( html );
+
+// Settings descriptions carry HTML, so help text has to reach controls as a
+// sanitized element; a plain string would be escaped and shown verbatim.
+export const createSettingsHelpElement = ( html?: string ) =>
+	html
+		? createElement( 'span', {
+				dangerouslySetInnerHTML: {
+					__html: sanitizeSettingsHtml( html ),
+				},
+		  } )
+		: undefined;

--- a/packages/js/settings-ui/src/native-fields.tsx
+++ b/packages/js/settings-ui/src/native-fields.tsx
@@ -15,7 +15,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { warn } from './diagnostics';
-import { sanitizeSettingsHtml } from './html';
+import {
+	createSettingsHelpElement as getHelp,
+	sanitizeSettingsHtml,
+} from './html';
 import { NumberSpinControl } from './number-spin-control';
 import type { SettingsFieldComponentProps, SettingsValue } from './types';
 
@@ -94,15 +97,6 @@ const getNumberInputAttributes = (
 		inputAttributes,
 	};
 };
-
-const getHelp = ( description?: string ) =>
-	description ? (
-		<span
-			dangerouslySetInnerHTML={ {
-				__html: sanitizeSettingsHtml( description ),
-			} }
-		/>
-	) : undefined;
 
 export const NativeSettingsField = ( {
 	field,

--- a/packages/js/settings-ui/src/settings-ui-page.tsx
+++ b/packages/js/settings-ui/src/settings-ui-page.tsx
@@ -43,6 +43,7 @@ import type {
 	SettingsValue,
 	SettingsValues,
 } from './types';
+import { areValuesEqual, valueMatchesVisibilityRule } from './values';
 
 type SaveNotice = {
 	status: 'success' | 'error';
@@ -69,19 +70,6 @@ const getInitialValues = ( schema: SettingsUISchema ): SettingsValues => {
 	} );
 
 	return values;
-};
-
-const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
-	if ( Array.isArray( a ) || Array.isArray( b ) ) {
-		return (
-			Array.isArray( a ) &&
-			Array.isArray( b ) &&
-			a.length === b.length &&
-			a.every( ( value, index ) => value === b[ index ] )
-		);
-	}
-
-	return a === b;
 };
 
 const getChangedValues = (
@@ -272,19 +260,6 @@ const GroupHeader = ( { group }: { group: SettingsUIGroup } ) => {
 				</div>
 			) : null }
 		</header>
-	);
-};
-
-const valueMatchesVisibilityRule = (
-	value: SettingsValue,
-	expected: SettingsValue | SettingsValue[] | undefined
-) => {
-	const expectedValues = Array.isArray( expected )
-		? expected
-		: [ expected ?? true ];
-
-	return expectedValues.some( ( expectedValue ) =>
-		areValuesEqual( value, expectedValue )
 	);
 };
 

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -208,26 +208,34 @@ describe( 'dataform adapter', () => {
 			expect( container.textContent ).toBe( 'See the docs.' );
 		} );
 
-		it( 'warns and leaves the control unset for an unknown type', () => {
-			const warnSpy = jest
-				.spyOn( console, 'warn' )
-				.mockImplementation( () => undefined );
-			const field = buildDataFormField(
-				{ ...textField, type: 'extension_defined' },
-				createOptions( [] )
-			);
+		it.each( [
+			'extension_defined',
+			'constructor',
+			'__proto__',
+			'toString',
+		] )(
+			'warns and leaves the control unset for unknown type "%s"',
+			( type ) => {
+				const warnSpy = jest
+					.spyOn( console, 'warn' )
+					.mockImplementation( () => undefined );
+				const field = buildDataFormField(
+					{ ...textField, type },
+					createOptions( [] )
+				);
 
-			expect( field.type ).toBeUndefined();
-			expect( field.Edit ).toBeUndefined();
-			expect( field.render ).toBeUndefined();
-			expect( field.readOnly ).toBeUndefined();
-			expect( warnSpy ).toHaveBeenCalledWith(
-				expect.stringContaining(
-					'Field type "extension_defined" is not supported.'
-				),
-				expect.any( Object )
-			);
-		} );
+				expect( field.type ).toBeUndefined();
+				expect( field.Edit ).toBeUndefined();
+				expect( field.render ).toBeUndefined();
+				expect( field.readOnly ).toBeUndefined();
+				expect( warnSpy ).toHaveBeenCalledWith(
+					expect.stringContaining(
+						`Field type "${ type }" is not supported.`
+					),
+					expect.any( Object )
+				);
+			}
+		);
 	} );
 
 	describe( 'visibility', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -16,6 +16,7 @@ import type {
 	SettingsUIField,
 	SettingsUISchema,
 	SettingsValues,
+	SettingsVisibilityPredicate,
 } from '../types';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -302,6 +303,26 @@ describe( 'dataform adapter', () => {
 			expect( field.isVisible?.( { toggle: 'on' } ) ).toBe( true );
 		} );
 
+		it( 'coerces loose predicate results to strict booleans', () => {
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					// Third-party predicates are not held to the typed
+					// boolean return.
+					test_field: ( ( { values }: { values: SettingsValues } ) =>
+						values.other === 'show' ||
+						undefined ) as SettingsVisibilityPredicate,
+				},
+			} );
+			const field = buildDataFormField(
+				textField,
+				createOptions( [ textField ] )
+			);
+
+			expect( field.isVisible?.( { other: 'show' } ) ).toBe( true );
+			expect( field.isVisible?.( { other: 'hide' } ) ).toBe( false );
+		} );
+
 		it( 'applies a predicate registered after the field is built', () => {
 			const field = buildDataFormField(
 				textField,
@@ -405,6 +426,23 @@ describe( 'dataform adapter', () => {
 
 			const hidden = adapter.getForm( { show: 'no', toggle: 'off' } );
 			expect( hidden.fields ).toEqual( [] );
+		} );
+
+		it( 'drops a group whose only field is hidden by a loose predicate', () => {
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					test_field: ( () =>
+						undefined ) as unknown as SettingsVisibilityPredicate,
+				},
+			} );
+			const adapter = createDataFormAdapter(
+				createOptions( [ textField ] )
+			);
+
+			// DataForm's layout hides the field, so keeping the group would
+			// leave an empty titled card behind.
+			expect( adapter.getForm( {} ).fields ).toEqual( [] );
 		} );
 
 		it( 'fails open and logs an error when a group predicate throws', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -139,15 +139,18 @@ describe( 'dataform adapter', () => {
 
 			const Render = field.render as ( props: {
 				item: SettingsValues;
+				field: typeof field;
 			} ) => JSX.Element;
-			const { container } = renderElement( <Render item={ {} } /> );
+			const { container } = renderElement(
+				<Render item={ {} } field={ field } />
+			);
 			expect(
 				container.querySelector( '.wc-settings-ui__info' )
 			).not.toBeNull();
-			expect( container.textContent ).toContain( 'Useful information.' );
 			expect( container.querySelector( 'script' ) ).toBeNull();
-			// DataForm owns the label for read-only fields.
-			expect( container.textContent ).not.toContain( 'Read this' );
+			// DataForm owns the label for read-only fields, so the render
+			// contributes the description and nothing else.
+			expect( container.textContent ).toBe( 'Useful information.' );
 		} );
 
 		it( 'maps field descriptions to sanitized help elements', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -91,7 +91,7 @@ describe( 'dataform adapter', () => {
 			[ 'radio', 'text', 'radio' ],
 			[ 'checkbox', 'boolean', 'checkbox' ],
 			[ 'number', 'number', 'number' ],
-			[ 'array', 'array', 'array' ],
+			[ 'array', 'array', 'select' ],
 		];
 
 		it.each( typeExpectations )(
@@ -493,6 +493,40 @@ describe( 'dataform adapter', () => {
 				1
 			);
 			expect( container.textContent ).toContain( 'Useful information.' );
+		} );
+
+		it( 'renders array fields as a closed multi-select', () => {
+			const arrayField: SettingsUIField = {
+				id: 'countries',
+				label: 'Countries',
+				type: 'array',
+				options: [
+					{ label: 'France', value: 'FR' },
+					{ label: 'Spain', value: 'ES' },
+				],
+			};
+			const options = createOptions( [ arrayField ] );
+			const adapter = createDataFormAdapter( options );
+			const data = { countries: [ 'FR' ] };
+
+			const { container } = renderElement(
+				<DataForm
+					data={ data }
+					fields={ adapter.fields }
+					form={ adapter.getForm( data ) }
+					onChange={ () => undefined }
+				/>
+			);
+
+			const select = container.querySelector( 'select' );
+			expect( select?.multiple ).toBe( true );
+			expect(
+				Array.from( select?.options ?? [] ).map( ( o ) => o.value )
+			).toEqual( [ 'FR', 'ES' ] );
+			// A closed control offers no free-text input.
+			expect(
+				container.querySelector( 'input[type="text"]' )
+			).toBeNull();
 		} );
 
 		it( 'surfaces grouped validity through FieldValidity children', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -1,0 +1,420 @@
+/**
+ * External dependencies
+ */
+import { DataForm } from '@wordpress/dataviews';
+import { act } from 'react';
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { buildDataFormField, createDataFormAdapter } from '../dataform-adapter';
+import type { DataFormAdapterOptions } from '../dataform-adapter';
+import { __resetRegistry, registerSettingsExtension } from '../registry';
+import type {
+	SettingsUIField,
+	SettingsUISchema,
+	SettingsValues,
+} from '../types';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const context = { page: 'test-page', section: 'default' };
+
+const createSchema = ( fields: SettingsUIField[] ): SettingsUISchema => ( {
+	id: 'test-page',
+	title: 'Test page',
+	section: 'default',
+	save: { adapter: 'none' },
+	groups: {
+		general: {
+			id: 'general',
+			title: 'General',
+			fields,
+		},
+	},
+} );
+
+const createOptions = (
+	fields: SettingsUIField[],
+	initialValues: SettingsValues = {}
+): DataFormAdapterOptions => ( {
+	schema: createSchema( fields ),
+	context,
+	initialValues,
+} );
+
+const textField: SettingsUIField = {
+	id: 'test_field',
+	label: 'Test field',
+	type: 'text',
+};
+
+const renderElement = ( element: JSX.Element ) => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	act( () => {
+		root.render( element );
+	} );
+	return {
+		container,
+		unmount: () => {
+			act( () => root.unmount() );
+			container.remove();
+		},
+	};
+};
+
+describe( 'dataform adapter', () => {
+	afterEach( () => {
+		__resetRegistry();
+		jest.restoreAllMocks();
+	} );
+
+	describe( 'field type mapping', () => {
+		const typeExpectations: Array< [ string, string, unknown ] > = [
+			[ 'text', 'text', 'text' ],
+			[ 'password', 'password', 'password' ],
+			[ 'datetime-local', 'datetime', 'datetime' ],
+			[ 'date', 'date', 'date' ],
+			[ 'time', 'text', 'text' ],
+			[ 'email', 'email', 'email' ],
+			[ 'url', 'url', 'url' ],
+			[ 'tel', 'telephone', 'telephone' ],
+			[ 'textarea', 'text', 'textarea' ],
+			[ 'select', 'text', 'select' ],
+			[ 'radio', 'text', 'radio' ],
+			[ 'checkbox', 'boolean', 'checkbox' ],
+			[ 'number', 'number', 'number' ],
+			[ 'array', 'array', 'array' ],
+		];
+
+		it.each( typeExpectations )(
+			'maps the "%s" settings type to DataForm type "%s" with the "%s" edit control',
+			( settingsType, dataFormType, editControl ) => {
+				const field = buildDataFormField(
+					{ ...textField, type: settingsType },
+					createOptions( [ { ...textField, type: settingsType } ] )
+				);
+
+				expect( field.type ).toBe( dataFormType );
+				expect( field.Edit ).toBe( editControl );
+			}
+		);
+
+		it( 'passes options through as elements', () => {
+			const options = [
+				{ label: 'One', value: 'one' },
+				{ label: 'Two', value: 'two' },
+			];
+			const field = buildDataFormField(
+				{ ...textField, type: 'select', options },
+				createOptions( [] )
+			);
+
+			expect( field.elements ).toEqual( options );
+		} );
+
+		it( 'renders info fields read-only through the native renderer', () => {
+			const infoField: SettingsUIField = {
+				id: 'info_field',
+				label: 'Read this',
+				type: 'info',
+				description: 'Useful <strong>information</strong>.',
+			};
+			const field = buildDataFormField(
+				infoField,
+				createOptions( [ infoField ] )
+			);
+
+			expect( field.readOnly ).toBe( true );
+			expect( field.Edit ).toBeUndefined();
+
+			const Render = field.render as ( props: {
+				item: SettingsValues;
+			} ) => JSX.Element;
+			const { container, unmount } = renderElement(
+				<Render item={ {} } />
+			);
+			expect(
+				container.querySelector( '.wc-settings-ui__info' )
+			).not.toBeNull();
+			expect( container.textContent ).toContain( 'Read this' );
+			unmount();
+		} );
+
+		it( 'warns and maps an unknown type to a read-only field rendering nothing', () => {
+			const warnSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => undefined );
+			const field = buildDataFormField(
+				{ ...textField, type: 'extension_defined' },
+				createOptions( [] )
+			);
+
+			expect( field.readOnly ).toBe( true );
+			expect( field.Edit ).toBeUndefined();
+			expect( ( field.render as () => null )() ).toBeNull();
+			expect( warnSpy ).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Field type "extension_defined" is not supported.'
+				),
+				expect.any( Object )
+			);
+		} );
+	} );
+
+	describe( 'visibility', () => {
+		it( 'maps a visibility rule to isVisible with single and list values', () => {
+			const single = buildDataFormField(
+				{
+					...textField,
+					visibility: { controller: 'toggle', value: 'on' },
+				},
+				createOptions( [] )
+			);
+			expect( single.isVisible?.( { toggle: 'on' } ) ).toBe( true );
+			expect( single.isVisible?.( { toggle: 'off' } ) ).toBe( false );
+
+			const list = buildDataFormField(
+				{
+					...textField,
+					visibility: { controller: 'toggle', value: [ 'a', 'b' ] },
+				},
+				createOptions( [] )
+			);
+			expect( list.isVisible?.( { toggle: 'b' } ) ).toBe( true );
+			expect( list.isVisible?.( { toggle: 'c' } ) ).toBe( false );
+
+			const defaulted = buildDataFormField(
+				{ ...textField, visibility: { controller: 'toggle' } },
+				createOptions( [] )
+			);
+			expect( defaulted.isVisible?.( { toggle: true } ) ).toBe( true );
+			expect( defaulted.isVisible?.( { toggle: false } ) ).toBe( false );
+		} );
+
+		it( 'prefers a registered predicate over the schema rule', () => {
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					test_field: ( { values } ) => values.other === 'show',
+				},
+			} );
+			const field = buildDataFormField(
+				{
+					...textField,
+					visibility: { controller: 'toggle', value: 'on' },
+				},
+				createOptions( [] )
+			);
+
+			expect(
+				field.isVisible?.( { toggle: 'off', other: 'show' } )
+			).toBe( true );
+			expect( field.isVisible?.( { toggle: 'on', other: 'hide' } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'fails open with a warning when a predicate throws', () => {
+			const warnSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => undefined );
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					test_field: () => {
+						throw new Error( 'broken predicate' );
+					},
+				},
+			} );
+			const field = buildDataFormField(
+				textField,
+				createOptions( [ textField ] )
+			);
+
+			expect( field.isVisible?.( {} ) ).toBe( true );
+			expect( warnSpy ).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Visibility predicate for field "test_field" failed.'
+				),
+				expect.any( Object )
+			);
+		} );
+	} );
+
+	describe( 'form configuration', () => {
+		it( 'maps groups to combined card fields', () => {
+			const schema: SettingsUISchema = {
+				id: 'test-page',
+				groups: {
+					titled: {
+						id: 'titled',
+						title: 'Titled group',
+						fields: [ textField ],
+					},
+					untitled: {
+						id: 'untitled',
+						fields: [
+							{ id: 'other_field', label: 'Other', type: 'text' },
+						],
+					},
+				},
+			};
+			const adapter = createDataFormAdapter( {
+				schema,
+				context,
+				initialValues: {},
+			} );
+			const form = adapter.getForm( {} );
+
+			expect( form.fields ).toEqual( [
+				{
+					id: 'titled',
+					label: 'Titled group',
+					layout: { type: 'card', isCollapsible: false },
+					children: [ 'test_field' ],
+				},
+				{
+					id: 'untitled',
+					label: undefined,
+					layout: { type: 'card', withHeader: false },
+					children: [ 'other_field' ],
+				},
+			] );
+		} );
+
+		it( 'drops a group when its predicate hides it or all fields are hidden', () => {
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				groupVisibility: {
+					by_predicate: ( { values } ) => values.show === 'yes',
+				},
+			} );
+			const schema: SettingsUISchema = {
+				id: 'test-page',
+				groups: {
+					by_predicate: {
+						id: 'by_predicate',
+						fields: [ textField ],
+					},
+					by_fields: {
+						id: 'by_fields',
+						fields: [
+							{
+								id: 'hidden_field',
+								label: 'Hidden',
+								type: 'text',
+								visibility: {
+									controller: 'toggle',
+									value: 'on',
+								},
+							},
+						],
+					},
+				},
+			};
+			const adapter = createDataFormAdapter( {
+				schema,
+				context,
+				initialValues: {},
+			} );
+
+			const visible = adapter.getForm( { show: 'yes', toggle: 'on' } );
+			expect(
+				visible.fields?.map( ( f ) => ( f as { id: string } ).id )
+			).toEqual( [ 'by_predicate', 'by_fields' ] );
+
+			const hidden = adapter.getForm( { show: 'no', toggle: 'off' } );
+			expect( hidden.fields ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'mounted DataForm behaviour', () => {
+		it( 'honours isDisabled on package controls', () => {
+			const enabledField: SettingsUIField = {
+				id: 'enabled_field',
+				label: 'Enabled field',
+				type: 'text',
+			};
+			const disabledField: SettingsUIField = {
+				id: 'disabled_field',
+				label: 'Disabled field',
+				type: 'text',
+				disabled: true,
+			};
+			const options = createOptions( [ enabledField, disabledField ] );
+			const adapter = createDataFormAdapter( options );
+			const data = { enabled_field: 'a', disabled_field: 'b' };
+
+			const { container, unmount } = renderElement(
+				<DataForm
+					data={ data }
+					fields={ adapter.fields }
+					form={ adapter.getForm( data ) }
+					onChange={ () => undefined }
+				/>
+			);
+
+			const inputs = Array.from( container.querySelectorAll( 'input' ) );
+			expect( inputs.length ).toBe( 2 );
+			expect(
+				inputs.some(
+					( input ) => input.value === 'a' && ! input.disabled
+				)
+			).toBe( true );
+			expect(
+				inputs.some(
+					( input ) => input.value === 'b' && input.disabled
+				)
+			).toBe( true );
+			unmount();
+		} );
+
+		it( 'surfaces grouped validity through FieldValidity children', () => {
+			const options = createOptions( [ textField ] );
+			const adapter = createDataFormAdapter( options );
+			const data = { test_field: 'value' };
+
+			const { container, unmount } = renderElement(
+				<DataForm
+					data={ data }
+					fields={ adapter.fields }
+					form={ adapter.getForm( data ) }
+					onChange={ () => undefined }
+					validity={ {
+						general: {
+							children: {
+								test_field: {
+									custom: {
+										type: 'invalid',
+										message: 'This value is not allowed.',
+									},
+								},
+							},
+						},
+					} }
+				/>
+			);
+
+			// The controls defer validation display until they are touched.
+			expect( container.textContent ).not.toContain(
+				'This value is not allowed.'
+			);
+
+			const input = container.querySelector( 'input' );
+			act( () => {
+				input?.focus();
+				input?.blur();
+			} );
+
+			expect( container.textContent ).toContain(
+				'This value is not allowed.'
+			);
+			unmount();
+		} );
+	} );
+} );

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -476,6 +476,24 @@ describe( 'dataform adapter', () => {
 		} );
 	} );
 
+	describe( 'validation rules', () => {
+		it( 'keeps the closed elements rule opt-in for option fields', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					type: 'select',
+					options: [
+						{ label: 'One', value: 'one' },
+						{ label: 'Two', value: 'two' },
+					],
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isValid?.elements ).toBe( false );
+		} );
+	} );
+
 	describe( 'disabled state', () => {
 		it( 'honours a disabled custom attribute with presence semantics', () => {
 			const attributeDisabled = buildDataFormField(

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -266,6 +266,42 @@ describe( 'dataform adapter', () => {
 			);
 		} );
 
+		it( 'compares array controller values by element equality', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					visibility: {
+						controller: 'regions',
+						value: [ [ 'eu', 'us' ] ],
+					},
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isVisible?.( { regions: [ 'eu', 'us' ] } ) ).toBe(
+				true
+			);
+			expect( field.isVisible?.( { regions: [ 'eu' ] } ) ).toBe( false );
+			expect( field.isVisible?.( { regions: [ 'us', 'eu' ] } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'keeps disabled and visibility independent on the same field', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					disabled: true,
+					visibility: { controller: 'toggle', value: 'on' },
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isDisabled ).toBe( true );
+			expect( field.isVisible?.( { toggle: 'off' } ) ).toBe( false );
+			expect( field.isVisible?.( { toggle: 'on' } ) ).toBe( true );
+		} );
+
 		it( 'applies a predicate registered after the field is built', () => {
 			const field = buildDataFormField(
 				textField,

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -51,6 +51,8 @@ const textField: SettingsUIField = {
 	type: 'text',
 };
 
+const mountedRoots: Array< () => void > = [];
+
 const renderElement = ( element: JSX.Element ) => {
 	const container = document.createElement( 'div' );
 	document.body.appendChild( container );
@@ -58,17 +60,18 @@ const renderElement = ( element: JSX.Element ) => {
 	act( () => {
 		root.render( element );
 	} );
-	return {
-		container,
-		unmount: () => {
-			act( () => root.unmount() );
-			container.remove();
-		},
-	};
+	mountedRoots.push( () => {
+		act( () => root.unmount() );
+		container.remove();
+	} );
+	return { container };
 };
 
 describe( 'dataform adapter', () => {
 	afterEach( () => {
+		while ( mountedRoots.length > 0 ) {
+			mountedRoots.pop()?.();
+		}
 		__resetRegistry();
 		jest.restoreAllMocks();
 	} );
@@ -135,14 +138,11 @@ describe( 'dataform adapter', () => {
 			const Render = field.render as ( props: {
 				item: SettingsValues;
 			} ) => JSX.Element;
-			const { container, unmount } = renderElement(
-				<Render item={ {} } />
-			);
+			const { container } = renderElement( <Render item={ {} } /> );
 			expect(
 				container.querySelector( '.wc-settings-ui__info' )
 			).not.toBeNull();
 			expect( container.textContent ).toContain( 'Read this' );
-			unmount();
 		} );
 
 		it( 'warns and maps an unknown type to a read-only field rendering nothing', () => {
@@ -426,7 +426,7 @@ describe( 'dataform adapter', () => {
 			const adapter = createDataFormAdapter( options );
 			const data = { enabled_field: 'a', disabled_field: 'b' };
 
-			const { container, unmount } = renderElement(
+			const { container } = renderElement(
 				<DataForm
 					data={ data }
 					fields={ adapter.fields }
@@ -447,7 +447,6 @@ describe( 'dataform adapter', () => {
 					( input ) => input.value === 'b' && input.disabled
 				)
 			).toBe( true );
-			unmount();
 		} );
 
 		it( 'surfaces grouped validity through FieldValidity children', () => {
@@ -455,7 +454,7 @@ describe( 'dataform adapter', () => {
 			const adapter = createDataFormAdapter( options );
 			const data = { test_field: 'value' };
 
-			const { container, unmount } = renderElement(
+			const { container } = renderElement(
 				<DataForm
 					data={ data }
 					fields={ adapter.fields }
@@ -490,7 +489,6 @@ describe( 'dataform adapter', () => {
 			expect( container.textContent ).toContain(
 				'This value is not allowed.'
 			);
-			unmount();
 		} );
 	} );
 } );

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -78,35 +78,74 @@ describe( 'dataform adapter', () => {
 	} );
 
 	describe( 'field type mapping', () => {
-		const typeExpectations: Array< [ string, string, unknown ] > = [
-			[ 'text', 'text', 'text' ],
-			[ 'password', 'password', 'password' ],
-			[ 'datetime-local', 'datetime', 'datetime' ],
-			[ 'date', 'date', 'date' ],
-			[ 'time', 'text', 'text' ],
-			[ 'email', 'email', 'email' ],
-			[ 'url', 'url', 'url' ],
-			[ 'tel', 'telephone', 'telephone' ],
-			[ 'textarea', 'text', 'textarea' ],
-			[ 'select', 'text', 'select' ],
-			[ 'radio', 'text', 'radio' ],
-			[ 'checkbox', 'boolean', 'checkbox' ],
-			[ 'number', 'number', 'number' ],
-			[ 'array', 'array', 'select' ],
+		const typeExpectations: Array< [ string, string ] > = [
+			[ 'text', 'text' ],
+			[ 'password', 'password' ],
+			[ 'datetime-local', 'datetime' ],
+			[ 'date', 'date' ],
+			[ 'time', 'text' ],
+			[ 'info', 'text' ],
+			[ 'email', 'email' ],
+			[ 'url', 'url' ],
+			[ 'tel', 'telephone' ],
+			[ 'textarea', 'text' ],
+			[ 'select', 'text' ],
+			[ 'radio', 'text' ],
+			[ 'checkbox', 'boolean' ],
+			[ 'number', 'number' ],
+			[ 'array', 'array' ],
 		];
 
 		it.each( typeExpectations )(
-			'maps the "%s" settings type to DataForm type "%s" with the "%s" edit control',
-			( settingsType, dataFormType, editControl ) => {
+			'maps the "%s" settings type to DataForm type "%s"',
+			( settingsType, dataFormType ) => {
 				const field = buildDataFormField(
 					{ ...textField, type: settingsType },
 					createOptions( [ { ...textField, type: settingsType } ] )
 				);
 
 				expect( field.type ).toBe( dataFormType );
+			}
+		);
+
+		// Naming a control DataForm already derives from the type would
+		// restate its default, so only these types name one.
+		it.each( [
+			[ 'textarea', 'textarea' ],
+			[ 'radio', 'radio' ],
+			[ 'select', 'select' ],
+			[ 'array', 'select' ],
+		] )(
+			'names the "%s" control for the "%s" type',
+			( settingsType, editControl ) => {
+				const field = buildDataFormField(
+					{ ...textField, type: settingsType },
+					createOptions( [] )
+				);
+
 				expect( field.Edit ).toBe( editControl );
 			}
 		);
+
+		it.each( [
+			'text',
+			'password',
+			'datetime-local',
+			'date',
+			'time',
+			'email',
+			'url',
+			'tel',
+			'checkbox',
+			'number',
+		] )( 'leaves the "%s" control to DataForm', ( settingsType ) => {
+			const field = buildDataFormField(
+				{ ...textField, type: settingsType },
+				createOptions( [] )
+			);
+
+			expect( field.Edit ).toBeUndefined();
+		} );
 
 		it( 'passes options through as elements', () => {
 			const options = [
@@ -664,6 +703,69 @@ describe( 'dataform adapter', () => {
 			expect( container.textContent ).toContain( 'Useful information.' );
 		} );
 
+		it.each( [
+			[ 'text', 'text' ],
+			[ 'password', 'password' ],
+			[ 'email', 'email' ],
+			[ 'url', 'url' ],
+			[ 'tel', 'tel' ],
+			[ 'number', 'number' ],
+			[ 'checkbox', 'checkbox' ],
+		] )(
+			'lets DataForm resolve the "%s" type to input[type=%s]',
+			( settingsType, inputType ) => {
+				const field: SettingsUIField = {
+					id: 'probe_field',
+					label: 'Probe field',
+					type: settingsType,
+				};
+				const options = createOptions( [ field ] );
+				const adapter = createDataFormAdapter( options );
+				const data = { probe_field: '' };
+
+				const { container } = renderElement(
+					<DataForm
+						data={ data }
+						fields={ adapter.fields }
+						form={ adapter.getForm( data ) }
+						onChange={ () => undefined }
+					/>
+				);
+
+				expect( container.querySelector( 'input' )?.type ).toBe(
+					inputType
+				);
+			}
+		);
+
+		it( 'never degrades a closed list to free text when options are empty', () => {
+			// get_options() returns an empty list when its source is
+			// unavailable. DataForm infers a select only from a non-empty
+			// list, so leaving the control unnamed would fall back to a text
+			// input and accept any value for a closed choice.
+			const emptySelect: SettingsUIField = {
+				id: 'country',
+				label: 'Country',
+				type: 'select',
+				options: [],
+			};
+			const options = createOptions( [ emptySelect ] );
+			const adapter = createDataFormAdapter( options );
+			const data = { country: '' };
+
+			const { container } = renderElement(
+				<DataForm
+					data={ data }
+					fields={ adapter.fields }
+					form={ adapter.getForm( data ) }
+					onChange={ () => undefined }
+				/>
+			);
+
+			expect( container.querySelector( 'input' ) ).toBeNull();
+			expect( container.querySelector( 'textarea' ) ).toBeNull();
+		} );
+
 		it( 'renders array fields as a closed multi-select', () => {
 			const arrayField: SettingsUIField = {
 				id: 'countries',
@@ -693,9 +795,7 @@ describe( 'dataform adapter', () => {
 				Array.from( select?.options ?? [] ).map( ( o ) => o.value )
 			).toEqual( [ 'FR', 'ES' ] );
 			// A closed control offers no free-text input.
-			expect(
-				container.querySelector( 'input[type="text"]' )
-			).toBeNull();
+			expect( container.querySelector( 'input' ) ).toBeNull();
 		} );
 
 		it( 'surfaces grouped validity through FieldValidity children', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -492,6 +492,79 @@ describe( 'dataform adapter', () => {
 
 			expect( field.isValid?.elements ).toBe( false );
 		} );
+
+		it( 'maps number range attributes to numeric constraints', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					type: 'number',
+					customAttributes: { min: '0', max: 100 },
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isValid?.min ).toBe( 0 );
+			expect( field.isValid?.max ).toBe( 100 );
+		} );
+
+		it( 'maps date range attributes as strings', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					type: 'date',
+					customAttributes: { min: '2026-01-01', max: '2026-12-31' },
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isValid?.min ).toBe( '2026-01-01' );
+			expect( field.isValid?.max ).toBe( '2026-12-31' );
+		} );
+
+		it( 'ignores range attributes on types without a range rule', () => {
+			const field = buildDataFormField(
+				{ ...textField, customAttributes: { min: '5', max: '10' } },
+				createOptions( [] )
+			);
+
+			expect( field.isValid?.min ).toBeUndefined();
+			expect( field.isValid?.max ).toBeUndefined();
+		} );
+
+		it( 'maps length and pattern attributes', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					customAttributes: {
+						minlength: 2,
+						maxlength: '10',
+						pattern: '[a-z]+',
+					},
+				},
+				createOptions( [] )
+			);
+
+			expect( field.isValid?.minLength ).toBe( 2 );
+			expect( field.isValid?.maxLength ).toBe( 10 );
+			expect( field.isValid?.pattern ).toBe( '[a-z]+' );
+		} );
+
+		it( 'honours a required attribute with presence semantics', () => {
+			const present = buildDataFormField(
+				{ ...textField, customAttributes: { required: 'required' } },
+				createOptions( [] )
+			);
+			expect( present.isValid?.required ).toBe( true );
+
+			const booleanFalse = buildDataFormField(
+				{ ...textField, customAttributes: { required: false } },
+				createOptions( [] )
+			);
+			expect( booleanFalse.isValid?.required ).toBeUndefined();
+
+			const absent = buildDataFormField( textField, createOptions( [] ) );
+			expect( absent.isValid?.required ).toBeUndefined();
+		} );
 	} );
 
 	describe( 'disabled state', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -219,9 +219,9 @@ describe( 'dataform adapter', () => {
 			);
 		} );
 
-		it( 'fails open with a warning when a predicate throws', () => {
-			const warnSpy = jest
-				.spyOn( console, 'warn' )
+		it( 'fails open and logs an error when a predicate throws', () => {
+			const errorSpy = jest
+				.spyOn( console, 'error' )
 				.mockImplementation( () => undefined );
 			registerSettingsExtension( {
 				scope: { page: 'test-page' },
@@ -237,7 +237,7 @@ describe( 'dataform adapter', () => {
 			);
 
 			expect( field.isVisible?.( {} ) ).toBe( true );
-			expect( warnSpy ).toHaveBeenCalledWith(
+			expect( errorSpy ).toHaveBeenCalledWith(
 				expect.stringContaining(
 					'Visibility predicate for field "test_field" failed.'
 				),
@@ -348,6 +348,36 @@ describe( 'dataform adapter', () => {
 
 			const hidden = adapter.getForm( { show: 'no', toggle: 'off' } );
 			expect( hidden.fields ).toEqual( [] );
+		} );
+
+		it( 'fails open and logs an error when a group predicate throws', () => {
+			const errorSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => undefined );
+			const adapter = createDataFormAdapter( {
+				schema: createSchema( [ textField ] ),
+				context,
+				initialValues: {},
+			} );
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				groupVisibility: {
+					general: () => {
+						throw new Error( 'broken predicate' );
+					},
+				},
+			} );
+
+			const form = adapter.getForm( {} );
+			expect(
+				form.fields?.map( ( f ) => ( f as { id: string } ).id )
+			).toEqual( [ 'general' ] );
+			expect( errorSpy ).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Visibility predicate for group "general" failed.'
+				),
+				expect.any( Object )
+			);
 		} );
 	} );
 

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -145,6 +145,22 @@ describe( 'dataform adapter', () => {
 			expect( container.textContent ).toContain( 'Read this' );
 		} );
 
+		it( 'maps field descriptions to sanitized help elements', () => {
+			const field = buildDataFormField(
+				{
+					...textField,
+					description:
+						'See the <a href="https://woocommerce.com">docs</a>.',
+				},
+				createOptions( [] )
+			);
+
+			const { container } = renderElement( <>{ field.description }</> );
+			const link = container.querySelector( 'a' );
+			expect( link?.textContent ).toBe( 'docs' );
+			expect( container.textContent ).toBe( 'See the docs.' );
+		} );
+
 		it( 'warns and maps an unknown type to a read-only field rendering nothing', () => {
 			const warnSpy = jest
 				.spyOn( console, 'warn' )

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -165,7 +165,7 @@ describe( 'dataform adapter', () => {
 			expect( container.textContent ).toBe( 'See the docs.' );
 		} );
 
-		it( 'warns and maps an unknown type to a read-only field rendering nothing', () => {
+		it( 'warns and leaves the control unset for an unknown type', () => {
 			const warnSpy = jest
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => undefined );
@@ -174,9 +174,10 @@ describe( 'dataform adapter', () => {
 				createOptions( [] )
 			);
 
-			expect( field.readOnly ).toBe( true );
+			expect( field.type ).toBeUndefined();
 			expect( field.Edit ).toBeUndefined();
-			expect( ( field.render as () => null )() ).toBeNull();
+			expect( field.render ).toBeUndefined();
+			expect( field.readOnly ).toBeUndefined();
 			expect( warnSpy ).toHaveBeenCalledWith(
 				expect.stringContaining(
 					'Field type "extension_defined" is not supported.'

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -244,6 +244,24 @@ describe( 'dataform adapter', () => {
 				expect.any( Object )
 			);
 		} );
+
+		it( 'applies a predicate registered after the field is built', () => {
+			const field = buildDataFormField(
+				textField,
+				createOptions( [ textField ] )
+			);
+			expect( field.isVisible?.( { other: 'hide' } ) ).toBe( true );
+
+			registerSettingsExtension( {
+				scope: { page: 'test-page' },
+				fieldVisibility: {
+					test_field: ( { values } ) => values.other === 'show',
+				},
+			} );
+
+			expect( field.isVisible?.( { other: 'hide' } ) ).toBe( false );
+			expect( field.isVisible?.( { other: 'show' } ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'form configuration', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -333,6 +333,34 @@ describe( 'dataform adapter', () => {
 		} );
 	} );
 
+	describe( 'disabled state', () => {
+		it( 'honours a disabled custom attribute with presence semantics', () => {
+			const attributeDisabled = buildDataFormField(
+				{ ...textField, customAttributes: { disabled: 'disabled' } },
+				createOptions( [] )
+			);
+			expect( attributeDisabled.isDisabled ).toBe( true );
+
+			const attributeFalse = buildDataFormField(
+				{ ...textField, customAttributes: { disabled: false } },
+				createOptions( [] )
+			);
+			expect( attributeFalse.isDisabled ).toBe( false );
+
+			const noAttribute = buildDataFormField(
+				textField,
+				createOptions( [] )
+			);
+			expect( noAttribute.isDisabled ).toBe( false );
+
+			const fieldDisabled = buildDataFormField(
+				{ ...textField, disabled: true },
+				createOptions( [] )
+			);
+			expect( fieldDisabled.isDisabled ).toBe( true );
+		} );
+	} );
+
 	describe( 'mounted DataForm behaviour', () => {
 		it( 'honours isDisabled on package controls', () => {
 			const enabledField: SettingsUIField = {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -120,12 +120,13 @@ describe( 'dataform adapter', () => {
 			expect( field.elements ).toEqual( options );
 		} );
 
-		it( 'renders info fields read-only through the native renderer', () => {
+		it( 'renders info fields read-only with only the sanitized description', () => {
 			const infoField: SettingsUIField = {
 				id: 'info_field',
 				label: 'Read this',
 				type: 'info',
-				description: 'Useful <strong>information</strong>.',
+				description:
+					'Useful <strong>information</strong>.<script>alert(1)</script>',
 			};
 			const field = buildDataFormField(
 				infoField,
@@ -142,7 +143,10 @@ describe( 'dataform adapter', () => {
 			expect(
 				container.querySelector( '.wc-settings-ui__info' )
 			).not.toBeNull();
-			expect( container.textContent ).toContain( 'Read this' );
+			expect( container.textContent ).toContain( 'Useful information.' );
+			expect( container.querySelector( 'script' ) ).toBeNull();
+			// DataForm owns the label for read-only fields.
+			expect( container.textContent ).not.toContain( 'Read this' );
 		} );
 
 		it( 'maps field descriptions to sanitized help elements', () => {
@@ -463,6 +467,32 @@ describe( 'dataform adapter', () => {
 					( input ) => input.value === 'b' && input.disabled
 				)
 			).toBe( true );
+		} );
+
+		it( 'shows an info field title exactly once', () => {
+			const infoField: SettingsUIField = {
+				id: 'info_field',
+				label: 'Read this',
+				type: 'info',
+				description: 'Useful <strong>information</strong>.',
+			};
+			const options = createOptions( [ infoField ] );
+			const adapter = createDataFormAdapter( options );
+			const data = {};
+
+			const { container } = renderElement(
+				<DataForm
+					data={ data }
+					fields={ adapter.fields }
+					form={ adapter.getForm( data ) }
+					onChange={ () => undefined }
+				/>
+			);
+
+			expect( container.textContent?.match( /Read this/g ) ).toHaveLength(
+				1
+			);
+			expect( container.textContent ).toContain( 'Useful information.' );
 		} );
 
 		it( 'surfaces grouped validity through FieldValidity children', () => {

--- a/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
+++ b/packages/js/settings-ui/src/test/dataform-adapter.test.tsx
@@ -527,7 +527,7 @@ describe( 'dataform adapter', () => {
 	} );
 
 	describe( 'validation rules', () => {
-		it( 'keeps the closed elements rule opt-in for option fields', () => {
+		it( 'leaves closed elements validation to DataForm', () => {
 			const field = buildDataFormField(
 				{
 					...textField,
@@ -540,7 +540,7 @@ describe( 'dataform adapter', () => {
 				createOptions( [] )
 			);
 
-			expect( field.isValid?.elements ).toBe( false );
+			expect( field.isValid?.elements ).toBeUndefined();
 		} );
 
 		it( 'maps number range attributes to numeric constraints', () => {

--- a/packages/js/settings-ui/src/values.ts
+++ b/packages/js/settings-ui/src/values.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import type { SettingsValue } from './types';
+
+export const areValuesEqual = ( a: SettingsValue, b: SettingsValue ) => {
+	if ( Array.isArray( a ) || Array.isArray( b ) ) {
+		return (
+			Array.isArray( a ) &&
+			Array.isArray( b ) &&
+			a.length === b.length &&
+			a.every( ( value, index ) => value === b[ index ] )
+		);
+	}
+
+	return a === b;
+};
+
+export const valueMatchesVisibilityRule = (
+	value: SettingsValue,
+	expected: SettingsValue | SettingsValue[] | undefined
+) => {
+	const expectedValues = Array.isArray( expected )
+		? expected
+		: [ expected ?? true ];
+
+	return expectedValues.some( ( expectedValue ) =>
+		areValuesEqual( value, expectedValue )
+	);
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

DataForm requires one field list plus a form config with groups as combined card fields. The schema arrives from PHP as JSON, so a JS module has to build the functions DataForm needs. This PR adds that module to `@woocommerce/settings-ui` as a private `dataform-adapter`. Nothing imports it yet, so the shipped bundle and rendered output are unchanged. Wiring the renderer to it is the follow-up.

- Map each built-in field type to a DataForm type and edit control. Options become `elements`, `field.disabled` becomes `isDisabled`.
- Map visibility rules and predicates to `isVisible`. A throwing predicate fails open.
- Build groups as combined card fields, dropped when a predicate or field visibility hides them.
- Mount DataForm in two tests to confirm controls honour `isDisabled` and grouped validity reaches fields through `FieldValidity.children` (shown once a control is touched).

Two things are left out on purpose: value coercion (the PHP schema builder is taking over canonicalisation) and extension component resolution (the renderer wiring owns how components attach).

### How to test the changes in this Pull Request:

1. From the repository root, run `pnpm --filter=@woocommerce/settings-ui test:js`.
2. Run `pnpm --filter=@woocommerce/settings-ui lint:lang:types` and confirm it passes.
3. With the `settings-ui` feature enabled, load WooCommerce > Settings > Products and confirm there is no visible change from trunk.

### Testing that has already taken place:

- Smoke tested in a browser with the adapter temporarily exported: the real Products schema mapped to 11 fields and 3 card groups, a checkbox toggle stayed boolean, and a select change stayed a string.
- The built asset from this branch does not contain the adapter, and the Products settings page renders the same as trunk.
- The bundled DataViews select control logs a React key warning that appears without this change too. This is tracked separately.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually for `@woocommerce/settings-ui`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This PR was written with the assistance of Claude Code. I reviewed the code and ran the testing described above.
