### PR TITLE
Fix preloading of recent emails in email editor template modal

### DIFF
--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -111,6 +111,7 @@ We may add, update and delete any of them.
 | `woocommerce_email_editor_allowed_iframe_style_handles`            | `Array` $allowed_iframe_style_handles                            | `Array` $allowed_iframe_style_handles                        | Filter the list of allowed stylesheet handles in the editor iframe.                                                                                                    |
 | `woocommerce_email_editor_script_localization_data`                | `Array` $localization_data                                       | `Array` $localization_data                                   | Use to modify inlined JavaScript variables used by Email Editor client.                                                                                                |
 | `woocommerce_email_editor_styles_unsupported_props`                | `Array` $unsupported_props                                       | `Array` $unsupported_props                                   | Filter the list of unsupported style properties (as nested key paths) that will be removed before block styles are converted to CSS.                                   |
+| `woocommerce_email_editor_preload_rest_api_routes`                 | `Array` $routes, `string` $post_type, `int\|string` $post_id     | `Array` $routes                                              | REST API routes preloaded for the email editor. A preloaded route is only used when it matches the request made by the editor.                                         |
 
 ## Logging
 

--- a/packages/php/email-editor/changelog/fix-recent-emails-preload
+++ b/packages/php/email-editor/changelog/fix-recent-emails-preload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preload the recent emails used by the template selection modal, and add the woocommerce_email_editor_preload_rest_api_routes filter.

--- a/packages/php/email-editor/src/Engine/class-assets-manager.php
+++ b/packages/php/email-editor/src/Engine/class-assets-manager.php
@@ -217,6 +217,7 @@ class Assets_Manager {
 	private function preload_rest_api_data( $post_id, string $post_type ): void {
 		$email_post_type    = $post_type;
 		$user_theme_post_id = $this->user_theme->get_user_theme_post()->ID;
+		$post               = is_numeric( $post_id ) ? get_post( (int) $post_id ) : null;
 		$template_slug      = get_post_meta( (int) $post_id, '_wp_page_template', true );
 		$routes             = array(
 			"/wp/v2/{$email_post_type}/" . intval( $post_id ) . '?context=edit',
@@ -230,13 +231,26 @@ class Assets_Manager {
 			'/wp/v2/taxonomies?context=view',
 		);
 
-		if ( is_string( $template_slug ) ) {
+		if ( is_string( $template_slug ) && '' !== $template_slug ) {
 			$routes[] = '/wp/v2/templates/lookup?slug=' . $template_slug;
-		} else {
+		}
+
+		// Recent emails listed by the template selection modal, which opens on emails with no content.
+		if ( $post instanceof \WP_Post && '' === $post->post_content ) {
 			$routes[] = "/wp/v2/{$email_post_type}?context=edit&per_page=30&status=publish,sent";
 		}
 
-		// Preload the data for the specified routes.
+		/**
+		 * Filters the REST API routes preloaded for the email editor.
+		 *
+		 * @param string[]   $routes    The routes to preload.
+		 * @param string     $post_type The edited post type.
+		 * @param int|string $post_id   The edited post ID.
+		 *
+		 * @since 11.2.0
+		 */
+		$routes = apply_filters( 'woocommerce_email_editor_preload_rest_api_routes', $routes, $post_type, $post_id );
+
 		$preload_data = array_reduce(
 			$routes,
 			'rest_preload_api_request',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Transactional emails always have a template slug, so the recent emails route was never added to the preloaded routes. That route is needed when the email content is empty, because this is when the template selection modal opens. The PHP condition now matches that.

Also adds a filter for the preloaded routes, so changes made through the recent emails query filter (#67859) by third-party plugins can be reflected here.

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Open **WooCommerce → Settings → Emails** and open any email in the block editor (you need to have the block emails feature enabled in WooCommerce settings).
2. Remove all content from the email so the template selection modal opens when you reload the editor.
3. Open the **Recent** category and inspect the networks request to confirm the preloaded data is used instead of making a request.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
