### PR TITLE
Fix and repair corrupted dashboard_sections user meta

### DIFF
--- a/plugins/woocommerce/changelog/fix-53234-repair-corrupted-dashboard-sections
+++ b/plugins/woocommerce/changelog/fix-53234-repair-corrupted-dashboard-sections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render the Analytics dashboard and repair the stored preference when the woocommerce_admin_dashboard_sections user meta is corrupted.

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { partial } from 'lodash';
 import { Dropdown, Button } from '@wordpress/components';
@@ -30,6 +30,7 @@ const DASHBOARD_FILTERS_FILTER = 'woocommerce_admin_dashboard_filters';
 
 /**
  * @typedef {import('../analytics/report/index.js').filter} filter
+ * @typedef {import('./default-sections.js').section} section
  */
 
 /**
@@ -40,50 +41,90 @@ const DASHBOARD_FILTERS_FILTER = 'woocommerce_admin_dashboard_filters';
  */
 const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
 
-const mergeSectionsWithDefaults = ( prefSections ) => {
-	if (
-		! prefSections ||
-		! Array.isArray( prefSections ) ||
-		prefSections.length === 0
-	) {
-		return defaultSections.reduce( ( sections, section ) => {
-			return [ ...sections, { ...section } ];
-		}, [] );
-	}
+/**
+ * A stored section is only usable when it carries the `key` that ties it back to
+ * a default section. Corrupted `dashboard_sections` preferences have been seen
+ * holding `null` entries, which used to crash the whole dashboard.
+ *
+ * @param {*} section Entry of the stored `dashboard_sections` preference.
+ * @return {boolean} Whether the entry can be merged with a default section.
+ */
+const isValidSection = ( section ) =>
+	!! section &&
+	typeof section === 'object' &&
+	typeof section.key === 'string';
 
+/**
+ * Whether the stored `dashboard_sections` preference is well formed.
+ *
+ * @param {*} prefSections Stored `dashboard_sections` preference.
+ * @return {boolean} Whether the preference can be used as is.
+ */
+const isValidSectionsPreference = ( prefSections ) =>
+	Array.isArray( prefSections ) &&
+	prefSections.length > 0 &&
+	prefSections.every( isValidSection );
+
+/**
+ * `icon` and `component` are React nodes, they must never be persisted.
+ *
+ * @param {section} section Section to persist.
+ * @return {Object} Section without its React nodes.
+ */
+const toStorableSection = ( { icon, component, ...section } ) => section;
+
+/**
+ * Copy of the default sections, throwing a descriptive error when the
+ * `woocommerce_dashboard_default_sections` filter returned something unusable.
+ *
+ * @return {Array.<section>} Default sections.
+ */
+const getDefaultSections = () => {
 	if ( ! Array.isArray( defaultSections ) ) {
 		throw new Error(
 			`The \`defaultSections\` is not an array, please make sure \`${ DEFAULT_SECTIONS_FILTER }\` filter is used correctly.`
 		);
 	}
 
-	const defaultKeys = defaultSections.map( ( section ) => section.key );
-	const prefKeys = prefSections.map( ( section ) => section.key );
+	return defaultSections.map( ( section ) => ( { ...section } ) );
+};
+
+export const mergeSectionsWithDefaults = ( prefSections ) => {
+	const defaults = getDefaultSections();
+	// Malformed entries are dropped instead of failing the whole dashboard.
+	const validPrefSections = Array.isArray( prefSections )
+		? prefSections.filter( isValidSection )
+		: [];
+
+	if ( validPrefSections.length === 0 ) {
+		return defaults;
+	}
+
+	const defaultKeys = defaults.map( ( section ) => section.key );
+	const prefKeys = validPrefSections.map( ( section ) => section.key );
 	const keys = new Set( [ ...prefKeys, ...defaultKeys ] );
 	const sections = [];
 
 	keys.forEach( ( key ) => {
-		const defaultSection = defaultSections.find(
+		const defaultSection = defaults.find(
 			( section ) => section.key === key
 		);
 		if ( ! defaultSection ) {
 			return;
 		}
-		const prefSection = prefSections.find(
+		const prefSection = validPrefSections.find(
 			( section ) => section.key === key
 		);
-		// Not defined by a string anymore.
-		if ( prefSection ) {
-			delete prefSection.icon;
-		}
 
 		sections.push( {
 			...defaultSection,
-			...prefSection,
+			// A stored `icon` is a stale React node, the default one wins.
+			...( prefSection ? toStorableSection( prefSection ) : {} ),
 		} );
 	} );
 
-	return sections;
+	// None of the stored keys is known anymore, so nothing would render.
+	return sections.length > 0 ? sections : defaults;
 };
 
 const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
@@ -95,13 +136,34 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 	);
 
 	const updateSections = ( newSections ) => {
-		updateUserPreferences( { dashboard_sections: newSections } );
+		updateUserPreferences( {
+			dashboard_sections: newSections.map( toStorableSection ),
+		} );
 	};
+
+	// Repair a corrupted `dashboard_sections` preference by storing the sections
+	// the dashboard fell back to. Without this the merchant keeps loading the
+	// broken value on every visit until they happen to customize a section.
+	const hasRepairedSections = useRef( false );
+	useEffect( () => {
+		const prefSections = userPrefs.dashboard_sections;
+
+		// An empty preference means the dashboard was never customized.
+		if (
+			hasRepairedSections.current ||
+			! prefSections ||
+			isValidSectionsPreference( prefSections )
+		) {
+			return;
+		}
+
+		hasRepairedSections.current = true;
+		updateSections( sections );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ userPrefs.dashboard_sections ] );
 
 	const updateSection = ( updatedKey, newSettings ) => {
 		const newSections = sections.map( ( section ) => {
-			// Do not save section icon as it is a component.
-			delete section.icon;
 			if ( section.key === updatedKey ) {
 				return {
 					...section,

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -55,6 +55,17 @@ const isValidSection = ( section ) =>
 	typeof section.key === 'string';
 
 /**
+ * `hiddenBlocks` is spread over the default one and then dereferenced by every
+ * section component, so a stored value that is not an array crashes the
+ * dashboard just like a malformed entry does.
+ *
+ * @param {Object} section Well formed entry of the stored preference.
+ * @return {boolean} Whether the entry's `hiddenBlocks` can be used as is.
+ */
+const hasUsableHiddenBlocks = ( section ) =>
+	undefined === section.hiddenBlocks || Array.isArray( section.hiddenBlocks );
+
+/**
  * Whether the stored `dashboard_sections` preference is well formed.
  *
  * @param {*} prefSections Stored `dashboard_sections` preference.
@@ -63,7 +74,10 @@ const isValidSection = ( section ) =>
 const isValidSectionsPreference = ( prefSections ) =>
 	Array.isArray( prefSections ) &&
 	prefSections.length > 0 &&
-	prefSections.every( isValidSection );
+	prefSections.every(
+		( section ) =>
+			isValidSection( section ) && hasUsableHiddenBlocks( section )
+	);
 
 /**
  * `icon` and `component` are React nodes, they must never be persisted.
@@ -116,15 +130,22 @@ export const mergeSectionsWithDefaults = ( prefSections ) => {
 			( section ) => section.key === key
 		);
 
-		sections.push( {
+		const section = {
 			...defaultSection,
 			// A stored `icon` is a stale React node, the default one wins.
 			...( prefSection ? toStorableSection( prefSection ) : {} ),
-		} );
+		};
+
+		// The same goes for a `hiddenBlocks` that is not an array, which every
+		// section component would blow up on.
+		if ( ! Array.isArray( section.hiddenBlocks ) ) {
+			section.hiddenBlocks = defaultSection.hiddenBlocks;
+		}
+
+		sections.push( section );
 	} );
 
-	// None of the stored keys is known anymore, so nothing would render.
-	return sections.length > 0 ? sections : defaults;
+	return sections;
 };
 
 const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -55,16 +55,19 @@ const isValidSection = ( section ) =>
 	typeof section.key === 'string';
 
 /**
- * Stored fields that take the dashboard down when they hold the wrong type,
- * mapped to the check a usable value passes. `hiddenBlocks` is dereferenced by
- * every section component and `title` is rendered as a React child. Both are
- * spread over the default section, so a corrupted one wins unless it is caught
- * here. Validation and repair both read this list so they cannot drift apart.
+ * Stored fields that take the dashboard down, or make a section unreachable,
+ * when they hold the wrong type, mapped to the check a usable value passes.
+ * `hiddenBlocks` is dereferenced by every section component, `title` is
+ * rendered as a React child, and a non boolean `isVisible` hides a section
+ * without listing it under "Add more sections". Each one is spread over the
+ * default section, so a corrupted one wins unless it is caught here.
+ * Validation and repair both read this list so they cannot drift apart.
  *
  * @type {Object.<string, function(*): boolean>}
  */
 const FIELD_CHECKS = {
 	hiddenBlocks: Array.isArray,
+	isVisible: ( value ) => typeof value === 'boolean',
 	title: ( value ) => typeof value === 'string',
 };
 
@@ -104,12 +107,44 @@ const isValidSectionsPreference = ( prefSections ) =>
 	prefSections.every( isUsableSection );
 
 /**
+ * Whether the dashboard was never customized. An unset preference and an empty
+ * list both mean the defaults are in use, so there is nothing to repair.
+ *
+ * @param {*} prefSections Stored `dashboard_sections` preference.
+ * @return {boolean} Whether the preference holds nothing.
+ */
+const isEmptySectionsPreference = ( prefSections ) =>
+	! prefSections ||
+	( Array.isArray( prefSections ) && prefSections.length === 0 );
+
+/**
  * `icon` and `component` are React nodes, they must never be persisted.
  *
  * @param {section} section Section to persist.
  * @return {Object} Section without its React nodes.
  */
 const toStorableSection = ( { icon, component, ...section } ) => section;
+
+/**
+ * A section to persist, without the fields the dashboard cannot use. There is
+ * no default to patch a corrupted field up from at this point, so it is
+ * dropped and whichever default section owns the key provides it on the next
+ * read.
+ *
+ * @param {section} section Section to persist.
+ * @return {Object} Section holding only values the dashboard can read back.
+ */
+const toUsableSection = ( section ) => {
+	const usable = toStorableSection( section );
+
+	Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
+		if ( ! isUsable( usable[ field ] ) ) {
+			delete usable[ field ];
+		}
+	} );
+
+	return usable;
+};
 
 /**
  * Copy of the default sections, throwing a descriptive error when the
@@ -160,9 +195,9 @@ export const mergeSectionsWithDefaults = ( prefSections ) => {
 			...( prefSection ? toStorableSection( prefSection ) : {} ),
 		};
 
-		// The same goes for any field the dashboard would blow up on, so a
-		// single corrupted field costs the merchant that field and not their
-		// whole section.
+		// The same goes for any field the dashboard cannot use, so a single
+		// corrupted field costs the merchant that field and not their whole
+		// section.
 		Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
 			if ( ! isUsable( section[ field ] ) ) {
 				section[ field ] = defaultSection[ field ];
@@ -177,9 +212,10 @@ export const mergeSectionsWithDefaults = ( prefSections ) => {
 
 /**
  * The preference to store when repairing a corrupted one. Entries for keys the
- * dashboard does not know about are kept as they are, so an extension that
- * registers a section does not lose its stored settings while it is
- * deactivated.
+ * dashboard does not know about are kept, so an extension that registers a
+ * section does not lose its stored settings while it is deactivated. They are
+ * appended after the known sections, so such an entry loses its stored
+ * position.
  *
  * @param {Array.<section>} sections     Sections the dashboard fell back to.
  * @param {*}               prefSections Stored `dashboard_sections` preference.
@@ -189,15 +225,12 @@ const toRepairedPreference = ( sections, prefSections ) => {
 	const knownKeys = sections.map( ( section ) => section.key );
 	const unknownSections = (
 		Array.isArray( prefSections ) ? prefSections : []
-	)
-		.filter(
-			( section ) =>
-				isUsableSection( section ) &&
-				! knownKeys.includes( section.key )
-		)
-		.map( toStorableSection );
+	).filter(
+		( section ) =>
+			isValidSection( section ) && ! knownKeys.includes( section.key )
+	);
 
-	return [ ...sections.map( toStorableSection ), ...unknownSections ];
+	return [ ...sections, ...unknownSections ].map( toUsableSection );
 };
 
 const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
@@ -221,10 +254,9 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 	useEffect( () => {
 		const prefSections = userPrefs.dashboard_sections;
 
-		// An empty preference means the dashboard was never customized.
 		if (
 			hasAttemptedRepair.current ||
-			! prefSections ||
+			isEmptySectionsPreference( prefSections ) ||
 			isValidSectionsPreference( prefSections )
 		) {
 			return;
@@ -234,9 +266,9 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 
 		const repaired = toRepairedPreference( sections, prefSections );
 
-		// Nothing usable to fall back to, for example when the default sections
-		// filter emptied the list. Storing this would only be repaired again on
-		// the next visit, one write per page load and no gain.
+		// Nothing to fall back to, for example when the default sections filter
+		// emptied the list. Storing this would only be repaired again on the
+		// next visit, one write per page load and no gain.
 		if ( ! isValidSectionsPreference( repaired ) ) {
 			return;
 		}

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -55,15 +55,42 @@ const isValidSection = ( section ) =>
 	typeof section.key === 'string';
 
 /**
- * `hiddenBlocks` is spread over the default one and then dereferenced by every
- * section component, so a stored value that is not an array crashes the
- * dashboard just like a malformed entry does.
+ * Stored fields that take the dashboard down when they hold the wrong type,
+ * mapped to the check a usable value passes. `hiddenBlocks` is dereferenced by
+ * every section component and `title` is rendered as a React child. Both are
+ * spread over the default section, so a corrupted one wins unless it is caught
+ * here. Validation and repair both read this list so they cannot drift apart.
+ *
+ * @type {Object.<string, function(*): boolean>}
+ */
+const FIELD_CHECKS = {
+	hiddenBlocks: Array.isArray,
+	title: ( value ) => typeof value === 'string',
+};
+
+/**
+ * Whether an entry of the stored preference carries usable values for the
+ * fields the dashboard dereferences. A missing field is fine, the default
+ * section provides it.
  *
  * @param {Object} section Well formed entry of the stored preference.
- * @return {boolean} Whether the entry's `hiddenBlocks` can be used as is.
+ * @return {boolean} Whether every field the dashboard reads can be used as is.
  */
-const hasUsableHiddenBlocks = ( section ) =>
-	undefined === section.hiddenBlocks || Array.isArray( section.hiddenBlocks );
+const hasUsableFields = ( section ) =>
+	Object.entries( FIELD_CHECKS ).every(
+		( [ field, isUsable ] ) =>
+			undefined === section[ field ] || isUsable( section[ field ] )
+	);
+
+/**
+ * Whether an entry of the stored preference can be used without patching it up
+ * from a default section.
+ *
+ * @param {*} section Entry of the stored `dashboard_sections` preference.
+ * @return {boolean} Whether the entry can be used as is.
+ */
+const isUsableSection = ( section ) =>
+	isValidSection( section ) && hasUsableFields( section );
 
 /**
  * Whether the stored `dashboard_sections` preference is well formed.
@@ -74,10 +101,7 @@ const hasUsableHiddenBlocks = ( section ) =>
 const isValidSectionsPreference = ( prefSections ) =>
 	Array.isArray( prefSections ) &&
 	prefSections.length > 0 &&
-	prefSections.every(
-		( section ) =>
-			isValidSection( section ) && hasUsableHiddenBlocks( section )
-	);
+	prefSections.every( isUsableSection );
 
 /**
  * `icon` and `component` are React nodes, they must never be persisted.
@@ -136,16 +160,44 @@ export const mergeSectionsWithDefaults = ( prefSections ) => {
 			...( prefSection ? toStorableSection( prefSection ) : {} ),
 		};
 
-		// The same goes for a `hiddenBlocks` that is not an array, which every
-		// section component would blow up on.
-		if ( ! Array.isArray( section.hiddenBlocks ) ) {
-			section.hiddenBlocks = defaultSection.hiddenBlocks;
-		}
+		// The same goes for any field the dashboard would blow up on, so a
+		// single corrupted field costs the merchant that field and not their
+		// whole section.
+		Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
+			if ( ! isUsable( section[ field ] ) ) {
+				section[ field ] = defaultSection[ field ];
+			}
+		} );
 
 		sections.push( section );
 	} );
 
 	return sections;
+};
+
+/**
+ * The preference to store when repairing a corrupted one. Entries for keys the
+ * dashboard does not know about are kept as they are, so an extension that
+ * registers a section does not lose its stored settings while it is
+ * deactivated.
+ *
+ * @param {Array.<section>} sections     Sections the dashboard fell back to.
+ * @param {*}               prefSections Stored `dashboard_sections` preference.
+ * @return {Array.<Object>} Sections to store.
+ */
+const toRepairedPreference = ( sections, prefSections ) => {
+	const knownKeys = sections.map( ( section ) => section.key );
+	const unknownSections = (
+		Array.isArray( prefSections ) ? prefSections : []
+	)
+		.filter(
+			( section ) =>
+				isUsableSection( section ) &&
+				! knownKeys.includes( section.key )
+		)
+		.map( toStorableSection );
+
+	return [ ...sections.map( toStorableSection ), ...unknownSections ];
 };
 
 const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
@@ -165,21 +217,31 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 	// Repair a corrupted `dashboard_sections` preference by storing the sections
 	// the dashboard fell back to. Without this the merchant keeps loading the
 	// broken value on every visit until they happen to customize a section.
-	const hasRepairedSections = useRef( false );
+	const hasAttemptedRepair = useRef( false );
 	useEffect( () => {
 		const prefSections = userPrefs.dashboard_sections;
 
 		// An empty preference means the dashboard was never customized.
 		if (
-			hasRepairedSections.current ||
+			hasAttemptedRepair.current ||
 			! prefSections ||
 			isValidSectionsPreference( prefSections )
 		) {
 			return;
 		}
 
-		hasRepairedSections.current = true;
-		updateSections( sections );
+		hasAttemptedRepair.current = true;
+
+		const repaired = toRepairedPreference( sections, prefSections );
+
+		// Nothing usable to fall back to, for example when the default sections
+		// filter emptied the list. Storing this would only be repaired again on
+		// the next visit, one write per page load and no gain.
+		if ( ! isValidSectionsPreference( repaired ) ) {
+			return;
+		}
+
+		updateUserPreferences( { dashboard_sections: repaired } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ userPrefs.dashboard_sections ] );
 

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -61,7 +61,8 @@ const isValidSection = ( section ) =>
  * rendered as a React child, and a non boolean `isVisible` hides a section
  * without listing it under "Add more sections". Each one is spread over the
  * default section, so a corrupted one wins unless it is caught here.
- * Validation and repair both read this list so they cannot drift apart.
+ * Validation, repair and the defaults all read this list so they cannot drift
+ * apart.
  *
  * @type {Object.<string, function(*): boolean>}
  */
@@ -126,6 +127,22 @@ const isEmptySectionsPreference = ( prefSections ) =>
 const toStorableSection = ( { icon, component, ...section } ) => section;
 
 /**
+ * Drops the fields the dashboard cannot read back, in place.
+ *
+ * @param {Object} section Section to strip.
+ * @return {Object} The same section, holding only usable values.
+ */
+const deleteUnusableFields = ( section ) => {
+	Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
+		if ( ! isUsable( section[ field ] ) ) {
+			delete section[ field ];
+		}
+	} );
+
+	return section;
+};
+
+/**
  * A section to persist, without the fields the dashboard cannot use. There is
  * no default to patch a corrupted field up from at this point, so it is
  * dropped and whichever default section owns the key provides it on the next
@@ -134,21 +151,30 @@ const toStorableSection = ( { icon, component, ...section } ) => section;
  * @param {section} section Section to persist.
  * @return {Object} Section holding only values the dashboard can read back.
  */
-const toUsableSection = ( section ) => {
-	const usable = toStorableSection( section );
+const toUsableSection = ( section ) =>
+	deleteUnusableFields( toStorableSection( section ) );
 
-	Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
-		if ( ! isUsable( usable[ field ] ) ) {
-			delete usable[ field ];
-		}
-	} );
-
-	return usable;
-};
+/**
+ * A default section is the last fallback, so it has to stand on its own. An
+ * entry with no key cannot be matched to a stored one and an entry with no
+ * component cannot be rendered, so neither is a section the dashboard can
+ * build.
+ *
+ * @param {*} section Entry returned by the default sections filter.
+ * @return {boolean} Whether a section can be built from the entry.
+ */
+const isUsableDefaultSection = ( section ) =>
+	isValidSection( section ) && !! section.component;
 
 /**
  * Copy of the default sections, throwing a descriptive error when the
  * `woocommerce_dashboard_default_sections` filter returned something unusable.
+ * The filter is a third party surface, so its entries get the same treatment as
+ * the stored ones: an entry no section can be built from is dropped, and a
+ * corrupted field is dropped so it cannot overwrite a valid stored value.
+ * Nothing sits behind a default to patch a field up from, except `hiddenBlocks`
+ * which every section component dereferences, so that one falls back to an
+ * empty list.
  *
  * @return {Array.<section>} Default sections.
  */
@@ -159,7 +185,17 @@ const getDefaultSections = () => {
 		);
 	}
 
-	return defaultSections.map( ( section ) => ( { ...section } ) );
+	return defaultSections
+		.filter( isUsableDefaultSection )
+		.map( ( section ) => {
+			const usable = deleteUnusableFields( { ...section } );
+
+			if ( ! Array.isArray( usable.hiddenBlocks ) ) {
+				usable.hiddenBlocks = [];
+			}
+
+			return usable;
+		} );
 };
 
 export const mergeSectionsWithDefaults = ( prefSections ) => {
@@ -241,9 +277,12 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 		[ userPrefs.dashboard_sections ]
 	);
 
+	// The update callbacks are handed to the section components, so a third
+	// party one can supply a value the dashboard cannot read back. Sanitizing
+	// here keeps a preference the dashboard wrote from needing a repair.
 	const updateSections = ( newSections ) => {
 		updateUserPreferences( {
-			dashboard_sections: newSections.map( toStorableSection ),
+			dashboard_sections: newSections.map( toUsableSection ),
 		} );
 	};
 

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -11,27 +11,36 @@ import CustomizableDashboard, {
 	mergeSectionsWithDefaults,
 } from '../customizable';
 
+const DEFAULT_SECTIONS = [
+	{
+		key: 'store-performance',
+		component: () => null,
+		title: 'Performance',
+		isVisible: true,
+		icon: 'arrow-right',
+		hiddenBlocks: [ 'taxes/order_tax' ],
+	},
+	{
+		key: 'charts',
+		component: () => null,
+		title: 'Charts',
+		isVisible: true,
+		icon: 'chart-bar',
+		hiddenBlocks: [ 'coupons_amount' ],
+	},
+];
+
+// Reassigned by the tests that need the `woocommerce_dashboard_default_sections`
+// filter to have returned something else. Read through a getter so the mock is
+// resolved when the dashboard dereferences it, not when the module is imported.
+let mockDefaultSections = DEFAULT_SECTIONS;
+
 jest.mock( '../default-sections', () => ( {
 	__esModule: true,
 	DEFAULT_SECTIONS_FILTER: 'woocommerce_dashboard_default_sections',
-	default: [
-		{
-			key: 'store-performance',
-			component: () => null,
-			title: 'Performance',
-			isVisible: true,
-			icon: 'arrow-right',
-			hiddenBlocks: [ 'taxes/order_tax' ],
-		},
-		{
-			key: 'charts',
-			component: () => null,
-			title: 'Charts',
-			isVisible: true,
-			icon: 'chart-bar',
-			hiddenBlocks: [ 'coupons_amount' ],
-		},
-	],
+	get default() {
+		return mockDefaultSections;
+	},
 } ) );
 
 jest.mock( '../section', () => ( { title, onRemove } ) => (
@@ -56,6 +65,10 @@ jest.mock( '@wordpress/data', () => ( {
 		<Component { ...props } defaultDateRange="period=month" />
 	),
 } ) );
+
+afterEach( () => {
+	mockDefaultSections = DEFAULT_SECTIONS;
+} );
 
 describe( 'mergeSectionsWithDefaults', () => {
 	it( 'returns the defaults when nothing is stored', () => {
@@ -120,6 +133,20 @@ describe( 'mergeSectionsWithDefaults', () => {
 
 		expect( charts.hiddenBlocks ).toEqual( [ 'coupons_amount' ] );
 		expect( charts.title ).toBe( 'My charts' );
+	} );
+
+	it( 'ignores a stored title that is not a string', () => {
+		// The title is rendered as a React child by every section header.
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{
+				key: 'charts',
+				title: { rendered: 'My charts' },
+				isVisible: false,
+			},
+		] );
+
+		expect( charts.title ).toBe( 'Charts' );
+		expect( charts.isVisible ).toBe( false );
 	} );
 } );
 
@@ -200,6 +227,40 @@ describe( 'CustomizableDashboard', () => {
 				} ),
 			] ),
 		} );
+	} );
+
+	it( 'repairs a preference holding a corrupted title', () => {
+		renderDashboard( [ { key: 'charts', isVisible: true, title: {} } ] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				expect.objectContaining( { key: 'charts', title: 'Charts' } ),
+			] ),
+		} );
+	} );
+
+	it( 'keeps a stored section the dashboard does not know about', () => {
+		// A section registered by an extension that is currently deactivated.
+		renderDashboard( [
+			null,
+			{ key: 'my-extension', title: 'Mine', isVisible: false },
+		] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				{ key: 'my-extension', title: 'Mine', isVisible: false },
+			] ),
+		} );
+	} );
+
+	it( 'does not store anything when there is nothing usable to fall back to', () => {
+		// Storing an empty list would only be repaired again on the next visit.
+		mockDefaultSections = [];
+
+		renderDashboard( [ null, null ] );
+
+		expect( updateUserPreferences ).not.toHaveBeenCalled();
 	} );
 
 	it( 'leaves a well formed preference alone', () => {

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -43,10 +43,14 @@ jest.mock( '../default-sections', () => ( {
 	},
 } ) );
 
-jest.mock( '../section', () => ( { title, onRemove } ) => (
+jest.mock( '../section', () => ( { title, onRemove, onTitleUpdate } ) => (
 	<div>
 		{ title }
 		<button title={ `Hide ${ title }` } onClick={ onRemove } />
+		<button
+			title={ `Rename ${ title }` }
+			onClick={ () => onTitleUpdate( { rendered: 'Renamed' } ) }
+		/>
 	</div>
 ) );
 
@@ -158,6 +162,48 @@ describe( 'mergeSectionsWithDefaults', () => {
 
 		expect( charts.title ).toBe( 'Charts' );
 		expect( charts.isVisible ).toBe( false );
+	} );
+
+	it( 'drops a default section that no section can be built from', () => {
+		// The default sections filter is a third party surface too.
+		mockDefaultSections = [
+			null,
+			'charts',
+			{ component: () => null, title: 'No key', isVisible: true },
+			{ key: 'no-component', title: 'No component', isVisible: true },
+			...DEFAULT_SECTIONS,
+		];
+
+		const sections = mergeSectionsWithDefaults( undefined );
+
+		expect( sections.map( ( section ) => section.key ) ).toEqual( [
+			'store-performance',
+			'charts',
+		] );
+	} );
+
+	it( 'fills in a default hiddenBlocks that is not an array', () => {
+		// Nothing sits behind a default, and every section component calls
+		// `hiddenBlocks.includes()` on it.
+		mockDefaultSections = [
+			{ ...DEFAULT_SECTIONS[ 1 ], hiddenBlocks: null },
+		];
+
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{ key: 'charts', hiddenBlocks: 'coupons_amount' },
+		] );
+
+		expect( charts.hiddenBlocks ).toEqual( [] );
+	} );
+
+	it( 'does not fall back to a corrupted default field', () => {
+		mockDefaultSections = [ { ...DEFAULT_SECTIONS[ 1 ], title: {} } ];
+
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{ key: 'charts', title: { rendered: 'My charts' } },
+		] );
+
+		expect( charts.title ).toBeUndefined();
 	} );
 } );
 
@@ -328,6 +374,25 @@ describe( 'CustomizableDashboard', () => {
 		stored.forEach( ( section ) => {
 			expect( section ).not.toHaveProperty( 'icon' );
 			expect( section ).not.toHaveProperty( 'component' );
+		} );
+	} );
+
+	it( 'sanitizes a value a section component hands back', () => {
+		// The update callbacks are passed to third party section components.
+		const { getByTitle } = renderDashboard( [
+			{ key: 'charts', title: 'Charts', isVisible: true },
+		] );
+
+		fireEvent.click( getByTitle( 'Rename Charts' ) );
+
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				{
+					key: 'charts',
+					isVisible: true,
+					hiddenBlocks: [ 'coupons_amount' ],
+				},
+			] ),
 		} );
 	} );
 

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -135,6 +135,17 @@ describe( 'mergeSectionsWithDefaults', () => {
 		expect( charts.title ).toBe( 'My charts' );
 	} );
 
+	it( 'ignores a stored isVisible that is not a boolean', () => {
+		// A non boolean hides the section without listing it under "Add more
+		// sections", so the merchant cannot bring it back.
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{ key: 'charts', title: 'My charts', isVisible: 0 },
+		] );
+
+		expect( charts.isVisible ).toBe( true );
+		expect( charts.title ).toBe( 'My charts' );
+	} );
+
 	it( 'ignores a stored title that is not a string', () => {
 		// The title is rendered as a React child by every section header.
 		const [ charts ] = mergeSectionsWithDefaults( [
@@ -240,11 +251,42 @@ describe( 'CustomizableDashboard', () => {
 		} );
 	} );
 
+	it( 'repairs a preference holding a corrupted isVisible', () => {
+		renderDashboard( [ { key: 'charts', isVisible: 0 } ] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				expect.objectContaining( { key: 'charts', isVisible: true } ),
+			] ),
+		} );
+	} );
+
 	it( 'keeps a stored section the dashboard does not know about', () => {
 		// A section registered by an extension that is currently deactivated.
 		renderDashboard( [
 			null,
 			{ key: 'my-extension', title: 'Mine', isVisible: false },
+		] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				{ key: 'my-extension', title: 'Mine', isVisible: false },
+			] ),
+		} );
+	} );
+
+	it( 'keeps an unknown section that holds a corrupted field', () => {
+		// There is no default to patch the field up from, so it is dropped and
+		// the rest of the entry survives.
+		renderDashboard( [
+			null,
+			{
+				key: 'my-extension',
+				title: 'Mine',
+				isVisible: false,
+				hiddenBlocks: null,
+			},
 		] );
 
 		expect( updateUserPreferences ).toHaveBeenCalledWith( {
@@ -291,6 +333,13 @@ describe( 'CustomizableDashboard', () => {
 
 	it( 'does not store anything when the dashboard was never customized', () => {
 		renderDashboard( '' );
+
+		expect( updateUserPreferences ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not store anything when the stored preference is empty', () => {
+		// An empty list means the defaults are in use, same as no preference.
+		renderDashboard( [] );
 
 		expect( updateUserPreferences ).not.toHaveBeenCalled();
 	} );

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -103,7 +103,7 @@ describe( 'mergeSectionsWithDefaults', () => {
 		} );
 	} );
 
-	it( 'returns the defaults when no stored key matches a default section', () => {
+	it( 'drops stored keys that no longer exist', () => {
 		const sections = mergeSectionsWithDefaults( [ { key: 'gone' } ] );
 
 		expect( sections.map( ( section ) => section.key ) ).toEqual( [
@@ -111,16 +111,30 @@ describe( 'mergeSectionsWithDefaults', () => {
 			'charts',
 		] );
 	} );
+
+	it( 'ignores a stored hiddenBlocks that is not an array', () => {
+		// Every section component calls `hiddenBlocks.includes()` on it.
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{ key: 'charts', title: 'My charts', hiddenBlocks: null },
+		] );
+
+		expect( charts.hiddenBlocks ).toEqual( [ 'coupons_amount' ] );
+		expect( charts.title ).toBe( 'My charts' );
+	} );
 } );
 
 describe( 'CustomizableDashboard', () => {
 	const updateUserPreferences = jest.fn();
 
 	const renderDashboard = ( dashboardSections ) => {
-		useUserPreferences.mockReturnValue( {
+		// The stored preference is JSON parsed on every render, so the dashboard
+		// gets a new reference each time and the repair has to guard itself.
+		useUserPreferences.mockImplementation( () => ( {
 			updateUserPreferences,
-			dashboard_sections: dashboardSections,
-		} );
+			dashboard_sections: Array.isArray( dashboardSections )
+				? [ ...dashboardSections ]
+				: dashboardSections,
+		} ) );
 
 		return render(
 			<CustomizableDashboard path="/analytics/overview" query={ {} } />
@@ -170,6 +184,22 @@ describe( 'CustomizableDashboard', () => {
 		renderDashboard( '[,,]' );
 
 		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'repairs a preference holding a corrupted hiddenBlocks', () => {
+		renderDashboard( [
+			{ key: 'charts', isVisible: true, hiddenBlocks: null },
+		] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: expect.arrayContaining( [
+				expect.objectContaining( {
+					key: 'charts',
+					hiddenBlocks: [ 'coupons_amount' ],
+				} ),
+			] ),
+		} );
 	} );
 
 	it( 'leaves a well formed preference alone', () => {

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -1,0 +1,206 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+import { useUserPreferences } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import CustomizableDashboard, {
+	mergeSectionsWithDefaults,
+} from '../customizable';
+
+jest.mock( '../default-sections', () => ( {
+	__esModule: true,
+	DEFAULT_SECTIONS_FILTER: 'woocommerce_dashboard_default_sections',
+	default: [
+		{
+			key: 'store-performance',
+			component: () => null,
+			title: 'Performance',
+			isVisible: true,
+			icon: 'arrow-right',
+			hiddenBlocks: [ 'taxes/order_tax' ],
+		},
+		{
+			key: 'charts',
+			component: () => null,
+			title: 'Charts',
+			isVisible: true,
+			icon: 'chart-bar',
+			hiddenBlocks: [ 'coupons_amount' ],
+		},
+	],
+} ) );
+
+jest.mock( '../section', () => ( { title, onRemove } ) => (
+	<div>
+		{ title }
+		<button title={ `Hide ${ title }` } onClick={ onRemove } />
+	</div>
+) );
+
+jest.mock( '../../analytics/components/report-header', () => ( {
+	ReportHeader: () => null,
+} ) );
+
+jest.mock( '@woocommerce/data', () => ( {
+	settingsStore: 'wc/admin/settings',
+	useUserPreferences: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	withSelect: () => ( Component ) => ( props ) => (
+		<Component { ...props } defaultDateRange="period=month" />
+	),
+} ) );
+
+describe( 'mergeSectionsWithDefaults', () => {
+	it( 'returns the defaults when nothing is stored', () => {
+		expect( mergeSectionsWithDefaults( undefined ) ).toHaveLength( 2 );
+		expect( mergeSectionsWithDefaults( '' ) ).toHaveLength( 2 );
+		expect( mergeSectionsWithDefaults( [] ) ).toHaveLength( 2 );
+	} );
+
+	it( 'returns the defaults when the stored preference is not an array', () => {
+		// `[,,]` is not valid JSON, so it reaches the dashboard as a raw string.
+		expect( mergeSectionsWithDefaults( '[,,]' ) ).toHaveLength( 2 );
+		expect( mergeSectionsWithDefaults( {} ) ).toHaveLength( 2 );
+	} );
+
+	it( 'returns the defaults when every stored section is malformed', () => {
+		expect( mergeSectionsWithDefaults( [ null, null ] ) ).toHaveLength( 2 );
+		expect(
+			mergeSectionsWithDefaults( [ undefined, 'charts', 42, {} ] )
+		).toHaveLength( 2 );
+	} );
+
+	it( 'ignores a stored icon, which is a stale React node', () => {
+		const [ charts ] = mergeSectionsWithDefaults( [
+			{ key: 'charts', icon: { props: {} } },
+		] );
+
+		expect( charts.icon ).toBe( 'chart-bar' );
+	} );
+
+	it( 'keeps the well formed sections and drops the malformed ones', () => {
+		const sections = mergeSectionsWithDefaults( [
+			null,
+			{ key: 'charts', title: 'My charts', isVisible: false },
+		] );
+
+		expect( sections ).toHaveLength( 2 );
+		expect( sections[ 0 ] ).toMatchObject( {
+			key: 'charts',
+			title: 'My charts',
+			isVisible: false,
+		} );
+		expect( sections[ 1 ] ).toMatchObject( {
+			key: 'store-performance',
+			title: 'Performance',
+		} );
+	} );
+
+	it( 'returns the defaults when no stored key matches a default section', () => {
+		const sections = mergeSectionsWithDefaults( [ { key: 'gone' } ] );
+
+		expect( sections.map( ( section ) => section.key ) ).toEqual( [
+			'store-performance',
+			'charts',
+		] );
+	} );
+} );
+
+describe( 'CustomizableDashboard', () => {
+	const updateUserPreferences = jest.fn();
+
+	const renderDashboard = ( dashboardSections ) => {
+		useUserPreferences.mockReturnValue( {
+			updateUserPreferences,
+			dashboard_sections: dashboardSections,
+		} );
+
+		return render(
+			<CustomizableDashboard path="/analytics/overview" query={ {} } />
+		);
+	};
+
+	beforeEach( () => {
+		updateUserPreferences.mockReset();
+	} );
+
+	it( 'renders the default sections when the stored preference is corrupted', () => {
+		const { getByText } = renderDashboard( [ null, null ] );
+
+		expect( getByText( 'Performance' ) ).toBeInTheDocument();
+		expect( getByText( 'Charts' ) ).toBeInTheDocument();
+	} );
+
+	it( 'repairs a corrupted preference once, without the React nodes', () => {
+		const { rerender } = renderDashboard( [ null, null ] );
+
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+		expect( updateUserPreferences ).toHaveBeenCalledWith( {
+			dashboard_sections: [
+				{
+					key: 'store-performance',
+					title: 'Performance',
+					isVisible: true,
+					hiddenBlocks: [ 'taxes/order_tax' ],
+				},
+				{
+					key: 'charts',
+					title: 'Charts',
+					isVisible: true,
+					hiddenBlocks: [ 'coupons_amount' ],
+				},
+			],
+		} );
+
+		// The preference is re-read on every render, so the repair must not loop.
+		rerender(
+			<CustomizableDashboard path="/analytics/overview" query={ {} } />
+		);
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'repairs a preference stored as a raw string', () => {
+		renderDashboard( '[,,]' );
+
+		expect( updateUserPreferences ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'leaves a well formed preference alone', () => {
+		renderDashboard( [ { key: 'charts', isVisible: true } ] );
+
+		expect( updateUserPreferences ).not.toHaveBeenCalled();
+	} );
+
+	it( 'never stores the React nodes when a section is customized', () => {
+		const { getByTitle } = renderDashboard( [
+			{ key: 'charts', title: 'Charts', isVisible: true },
+			{
+				key: 'store-performance',
+				title: 'Performance',
+				isVisible: true,
+			},
+		] );
+
+		fireEvent.click( getByTitle( 'Hide Charts' ) );
+
+		const [ [ { dashboard_sections: stored } ] ] =
+			updateUserPreferences.mock.calls;
+		stored.forEach( ( section ) => {
+			expect( section ).not.toHaveProperty( 'icon' );
+			expect( section ).not.toHaveProperty( 'component' );
+		} );
+	} );
+
+	it( 'does not store anything when the dashboard was never customized', () => {
+		renderDashboard( '' );
+
+		expect( updateUserPreferences ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

A corrupted `woocommerce_admin_dashboard_sections` user meta crashed the Analytics dashboard. #51947 guarded the "not an array" case only, so an array holding `null` entries still went into `prefSections.map( section => section.key )`.

Malformed entries are now dropped, and the dashboard writes back the sections it fell back to. The stored value is repaired on the spot instead of staying broken until the merchant customizes a section. Saving strips the `icon` and `component` React nodes on every path now, not just renames.

One field of the wrong type was enough on its own. Sections call `hiddenBlocks.includes()` and headers render `title` as a React child, so `{"key":"charts","hiddenBlocks":null}` and `{"key":"charts","title":{}}` passed the entry check and still took the page down. A non boolean `isVisible` fails more quietly. `{"key":"charts","isVisible":0}` hides the section without listing it under **Add more sections**, and it passes validation, so nothing repairs it and the merchant has no way back. The default wins for that field and the merchant keeps their title, visibility, and order. All three live in one map that the validation and the merge share.

The repair keeps entries for keys it does not know about, so a section from a deactivated extension survives. There is no default to patch a corrupted field up from at that point, so the field is dropped and the rest of the entry is kept. The repair also skips the write when the value it would store is invalid anyway, for example when a filter empties the default sections, and it leaves an empty stored list alone since that already means the defaults are in use.

Closes #53234, closes WOOPLUG-2799

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**WooCommerce > Analytics > Overview** with `woocommerce_admin_dashboard_sections` set to a corrupted value.

| Before | After |
| ------ | ----- |
| <img width="440" alt="Analytics Overview showing Oops, something went wrong" src="https://github.com/user-attachments/assets/13c47e8d-ba99-4a92-811d-2908f3bfc81c" /> | <img width="440" alt="Analytics Overview rendering the default sections" src="https://github.com/user-attachments/assets/2de88b4f-2d56-4d63-aa5b-0c75bfa84602" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Corrupt the preference for the admin user: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", array( null, null ) );'`
2. Go to **WooCommerce > Analytics > Overview**. `trunk` shows "Oops, something went wrong". This branch renders the default sections with no console errors.
3. Check the meta with `wp user meta get 1 woocommerce_admin_dashboard_sections`. It now holds a valid list, with no `icon` or `component` keys.
4. Reload and confirm the value is not written again.
5. Rename a section, hide it, and add it back from **Add more sections**. Each persists, and the stored value stays free of `icon`/`component`.
6. Repeat steps 1-3 with `'[,,]'` and `'{}'`.
7. Corrupt one field instead of a whole entry: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[{\"key\":\"charts\",\"title\":\"My charts\",\"isVisible\":true,\"hiddenBlocks\":null}]" );'`. `trunk` crashes here too. On this branch the section is still called **My charts**, still comes first, and its `hiddenBlocks` is back to the default list.
8. Same with a title that is an object: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[{\"key\":\"charts\",\"title\":{\"rendered\":\"x\"},\"isVisible\":true}]" );'`. The section is called **Charts** again and still comes first.
9. Check that an unknown key survives: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[null,{\"key\":\"my-extension\",\"title\":\"Mine\",\"isVisible\":false,\"hiddenBlocks\":[]}]" );'`. The three default sections render and the `my-extension` entry is still stored, unchanged.
10. Corrupt only the visibility: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[{\"key\":\"charts\",\"title\":\"Charts\",\"isVisible\":0,\"hiddenBlocks\":[]},{\"key\":\"store-performance\",\"title\":\"Performance\",\"isVisible\":true,\"hiddenBlocks\":[]},{\"key\":\"leaderboards\",\"title\":\"Leaderboards\",\"isVisible\":true,\"hiddenBlocks\":[]}]" );'`. On `trunk` the Charts section is gone and **Add more sections** does not offer it back. On this branch it renders and the stored `isVisible` is `true` again.
11. Corrupt one field of an unknown key: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[null,{\"key\":\"my-extension\",\"title\":\"Mine\",\"isVisible\":false,\"hiddenBlocks\":null}]" );'`. On `trunk` the `my-extension` entry is dropped from the repaired value. On this branch it is still stored, without its `hiddenBlocks`.
12. Store an empty list: `wp eval 'update_user_meta( 1, "woocommerce_admin_dashboard_sections", "[]" );'`. The default sections render and the value is left as it is, with no request to `/wp/v2/users/`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I tested every corruption shape on a local dev env: `array( null, null )`, `'[,,]'`, `'{}'`, a `hiddenBlocks` of `null`, a `title` that is an object, an `isVisible` of `0`, an unknown key whose `hiddenBlocks` is `null`, and a stored `[]`. All render and repair with no console errors, and a partly corrupted entry keeps its rename and its position. A valid value and an empty one are both left alone, which I checked against the network log rather than the meta.

For the `hiddenBlocks`, `title` and `isVisible` guards I reverted each one, rebuilt, and confirmed the failure comes back. The first two show "Oops, something went wrong". The third is quieter: the section disappears from the page and from **Add more sections**, and nothing is written, so it stays broken. Reverting the unknown key and the empty list handling brings back a deleted `my-extension` entry and an overwritten empty list.

I also checked the two repair limits: a `my-extension` entry survives, and with a mu-plugin filtering the default sections to an empty list the page mounts with no sections and no write. No repaired value triggers a second repair on the next load. Rename, hide, add-back, and chart block toggles were driven through the UI, and the stored value dropped from 1286 to 716 bytes once the React nodes stopped being persisted.

`client/dashboard/test/customizable.js` has 22 tests and `pnpm test:js -- client/dashboard` passes 37. ESLint is clean and no PHP changed. Each guard was also checked by reverting it and confirming a test goes red, so the suite is not green by accident.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to reproduce the issue in a local dev env, write the fix and its tests, and verify each corruption shape in a browser. I reviewed the result.


