### PR TITLE
Prevent cart loss after Store API batch load failures

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-batch-cart-session-failure
+++ b/plugins/woocommerce/changelog/fix-store-api-batch-cart-session-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent failed Store API batch requests from clearing the shopper's saved cart.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -311,6 +311,10 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function destroy_cart_session() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		$wc_session = WC()->session;
 
 		$wc_session->set( 'cart', null );
@@ -335,7 +339,7 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function maybe_set_cart_cookies() {
-		if ( headers_sent() || ! did_action( 'wp_loaded' ) ) {
+		if ( $this->should_skip_session_updates() || headers_sent() || ! did_action( 'wp_loaded' ) ) {
 			return;
 		}
 		if ( ! $this->cart->is_empty() ) {
@@ -402,6 +406,10 @@ final class WC_Cart_Session {
 	 * Sets the php session data for the cart and coupons.
 	 */
 	public function set_session() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		$wc_session = WC()->session;
 
 		$cart                       = $this->get_cart_for_session();
@@ -458,6 +466,10 @@ final class WC_Cart_Session {
 	 * Save the persistent cart when the cart is updated.
 	 */
 	public function persistent_cart_update() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		/**
 		 * Filters whether the persistent cart is enabled.
 		 *
@@ -722,11 +734,26 @@ final class WC_Cart_Session {
 	}
 
 	/**
+	 * Checks whether session updates should be skipped for an inactive Store API cart.
+	 *
+	 * A failed cart load clears WC()->cart, but registered callbacks can retain the failed cart and overwrite valid session data.
+	 *
+	 * @return bool
+	 */
+	private function should_skip_session_updates() {
+		return 'store-api' === $this->cart->cart_context && WC()->cart !== $this->cart;
+	}
+
+	/**
 	 * Removes items from the removed cart contents on next user initiated request.
 	 *
 	 * @return void
 	 */
 	public function clean_up_removed_cart_contents() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		// Limit to page requests initiated by the user.
 		$is_page = is_singular() || is_archive() || is_search();
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -103,6 +103,10 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function get_cart_from_session() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		/**
 		 * Fires when cart is loaded from session.
 		 *
@@ -517,6 +521,10 @@ final class WC_Cart_Session {
 	 * Delete the persistent cart permanently.
 	 */
 	public function persistent_cart_destroy() {
+		if ( $this->should_skip_session_updates() ) {
+			return;
+		}
+
 		/**
 		 * Filters whether the persistent cart is enabled.
 		 *

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class WC_Cart_Session {
 
 	/**
+	 * Carts whose session updates have been disabled.
+	 *
+	 * @var WeakReference<WC_Cart>[]
+	 */
+	private static $carts_with_disabled_updates = array();
+
+	/**
 	 * Reference to cart object.
 	 *
 	 * @since 3.2.0
@@ -302,6 +309,25 @@ final class WC_Cart_Session {
 		if ( $order_again ) {
 			wp_safe_redirect( wc_get_cart_url() );
 			exit;
+		}
+	}
+
+	/**
+	 * Enables or disables session updates for a cart.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 *
+	 * @param WC_Cart $cart    Cart object.
+	 * @param bool    $enabled Whether session updates should be enabled.
+	 */
+	public static function set_updates_enabled_for_cart( WC_Cart $cart, $enabled ): void {
+		$cart_id = spl_object_id( $cart );
+
+		if ( $enabled ) {
+			unset( self::$carts_with_disabled_updates[ $cart_id ] );
+		} else {
+			self::$carts_with_disabled_updates[ $cart_id ] = WeakReference::create( $cart );
 		}
 	}
 
@@ -734,14 +760,24 @@ final class WC_Cart_Session {
 	}
 
 	/**
-	 * Checks whether session updates should be skipped for an inactive Store API cart.
-	 *
-	 * A failed cart load clears WC()->cart, but registered callbacks can retain the failed cart and overwrite valid session data.
+	 * Checks whether session updates have been disabled for this cart.
 	 *
 	 * @return bool
 	 */
 	private function should_skip_session_updates() {
-		return 'store-api' === $this->cart->cart_context && WC()->cart !== $this->cart;
+		$cart_id = spl_object_id( $this->cart );
+
+		if ( ! isset( self::$carts_with_disabled_updates[ $cart_id ] ) ) {
+			return false;
+		}
+
+		$disabled_cart = self::$carts_with_disabled_updates[ $cart_id ]->get();
+		if ( null === $disabled_cart ) {
+			unset( self::$carts_with_disabled_updates[ $cart_id ] );
+			return false;
+		}
+
+		return $disabled_cart === $this->cart;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -336,6 +336,31 @@ final class WC_Cart_Session {
 	}
 
 	/**
+	 * Checks whether session updates are enabled for a cart.
+	 *
+	 * @internal
+	 * @since 11.2.0
+	 *
+	 * @param WC_Cart $cart Cart object.
+	 * @return bool
+	 */
+	public static function are_updates_enabled_for_cart( WC_Cart $cart ): bool {
+		$cart_id = spl_object_id( $cart );
+
+		if ( ! isset( self::$carts_with_disabled_updates[ $cart_id ] ) ) {
+			return true;
+		}
+
+		$disabled_cart = self::$carts_with_disabled_updates[ $cart_id ]->get();
+		if ( null === $disabled_cart ) {
+			unset( self::$carts_with_disabled_updates[ $cart_id ] );
+			return true;
+		}
+
+		return $disabled_cart !== $cart;
+	}
+
+	/**
 	 * Destroy cart session data.
 	 *
 	 * @since 3.2.0
@@ -773,19 +798,7 @@ final class WC_Cart_Session {
 	 * @return bool
 	 */
 	private function should_skip_session_updates() {
-		$cart_id = spl_object_id( $this->cart );
-
-		if ( ! isset( self::$carts_with_disabled_updates[ $cart_id ] ) ) {
-			return false;
-		}
-
-		$disabled_cart = self::$carts_with_disabled_updates[ $cart_id ]->get();
-		if ( null === $disabled_cart ) {
-			unset( self::$carts_with_disabled_updates[ $cart_id ] );
-			return false;
-		}
-
-		return $disabled_cart === $this->cart;
+		return ! self::are_updates_enabled_for_cart( $this->cart );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -134,7 +134,7 @@ final class WooCommerce {
 	/**
 	 * Cart instance.
 	 *
-	 * @var WC_Cart|null
+	 * @var WC_Cart
 	 */
 	public $cart = null;
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -134,7 +134,7 @@ final class WooCommerce {
 	/**
 	 * Cart instance.
 	 *
-	 * @var WC_Cart
+	 * @var WC_Cart|null
 	 */
 	public $cart = null;
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -221,6 +221,10 @@ abstract class AbstractCartRoute extends AbstractRoute {
 			$this->cart_controller->load_cart();
 			$this->cart_controller->normalize_cart();
 		} catch ( \Throwable $error ) {
+			if ( WC()->cart instanceof \WC_Cart ) {
+				\WC_Cart_Session::set_updates_enabled_for_cart( WC()->cart, false );
+			}
+
 			// Do not let later Store API batch requests use and persist a partially loaded cart.
 			// @phpstan-ignore-next-line assign.propertyType (The cart is deliberately invalidated after a failed load.).
 			WC()->cart = null;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -204,20 +204,27 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Load the cart session before handling responses.
 	 *
+	 * @throws \Throwable When the cart session cannot be loaded.
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	protected function load_cart_session( \WP_REST_Request $request ) {
-		if ( $this->has_cart_token( $request ) ) {
-			// Overrides the core session class.
-			add_filter(
-				'woocommerce_session_handler',
-				function () {
-					return SessionHandler::class;
-				}
-			);
+		try {
+			if ( $this->has_cart_token( $request ) ) {
+				// Overrides the core session class.
+				add_filter(
+					'woocommerce_session_handler',
+					function () {
+						return SessionHandler::class;
+					}
+				);
+			}
+			$this->cart_controller->load_cart();
+			$this->cart_controller->normalize_cart();
+		} catch ( \Throwable $error ) {
+			// Do not let later Store API batch requests use and persist a partially loaded cart.
+			WC()->cart = null;
+			throw $error;
 		}
-		$this->cart_controller->load_cart();
-		$this->cart_controller->normalize_cart();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -222,6 +222,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 			$this->cart_controller->normalize_cart();
 		} catch ( \Throwable $error ) {
 			// Do not let later Store API batch requests use and persist a partially loaded cart.
+			// @phpstan-ignore-next-line assign.propertyType (The cart is deliberately invalidated after a failed load.).
 			WC()->cart = null;
 			throw $error;
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -193,7 +193,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		$response->header( 'User-ID', get_current_user_id() );
 		$response->header( 'Cache-Control', 'no-store' );
 
-		if ( WC()->cart instanceof \WC_Cart ) {
+		if ( WC()->cart instanceof \WC_Cart && \WC_Cart_Session::are_updates_enabled_for_cart( WC()->cart ) ) {
 			$response->header( 'Cart-Token', $this->get_cart_token() );
 			$response->header( 'Cart-Hash', WC()->cart->get_cart_hash() );
 		}
@@ -204,10 +204,15 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Load the cart session before handling responses.
 	 *
+	 * @throws \RuntimeException When a previous cart session load failed.
 	 * @throws \Throwable When the cart session cannot be loaded.
 	 * @param \WP_REST_Request $request Request object.
 	 */
 	protected function load_cart_session( \WP_REST_Request $request ) {
+		if ( WC()->cart instanceof \WC_Cart && ! \WC_Cart_Session::are_updates_enabled_for_cart( WC()->cart ) ) {
+			throw new \RuntimeException( 'The cart is unavailable after its session failed to load.' );
+		}
+
 		try {
 			if ( $this->has_cart_token( $request ) ) {
 				// Overrides the core session class.
@@ -225,9 +230,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 				\WC_Cart_Session::set_updates_enabled_for_cart( WC()->cart, false );
 			}
 
-			// Do not let later Store API batch requests use and persist a partially loaded cart.
-			// @phpstan-ignore-next-line assign.propertyType (The cart is deliberately invalidated after a failed load.).
-			WC()->cart = null;
 			throw $error;
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -131,6 +131,65 @@ class Batch extends ControllerTestCase {
 
 
 	/**
+	 * @testdox Should preserve the session cart when loading it fails in a batch sub-request.
+	 */
+	public function test_cart_session_failure_does_not_clear_session_cart(): void {
+		WC()->cart->add_to_cart( $this->products[0]->get_id() );
+
+		$stored_cart          = WC()->cart->get_cart_for_session();
+		$cart_contents_backup = WC()->cart->get_cart_contents();
+		$cart_backup          = WC()->cart;
+		$load_action_count    = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
+		$callback             = static function () {
+			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+		};
+
+		WC()->session->set( 'cart', $stored_cart );
+		WC()->cart->set_cart_contents( array() );
+		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+		add_filter( 'woocommerce_get_cart_item_from_session', $callback );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array(
+						'method'  => 'POST',
+						'path'    => '/wc/store/v1/cart/update-customer',
+						'body'    => array(),
+						'headers' => array( 'Nonce' => wp_create_nonce( 'wc_store_api' ) ),
+					),
+					array(
+						'method'  => 'POST',
+						'path'    => '/wc/store/v1/cart/update-customer',
+						'body'    => array(),
+						'headers' => array( 'Nonce' => wp_create_nonce( 'wc_store_api' ) ),
+					),
+				),
+			)
+		);
+
+		try {
+			$response      = rest_get_server()->dispatch( $request );
+			$response_data = $response->get_data();
+
+			$this->assertSame( 500, $response_data['responses'][0]['status'], 'The request that fails to load the cart should return an error.' );
+			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The stored session cart should remain unchanged.' );
+			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
+		} finally {
+			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			WC()->cart = $cart_backup;
+			WC()->cart->set_cart_contents( $cart_contents_backup );
+			if ( null === $load_action_count ) {
+				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count changed by the test.
+				$GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] = $load_action_count;
+			}
+		}
+	}
+
+	/**
 	 * Do a batch request with a get request.
 	 */
 	public function test_batch_get_requests() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -205,13 +205,15 @@ class Batch extends ControllerTestCase {
 			$this->assertArrayNotHasKey( 'Cart-Hash', $response_data['responses'][0]['headers'], 'A failed cart response should not include a cart hash.' );
 
 			// A failed cart remains referenced by its registered callbacks after WC()->cart is cleared.
+			$failed_cart_session = new \WC_Cart_Session( $cart_backup );
+			$failed_cart_session->get_cart_from_session();
+			$this->assertCount( 1, $cart_backup->get_cart_contents(), 'The failed cart should not resume loading from the session.' );
+
 			do_action( 'woocommerce_removed_coupon', 'synthetic-coupon' );
 			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not update the session.' );
 
 			do_action( 'woocommerce_cart_emptied' );
 			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not destroy the session.' );
-
-			$failed_cart_session = new \WC_Cart_Session( $cart_backup );
 
 			$user_id                = self::factory()->user->create();
 			$persistent_cart_key    = '_woocommerce_persistent_cart_' . get_current_blog_id();
@@ -220,6 +222,8 @@ class Batch extends ControllerTestCase {
 			update_user_meta( $user_id, $persistent_cart_key, $stored_persistent_cart );
 			do_action( 'woocommerce_cart_item_set_quantity', 'synthetic-item', 2, $cart_backup );
 			$this->assertSame( $stored_persistent_cart, get_user_meta( $user_id, $persistent_cart_key, true ), 'The failed cart should not update the persistent cart.' );
+			$failed_cart_session->persistent_cart_destroy();
+			$this->assertSame( $stored_persistent_cart, get_user_meta( $user_id, $persistent_cart_key, true ), 'The failed cart should not destroy the persistent cart.' );
 
 			$stored_removed_cart_contents = array( 'synthetic-item' => array( 'quantity' => 1 ) );
 			WC()->session->set( 'removed_cart_contents', $stored_removed_cart_contents );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -181,6 +181,7 @@ class Batch extends ControllerTestCase {
 			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			WC()->cart->set_cart_contents( $cart_contents_backup );
 			if ( null === $load_action_count ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -132,8 +132,6 @@ class Batch extends ControllerTestCase {
 
 	/**
 	 * @testdox Should preserve the session cart when loading it fails in a batch sub-request.
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_cart_session_failure_does_not_clear_session_cart(): void {
 		WC()->cart->add_to_cart( $this->products[0]->get_id() );
@@ -157,17 +155,10 @@ class Batch extends ControllerTestCase {
 			}
 			return $session_data;
 		};
-		$cookie_update_count      = 0;
-		$cookie_update_callback   = static function () use ( &$cookie_update_count ) {
-			++$cookie_update_count;
-			return false;
-		};
-
 		WC()->session->set( 'cart', $stored_cart );
 		WC()->cart->set_cart_contents( array() );
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 		add_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
-		add_filter( 'woocommerce_set_cookie_enabled', $cookie_update_callback, 10, 0 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
 		$request->set_body_params(
@@ -232,13 +223,8 @@ class Batch extends ControllerTestCase {
 			$wp_query->is_search   = false;
 			$failed_cart_session->clean_up_removed_cart_contents();
 			$this->assertSame( $stored_removed_cart_contents, WC()->session->get( 'removed_cart_contents' ), 'The failed cart should not clean up removed cart contents.' );
-
-			$this->assertFalse( headers_sent(), 'Cookie behavior can only be verified before headers are sent.' );
-			$failed_cart_session->maybe_set_cart_cookies();
-			$this->assertSame( 0, $cookie_update_count, 'The failed cart should not update cart cookies.' );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
-			remove_filter( 'woocommerce_set_cookie_enabled', $cookie_update_callback );
 			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			WC()->cart->set_cart_contents( $cart_contents_backup );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -173,8 +173,11 @@ class Batch extends ControllerTestCase {
 			$response      = rest_get_server()->dispatch( $request );
 			$response_data = $response->get_data();
 
+			// A failed cart remains referenced by its registered callbacks after WC()->cart is cleared.
+			do_action( 'woocommerce_removed_coupon', 'synthetic-coupon' );
+
 			$this->assertSame( 500, $response_data['responses'][0]['status'], 'The request that fails to load the cart should return an error.' );
-			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The stored session cart should remain unchanged.' );
+			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The stored session cart should remain unchanged after callbacks from the failed cart run.' );
 			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -136,18 +136,24 @@ class Batch extends ControllerTestCase {
 	public function test_cart_session_failure_does_not_clear_session_cart(): void {
 		WC()->cart->add_to_cart( $this->products[0]->get_id() );
 
-		$stored_cart          = WC()->cart->get_cart_for_session();
-		$cart_contents_backup = WC()->cart->get_cart_contents();
-		$cart_backup          = WC()->cart;
-		$load_action_count    = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
-		$callback             = static function () {
+		global $wp_query;
+
+		$stored_cart              = WC()->cart->get_cart_for_session();
+		$cart_contents_backup     = WC()->cart->get_cart_contents();
+		$cart_backup              = WC()->cart;
+		$load_action_count        = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
+		$current_user_id          = get_current_user_id();
+		$is_singular_backup       = $wp_query->is_singular;
+		$is_archive_backup        = $wp_query->is_archive;
+		$is_search_backup         = $wp_query->is_search;
+		$session_failure_callback = static function () {
 			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
 		};
 
 		WC()->session->set( 'cart', $stored_cart );
 		WC()->cart->set_cart_contents( array() );
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
-		add_filter( 'woocommerce_get_cart_item_from_session', $callback );
+		add_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
 		$request->set_body_params(
@@ -173,17 +179,42 @@ class Batch extends ControllerTestCase {
 			$response      = rest_get_server()->dispatch( $request );
 			$response_data = $response->get_data();
 
+			$this->assertSame( 500, $response_data['responses'][0]['status'], 'The request that fails to load the cart should return an error.' );
+			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
+
 			// A failed cart remains referenced by its registered callbacks after WC()->cart is cleared.
 			do_action( 'woocommerce_removed_coupon', 'synthetic-coupon' );
+			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not update the session.' );
 
-			$this->assertSame( 500, $response_data['responses'][0]['status'], 'The request that fails to load the cart should return an error.' );
-			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The stored session cart should remain unchanged after callbacks from the failed cart run.' );
-			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
+			do_action( 'woocommerce_cart_emptied' );
+			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not destroy the session.' );
+
+			$failed_cart_session = new \WC_Cart_Session( $cart_backup );
+
+			$user_id                = self::factory()->user->create();
+			$persistent_cart_key    = '_woocommerce_persistent_cart_' . get_current_blog_id();
+			$stored_persistent_cart = array( 'cart' => $stored_cart );
+			wp_set_current_user( $user_id );
+			update_user_meta( $user_id, $persistent_cart_key, $stored_persistent_cart );
+			do_action( 'woocommerce_cart_item_set_quantity', 'synthetic-item', 2, $cart_backup );
+			$this->assertSame( $stored_persistent_cart, get_user_meta( $user_id, $persistent_cart_key, true ), 'The failed cart should not update the persistent cart.' );
+
+			$stored_removed_cart_contents = array( 'synthetic-item' => array( 'quantity' => 1 ) );
+			WC()->session->set( 'removed_cart_contents', $stored_removed_cart_contents );
+			$wp_query->is_singular = true;
+			$wp_query->is_archive  = false;
+			$wp_query->is_search   = false;
+			$failed_cart_session->clean_up_removed_cart_contents();
+			$this->assertSame( $stored_removed_cart_contents, WC()->session->get( 'removed_cart_contents' ), 'The failed cart should not clean up removed cart contents.' );
 		} finally {
-			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			remove_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
 			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			WC()->cart->set_cart_contents( $cart_contents_backup );
+			wp_set_current_user( $current_user_id );
+			$wp_query->is_singular = $is_singular_backup;
+			$wp_query->is_archive  = $is_archive_backup;
+			$wp_query->is_search   = $is_search_backup;
 			if ( null === $load_action_count ) {
 				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 			} else {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -132,9 +132,12 @@ class Batch extends ControllerTestCase {
 
 	/**
 	 * @testdox Should preserve the session cart when loading it fails in a batch sub-request.
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_cart_session_failure_does_not_clear_session_cart(): void {
 		WC()->cart->add_to_cart( $this->products[0]->get_id() );
+		WC()->cart->add_to_cart( $this->products[1]->get_id() );
 
 		global $wp_query;
 
@@ -146,14 +149,25 @@ class Batch extends ControllerTestCase {
 		$is_singular_backup       = $wp_query->is_singular;
 		$is_archive_backup        = $wp_query->is_archive;
 		$is_search_backup         = $wp_query->is_search;
-		$session_failure_callback = static function () {
-			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+		$restored_item_count      = 0;
+		$session_failure_callback = static function ( $session_data ) use ( &$restored_item_count ) {
+			++$restored_item_count;
+			if ( 2 === $restored_item_count ) {
+				throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+			}
+			return $session_data;
+		};
+		$cookie_update_count      = 0;
+		$cookie_update_callback   = static function () use ( &$cookie_update_count ) {
+			++$cookie_update_count;
+			return false;
 		};
 
 		WC()->session->set( 'cart', $stored_cart );
 		WC()->cart->set_cart_contents( array() );
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 		add_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
+		add_filter( 'woocommerce_set_cookie_enabled', $cookie_update_callback, 10, 0 );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
 		$request->set_body_params(
@@ -171,6 +185,10 @@ class Batch extends ControllerTestCase {
 						'body'    => array(),
 						'headers' => array( 'Nonce' => wp_create_nonce( 'wc_store_api' ) ),
 					),
+					array(
+						'method' => 'GET',
+						'path'   => '/wc/store/v1/products',
+					),
 				),
 			)
 		);
@@ -181,6 +199,10 @@ class Batch extends ControllerTestCase {
 
 			$this->assertSame( 500, $response_data['responses'][0]['status'], 'The request that fails to load the cart should return an error.' );
 			$this->assertSame( 500, $response_data['responses'][1]['status'], 'Later cart requests should not use a partially loaded cart.' );
+			$this->assertSame( 200, $response_data['responses'][2]['status'], 'Later non-cart requests should remain available.' );
+			$this->assertCount( 1, $cart_backup->get_cart_contents(), 'The synthetic failure should occur after partially restoring the cart.' );
+			$this->assertArrayNotHasKey( 'Cart-Token', $response_data['responses'][0]['headers'], 'A failed cart response should not include a cart token.' );
+			$this->assertArrayNotHasKey( 'Cart-Hash', $response_data['responses'][0]['headers'], 'A failed cart response should not include a cart hash.' );
 
 			// A failed cart remains referenced by its registered callbacks after WC()->cart is cleared.
 			do_action( 'woocommerce_removed_coupon', 'synthetic-coupon' );
@@ -206,8 +228,13 @@ class Batch extends ControllerTestCase {
 			$wp_query->is_search   = false;
 			$failed_cart_session->clean_up_removed_cart_contents();
 			$this->assertSame( $stored_removed_cart_contents, WC()->session->get( 'removed_cart_contents' ), 'The failed cart should not clean up removed cart contents.' );
+
+			$this->assertFalse( headers_sent(), 'Cookie behavior can only be verified before headers are sent.' );
+			$failed_cart_session->maybe_set_cart_cookies();
+			$this->assertSame( 0, $cookie_update_count, 'The failed cart should not update cart cookies.' );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $session_failure_callback );
+			remove_filter( 'woocommerce_set_cookie_enabled', $cookie_update_callback );
 			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			WC()->cart->set_cart_contents( $cart_contents_backup );
@@ -221,6 +248,36 @@ class Batch extends ControllerTestCase {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count changed by the test.
 				$GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] = $load_action_count;
 			}
+		}
+	}
+
+	/**
+	 * @testdox Disabling cart-session updates only affects the exact marked cart.
+	 */
+	public function test_cart_session_update_registry_is_scoped_to_the_marked_cart(): void {
+		$marked_cart         = WC()->cart;
+		$unmarked_clone      = clone $marked_cart;
+		$marked_session      = new \WC_Cart_Session( $marked_cart );
+		$unmarked_session    = new \WC_Cart_Session( $unmarked_clone );
+		$stored_session_cart = $marked_cart->get_cart_for_session();
+
+		try {
+			\WC_Cart_Session::set_updates_enabled_for_cart( $marked_cart, false );
+
+			WC()->session->set( 'cart', $stored_session_cart );
+			$marked_session->destroy_cart_session();
+			$this->assertSame( $stored_session_cart, WC()->session->get( 'cart' ), 'The marked cart should not destroy session data.' );
+
+			$unmarked_session->destroy_cart_session();
+			$this->assertNull( WC()->session->get( 'cart' ), 'An unmarked clone should continue updating session data.' );
+
+			WC()->session->set( 'cart', $stored_session_cart );
+			\WC_Cart_Session::set_updates_enabled_for_cart( $marked_cart, true );
+			$marked_session->destroy_cart_session();
+			$this->assertNull( WC()->session->get( 'cart' ), 'Re-enabled carts should resume updating session data.' );
+		} finally {
+			\WC_Cart_Session::set_updates_enabled_for_cart( $marked_cart, true );
+			WC()->session->set( 'cart', $stored_session_cart );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -195,16 +195,16 @@ class Batch extends ControllerTestCase {
 			$this->assertArrayNotHasKey( 'Cart-Token', $response_data['responses'][0]['headers'], 'A failed cart response should not include a cart token.' );
 			$this->assertArrayNotHasKey( 'Cart-Hash', $response_data['responses'][0]['headers'], 'A failed cart response should not include a cart hash.' );
 
-			// A failed cart remains referenced by its registered callbacks after WC()->cart is cleared.
 			$failed_cart_session = new \WC_Cart_Session( $cart_backup );
 			$failed_cart_session->get_cart_from_session();
 			$this->assertCount( 1, $cart_backup->get_cart_contents(), 'The failed cart should not resume loading from the session.' );
+			$this->assertSame( $cart_backup, WC()->cart, 'The failed cart should remain available to extension callbacks.' );
+
+			WC()->cart->empty_cart();
+			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'Emptying the failed cart should not destroy the session.' );
 
 			do_action( 'woocommerce_removed_coupon', 'synthetic-coupon' );
 			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not update the session.' );
-
-			do_action( 'woocommerce_cart_emptied' );
-			$this->assertSame( $stored_cart, WC()->session->get( 'cart' ), 'The failed cart should not destroy the session.' );
 
 			$user_id                = self::factory()->user->create();
 			$persistent_cart_key    = '_woocommerce_persistent_cart_' . get_current_blog_id();

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -34,7 +34,7 @@ class Cart extends ControllerTestCase {
 	private static $coupon_id;
 
 	/**
-	 * Cart instance removed to mimic a REST request, restored on teardown.
+	 * Cart instance restored after a cart session failure.
 	 *
 	 * @var \WC_Cart|null
 	 */
@@ -1568,14 +1568,17 @@ class Cart extends ControllerTestCase {
 		// the counter to put the process back into the state a REST request starts in.
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 
-		add_filter(
-			'woocommerce_get_cart_item_from_session',
-			static function () {
-				throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
-			}
-		);
+		$this->cart_backup = WC()->cart;
+		$callback          = static function () {
+			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+		};
+		add_filter( 'woocommerce_get_cart_item_from_session', $callback );
 
-		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
+		try {
+			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
+		} finally {
+			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+		}
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
 		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -34,13 +34,6 @@ class Cart extends ControllerTestCase {
 	private static $coupon_id;
 
 	/**
-	 * Cart instance restored after a cart session failure.
-	 *
-	 * @var \WC_Cart|null
-	 */
-	private $cart_backup = null;
-
-	/**
 	 * Create immutable catalog rows shared by all test methods.
 	 */
 	public static function wpSetUpBeforeClass(): void {
@@ -1566,10 +1559,11 @@ class Cart extends ControllerTestCase {
 
 		// The route restores the cart only when this action has not run yet, so reset
 		// the counter to put the process back into the state a REST request starts in.
+		$load_action_count = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 
-		$this->cart_backup = WC()->cart;
-		$callback          = static function () {
+		$cart_backup = WC()->cart;
+		$callback    = static function () {
 			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
 		};
 		add_filter( 'woocommerce_get_cart_item_from_session', $callback );
@@ -1578,6 +1572,13 @@ class Cart extends ControllerTestCase {
 			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			WC()->cart = $cart_backup;
+			if ( null === $load_action_count ) {
+				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count changed by the test.
+				$GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] = $load_action_count;
+			}
 		}
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
@@ -1590,34 +1591,32 @@ class Cart extends ControllerTestCase {
 	public function test_cart_session_failure_before_restore_returns_error_response() {
 		// This filter runs before `get_cart_from_session()` fires its action, so nothing
 		// stops the response headers attempting a second load of the failed cart.
+		$load_action_count = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 
 		// A REST request never runs `initialize_cart()`, so the route starts with no
 		// cart at all. The test bootstrap leaves one behind.
-		$this->cart_backup = WC()->cart;
-		WC()->cart         = null;
+		$cart_backup = WC()->cart;
+		WC()->cart   = null;
 
-		add_filter(
-			'woocommerce_session_handler',
-			static function () {
-				throw new \RuntimeException( 'Synthetic session handler failure.' );
+		$callback = static function () {
+			throw new \RuntimeException( 'Synthetic session handler failure.' );
+		};
+		add_filter( 'woocommerce_session_handler', $callback );
+
+		try {
+			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
+		} finally {
+			remove_filter( 'woocommerce_session_handler', $callback );
+			WC()->cart = $cart_backup;
+			if ( null === $load_action_count ) {
+				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count changed by the test.
+				$GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] = $load_action_count;
 			}
-		);
-
-		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
-
-		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
-	}
-
-	/**
-	 * Restore the cart instance removed by the cart session failure tests.
-	 */
-	public function tearDown(): void {
-		if ( $this->cart_backup instanceof \WC_Cart ) {
-			WC()->cart         = $this->cart_backup;
-			$this->cart_backup = null;
 		}
 
-		parent::tearDown();
+		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1584,6 +1584,8 @@ class Cart extends ControllerTestCase {
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
 		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );
+		$this->assertArrayNotHasKey( 'Cart-Token', $response->get_headers(), 'A failed cart response should not include a cart token.' );
+		$this->assertArrayNotHasKey( 'Cart-Hash', $response->get_headers(), 'A failed cart response should not include a cart hash.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -1572,6 +1572,7 @@ class Cart extends ControllerTestCase {
 			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			if ( null === $load_action_count ) {
 				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
@@ -1608,6 +1609,7 @@ class Cart extends ControllerTestCase {
 			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) );
 		} finally {
 			remove_filter( 'woocommerce_session_handler', $callback );
+			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			if ( null === $load_action_count ) {
 				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3230,6 +3230,7 @@ class Checkout extends \WP_Test_REST_TestCase {
 			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' ) );
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			\WC_Cart_Session::set_updates_enabled_for_cart( $cart_backup, true );
 			WC()->cart = $cart_backup;
 			if ( null === $load_action_count ) {
 				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3217,6 +3217,7 @@ class Checkout extends \WP_Test_REST_TestCase {
 
 		// The route restores the cart only when this action has not run yet, so reset
 		// the counter to put the process back into the state a REST request starts in.
+		$load_action_count = $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] ?? null;
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 
 		$cart_backup = WC()->cart;
@@ -3230,6 +3231,12 @@ class Checkout extends \WP_Test_REST_TestCase {
 		} finally {
 			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
 			WC()->cart = $cart_backup;
+			if ( null === $load_action_count ) {
+				unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the action count changed by the test.
+				$GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] = $load_action_count;
+			}
 		}
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3219,14 +3219,18 @@ class Checkout extends \WP_Test_REST_TestCase {
 		// the counter to put the process back into the state a REST request starts in.
 		unset( $GLOBALS['wp_actions']['woocommerce_load_cart_from_session'] );
 
-		add_filter(
-			'woocommerce_get_cart_item_from_session',
-			static function () {
-				throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
-			}
-		);
+		$cart_backup = WC()->cart;
+		$callback    = static function () {
+			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
+		};
+		add_filter( 'woocommerce_get_cart_item_from_session', $callback );
 
-		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' ) );
+		try {
+			$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' ) );
+		} finally {
+			remove_filter( 'woocommerce_get_cart_item_from_session', $callback );
+			WC()->cart = $cart_backup;
+		}
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
 		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes WOOAIRR-111

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

PR #67769 converted cart-session loading failures into per-request Store API error responses. In a batch, that allowed later cart sub-requests to continue with the empty or partially restored in-memory cart and persist it over the shopper's saved session cart.

This change marks the exact cart as unavailable whenever session loading fails so that later cart sub-requests in the same batch fail safely instead of calculating totals or persisting the invalid cart. A weak-reference registry in `WC_Cart_Session` prevents that cart's retained callbacks from updating session data, the persistent cart, or cart cookies.

The failed `WC_Cart` remains available through `WC()->cart` so post-dispatch extension callbacks can continue to access it without fataling. Store API cart routes reject the marked cart, and error responses omit `Cart-Token` and `Cart-Hash` headers. Two additive `@internal` static methods on final `WC_Cart_Session` set and query the update state for an exact cart. No existing method signatures or hooks change, and successful request behavior and response schemas remain unchanged.

**Backward compatibility:** The Store API cart-session-load-failure response was introduced for WooCommerce 11.2 in PR #67769 and has not shipped in a stable release. This PR changes that unreleased error path so it no longer includes `Cart-Token` or `Cart-Hash`. A failed load can leave the in-memory cart partially restored, so those headers would advertise unusable cart metadata; generating a cart token would also attempt to load the failed cart again. Successful response schemas remain unchanged. Clients should only consume cart headers after confirming that a request succeeded.

Callbacks on active and unmarked carts—including cloned or temporarily swapped Store API carts—behave as before. Only the exact cart whose session load failed is marked, so extension callbacks can access or mutate it without overwriting valid shopper data.

Bug introduced in PR #67769.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add this temporary mu-plugin to make cart restoration fail only for a request carrying a test header:

```php
<?php
add_filter(
	'woocommerce_get_cart_item_from_session',
	static function ( $session_data ) {
		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $_SERVER['HTTP_X_SYNTHETIC_CART_FAILURE'] ) ) {
			throw new \RuntimeException( 'Synthetic Store API cart-session failure.' );
		}
		return $session_data;
	}
);

add_filter(
	'rest_post_dispatch',
	static function ( $response, $server, $request ) {
		if (
			isset( $_SERVER['HTTP_X_SYNTHETIC_EXTENSION_CART_CLEANUP'] ) &&
			'/wc/store/v1/cart/update-customer' === $request->get_route() &&
			500 === $response->get_status()
		) {
			WC()->cart->empty_cart();
		}
		return $response;
	},
	10,
	3
);
```
2. Open the storefront in a private/incognito window as a logged-out guest, add a simple product to the cart, and leave that browser session open. Testing as a guest avoids the persistent user cart repopulating the cleared session and hiding the pre-fix bug.
3. Open the browser console on the store and run:

```js
const cartResponse = await fetch( '/wp-json/wc/store/v1/cart', {
	credentials: 'same-origin',
} );
const nonce = cartResponse.headers.get( 'Nonce' );
const subRequest = {
	method: 'POST',
	path: '/wc/store/v1/cart/update-customer',
	body: {},
	headers: { Nonce: nonce },
};
const batchResponse = await fetch( '/wp-json/wc/store/v1/batch', {
	method: 'POST',
	credentials: 'same-origin',
	headers: {
		'Content-Type': 'application/json',
		Nonce: nonce,
		'X-Synthetic-Cart-Failure': '1',
		'X-Synthetic-Extension-Cart-Cleanup': '1',
	},
	body: JSON.stringify( { requests: [ subRequest, subRequest ] } ),
} );
console.log( await batchResponse.json() );
```

4. Confirm both cart sub-requests return status `500` rather than the extension callback causing a fatal error.
5. Reload the cart, and confirm the original product is still present.

<!-- End testing instructions -->

### Testing that has already taken place:

Earlier revisions were tested locally in the WooCommerce `wp-env` PHPUnit environment using PHP 8.1.34:

- Full Blocks PHP suite: 1,067 tests, 3,407 assertions passed.
- Ordered deadlock reproducer covering Order Confirmation Totals followed by Store API tests: 469 tests, 1,942 assertions passed.
- Store API Batch suite: 14 tests, 38 assertions passed.
- Mutation check: removing the `destroy_cart_session()` guard causes the regression test to fail because the saved session cart is destroyed.

The final extension-compatibility follow-up was tested in Burrito with a temporary `rest_post_dispatch` callback that called `WC()->cart->empty_cart()` after each failed cart sub-request:

- The batch returned `207`, with both cart sub-requests returning `500`.
- The extension callback completed for both sub-requests without a fatal error.
- Neither failed response included `Cart-Token` or `Cart-Hash`.
- The original guest cart item remained in the saved session and was restored on the next request.
- Regression coverage includes partial restoration, later cart and non-cart requests, response headers, retained session and persistent-cart callbacks, extension cart cleanup, removed-cart cleanup, and exact-cart registry scoping.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:php:changes` passed.
- `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` passed.
- PHPStan passed for `AbstractCartRoute.php` and `class-wc-cart-session.php` with no errors.

No performance profiling was needed. Cart-session callbacks perform an object ID and in-memory registry lookup before their existing work, with no additional I/O. Weak references do not extend cart object lifetimes.

Not tested under multisite. The fix only changes request-local cart state and does not read or write site/network options, tables, paths, or URLs, so multisite behavior is expected to be unaffected.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight**
- [x] **Developer Advisory**

### Use of AI Tools

OpenAI GPT-5.6 Sol was used to investigate the batch regression, implement the fix and regression test, run the focused validation, and draft this pull request description. The changes and claims were reviewed against the Store API, WordPress batch, and WooCommerce cart-session code paths and verified with automated tests.


