### PR TITLE
[DEVPROD-1210] Survive transient GitHub API errors in the CI queue sentinel

### DIFF
--- a/.github/workflows/ci-queue-sentinel.yml
+++ b/.github/workflows/ci-queue-sentinel.yml
@@ -73,4 +73,4 @@ jobs:
           SLACK_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
           SLACK_CHANNELS: ${{ secrets.DAILY_CHECKS_CHANNEL }}
         run: |
-          pnpm utils slack ":warning: CI Queue Sentinel failed — the CI_QUEUE_OVERFLOW switch may be stranded in its last state.\n<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View workflow run>"
+          pnpm utils slack ":warning: CI Queue Sentinel failed — ${SENTINEL_FAILURE:-the CI_QUEUE_OVERFLOW switch may be stranded in its last state}.\n<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View workflow run>"

--- a/.github/workflows/scripts/ci-queue-sentinel.js
+++ b/.github/workflows/scripts/ci-queue-sentinel.js
@@ -15,6 +15,7 @@ const {
 	QUEUE_AGE_THRESHOLD_MIN = '5',
 	HYSTERESIS_MIN = '20',
 	GITHUB_STEP_SUMMARY,
+	GITHUB_ENV,
 } = process.env;
 
 const VARIABLE_NAME = 'CI_QUEUE_OVERFLOW';
@@ -391,5 +392,11 @@ const main = async () => {
 
 main().catch( ( error ) => {
 	summarize( [ '### CI Queue Sentinel', `- FAILED: ${ error.message }` ] );
+	// Hand the reason to the Slack step, which otherwise reports every cause
+	// identically. Stripped of characters the shell would act on inside quotes.
+	if ( GITHUB_ENV ) {
+		const reason = error.message.replace( /[\r\n]+/g, ' ' ).replace( /[`$\\"]/g, '' );
+		fs.appendFileSync( GITHUB_ENV, `SENTINEL_FAILURE=${ reason }\n` );
+	}
 	process.exit( 1 );
 } );

--- a/.github/workflows/scripts/ci-queue-sentinel.js
+++ b/.github/workflows/scripts/ci-queue-sentinel.js
@@ -38,10 +38,11 @@ const MAX_FETCH_RETRIES = 2;
 // Each unreadable run costs ~45s of retry sleep. Probing 60 of them would burn
 // the job timeout without producing an answer, so give up early instead.
 const MAX_PROBE_FAILURES = 3;
-// The longest real overflow window observed is 102 min. Past this, combined with
-// a probe that cannot prove the queue is healthy, the switch is stuck rather than
-// busy, and it bills the paid group for as long as nobody notices.
-const MAX_ON_MINUTES = 240;
+// Real overflow windows run 26-42 min (20 of that is the hysteresis floor); the
+// longest observed is 102. Past this, with a probe that can neither prove the
+// queue healthy nor show any over-threshold work, the switch is stuck rather
+// than busy, and it bills the paid group for as long as nobody notices.
+const MAX_ON_MINUTES = 120;
 
 const sleep = ( seconds ) => new Promise( ( resolve ) => setTimeout( resolve, seconds * 1000 ) );
 
@@ -386,12 +387,16 @@ const main = async () => {
 
 	// Checked last: the decision above still stands and is recorded. Failing here
 	// only rings the alarm, so a switch nobody can turn off cannot bill quietly.
-	// Requires an incomplete probe: a long window backed by a healthy probe is
-	// real congestion doing its job, not a stuck switch, and must stay quiet.
+	// Fires only when the probe can say nothing either way. A probe that found
+	// over-threshold work has explained the ON state, and heavy congestion is
+	// itself a common reason for an incomplete probe — it overruns the run caps,
+	// leaving a non-empty remainder that escalation declines to touch while the
+	// queue reads busy. Without this clause a long real backlog would page.
 	const onForMin = ( nowMs - updatedAtMs ) / 60000;
-	if ( value === '1' && rawValue === '1' && ! probeComplete && onForMin > MAX_ON_MINUTES ) {
+	const provenCongested = oldestAgeMin !== null && oldestAgeMin > thresholdMin;
+	if ( value === '1' && rawValue === '1' && ! probeComplete && ! provenCongested && onForMin > MAX_ON_MINUTES ) {
 		throw new Error(
-			`${ VARIABLE_NAME } has been ON for ${ Math.round( onForMin ) } min with an incomplete queue probe — the switch cannot be proven safe to turn off`
+			`${ VARIABLE_NAME } has been ON for ${ Math.round( onForMin ) } min; the probe is incomplete and found no queued work over the threshold, so the switch cannot be proven safe to turn off`
 		);
 	}
 };

--- a/.github/workflows/scripts/ci-queue-sentinel.js
+++ b/.github/workflows/scripts/ci-queue-sentinel.js
@@ -35,13 +35,10 @@ const MAX_IN_PROGRESS_RUNS_TO_PROBE = 30;
 const MAX_ESCALATION_RUNS_TO_PROBE = 60;
 const MAX_RUN_LIST_PAGES = 3;
 const MAX_FETCH_RETRIES = 2;
-// Each unreadable run costs ~45s of retry sleep. Probing 60 of them would burn
-// the job timeout without producing an answer, so give up early instead.
+// Each unreadable run costs ~45s of retry sleep; 60 would burn the job timeout.
 const MAX_PROBE_FAILURES = 3;
-// Real overflow windows run 26-42 min (20 of that is the hysteresis floor); the
-// longest observed is 102. Past this, with a probe that can neither prove the
-// queue healthy nor show any over-threshold work, the switch is stuck rather
-// than busy, and it bills the paid group for as long as nobody notices.
+// Observed overflow windows run 26-42 min; the longest ever recorded is 102.
+// Past this with nothing to explain the ON state, the switch is stuck, not busy.
 const MAX_ON_MINUTES = 120;
 
 const sleep = ( seconds ) => new Promise( ( resolve ) => setTimeout( resolve, seconds * 1000 ) );
@@ -166,9 +163,8 @@ const collectQueuedJobs = async ( runList ) => {
 		try {
 			jobs = await fetchJobsForRun( run.id );
 		} catch ( error ) {
-			// Any error outliving the retries used to abort the tick and alert.
 			// Missing one run's jobs can only understate the queue, so record it
-			// and let the incomplete probe suppress switch-off instead.
+			// and let the incomplete probe suppress switch-off instead of aborting.
 			failed++;
 			console.log( `Probe skipped run ${ run.id }: ${ error.message }` );
 			if ( failed >= MAX_PROBE_FAILURES ) {
@@ -323,9 +319,9 @@ const main = async () => {
 	// is ON and the probed hosted queue looks healthy, that suppression may
 	// rest only on unprobed runs — probe them so the off decision is proven
 	// rather than dependent on the run count fitting the caps. Runs only in
-	// that narrow state, so normal ticks pay nothing extra. Skipped once any probe
-	// has failed: probeComplete can no longer become true, so it could not change
-	// the outcome, and the failure allowance stays global to the tick.
+	// that narrow state, so normal ticks pay nothing extra. Skipped once a probe
+	// has failed: probeComplete can no longer become true, so it would change
+	// nothing, and the failure allowance stays global to the tick.
 	let escalated = 0;
 	if (
 		! forced && ! probeComplete && failedProbes === 0 && current === '1' &&
@@ -341,15 +337,11 @@ const main = async () => {
 		escalated = extra.attempted;
 		nowMs = Date.now();
 		oldestAgeMin = oldestAge( queuedJobs, nowMs );
-		// Every listed run has now been attempted; run-list page truncation and
-		// unreadable runs are the only things that can still leave it incomplete.
 		probeComplete = runsListComplete && failedProbes === 0;
 	}
 
-	// A blind tick is deliberately not an alert: most ticks see a single active
-	// run, so one transient error would page constantly for a state that
-	// self-heals on the next tick and costs nothing while the switch is off.
-	// Sustained blindness that is actually costing money is caught at the end.
+	// Not an alert: this self-heals next tick and costs nothing while the switch
+	// is off. Blindness that is actually costing money is caught at the end.
 	if ( failedProbes > 0 ) {
 		console.log(
 			`::warning::Queue probe could not read ${ failedProbes } of ${ probeAttempts } active runs; switch-off is suppressed this tick.`
@@ -377,21 +369,17 @@ const main = async () => {
 		...( forced ? [ '- Probe skipped (forced mode)' ] : [
 			`- Active runs attempted: ${ probeAttempts } of ${ runs.length }${ dropped ? ` (${ dropped } dropped by age window)` : '' }${ escalated ? ` (escalated: +${ escalated } runs to verify switch-off)` : '' }${ failedProbes ? ` (${ failedProbes } unreadable — API errors)` : '' }${ probeComplete ? '' : ' (probe incomplete — switch-off suppressed)' }`,
 			`- Queued jobs found: ${ queuedJobs.length } (hosted pool${ ignoredPools ? `; ${ ignoredPools } in runner groups ignored` : '' })`,
-			// An incomplete probe establishes neither a clear queue nor the true
-			// oldest job: an unread run can hold an older one, so the figure is a
-			// lower bound and is reported as such.
+			// An unread run can hold an older job, so an incomplete probe gives a
+			// lower bound, never a clear queue.
 			`- Oldest queued job age: ${ oldestAgeMin === null ? ( probeComplete ? 'n/a (queue clear)' : 'unknown (probe incomplete)' ) : `${ probeComplete ? '' : '≥ ' }${ oldestAgeMin.toFixed( 1 ) } min${ probeComplete ? '' : ' (probe incomplete)' }` } (threshold ${ QUEUE_AGE_THRESHOLD_MIN } min)`,
 		] ),
 		`- ${ VARIABLE_NAME }: \`${ rawValue }\` -> \`${ value }\`${ value === rawValue ? ' (no change)' : '' }`,
 	] );
 
-	// Checked last: the decision above still stands and is recorded. Failing here
-	// only rings the alarm, so a switch nobody can turn off cannot bill quietly.
-	// Fires only when the probe can say nothing either way. A probe that found
-	// over-threshold work has explained the ON state, and heavy congestion is
-	// itself a common reason for an incomplete probe — it overruns the run caps,
-	// leaving a non-empty remainder that escalation declines to touch while the
-	// queue reads busy. Without this clause a long real backlog would page.
+	// Checked after the decision is recorded, so ringing the alarm cannot strand
+	// the switch. Fires only when the probe explains nothing: congestion itself
+	// overruns the run caps and leaves the probe incomplete, so without the
+	// provenCongested clause a long real backlog would page.
 	const onForMin = ( nowMs - updatedAtMs ) / 60000;
 	const provenCongested = oldestAgeMin !== null && oldestAgeMin > thresholdMin;
 	if ( value === '1' && rawValue === '1' && ! probeComplete && ! provenCongested && onForMin > MAX_ON_MINUTES ) {

--- a/.github/workflows/scripts/ci-queue-sentinel.js
+++ b/.github/workflows/scripts/ci-queue-sentinel.js
@@ -35,6 +35,13 @@ const MAX_IN_PROGRESS_RUNS_TO_PROBE = 30;
 const MAX_ESCALATION_RUNS_TO_PROBE = 60;
 const MAX_RUN_LIST_PAGES = 3;
 const MAX_FETCH_RETRIES = 2;
+// Each unreadable run costs ~45s of retry sleep. Probing 60 of them would burn
+// the job timeout without producing an answer, so give up early instead.
+const MAX_PROBE_FAILURES = 3;
+// The longest real overflow window observed is 102 min. Past this, combined with
+// a probe that cannot prove the queue is healthy, the switch is stuck rather than
+// busy, and it bills the paid group for as long as nobody notices.
+const MAX_ON_MINUTES = 240;
 
 const sleep = ( seconds ) => new Promise( ( resolve ) => setTimeout( resolve, seconds * 1000 ) );
 
@@ -150,8 +157,25 @@ const isHostedPoolJob = ( job ) =>
 const collectQueuedJobs = async ( runList ) => {
 	const queued = [];
 	let ignoredPools = 0;
+	let failed = 0;
+	let attempted = 0;
 	for ( const run of runList ) {
-		const jobs = await fetchJobsForRun( run.id );
+		let jobs;
+		attempted++;
+		try {
+			jobs = await fetchJobsForRun( run.id );
+		} catch ( error ) {
+			// Any error outliving the retries used to abort the tick and alert.
+			// Missing one run's jobs can only understate the queue, so record it
+			// and let the incomplete probe suppress switch-off instead.
+			failed++;
+			console.log( `Probe skipped run ${ run.id }: ${ error.message }` );
+			if ( failed >= MAX_PROBE_FAILURES ) {
+				console.log( 'Probe abandoned: too many unreadable runs' );
+				break;
+			}
+			continue;
+		}
 		for ( const job of jobs ) {
 			if ( job.status !== 'queued' ) {
 				continue;
@@ -163,7 +187,7 @@ const collectQueuedJobs = async ( runList ) => {
 			}
 		}
 	}
-	return { queued, ignoredPools };
+	return { queued, ignoredPools, failed, attempted };
 };
 
 const fetchQueuedJobs = async ( runs ) => {
@@ -179,8 +203,15 @@ const fetchQueuedJobs = async ( runs ) => {
 		...allQueued.slice( MAX_QUEUED_RUNS_TO_PROBE ),
 		...allInProgress.slice( MAX_IN_PROGRESS_RUNS_TO_PROBE ),
 	];
-	const { queued, ignoredPools } = await collectQueuedJobs( probeList );
-	return { queued, complete: remainder.length === 0, ignoredPools, remainder };
+	const { queued, ignoredPools, failed, attempted } = await collectQueuedJobs( probeList );
+	return {
+		queued,
+		complete: remainder.length === 0 && failed === 0,
+		ignoredPools,
+		remainder,
+		failed,
+		attempted,
+	};
 };
 
 const fetchVariable = async () => {
@@ -256,7 +287,7 @@ const main = async () => {
 	// Forced modes skip the probe: a manual override must succeed even when
 	// the queue API is failing, and needs no queue data to decide.
 	const forced = MODE === 'on' || MODE === 'off';
-	let runs = [], queuedJobs = [], dropped = 0, ignoredPools = 0, remainder = [];
+	let runs = [], queuedJobs = [], dropped = 0, ignoredPools = 0, remainder = [], failedProbes = 0, probeAttempts = 0;
 	let runsListComplete = true, probeComplete = true;
 	if ( ! forced ) {
 		const runsResult = await fetchActiveRuns();
@@ -268,6 +299,8 @@ const main = async () => {
 		dropped = runsResult.dropped;
 		ignoredPools = jobsResult.ignoredPools;
 		remainder = jobsResult.remainder;
+		failedProbes = jobsResult.failed;
+		probeAttempts = jobsResult.attempted;
 	}
 	// Measure ages after the probe; retries can stretch it by minutes.
 	let nowMs = Date.now();
@@ -289,10 +322,12 @@ const main = async () => {
 	// is ON and the probed hosted queue looks healthy, that suppression may
 	// rest only on unprobed runs — probe them so the off decision is proven
 	// rather than dependent on the run count fitting the caps. Runs only in
-	// that narrow state, so normal ticks pay nothing extra.
+	// that narrow state, so normal ticks pay nothing extra. Skipped once any probe
+	// has failed: probeComplete can no longer become true, so it could not change
+	// the outcome, and the failure allowance stays global to the tick.
 	let escalated = 0;
 	if (
-		! forced && ! probeComplete && current === '1' &&
+		! forced && ! probeComplete && failedProbes === 0 && current === '1' &&
 		! ( oldestAgeMin !== null && oldestAgeMin > thresholdMin ) &&
 		nowMs - updatedAtMs >= hysteresisMin * 60 * 1000 &&
 		remainder.length > 0 && remainder.length <= MAX_ESCALATION_RUNS_TO_PROBE
@@ -300,12 +335,24 @@ const main = async () => {
 		const extra = await collectQueuedJobs( remainder );
 		queuedJobs = [ ...queuedJobs, ...extra.queued ];
 		ignoredPools += extra.ignoredPools;
-		escalated = remainder.length;
+		failedProbes += extra.failed;
+		probeAttempts += extra.attempted;
+		escalated = extra.attempted;
 		nowMs = Date.now();
 		oldestAgeMin = oldestAge( queuedJobs, nowMs );
-		// Every listed run is now probed; only run-list page truncation can
-		// still leave the probe incomplete.
-		probeComplete = runsListComplete;
+		// Every listed run has now been attempted; run-list page truncation and
+		// unreadable runs are the only things that can still leave it incomplete.
+		probeComplete = runsListComplete && failedProbes === 0;
+	}
+
+	// A blind tick is deliberately not an alert: most ticks see a single active
+	// run, so one transient error would page constantly for a state that
+	// self-heals on the next tick and costs nothing while the switch is off.
+	// Sustained blindness that is actually costing money is caught at the end.
+	if ( failedProbes > 0 ) {
+		console.log(
+			`::warning::Queue probe could not read ${ failedProbes } of ${ probeAttempts } active runs; switch-off is suppressed this tick.`
+		);
 	}
 
 	const value = decide( {
@@ -323,19 +370,29 @@ const main = async () => {
 		await writeVariable( value, !! variable );
 	}
 
-	const probed = escalated +
-		Math.min( runs.filter( ( run ) => run.status === 'queued' ).length, MAX_QUEUED_RUNS_TO_PROBE ) +
-		Math.min( runs.filter( ( run ) => run.status !== 'queued' ).length, MAX_IN_PROGRESS_RUNS_TO_PROBE );
 	summarize( [
 		'### CI Queue Sentinel',
 		`- Mode: \`${ MODE }\``,
 		...( forced ? [ '- Probe skipped (forced mode)' ] : [
-			`- Active runs probed: ${ probed } of ${ runs.length }${ dropped ? ` (${ dropped } dropped by age window)` : '' }${ escalated ? ` (escalated: +${ escalated } runs to verify switch-off)` : '' }${ probeComplete ? '' : ' (probe truncated — switch-off suppressed)' }`,
+			`- Active runs attempted: ${ probeAttempts } of ${ runs.length }${ dropped ? ` (${ dropped } dropped by age window)` : '' }${ escalated ? ` (escalated: +${ escalated } runs to verify switch-off)` : '' }${ failedProbes ? ` (${ failedProbes } unreadable — API errors)` : '' }${ probeComplete ? '' : ' (probe incomplete — switch-off suppressed)' }`,
 			`- Queued jobs found: ${ queuedJobs.length } (hosted pool${ ignoredPools ? `; ${ ignoredPools } in runner groups ignored` : '' })`,
-			`- Oldest queued job age: ${ oldestAgeMin === null ? 'n/a (queue clear)' : `${ oldestAgeMin.toFixed( 1 ) } min` } (threshold ${ QUEUE_AGE_THRESHOLD_MIN } min)`,
+			// An incomplete probe has not established a clear queue, so it must not
+			// be reported as one.
+			`- Oldest queued job age: ${ oldestAgeMin === null ? ( probeComplete ? 'n/a (queue clear)' : 'unknown (probe incomplete)' ) : `${ oldestAgeMin.toFixed( 1 ) } min` } (threshold ${ QUEUE_AGE_THRESHOLD_MIN } min)`,
 		] ),
 		`- ${ VARIABLE_NAME }: \`${ rawValue }\` -> \`${ value }\`${ value === rawValue ? ' (no change)' : '' }`,
 	] );
+
+	// Checked last: the decision above still stands and is recorded. Failing here
+	// only rings the alarm, so a switch nobody can turn off cannot bill quietly.
+	// Requires an incomplete probe: a long window backed by a healthy probe is
+	// real congestion doing its job, not a stuck switch, and must stay quiet.
+	const onForMin = ( nowMs - updatedAtMs ) / 60000;
+	if ( value === '1' && rawValue === '1' && ! probeComplete && onForMin > MAX_ON_MINUTES ) {
+		throw new Error(
+			`${ VARIABLE_NAME } has been ON for ${ Math.round( onForMin ) } min with an incomplete queue probe — the switch cannot be proven safe to turn off`
+		);
+	}
 };
 
 main().catch( ( error ) => {

--- a/.github/workflows/scripts/ci-queue-sentinel.js
+++ b/.github/workflows/scripts/ci-queue-sentinel.js
@@ -376,9 +376,10 @@ const main = async () => {
 		...( forced ? [ '- Probe skipped (forced mode)' ] : [
 			`- Active runs attempted: ${ probeAttempts } of ${ runs.length }${ dropped ? ` (${ dropped } dropped by age window)` : '' }${ escalated ? ` (escalated: +${ escalated } runs to verify switch-off)` : '' }${ failedProbes ? ` (${ failedProbes } unreadable — API errors)` : '' }${ probeComplete ? '' : ' (probe incomplete — switch-off suppressed)' }`,
 			`- Queued jobs found: ${ queuedJobs.length } (hosted pool${ ignoredPools ? `; ${ ignoredPools } in runner groups ignored` : '' })`,
-			// An incomplete probe has not established a clear queue, so it must not
-			// be reported as one.
-			`- Oldest queued job age: ${ oldestAgeMin === null ? ( probeComplete ? 'n/a (queue clear)' : 'unknown (probe incomplete)' ) : `${ oldestAgeMin.toFixed( 1 ) } min` } (threshold ${ QUEUE_AGE_THRESHOLD_MIN } min)`,
+			// An incomplete probe establishes neither a clear queue nor the true
+			// oldest job: an unread run can hold an older one, so the figure is a
+			// lower bound and is reported as such.
+			`- Oldest queued job age: ${ oldestAgeMin === null ? ( probeComplete ? 'n/a (queue clear)' : 'unknown (probe incomplete)' ) : `${ probeComplete ? '' : '≥ ' }${ oldestAgeMin.toFixed( 1 ) } min${ probeComplete ? '' : ' (probe incomplete)' }` } (threshold ${ QUEUE_AGE_THRESHOLD_MIN } min)`,
 		] ),
 		`- ${ VARIABLE_NAME }: \`${ rawValue }\` -> \`${ value }\`${ value === rawValue ? ' (no change)' : '' }`,
 	] );


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Scope reduced.** This PR previously also added a `workflow_run` trigger firing the sentinel on every CI run creation. Per review that has been split out and parked on `parked/DEVPROD-1210-sentinel-event-trigger`: it is a latency improvement on a mitigation that is already working, and it carried a rate-limit question worth settling on its own. What remains is the error handling — the one failure this workflow actually produces today.

A transient API error while probing one run's jobs aborts the whole tick and pages Slack. 6 failures in the last ~400 runs, every readable one identical:

```
FAILED: GET .../actions/runs/<id>/jobs?per_page=100&page=1 -> HTTP 502
```

`ghFetch` already retries `>= 500` three times, so these survived ~45s of retrying. This changes what happens after the retries are exhausted.

A missing run can only understate the queue, so an unreadable run is now recorded instead of fatal:

- Skipped, and the probe marked incomplete — which already suppresses switch-OFF.
- A `::warning::` records how many runs were unreadable, rather than failing the job.
- The probe gives up after 3 unreadable runs instead of spending the timeout on backoff.
- Escalation is skipped once a probe has failed, since `probeComplete` can no longer become true.
- The summary reports runs *attempted*. An incomplete probe reports `unknown (probe incomplete)` when nothing was found, and `≥ N min` when something was — an unread run can hold an older job, so the figure is a lower bound.

Because a blind probe can now hold the switch ON without proof it is safe to release, a backstop fails the job if `CI_QUEUE_OVERFLOW` has been ON past `MAX_ON_MINUTES` *and* the probe can say nothing either way — it neither proved the queue healthy nor found any over-threshold work. The decision is written before the alarm fires, so it never strands the switch.

`MAX_ON_MINUTES` is 120. Observed ON windows run 26-42 min (20 of that is the hysteresis floor), and the longest ever recorded is 102. The "found no over-threshold work" half of the condition matters: heavy congestion overruns the run caps, leaving a non-empty `remainder` that escalation declines to probe while the queue reads busy — so without it, a long genuine backlog would page.

No change to the threshold, hysteresis, or triggers.

### How to test the changes in this Pull Request

Verified against a stubbed GitHub API driving the real script:

- [x] One run unreadable, others fine, switch ON → `trunk` exits 1 and pages Slack; this branch exits 0 and holds the switch. This is the production failure above.
- [x] Every run unreadable → reports `unknown (probe incomplete)`, exits 0.
- [x] Clean probe, clear queue, hysteresis elapsed → switches off.
- [x] Genuine 12-minute queue → still switches on.
- [x] ON past `MAX_ON_MINUTES` with a blind probe → records the decision, then fails loudly.
- [x] ON past `MAX_ON_MINUTES` with over-threshold work found → stays quiet. (Without the `provenCongested` clause this exits 1, i.e. pages during real congestion.)

After merge: ticks logging `Probe skipped run …` should complete instead of failing, and isolated 502s should stop paging Slack.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

- [x] This Pull Request does not require a changelog entry. (CI tooling only; "Validate changelog" skips for `.github/`-only changes.)
