### PR TITLE
Avoid customized WooCommerce template parts taking priority over template parts queried directly

### DIFF
--- a/plugins/woocommerce/changelog/fix-67862-woocommerce-template-parts-leaking-on-creation
+++ b/plugins/woocommerce/changelog/fix-67862-woocommerce-template-parts-leaking-on-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid customized WooCommerce template parts from taking priority over template parts queried directly

--- a/plugins/woocommerce/changelog/fix-67862-woocommerce-template-parts-leaking-on-creation
+++ b/plugins/woocommerce/changelog/fix-67862-woocommerce-template-parts-leaking-on-creation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Avoid customized WooCommerce template parts from taking priority over template parts queried directly
+Avoid customized WooCommerce template parts taking priority over template parts queried directly

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -259,6 +259,12 @@ class BlockTemplatesController {
 		$new_templates  = array();
 
 		foreach ( $template_files as $template_file ) {
+			// Queries for a specific post must not inject other WooCommerce templates.
+			// See https://github.com/woocommerce/woocommerce/issues/67862.
+			if ( isset( $query['wp_id'] ) && (int) ( $template_file->wp_id ?? 0 ) !== (int) $query['wp_id'] ) {
+				continue;
+			}
+
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
 			if ( 'custom' === $template_file->source ) {

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -252,6 +252,12 @@ class BlockTemplatesController {
 			return $query_result;
 		}
 
+		// Queries for a specific template parts must not inject other WooCommerce templates.
+		// See https://github.com/woocommerce/woocommerce/issues/67862.
+		if ( isset( $query['wp_id'] ) ) {
+			return $query_result;
+		}
+
 		// For templates, we only need to load templates from the database. For
 		// template parts, we also need to load them from the filesystem, as
 		// there is no Template registration API for template parts.
@@ -259,12 +265,6 @@ class BlockTemplatesController {
 		$new_templates  = array();
 
 		foreach ( $template_files as $template_file ) {
-			// Queries for a specific post must not inject other WooCommerce templates.
-			// See https://github.com/woocommerce/woocommerce/issues/67862.
-			if ( isset( $query['wp_id'] ) && (int) ( $template_file->wp_id ?? 0 ) !== (int) $query['wp_id'] ) {
-				continue;
-			}
-
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
 			if ( 'custom' === $template_file->source ) {

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -252,12 +252,6 @@ class BlockTemplatesController {
 			return $query_result;
 		}
 
-		// Queries for a specific template parts must not inject other WooCommerce templates.
-		// See https://github.com/woocommerce/woocommerce/issues/67862.
-		if ( isset( $query['wp_id'] ) ) {
-			return $query_result;
-		}
-
 		// For templates, we only need to load templates from the database. For
 		// template parts, we also need to load them from the filesystem, as
 		// there is no Template registration API for template parts.
@@ -265,6 +259,12 @@ class BlockTemplatesController {
 		$new_templates  = array();
 
 		foreach ( $template_files as $template_file ) {
+			// Queries for a specific post must not inject other WooCommerce templates.
+			// See https://github.com/woocommerce/woocommerce/issues/67862.
+			if ( isset( $query['wp_id'] ) && (int) ( $template_file->wp_id ?? 0 ) !== (int) $query['wp_id'] ) {
+				continue;
+			}
+
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
 			if ( 'custom' === $template_file->source ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks;
+
+use Automattic\WooCommerce\Blocks\BlockTemplatesController;
+use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the BlockTemplatesController class.
+ */
+class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var BlockTemplatesController
+	 */
+	private $sut;
+
+	/**
+	 * Post IDs created during a test.
+	 *
+	 * @var int[]
+	 */
+	private $created_post_ids = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		switch_theme( 'twentytwentytwo' );
+		$this->sut = new BlockTemplatesController();
+		$this->flush_block_template_caches();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		foreach ( $this->created_post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		$this->created_post_ids = array();
+		$this->flush_block_template_caches();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should not prepend customised WooCommerce template parts when querying by wp_id.
+	 */
+	public function test_wp_id_query_does_not_prepend_unrelated_woo_templates(): void {
+		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
+		$new_post = $this->create_template_post( 'new-part-' . uniqid(), 'wp_template_part', get_stylesheet() );
+		$this->flush_block_template_caches();
+
+		$new_template = BlockTemplateUtils::build_template_result_from_post( $new_post );
+		$result       = $this->sut->add_db_templates_with_woo_slug(
+			array( $new_template ),
+			array( 'wp_id' => $new_post->ID ),
+			'wp_template_part'
+		);
+
+		$this->assertNotEmpty( $result, 'A wp_id query should return the requested template part.' );
+		$this->assertSame(
+			$new_post->ID,
+			(int) $result[0]->wp_id,
+			'create_item uses the first result as the created template part.'
+		);
+
+		foreach ( $result as $template ) {
+			$this->assertSame(
+				$new_post->ID,
+				(int) ( $template->wp_id ?? 0 ),
+				'A wp_id query must not include unrelated WooCommerce templates.'
+			);
+		}
+
+		$this->assertNotContains(
+			$woo_post->post_name,
+			array_column( $result, 'slug' ),
+			'Customised WooCommerce template parts must not leak into wp_id queries for other parts.'
+		);
+	}
+
+	/**
+	 * @testdox Should still return a customised WooCommerce template part when queried by its own wp_id.
+	 */
+	public function test_wp_id_query_returns_matching_customised_woo_template(): void {
+		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
+		$this->create_template_post( 'other-woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
+		$this->flush_block_template_caches();
+
+		$result = $this->sut->add_db_templates_with_woo_slug(
+			array(),
+			array( 'wp_id' => $woo_post->ID ),
+			'wp_template_part'
+		);
+
+		$this->assertNotEmpty( $result, 'Customised WooCommerce template parts must remain findable by wp_id.' );
+		$this->assertSame(
+			$woo_post->ID,
+			(int) $result[0]->wp_id,
+			'The matching customised WooCommerce template part should be returned first.'
+		);
+
+		foreach ( $result as $template ) {
+			$this->assertSame(
+				$woo_post->ID,
+				(int) ( $template->wp_id ?? 0 ),
+				'A wp_id query must not include other customised WooCommerce templates.'
+			);
+		}
+	}
+
+	/**
+	 * @testdox Should still include customised WooCommerce template parts when the query has no wp_id.
+	 */
+	public function test_query_without_wp_id_includes_customised_woo_templates(): void {
+		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
+		$this->flush_block_template_caches();
+
+		$result = $this->sut->add_db_templates_with_woo_slug( array(), array(), 'wp_template_part' );
+
+		$this->assertContains(
+			$woo_post->post_name,
+			array_column( $result, 'slug' ),
+			'Unfiltered queries should still surface customised WooCommerce template parts.'
+		);
+	}
+
+	/**
+	 * Creates a template or template part post attributed to a theme.
+	 *
+	 * @param string $slug          Post slug.
+	 * @param string $template_type wp_template or wp_template_part.
+	 * @param string $theme         Theme term name.
+	 * @return \WP_Post
+	 */
+	private function create_template_post( string $slug, string $template_type, string $theme ): \WP_Post {
+		$term = get_term_by( 'name', $theme, 'wp_theme', ARRAY_A );
+		if ( ! $term ) {
+			$term = wp_insert_term( $theme, 'wp_theme' );
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_name'    => $slug,
+				'post_type'    => $template_type,
+				'post_title'   => $slug,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		wp_set_post_terms( $post_id, array( $term['term_id'] ), 'wp_theme' );
+		$this->created_post_ids[] = $post_id;
+
+		return get_post( $post_id );
+	}
+
+	/**
+	 * Clears template ID caches so newly created posts are visible.
+	 */
+	private function flush_block_template_caches(): void {
+		wp_cache_delete( 'wp_template-ids', 'woocommerce_blocks' );
+		wp_cache_delete( 'wp_template_part-ids', 'woocommerce_blocks' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -31,7 +31,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		switch_theme( 'twentytwentytwo' );
+		switch_theme( 'twentytwentyfour' );
 		$this->sut = new BlockTemplatesController();
 		$this->flush_block_template_caches();
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -27,10 +27,18 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	private $created_template_part_ids = array();
 
 	/**
+	 * Active theme before each test, restored in tearDown.
+	 *
+	 * @var string
+	 */
+	private $original_theme;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->original_theme = get_stylesheet();
 		switch_theme( 'twentytwentyfour' );
 		$this->sut = new BlockTemplatesController();
 		$this->flush_block_template_caches();
@@ -45,6 +53,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 		}
 		$this->created_template_part_ids = array();
 		$this->flush_block_template_caches();
+		switch_theme( $this->original_theme );
 		parent::tearDown();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -86,6 +86,36 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should still return a customised WooCommerce template part when queried by its own wp_id.
+	 */
+	public function test_wp_id_query_returns_matching_customised_woo_template(): void {
+		$woo_template_part = $this->create_template_part( 'woo-custom-template-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
+		$this->create_template_part( 'other-woo-custom-template-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
+		$this->flush_block_template_caches();
+
+		$result = $this->sut->add_db_templates_with_woo_slug(
+			array(),
+			array( 'wp_id' => $woo_template_part->ID ),
+			'wp_template_part'
+		);
+
+		$this->assertNotEmpty( $result, 'Customised WooCommerce template parts must remain findable by wp_id.' );
+		$this->assertSame(
+			$woo_template_part->ID,
+			(int) $result[0]->wp_id,
+			'The matching customised WooCommerce template part should be returned first.'
+		);
+
+		foreach ( $result as $template ) {
+			$this->assertSame(
+				$woo_template_part->ID,
+				(int) ( $template->wp_id ?? 0 ),
+				'A wp_id query must not include other customised WooCommerce templates.'
+			);
+		}
+	}
+
+	/**
 	 * @testdox Should still include customised WooCommerce template parts when the query has no wp_id.
 	 */
 	public function test_query_without_wp_id_includes_customised_woo_templates(): void {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -24,7 +24,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	 *
 	 * @var int[]
 	 */
-	private $created_post_ids = array();
+	private $created_template_part_ids = array();
 
 	/**
 	 * Set up test fixtures.
@@ -40,10 +40,10 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	 * Tear down test fixtures.
 	 */
 	public function tearDown(): void {
-		foreach ( $this->created_post_ids as $post_id ) {
+		foreach ( $this->created_template_part_ids as $post_id ) {
 			wp_delete_post( $post_id, true );
 		}
-		$this->created_post_ids = array();
+		$this->created_template_part_ids = array();
 		$this->flush_block_template_caches();
 		parent::tearDown();
 	}
@@ -52,94 +52,63 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	 * @testdox Should not prepend customised WooCommerce template parts when querying by wp_id.
 	 */
 	public function test_wp_id_query_does_not_prepend_unrelated_woo_templates(): void {
-		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
-		$new_post = $this->create_template_post( 'new-part-' . uniqid(), 'wp_template_part', get_stylesheet() );
+		$woo_template_part   = $this->create_template_part( 'woo-custom-template-parttemplate-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
+		$theme_template_part = $this->create_template_part( 'theme-custom-template-part' . uniqid(), get_stylesheet() );
 		$this->flush_block_template_caches();
 
-		$new_template = BlockTemplateUtils::build_template_result_from_post( $new_post );
+		$new_template = BlockTemplateUtils::build_template_result_from_post( $theme_template_part );
 		$result       = $this->sut->add_db_templates_with_woo_slug(
 			array( $new_template ),
-			array( 'wp_id' => $new_post->ID ),
+			array( 'wp_id' => $theme_template_part->ID ),
 			'wp_template_part'
 		);
 
 		$this->assertNotEmpty( $result, 'A wp_id query should return the requested template part.' );
 		$this->assertSame(
-			$new_post->ID,
+			$theme_template_part->ID,
 			(int) $result[0]->wp_id,
 			'create_item uses the first result as the created template part.'
 		);
 
 		foreach ( $result as $template ) {
 			$this->assertSame(
-				$new_post->ID,
+				$theme_template_part->ID,
 				(int) ( $template->wp_id ?? 0 ),
 				'A wp_id query must not include unrelated WooCommerce templates.'
 			);
 		}
 
 		$this->assertNotContains(
-			$woo_post->post_name,
+			$woo_template_part->post_name,
 			array_column( $result, 'slug' ),
 			'Customised WooCommerce template parts must not leak into wp_id queries for other parts.'
 		);
 	}
 
 	/**
-	 * @testdox Should still return a customised WooCommerce template part when queried by its own wp_id.
-	 */
-	public function test_wp_id_query_returns_matching_customised_woo_template(): void {
-		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
-		$this->create_template_post( 'other-woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
-		$this->flush_block_template_caches();
-
-		$result = $this->sut->add_db_templates_with_woo_slug(
-			array(),
-			array( 'wp_id' => $woo_post->ID ),
-			'wp_template_part'
-		);
-
-		$this->assertNotEmpty( $result, 'Customised WooCommerce template parts must remain findable by wp_id.' );
-		$this->assertSame(
-			$woo_post->ID,
-			(int) $result[0]->wp_id,
-			'The matching customised WooCommerce template part should be returned first.'
-		);
-
-		foreach ( $result as $template ) {
-			$this->assertSame(
-				$woo_post->ID,
-				(int) ( $template->wp_id ?? 0 ),
-				'A wp_id query must not include other customised WooCommerce templates.'
-			);
-		}
-	}
-
-	/**
 	 * @testdox Should still include customised WooCommerce template parts when the query has no wp_id.
 	 */
 	public function test_query_without_wp_id_includes_customised_woo_templates(): void {
-		$woo_post = $this->create_template_post( 'woo-custom-' . uniqid(), 'wp_template_part', BlockTemplateUtils::PLUGIN_SLUG );
+		$woo_template_part = $this->create_template_part( 'woo-custom-template-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
 		$this->flush_block_template_caches();
 
 		$result = $this->sut->add_db_templates_with_woo_slug( array(), array(), 'wp_template_part' );
 
 		$this->assertContains(
-			$woo_post->post_name,
+			$woo_template_part->post_name,
 			array_column( $result, 'slug' ),
 			'Unfiltered queries should still surface customised WooCommerce template parts.'
 		);
 	}
 
 	/**
-	 * Creates a template or template part post attributed to a theme.
+	 * Creates a template part post attributed to a theme.
 	 *
 	 * @param string $slug          Post slug.
-	 * @param string $template_type wp_template or wp_template_part.
 	 * @param string $theme         Theme term name.
 	 * @return \WP_Post
 	 */
-	private function create_template_post( string $slug, string $template_type, string $theme ): \WP_Post {
+	private function create_template_part( string $slug, string $theme ): \WP_Post {
 		$term = get_term_by( 'name', $theme, 'wp_theme', ARRAY_A );
 		if ( ! $term ) {
 			$term = wp_insert_term( $theme, 'wp_theme' );
@@ -148,7 +117,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 		$post_id = wp_insert_post(
 			array(
 				'post_name'    => $slug,
-				'post_type'    => $template_type,
+				'post_type'    => 'wp_template_part',
 				'post_title'   => $slug,
 				'post_status'  => 'publish',
 				'post_content' => '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTemplatesControllerTest.php
@@ -52,7 +52,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 	 * @testdox Should not prepend customised WooCommerce template parts when querying by wp_id.
 	 */
 	public function test_wp_id_query_does_not_prepend_unrelated_woo_templates(): void {
-		$woo_template_part   = $this->create_template_part( 'woo-custom-template-parttemplate-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
+		$woo_template_part   = $this->create_template_part( 'woo-custom-template-part' . uniqid(), BlockTemplateUtils::PLUGIN_SLUG );
 		$theme_template_part = $this->create_template_part( 'theme-custom-template-part' . uniqid(), get_stylesheet() );
 		$this->flush_block_template_caches();
 
@@ -155,7 +155,7 @@ class BlockTemplatesControllerTest extends WC_Unit_Test_Case {
 		);
 
 		wp_set_post_terms( $post_id, array( $term['term_id'] ), 'wp_theme' );
-		$this->created_post_ids[] = $post_id;
+		$this->created_template_part_ids[] = $post_id;
 
 		return get_post( $post_id );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/67862.

We were prepending WooCommerce template parts even when the query was targetting a specific template part by its id. This PR fixes that.

### How to test the changes in this Pull Request:

1. In the Site Editor, open a WooCommerce-provided template part (e.g. Checkout Header), make any edit and save.
2. Go to Appearance > Editor > Patterns and add a new template part (any name, any area).
3. Verify the editor opens in the newly-create template part. Instead of displaying the template part you edited in step 1.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->