### PR TITLE
Restore editor incompatibility notice regression coverage

### DIFF
--- a/plugins/woocommerce/changelog/42469-keep-incompatible-notice-dismissed
+++ b/plugins/woocommerce/changelog/42469-keep-incompatible-notice-dismissed
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Keep the Cart and Checkout incompatible extensions notices (editor sidebar and storefront banner) dismissed when an incompatible extension or payment gateway is disabled, and warn again only when something the merchant has not yet acknowledged becomes incompatible. Dismissals are now stored per site; existing ones carry over on single-site installs.
+Keep the Cart and Checkout incompatible extensions notices (editor sidebar and storefront banner) dismissed when an incompatible extension or payment gateway is disabled, and warn again only when something the merchant has not yet acknowledged becomes incompatible. Dismissals are now stored per site. Existing dismissals carry over on single-site installs but not on multisite installs, where notices may need to be dismissed again after upgrading.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/test/incompatible-extensions-notice.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/test/incompatible-extensions-notice.tsx
@@ -14,16 +14,25 @@ import {
 } from '@woocommerce/editor-components/incompatible-extension-notice/storage';
 import { IncompatibleExtensionsFrontendNotice } from '../incompatible-extensions-notice';
 
+const SITE_A = 1;
+const SITE_B = 2;
+
 let mockIsAdmin = true;
+let mockSiteId = SITE_A;
+let mockIsMultisite = false;
 
 jest.mock( '@woocommerce/settings', () => ( {
 	getSetting: jest.fn(),
-	// A getter, not a value: the viewer changes between renders.
+	// Getters, not values: the viewer and site change between renders.
 	get CURRENT_USER_IS_ADMIN() {
 		return mockIsAdmin;
 	},
-	CURRENT_SITE_ID: 1,
-	IS_MULTISITE: false,
+	get CURRENT_SITE_ID() {
+		return mockSiteId;
+	},
+	get IS_MULTISITE() {
+		return mockIsMultisite;
+	},
 } ) );
 
 // Use the real localStorage-backed hook (via its source module) without pulling
@@ -86,6 +95,8 @@ describe( 'IncompatibleExtensionsFrontendNotice', () => {
 		window.localStorage.clear();
 		setIncompatibleExtensions( [] );
 		mockIsAdmin = true;
+		mockSiteId = SITE_A;
+		mockIsMultisite = false;
 	} );
 
 	describe( 'rendering', () => {
@@ -304,6 +315,32 @@ describe( 'IncompatibleExtensionsFrontendNotice', () => {
 			);
 
 			expect( container ).toBeEmptyDOMElement();
+		} );
+	} );
+
+	// Sites on a subdirectory multisite share one localStorage origin, so the
+	// storefront banner must use the current site's key rather than another
+	// site's acknowledgement.
+	describe( 'site scoping', () => {
+		it( 'does not carry a dismissal to another site on the same origin', () => {
+			mockIsMultisite = true;
+			setIncompatibleExtensions( [
+				{ id: 'test-plugin', title: 'Test Plugin' },
+			] );
+			const { unmount } = render(
+				<IncompatibleExtensionsFrontendNotice block="woocommerce/checkout" />
+			);
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Dismiss' } )
+			);
+			unmount();
+
+			mockSiteId = SITE_B;
+
+			render(
+				<IncompatibleExtensionsFrontendNotice block="woocommerce/checkout" />
+			);
+			expect( screen.getByTestId( 'notice-banner' ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/incompatible-extension-notice/test/use-combined-incompatibility-notice.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/incompatible-extension-notice/test/use-combined-incompatibility-notice.ts
@@ -28,10 +28,20 @@ let mockIncompatibleExtensions:
 	| Array< { id: string; title: string } >
 	| undefined = [];
 
+const SITE_A = 1;
+const SITE_B = 2;
+
+let mockSiteId = SITE_A;
+let mockIsMultisite = false;
+
 jest.mock( '@woocommerce/settings', () => ( {
 	...jest.requireActual( '@woocommerce/settings' ),
-	CURRENT_SITE_ID: 1,
-	IS_MULTISITE: false,
+	get CURRENT_SITE_ID() {
+		return mockSiteId;
+	},
+	get IS_MULTISITE() {
+		return mockIsMultisite;
+	},
 	getSetting: jest.fn().mockImplementation( ( name: string, ...rest ) => {
 		if ( name === 'incompatibleExtensions' ) {
 			return mockIncompatibleExtensions;
@@ -93,6 +103,8 @@ describe( 'useCombinedIncompatibilityNotice', () => {
 		mockIncompatiblePaymentMethods = {};
 		mockIncompatibleExtensions = [];
 		mockPaymentMethodsLoaded = true;
+		mockSiteId = SITE_A;
+		mockIsMultisite = false;
 	} );
 
 	it( 'shows the notice when there is an incompatible gateway', () => {
@@ -395,11 +407,26 @@ describe( 'useCombinedIncompatibilityNotice', () => {
 		} );
 	} );
 
+	// Sites on a subdirectory multisite share one localStorage origin, so the
+	// editor hook must use the current site's key rather than another site's
+	// acknowledgement.
+	describe( 'site scoping', () => {
+		it( 'does not carry a dismissal to another site on the same origin', () => {
+			mockIsMultisite = true;
+			mockIncompatiblePaymentMethods = { gw_a: 'Gateway A' };
+			mountAndDismiss( CHECKOUT );
+			expect( mountVisibility( CHECKOUT ) ).toBe( false );
+
+			mockSiteId = SITE_B;
+
+			expect( mountVisibility( CHECKOUT ) ).toBe( true );
+		} );
+	} );
+
 	// The dismissals merchants already made live under the unscoped key, so
 	// without a migration every one of them would see the notice one more time.
-	// Site scoping, the multisite refusal, and the corrupt-value rules are the
-	// storage contract's and are pinned in test/storage.ts; these two pin this
-	// surface's wiring to it.
+	// The storage contract's full matrix is pinned in test/storage.ts; these
+	// cases pin the editor hook's wiring to it.
 	describe( 'migration from before site scoping', () => {
 		const seedUnscoped = ( value: unknown ) =>
 			window.localStorage.setItem(
@@ -428,6 +455,17 @@ describe( 'useCombinedIncompatibilityNotice', () => {
 			expect( window.localStorage.getItem( UNSCOPED_STORAGE_KEY ) ).toBe(
 				before
 			);
+		} );
+
+		// Only an absent scoped key may open migration. Otherwise a corrupt value
+		// would revive a dismissal the merchant has since replaced.
+		it( 'does not migrate over a scoped value it cannot parse', () => {
+			window.localStorage.setItem( storageKey(), '{not valid json' );
+			seedUnscoped( [ { [ CHECKOUT ]: [ 'gw_a' ] } ] );
+			mockIncompatiblePaymentMethods = { gw_a: 'Gateway A' };
+
+			expect( mountVisibility( CHECKOUT ) ).toBe( true );
+			expect( console ).toHaveErrored();
 		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up to #67108. Its final review identified two important editor-hook regressions that were covered only at the storage-helper layer, leaving the integration wiring easier to break unnoticed.

Restore behavior-level editor tests proving that dismissals do not cross sites on the same origin and that an unreadable scoped value cannot revive a dismissal from the old unscoped key. Also clarify the existing changelog entry so multisite administrators know that pre-upgrade dismissals do not carry over and notices may need to be dismissed again.

No production code or runtime behavior changes in this PR.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

Not applicable; this PR changes tests and changelog copy only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce/client/blocks`, run:

    ```bash
    pnpm test:js --runInBand assets/js/editor-components/incompatible-extension-notice/test/storage.ts assets/js/editor-components/incompatible-extension-notice/test/use-combined-incompatibility-notice.ts assets/js/blocks/cart-checkout-shared/test/incompatible-extensions-notice.tsx
    ```

2. Confirm that all three suites and 82 tests pass, including:
    - `does not carry a dismissal to another site on the same origin`
    - `does not migrate over a scoped value it cannot parse`
3. From the repository root, run `pnpm --filter=@woocommerce/block-library lint:js` and confirm it exits with no errors.
4. From `plugins/woocommerce`, run `vendor/bin/changelogger validate` and confirm it exits successfully.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Focused Jest run: 3 suites and 82 tests passed.
- Mutation checks: each restored regression test failed when its corresponding editor-hook wiring was intentionally broken, then passed after the production code was restored.
- Blocks package lint: 0 errors; 1,554 pre-existing warnings.
- Changelog validation and `git diff --check` passed.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Updated manually; this PR clarifies the existing entry from #67108.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to validate the review feedback, implement the regression tests and changelog clarification, run verification, and draft this description. The changes were reviewed before commit.
