### PR TITLE
Fix day-precision date queries ignoring the site timezone

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-get-orders-day-precision-timezone
+++ b/plugins/woocommerce/changelog/fix-wc-get-orders-day-precision-timezone
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Anchor day-precision date queries on the store's local midnight instead of UTC midnight, so wc_get_orders() and wc_get_products() match the day a merchant means when filtering on date_paid, date_completed, date_on_sale_from and date_on_sale_to.
+Anchor day-precision date queries on the store's local midnight instead of UTC midnight, so wc_get_orders() and wc_get_products() match the day a merchant means when filtering on date_paid, date_completed, date_on_sale_from and date_on_sale_to. A `start...end` range now covers the whole of its final day, where before it collapsed that day down to a single second, so range queries return one more day of results than they used to.

--- a/plugins/woocommerce/changelog/fix-wc-get-orders-day-precision-timezone
+++ b/plugins/woocommerce/changelog/fix-wc-get-orders-day-precision-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Anchor day-precision date queries on the store's local midnight instead of UTC midnight, so wc_get_orders() and wc_get_products() match the day a merchant means when filtering on date_paid, date_completed, date_on_sale_from and date_on_sale_to.

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -350,8 +350,7 @@ class WC_Data_Store_WP {
 		$dates    = array();
 		$operator = '=';
 
-		// The raw strings $dates[0] and $dates[1] were parsed from, so the day they name can be
-		// resolved later. Only day precision reads these, and only string input reaches it.
+		// The raw strings $dates[0] and $dates[1] came from. Only day precision reads them.
 		$raw_start = '';
 		$raw_end   = '';
 
@@ -453,21 +452,10 @@ class WC_Data_Store_WP {
 		// Check against beginning/end-of-day timestamps when using 'day' precision.
 		if ( 'day' === $precision ) {
 			/*
-			 * The meta values are UTC timestamps, while a day-precision query var names a calendar day,
-			 * so both boundaries have to be anchored on that day's local midnight.
-			 *
-			 * The day is named the same way OrdersTableQuery::local_time_to_gmt_date_query() names it:
-			 * the UTC calendar date of a bare strtotime() of the raw string, not of the timezone-aware
-			 * WC_DateTime in $dates. Deriving it from $dates instead would diverge for a naive datetime
-			 * such as '2026-07-20 22:00:00', which wc_string_to_datetime() reads as local time first.
-			 * Deriving it identically is what keeps the two order storage backends from resolving one
-			 * query var to different days on these meta keys.
-			 *
-			 * Constructing the bounds can still throw on a date beyond year 9999. Returning here with
-			 * no clause is not an option: both callers strip their own clause for this key before
-			 * calling, so an empty meta_query drops the date filter entirely and widens the query to
-			 * every record. A day that cannot be represented matches nothing instead, which is what
-			 * HPOS also does with the same input.
+			 * Anchor both bounds on the named day's local midnight. The day is named from the raw
+			 * string the way OrdersTableQuery::local_time_to_gmt_date_query() names it, never from
+			 * the timezone-aware $dates, or the two storage backends resolve one query var to
+			 * different days.
 			 */
 			try {
 				$timezone = wp_timezone();
@@ -477,9 +465,9 @@ class WC_Data_Store_WP {
 					: clone $start;
 			} catch ( Exception $e ) {
 				/*
-				 * An empty range: no value can be both at least 1 and at most 0. A one-sided bound
-				 * would not do, because these keys can legitimately hold a negative timestamp for a
-				 * date before 1970.
+				 * A date beyond year 9999 matches nothing. Adding no clause would instead drop the
+				 * filter and return everything, and a one-sided bound would still match the negative
+				 * timestamp of a pre-1970 date.
 				 */
 				$wp_query_args['meta_query'][] = array(
 					'key'     => $key,
@@ -492,10 +480,9 @@ class WC_Data_Store_WP {
 			}
 
 			/*
-			 * Derive the upper bound from the next local midnight rather than adding a fixed 86400 seconds,
-			 * so the range follows the real length of the day across a DST transition (a local day can be 23
-			 * or 25 hours). '+1 day' is not equivalent: it carries over the start time, which is not midnight
-			 * on days where DST begins at 00:00 and the constructor above had to shift the start forward.
+			 * Next local midnight, not a fixed 86400: a local day runs 23 or 25 hours across a DST
+			 * transition. '+1 day' would carry over the start time, which is not midnight on days
+			 * where DST begins at 00:00.
 			 */
 			$end->modify( 'tomorrow' );
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -452,9 +452,8 @@ class WC_Data_Store_WP {
 		// Check against beginning/end-of-day timestamps when using 'day' precision.
 		if ( 'day' === $precision ) {
 			/*
-			 * Anchor both bounds on the named day's local midnight. The day is named from the raw
-			 * string the way OrdersTableQuery::local_time_to_gmt_date_query() names it, never from
-			 * the timezone-aware $dates, or the two storage backends resolve one query var to
+			 * Name the day from the raw string the way OrdersTableQuery::local_time_to_gmt_date_query()
+			 * does, never from the timezone-aware $dates, or posts and HPOS resolve one query var to
 			 * different days.
 			 */
 			try {
@@ -465,9 +464,8 @@ class WC_Data_Store_WP {
 					: clone $start;
 			} catch ( Exception $e ) {
 				/*
-				 * A date beyond year 9999 matches nothing. Adding no clause would instead drop the
-				 * filter and return everything, and a one-sided bound would still match the negative
-				 * timestamp of a pre-1970 date.
+				 * A year past 9999 throws here. Match nothing: no clause would drop the filter and
+				 * return everything, and a one-sided bound would still match a pre-1970 negative.
 				 */
 				$wp_query_args['meta_query'][] = array(
 					'key'     => $key,
@@ -480,9 +478,8 @@ class WC_Data_Store_WP {
 			}
 
 			/*
-			 * Next local midnight, not a fixed 86400: a local day runs 23 or 25 hours across a DST
-			 * transition. '+1 day' would carry over the start time, which is not midnight on days
-			 * where DST begins at 00:00.
+			 * Not a fixed 86400: a local day runs 23 or 25 hours across a DST transition. '+1 day'
+			 * would carry over the start time, which is not midnight when DST begins at 00:00.
 			 */
 			$end->modify( 'tomorrow' );
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -442,15 +442,42 @@ class WC_Data_Store_WP {
 		// Meta dates are stored as timestamps in the db.
 		// Check against beginning/end-of-day timestamps when using 'day' precision.
 		if ( 'day' === $precision ) {
-			$start_timestamp = strtotime( gmdate( 'm/d/Y 00:00:00', $dates[0]->getTimestamp() ) );
-			$end_timestamp   = '...' !== $operator ? ( $start_timestamp + DAY_IN_SECONDS ) : strtotime( gmdate( 'm/d/Y 00:00:00', $dates[1]->getTimestamp() ) );
+			/*
+			 * The meta values are UTC timestamps, while a YYYY-MM-DD query var names a day in the site's
+			 * timezone, so both boundaries have to be anchored on local midnight. Building them from the
+			 * local calendar date keeps that anchor even when the local day starts on a different UTC date.
+			 */
+			$timezone = wp_timezone();
+			$start    = new DateTime( $dates[0]->date( 'Y-m-d' ) . ' 00:00:00', $timezone );
+			$end      = '...' === $operator
+				? new DateTime( $dates[1]->date( 'Y-m-d' ) . ' 00:00:00', $timezone )
+				: clone $start;
+
+			/*
+			 * Derive the upper bound from the next local midnight rather than adding a fixed 86400 seconds,
+			 * so the range follows the real length of the day across a DST transition (a local day can be 23
+			 * or 25 hours). '+1 day' is not equivalent: it carries over the start time, which is not midnight
+			 * on days where DST begins at 00:00 and the constructor above had to shift the start forward.
+			 */
+			$end->modify( 'tomorrow' );
+
+			$start_timestamp = $start->getTimestamp();
+			$end_timestamp   = $end->getTimestamp();
+
+			// The bounds are half-open (>= start, < end) so that a day is matched in full and exactly once.
 			switch ( $operator ) {
 				case '>':
+					$wp_query_args['meta_query'][] = array(
+						'key'     => $key,
+						'value'   => $end_timestamp,
+						'compare' => '>=',
+					);
+					break;
 				case '<=':
 					$wp_query_args['meta_query'][] = array(
 						'key'     => $key,
 						'value'   => $end_timestamp,
-						'compare' => $operator,
+						'compare' => '<',
 					);
 					break;
 				case '<':
@@ -470,7 +497,7 @@ class WC_Data_Store_WP {
 					$wp_query_args['meta_query'][] = array(
 						'key'     => $key,
 						'value'   => $end_timestamp,
-						'compare' => '<=',
+						'compare' => '<',
 					);
 			}
 		} elseif ( '...' !== $operator ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -454,16 +454,28 @@ class WC_Data_Store_WP {
 		if ( 'day' === $precision ) {
 			/*
 			 * The meta values are UTC timestamps, while a day-precision query var names a calendar day,
-			 * so both boundaries have to be anchored on that day's local midnight. The day itself is
-			 * named the same way HPOS names it in OrdersTableQuery::local_time_to_gmt_date_query(): the
-			 * UTC calendar date of the parsed instant. Deriving it identically is what keeps the two
-			 * order storage backends from resolving one query var to different days on these meta keys.
+			 * so both boundaries have to be anchored on that day's local midnight.
+			 *
+			 * The day is named the same way OrdersTableQuery::local_time_to_gmt_date_query() names it:
+			 * the UTC calendar date of a bare strtotime() of the raw string, not of the timezone-aware
+			 * WC_DateTime in $dates. Deriving it from $dates instead would diverge for a naive datetime
+			 * such as '2026-07-20 22:00:00', which wc_string_to_datetime() reads as local time first.
+			 * Deriving it identically is what keeps the two order storage backends from resolving one
+			 * query var to different days on these meta keys.
+			 *
+			 * Constructing the bounds can still throw on a date beyond year 9999, which the caller's
+			 * date parsing above also guards against, so keep the same "unparseable means no date
+			 * constraint" contract rather than letting it surface as a fatal.
 			 */
-			$timezone = wp_timezone();
-			$start    = new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_start ) ) . ' 00:00:00', $timezone );
-			$end      = '...' === $operator
-				? new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_end ) ) . ' 00:00:00', $timezone )
-				: clone $start;
+			try {
+				$timezone = wp_timezone();
+				$start    = new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_start ) ) . ' 00:00:00', $timezone );
+				$end      = '...' === $operator
+					? new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_end ) ) . ' 00:00:00', $timezone )
+					: clone $start;
+			} catch ( Exception $e ) {
+				return $wp_query_args;
+			}
 
 			/*
 			 * Derive the upper bound from the next local midnight rather than adding a fixed 86400 seconds,

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -463,9 +463,11 @@ class WC_Data_Store_WP {
 			 * Deriving it identically is what keeps the two order storage backends from resolving one
 			 * query var to different days on these meta keys.
 			 *
-			 * Constructing the bounds can still throw on a date beyond year 9999, which the caller's
-			 * date parsing above also guards against, so keep the same "unparseable means no date
-			 * constraint" contract rather than letting it surface as a fatal.
+			 * Constructing the bounds can still throw on a date beyond year 9999. Returning here with
+			 * no clause is not an option: both callers strip their own clause for this key before
+			 * calling, so an empty meta_query drops the date filter entirely and widens the query to
+			 * every record. A day that cannot be represented matches nothing instead, which is what
+			 * HPOS also does with the same input.
 			 */
 			try {
 				$timezone = wp_timezone();
@@ -474,6 +476,13 @@ class WC_Data_Store_WP {
 					? new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_end ) ) . ' 00:00:00', $timezone )
 					: clone $start;
 			} catch ( Exception $e ) {
+				$wp_query_args['meta_query'][] = array(
+					'key'     => $key,
+					'value'   => 0,
+					'type'    => 'NUMERIC',
+					'compare' => '<',
+				);
+
 				return $wp_query_args;
 			}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -330,30 +330,6 @@ class WC_Data_Store_WP {
 	}
 
 	/**
-	 * Resolve the calendar day that a day-precision date query var names.
-	 *
-	 * A bare date or a naive datetime names a day in the site's timezone, so the local calendar date
-	 * is the one to use. A string carrying an explicit UTC designator or offset names an instant
-	 * instead, and HPOS buckets those by their UTC calendar date; matching that here is what keeps
-	 * the two order storage backends from resolving the same query to different days.
-	 *
-	 * @param WC_DateTime $date The parsed date.
-	 * @param string|null $raw  The raw query var section this date was parsed from, or null when it
-	 *                          did not come from a string.
-	 * @return string The named calendar day, as YYYY-MM-DD.
-	 */
-	private function get_date_query_day( $date, $raw ) {
-		// The same pattern wc_string_to_datetime() uses to decide a string carries its own timezone.
-		$iso8601_with_timezone = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/';
-
-		if ( is_string( $raw ) && 1 === preg_match( $iso8601_with_timezone, $raw ) ) {
-			return gmdate( 'Y-m-d', $date->getTimestamp() );
-		}
-
-		return $date->date( 'Y-m-d' );
-	}
-
-	/**
 	 * Map a valid date query var to WP_Query arguments.
 	 * Valid date formats: YYYY-MM-DD or timestamp, possibly combined with an operator from $valid_operators.
 	 * Also accepts a WC_DateTime object.
@@ -375,9 +351,9 @@ class WC_Data_Store_WP {
 		$operator = '=';
 
 		// The raw strings $dates[0] and $dates[1] were parsed from, so the day they name can be
-		// resolved later. Null when the date did not come from a string.
-		$raw_start = null;
-		$raw_end   = null;
+		// resolved later. Only day precision reads these, and only string input reaches it.
+		$raw_start = '';
+		$raw_end   = '';
 
 		try {
 			// Specific time query with a WC_DateTime.
@@ -478,13 +454,15 @@ class WC_Data_Store_WP {
 		if ( 'day' === $precision ) {
 			/*
 			 * The meta values are UTC timestamps, while a day-precision query var names a calendar day,
-			 * so both boundaries have to be anchored on that day's local midnight. Building them from the
-			 * named date keeps that anchor even when the local day starts on a different UTC date.
+			 * so both boundaries have to be anchored on that day's local midnight. The day itself is
+			 * named the same way HPOS names it in OrdersTableQuery::local_time_to_gmt_date_query(): the
+			 * UTC calendar date of the parsed instant. Deriving it identically is what keeps the two
+			 * order storage backends from resolving one query var to different days on these meta keys.
 			 */
 			$timezone = wp_timezone();
-			$start    = new DateTime( $this->get_date_query_day( $dates[0], $raw_start ) . ' 00:00:00', $timezone );
+			$start    = new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_start ) ) . ' 00:00:00', $timezone );
 			$end      = '...' === $operator
-				? new DateTime( $this->get_date_query_day( $dates[1], $raw_end ) . ' 00:00:00', $timezone )
+				? new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_end ) ) . ' 00:00:00', $timezone )
 				: clone $start;
 
 			/*

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -464,8 +464,13 @@ class WC_Data_Store_WP {
 					: clone $start;
 			} catch ( Exception $e ) {
 				/*
-				 * A year past 9999 throws here. Match nothing: no clause would drop the filter and
-				 * return everything, and a one-sided bound would still match a pre-1970 negative.
+				 * The date could not be constructed, which a year past 9999 does. Match nothing, by
+				 * asking for a value that is both at least 1 and at most 0.
+				 *
+				 * Returning without a clause would not do that: the callers have already dropped
+				 * their own date clause, so the query would come back unfiltered. Nor would a single
+				 * bound like "below 0", since these keys hold a negative timestamp for a date before
+				 * 1970.
 				 */
 				$wp_query_args['meta_query'][] = array(
 					'key'     => $key,
@@ -478,8 +483,10 @@ class WC_Data_Store_WP {
 			}
 
 			/*
-			 * Not a fixed 86400: a local day runs 23 or 25 hours across a DST transition. '+1 day'
-			 * would carry over the start time, which is not midnight when DST begins at 00:00.
+			 * The end of the day is the next local midnight, not the start plus 24 hours: a local day
+			 * runs 23 or 25 hours across a DST transition. '+1 day' would not do either, because it
+			 * keeps the start's time of day, and that is not midnight in a timezone where DST begins
+			 * at 00:00 and the constructor above had to move the start forward.
 			 */
 			$end->modify( 'tomorrow' );
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -476,11 +476,16 @@ class WC_Data_Store_WP {
 					? new DateTime( gmdate( 'Y-m-d', (int) wc_string_to_timestamp( $raw_end ) ) . ' 00:00:00', $timezone )
 					: clone $start;
 			} catch ( Exception $e ) {
+				/*
+				 * An empty range: no value can be both at least 1 and at most 0. A one-sided bound
+				 * would not do, because these keys can legitimately hold a negative timestamp for a
+				 * date before 1970.
+				 */
 				$wp_query_args['meta_query'][] = array(
 					'key'     => $key,
-					'value'   => 0,
+					'value'   => array( 1, 0 ),
 					'type'    => 'NUMERIC',
-					'compare' => '<',
+					'compare' => 'BETWEEN',
 				);
 
 				return $wp_query_args;

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -330,6 +330,30 @@ class WC_Data_Store_WP {
 	}
 
 	/**
+	 * Resolve the calendar day that a day-precision date query var names.
+	 *
+	 * A bare date or a naive datetime names a day in the site's timezone, so the local calendar date
+	 * is the one to use. A string carrying an explicit UTC designator or offset names an instant
+	 * instead, and HPOS buckets those by their UTC calendar date; matching that here is what keeps
+	 * the two order storage backends from resolving the same query to different days.
+	 *
+	 * @param WC_DateTime $date The parsed date.
+	 * @param string|null $raw  The raw query var section this date was parsed from, or null when it
+	 *                          did not come from a string.
+	 * @return string The named calendar day, as YYYY-MM-DD.
+	 */
+	private function get_date_query_day( $date, $raw ) {
+		// The same pattern wc_string_to_datetime() uses to decide a string carries its own timezone.
+		$iso8601_with_timezone = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/';
+
+		if ( is_string( $raw ) && 1 === preg_match( $iso8601_with_timezone, $raw ) ) {
+			return gmdate( 'Y-m-d', $date->getTimestamp() );
+		}
+
+		return $date->date( 'Y-m-d' );
+	}
+
+	/**
 	 * Map a valid date query var to WP_Query arguments.
 	 * Valid date formats: YYYY-MM-DD or timestamp, possibly combined with an operator from $valid_operators.
 	 * Also accepts a WC_DateTime object.
@@ -350,6 +374,11 @@ class WC_Data_Store_WP {
 		$dates    = array();
 		$operator = '=';
 
+		// The raw strings $dates[0] and $dates[1] were parsed from, so the day they name can be
+		// resolved later. Null when the date did not come from a string.
+		$raw_start = null;
+		$raw_end   = null;
+
 		try {
 			// Specific time query with a WC_DateTime.
 			if ( is_a( $query_var, 'WC_DateTime' ) ) {
@@ -358,7 +387,11 @@ class WC_Data_Store_WP {
 				$dates[] = new WC_DateTime( "@{$query_var}", new DateTimeZone( 'UTC' ) );
 			} elseif ( preg_match( $query_parse_regex, $query_var, $sections ) ) { // Query with operators and possible range of dates.
 				if ( ! empty( $sections[1] ) ) {
-					$dates[] = is_numeric( $sections[1] ) ? new WC_DateTime( "@{$sections[1]}", new DateTimeZone( 'UTC' ) ) : wc_string_to_datetime( $sections[1] );
+					$dates[]   = is_numeric( $sections[1] ) ? new WC_DateTime( "@{$sections[1]}", new DateTimeZone( 'UTC' ) ) : wc_string_to_datetime( $sections[1] );
+					$raw_start = $sections[1];
+					$raw_end   = $sections[3];
+				} else {
+					$raw_start = $sections[3];
 				}
 
 				$operator = in_array( $sections[2], $valid_operators, true ) ? $sections[2] : '';
@@ -369,6 +402,7 @@ class WC_Data_Store_WP {
 				}
 			} else { // Specific time query with a string.
 				$dates[]   = wc_string_to_datetime( $query_var );
+				$raw_start = $query_var;
 				$precision = 'day';
 			}
 		} catch ( Exception $e ) {
@@ -443,14 +477,14 @@ class WC_Data_Store_WP {
 		// Check against beginning/end-of-day timestamps when using 'day' precision.
 		if ( 'day' === $precision ) {
 			/*
-			 * The meta values are UTC timestamps, while a YYYY-MM-DD query var names a day in the site's
-			 * timezone, so both boundaries have to be anchored on local midnight. Building them from the
-			 * local calendar date keeps that anchor even when the local day starts on a different UTC date.
+			 * The meta values are UTC timestamps, while a day-precision query var names a calendar day,
+			 * so both boundaries have to be anchored on that day's local midnight. Building them from the
+			 * named date keeps that anchor even when the local day starts on a different UTC date.
 			 */
 			$timezone = wp_timezone();
-			$start    = new DateTime( $dates[0]->date( 'Y-m-d' ) . ' 00:00:00', $timezone );
+			$start    = new DateTime( $this->get_date_query_day( $dates[0], $raw_start ) . ' 00:00:00', $timezone );
 			$end      = '...' === $operator
-				? new DateTime( $dates[1]->date( 'Y-m-d' ) . ' 00:00:00', $timezone )
+				? new DateTime( $this->get_date_query_day( $dates[1], $raw_end ) . ' 00:00:00', $timezone )
 				: clone $start;
 
 			/*

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -17205,7 +17205,7 @@ parameters:
 		-
 			message: '#^Offset 1 might not exist on array\{0\: WC_DateTime, 1\?\: WC_DateTime\}\.$#'
 			identifier: offsetAccess.notFound
-			count: 2
+			count: 1
 			path: includes/data-stores/class-wc-data-store-wp.php
 
 		-

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -191,6 +191,19 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
+			'single-day range'       => array(
+				'2026-07-20...2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -285,6 +285,22 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A day-precision date the calendar cannot represent should drop the date constraint rather than throw.
+	 */
+	public function test_day_precision_meta_boundaries_survive_an_unrepresentable_date(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		// Resolves to the year 10026, which DateTime refuses to parse.
+		$result = $this->sut->parse_date_for_wp_query( '+8000 years', '_date_paid' );
+
+		$this->assertSame(
+			array(),
+			$result['meta_query'],
+			'An unrepresentable date should leave the query unconstrained instead of raising an exception'
+		);
+	}
+
+	/**
 	 * @testdox Day-precision meta date queries should anchor on local midnight on sites using a manual UTC offset.
 	 */
 	public function test_day_precision_meta_boundaries_use_manual_utc_offset(): void {

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -41,15 +41,15 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	private const NY_MAR_09_MIDNIGHT = 1773028800;
 
 	/**
-	 * Timestamp of the first instant of 2026-04-24 in Africa/Cairo. DST starts at 00:00 that day,
+	 * Timestamp of the first instant of 2026-03-29 in Asia/Beirut. DST starts at 00:00 that day,
 	 * so local midnight never happens and the day starts at 01:00:00 +03:00 instead.
 	 */
-	private const CAIRO_APR_24_START = 1776981600;
+	private const BEIRUT_MAR_29_START = 1774735200;
 
 	/**
-	 * Timestamp of 2026-04-25 00:00:00 +03:00, 23 hours after the start of 2026-04-24.
+	 * Timestamp of 2026-03-30 00:00:00 +03:00, 23 hours after the start of 2026-03-29.
 	 */
-	private const CAIRO_APR_25_MIDNIGHT = 1777064400;
+	private const BEIRUT_MAR_30_MIDNIGHT = 1774818000;
 
 	/**
 	 * The System Under Test.
@@ -273,10 +273,10 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 				self::NY_MAR_09_MIDNIGHT,
 			),
 			'DST starts at midnight, 23-hour day' => array(
-				'Africa/Cairo',
-				'2026-04-24',
-				self::CAIRO_APR_24_START,
-				self::CAIRO_APR_25_MIDNIGHT,
+				'Asia/Beirut',
+				'2026-03-29',
+				self::BEIRUT_MAR_29_START,
+				self::BEIRUT_MAR_30_MIDNIGHT,
 			),
 		);
 	}
@@ -306,10 +306,15 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	 * Skip a DST case when the runtime's timezone database puts no transition on that day.
 	 *
 	 * PHP resolves timezones against the tz database compiled into the binary, not the one the OS
-	 * ships, and DST policy changes over time. Egypt reinstated DST in tzdata 2023a, so on PHP 7.4
-	 * (tzdata 2022.1) 2026-04-24 in Cairo is an ordinary 24-hour day and the case has no transition
-	 * to assert against. The expected timestamps stay hard-coded, which is the stronger assertion;
-	 * this only skips the runtimes that cannot exercise them.
+	 * ships, so a case is only meaningful on a runtime whose database still places a transition
+	 * where the case expects one. The zones above were picked because their rules hold across the
+	 * tzdata versions this suite runs under, but DST policy is set by governments and does change:
+	 * Egypt, for one, has reinstated and repealed it repeatedly. This is the backstop that turns a
+	 * future policy change into a skip rather than a failure that reads like a real regression.
+	 *
+	 * The expected timestamps stay hard-coded on purpose. Recomputing them through the same
+	 * DateTime API the production code uses would make the assertion tautological; this guard only
+	 * reads the environment, never the code under test.
 	 *
 	 * @param string $timezone Site timezone.
 	 * @param string $date     The queried day.
@@ -322,7 +327,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 
 		if ( DAY_IN_SECONDS === $end->getTimestamp() - $start->getTimestamp() ) {
 			$this->markTestSkipped(
-				"Timezone database " . timezone_version_get() . " puts no DST transition on {$date} in {$timezone}."
+				'Timezone database ' . timezone_version_get() . " puts no DST transition on {$date} in {$timezone}."
 			);
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -57,12 +57,6 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	private const BEIRUT_MAR_30_MIDNIGHT = 1774818000;
 
 	/**
-	 * Timestamp of 2026-07-20 02:00:00 UTC, which is 2026-07-19 22:00 in America/New_York. A query
-	 * var naming this instant with an explicit designator names 2026-07-20, the way HPOS reads it.
-	 */
-	private const UTC_JUL_20_0200 = 1784512800;
-
-	/**
 	 * The System Under Test.
 	 *
 	 * @var WC_Data_Store_WP

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -6,6 +6,77 @@
 final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 
 	/**
+	 * Timestamp of 2026-07-20 00:00:00 -04:00, in America/New_York.
+	 */
+	private const NY_JUL_20_MIDNIGHT = 1784520000;
+
+	/**
+	 * Timestamp of 2026-07-21 00:00:00 -04:00, in America/New_York.
+	 */
+	private const NY_JUL_21_MIDNIGHT = 1784606400;
+
+	/**
+	 * Timestamp of 2026-07-26 00:00:00 -04:00, in America/New_York.
+	 */
+	private const NY_JUL_26_MIDNIGHT = 1785038400;
+
+	/**
+	 * Timestamp of 2026-11-01 00:00:00 -04:00, the last day of DST in America/New_York.
+	 */
+	private const NY_NOV_01_MIDNIGHT = 1793505600;
+
+	/**
+	 * Timestamp of 2026-11-02 00:00:00 -05:00, 25 hours after the start of 2026-11-01.
+	 */
+	private const NY_NOV_02_MIDNIGHT = 1793595600;
+
+	/**
+	 * Timestamp of 2026-03-08 00:00:00 -05:00, the day DST starts in America/New_York.
+	 */
+	private const NY_MAR_08_MIDNIGHT = 1772946000;
+
+	/**
+	 * Timestamp of 2026-03-09 00:00:00 -04:00, 23 hours after the start of 2026-03-08.
+	 */
+	private const NY_MAR_09_MIDNIGHT = 1773028800;
+
+	/**
+	 * Timestamp of the first instant of 2026-04-24 in Africa/Cairo. DST starts at 00:00 that day,
+	 * so local midnight never happens and the day starts at 01:00:00 +03:00 instead.
+	 */
+	private const CAIRO_APR_24_START = 1776981600;
+
+	/**
+	 * Timestamp of 2026-04-25 00:00:00 +03:00, 23 hours after the start of 2026-04-24.
+	 */
+	private const CAIRO_APR_25_MIDNIGHT = 1777064400;
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var WC_Data_Store_WP
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new WC_Data_Store_WP();
+	}
+
+	/**
+	 * Restore the default timezone settings.
+	 */
+	public function tearDown(): void {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 0 );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * @return array
 	 */
 	public function provider_update_or_delete_post_meta(): array {
@@ -46,5 +117,173 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 		$this->assertSame( $expected_stored, get_post_meta( $product_id, '_sku', true ) );
 
 		$product->delete();
+	}
+
+	/**
+	 * Day-precision meta date boundaries per operator, for a site in America/New_York.
+	 *
+	 * The bounds are half-open, so a day is matched in full and exactly once. For a range the
+	 * upper bound is the midnight *after* the final day, so that the whole final day is covered.
+	 *
+	 * @return array
+	 */
+	public function day_precision_meta_boundary_provider(): array {
+		return array(
+			'equals'                 => array(
+				'2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'greater than'           => array(
+				'>2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '>=',
+					),
+				),
+			),
+			'greater than or equals' => array(
+				'>=2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+				),
+			),
+			'less than'              => array(
+				'<2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'less than or equals'    => array(
+				'<=2026-07-20',
+				array(
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'range'                  => array(
+				'2026-07-20...2026-07-25',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_26_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @testdox Day-precision meta date queries should anchor on the site's local midnight for every operator.
+	 *
+	 * @dataProvider day_precision_meta_boundary_provider
+	 *
+	 * @param string $query_var The date query var.
+	 * @param array  $expected  Expected value/compare pairs, in order.
+	 */
+	public function test_day_precision_meta_boundaries_use_site_timezone( string $query_var, array $expected ): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$result = $this->sut->parse_date_for_wp_query( $query_var, '_date_paid' );
+
+		$this->assertCount(
+			count( $expected ),
+			$result['meta_query'],
+			'Wrong number of meta query clauses for ' . $query_var
+		);
+
+		foreach ( $expected as $index => $clause ) {
+			$this->assertSame(
+				$clause['value'],
+				$result['meta_query'][ $index ]['value'],
+				"Wrong boundary timestamp in clause {$index} for {$query_var}"
+			);
+			$this->assertSame(
+				$clause['compare'],
+				$result['meta_query'][ $index ]['compare'],
+				"Wrong comparison operator in clause {$index} for {$query_var}"
+			);
+		}
+	}
+
+	/**
+	 * @testdox Day-precision meta date queries should anchor on local midnight on sites using a manual UTC offset.
+	 */
+	public function test_day_precision_meta_boundaries_use_manual_utc_offset(): void {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -4 );
+
+		$result = $this->sut->parse_date_for_wp_query( '2026-07-20', '_date_paid' );
+
+		$this->assertSame( self::NY_JUL_20_MIDNIGHT, $result['meta_query'][0]['value'], 'Start should be local midnight, not UTC midnight' );
+		$this->assertSame( self::NY_JUL_21_MIDNIGHT, $result['meta_query'][1]['value'], 'End should be the next local midnight' );
+	}
+
+	/**
+	 * Days whose local length is not 24 hours.
+	 *
+	 * @return array
+	 */
+	public function dst_transition_provider(): array {
+		return array(
+			'DST ends, 25-hour day'               => array(
+				'America/New_York',
+				'2026-11-01',
+				self::NY_NOV_01_MIDNIGHT,
+				self::NY_NOV_02_MIDNIGHT,
+			),
+			'DST starts, 23-hour day'             => array(
+				'America/New_York',
+				'2026-03-08',
+				self::NY_MAR_08_MIDNIGHT,
+				self::NY_MAR_09_MIDNIGHT,
+			),
+			'DST starts at midnight, 23-hour day' => array(
+				'Africa/Cairo',
+				'2026-04-24',
+				self::CAIRO_APR_24_START,
+				self::CAIRO_APR_25_MIDNIGHT,
+			),
+		);
+	}
+
+	/**
+	 * @testdox Day-precision meta date queries should span the real length of a day across DST transitions.
+	 *
+	 * @dataProvider dst_transition_provider
+	 *
+	 * @param string $timezone       Site timezone.
+	 * @param string $date           The queried day.
+	 * @param int    $expected_start Expected start-of-day timestamp.
+	 * @param int    $expected_end   Expected next-midnight timestamp.
+	 */
+	public function test_day_precision_meta_boundaries_follow_dst_transitions( string $timezone, string $date, int $expected_start, int $expected_end ): void {
+		update_option( 'timezone_string', $timezone );
+
+		$result = $this->sut->parse_date_for_wp_query( $date, '_date_paid' );
+
+		$this->assertSame( $expected_start, $result['meta_query'][0]['value'], "Wrong start of day for {$date} in {$timezone}" );
+		$this->assertSame( $expected_end, $result['meta_query'][1]['value'], "Wrong end of day for {$date} in {$timezone}" );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -297,13 +297,13 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 			array(
 				array(
 					'key'     => '_date_paid',
-					'value'   => 0,
+					'value'   => array( 1, 0 ),
 					'type'    => 'NUMERIC',
-					'compare' => '<',
+					'compare' => 'BETWEEN',
 				),
 			),
 			$result['meta_query'],
-			'An unrepresentable date should constrain the query to nothing rather than dropping the date filter'
+			'An unrepresentable date should constrain the query to an empty range rather than dropping the date filter'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -294,9 +294,16 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 		$result = $this->sut->parse_date_for_wp_query( '+8000 years', '_date_paid' );
 
 		$this->assertSame(
-			array(),
+			array(
+				array(
+					'key'     => '_date_paid',
+					'value'   => 0,
+					'type'    => 'NUMERIC',
+					'compare' => '<',
+				),
+			),
 			$result['meta_query'],
-			'An unrepresentable date should leave the query unconstrained instead of raising an exception'
+			'An unrepresentable date should constrain the query to nothing rather than dropping the date filter'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -6,6 +6,11 @@
 final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 
 	/**
+	 * Timestamp of 2026-07-19 00:00:00 -04:00, in America/New_York.
+	 */
+	private const NY_JUL_19_MIDNIGHT = 1784433600;
+
+	/**
 	 * Timestamp of 2026-07-20 00:00:00 -04:00, in America/New_York.
 	 */
 	private const NY_JUL_20_MIDNIGHT = 1784520000;
@@ -50,6 +55,12 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	 * Timestamp of 2026-03-30 00:00:00 +03:00, 23 hours after the start of 2026-03-29.
 	 */
 	private const BEIRUT_MAR_30_MIDNIGHT = 1774818000;
+
+	/**
+	 * Timestamp of 2026-07-20 02:00:00 UTC, which is 2026-07-19 22:00 in America/New_York. A query
+	 * var naming this instant with an explicit designator names 2026-07-20, the way HPOS reads it.
+	 */
+	private const UTC_JUL_20_0200 = 1784512800;
 
 	/**
 	 * The System Under Test.
@@ -129,7 +140,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	 */
 	public function day_precision_meta_boundary_provider(): array {
 		return array(
-			'equals'                 => array(
+			'equals'                  => array(
 				'2026-07-20',
 				array(
 					array(
@@ -142,7 +153,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'greater than'           => array(
+			'greater than'            => array(
 				'>2026-07-20',
 				array(
 					array(
@@ -151,7 +162,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'greater than or equals' => array(
+			'greater than or equals'  => array(
 				'>=2026-07-20',
 				array(
 					array(
@@ -160,7 +171,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'less than'              => array(
+			'less than'               => array(
 				'<2026-07-20',
 				array(
 					array(
@@ -169,7 +180,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'less than or equals'    => array(
+			'less than or equals'     => array(
 				'<=2026-07-20',
 				array(
 					array(
@@ -178,7 +189,7 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'range'                  => array(
+			'range'                   => array(
 				'2026-07-20...2026-07-25',
 				array(
 					array(
@@ -191,7 +202,46 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'single-day range'       => array(
+			'explicit UTC instant'    => array(
+				'2026-07-20T02:00:00Z',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'explicit offset instant' => array(
+				'2026-07-20T02:00:00+05:00',
+				array(
+					array(
+						'value'   => self::NY_JUL_19_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'naive datetime'          => array(
+				'2026-07-20 22:00:00',
+				array(
+					array(
+						'value'   => self::NY_JUL_20_MIDNIGHT,
+						'compare' => '>=',
+					),
+					array(
+						'value'   => self::NY_JUL_21_MIDNIGHT,
+						'compare' => '<',
+					),
+				),
+			),
+			'single-day range'        => array(
 				'2026-07-20...2026-07-20',
 				array(
 					array(

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-data-store-wp-test.php
@@ -292,11 +292,38 @@ final class WC_Data_Store_WP_Test extends WC_Unit_Test_Case {
 	 * @param int    $expected_end   Expected next-midnight timestamp.
 	 */
 	public function test_day_precision_meta_boundaries_follow_dst_transitions( string $timezone, string $date, int $expected_start, int $expected_end ): void {
+		$this->skip_if_day_has_no_dst_transition( $timezone, $date );
+
 		update_option( 'timezone_string', $timezone );
 
 		$result = $this->sut->parse_date_for_wp_query( $date, '_date_paid' );
 
 		$this->assertSame( $expected_start, $result['meta_query'][0]['value'], "Wrong start of day for {$date} in {$timezone}" );
 		$this->assertSame( $expected_end, $result['meta_query'][1]['value'], "Wrong end of day for {$date} in {$timezone}" );
+	}
+
+	/**
+	 * Skip a DST case when the runtime's timezone database puts no transition on that day.
+	 *
+	 * PHP resolves timezones against the tz database compiled into the binary, not the one the OS
+	 * ships, and DST policy changes over time. Egypt reinstated DST in tzdata 2023a, so on PHP 7.4
+	 * (tzdata 2022.1) 2026-04-24 in Cairo is an ordinary 24-hour day and the case has no transition
+	 * to assert against. The expected timestamps stay hard-coded, which is the stronger assertion;
+	 * this only skips the runtimes that cannot exercise them.
+	 *
+	 * @param string $timezone Site timezone.
+	 * @param string $date     The queried day.
+	 */
+	private function skip_if_day_has_no_dst_transition( string $timezone, string $date ): void {
+		$zone  = new DateTimeZone( $timezone );
+		$start = new DateTime( $date . ' 00:00:00', $zone );
+		$end   = new DateTime( $date . ' 00:00:00', $zone );
+		$end->modify( 'tomorrow' );
+
+		if ( DAY_IN_SECONDS === $end->getTimestamp() - $start->getTimestamp() ) {
+			$this->markTestSkipped(
+				"Timezone database " . timezone_version_get() . " puts no DST transition on {$date} in {$timezone}."
+			);
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -7,6 +7,11 @@
  * that runs 23 or 25 hours across a DST transition the two backends still disagree by an hour.
  * Post storage is the correct side there; closing the gap means fixing `OrdersTableQuery`.
  *
+ * It is also asserted for `date_paid` only, which stands in for the meta-backed date fields.
+ * `date_created` and `date_modified` map to `post_date`/`post_modified` and take a different
+ * branch that still names the day in the site timezone, so they can disagree with HPOS on a
+ * query var carrying an explicit UTC designator. That is pre-existing and out of scope here.
+ *
  * @package WooCommerce\Tests\DataStores
  */
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -2,15 +2,9 @@
 /**
  * Tests that day-precision date queries behave identically on both order storage backends.
  *
- * Parity is asserted for ordinary 24-hour days only. HPOS derives its upper bound as
- * `$date1 + DAY_IN_SECONDS` in `OrdersTableQuery::local_time_to_gmt_date_query()`, so on a day
- * that runs 23 or 25 hours across a DST transition the two backends still disagree by an hour.
- * Post storage is the correct side there; closing the gap means fixing `OrdersTableQuery`.
- *
- * It is also asserted for `date_paid` only, which stands in for the meta-backed date fields.
- * `date_created` and `date_modified` map to `post_date`/`post_modified` and take a different
- * branch that still names the day in the site timezone, so they can disagree with HPOS on a
- * query var carrying an explicit UTC designator. That is pre-existing and out of scope here.
+ * Parity is scoped to ordinary 24-hour days and to `date_paid`. HPOS is an hour out on DST
+ * transition days, tracked in #68060. `date_created` and `date_modified` take the `post_date`
+ * branch, which names the day in the site timezone rather than UTC. Both predate this suite.
  *
  * @package WooCommerce\Tests\DataStores
  */

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -78,6 +78,7 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 			'a range starting on the local day'    => array( '2026-07-20...2026-07-21', true ),
 			'a range starting after the local day' => array( '2026-07-21...2026-07-22', false ),
 			'a single-day range on the local day'  => array( '2026-07-20...2026-07-20', true ),
+			'an explicit UTC instant on the day'   => array( '2026-07-20T02:00:00Z', true ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests that day-precision date queries behave identically on both order storage backends.
+ *
+ * @package WooCommerce\Tests\DataStores
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+//phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Legacy class name.
+
+/**
+ * Class WC_Order_Date_Query_Test.
+ *
+ * @group order-query-tests
+ */
+class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Timestamp of 2026-07-20 21:00:00 -04:00, which falls on 2026-07-21 in UTC. This is the case a
+	 * UTC-anchored day boundary gets wrong: the order belongs to the 20th in the site's timezone.
+	 */
+	private const PAID_AT = 1784595600;
+
+	/**
+	 * The order storage state before the test.
+	 *
+	 * @var bool
+	 */
+	private $previous_cot_state;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->previous_cot_state = OrderUtil::custom_orders_table_usage_is_enabled();
+		OrderHelper::create_order_custom_table_if_not_exist();
+
+		update_option( 'timezone_string', 'America/New_York' );
+	}
+
+	/**
+	 * Restore the order storage and timezone settings.
+	 */
+	public function tearDown(): void {
+		OrderHelper::toggle_cot_feature_and_usage( $this->previous_cot_state );
+		update_option( 'timezone_string', '' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Day-precision `date_paid` queries and whether an order paid at {@see self::PAID_AT} should match.
+	 *
+	 * @return array
+	 */
+	public function date_paid_query_provider(): array {
+		return array(
+			'the local day the order was paid'     => array( '2026-07-20', true ),
+			'the following local day'              => array( '2026-07-21', false ),
+			'the preceding local day'              => array( '2026-07-19', false ),
+			'on or after the local day'            => array( '>=2026-07-20', true ),
+			'strictly after the local day'         => array( '>2026-07-20', false ),
+			'on or before the local day'           => array( '<=2026-07-20', true ),
+			'strictly before the local day'        => array( '<2026-07-20', false ),
+			'a range ending on the local day'      => array( '2026-07-19...2026-07-20', true ),
+			'a range ending before the local day'  => array( '2026-07-18...2026-07-19', false ),
+			'a range starting on the local day'    => array( '2026-07-20...2026-07-21', true ),
+			'a range starting after the local day' => array( '2026-07-21...2026-07-22', false ),
+		);
+	}
+
+	/**
+	 * @testdox Day-precision date_paid queries should match on the local day the order was paid, on both order storage backends.
+	 *
+	 * @dataProvider date_paid_query_provider
+	 *
+	 * @param string $date_paid_query The date_paid query var.
+	 * @param bool   $should_match    Whether the order is expected to match.
+	 */
+	public function test_date_paid_day_queries_match_the_local_day( string $date_paid_query, bool $should_match ): void {
+		$results = array();
+
+		$storage_backends = array(
+			'posts' => false,
+			'hpos'  => true,
+		);
+
+		foreach ( $storage_backends as $storage => $use_hpos ) {
+			OrderHelper::toggle_cot_feature_and_usage( $use_hpos );
+
+			$order = new WC_Order();
+			$order->set_date_paid( self::PAID_AT );
+			$order->save();
+
+			$matched_ids = wc_get_orders(
+				array(
+					'date_paid' => $date_paid_query,
+					'limit'     => -1,
+					'return'    => 'ids',
+				)
+			);
+
+			$results[ $storage ] = in_array( $order->get_id(), $matched_ids, true );
+
+			$order->delete( true );
+		}
+
+		$this->assertSame(
+			$results['posts'],
+			$results['hpos'],
+			"Post and HPOS storage disagree on 'date_paid' => '{$date_paid_query}'"
+		);
+		$this->assertSame(
+			$should_match,
+			$results['posts'],
+			"Wrong result for 'date_paid' => '{$date_paid_query}' on an order paid at 2026-07-20 21:00 local time"
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -92,6 +92,7 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 			'a range starting after the local day' => array( '2026-07-21...2026-07-22', false ),
 			'a single-day range on the local day'  => array( '2026-07-20...2026-07-20', true ),
 			'an explicit UTC instant on the day'   => array( '2026-07-20T02:00:00Z', true ),
+			'a date the calendar cannot represent' => array( '+8000 years', false ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -2,6 +2,11 @@
 /**
  * Tests that day-precision date queries behave identically on both order storage backends.
  *
+ * Parity is asserted for ordinary 24-hour days only. HPOS derives its upper bound as
+ * `$date1 + DAY_IN_SECONDS` in `OrdersTableQuery::local_time_to_gmt_date_query()`, so on a day
+ * that runs 23 or 25 hours across a DST transition the two backends still disagree by an hour.
+ * Post storage is the correct side there; closing the gap means fixing `OrdersTableQuery`.
+ *
  * @package WooCommerce\Tests\DataStores
  */
 
@@ -72,11 +77,12 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 			'a range ending before the local day'  => array( '2026-07-18...2026-07-19', false ),
 			'a range starting on the local day'    => array( '2026-07-20...2026-07-21', true ),
 			'a range starting after the local day' => array( '2026-07-21...2026-07-22', false ),
+			'a single-day range on the local day'  => array( '2026-07-20...2026-07-20', true ),
 		);
 	}
 
 	/**
-	 * @testdox Day-precision date_paid queries should match on the local day the order was paid, on both order storage backends.
+	 * @testdox Day-precision date_paid queries should match on the local day the order was paid, and agree across order storage backends on an ordinary 24-hour day.
 	 *
 	 * @dataProvider date_paid_query_provider
 	 *

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -107,7 +107,12 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 	public function test_an_unrepresentable_date_matches_nothing_on_both_backends(): void {
 		$results = array();
 
-		foreach ( array( 'posts' => false, 'hpos' => true ) as $storage => $use_hpos ) {
+		$storage_backends = array(
+			'posts' => false,
+			'hpos'  => true,
+		);
+
+		foreach ( $storage_backends as $storage => $use_hpos ) {
 			OrderHelper::toggle_cot_feature_and_usage( $use_hpos );
 
 			$this->assertSame(

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -43,6 +43,13 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		/*
+		 * Toggling the authoritative order storage throws when any order is pending sync, and the
+		 * HPOS tables outlive the per-test transaction, so a row left by an earlier test would make
+		 * this suite fail for a reason unrelated to what it asserts.
+		 */
+		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+
 		$this->previous_cot_state = OrderUtil::custom_orders_table_usage_is_enabled();
 		OrderHelper::create_order_custom_table_if_not_exist();
 
@@ -54,6 +61,7 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		OrderHelper::toggle_cot_feature_and_usage( $this->previous_cot_state );
+		remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		update_option( 'timezone_string', '' );
 
 		parent::tearDown();
@@ -100,6 +108,12 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 
 		foreach ( $storage_backends as $storage => $use_hpos ) {
 			OrderHelper::toggle_cot_feature_and_usage( $use_hpos );
+
+			$this->assertSame(
+				$use_hpos,
+				OrderUtil::custom_orders_table_usage_is_enabled(),
+				"Could not switch order storage to {$storage}"
+			);
 
 			$order = new WC_Order();
 			$order->set_date_paid( self::PAID_AT );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-date-query-test.php
@@ -36,6 +36,11 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 	private const PAID_AT = 1784595600;
 
 	/**
+	 * Timestamp of 1960-01-01 00:00:00 UTC, a date WooCommerce stores as a negative number.
+	 */
+	private const PAID_BEFORE_EPOCH = -315619200;
+
+	/**
 	 * The order storage state before the test.
 	 *
 	 * @var bool
@@ -94,6 +99,45 @@ class WC_Order_Date_Query_Test extends WC_Unit_Test_Case {
 			'an explicit UTC instant on the day'   => array( '2026-07-20T02:00:00Z', true ),
 			'a date the calendar cannot represent' => array( '+8000 years', false ),
 		);
+	}
+
+	/**
+	 * @testdox An unrepresentable date should match no orders on either storage backend, including orders paid before 1970.
+	 */
+	public function test_an_unrepresentable_date_matches_nothing_on_both_backends(): void {
+		$results = array();
+
+		foreach ( array( 'posts' => false, 'hpos' => true ) as $storage => $use_hpos ) {
+			OrderHelper::toggle_cot_feature_and_usage( $use_hpos );
+
+			$this->assertSame(
+				$use_hpos,
+				OrderUtil::custom_orders_table_usage_is_enabled(),
+				"Could not switch order storage to {$storage}"
+			);
+
+			// A negative timestamp, which a one-sided lower bound would still match.
+			$order = new WC_Order();
+			$order->set_date_paid( self::PAID_BEFORE_EPOCH );
+			$order->save();
+
+			$results[ $storage ] = in_array(
+				$order->get_id(),
+				wc_get_orders(
+					array(
+						'date_paid' => '+8000 years',
+						'limit'     => -1,
+						'return'    => 'ids',
+					)
+				),
+				true
+			);
+
+			$order->delete( true );
+		}
+
+		$this->assertSame( $results['posts'], $results['hpos'], 'Post and HPOS storage disagree on an unrepresentable date' );
+		$this->assertFalse( $results['posts'], 'An unrepresentable date should match no orders' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`wc_get_orders( array( 'date_paid' => '2026-07-20' ) )` on a store in `America/New_York` misses an order paid at 21:00 that evening and returns it under `2026-07-21` instead. `WC_Data_Store_WP::parse_date_for_wp_query()` built the day boundaries by passing a local-midnight timestamp through `gmdate()` and back through `strtotime()`. `gmdate()` re-derives a UTC calendar date, and `strtotime()` runs under PHP's default timezone, which WordPress forces to UTC, so both steps discarded the local anchor `wc_string_to_datetime()` had already established.

Both bounds are now rebuilt in `wp_timezone()` from the local calendar date, and the upper bound comes from the next local midnight rather than a fixed 86400 seconds, so a day that runs 23 or 25 hours across a DST transition is covered correctly.

Same root cause as #39462, which fixes it for the admin orders screen. This is the `wc_get_orders()` / `wc_get_products()` path, which #67134 does not touch.

Closes #67902.

(For Bug Fixes) Bug introduced in PR #14971.

### Backward compatibility

This changes query results on live stores, so it is worth stating plainly.

- A store is unaffected by the timezone shift only when its UTC offset is zero **on the queried date**, which is a per-date property rather than a per-store one: `Europe/London` is UTC+0 in winter and UTC+1 in summer, so the same store is correct in January and wrong in July. Those stores still get the operator change: an order paid at exactly the next local midnight now moves to the day it belongs to. Everywhere else the old bounds did not describe the requested local day at all, and how wrong they were depends on the sign of the offset. West of UTC a query returned `24 - |offset|` hours of the right day; east of UTC it returned only `offset` hours, with the remainder coming from the previous day. Small positive offsets are the worst case, which puts most of Europe at the bad end:

  | Store timezone | Offset | Old window (local) | Correct-day content |
  |---|---|---|---|
  | Europe/London | +1 | Jul 19 01:00 to Jul 20 01:00 | 1h of 24 (4%) |
  | Europe/Berlin | +2 | Jul 19 02:00 to Jul 20 02:00 | 2h (8%) |
  | Asia/Kolkata | +5.5 | Jul 19 05:30 to Jul 20 05:30 | 6h (23%) |
  | Asia/Tokyo | +9 | Jul 19 09:00 to Jul 20 09:00 | 9h (38%) |
  | Australia/Sydney | +10 | Jul 19 10:00 to Jul 20 10:00 | 10h (42%) |
  | America/Los_Angeles | -7 | Jul 19 17:00 to Jul 20 17:00 | 17h (71%) |
  | America/New_York | -4 | Jul 19 20:00 to Jul 20 20:00 | 20h (83%) |

  The asymmetry comes from `gmdate()` naming the UTC calendar date of the local-midnight instant. East of UTC that instant falls on the previous UTC date, so the whole window slides back a day on top of the offset error.

  Measured on post storage with a `Europe/London` store, one order placed at every local hour across 2026-07-19 and 2026-07-20, querying `'date_paid' => '2026-07-20'`: the old code matched 25 orders, 23 of which were placed on the 19th. The fix matches exactly the 24 orders placed on the 20th. The extra order in the old result is the upper bound being inclusive, which is the same off-by-one-instant the `<=` to `<` change removes.
- Affected query vars: `date_paid` and `date_completed` on `wc_get_orders()`, `date_on_sale_from` and `date_on_sale_to` on `wc_get_products()`, on post storage. `date_created` and `date_modified` map to `post_date` / `post_modified` and take a different branch, which is untouched. Those are the core query vars, not the limit of the change: `parse_date_for_wp_query()` is public and takes an arbitrary meta key, so an extension calling it for its own timestamp meta gets the corrected boundaries too.
- A query var carrying a time now names the day of that instant in UTC, matching HPOS. `'2026-07-20 22:00:00'` on a `-04:00` store named the 21st before and names the 20th now.
- Two bad inputs still fail in opposite directions, both silently: `'...2026-07-20'` drops the filter and returns everything, `'+8000 years'` matches nothing. The first is untouched here and tracked in #68060.
- No signature, interface, or hook changes. `parse_date_for_wp_query()` keeps its signature and its return shape; only the boundary values and comparison operators change.
- The comparison operators now match HPOS, which was already the correct reference: `>` was excluding the next-midnight instant, `<=` was including it, and a `...` range was collapsing its final day down to that day's first second. That last one is the change a store is most likely to notice, since a range query now includes a whole extra day of data.
- Nothing is written or migrated, so a revert is safe.

Extensions running scheduled reconciliation against a day-precision `date_paid` filter will see one shifted window as a store upgrades. That is the fix landing, but worth knowing about.

The one case where this is not simply a correction: code that compensated for the bug by shifting its own window to make daily totals line up now double-corrects and starts reporting the wrong day. There is no signal when that happens, and I cannot enumerate which integrations do it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In **Settings > General**, set the store timezone to `New York` (any non-UTC zone works).
2. Create an order and mark it paid, then set its paid date to 21:00 local time on a given day. From the repo root:
   ```
   pnpm wp eval '$o = wc_create_order(); $o->set_date_paid( strtotime( "2026-07-20 21:00:00 America/New_York" ) ); $o->save(); echo $o->get_id();'
   ```
3. Query for the local day the order was paid, and for the day after:
   ```
   pnpm wp eval 'var_dump( wc_get_orders( array( "date_paid" => "2026-07-20", "return" => "ids" ) ), wc_get_orders( array( "date_paid" => "2026-07-21", "return" => "ids" ) ) );'
   ```
   Before this change the order shows up under `2026-07-21`. After it, it shows up under `2026-07-20` and not under `2026-07-21`.
4. Check a range picks up its final day: `"date_paid" => "2026-07-19...2026-07-20"` should match. Before this change it did not.
5. Repeat steps 2 to 4 with HPOS enabled and confirm both storage backends return the same order IDs.

<!-- End testing instructions -->

### Testing that has already taken place:

Two new test classes, both watched failing before the fix:

- `WC_Data_Store_WP_Test` drives `parse_date_for_wp_query()` directly. Ten boundary cases cover all six operators (`=`, `>`, `>=`, `<`, `<=`, `...`) in `America/New_York`, plus a single-day range, a naive datetime, and query vars carrying an explicit `Z` or `+05:00` designator. Separate cases cover a site on a manual UTC offset rather than a timezone string, a date the calendar cannot represent, and three DST-transition days: a 25-hour day, a 23-hour day, and `Asia/Beirut` on the day DST starts at 00:00 and local midnight does not exist. Every boundary constant is hard-coded and was recomputed independently rather than derived from the code under test.
- `WC_Order_Date_Query_Test` runs thirteen `wc_get_orders()` queries against an order paid 2026-07-20 21:00 local, on both post storage and HPOS, and asserts the two agree and that the result matches the local day. Reverting the production change fails it on both assertions.

All three `unit:php` CI jobs pass, including PHP 7.4 and the HPOS-off variant. PHPStan is clean across the full analysis and the run removes one entry from the baseline rather than adding any; `lint:changes:branch` is clean.

One gap this does not close: HPOS still uses `+ DAY_IN_SECONDS` in `OrdersTableQuery::local_time_to_gmt_date_query()`, so it keeps the DST defect that this PR removes from post storage. The two backends now agree on ordinary days and disagree only on DST-transition days. Reproduced with a probe order paid 2026-11-01 23:30 local, a 25-hour day: post storage correctly matches `2026-11-01`, HPOS does not. Worth a follow-up on `OrdersTableQuery`. `WC_Order_Date_Query_Test` scopes its parity assertion to ordinary days and names `OrdersTableQuery` as the reason, so the caveat is recorded in the code rather than only here.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select if this PR needs a generated summary for release notes:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)





