### PR TITLE
Hide empty star ratings on Discover page product cards

### DIFF
--- a/plugins/woocommerce/changelog/fix-marketplace-missing-rating-guard
+++ b/plugins/woocommerce/changelog/fix-marketplace-missing-rating-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide the rating block on in-app Marketplace product cards when a product has no rating

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -199,6 +199,9 @@ function ProductCardFooter( props: { product: Product } ) {
 		);
 	}
 
+	// Ratings run 1-5, so 0 -- like a missing value -- means "no rating".
+	const averageRating = product.averageRating ?? 0;
+
 	return (
 		<>
 			<div className="woocommerce-marketplace__product-card__price">
@@ -230,18 +233,18 @@ function ProductCardFooter( props: { product: Product } ) {
 				</span>
 			</div>
 			<div className="woocommerce-marketplace__product-card__rating">
-				{ typeof product.averageRating === 'number' && (
+				{ averageRating > 0 && (
 					<>
 						<span className="woocommerce-marketplace__product-card__rating-icon">
 							<Icon icon={ 'star-filled' } size={ 16 } />
 						</span>
 						<span className="woocommerce-marketplace__product-card__rating-average">
-							<span aria-hidden>{ product.averageRating }</span>
+							<span aria-hidden>{ averageRating }</span>
 							<span className="screen-reader-text">
 								{ sprintf(
 									// translators: %.1f: average rating
 									__( '%.1f stars', 'woocommerce' ),
-									product.averageRating
+									averageRating
 								) }
 							</span>
 						</span>

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -233,7 +233,7 @@ function ProductCardFooter( props: { product: Product } ) {
 				</span>
 			</div>
 			<div className="woocommerce-marketplace__product-card__rating">
-				{ averageRating > 0 && (
+				{ Number.isFinite( averageRating ) && averageRating > 0 && (
 					<>
 						<span className="woocommerce-marketplace__product-card__rating-icon">
 							<Icon icon={ 'star-filled' } size={ 16 } />

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -230,7 +230,7 @@ function ProductCardFooter( props: { product: Product } ) {
 				</span>
 			</div>
 			<div className="woocommerce-marketplace__product-card__rating">
-				{ product.averageRating !== null && (
+				{ typeof product.averageRating === 'number' && (
 					<>
 						<span className="woocommerce-marketplace__product-card__rating-icon">
 							<Icon icon={ 'star-filled' } size={ 16 } />
@@ -241,7 +241,7 @@ function ProductCardFooter( props: { product: Product } ) {
 								{ sprintf(
 									// translators: %.1f: average rating
 									__( '%.1f stars', 'woocommerce' ),
-									product.averageRating ?? 0
+									product.averageRating
 								) }
 							</span>
 						</span>

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
@@ -51,6 +51,19 @@ const product: Product = {
 	reviewsCount: 10,
 };
 
+function expectNoRating( container: HTMLElement ) {
+	expect(
+		container.querySelector(
+			'.woocommerce-marketplace__product-card__rating'
+		)?.textContent
+	).toBe( '' );
+	expect(
+		container.querySelector(
+			'.woocommerce-marketplace__product-card__rating-icon'
+		)
+	).toBeNull();
+}
+
 function renderFooter( averageRating: number | null | undefined ) {
 	return render(
 		<MarketplaceContext.Provider value={ context }>
@@ -69,30 +82,18 @@ describe( 'ProductCardFooter rating', () => {
 	it( 'renders no rating when the product has none', () => {
 		const { container } = renderFooter( null );
 
-		expect(
-			container.querySelector(
-				'.woocommerce-marketplace__product-card__rating'
-			)?.textContent
-		).toBe( '' );
+		expectNoRating( container );
 	} );
 
 	it( 'renders no rating when the rating is zero', () => {
 		const { container } = renderFooter( 0 );
 
-		expect(
-			container.querySelector(
-				'.woocommerce-marketplace__product-card__rating'
-			)?.textContent
-		).toBe( '' );
+		expectNoRating( container );
 	} );
 
 	it( 'renders no rating when the API omits the rating', () => {
 		const { container } = renderFooter( undefined );
 
-		expect(
-			container.querySelector(
-				'.woocommerce-marketplace__product-card__rating'
-			)?.textContent
-		).toBe( '' );
+		expectNoRating( container );
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
@@ -51,19 +51,6 @@ const product: Product = {
 	reviewsCount: 10,
 };
 
-function expectNoRating( container: HTMLElement ) {
-	expect(
-		container.querySelector(
-			'.woocommerce-marketplace__product-card__rating'
-		)?.textContent
-	).toBe( '' );
-	expect(
-		container.querySelector(
-			'.woocommerce-marketplace__product-card__rating-icon'
-		)
-	).toBeNull();
-}
-
 function renderFooter( averageRating: number | null | undefined ) {
 	return render(
 		<MarketplaceContext.Provider value={ context }>
@@ -82,18 +69,45 @@ describe( 'ProductCardFooter rating', () => {
 	it( 'renders no rating when the product has none', () => {
 		const { container } = renderFooter( null );
 
-		expectNoRating( container );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating-icon'
+			)
+		).toBeNull();
 	} );
 
 	it( 'renders no rating when the rating is zero', () => {
 		const { container } = renderFooter( 0 );
 
-		expectNoRating( container );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating-icon'
+			)
+		).toBeNull();
 	} );
 
 	it( 'renders no rating when the API omits the rating', () => {
 		const { container } = renderFooter( undefined );
 
-		expectNoRating( container );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating-icon'
+			)
+		).toBeNull();
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
@@ -76,6 +76,16 @@ describe( 'ProductCardFooter rating', () => {
 		).toBe( '' );
 	} );
 
+	it( 'renders no rating when the rating is zero', () => {
+		const { container } = renderFooter( 0 );
+
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+	} );
+
 	it( 'renders no rating when the API omits the rating', () => {
 		const { container } = renderFooter( undefined );
 

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/test/product-card-footer.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getNewPath: jest.fn( () => '/new-path' ),
+	navigateTo: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/data', () => ( {
+	useUser: jest.fn( () => ( {
+		user: null,
+		currentUserCan: jest.fn( () => false ),
+	} ) ),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import ProductCardFooter from '../product-card-footer';
+import { MarketplaceContext } from '../../../contexts/marketplace-context';
+import { MarketplaceContextType } from '../../../contexts/types';
+import { Product, ProductType } from '../../product-list/types';
+
+const context = {
+	selectedTab: 'extensions',
+	isProductInstalled: () => false,
+} as unknown as MarketplaceContextType;
+
+const product: Product = {
+	id: 1,
+	title: 'Test extension',
+	image: '',
+	type: ProductType.extension,
+	description: '',
+	vendorName: '',
+	vendorUrl: '',
+	icon: '',
+	url: '',
+	price: 0,
+	isInstallable: false,
+	currency: 'USD',
+	isOnSale: false,
+	regularPrice: 0,
+	reviewsCount: 10,
+};
+
+function renderFooter( averageRating: number | null | undefined ) {
+	return render(
+		<MarketplaceContext.Provider value={ context }>
+			<ProductCardFooter product={ { ...product, averageRating } } />
+		</MarketplaceContext.Provider>
+	);
+}
+
+describe( 'ProductCardFooter rating', () => {
+	it( 'renders the rating when the product has one', () => {
+		const { getByText } = renderFooter( 4.5 );
+
+		expect( getByText( '4.5' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders no rating when the product has none', () => {
+		const { container } = renderFooter( null );
+
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+	} );
+
+	it( 'renders no rating when the API omits the rating', () => {
+		const { container } = renderFooter( undefined );
+
+		expect(
+			container.querySelector(
+				'.woocommerce-marketplace__product-card__rating'
+			)?.textContent
+		).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Marketplace product cards render a star for products with no rating: a missing `averageRating` shows a star with no number and "0.0 stars" screen-reader text, and a `0` rating (what the Algolia search path returns for unrated products) shows a star with a literal "0" — a rating that isn't actually possible.

Fix: treat missing and `0` ratings as "no rating" and render no star at all.

Rating *rounding* is handled at the API boundary in the companion PR Automattic/woocommerce.com#26233; no client change is needed for it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. From the repo root, apply this patch to simulate both broken cases (odd cards lose `averageRating`, even cards get `0`):

   ```sh
   git apply <<'PATCH'
   diff --git a/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx b/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx
   index 7afbc9e0d6..d2b344db95 100644
   --- a/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx
   +++ b/plugins/woocommerce/client/admin/client/marketplace/utils/functions.tsx
   @@ -198,9 +198,15 @@ async function fetchDiscoverPageData(): Promise< ProductGroup[] > {
    	}
    
    	try {
   -		return ( await apiFetchWithCache( {
   +		const groups = ( await apiFetchWithCache( {
    			path: url.toString(),
   -		} ) ) as Promise< ProductGroup[] >;
   +		} ) ) as ProductGroup[];
   +		groups.forEach( ( g ) =>
   +			g.items.forEach( ( p, i ) =>
   +				i % 2 ? delete p.averageRating : ( p.averageRating = 0 )
   +			)
   +		);
   +		return groups;
    	} catch ( error ) {
    		return [];
    	}

   PATCH
   ```

2. Build the admin client (`pnpm wc:build:admin`) and load **WooCommerce > Extensions > Discover**. On **this branch**: no stars, no rating text on the simulated cards.
3. To see the bug, flip to trunk with the patch riding along, rebuild, and hard-reload:

   ```sh
   git stash && git checkout trunk && git stash pop && pnpm wc:build:admin
   ```

   Every simulated card now shows a star with no number, or a star with "0". Flip back the same way:

   ```sh
   git stash && git checkout woomkt-826-fix-ratings-rounding-to-1-decimal && git stash pop && pnpm wc:build:admin
   ```

4. Please test around this issue

<!-- End testing instructions -->

### Testing that has already taken place:

- Jest tests cover a present rating, `null`, `undefined`, and `0`.
- Verified end-to-end against a local WooCommerce.com running the companion PR: an unrated product (`null` from the featured API, `0` from Algolia search) renders no star; rated products are unaffected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Changelog entry added manually in `plugins/woocommerce/changelog/fix-marketplace-missing-rating-guard` (Significance: patch, Type: fix).

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Authored with Claude Code (Claude Opus 5); all changes, tests, and the end-to-end verification were reviewed by the submitter.
