### PR TITLE
Rename patterns category from 'WooCommerce' to 'Shop'

### DIFF
--- a/plugins/woocommerce/changelog/update-patterns-category-name
+++ b/plugins/woocommerce/changelog/update-patterns-category-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Rename patterns category from WooCommerce to Shop

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -19,7 +19,7 @@ class PatternRegistry {
 	 */
 	private function get_category_labels() {
 		return [
-			'woo-commerce'     => __( 'WooCommerce', 'woocommerce' ),
+			'woo-commerce'     => __( 'Shop', 'woocommerce' ),
 			'intro'            => __( 'Intro', 'woocommerce' ),
 			'featured-selling' => __( 'Featured Selling', 'woocommerce' ),
 			'about'            => __( 'About', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOTHME-482.

This PR renames the _WooCommerce_ pattern category to _Shop_.

### How to test the changes in this Pull Request:

1. Create a post or page.
2. Open the inserter.
3. Verify there is no _WooCommerce_ category and instead there is _Shop_.

Before | After
--- | ---
<img width="468" height="421" alt="imatge" src="https://github.com/user-attachments/assets/eab42d0e-f904-4636-b98f-3d87bd4ec4f7" /> | <img width="468" height="421" alt="imatge" src="https://github.com/user-attachments/assets/c99169e6-a24b-4005-a81b-d1e62b9ad345" />

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->