### PR TITLE
Properly sanitize product category display types

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-category-display-type-normalization
+++ b/plugins/woocommerce/changelog/fix-product-category-display-type-normalization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Properly sanitize product category display settings before storage.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -314,8 +314,10 @@ class WC_Admin_Taxonomies {
 	 * @param string $taxonomy Taxonomy slug.
 	 */
 	public function save_category_fields( $term_id, $tt_id = '', $taxonomy = '' ) {
-		if ( isset( $_POST['display_type'] ) && 'product_cat' === $taxonomy ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow supplies authorization checks; IDs are cast.
-			update_term_meta( $term_id, 'display_type', esc_attr( $_POST['display_type'] ) ); // WPCS: CSRF ok, sanitization ok, input var ok.
+		if ( isset( $_POST['display_type'] ) && 'product_cat' === $taxonomy ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow verifies the nonce before firing this hook.
+			$display_type = is_string( $_POST['display_type'] ) ? sanitize_key( wp_unslash( $_POST['display_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow verifies the nonce before firing this hook.
+
+			update_term_meta( $term_id, 'display_type', $display_type );
 		}
 		if ( isset( $_POST['product_cat_thumbnail_id'] ) && 'product_cat' === $taxonomy ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow supplies authorization checks; IDs are cast.
 			update_term_meta( $term_id, 'thumbnail_id', absint( $_POST['product_cat_thumbnail_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow supplies authorization checks; IDs are cast.
@@ -414,10 +416,11 @@ class WC_Admin_Taxonomies {
 	 * Handle custom row actions.
 	 */
 	public function handle_product_cat_row_actions() {
-		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && 'make_default' === $_GET['action'] ) {
+		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && is_string( $_GET['action'] ) && 'make_default' === sanitize_key( wp_unslash( $_GET['action'] ) ) ) {
 			$make_default_id = absint( $_GET['tag_ID'] );
+			$nonce           = is_string( $_GET['_wpnonce'] ) ? sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 
-			if ( wp_verify_nonce( $_GET['_wpnonce'], 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) { // WPCS: Sanitization ok, input var ok, CSRF ok.
+			if ( wp_verify_nonce( $nonce, 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) {
 				update_option( 'default_product_cat', $make_default_id );
 			}
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -315,7 +315,7 @@ class WC_Admin_Taxonomies {
 	 */
 	public function save_category_fields( $term_id, $tt_id = '', $taxonomy = '' ) {
 		if ( isset( $_POST['display_type'] ) && 'product_cat' === $taxonomy ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow verifies the nonce before firing this hook.
-			$display_type = is_string( $_POST['display_type'] ) ? sanitize_key( wp_unslash( $_POST['display_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow verifies the nonce before firing this hook.
+			$display_type = is_string( $_POST['display_type'] ) ? sanitize_key( $_POST['display_type'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Core term-edit flow verifies the nonce before firing this hook.
 
 			update_term_meta( $term_id, 'display_type', $display_type );
 		}
@@ -416,11 +416,11 @@ class WC_Admin_Taxonomies {
 	 * Handle custom row actions.
 	 */
 	public function handle_product_cat_row_actions() {
-		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && is_string( $_GET['action'] ) && 'make_default' === sanitize_key( wp_unslash( $_GET['action'] ) ) ) {
+		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && 'make_default' === $_GET['action'] ) {
 			$make_default_id = absint( $_GET['tag_ID'] );
-			$nonce           = is_string( $_GET['_wpnonce'] ) ? sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 
-			if ( wp_verify_nonce( $nonce, 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_verify_nonce() validates the raw nonce value.
+			if ( wp_verify_nonce( $_GET['_wpnonce'], 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) {
 				update_option( 'default_product_cat', $make_default_id );
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-taxonomies-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-taxonomies-test.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for WC_Admin_Taxonomies.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+declare( strict_types = 1 );
+
+require_once WC_ABSPATH . 'includes/admin/class-wc-admin-taxonomies.php';
+
+/**
+ * WC_Admin_Taxonomies tests.
+ */
+class WC_Admin_Taxonomies_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Admin_Taxonomies
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = WC_Admin_Taxonomies::get_instance();
+		$_POST     = array();
+	}
+
+	/**
+	 * Restore request and user state.
+	 */
+	public function tearDown(): void {
+		$_POST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Should normalize product category display types before storage.
+	 * @dataProvider display_type_provider
+	 *
+	 * @param mixed  $request_value Request display type.
+	 * @param string $expected      Expected stored display type.
+	 */
+	public function test_save_category_fields_normalizes_display_type( $request_value, string $expected ): void {
+		$term_id = $this->factory()->term->create(
+			array(
+				'taxonomy' => 'product_cat',
+				'name'     => 'Display type test',
+			)
+		);
+
+		$_POST['display_type'] = $request_value;
+
+		$this->sut->save_category_fields( $term_id, '', 'product_cat' );
+
+		$this->assertSame( $expected, get_term_meta( $term_id, 'display_type', true ), 'Display type should be normalized before storage.' );
+	}
+
+	/**
+	 * Data provider for display type normalization.
+	 *
+	 * @return array<string, array{mixed, string}>
+	 */
+	public function display_type_provider(): array {
+		return array(
+			'core value'       => array( 'products', 'products' ),
+			'slashed value'    => array( 'sub\\categories', 'subcategories' ),
+			'extension value'  => array( 'custom-layout', 'custom-layout' ),
+			'non-string value' => array( array( 'both' ), '' ),
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product category display settings are currently escaped with `esc_attr()` before being stored. Escaping is output-context handling rather than storage sanitization. This change sanitizes string values with `sanitize_key()` before storage, preserves extension-defined slug values, and handles non-string input as the default. `update_term_meta()` already performs the required unslashing, so it remains responsible for that normalization.

Backward compatibility: core values and custom slug-style display types remain accepted. Values containing uppercase letters or characters removed by `sanitize_key()` will now be normalized before storage; public method signatures, hooks, stored meta keys, and the existing category row-action flow are unchanged. Term metadata remains site-scoped as before; multisite behavior was reviewed but not separately exercised.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter WC_Admin_Taxonomies_Test`.
2. Confirm the four cases pass: a core value, a slashed value, an extension-defined value, and non-string input.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused PHPUnit on WordPress 7.1 and PHP 8.1: 4 tests and 4 assertions passed.
- Targeted PHPCS passed for the changed PHP lines.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed against current `origin/trunk`.
- PHPStan passed for `includes/admin/class-wc-admin-taxonomies.php` with no errors.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone that is not in the past.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs created from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If this Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in `plugins/woocommerce/changelog/fix-product-category-display-type-normalization`.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to inspect the existing behavior and history, port the reviewed change to current trunk, add regression coverage, and run validation. The resulting diff and test evidence were reviewed before submission.
