### PR TITLE
Document settings request boundaries

### DIFF
--- a/plugins/woocommerce/changelog/dev-settings-request-boundary-suppressions
+++ b/plugins/woocommerce/changelog/dev-settings-request-boundary-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document intentional raw-data boundaries in the settings APIs with exact coding-standard annotations.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -137,7 +137,7 @@ abstract class WC_Settings_API {
 	public function get_field_value( $key, $field, $post_data = array() ) {
 		$type      = $this->get_field_type( $field );
 		$field_key = $this->get_field_key( $key );
-		$post_data = empty( $post_data ) ? $_POST : $post_data; // WPCS: CSRF ok, input var ok.
+		$post_data = empty( $post_data ) ? $_POST : $post_data; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Raw settings values are passed to field-specific validators; authorization belongs to the caller.
 		$value     = isset( $post_data[ $field_key ] ) ? $post_data[ $field_key ] : null;
 
 		if ( isset( $field['sanitize_callback'] ) && is_callable( $field['sanitize_callback'] ) ) {
@@ -176,7 +176,7 @@ abstract class WC_Settings_API {
 		if ( ! empty( $this->data ) && is_array( $this->data ) ) {
 			return $this->data;
 		}
-		return $_POST; // WPCS: CSRF ok, input var ok.
+		return $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Raw settings values are returned for field-specific validation; authorization belongs to the caller.
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -932,7 +932,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 		 */
 		public static function save_fields( $options, $data = null ) {
 			if ( is_null( $data ) ) {
-				$data = $_POST; // WPCS: input var okay, CSRF ok.
+				$data = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Values are unslashed and sanitized by declared field type below; authorization belongs to the caller.
 			}
 			if ( empty( $data ) ) {
 				return false;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce settings APIs deliberately retain raw request arrays until each declared field type or extension callback validates the corresponding value. This replaces three broad legacy WPCS comments with the exact nonce-verification diagnostic and reasons that describe the caller-owned authorization boundary.

This is comment-only: public signatures, request values, sanitization, hook timing, multisite behavior, and install-layout behavior are unchanged. The normal admin settings route continues to require `manage_woocommerce` and verify the `woocommerce-settings` nonce before saving.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` and confirm it passes.
2. Run PHPCS for `WordPress.Security.NonceVerification` on the two modified PHP files and confirm the normal run reports no findings.
3. Repeat PHPCS with `--ignore-annotations` and confirm the intended findings appear at `abstract-wc-settings-api.php:140`, `abstract-wc-settings-api.php:179`, and `class-wc-admin-settings.php:935`. The latter file also contains unrelated pre-existing findings at lines 116 and 123.
4. Run PHPStan for both modified PHP files and confirm it reports no errors.
5. Compare non-comment PHP tokens with `origin/trunk` and confirm both files are unchanged.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed against current public `trunk`.
- Targeted PHPCS passed normally; `--ignore-annotations` exposed the intended diagnostics at all three changed boundaries.
- PHPStan reported no errors for either modified PHP file.
- Non-comment PHP tokens for both files are identical to `origin/trunk`.
- Critical review found no runtime, backward-compatibility, security, performance, multisite, or install-layout behavior change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.
- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.
- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

An AI will analyze your PR and post a draft comment for you to review and edit.
</details>
