### PR TITLE
Move role column to end of customers report table for consistent CSV order

### DIFF
--- a/plugins/woocommerce/changelog/role-column-last-in-customers-table
+++ b/plugins/woocommerce/changelog/role-column-last-in-customers-table
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Aligns the browser-side Customers CSV with the server export order from #67843; the Role column feature (#67653) is unreleased so no shipped behavior changes.
+
+

--- a/plugins/woocommerce/client/admin/client/analytics/report/customers/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/customers/table.js
@@ -35,6 +35,11 @@ function CustomersReportTable( {
 		};
 	} );
 
+	// This order is also the browser-side CSV export order (ReportTable exports
+	// the table as-is when the report fits one page), so it must match
+	// Controller::get_export_columns() in
+	// src/Admin/API/Reports/Customers/Controller.php, which the same Download
+	// button uses for larger reports. New columns go last in both.
 	const getHeadersContent = () => {
 		return [
 			{
@@ -48,10 +53,6 @@ function CustomersReportTable( {
 				label: __( 'Username', 'woocommerce' ),
 				key: 'username',
 				hiddenByDefault: true,
-			},
-			{
-				label: __( 'Role', 'woocommerce' ),
-				key: 'role',
 			},
 			{
 				label: __( 'Last active', 'woocommerce' ),
@@ -118,6 +119,10 @@ function CustomersReportTable( {
 				label: __( 'Shipping phone', 'woocommerce' ),
 				key: 'shipping_phone',
 				hiddenByDefault: true,
+			},
+			{
+				label: __( 'Role', 'woocommerce' ),
+				key: 'role',
 			},
 		];
 	};
@@ -207,10 +212,6 @@ function CustomersReportTable( {
 					value: username,
 				},
 				{
-					display: role,
-					value: role,
-				},
-				{
 					display: dateLastActiveDisplay,
 					value: dateLastActive,
 				},
@@ -261,6 +262,10 @@ function CustomersReportTable( {
 				{
 					display: shippingPhone,
 					value: shippingPhone,
+				},
+				{
+					display: role,
+					value: role,
 				},
 			];
 		} );

--- a/plugins/woocommerce/client/admin/client/analytics/report/customers/test/table.test.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/customers/test/table.test.js
@@ -71,8 +71,30 @@ const baseCustomer = {
 	country: '',
 };
 
-// Country cell is the 10th column (0-indexed: 9) per getHeadersContent in table.js.
-const COUNTRY_COL = 9;
+// getHeadersContent in table.js, in order. This is also the browser-side CSV
+// export order, so it must match Controller::get_export_columns() in
+// src/Admin/API/Reports/Customers/Controller.php.
+const HEADER_KEYS = [
+	'name',
+	'username',
+	'date_last_active',
+	'date_registered',
+	'email',
+	'orders_count',
+	'total_spend',
+	'avg_order_value',
+	'country',
+	'city',
+	'state',
+	'postcode',
+	'billing_phone',
+	'shipping_phone',
+	'role',
+];
+
+const col = ( key ) => HEADER_KEYS.indexOf( key );
+
+const COUNTRY_COL = col( 'country' );
 
 function getCountryCell( customer ) {
 	captured.getRowsContent = null;
@@ -160,10 +182,63 @@ describe( 'CustomersReportTable country cell', () => {
 	} );
 } );
 
+describe( 'CustomersReportTable column order', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// The same Download button exports the table client-side for single-page
+	// reports and server-side for larger ones, so drift between the two orders
+	// makes identical reports produce differently ordered CSVs.
+	it( 'keeps the header order in sync with the server-side CSV export', () => {
+		mockCountriesStore( [] );
+		captured.getHeadersContent = null;
+		render( <CustomersReportTable query={ {} } /> );
+
+		expect(
+			captured.getHeadersContent().map( ( header ) => header.key )
+		).toEqual( HEADER_KEYS );
+	} );
+
+	it( 'emits every cell under its own header', () => {
+		mockCountriesStore( [] );
+		captured.getRowsContent = null;
+		render( <CustomersReportTable query={ {} } /> );
+
+		// One distinct value per field, so a cell landing under the wrong
+		// header surfaces as a mismatch instead of passing by coincidence.
+		const customer = {
+			name: 'Alice',
+			username: 'alice',
+			date_last_active: '2026-08-01T00:00:00',
+			date_registered: '2026-07-01T00:00:00',
+			email: 'alice@example.com',
+			orders_count: 7,
+			total_spend: 123,
+			avg_order_value: 45,
+			country: 'FR',
+			city: 'Paris',
+			state: 'IDF',
+			postcode: '75001',
+			billing_phone: '555-32123',
+			shipping_phone: '555-99887',
+			role: 'Customer',
+		};
+
+		const row = captured.getRowsContent( [ customer ] )[ 0 ];
+
+		expect( row ).toHaveLength( HEADER_KEYS.length );
+		expect(
+			Object.fromEntries(
+				HEADER_KEYS.map( ( key, index ) => [ key, row[ index ].value ] )
+			)
+		).toEqual( customer );
+	} );
+} );
+
 describe( 'CustomersReportTable phone cells', () => {
-	// Phone cells are the last two columns per getHeadersContent in table.js.
-	const BILLING_PHONE_COL = 13;
-	const SHIPPING_PHONE_COL = 14;
+	const BILLING_PHONE_COL = col( 'billing_phone' );
+	const SHIPPING_PHONE_COL = col( 'shipping_phone' );
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -193,6 +268,5 @@ describe( 'CustomersReportTable phone cells', () => {
 
 		expect( headers[ BILLING_PHONE_COL ].key ).toBe( 'billing_phone' );
 		expect( headers[ SHIPPING_PHONE_COL ].key ).toBe( 'shipping_phone' );
-		expect( headers ).toHaveLength( SHIPPING_PHONE_COL + 1 );
 	} );
 } );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -751,6 +751,10 @@ class Controller extends GenericController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
+		// Appending keeps positional consumers of the released columns working, and
+		// this order must match getHeadersContent() in
+		// client/admin/client/analytics/report/customers/table.js, which produces the
+		// browser-side CSV for single-page reports from the same Download button.
 		$export_columns = array(
 			'name'            => __( 'Name', 'woocommerce' ),
 			'username'        => __( 'Username', 'woocommerce' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -257,7 +257,6 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$export_columns = $controller->get_export_columns();
 		$this->assertArrayHasKey( 'role', $export_columns, 'CSV export should include a role column' );
 		$this->assertEquals( 'Role', $export_columns['role'] );
-		$this->assertSame( 'role', array_key_last( $export_columns ), 'Role must stay the last CSV column so positional consumers of the pre-existing columns are unaffected' );
 
 		$export_roles_by_user_id = array();
 		foreach ( $reports as $report ) {
@@ -268,6 +267,39 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'Editor, Shop manager', $export_roles_by_user_id[ $editor_id ], 'CSV export should carry the role value' );
 		$this->assertSame( '', $export_roles_by_user_id[0], 'CSV export should leave the role empty for guests' );
+	}
+
+	/**
+	 * The same Download button exports single-page reports in the browser from the
+	 * table column order and larger ones from here, so the two must not drift.
+	 *
+	 * @testdox Should keep the CSV export column order in sync with the report table.
+	 */
+	public function test_export_column_order_matches_report_table() {
+		// Mirrors getHeadersContent() in
+		// client/admin/client/analytics/report/customers/table.js. Keys differ
+		// between the two, the order must not.
+		$expected_order = array(
+			'name',
+			'username',
+			'last_active',
+			'registered',
+			'email',
+			'orders_count',
+			'total_spend',
+			'avg_order_value',
+			'country',
+			'city',
+			'region',
+			'postcode',
+			'billing_phone',
+			'shipping_phone',
+			'role',
+		);
+
+		$controller = new \Automattic\WooCommerce\Admin\API\Reports\Customers\Controller();
+
+		$this->assertSame( $expected_order, array_keys( $controller->get_export_columns() ), 'New CSV columns must be appended, and table.js must be updated to match' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

The Customers report Download button has two CSV paths: single-page reports are exported in the browser from the table column order, larger ones are exported server-side from `Controller::get_export_columns()`. #67843 moved Role to the end of the server list but left the table at position 3, so the same button produced two different column orders. This moves Role to the end of the table too, matching where billing/shipping phone were appended in #67641.

There is no shared source of truth between the PHP list and the JS one, so the best available guard is a tripwire: each list now carries a comment naming the other, and each side pins its own full column order in a test. Editing one list fails that side's test, which points at the other file. Editing both lists in the same way still passes, so the comments are doing real work here.

Bug introduced in PR #67843. Reported in WOOAIRR-96.

BC note: none. The Role column (#67653) is unreleased, and the pre-existing columns keep the positions they have in 11.0.1.

### Screenshots or screen recordings:

| Before (role third column) | After (role last column) | After (role not in first columns) |
| ------ | ----- | - |
| <img width="1292" height="951" alt="wooairr-96-before-role-third-column" src="https://github.com/user-attachments/assets/1894a3f1-5b4a-4de8-9ede-d4dbc4cfd8c1" /> | <img width="1292" height="951" alt="wooairr-96-after-role-last-column" src="https://github.com/user-attachments/assets/b958d1b7-449c-4e79-a87f-398b0848e9fb" /> | <img width="1292" height="951" alt="wooairr-96-after-role-not-in-first-columns" src="https://github.com/user-attachments/assets/6f54d1f7-d7bd-4318-a8b7-91bb918e5e01" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a store with 25 or fewer customers, go to WooCommerce > Analytics > Customers and click Download. The CSV downloads in the browser.
2. Verify the header row ends with `Role` and the columns before it are in the pre-#67653 order (Name, Username, Last active, ... Billing phone, Shipping phone).
3. On a store with more than 25 customers, click Download to get the emailed server-side export, and verify its header ends with `Role` in the same way.

<!-- End testing instructions -->

### Testing that has already taken place:

-   `WC_Admin_Tests_API_Reports_Customers` (33 tests) and the customers `table.test.js` suite (9 tests) pass, including the two new column-order assertions.
-   Checked the table in the browser on a local store before and after; phpcs, PHPStan and ESLint clean on the changed files.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Comment-only changelog entry included (`plugins/woocommerce/changelog/role-column-last-in-customers-table`), since the Role column ships unreleased in this same cycle and its entry from #67653 already describes the behavior.

### Use of AI Tools

Authored with the assistance of Claude Code; reviewed and tested by me.

