### PR TITLE
Fix product description recursion guard

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-description-recursion-guard
+++ b/plugins/woocommerce/changelog/fix-product-description-recursion-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent recursive product description formatting between the Product Description block and Store API product schema.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
+
 /**
  * ProductDescription class.
  */
@@ -12,14 +14,6 @@ class ProductDescription extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-description';
-
-	/**
-	 * Keeps track of seen product IDs to prevent recursive rendering.
-	 *
-	 * @var array
-	 */
-	private static $seen_ids = array();
-
 
 	/**
 	 * Render the block.
@@ -36,40 +30,29 @@ class ProductDescription extends AbstractBlock {
 			return '';
 		}
 
-		$product_id = $block->context['postId'];
-
-		// Prevent recursive rendering.
-		if ( isset( self::$seen_ids[ $product_id ] ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
-				return __( '[product description rendering halted]', 'woocommerce' );
-			}
-			return '';
-		}
-
-		self::$seen_ids[ $product_id ] = true;
+		$product_id = absint( $block->context['postId'] );
 
 		// Get the product.
 		$product = wc_get_product( $product_id );
 		if ( ! $product ) {
-			unset( self::$seen_ids[ $product_id ] );
 			return '';
 		}
 
-		// Get the description content.
-		$description = $product->get_description();
-		/**
-		 * This filter is documented in wp-includes/post-template.php.
-		 * We follow core/content block to replace ]]> with ]&gt;
-		 */
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$description = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $description ) );
+		$description = ProductDescriptionUtils::guarded_format(
+			$product,
+			function () use ( $product ) {
+				/**
+				 * This filter is documented in wp-includes/post-template.php.
+				 * We follow core/content block to replace ]]> with ]&gt;
+				 */
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $product->get_description() ) );
+			}
+		);
+
 		if ( empty( $description ) ) {
-			unset( self::$seen_ids[ $product_id ] );
 			return '';
 		}
-
-		// Remove this product from the seen array.
-		unset( self::$seen_ids[ $product_id ] );
 
 		// Add wrapper with block attributes.
 		$wrapper_attributes = get_block_wrapper_attributes(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSummary.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSummary.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
@@ -200,7 +201,12 @@ class ProductSummary extends AbstractBlock {
 		}
 
 		$show_description_if_empty = isset( $attributes['showDescriptionIfEmpty'] ) && $attributes['showDescriptionIfEmpty'];
-		$source                    = $this->get_source( $product, $show_description_if_empty );
+		$source                    = ProductDescriptionUtils::guarded_format(
+			$product,
+			function () use ( $product, $show_description_if_empty ) {
+				return $this->get_source( $product, $show_description_if_empty );
+			}
+		);
 
 		if ( ! $source ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/Utils/ProductDescriptionUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductDescriptionUtils.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+/**
+ * Product description utilities.
+ */
+class ProductDescriptionUtils {
+
+	/**
+	 * Product IDs whose descriptions are currently being formatted.
+	 *
+	 * @var array<int, true>
+	 */
+	private static array $formatting_product_descriptions = array();
+
+	/**
+	 * Format a product description while preventing same-product recursive formatting.
+	 *
+	 * @param \WC_Product $product         Product object.
+	 * @param callable    $format_callback Callback that formats the product description.
+	 * @return string Formatted product description.
+	 */
+	public static function guarded_format( \WC_Product $product, callable $format_callback ): string {
+		$product_id = $product->get_id();
+
+		if ( isset( self::$formatting_product_descriptions[ $product_id ] ) ) {
+			return '';
+		}
+
+		self::$formatting_product_descriptions[ $product_id ] = true;
+
+		try {
+			$result = $format_callback();
+
+			return is_string( $result ) ? $result : '';
+		} finally {
+			unset( self::$formatting_product_descriptions[ $product_id ] );
+		}
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -596,7 +596,14 @@ class ProductSchema extends AbstractSchema {
 	public function get_item_response( $product ) {
 		$availability      = ProductAvailabilityUtils::get_product_availability( $product );
 		$password_required = post_password_required( $product->get_id() );
-		$short_description = $password_required ? '' : $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) );
+		$short_description = $password_required ? '' : $this->prepare_html_response(
+			ProductDescriptionUtils::guarded_format(
+				$product,
+				function () use ( $product ) {
+					return wc_format_content( wp_kses_post( $product->get_short_description() ) );
+				}
+			)
+		);
 		$description       = $password_required ? '' : $this->prepare_html_response(
 			ProductDescriptionUtils::guarded_format(
 				$product,

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
 use Automattic\WooCommerce\Blocks\Utils\ProductAvailabilityUtils;
+use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\StockDisplayFormat;
 use Automattic\WooCommerce\Enums\TaxDisplayMode;
@@ -596,7 +597,14 @@ class ProductSchema extends AbstractSchema {
 		$availability      = ProductAvailabilityUtils::get_product_availability( $product );
 		$password_required = post_password_required( $product->get_id() );
 		$short_description = $password_required ? '' : $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) );
-		$description       = $password_required ? '' : $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_description() ) ) );
+		$description       = $password_required ? '' : $this->prepare_html_response(
+			ProductDescriptionUtils::guarded_format(
+				$product,
+				function () use ( $product ) {
+					return wc_format_content( wp_kses_post( $product->get_description() ) );
+				}
+			)
+		);
 
 		return [
 			'id'                    => $product->get_id(),

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
@@ -3,13 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\Utils;
 
-use Automattic\WooCommerce\Blocks\BlockTypes\ProductDescription;
 use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
-use Automattic\WooCommerce\StoreApi\Formatters;
-use Automattic\WooCommerce\StoreApi\SchemaController;
-use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
-use Automattic\WooCommerce\StoreApi\Schemas\V1\ImageAttachmentSchema;
-use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema;
 use WC_Helper_Product;
 
 /**
@@ -18,104 +12,24 @@ use WC_Helper_Product;
 class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
 
 	/**
-	 * @testdox guarded_format() returns an empty string for same-product recursive formatting.
+	 * @testdox guarded_format() returns the formatted product description.
 	 */
-	public function test_guarded_format_returns_empty_string_for_recursive_same_product_formatting(): void {
+	public function test_guarded_format_returns_formatted_product_description(): void {
 		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description( 'A formatted product description.' );
+		$product->save();
 
 		try {
 			$result = ProductDescriptionUtils::guarded_format(
 				$product,
 				function () use ( $product ) {
-					$recursive_result = ProductDescriptionUtils::guarded_format(
-						$product,
-						function () {
-							return 'Recursive description';
-						}
-					);
-
-					return 'Outer description: ' . $recursive_result;
+					return $product->get_description();
 				}
 			);
 
-			$this->assertSame( 'Outer description: ', $result );
+			$this->assertSame( 'A formatted product description.', $result );
 		} finally {
 			WC_Helper_Product::delete_product( $product->get_id() );
-		}
-	}
-
-	/**
-	 * @testdox ProductSchema shares the active ProductDescription recursion guard for the same product.
-	 */
-	public function test_product_schema_uses_same_guard_as_product_description_block(): void {
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_short_description( 'Short product description.' );
-		$product->set_description( 'Outer product description.' );
-		$product->save();
-
-		$schema                       = $this->create_product_schema();
-		$schema_response              = null;
-		$schema_calls                 = 0;
-		$formatted_content_raw_values = array();
-
-		$format_content_callback = function ( $content, $raw_content ) use ( &$formatted_content_raw_values ) {
-			$formatted_content_raw_values[] = $raw_content;
-			return $content;
-		};
-
-		$the_content_callback = function ( $content ) use ( $schema, $product, &$schema_response, &$schema_calls ) {
-			++$schema_calls;
-			$schema_response = $schema->get_item_response( $product );
-
-			return $content;
-		};
-
-		add_filter( 'woocommerce_format_content', $format_content_callback, 10, 2 );
-		add_filter( 'the_content', $the_content_callback );
-
-		try {
-			$rendered_block = $this->render_product_description_block( $product );
-
-			$this->assertSame( 1, $schema_calls );
-			$this->assertSame( array( 'Short product description.' ), $formatted_content_raw_values );
-			$this->assertIsArray( $schema_response );
-			$this->assertSame( '', $schema_response['description'] );
-			$this->assertStringContainsString( 'Outer product description.', $rendered_block );
-		} finally {
-			remove_filter( 'woocommerce_format_content', $format_content_callback );
-			remove_filter( 'the_content', $the_content_callback );
-			WC_Helper_Product::delete_product( $product->get_id() );
-		}
-	}
-
-	/**
-	 * @testdox guarded_format() allows nested formatting for a different product.
-	 */
-	public function test_guarded_format_allows_nested_different_product_formatting(): void {
-		$product       = WC_Helper_Product::create_simple_product();
-		$other_product = WC_Helper_Product::create_simple_product();
-		$other_product->set_name( 'Nested Product' );
-		$other_product->save();
-
-		try {
-			$result = ProductDescriptionUtils::guarded_format(
-				$product,
-				function () use ( $other_product ) {
-					$nested_result = ProductDescriptionUtils::guarded_format(
-						$other_product,
-						function () use ( $other_product ) {
-							return $other_product->get_name();
-						}
-					);
-
-					return 'Outer description: ' . $nested_result;
-				}
-			);
-
-			$this->assertSame( 'Outer description: Nested Product', $result );
-		} finally {
-			WC_Helper_Product::delete_product( $product->get_id() );
-			WC_Helper_Product::delete_product( $other_product->get_id() );
 		}
 	}
 
@@ -136,88 +50,6 @@ class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
 			$this->assertSame( '', $result );
 		} finally {
 			WC_Helper_Product::delete_product( $product->get_id() );
-		}
-	}
-
-	/**
-	 * @testdox guarded_format() clears the recursion guard when formatting throws.
-	 */
-	public function test_guarded_format_clears_guard_when_callback_throws(): void {
-		$product = WC_Helper_Product::create_simple_product();
-
-		try {
-			try {
-				ProductDescriptionUtils::guarded_format(
-					$product,
-					function () {
-						throw new \Exception( 'Formatting failed.' );
-					}
-				);
-			} catch ( \Exception $exception ) {
-				$this->assertSame( 'Formatting failed.', $exception->getMessage() );
-			}
-
-			$result = ProductDescriptionUtils::guarded_format(
-				$product,
-				function () {
-					return 'Description after failure';
-				}
-			);
-
-			$this->assertSame( 'Description after failure', $result );
-		} finally {
-			WC_Helper_Product::delete_product( $product->get_id() );
-		}
-	}
-
-	/**
-	 * Create a ProductSchema instance for testing product response formatting.
-	 *
-	 * @return ProductSchema
-	 */
-	private function create_product_schema(): ProductSchema {
-		$formatters   = new Formatters();
-		$extend       = new ExtendSchema( $formatters );
-		$controller   = $this->createMock( SchemaController::class );
-		$image_schema = $this->createMock( ImageAttachmentSchema::class );
-
-		$controller
-			->method( 'get' )
-			->with( ImageAttachmentSchema::IDENTIFIER )
-			->willReturn( $image_schema );
-
-		return new ProductSchema( $extend, $controller );
-	}
-
-	/**
-	 * Render the Product Description block for a product.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return string Rendered block output.
-	 */
-	private function render_product_description_block( \WC_Product $product ): string {
-		$reflection = new \ReflectionClass( ProductDescription::class );
-		$block_type = $reflection->newInstanceWithoutConstructor();
-
-		$render_method = $reflection->getMethod( 'render' );
-		$render_method->setAccessible( true );
-
-		$block = (object) array(
-			'context' => array(
-				'postId' => $product->get_id(),
-			),
-		);
-
-		$previous_block_to_render            = \WP_Block_Supports::$block_to_render;
-		\WP_Block_Supports::$block_to_render = array(
-			'blockName' => 'woocommerce/product-description',
-			'attrs'     => array(),
-		);
-
-		try {
-			return (string) $render_method->invoke( $block_type, array(), '', $block );
-		} finally {
-			\WP_Block_Supports::$block_to_render = $previous_block_to_render;
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
@@ -3,7 +3,13 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\Utils;
 
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductDescription;
 use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ImageAttachmentSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema;
 use WC_Helper_Product;
 
 /**
@@ -34,6 +40,50 @@ class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
 
 			$this->assertSame( 'Outer description: ', $result );
 		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * @testdox ProductSchema shares the active ProductDescription recursion guard for the same product.
+	 */
+	public function test_product_schema_uses_same_guard_as_product_description_block(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_short_description( 'Short product description.' );
+		$product->set_description( 'Outer product description.' );
+		$product->save();
+
+		$schema                       = $this->create_product_schema();
+		$schema_response              = null;
+		$schema_calls                 = 0;
+		$formatted_content_raw_values = array();
+
+		$format_content_callback = function ( $content, $raw_content ) use ( &$formatted_content_raw_values ) {
+			$formatted_content_raw_values[] = $raw_content;
+			return $content;
+		};
+
+		$the_content_callback = function ( $content ) use ( $schema, $product, &$schema_response, &$schema_calls ) {
+			++$schema_calls;
+			$schema_response = $schema->get_item_response( $product );
+
+			return $content;
+		};
+
+		add_filter( 'woocommerce_format_content', $format_content_callback, 10, 2 );
+		add_filter( 'the_content', $the_content_callback );
+
+		try {
+			$rendered_block = $this->render_product_description_block( $product );
+
+			$this->assertSame( 1, $schema_calls );
+			$this->assertSame( array( 'Short product description.' ), $formatted_content_raw_values );
+			$this->assertIsArray( $schema_response );
+			$this->assertSame( '', $schema_response['description'] );
+			$this->assertStringContainsString( 'Outer product description.', $rendered_block );
+		} finally {
+			remove_filter( 'woocommerce_format_content', $format_content_callback );
+			remove_filter( 'the_content', $the_content_callback );
 			WC_Helper_Product::delete_product( $product->get_id() );
 		}
 	}
@@ -117,6 +167,57 @@ class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
 			$this->assertSame( 'Description after failure', $result );
 		} finally {
 			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * Create a ProductSchema instance for testing product response formatting.
+	 *
+	 * @return ProductSchema
+	 */
+	private function create_product_schema(): ProductSchema {
+		$formatters   = new Formatters();
+		$extend       = new ExtendSchema( $formatters );
+		$controller   = $this->createMock( SchemaController::class );
+		$image_schema = $this->createMock( ImageAttachmentSchema::class );
+
+		$controller
+			->method( 'get' )
+			->with( ImageAttachmentSchema::IDENTIFIER )
+			->willReturn( $image_schema );
+
+		return new ProductSchema( $extend, $controller );
+	}
+
+	/**
+	 * Render the Product Description block for a product.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return string Rendered block output.
+	 */
+	private function render_product_description_block( \WC_Product $product ): string {
+		$reflection = new \ReflectionClass( ProductDescription::class );
+		$block_type = $reflection->newInstanceWithoutConstructor();
+
+		$render_method = $reflection->getMethod( 'render' );
+		$render_method->setAccessible( true );
+
+		$block = (object) array(
+			'context' => array(
+				'postId' => $product->get_id(),
+			),
+		);
+
+		$previous_block_to_render            = \WP_Block_Supports::$block_to_render;
+		\WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'woocommerce/product-description',
+			'attrs'     => array(),
+		);
+
+		try {
+			return (string) $render_method->invoke( $block_type, array(), '', $block );
+		} finally {
+			\WP_Block_Supports::$block_to_render = $previous_block_to_render;
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
@@ -20,13 +20,22 @@ class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
 		$product->save();
 
 		try {
-			$result = ProductDescriptionUtils::guarded_format(
+			$nested_result = null;
+			$result        = ProductDescriptionUtils::guarded_format(
 				$product,
-				function () use ( $product ) {
+				function () use ( $product, &$nested_result ) {
+					$nested_result = ProductDescriptionUtils::guarded_format(
+						$product,
+						function () use ( $product ) {
+							return $product->get_description();
+						}
+					);
+
 					return $product->get_description();
 				}
 			);
 
+			$this->assertSame( '', $nested_result );
 			$this->assertSame( 'A formatted product description.', $result );
 		} finally {
 			WC_Helper_Product::delete_product( $product->get_id() );

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductDescriptionUtilsTest.php
@@ -1,0 +1,122 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Utils;
+
+use Automattic\WooCommerce\Blocks\Utils\ProductDescriptionUtils;
+use WC_Helper_Product;
+
+/**
+ * Tests for ProductDescriptionUtils.
+ */
+class ProductDescriptionUtilsTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox guarded_format() returns an empty string for same-product recursive formatting.
+	 */
+	public function test_guarded_format_returns_empty_string_for_recursive_same_product_formatting(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		try {
+			$result = ProductDescriptionUtils::guarded_format(
+				$product,
+				function () use ( $product ) {
+					$recursive_result = ProductDescriptionUtils::guarded_format(
+						$product,
+						function () {
+							return 'Recursive description';
+						}
+					);
+
+					return 'Outer description: ' . $recursive_result;
+				}
+			);
+
+			$this->assertSame( 'Outer description: ', $result );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * @testdox guarded_format() allows nested formatting for a different product.
+	 */
+	public function test_guarded_format_allows_nested_different_product_formatting(): void {
+		$product       = WC_Helper_Product::create_simple_product();
+		$other_product = WC_Helper_Product::create_simple_product();
+		$other_product->set_name( 'Nested Product' );
+		$other_product->save();
+
+		try {
+			$result = ProductDescriptionUtils::guarded_format(
+				$product,
+				function () use ( $other_product ) {
+					$nested_result = ProductDescriptionUtils::guarded_format(
+						$other_product,
+						function () use ( $other_product ) {
+							return $other_product->get_name();
+						}
+					);
+
+					return 'Outer description: ' . $nested_result;
+				}
+			);
+
+			$this->assertSame( 'Outer description: Nested Product', $result );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+			WC_Helper_Product::delete_product( $other_product->get_id() );
+		}
+	}
+
+	/**
+	 * @testdox guarded_format() returns an empty string for non-string formatted values.
+	 */
+	public function test_guarded_format_returns_empty_string_for_non_string_result(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		try {
+			$result = ProductDescriptionUtils::guarded_format(
+				$product,
+				function () {
+					return array( 'not a string' );
+				}
+			);
+
+			$this->assertSame( '', $result );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+
+	/**
+	 * @testdox guarded_format() clears the recursion guard when formatting throws.
+	 */
+	public function test_guarded_format_clears_guard_when_callback_throws(): void {
+		$product = WC_Helper_Product::create_simple_product();
+
+		try {
+			try {
+				ProductDescriptionUtils::guarded_format(
+					$product,
+					function () {
+						throw new \Exception( 'Formatting failed.' );
+					}
+				);
+			} catch ( \Exception $exception ) {
+				$this->assertSame( 'Formatting failed.', $exception->getMessage() );
+			}
+
+			$result = ProductDescriptionUtils::guarded_format(
+				$product,
+				function () {
+					return 'Description after failure';
+				}
+			);
+
+			$this->assertSame( 'Description after failure', $result );
+		} finally {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product descriptions can be formatted by both the Product Description block and the Store API product schema. When those paths request each other for the same product, formatting can result in an infinite loop.

This adds a shared product-description formatting guard so both paths use the same in-progress state and stop same-product recursive formatting.

**Note:** There was already something _similar_ in the Product Description block, but this didn't guard against when it was also requesting the StoreAPI. So we create a shared util for both places.

Closes [WOOPLUG-7529](https://linear.app/a8c/issue/WOOPLUG-7529/single-product-block-embedded-in-product-description-causes-memory)

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to a product, e.g. Beanie in WP Admin and take note of its product ID
2. Add the below snippet to the product description, replacing `1912` with its own ID
3. Load the product on the frontend and ensure it doesnt crash
4. Do some regression testing that other products load their descriptions as normal


```
<!-- wp:woocommerce/single-product {"productId":1912} -->
<div class="wp-block-woocommerce-single-product woocommerce"><!-- wp:woocommerce/add-to-cart-form /--></div>
<!-- /wp:woocommerce/single-product -->
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Manual steps above
- Unit tests
- Regression testing

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI GPT-5.5 via OpenCode assisted with implementation and PR drafting. The changes were reviewed and verified locally.