### PR TITLE
Fix dropdown icon overlap on WP 7.0+ admin screens

### DIFF
--- a/plugins/woocommerce/changelog/67632-fix-select-icon-overlap-wp70
+++ b/plugins/woocommerce/changelog/67632-fix-select-icon-overlap-wp70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dropdown text and the clear icon running under the chevron in admin single selects on WP 7.0+, including the Order edit Country, State and Customer fields.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8061,18 +8061,17 @@ table.bar_chart {
 		width: 100% !important;
 	}
 
-	// Reserve room for the clear (x) and chevron icons; .wc-backbone-modal-content lifts specificity
-	// to 0,5,0 so the later, equal-specificity WP 7.0 reset (`.wc-wp-version-gte-70 ... padding: 0 12px`)
-	// no longer wins the right padding.
+	// Reserve the end of the field for the clear (x) and chevron inside modals on every WP
+	// version; the .wc-wp-version-gte-70 rule below only reaches WP 7.0+.
 	.wc-backbone-modal-content .select2-container .select2-selection--single {
 		.select2-selection__rendered {
-			padding-right: 40px;
+			padding-inline-end: 40px;
 		}
 
 		// Pull the clear (x) into the 40px padding zone so it sits beside the chevron
 		// rather than at the text edge.
 		.select2-selection__clear {
-			margin-right: -10px;
+			margin-inline-end: -10px;
 		}
 	}
 }
@@ -8531,7 +8530,15 @@ table.bar_chart {
 
 			.select2-selection__rendered {
 				line-height: 38px;
-				padding: 0 12px; // Match WP 7.0 native input padding so text aligns with sibling inputs.
+				padding-block: 0;
+				// 12px matches WP 7.0 native input padding; 40px reserves the end for the chevron and the clear (x).
+				padding-inline: 12px 40px;
+			}
+
+			// Pull the clear (x) into the reserved zone so it sits beside the chevron
+			// rather than out at the text edge.
+			.select2-selection__clear {
+				margin-inline-end: -10px;
 			}
 
 			.select2-selection__arrow {
@@ -8566,7 +8573,8 @@ table.bar_chart {
 
 		.select2-selection__rendered {
 			line-height: 38px;
-			padding: 0 12px; // Match WP 7.0 native input padding.
+			padding-block: 0;
+			padding-inline: 12px 40px; // Match WP 7.0 native input padding, reserving the end for the icons.
 		}
 
 		.select2-selection__arrow {
@@ -8582,7 +8590,8 @@ table.bar_chart {
 
 		.select2-selection__rendered {
 			line-height: 38px;
-			padding: 0 12px;
+			padding-block: 0;
+			padding-inline: 12px 40px; // Match WP 7.0 native input padding, reserving the end for the icons.
 		}
 
 		.select2-selection__arrow {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- On WordPress 7.0+, the text in admin dropdowns runs underneath the chevron, and where a clear (×) exists the two icons sit on top of each other.
- We now reserve space at the end of every single dropdown so the text stops before the icons, and the × sits beside the chevron instead of on it.
- Same amount of space everywhere, so text always ends in the same place rather than shifting field to field.
- Includes the Order edit screen (Customer, Country, State), which needed its own treatment and was missed by earlier fixes.
- Known side effect: these dropdowns already redraw a moment after the page loads, because WooCommerce swaps a plain dropdown for an enhanced one. Reserving more space makes that shift slightly bigger. Pre-existing and wider than this fix, tracked separately in #67919.

Closes #67632.
Closes #67756.

(For Bug Fixes) Bug introduced in PR #64322.

<details>
<summary>Why this differs from the fix suggested in the issue</summary>

- The `margin-right: 18px` quoted in the issue is a stale value. It was the first version of #66381 and became `-10px` in #67183. At 18px the × lands out in the text rather than next to the chevron.
- The reset appears three times in the `.wc-wp-version-gte-70` block, not once. The two Order edit rules carry an ID and outrank the shared one, so Country, State and Customer stay broken unless all three change.
- `padding-right` is a physical direction, so RTL reserves the space on the wrong side. Logical properties follow the text direction.
- 40px rather than restoring the old 24px: 24px leaves about 3px of clearance and puts settings pages on a different value from the Add products modal.
- The `.wc-backbone-modal` override is redundant on WP 7.0+ but still applies below it, so it stays for now.

</details>

### Screenshots or screen recordings:

| Screen | Before | After |
| --- | --- | --- |
| Settings > Advanced > Page setup | <img src="https://github.com/user-attachments/assets/81d1bae5-4f37-40bf-871c-13b6643ca06a" /> | <img src="https://github.com/user-attachments/assets/05ec4f38-f032-4fc3-93e6-625d66a0e1d2" /> |
| Settings > Products > General, Shop page | <img src="https://github.com/user-attachments/assets/b2514c15-08db-431b-84db-8ab78971f27c" /> | <img src="https://github.com/user-attachments/assets/e62a0ba3-7485-4d85-9656-b050953691f5" /> |
| Settings > Products > Inventory, Stock display format | <img src="https://github.com/user-attachments/assets/857e1cc9-837b-4d05-a7e1-f1d12d72c7fa" /> | <img src="https://github.com/user-attachments/assets/ba5c3803-16b6-4834-9cd3-80aacb0988db" /> |
| Order edit, Customer | <img src="https://github.com/user-attachments/assets/dc3ec128-2d0c-48d9-b309-cd25e060c300" /> | <img src="https://github.com/user-attachments/assets/f3ef4c78-8c10-4d19-9f82-77e8dbd0eefd" /> |
| Order edit, Country / Region | <img src="https://github.com/user-attachments/assets/22c92b63-1547-496e-b498-293414d8a24c" /> | <img src="https://github.com/user-attachments/assets/659b690d-a443-4114-ad95-fc52530c8624" /> |
| Settings > Advanced > Page setup, RTL |  | <img src="https://github.com/user-attachments/assets/aa9df8cb-0f47-45f2-930e-506518b78c97" /> |

RTL was checked with the admin rendering right to left. The chevron and clear (×) mirror to the start of the field with the same spacing, and the text stops before them.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Needs WordPress 7.0 or above.

1. Settings > Products > General: the Shop page × no longer sits on the chevron.
2. Settings > Advanced > Page setup: set a page with a long title, text truncates before the icons.
3. Settings > Products > Inventory: Stock display format text stops before the chevron.
4. Open any order: Customer, and Country / State under Billing, all clear the icons.
5. Order > Add items > Add products: unchanged from #66381.
6. RTL is already verified, no need to repeat: the icons mirror to the start of the field with the same spacing, screenshot included above.

<!-- End testing instructions -->

<details>
<summary>Milestone</summary>

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

</details>

<details>
<summary>Changelog entry</summary>

Changelog entry was added manually in `plugins/woocommerce/changelog/67632-fix-select-icon-overlap-wp70`.

- [ ] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fix - Fixes an existing bug

#### Message

Fix dropdown text and the clear icon running under the chevron in admin single selects on WP 7.0+, including the Order edit Country, State and Customer fields.

</details>

</details>

<details>
<summary>Release Communication</summary>

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

</details>

### Use of AI Tools

Written with Claude Code. CSS authored with AI assistance, reviewed and QA'd manually in a local WordPress 7.0 site with before/after screenshots on each affected screen.





