### PR TITLE
Restore recently viewed widget filter compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-97-restore-recently-viewed-query-ids
+++ b/plugins/woocommerce/changelog/fix-wooairr-97-restore-recently-viewed-query-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the full Recently Viewed Products cookie ID list for widget query filters to preserve extension compatibility.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-recently-viewed.php
@@ -51,7 +51,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$viewed_products = ! empty( $_COOKIE['woocommerce_recently_viewed'] ) ? (array) explode( '|', wp_unslash( $_COOKIE['woocommerce_recently_viewed'] ) ) : array(); // @codingStandardsIgnoreLine
-		$viewed_products = array_slice( array_reverse( array_filter( array_map( 'absint', $viewed_products ) ) ), 0, 15 );
+		$viewed_products = array_reverse( array_filter( array_map( 'absint', $viewed_products ) ) );
 
 		if ( empty( $viewed_products ) ) {
 			return;
@@ -71,7 +71,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Recently viewed product IDs are capped at 15.
+			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Required to exclude hidden out-of-stock products from the recently viewed widget.
 				array(
 					'taxonomy' => 'product_visibility',
 					'field'    => 'name',

--- a/plugins/woocommerce/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
@@ -66,9 +66,9 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Should limit recently viewed widget queries from oversized cookies.
+	 * @testdox Should preserve extension-provided recently viewed cookie IDs in widget queries.
 	 */
-	public function test_recently_viewed_widget_query_limits_oversized_cookie(): void {
+	public function test_recently_viewed_widget_query_preserves_extension_cookie_ids(): void {
 		$viewed_product_ids = range( 1, 20 );
 		$query_args         = array();
 		$query_args_filter  = static function ( $args ) use ( &$query_args ) {
@@ -82,19 +82,19 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_recently_viewed_products_widget_query_args', $query_args_filter );
 
 		try {
-			$widget = new WC_Widget_Recently_Viewed();
+			$sut = new WC_Widget_Recently_Viewed();
 
 			ob_start();
 			try {
-				$widget->widget( array(), array() );
+				$sut->widget( array(), array() );
 			} finally {
 				ob_end_clean();
 			}
 
 			$this->assertSame(
-				array_slice( array_reverse( $viewed_product_ids ), 0, 15 ),
+				array_reverse( $viewed_product_ids ),
 				$query_args['post__in'],
-				'An oversized recently viewed cookie should only send the 15 newest product IDs to the query.'
+				'The recently viewed widget query should preserve every product ID provided through the shared cookie.'
 			);
 		} finally {
 			remove_filter( 'woocommerce_recently_viewed_products_widget_query_args', $query_args_filter );


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The cap added in #67825 truncates the sanitized `woocommerce_recently_viewed` ID list before the public `woocommerce_recently_viewed_products_widget_query_args` filter runs. WordPress.org plugins legitimately write up to 30 IDs to that shared cookie, so filter callbacks can no longer inspect or select older extension-provided IDs.

Restore the complete sanitized, newest-first cookie list to the widget query and public filter. Retain the exact line-scoped `WordPress.DB.SlowDBQuery.slow_db_query_tax_query` suppression on the out-of-stock taxonomy assignment with a reason that remains true without the cap.

Bug introduced in PR #67825.

Compatibility: this restores the filter payload that existed before #67825 without changing the hook signature or execution point. Normal WooCommerce browsing remains unchanged because the core tracker retains 15 IDs. Extensions that write more than 15 IDs to the shared cookie can again expose the complete list through `post__in`; `posts_per_page` still controls how many products the query returns. The change does not modify stored site or network data and has no multisite or install-layout implications.

Ecosystem evidence: a [Veloria shared-cookie writer search](https://veloria.dev/search/d78e3a21-9fee-4276-a3dd-44d43dbc423f) found public plugins that retain up to 30 IDs, and an [exact public-filter search](https://veloria.dev/search/197eb196-8781-4e20-bd8f-6236e4ebe8c9) found callbacks that modify the recently viewed query. This makes the affected input reachable through extension behavior rather than only manual cookie mutation.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/):

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter WC_Tests_Widget::test_recently_viewed_widget_query_preserves_extension_cookie_ids`.
2. Confirm the test passes. It supplies 20 IDs through the shared cookie and verifies that the query filter receives all 20 in newest-first order.
3. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` and `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch`.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused Docker PHPUnit regression passed with PHP 8.1: 1 test, 1 assertion.
- Targeted PHPStan passed for `class-wc-widget-recently-viewed.php`.
- PHP syntax and `git diff --check` passed.
- Targeted SlowDBQuery PHPCS passed normally. With annotations ignored, it exposed exactly the expected `WordPress.DB.SlowDBQuery.slow_db_query_tax_query` warning on the retained directive.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed after commit against the complete branch diff.
- Veloria's indexed WordPress.org corpus was searched for literal shared-cookie writers and public-filter consumers; the linked searches provide the public evidence.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g., for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI tooling assisted with implementation, ecosystem research, testing, and PR drafting. The changes and evidence were reviewed before submission.
