### PR TITLE
Keep the Analytics range end when the date format uses a localized moment token

### DIFF
--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -176,21 +176,28 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 }
 
 /**
- * Swaps the day of month token of a moment format string for an escaped literal.
+ * Prefixes the day of month token of a moment format string with an escaped literal.
  *
  * Substituting in the format instead of in the formatted date keeps the value
  * away from the rest of the localized output: Japanese renders October as
  * "10月", where replacing the day "1" lands on the month instead, and locales
  * with non-Latin digits never match a Latin day number at all.
  *
- * @param {string}   format      - localized date string format
- * @param {Function} replacement - builds the literal text to render in place of
- *                               the day, from the token it replaces
+ * The token is kept rather than consumed because moment picks the genitive or
+ * the nominative month name by testing the format string for a day token next
+ * to the month one. Locales disagree on what may sit between the two: the
+ * default `MONTHS_IN_FORMAT` accepts a bracketed literal, Catalan accepts only
+ * whitespace, and Polish matches "D MMMM" outright. Leaving the day token and
+ * its separator untouched is what every one of them recognizes.
+ *
+ * @param {string}   format - localized date string format
+ * @param {Function} prefix - builds the literal text to render before the day,
+ *                          from the token it precedes
  * @return {string|null} - format string, or null when it holds no day token
  */
-function replaceDayToken(
+function prefixDayToken(
 	format: string,
-	replacement: ( dayToken: string ) => string
+	prefix: ( dayToken: string ) => string
 ) {
 	let replaced = false;
 	// Backslash escapes and bracketed sections are moment's literals, so a "D"
@@ -213,7 +220,7 @@ function replaceDayToken(
 			}
 
 			replaced = true;
-			return `[${ replacement( token ) }]`;
+			return `[${ prefix( token ) }]${ token }`;
 		}
 	);
 
@@ -237,21 +244,23 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 	if ( isSameDay ) {
 		return after.format( fullDateFormat );
 	} else if ( isSameMonth ) {
-		// Formatting each day through the token it replaces keeps whatever the
-		// format asked for, such as the zero padding of "DD" or the ordinal of "Do".
-		const dayRangeFormat = replaceDayToken(
+		// Formatting the start day through the token it precedes keeps whatever
+		// the format asked for, such as the zero padding of "DD" or the ordinal
+		// of "Do". The token itself renders the end day, so the range is
+		// formatted through `before`; both dates share the month and the year
+		// here, so nothing else in the label moves.
+		const dayRangeFormat = prefixDayToken(
 			expandLocalizedFormat( fullDateFormat, after.localeData() ),
-			( dayToken ) =>
-				`${ after.format( dayToken ) } - ${ before.format( dayToken ) }`
+			( dayToken ) => `${ after.format( dayToken ) } - `
 		);
 
-		// No day of month token to swap: the format omits the day altogether,
+		// No day of month token to prefix: the format omits the day altogether,
 		// so the shared month is as much of the range as it can carry.
 		if ( dayRangeFormat === null ) {
 			return after.format( fullDateFormat );
 		}
 
-		return after.format( dayRangeFormat );
+		return before.format( dayRangeFormat );
 	} else if ( isSameYear ) {
 		const monthDayFormat = __( 'MMM D', 'woocommerce' );
 		return `${ after.format( monthDayFormat ) } - ${ before.format(

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -197,8 +197,10 @@ function escapeMonthName(
 	localeData: moment.Locale
 ) {
 	// Backslash escapes and bracketed sections are moment's literals, so an "M"
-	// inside one is text. "MM" and "M" render digits, which carry no grammar.
-	return format.replace( /\\.|\[[^\]]*\]|M{3,4}/g, ( token ) => {
+	// inside one is text. A backslash escapes the whole token that follows it,
+	// not just its first character. "MM" and "M" render digits, which carry no
+	// grammar.
+	return format.replace( /\\M{1,4}|\\.|\[[^\]]*\]|M{3,4}/g, ( token ) => {
 		if ( ! token.startsWith( 'M' ) ) {
 			return token;
 		}
@@ -231,9 +233,10 @@ function replaceDayToken(
 ) {
 	let replaced = false;
 	// Backslash escapes and bracketed sections are moment's literals, so a "D"
-	// inside one is text.
+	// inside one is text. A backslash escapes the whole token that follows it,
+	// not just its first character.
 	const dayRangeFormat = format.replace(
-		/\\.|\[[^\]]*\]|D+o?/g,
+		/\\D+o?|\\.|\[[^\]]*\]|D+o?/g,
 		( token ) => {
 			// Runs longer than "DD" are day of year tokens, not day of month.
 			const dayDigits = token.endsWith( 'o' )

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -151,7 +151,7 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 	// Bracketed sections and backslash escapes are moment's literals, so an "L"
 	// inside one is text; matching them first leaves them untouched, as
 	// `longDateFormat` has no entry for them.
-	const localizedTokens = /(\[[^[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
+	const localizedTokens = /\[[^[]*\]|\\?(?:LTS|LT|LL?L?L?|l{1,4})/g;
 	let expanded = format;
 	// An expansion can itself hold localized tokens; moment allows six passes.
 	let passes = 6;

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -144,7 +144,8 @@ export function toMoment( format: string, str: unknown ) {
  *
  * @param {string}        format     - localized date string format
  * @param {moment.Locale} localeData - locale the format will be rendered with
- * @return {string} - format string with no localized format tokens left
+ * @return {string} - format string with its localized tokens expanded, leaving
+ *                      escaped and bracketed ones as the literals they are
  */
 function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 	// Bracketed sections and backslash escapes are moment's literals, so an "L"

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -176,28 +176,58 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 }
 
 /**
- * Prefixes the day of month token of a moment format string with an escaped literal.
+ * Renders the month name of a moment format string into an escaped literal.
+ *
+ * Moment picks between the genitive and the nominative month name by testing
+ * the format string for a day token next to the month one, and locales disagree
+ * on what may sit between the two: the default `MONTHS_IN_FORMAT` accepts a
+ * bracketed literal, Catalan accepts only whitespace, and Polish matches
+ * "D MMMM" outright. Rendering the name here, against the format as the locale
+ * received it, resolves that choice before the day token is substituted, so
+ * whatever shape the substitution leaves behind can no longer change it.
+ *
+ * @param {string}        format     - localized date string format
+ * @param {moment.Moment} date       - date whose month name to render
+ * @param {moment.Locale} localeData - locale the format will be rendered with
+ * @return {string} - format string with its month name tokens escaped
+ */
+function escapeMonthName(
+	format: string,
+	date: moment.Moment,
+	localeData: moment.Locale
+) {
+	// Backslash escapes and bracketed sections are moment's literals, so an "M"
+	// inside one is text. "MM" and "M" render digits, which carry no grammar.
+	return format.replace( /\\.|\[[^\]]*\]|M{3,4}/g, ( token ) => {
+		if ( ! token.startsWith( 'M' ) ) {
+			return token;
+		}
+
+		const name =
+			token.length === 4
+				? localeData.months( date, format )
+				: localeData.monthsShort( date, format );
+
+		return `[${ name }]`;
+	} );
+}
+
+/**
+ * Swaps the day of month token of a moment format string for an escaped literal.
  *
  * Substituting in the format instead of in the formatted date keeps the value
  * away from the rest of the localized output: Japanese renders October as
  * "10月", where replacing the day "1" lands on the month instead, and locales
  * with non-Latin digits never match a Latin day number at all.
  *
- * The token is kept rather than consumed because moment picks the genitive or
- * the nominative month name by testing the format string for a day token next
- * to the month one. Locales disagree on what may sit between the two: the
- * default `MONTHS_IN_FORMAT` accepts a bracketed literal, Catalan accepts only
- * whitespace, and Polish matches "D MMMM" outright. Leaving the day token and
- * its separator untouched is what every one of them recognizes.
- *
- * @param {string}   format - localized date string format
- * @param {Function} prefix - builds the literal text to render before the day,
- *                          from the token it precedes
+ * @param {string}   format      - localized date string format
+ * @param {Function} replacement - builds the literal text to render in place of
+ *                               the day, from the token it replaces
  * @return {string|null} - format string, or null when it holds no day token
  */
-function prefixDayToken(
+function replaceDayToken(
 	format: string,
-	prefix: ( dayToken: string ) => string
+	replacement: ( dayToken: string ) => string
 ) {
 	let replaced = false;
 	// Backslash escapes and bracketed sections are moment's literals, so a "D"
@@ -220,7 +250,7 @@ function prefixDayToken(
 			}
 
 			replaced = true;
-			return `[${ prefix( token ) }]${ token }`;
+			return `[${ replacement( token ) }]`;
 		}
 	);
 
@@ -244,23 +274,28 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 	if ( isSameDay ) {
 		return after.format( fullDateFormat );
 	} else if ( isSameMonth ) {
-		// Formatting the start day through the token it precedes keeps whatever
-		// the format asked for, such as the zero padding of "DD" or the ordinal
-		// of "Do". The token itself renders the end day, so the range is
-		// formatted through `before`; both dates share the month and the year
-		// here, so nothing else in the label moves.
-		const dayRangeFormat = prefixDayToken(
-			expandLocalizedFormat( fullDateFormat, after.localeData() ),
-			( dayToken ) => `${ after.format( dayToken ) } - `
+		// Formatting each day through the token it replaces keeps whatever the
+		// format asked for, such as the zero padding of "DD" or the ordinal of "Do".
+		// Everything else still renders from `after`, so a weekday, week number
+		// or time in the format stays the one the range starts on.
+		const localeData = after.localeData();
+		const dayRangeFormat = replaceDayToken(
+			escapeMonthName(
+				expandLocalizedFormat( fullDateFormat, localeData ),
+				after,
+				localeData
+			),
+			( dayToken ) =>
+				`${ after.format( dayToken ) } - ${ before.format( dayToken ) }`
 		);
 
-		// No day of month token to prefix: the format omits the day altogether,
+		// No day of month token to swap: the format omits the day altogether,
 		// so the shared month is as much of the range as it can carry.
 		if ( dayRangeFormat === null ) {
 			return after.format( fullDateFormat );
 		}
 
-		return before.format( dayRangeFormat );
+		return after.format( dayRangeFormat );
 	} else if ( isSameYear ) {
 		const monthDayFormat = __( 'MMM D', 'woocommerce' );
 		return `${ after.format( monthDayFormat ) } - ${ before.format(

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -134,6 +134,47 @@ export function toMoment( format: string, str: unknown ) {
 }
 
 /**
+ * Expands moment's localized format tokens ("L", "LL", "ll", ...) into the
+ * underlying format the locale defines for them.
+ *
+ * Moment resolves those tokens only while formatting, so a day rendered through
+ * one is invisible to the day token scan below and the range end would be
+ * dropped. This mirrors moment's own expansion, including its pass limit, so
+ * the expanded format renders exactly what the original one would.
+ *
+ * @param {string}        format     - localized date string format
+ * @param {moment.Locale} localeData - locale the format will be rendered with
+ * @return {string} - format string with no localized format tokens left
+ */
+function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
+	// Bracketed sections and backslash escapes are moment's literals, so an "L"
+	// inside one is text; matching them first leaves them untouched, as
+	// `longDateFormat` has no entry for them.
+	const localizedTokens = /(\[[^[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
+	let expanded = format;
+	let passes = 5;
+
+	// An expansion can itself hold localized tokens.
+	while ( passes-- > 0 ) {
+		localizedTokens.lastIndex = 0;
+
+		if ( ! localizedTokens.test( expanded ) ) {
+			break;
+		}
+
+		expanded = expanded.replace(
+			localizedTokens,
+			( token ) =>
+				localeData.longDateFormat(
+					token as moment.LongDateFormatKey
+				) || token
+		);
+	}
+
+	return expanded;
+}
+
+/**
  * Swaps the day of month token of a moment format string for an escaped literal.
  *
  * Substituting in the format instead of in the formatted date keeps the value
@@ -198,15 +239,13 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 		// Formatting each day through the token it replaces keeps whatever the
 		// format asked for, such as the zero padding of "DD" or the ordinal of "Do".
 		const dayRangeFormat = replaceDayToken(
-			fullDateFormat,
+			expandLocalizedFormat( fullDateFormat, after.localeData() ),
 			( dayToken ) =>
 				`${ after.format( dayToken ) } - ${ before.format( dayToken ) }`
 		);
 
-		// No day of month token to swap: the format either omits the day, or
-		// renders one through an aggregate token such as "LL" that is not
-		// scanned. Either way the shared month is as much of the range as this
-		// format can carry.
+		// No day of month token to swap: the format omits the day altogether,
+		// so the shared month is as much of the range as it can carry.
 		if ( dayRangeFormat === null ) {
 			return after.format( fullDateFormat );
 		}

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -186,6 +186,9 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
  * received it, resolves that choice before the day token is substituted, so
  * whatever shape the substitution leaves behind can no longer change it.
  *
+ * Weekday names can be format-sensitive the same way, but no shipped locale
+ * keys that choice on the day token, so they are left for moment to render.
+ *
  * @param {string}        format     - localized date string format
  * @param {moment.Moment} date       - date whose month name to render
  * @param {moment.Locale} localeData - locale the format will be rendered with

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -296,8 +296,9 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 				`${ after.format( dayToken ) } - ${ before.format( dayToken ) }`
 		);
 
-		// No day of month token to swap: the format omits the day altogether,
-		// so the shared month is as much of the range as it can carry.
+		// No day of month token to swap: the format either omits the day or
+		// holds only a day of year token, which is left alone. Either way the
+		// shared month is as much of the range as this format can carry.
 		if ( dayRangeFormat === null ) {
 			return after.format( fullDateFormat );
 		}

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -237,9 +237,10 @@ function replaceDayToken(
 	let replaced = false;
 	// Backslash escapes and bracketed sections are moment's literals, so a "D"
 	// inside one is text. A backslash escapes the whole token that follows it,
-	// not just its first character.
+	// not just its first character; the escaped alternatives mirror moment's
+	// own day tokens, so a longer run of "D"s leaves the rest live.
 	const dayRangeFormat = format.replace(
-		/\\D+o?|\\.|\[[^\]]*\]|D+o?/g,
+		/\\(?:Do|DDDo|DD?D?D?)|\\.|\[[^\]]*\]|D+o?/g,
 		( token ) => {
 			// Runs longer than "DD" are day of year tokens, not day of month.
 			const dayDigits = token.endsWith( 'o' )

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -176,45 +176,60 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 }
 
 /**
- * Renders the month name of a moment format string into an escaped literal.
+ * Renders the month and weekday names of a moment format string into escaped
+ * literals.
  *
- * Moment picks between the genitive and the nominative month name by testing
- * the format string for a day token next to the month one, and locales disagree
- * on what may sit between the two: the default `MONTHS_IN_FORMAT` accepts a
- * bracketed literal, Catalan accepts only whitespace, and Polish matches
- * "D MMMM" outright. Rendering the name here, against the format as the locale
- * received it, resolves that choice before the day token is substituted, so
- * whatever shape the substitution leaves behind can no longer change it.
- *
- * Weekday names can be format-sensitive the same way, but no shipped locale
- * keys that choice on the day token, so they are left for moment to render.
+ * Moment picks the grammatical form of both names by pattern-testing the
+ * format string while rendering: month choosers look for a day token next to
+ * the month one, and Ukrainian renders the genitive weekday whenever a
+ * bracketed literal sits before "dddd" - exactly the shape the substitutions
+ * here leave behind. Months and weekdays are the only tokens moment resolves
+ * against the format, so rendering every name in one pass, against the format
+ * as the locale received it, settles each choice before any substitution can
+ * flip one.
  *
  * @param {string}        format     - localized date string format
- * @param {moment.Moment} date       - date whose month name to render
+ * @param {moment.Moment} date       - date whose month and weekday to render
  * @param {moment.Locale} localeData - locale the format will be rendered with
- * @return {string} - format string with its month name tokens escaped
+ * @return {string} - format string with its month and weekday tokens escaped
  */
-function escapeMonthName(
+function escapeNameTokens(
 	format: string,
 	date: moment.Moment,
 	localeData: moment.Locale
 ) {
-	// Backslash escapes and bracketed sections are moment's literals, so an "M"
-	// inside one is text. A backslash escapes the whole token that follows it,
-	// not just its first character. "MM" and "M" render digits, which carry no
-	// grammar.
-	return format.replace( /\\M{1,4}|\\.|\[[^\]]*\]|M{3,4}/g, ( token ) => {
-		if ( ! token.startsWith( 'M' ) ) {
-			return token;
+	// Backslash escapes and bracketed sections are moment's literals, so an
+	// "M" or "d" inside one is text. A backslash escapes the whole token that
+	// follows it; the escaped alternatives mirror moment's own tokens. "MM",
+	// "M", "Mo", "do" and "d" render digits, which carry no grammar.
+	return format.replace(
+		/\\(?:Mo|MM?M?M?|ddd?d?|do?)|\\.|\[[^\]]*\]|M{3,4}|d{2,4}/g,
+		( token ) => {
+			if ( token.startsWith( 'M' ) ) {
+				const name =
+					token.length === 4
+						? localeData.months( date, format )
+						: localeData.monthsShort( date, format );
+
+				return `[${ name }]`;
+			}
+
+			if ( ! token.startsWith( 'd' ) ) {
+				return token;
+			}
+
+			if ( token.length === 4 ) {
+				return `[${ localeData.weekdays( date, format ) }]`;
+			}
+
+			const name =
+				token.length === 3
+					? localeData.weekdaysShort( date )
+					: localeData.weekdaysMin( date );
+
+			return `[${ name }]`;
 		}
-
-		const name =
-			token.length === 4
-				? localeData.months( date, format )
-				: localeData.monthsShort( date, format );
-
-		return `[${ name }]`;
-	} );
+	);
 }
 
 /**
@@ -287,7 +302,7 @@ export function getRangeLabel( after: moment.Moment, before: moment.Moment ) {
 		// or time in the format stays the one the range starts on.
 		const localeData = after.localeData();
 		const dayRangeFormat = replaceDayToken(
-			escapeMonthName(
+			escapeNameTokens(
 				expandLocalizedFormat( fullDateFormat, localeData ),
 				after,
 				localeData

--- a/packages/js/date/src/index.ts
+++ b/packages/js/date/src/index.ts
@@ -152,9 +152,9 @@ function expandLocalizedFormat( format: string, localeData: moment.Locale ) {
 	// `longDateFormat` has no entry for them.
 	const localizedTokens = /(\[[^[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
 	let expanded = format;
-	let passes = 5;
+	// An expansion can itself hold localized tokens; moment allows six passes.
+	let passes = 6;
 
-	// An expansion can itself hold localized tokens.
 	while ( passes-- > 0 ) {
 		localizedTokens.lastIndex = 0;
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1059,6 +1059,20 @@ describe( 'getRangeLabel', () => {
 			expect( label ).toBe( 'أكتوبر ١, ٢٠٢٤' );
 		} );
 	} );
+	it( 'should leave a whole backslash escaped token alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '\\MMMM MMM D, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'MMMM Oct 1 - 31, 2024' );
+
+		( __ as jest.Mock ).mockReturnValueOnce( '\\DD MMM D, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'DD Oct 1 - 31, 2024' );
+	} );
+
 	it( 'should render a weekday from the start of the range', () => {
 		( __ as jest.Mock ).mockReturnValueOnce( 'ddd, MMM D, YYYY' );
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -872,6 +872,20 @@ describe( 'getRangeLabel', () => {
 		expect( label ).toBe( 'LL Oct 1 - 31, 2024' );
 	} );
 
+	it( 'should leave a backslash escaped localized format token alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '\\LL MMM D, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'LL Oct 1 - 31, 2024' );
+
+		( __ as jest.Mock ).mockReturnValueOnce( '\\L\\L MMM D, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'LL Oct 1 - 31, 2024' );
+	} );
+
 	it( 'should keep the zero padding a "DD" format asks for', () => {
 		// Mirrors the Serbian translation of the format.
 		( __ as jest.Mock ).mockReturnValueOnce( 'DD. MMM YYYY.' );

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1071,6 +1071,12 @@ describe( 'getRangeLabel', () => {
 		expect(
 			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
 		).toBe( 'DD Oct 1 - 31, 2024' );
+
+		( __ as jest.Mock ).mockReturnValueOnce( '\\DDDo MMM D, YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'DDDo Oct 1 - 31, 2024' );
 	} );
 
 	it( 'should render a weekday from the start of the range', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1160,6 +1160,29 @@ describe( 'getRangeLabel', () => {
 			).toBe( '1 - 31 month10-genitive 2024' );
 		} );
 
+		it( 'should keep the genitive short month name of a "MMM" format', () => {
+			const shortGenitive = Array.from(
+				{ length: 12 },
+				( _, index ) => `short${ index + 1 }-genitive`
+			);
+			const shortNominative = Array.from(
+				{ length: 12 },
+				( _, index ) => `short${ index + 1 }-nominative`
+			);
+			moment.defineLocale( 'inflected-months-abbreviated', {
+				months: { format: genitive, standalone: nominative },
+				monthsShort: {
+					format: shortGenitive,
+					standalone: shortNominative,
+				},
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'D MMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 short10-genitive 2024' );
+		} );
+
 		it( 'should keep the nominative month name when the format holds no day token', () => {
 			moment.defineLocale( 'inflected-months-standalone', {
 				months: { format: genitive, standalone: nominative },

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1195,6 +1195,39 @@ describe( 'getRangeLabel', () => {
 			).toBe( 'month10-nominative 2024' );
 		} );
 	} );
+
+	describe( 'with a locale that nests localized format tokens', () => {
+		// `loadLocaleData` below builds "LLL" from a translation that still
+		// holds "LT", so on a real site an expansion can itself hold a
+		// localized token and a single pass is not enough.
+		let originalLocale: string;
+
+		beforeAll( () => {
+			originalLocale = moment.locale();
+		} );
+
+		afterEach( () => {
+			moment.locale( originalLocale );
+		} );
+
+		it( 'should expand a localized format token that expands to another', () => {
+			moment.defineLocale( 'nested-long-formats', {
+				longDateFormat: {
+					LT: 'HH:mm',
+					LTS: 'HH:mm:ss',
+					L: 'MM/DD/YYYY',
+					LL: 'LLL',
+					LLL: 'MMMM D, YYYY',
+					LLLL: 'dddd, MMMM D, YYYY',
+				},
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'LL' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( 'October 1 - 31, 2024' );
+		} );
+	} );
 } );
 
 describe( 'loadLocaleData', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -920,6 +920,17 @@ describe( 'getRangeLabel', () => {
 		expect( label ).toBe( 'Day Apr 1 - 15, 2018' );
 	} );
 
+	it( 'should leave a bracketed month literal alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '[MMMM] MMM D, YYYY' );
+
+		const label = getRangeLabel(
+			moment( '2018-04-01' ),
+			moment( '2018-04-15' )
+		);
+
+		expect( label ).toBe( 'MMMM Apr 1 - 15, 2018' );
+	} );
+
 	it( 'should leave a backslash escaped day literal alone', () => {
 		( __ as jest.Mock ).mockReturnValueOnce( '\\D MMM D, YYYY' );
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1059,6 +1059,88 @@ describe( 'getRangeLabel', () => {
 			expect( label ).toBe( 'أكتوبر ١, ٢٠٢٤' );
 		} );
 	} );
+	describe( 'with a locale that inflects the month name', () => {
+		// Moment picks the genitive month name over the nominative one by
+		// testing the format string for a day token next to the month one, and
+		// locales disagree on how: some rely on moment's own regex, some ship a
+		// stricter one, and some replace the month names with a function that
+		// tests the format itself. Each is covered here because a format string
+		// that stops matching renders the wrong grammatical form.
+		const genitive = Array.from(
+			{ length: 12 },
+			( _, index ) => `month${ index + 1 }-genitive`
+		);
+		const nominative = Array.from(
+			{ length: 12 },
+			( _, index ) => `month${ index + 1 }-nominative`
+		);
+		let originalLocale: string;
+
+		beforeAll( () => {
+			originalLocale = moment.locale();
+		} );
+
+		afterEach( () => {
+			moment.locale( originalLocale );
+		} );
+
+		it( "should keep the genitive month name of moment's own format test", () => {
+			moment.defineLocale( 'inflected-months', {
+				months: { format: genitive, standalone: nominative },
+				monthsShort: { format: genitive, standalone: nominative },
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'D MMMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 month10-genitive 2024' );
+		} );
+
+		it( 'should keep the genitive month name of a locale that allows only whitespace before the month', () => {
+			// Mirrors the Catalan locale's stricter `isFormat`.
+			moment.defineLocale( 'inflected-months-strict', {
+				months: {
+					format: genitive,
+					standalone: nominative,
+					isFormat: /D[oD]?(\s)+MMMM/,
+				},
+				monthsShort: { format: genitive, standalone: nominative },
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'D MMMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 month10-genitive 2024' );
+		} );
+
+		it( 'should keep the genitive month name of a locale that tests the format itself', () => {
+			// Mirrors the Polish locale, which resolves month names in code.
+			moment.defineLocale( 'inflected-months-fn', {
+				months: ( monthMoment, format ) =>
+					( /D MMMM/.test( format || '' ) ? genitive : nominative )[
+						monthMoment.month()
+					],
+				monthsShort: { format: genitive, standalone: nominative },
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'D MMMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 month10-genitive 2024' );
+		} );
+
+		it( 'should keep the nominative month name when the format holds no day token', () => {
+			moment.defineLocale( 'inflected-months-standalone', {
+				months: { format: genitive, standalone: nominative },
+				monthsShort: { format: genitive, standalone: nominative },
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'MMMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( 'month10-nominative 2024' );
+		} );
+	} );
 } );
 
 describe( 'loadLocaleData', () => {

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1246,6 +1246,60 @@ describe( 'getRangeLabel', () => {
 		} );
 	} );
 
+	describe( 'with a locale that inflects the weekday name', () => {
+		// Mirrors the Ukrainian locale, which renders the genitive weekday
+		// whenever a bracketed literal precedes "dddd" - exactly the shape the
+		// month and day substitutions leave behind.
+		const weekdayGenitive = Array.from(
+			{ length: 7 },
+			( _, index ) => `weekday${ index }-genitive`
+		);
+		const weekdayNominative = Array.from(
+			{ length: 7 },
+			( _, index ) => `weekday${ index }-nominative`
+		);
+		const weekdays = ( dayMoment: moment.Moment, format?: string ) =>
+			( /\] ?dddd/.test( format || '' )
+				? weekdayGenitive
+				: weekdayNominative )[ dayMoment.day() ];
+		let originalLocale: string;
+
+		beforeAll( () => {
+			originalLocale = moment.locale();
+		} );
+
+		afterEach( () => {
+			moment.locale( originalLocale );
+		} );
+
+		it( 'should keep the nominative weekday after the month name', () => {
+			moment.defineLocale( 'inflected-weekdays', { weekdays } );
+			( __ as jest.Mock ).mockReturnValueOnce( 'MMM dddd D YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( 'Oct weekday2-nominative 1 - 31 2024' );
+		} );
+
+		it( 'should keep the nominative weekday after the day of month', () => {
+			moment.defineLocale( 'inflected-weekdays-after-day', { weekdays } );
+			( __ as jest.Mock ).mockReturnValueOnce( 'D dddd MMM YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 weekday2-nominative Oct 2024' );
+		} );
+
+		it( 'should keep the genitive weekday of a format that asks for it', () => {
+			moment.defineLocale( 'inflected-weekdays-literal', { weekdays } );
+			( __ as jest.Mock ).mockReturnValueOnce( '[у] dddd, MMM D, YYYY' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( 'у weekday2-genitive, Oct 1 - 31, 2024' );
+		} );
+	} );
+
 	describe( 'with a locale that nests localized format tokens', () => {
 		// `loadLocaleData` below builds "LLL" from a translation that still
 		// holds "LT", so on a real site an expansion can itself hold a

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -839,6 +839,39 @@ describe( 'getRangeLabel', () => {
 		expect( label ).toBe( '2024年10月' );
 	} );
 
+	it( 'should keep the range when the format uses a localized format token', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'LL' );
+
+		const label = getRangeLabel(
+			moment( '2024-10-01' ),
+			moment( '2024-10-31' )
+		);
+
+		expect( label ).toBe( 'October 1 - 31, 2024' );
+	} );
+
+	it( 'should keep the range when the format uses an abbreviated localized format token', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'll' );
+
+		const label = getRangeLabel(
+			moment( '2024-10-01' ),
+			moment( '2024-10-31' )
+		);
+
+		expect( label ).toBe( 'Oct 1 - 31, 2024' );
+	} );
+
+	it( 'should leave a bracketed localized format token alone', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( '[LL] MMM D, YYYY' );
+
+		const label = getRangeLabel(
+			moment( '2024-10-01' ),
+			moment( '2024-10-31' )
+		);
+
+		expect( label ).toBe( 'LL Oct 1 - 31, 2024' );
+	} );
+
 	it( 'should keep the zero padding a "DD" format asks for', () => {
 		// Mirrors the Serbian translation of the format.
 		( __ as jest.Mock ).mockReturnValueOnce( 'DD. MMM YYYY.' );

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1079,6 +1079,16 @@ describe( 'getRangeLabel', () => {
 		).toBe( 'DDDo Oct 1 - 31, 2024' );
 	} );
 
+	it( 'should escape no more of a backslashed day run than moment does', () => {
+		// Moment reads "\DDDDD" as an escaped "DDDD" and a live day of month
+		// token, so the fifth "D" still carries the range.
+		( __ as jest.Mock ).mockReturnValueOnce( '\\DDDDD MMM YYYY' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'DDDD1 - 31 Oct 2024' );
+	} );
+
 	it( 'should render a weekday from the start of the range', () => {
 		( __ as jest.Mock ).mockReturnValueOnce( 'ddd, MMM D, YYYY' );
 

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1059,6 +1059,23 @@ describe( 'getRangeLabel', () => {
 			expect( label ).toBe( 'أكتوبر ١, ٢٠٢٤' );
 		} );
 	} );
+	it( 'should render a weekday from the start of the range', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'ddd, MMM D, YYYY' );
+
+		// Oct 1 2024 is a Tuesday, Oct 31 a Thursday.
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'Tue, Oct 1 - 31, 2024' );
+	} );
+
+	it( 'should render a week number from the start of the range', () => {
+		( __ as jest.Mock ).mockReturnValueOnce( 'MMM D, YYYY [w]w' );
+
+		expect(
+			getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+		).toBe( 'Oct 1 - 31, 2024 w40' );
+	} );
+
 	describe( 'with a locale that inflects the month name', () => {
 		// Moment picks the genitive month name over the nominative one by
 		// testing the format string for a day token next to the month one, and

--- a/packages/js/date/src/test/index.ts
+++ b/packages/js/date/src/test/index.ts
@@ -1189,6 +1189,29 @@ describe( 'getRangeLabel', () => {
 			).toBe( '1 - 31 short10-genitive 2024' );
 		} );
 
+		it( 'should keep the genitive month name behind a localized format token', () => {
+			// The WOOAIRR-105 shape itself: the translation resolves to a
+			// localized token, and only its expansion reveals the day sitting
+			// next to the month.
+			moment.defineLocale( 'inflected-months-localized', {
+				months: { format: genitive, standalone: nominative },
+				monthsShort: { format: genitive, standalone: nominative },
+				longDateFormat: {
+					LT: 'HH:mm',
+					LTS: 'HH:mm:ss',
+					L: 'DD/MM/YYYY',
+					LL: 'D MMMM YYYY',
+					LLL: 'D MMMM YYYY HH:mm',
+					LLLL: 'dddd, D MMMM YYYY HH:mm',
+				},
+			} );
+			( __ as jest.Mock ).mockReturnValueOnce( 'LL' );
+
+			expect(
+				getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )
+			).toBe( '1 - 31 month10-genitive 2024' );
+		} );
+
 		it( 'should keep the nominative month name when the format holds no day token', () => {
 			moment.defineLocale( 'inflected-months-standalone', {
 				months: { format: genitive, standalone: nominative },


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes two regressions in the same-month Analytics range label, both from #67804, which has not shipped yet.

The day token scan only looked for a literal `D`, so a translation of `MMM D, YYYY` that resolves to a localized token (`LL`, `ll`, ...) had no day to find and the label dropped the end of the range. Substituting the token away also left the format string without the `D` that moment tests for when it picks between the genitive and the nominative month name, so locales that inflect it rendered the wrong form. The bracketed literals the substitutions inject also tripped Ukrainian's weekday chooser, which renders the genitive whenever a `]` precedes `dddd`, so month and weekday names are now both rendered against the original format before anything is substituted. Months and weekdays are the only tokens moment resolves against the format string.

`getRangeLabel` is a public `@woocommerce/date` export. Its signature and return type are unchanged; only the rendered label text differs, and only for the cases above.

Bug introduced in PR #67804.

Addresses [WOOAIRR-105](https://linear.app/a8c/issue/WOOAIRR-105/ai-regression-reviewtrunk-same-month-range-label-silently-drops-the).

### Screenshots or screen recordings:

No screenshots: both paths need a translation that resolves `MMM D, YYYY` to a localized format token, which no shipped locale does by default, so there is nothing to capture on a stock site. Label text for `getRangeLabel( moment( '2024-10-01' ), moment( '2024-10-31' ) )` with that format:

| Locale | Before | After |
| ------ | ------ | ----- |
| `en` | `October 1, 2024` | `October 1 - 31, 2024` |
| `ru` | `1 октября 2024 г.` | `1 - 31 октября 2024 г.` |

### How to test the changes in this Pull Request:

1. On a stock site, go to Analytics > Overview and pick a custom range inside one month, for example Oct 1 2024 to Oct 31 2024. The picker should read `Custom (Oct 1 - 31, 2024)`, identical to trunk: for the default untranslated format the label is unchanged across all 138 moment locales.
2. The fixed paths need moment locale data with localized-token formats or format-sensitive month/weekday names. Stock WordPress feeds its global moment a PHP date format for `LL` and flat name arrays, so those paths are not reachable in the browser without loading real moment locale files; they are covered by the unit suite instead.
3. Run `pnpm --filter @woocommerce/date test:js` and confirm the suite is green (130 tests, including the localized-token, genitive month, and Ukrainian-style weekday cases).

### Testing that has already taken place:

- `@woocommerce/date` suite green, eslint and tsc clean on the package.
- New cases cover `LL`, `ll`, nested and escaped tokens, the genitive month name (long and abbreviated) under moment's own format test, a locale with a stricter `isFormat` (Catalan), a locale that resolves month names in code (Polish), and a locale that inflects the weekday after a bracketed literal (Ukrainian).

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This fixes a regression in #67804, which has not shipped in a release yet, so the changelog entries already on trunk for that PR cover it.

</details>

### Release Communication

<!-- release-communication-section -->

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This PR was developed with AI assistance (Claude Code): investigation, implementation, tests, and verification were AI-generated and human-reviewed.




