### PR TITLE
Clarify what get_all() returns on the product and order enums

### DIFF
--- a/plugins/woocommerce/changelog/docs-enum-get-all-scope
+++ b/plugins/woocommerce/changelog/docs-enum-get-all-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document that Enums get_all() returns the complete enum rather than the set of values a product or order can be assigned, and point to the filterable wc_get_*() helpers for that.

--- a/plugins/woocommerce/changelog/docs-enum-get-all-scope
+++ b/plugins/woocommerce/changelog/docs-enum-get-all-scope
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Document that Enums get_all() returns the complete enum rather than the set of values a product or order can be assigned, and point to the filterable wc_get_*() helpers for that.
+Document what Enums get_all() returns compared with the filterable wc_get_*() helpers, including the differing return shapes and the wc- prefix on order statuses.

--- a/plugins/woocommerce/src/Enums/CatalogVisibility.php
+++ b/plugins/woocommerce/src/Enums/CatalogVisibility.php
@@ -33,12 +33,12 @@ final class CatalogVisibility {
 	/**
 	 * Returns every catalog visibility value defined by this enum, as a flat list.
 	 *
-	 * These happen to be the same four values wc_get_product_visibility_options() returns today, so
-	 * the two look interchangeable. They are not: that helper returns a value => label map, it is
-	 * filterable, and it is what WC_Product::set_catalog_visibility() validates against -- so a site
-	 * can legitimately accept a visibility this list does not contain.
+	 * These are the same four values wc_get_product_visibility_options() returns by default, which
+	 * makes the two look interchangeable. They are not. That helper returns a value => label map,
+	 * it is filterable, and WC_Product::set_catalog_visibility() validates against it, so a site can
+	 * accept a visibility this list does not contain.
 	 *
-	 * Use wc_get_product_visibility_options() for anything that validates or presents a choice.
+	 * Use wc_get_product_visibility_options() wherever you validate or present a choice.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/CatalogVisibility.php
+++ b/plugins/woocommerce/src/Enums/CatalogVisibility.php
@@ -31,7 +31,14 @@ final class CatalogVisibility {
 	public const HIDDEN = 'hidden';
 
 	/**
-	 * Returns all catalog visibility values.
+	 * Returns every catalog visibility value defined by this enum, as a flat list.
+	 *
+	 * These happen to be the same four values wc_get_product_visibility_options() returns today, so
+	 * the two look interchangeable. They are not: that helper returns a value => label map, it is
+	 * filterable, and it is what WC_Product::set_catalog_visibility() validates against -- so a site
+	 * can legitimately accept a visibility this list does not contain.
+	 *
+	 * Use wc_get_product_visibility_options() for anything that validates or presents a choice.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/OrderInternalStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderInternalStatus.php
@@ -62,14 +62,14 @@ final class OrderInternalStatus {
 	 * Returns every internal order status value defined by this enum, as a flat list of `wc-`
 	 * prefixed slugs.
 	 *
-	 * These are the seven core statuses, which is narrower than the set an order can hold. The list
-	 * has no entry for `wc-checkout-draft`, a status WooCommerce itself registers through the
-	 * `wc_order_statuses` filter and the Store API assigns to live orders during checkout, and it
-	 * cannot carry statuses an extension registers.
+	 * These are the seven core statuses, which is narrower than the set an order can hold. The enum
+	 * has no `wc-checkout-draft`, a status WooCommerce registers through the `wc_order_statuses`
+	 * filter and the Store API assigns to live orders during checkout. It cannot carry statuses an
+	 * extension registers either.
 	 *
-	 * For the registered statuses, use wc_get_order_statuses(). It returns a value => label map on
-	 * these same prefixed keys. OrderStatus lists a wider set of unprefixed slugs, including
-	 * post-level states such as trash and auto-draft.
+	 * For the registered statuses, use wc_get_order_statuses(), which returns a value => label map
+	 * on these same prefixed keys. OrderStatus lists a wider set of unprefixed slugs, including
+	 * WordPress post statuses such as trash and auto-draft.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/OrderInternalStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderInternalStatus.php
@@ -59,7 +59,17 @@ final class OrderInternalStatus {
 	public const FAILED = 'wc-failed';
 
 	/**
-	 * Returns all internal order status values.
+	 * Returns every internal order status value defined by this enum, as a flat list of `wc-`
+	 * prefixed slugs.
+	 *
+	 * These are the seven core statuses, which is narrower than the set an order can hold. The list
+	 * has no entry for `wc-checkout-draft`, a status WooCommerce itself registers through the
+	 * `wc_order_statuses` filter and the Store API assigns to live orders during checkout, and it
+	 * cannot carry statuses an extension registers.
+	 *
+	 * For the registered statuses, use wc_get_order_statuses(). It returns a value => label map on
+	 * these same prefixed keys. OrderStatus lists a wider set of unprefixed slugs, including
+	 * post-level states such as trash and auto-draft.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/OrderStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderStatus.php
@@ -112,7 +112,7 @@ final class OrderStatus {
 	 *
 	 * The list is not the set of statuses WooCommerce registers, in either direction. It carries
 	 * self::TRASH, self::NEW, self::AUTO_DRAFT and self::DRAFT, which wc_get_order_statuses() does
-	 * not; self::TRASH and self::AUTO_DRAFT are nonetheless accepted by
+	 * not return by default; self::TRASH and self::AUTO_DRAFT are nonetheless accepted by
 	 * WC_Abstract_Order::set_status(), which exempts them from its own validation. It also cannot
 	 * carry statuses an extension registers. self::CHECKOUT_DRAFT is not an exception to the
 	 * helper: WooCommerce adds it through the `wc_order_statuses` filter, and the Store API assigns

--- a/plugins/woocommerce/src/Enums/OrderStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderStatus.php
@@ -108,14 +108,20 @@ final class OrderStatus {
 	);
 
 	/**
-	 * Returns every order status value defined by this enum.
+	 * Returns every order status value defined by this enum, as a flat list of unprefixed slugs.
 	 *
-	 * This is the complete enum, not the set of statuses an order can be assigned. It includes
-	 * post-level states such as self::TRASH, self::AUTO_DRAFT and self::CHECKOUT_DRAFT.
+	 * The list is not the set of statuses WooCommerce registers, in either direction. It carries
+	 * self::TRASH, self::NEW, self::AUTO_DRAFT and self::DRAFT, which wc_get_order_statuses() does
+	 * not; self::TRASH and self::AUTO_DRAFT are nonetheless accepted by
+	 * WC_Abstract_Order::set_status(), which exempts them from its own validation. It also cannot
+	 * carry statuses an extension registers. self::CHECKOUT_DRAFT is not an exception to the
+	 * helper: WooCommerce adds it through the `wc_order_statuses` filter, and the Store API assigns
+	 * it to live orders during checkout.
 	 *
-	 * For assignable statuses, use wc_get_order_statuses(). That helper is filterable, so unlike
-	 * this method it also reflects statuses an extension has registered; OrderInternalStatus lists
-	 * the same seven core statuses in their prefixed form.
+	 * For the registered statuses, use wc_get_order_statuses(). It returns a value => label map
+	 * keyed on the `wc-` prefixed slug, so its keys never compare equal to this enum's values
+	 * without OrderUtil::remove_status_prefix(). OrderInternalStatus lists the seven core statuses
+	 * in prefixed form.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/OrderStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderStatus.php
@@ -108,7 +108,14 @@ final class OrderStatus {
 	);
 
 	/**
-	 * Returns all order status values defined in this class.
+	 * Returns every order status value defined by this enum.
+	 *
+	 * This is the complete enum, not the set of statuses an order can be assigned. It includes
+	 * post-level states such as self::TRASH, self::AUTO_DRAFT and self::CHECKOUT_DRAFT.
+	 *
+	 * For assignable statuses, use wc_get_order_statuses(). That helper is filterable, so unlike
+	 * this method it also reflects statuses an extension has registered; OrderInternalStatus lists
+	 * the same seven core statuses in their prefixed form.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/OrderStatus.php
+++ b/plugins/woocommerce/src/Enums/OrderStatus.php
@@ -110,18 +110,19 @@ final class OrderStatus {
 	/**
 	 * Returns every order status value defined by this enum, as a flat list of unprefixed slugs.
 	 *
-	 * The list is not the set of statuses WooCommerce registers, in either direction. It carries
+	 * It differs from the statuses WooCommerce registers in both directions. It carries
 	 * self::TRASH, self::NEW, self::AUTO_DRAFT and self::DRAFT, which wc_get_order_statuses() does
-	 * not return by default; self::TRASH and self::AUTO_DRAFT are nonetheless accepted by
-	 * WC_Abstract_Order::set_status(), which exempts them from its own validation. It also cannot
-	 * carry statuses an extension registers. self::CHECKOUT_DRAFT is not an exception to the
-	 * helper: WooCommerce adds it through the `wc_order_statuses` filter, and the Store API assigns
-	 * it to live orders during checkout.
+	 * not return by default, and it cannot carry statuses an extension registers.
+	 * WC_Abstract_Order::set_status() accepts self::TRASH and self::AUTO_DRAFT even so, exempting
+	 * them from its own validation.
+	 *
+	 * self::CHECKOUT_DRAFT sits on the helper's side of that line: WooCommerce adds it through the
+	 * `wc_order_statuses` filter, and the Store API assigns it to live orders during checkout.
 	 *
 	 * For the registered statuses, use wc_get_order_statuses(). It returns a value => label map
-	 * keyed on the `wc-` prefixed slug, so its keys never compare equal to this enum's values
-	 * without OrderUtil::remove_status_prefix(). OrderInternalStatus lists the seven core statuses
-	 * in prefixed form.
+	 * keyed on the `wc-` prefixed slug, so comparing its keys with this enum's values needs
+	 * OrderUtil::remove_status_prefix(). OrderInternalStatus lists the seven core statuses in
+	 * prefixed form.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStatus.php
@@ -58,7 +58,11 @@ final class ProductStatus {
 	public const FUTURE = 'future';
 
 	/**
-	 * Returns all product status values.
+	 * Returns every product status value defined by this enum.
+	 *
+	 * This is the complete enum, including statuses WordPress manages rather than ones an author
+	 * chooses: self::AUTO_DRAFT, self::TRASH and self::FUTURE. WooCommerce has no narrower helper,
+	 * so callers that need only the editorial statuses should narrow this list themselves.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStatus.php
@@ -60,14 +60,13 @@ final class ProductStatus {
 	/**
 	 * Returns every product status value defined by this enum, as a flat list.
 	 *
-	 * All of these can be set on a product: WC_Product::set_status() does not validate, and core
-	 * assigns self::AUTO_DRAFT and self::TRASH itself. The distinction is who chooses them --
-	 * self::AUTO_DRAFT, self::TRASH and self::FUTURE are driven by WordPress rather than picked by
-	 * an author, so they are not offered everywhere a status is.
+	 * A product can hold any of them: WC_Product::set_status() does not validate, and core assigns
+	 * self::AUTO_DRAFT and self::TRASH itself. What separates them is who decides. WordPress sets
+	 * self::AUTO_DRAFT, self::TRASH and self::FUTURE; an author chooses the rest.
 	 *
 	 * WooCommerce has no narrower helper, and get_post_statuses() is not one: it is unfiltered and
-	 * omits self::FUTURE. Callers that need only what a particular editor or REST schema exposes
-	 * should narrow this list themselves.
+	 * lists only draft, pending, private and publish. Narrow this list yourself for a particular
+	 * editor or REST schema.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStatus.php
@@ -58,11 +58,16 @@ final class ProductStatus {
 	public const FUTURE = 'future';
 
 	/**
-	 * Returns every product status value defined by this enum.
+	 * Returns every product status value defined by this enum, as a flat list.
 	 *
-	 * This is the complete enum, including statuses WordPress manages rather than ones an author
-	 * chooses: self::AUTO_DRAFT, self::TRASH and self::FUTURE. WooCommerce has no narrower helper,
-	 * so callers that need only the editorial statuses should narrow this list themselves.
+	 * All of these can be set on a product: WC_Product::set_status() does not validate, and core
+	 * assigns self::AUTO_DRAFT and self::TRASH itself. The distinction is who chooses them --
+	 * self::AUTO_DRAFT, self::TRASH and self::FUTURE are driven by WordPress rather than picked by
+	 * an author, so they are not offered everywhere a status is.
+	 *
+	 * WooCommerce has no narrower helper, and get_post_statuses() is not one: it is unfiltered and
+	 * omits self::FUTURE. Callers that need only what a particular editor or REST schema exposes
+	 * should narrow this list themselves.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStockStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStockStatus.php
@@ -39,14 +39,15 @@ final class ProductStockStatus {
 	/**
 	 * Returns every stock status value defined by this enum, as a flat list.
 	 *
-	 * The list is wider than the set of statuses stored against products: self::LOW_STOCK is
-	 * derived from stock quantity rather than persisted, so a query filtering the stock_status
-	 * column can never match it. It remains a legitimate choice elsewhere -- the Analytics stock
-	 * report offers it, and adds it back explicitly for that reason.
+	 * It is wider than the set of statuses products store. self::LOW_STOCK is a reporting
+	 * aggregate: the Analytics stock report counts in-stock products whose quantity has fallen to
+	 * their low-stock threshold, so a low-stock product stores self::IN_STOCK. That report adds
+	 * self::LOW_STOCK to its own enum for exactly that reason.
 	 *
-	 * For the persisted statuses, and the options a stock_status filter should offer, use
-	 * wc_get_product_stock_status_options(). It returns a value => label map rather than a list,
-	 * and being filterable it also reflects statuses an extension has added.
+	 * WC_Product::set_stock_status() coerces anything outside wc_get_product_stock_status_options()
+	 * to self::IN_STOCK, so use that helper for values you intend to store or filter on. It returns
+	 * a value => label map rather than a list, and being filterable it also carries statuses an
+	 * extension added.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStockStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStockStatus.php
@@ -37,7 +37,14 @@ final class ProductStockStatus {
 	public const LOW_STOCK = 'lowstock';
 
 	/**
-	 * Returns all product stock status values.
+	 * Returns every stock status value defined by this enum.
+	 *
+	 * This is the complete enum, not the set of statuses a product can hold. It includes
+	 * self::LOW_STOCK, which is a derived reporting state and is never stored against a product.
+	 *
+	 * For the statuses a product can be set to, and the options a stock filter should offer, use
+	 * wc_get_product_stock_status_options(). That helper is filterable, so unlike this method it
+	 * also reflects statuses an extension has added.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductStockStatus.php
+++ b/plugins/woocommerce/src/Enums/ProductStockStatus.php
@@ -37,14 +37,16 @@ final class ProductStockStatus {
 	public const LOW_STOCK = 'lowstock';
 
 	/**
-	 * Returns every stock status value defined by this enum.
+	 * Returns every stock status value defined by this enum, as a flat list.
 	 *
-	 * This is the complete enum, not the set of statuses a product can hold. It includes
-	 * self::LOW_STOCK, which is a derived reporting state and is never stored against a product.
+	 * The list is wider than the set of statuses stored against products: self::LOW_STOCK is
+	 * derived from stock quantity rather than persisted, so a query filtering the stock_status
+	 * column can never match it. It remains a legitimate choice elsewhere -- the Analytics stock
+	 * report offers it, and adds it back explicitly for that reason.
 	 *
-	 * For the statuses a product can be set to, and the options a stock filter should offer, use
-	 * wc_get_product_stock_status_options(). That helper is filterable, so unlike this method it
-	 * also reflects statuses an extension has added.
+	 * For the persisted statuses, and the options a stock_status filter should offer, use
+	 * wc_get_product_stock_status_options(). It returns a value => label map rather than a list,
+	 * and being filterable it also reflects statuses an extension has added.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductType.php
+++ b/plugins/woocommerce/src/Enums/ProductType.php
@@ -44,13 +44,15 @@ final class ProductType {
 	public const VARIATION = 'variation';
 
 	/**
-	 * Returns every product type value defined by this enum.
+	 * Returns every product type value defined by this enum, as a flat list.
 	 *
-	 * This is the complete enum, not the set of types a product can be created as. It includes
-	 * self::VARIATION, which is a child post type rather than a selectable product type.
+	 * The list includes self::VARIATION. Variations are real products that can be created --
+	 * WC_Product_Variation::get_type() returns this value -- but they belong to a parent, so they
+	 * are not a standalone choice when creating a product.
 	 *
-	 * For the selectable types, use wc_get_product_types(). That helper is filterable, so unlike
-	 * this method it also reflects types an extension has registered.
+	 * For the top-level types a merchant can pick, use wc_get_product_types(). It returns a
+	 * value => label map rather than a list, and being filterable it also reflects types an
+	 * extension has registered.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductType.php
+++ b/plugins/woocommerce/src/Enums/ProductType.php
@@ -44,7 +44,13 @@ final class ProductType {
 	public const VARIATION = 'variation';
 
 	/**
-	 * Returns all product type values.
+	 * Returns every product type value defined by this enum.
+	 *
+	 * This is the complete enum, not the set of types a product can be created as. It includes
+	 * self::VARIATION, which is a child post type rather than a selectable product type.
+	 *
+	 * For the selectable types, use wc_get_product_types(). That helper is filterable, so unlike
+	 * this method it also reflects types an extension has registered.
 	 *
 	 * @since 10.9.0
 	 *

--- a/plugins/woocommerce/src/Enums/ProductType.php
+++ b/plugins/woocommerce/src/Enums/ProductType.php
@@ -46,13 +46,13 @@ final class ProductType {
 	/**
 	 * Returns every product type value defined by this enum, as a flat list.
 	 *
-	 * The list includes self::VARIATION. Variations are real products that can be created --
-	 * WC_Product_Variation::get_type() returns this value -- but they belong to a parent, so they
-	 * are not a standalone choice when creating a product.
+	 * It includes self::VARIATION. Variations are real, creatable products, and
+	 * WC_Product_Variation::get_type() returns this value, but each belongs to a parent rather than
+	 * standing on its own.
 	 *
 	 * For the top-level types a merchant can pick, use wc_get_product_types(). It returns a
-	 * value => label map rather than a list, and being filterable it also reflects types an
-	 * extension has registered.
+	 * value => label map rather than a list, and being filterable it also carries types an
+	 * extension registered.
 	 *
 	 * @since 10.9.0
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Documentation only. No behaviour change.

`Enums\*::get_all()` returns every constant on its class, as a flat list. The `wc_get_*()` helpers beside them return something different in two ways at once: a narrower, context-specific set, and a `value => label` map rather than a list. Neither difference is documented, and the docblocks ("Returns all product stock status values") read as though the enum is authoritative.

| Enum | What `get_all()` carries that the helper does not | Helper |
| ---- | ------------------------------------------------ | ------ |
| `ProductStockStatus` | `lowstock` — derived from stock quantity, never persisted, so a `stock_status` query cannot match it | `wc_get_product_stock_status_options()` |
| `ProductType` | `variation` — a real, creatable type, but owned by a parent rather than a top-level choice | `wc_get_product_types()` |
| `ProductStatus` | `auto-draft`, `trash`, `future` — driven by WordPress rather than chosen by an author | none exists |
| `OrderStatus` | `trash`, `new`, `auto-draft`, `draft` | `wc_get_order_statuses()` |
| `CatalogVisibility` | nothing today — the values match, which is what makes it deceptive | `wc_get_product_visibility_options()` |
| `OrderInternalStatus` | nothing — it is *missing* `wc-checkout-draft`, which core registers and assigns | `wc_get_order_statuses()` |

The reverse direction matters too, and is the part a static enum can never fix: the helpers are filterable, so they carry values the enum cannot. `checkout-draft` is the in-core example — WooCommerce adds it to `wc_get_order_statuses()` via the `wc_order_statuses` filter, and the Store API assigns it to live orders during checkout.

And the shape mismatch is its own trap. `get_all()` is `@return string[]`; `wc_get_order_statuses()` is keyed on the `wc-` prefixed slug, so `in_array( 'processing', wc_get_order_statuses() )` is `false` and stays silent. `OrderAbilityTrait` needs both `array_keys()` and `remove_status_prefix()` for exactly this reason. Each docblock now names the shape, and the order one names the prefix.

Worth noting the codebase already works around this boundary in two places rather than documenting it:

```php
// src/Admin/API/Reports/Stock/Controller.php:481
'enum' => array_merge( array( 'all', 'lowstock' ), array_keys( wc_get_product_stock_status_options() ) ),

// src/Internal/Abilities/Domain/Traits/OrderAbilityTrait.php:47
array_merge( OrderStatus::get_all(), array_keys( wc_get_order_statuses() ) )
```

Neither treats one list as sufficient on its own.

The last two rows are the interesting ones, and the reason this covers six enums rather than four.

`CatalogVisibility::get_all()` returns exactly the same four values as `wc_get_product_visibility_options()` today, so they look interchangeable — and that is precisely the trap. The helper is filterable, returns a map, and is what `WC_Product::set_catalog_visibility()` validates against, so a site can accept a visibility the enum does not list. Nothing about the current equality is guaranteed.

`OrderInternalStatus::get_all()` fails in the opposite direction from the others: it is missing a status. There is no `CHECKOUT_DRAFT` constant on it, yet WooCommerce registers `wc-checkout-draft` through the `wc_order_statuses` filter and the Store API assigns it to live orders during checkout. That is an in-core gap, not a hypothetical extension one.

`WeightUnit` and `DimensionUnit` are the only ones left alone, for a substantive reason rather than diff size: they have no companion helper, and their `woocommerce_weight_units` / `woocommerce_dimension_units` filters are applied at a single call site each in the V4 settings controller. Documenting those as an extension point on the enum would imply a general contract that does not exist.

### Backwards compatibility:

None affected. Docblock text only; no signature, return value, or behaviour changes.

### How to test the changes in this Pull Request:

1. Read the four modified docblocks in `plugins/woocommerce/src/Enums/`.
- [ ] Verify each accurately describes what its `get_all()` returns, and that the helper it names exists and returns the narrower set.
2. Confirm nothing else changed:
   ```
   git diff trunk...HEAD -- plugins/woocommerce/src
   ```
- [ ] Verify the diff touches only comment lines.
3. Run the linters:
   ```
   pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch
   ```
- [ ] Verify it passes.

### Testing that has already taken place:

-   `lint:changes:branch` (JS + PHP) clean; `phpstan analyse` and `phpcs-changed` on all six files report no errors.
-   Every claim in the docblocks was checked against the source rather than asserted: `WC_Product::set_status()` (bare `set_prop()`, no validation), `WC_Abstract_Order::set_status()` (`$status_exceptions = array( AUTO_DRAFT, TRASH )`), `WC_Product_Variation::get_type()`, `DraftOrders::register_draft_order_status()` on the `wc_order_statuses` filter, `StoreApi\Utilities\OrderController` assigning `checkout-draft`, and the key shape of each helper.
-   Audited every caller of `get_all()` across the `Enums` namespace before writing anything. There are four, and all are correct for their purpose, so this PR fixes no bug — it prevents one:
    -   `ProductCountCacheTest.php:92` (`ProductStatus`) — asserts a cached count exists for every status; enum-complete is the intent.
    -   `Settings/Products/Controller.php:248` and `:266` (`WeightUnit`, `DimensionUnit`) — those enums have no derived members.
    -   `OrderAbilityTrait.php:47` (`OrderStatus`) — an output schema, where `trash` and `checkout-draft` genuinely belong.
-   `ProductStockStatus::get_all()` in particular has **zero** callers anywhere in the repo, tests included.
-   The motivation was a review suggestion on #67871 to add `lowstock` to a Products list stock filter test, on the grounds that `get_all()` includes it. It does; the Products list only ever receives the three values from `wc_get_product_stock_status_options()`. A careful reader landing on the old docblock had no way to tell.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

The changelog entry was added manually in this branch (`plugins/woocommerce/changelog/docs-enum-get-all-scope`), so neither box below is checked.

-   [ ] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

---
🤖 Generated with [Claude Code](https://claude.ai/code)


