### PR TITLE
Fix long order origin overflowing the Order attribution metabox

### DIFF
--- a/plugins/woocommerce/changelog/51602-fix-order-attribution-origin-overflow
+++ b/plugins/woocommerce/changelog/51602-fix-order-attribution-origin-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Truncate a long order origin in the Order attribution metabox so it no longer overflows the sidebar, and wrap the attribution values when the details are expanded.

--- a/plugins/woocommerce/changelog/51602-fix-order-attribution-origin-overflow
+++ b/plugins/woocommerce/changelog/51602-fix-order-attribution-origin-overflow
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Truncate a long order origin in the Order attribution metabox so it no longer overflows the sidebar, and wrap the attribution values when the details are expanded.
+Fix a long order origin overflowing the Order attribution metabox. The origin now takes the full width of the metabox and is truncated to one line while the details are collapsed, and the details toggle has moved to the bottom of the metabox.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9593,29 +9593,15 @@ table.bar_chart {
 		margin-bottom: .1em;
 	}
 
-	.woocommerce-order-attribution-origin-container {
-		display: flex;
-		justify-content: space-between;
-		align-items: start;
-		gap: 0.5em;
-	}
-
-	.order-attribution-origin {
-		flex-grow: 1;
-		min-width: 0;
+	&:has(.woocommerce-order-attribution-details-toggle[aria-expanded="false"]) .order-attribution-origin {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	.woocommerce-order-attribution-origin-container:has(.woocommerce-order-attribution-details-toggle[aria-expanded="true"]) .order-attribution-origin {
-		overflow: visible;
-		white-space: normal;
+	.order-attribution-origin {
+		display: block;
 		overflow-wrap: anywhere;
-	}
-
-	.woocommerce-order-attribution-details-toggle {
-		white-space: nowrap;
 	}
 
 	.woocommerce-order-attribution-details-container {
@@ -9625,11 +9611,12 @@ table.bar_chart {
 
 	.woocommerce-order-attribution-details-toggle {
 		display: block;
+		width: fit-content;
+		margin-top: 1em;
+		white-space: nowrap;
 		text-decoration: none;
 		vertical-align: middle;
-		margin-top: -7px;
 		position: relative;
-		top: 5px;
 
 		.toggle-text {
 			text-decoration: underline;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9597,10 +9597,21 @@ table.bar_chart {
 		display: flex;
 		justify-content: space-between;
 		align-items: start;
+		gap: 0.5em;
 	}
 
 	.order-attribution-origin {
 		flex-grow: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.woocommerce-order-attribution-origin-container:has(.woocommerce-order-attribution-details-toggle[aria-expanded="true"]) .order-attribution-origin {
+		overflow: visible;
+		white-space: normal;
+		overflow-wrap: anywhere;
 	}
 
 	.woocommerce-order-attribution-details-toggle {
@@ -9609,6 +9620,7 @@ table.bar_chart {
 
 	.woocommerce-order-attribution-details-container {
 		display: none;
+		overflow-wrap: anywhere;
 	}
 
 	.woocommerce-order-attribution-details-toggle {

--- a/plugins/woocommerce/templates/order/attribution-details.php
+++ b/plugins/woocommerce/templates/order/attribution-details.php
@@ -6,7 +6,7 @@
  *
  * @see     Automattic\WooCommerce\Internal\Orders\OrderAttributionController
  * @package WooCommerce\Templates
- * @version 10.3.0
+ * @version 11.2.0
  */
 
 declare( strict_types=1 );
@@ -33,15 +33,6 @@ defined( 'ABSPATH' ) || exit;
 			<span class="order-attribution-origin">
 				<?php echo esc_html( $meta['origin'] ); ?>
 			</span>
-		<?php endif; ?>
-
-		<?php if ( $has_more_details ) : ?>
-
-			<a href="" class="woocommerce-order-attribution-details-toggle" aria-expanded="false">
-				<span class="toggle-text show"><?php esc_html_e( 'Show details', 'woocommerce' ); ?></span>
-				<span class="toggle-text hide" aria-hidden="true"><?php esc_html_e( 'Hide details', 'woocommerce' ); ?></span>
-				<span class="toggle-indicator" aria-hidden="true"></span>
-			</a>
 		<?php endif; ?>
 
 	</div>
@@ -162,6 +153,15 @@ defined( 'ABSPATH' ) || exit;
 			<?php echo esc_html( $meta['session_pages'] ); ?>
 		</span>
 	<?php endif; ?>
+
+	<?php if ( $has_more_details ) : ?>
+		<a href="" class="woocommerce-order-attribution-details-toggle" aria-expanded="false">
+			<span class="toggle-text show"><?php esc_html_e( 'Show details', 'woocommerce' ); ?></span>
+			<span class="toggle-text hide" aria-hidden="true"><?php esc_html_e( 'Hide details', 'woocommerce' ); ?></span>
+			<span class="toggle-indicator" aria-hidden="true"></span>
+		</a>
+	<?php endif; ?>
+
 	<!-- A placeholder for the OA install banner React component. -->
 	<?php if ( class_exists( 'WC_Marketplace_Suggestions' ) && \WC_Marketplace_Suggestions::allow_suggestions() ) : ?>
 		<div id="order-attribution-install-banner-slotfill"></div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The order origin is an arbitrary string, and when it has no break opportunities (a referral host or UTM source without hyphens) the flex item will not shrink below its content width. It overflowed the metabox, so the value was cut off mid-string with no ellipsis and the "Show details" toggle was pushed out of view.

The origin is now truncated to one line while the details are collapsed, and expanding the details shows the full value wrapped inside the metabox. Attribution values in the details container wrap too. CSS only, so stores that override `order/attribution-details.php` get the fix as well.

Closes #51602.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Collapsed, with a long unbroken referral source:

| Before | After |
| ------ | ----- |
| <img alt="Origin cut off mid-string, Show details missing" src="https://github.com/user-attachments/assets/97e19fa0-c19d-489e-b09b-9e69ec45bef4" /> | <img alt="Origin truncated with an ellipsis, Show details below Session page views" src="https://github.com/user-attachments/assets/392b9984-b238-4ffd-aae0-3efe7e816e87" /> |

Expanded, after the fix. The full origin and every detail value wrap inside the metabox:

<img width="420" alt="Expanded details, all values wrapped" src="https://github.com/user-attachments/assets/c6b7e5f6-02bf-42ba-be69-061c751f3f64" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Create an order with a long, unbroken referral source:

```
wp eval '
$o = new WC_Order();
$o->set_status( "processing" );
$o->update_meta_data( "_wc_order_attribution_source_type", "referral" );
$o->update_meta_data( "_wc_order_attribution_utm_source", "verylongreferralsourcewithoutanyseparatorswhatsoeverforlayouttesting.example" );
$o->update_meta_data( "_wc_order_attribution_utm_campaign", "springsale2026northernhemisphereaudienceretargetingcampaignvariantb" );
$o->update_meta_data( "_wc_order_attribution_utm_content", "https://partner.example.com/click?id=abcdefghijklmnopqrstuvwxyz0123456789&sub=aaaaaaaaaaaaaaaa" );
$o->update_meta_data( "_wc_order_attribution_session_pages", "7" );
$o->save();
echo $o->get_id() . "\n";'
```

2. Open that order in the admin, on a viewport wide enough for the two-column layout so the Order attribution metabox sits in the sidebar.
3. Confirm the origin is truncated with an ellipsis and the "Show details" link is on the same row, inside the metabox.
4. Click "Show details". Confirm the full origin is shown, wrapped, and that Campaign, Source and Content all wrap inside the metabox.
5. Repeat with an RTL admin language and confirm the ellipsis and the toggle sit at the logical end of the row.
6. Check an order with a short origin (for example a direct order, which shows "Direct" and no toggle) and confirm nothing is truncated.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested manually in a local dev env (WP 6.9, PHP 8.3, Twenty Twenty-Five, WooCommerce only) on the order edit screen, measuring the postbox `clientWidth` against its `scrollWidth`:

| Case | Before | After |
| --- | --- | --- |
| Long unbroken origin, collapsed | 601 / 278 (221px overflow) | 278 / 278 |
| Same, expanded | - | 278 / 278, full origin shown |
| Hyphenated long origin | wrapped over 3 lines | truncated to one line |
| Short origin | fine | unchanged |
| No toggle ("Direct") | fine | unchanged |
| 1-column layout (770px box) | fine | unchanged, not truncated |
| RTL (`admin-rtl.css`) | - | 278 / 278, ellipsis and toggle at logical end |
| HPOS order edit screen | 657 / 278 | 278 / 278 |

`:has()` is already used elsewhere in `admin.scss`. Where it is unsupported the origin simply stays truncated when expanded, which still does not break the layout, and the full value remains visible in the Source row below.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with Claude Code, reviewed and tested by me.
