### PR TITLE
Fix install version check test on prereleases

### DIFF
--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -314,17 +314,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 * @testdox The version check schedules the automatic database update.
 	 */
 	public function test_version_check_schedules_db_auto_update(): void {
-		$older_update_versions = array_filter(
-			array_keys( WC_Install::get_db_update_callbacks() ),
-			fn( $version ) => version_compare( $version, WC()->version, '<' )
-		);
-
-		$this->assertNotEmpty(
-			$older_update_versions,
-			sprintf( 'Expected at least one database update version older than WooCommerce %s.', WC()->version )
-		);
-
-		$from_version = end( $older_update_versions );
+		$from_version = '10.9.0';
 
 		update_option( 'woocommerce_db_version', $from_version );
 		update_option( 'woocommerce_version', $from_version );

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -314,8 +314,17 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 * @testdox The version check schedules the automatic database update.
 	 */
 	public function test_version_check_schedules_db_auto_update(): void {
-		$update_versions = array_keys( WC_Install::get_db_update_callbacks() );
-		$from_version    = $update_versions[ count( $update_versions ) - 2 ];
+		$older_update_versions = array_filter(
+			array_keys( WC_Install::get_db_update_callbacks() ),
+			fn( $version ) => version_compare( $version, WC()->version, '<' )
+		);
+
+		$this->assertNotEmpty(
+			$older_update_versions,
+			sprintf( 'Expected at least one database update version older than WooCommerce %s.', WC()->version )
+		);
+
+		$from_version = end( $older_update_versions );
 
 		update_option( 'woocommerce_db_version', $from_version );
 		update_option( 'woocommerce_version', $from_version );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The version-check smoke test treated the second-to-last database migration key as an installed WooCommerce version. Database schema versions and WooCommerce code versions are separate values, and the positional assumption failed when an `11.1.0-1` migration was added while the release branch ran `11.1.0-beta.1`.

Restore a known older `10.9.0` fixture for both installed options, following the test's original approach before #66522 made the value dynamic. This preserves the full `check_version()` to automatic database updater coverage without changing production upgrade logic.

Failure observed in PR #67915.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #66522.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. From `plugins/woocommerce`, run `pnpm test:php:env -- --filter WC_Install_Test::test_version_check_schedules_db_auto_update`.
2. Confirm the focused test passes on trunk.
3. Cherry-pick the commits onto `release/11.1` with the `11.1.0-1` database update from #67915 and rerun the focused test.
4. Confirm the test passes and schedules `woocommerce_run_update_callback` in both version contexts.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- `php -l plugins/woocommerce/tests/php/includes/class-wc-install-test.php` passed.
- `git diff --check` passed.
- PHPCS passed for the changed code; the full file has two unrelated pre-existing post-statement comment violations at lines 34 and 75.
- The focused PHPUnit command could not start locally because the active dependency policy rejected existing WordPress package metadata in the lockfile, and Docker was unavailable. CI is running the coverage on trunk and in temporary release verification PR #67924.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Test-only change; no merchant-facing code is shipped.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to analyze the failure, implement and validate the test-only fix, and draft this Pull Request.
