### PR TITLE
[DO NOT MERGE] Verify variation gallery backport with install test fix

### DIFF
--- a/plugins/woocommerce/changelog/codex-variation-gallery-100
+++ b/plugins/woocommerce/changelog/codex-variation-gallery-100
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Enable variation galleries for all stores and remove the experimental feature toggle.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -347,6 +347,9 @@ class WC_Install {
 			'wc_update_1110_cleanup_block_email_posts',
 			'wc_update_1110_flush_product_count_cache',
 		),
+		'11.1.0-1' => array(
+			'wc_update_11101_remove_deprecated_variation_gallery_option',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -11,7 +11,6 @@
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
-use Automattic\WooCommerce\Internal\VariationGallery\Package as VariationGalleryPackage;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -442,17 +441,13 @@ class WC_Product_Variable extends WC_Product {
 		$parent_featured_id       = (int) $this->get_image_id();
 		$parent_featured_valid    = $parent_featured_id && wp_attachment_is_image( $parent_featured_id );
 
-		$variation_gallery_image_ids = array();
+		$variation_gallery_image_ids = array_values(
+			array_filter(
+				array_map( 'intval', $variation->get_gallery_image_ids() ),
+				'wp_attachment_is_image'
+			)
+		);
 		$variation_gallery_html      = '';
-
-		if ( VariationGalleryPackage::is_enabled() ) {
-			$variation_gallery_image_ids = array_values(
-				array_filter(
-					array_map( 'intval', $variation->get_gallery_image_ids() ),
-					'wp_attachment_is_image'
-				)
-			);
-		}
 
 		// Prefer variation-owned images over the parent fallback.
 		if ( $variation_featured_valid ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2211,11 +2211,8 @@ if ( ! function_exists( 'woocommerce_variable_add_to_cart' ) ) {
 		// Enqueue variation scripts.
 		wp_enqueue_script( 'wc-add-to-cart-variation' );
 
-		// Attach a reset snapshot only when variation-gallery swaps are enabled.
-		if (
-			\Automattic\WooCommerce\Internal\VariationGallery\Package::is_enabled() &&
-			! isset( $attached_gallery_defaults[ $product->get_id() ] )
-		) {
+		// Attach the reset snapshot once per product.
+		if ( ! isset( $attached_gallery_defaults[ $product->get_id() ] ) ) {
 			wp_add_inline_script(
 				'wc-add-to-cart-variation',
 				sprintf(

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -40,6 +40,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchro
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\Utilities\FilesystemUtil;
 use Automattic\WooCommerce\Internal\Utilities\ProductUtil;
+use Automattic\WooCommerce\Internal\VariationGallery\Package as VariationGalleryPackage;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use Automattic\WooCommerce\Blocks\Options as BlockOptions;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
@@ -3582,6 +3583,21 @@ function wc_update_10902_remove_deprecated_push_notifications_option(): void {
  */
 function wc_update_1100_enable_point_of_sale_feature() {
 	update_option( 'woocommerce_feature_point_of_sale_enabled', 'yes' );
+}
+
+/**
+ * Remove the deprecated variation gallery feature option from the database.
+ *
+ * The variation gallery feature flag is deprecated as of 11.1.0 and is now always enabled.
+ * The option is no longer needed as FeaturesUtil::feature_is_enabled('variation_gallery')
+ * returns the deprecated_value directly without reading from the database.
+ *
+ * @since 11.1.0
+ *
+ * @return void
+ */
+function wc_update_11101_remove_deprecated_variation_gallery_option(): void {
+	delete_option( VariationGalleryPackage::ENABLE_OPTION_NAME );
 }
 
 /**

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -2,7 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\Utils;
 
 use Automattic\WooCommerce\Internal\ProductGallery\ProductMediaGallery;
-use Automattic\WooCommerce\Internal\VariationGallery\Package as VariationGalleryPackage;
 
 /**
  * Utility methods used for the Product Gallery block.
@@ -442,7 +441,7 @@ class ProductGalleryUtils {
 	 * Decision tree (variation chosen):
 	 * - no variation images → parent featured + parent gallery
 	 * - own featured only → variation featured + parent gallery extras
-	 * - own featured + gallery (flag on) → variation images only
+	 * - own featured + gallery → variation images only
 	 * - gallery only, no own featured (potential AVI shape) → parent featured + variation gallery
 	 *
 	 * @param int   $variation_id          Variation post ID.
@@ -460,12 +459,9 @@ class ProductGalleryUtils {
 		$featured_id    = (int) $variation->get_image_id();
 		$featured_valid = $featured_id && wp_attachment_is_image( $featured_id );
 
-		$variation_gallery_ids = array();
-		if ( VariationGalleryPackage::is_enabled() ) {
-			$variation_gallery_ids = array_map( 'intval', $variation->get_gallery_image_ids() );
-			$variation_gallery_ids = array_filter( $variation_gallery_ids, 'wp_attachment_is_image' );
-			$variation_gallery_ids = array_values( $variation_gallery_ids );
-		}
+		$variation_gallery_ids = array_map( 'intval', $variation->get_gallery_image_ids() );
+		$variation_gallery_ids = array_filter( $variation_gallery_ids, 'wp_attachment_is_image' );
+		$variation_gallery_ids = array_values( $variation_gallery_ids );
 
 		// No images from variation - full parent fallback.
 		if ( ! $featured_valid && empty( $variation_gallery_ids ) ) {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -541,15 +541,14 @@ class FeaturesController {
 			),
 			\Automattic\WooCommerce\Internal\VariationGallery\Package::FEATURE_ID => array(
 				'name'                         => __( 'Variation gallery', 'woocommerce' ),
-				'description'                  => __(
-					'Add multiple images per product variation. Once enabled, the Additional Variation Images extension will be deactivated and its data migrated.',
-					'woocommerce'
-				),
-				'option_key'                   => \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME,
-				'is_experimental'              => true,
-				'enabled_by_default'           => \Automattic\WooCommerce\Internal\VariationGallery\Package::is_in_canary_cohort(),
+				'description'                  => __( 'Add multiple images per product variation.', 'woocommerce' ),
+				'is_experimental'              => false,
+				'enabled_by_default'           => true,
+				'disable_ui'                   => true,
 				'skip_compatibility_checks'    => true,
 				'default_plugin_compatibility' => FeaturePluginCompatibility::COMPATIBLE,
+				'deprecated_since'             => '11.1.0',
+				'deprecated_value'             => true,
 			),
 			'wc-visual-attribute'                  => array(
 				'name'                         => __( 'Color swatches for attributes', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/VariationGallery/Package.php
+++ b/plugins/woocommerce/src/Internal/VariationGallery/Package.php
@@ -39,48 +39,30 @@ class Package {
 	public const ENABLE_OPTION_NAME = 'wc_feature_woocommerce_additional_variation_images_enabled';
 
 	/**
-	 * `woocommerce_remote_variant_assignment` option name.
-	 */
-	private const REMOTE_VARIANT_OPTION_NAME = 'woocommerce_remote_variant_assignment';
-
-	/**
-	 * Highest variant bucket in the canary cohort. Range is 1-120, so
-	 * `<= 6` gets exactly 5%. Matches the Brands merge precedent.
+	 * Highest variant bucket in the former canary cohort.
+	 *
+	 * @deprecated 11.1.0 The variation gallery is enabled for all users.
 	 */
 	public const CANARY_MAX_VARIANT = 6;
 
 	/**
-	 * Whether the current store is in the canary cohort.
+	 * Whether the current store is in the former canary cohort.
 	 *
-	 * @internal Removable once the feature is at 100% rollout.
+	 * @deprecated 11.1.0 Use Package::is_enabled() instead.
 	 * @return bool
 	 */
 	public static function is_in_canary_cohort(): bool {
-		$variant_assignment = (int) get_option( self::REMOTE_VARIANT_OPTION_NAME, 0 );
-		return $variant_assignment > 0 && $variant_assignment <= self::CANARY_MAX_VARIANT;
+		wc_deprecated_function( __METHOD__, '11.1.0', __CLASS__ . '::is_enabled' );
+		return self::is_enabled();
 	}
 
 	/**
-	 * Whether the merged variation gallery feature is enabled for the current
-	 * request.
-	 *
-	 * Explicit `yes`/`no` on the option wins; unset falls back to the canary
-	 * cohort.
+	 * As of WooCommerce 11.1, the variation gallery is enabled for all users.
 	 *
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		$option_value = get_option( self::ENABLE_OPTION_NAME, '' );
-
-		if ( 'yes' === $option_value ) {
-			return true;
-		}
-
-		if ( 'no' === $option_value ) {
-			return false;
-		}
-
-		return self::is_in_canary_cohort();
+		return true;
 	}
 
 	/**
@@ -98,10 +80,6 @@ class Package {
 	 * @internal
 	 */
 	final public static function init(): void {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
-
 		$container = wc_get_container();
 		$container->get( ClassicVariationGalleryAdmin::class )->register();
 		$container->get( LegacyVariationGalleryCompatibility::class )->register();

--- a/plugins/woocommerce/src/Internal/VariationGallery/Telemetry.php
+++ b/plugins/woocommerce/src/Internal/VariationGallery/Telemetry.php
@@ -50,9 +50,6 @@ class Telemetry implements RegisterHooksInterface {
 	public static function collect_snapshot(): array {
 		global $wpdb;
 
-		$option_value         = get_option( Package::ENABLE_OPTION_NAME, '' );
-		$variant_assignment   = (int) get_option( 'woocommerce_remote_variant_assignment', 0 );
-		$cohort               = Package::is_in_canary_cohort() ? 'treatment' : 'control';
 		$legacy_plugin_active = self::is_legacy_plugin_active();
 		$legacy_plugin_file   = WP_PLUGIN_DIR . '/' . self::LEGACY_PLUGIN_FILE;
 
@@ -105,10 +102,7 @@ class Telemetry implements RegisterHooksInterface {
 		);
 
 		return array(
-			'feature_enabled'               => Package::is_enabled() ? 'yes' : 'no',
-			'feature_option_explicit'       => '' === $option_value ? 'no' : 'yes',
-			'remote_variant_assignment'     => $variant_assignment,
-			'remote_variant_cohort'         => $cohort,
+			'feature_enabled'               => 'yes',
 			'legacy_avi_plugin_active'      => $legacy_plugin_active ? 'yes' : 'no',
 			'legacy_avi_plugin_installed'   => file_exists( $legacy_plugin_file ) ? 'yes' : 'no',
 			'migrated_variation_count'      => $migrated_variation_count,

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -193,7 +193,16 @@ class Packages {
 		}
 
 		// Scroll through all of the active plugins and disable them if they're merged packages.
-		$active_plugins = get_option( 'active_plugins', array() );
+		$active_plugins = (array) get_option( 'active_plugins', array() );
+		if ( is_multisite() ) {
+			$active_plugins = array_unique(
+				array_merge(
+					$active_plugins,
+					array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) )
+				)
+			);
+		}
+
 		// Deactivate the plugin if possible so that there are no conflicts.
 		foreach ( $active_plugins as $active_plugin_path ) {
 			$plugin_file = basename( plugin_basename( $active_plugin_path ), '.php' );

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.9.0
+ * @version 11.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -62,12 +62,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 		<div class="reset_variations_alert screen-reader-text" role="alert" aria-live="polite" aria-relevant="all"></div>
 		<?php
 		// Reset snapshot for cases where a theme/plugin loads the variation form later, like quick-view modals.
-		if ( \Automattic\WooCommerce\Internal\VariationGallery\Package::is_enabled() ) :
-			?>
-			<script type="text/template" class="wc-product-gallery-default-template"><?php echo wc_get_product_gallery_html( $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></script>
-			<?php
-		endif;
 		?>
+		<script type="text/template" class="wc-product-gallery-default-template"><?php echo wc_get_product_gallery_html( $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></script>
 		<?php do_action( 'woocommerce_after_variations_table' ); ?>
 
 		<div class="single_variation_wrap">

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Internal\Admin\FeaturePlugin;
+use Automattic\WooCommerce\Internal\VariationGallery\Migration as VariationGalleryMigration;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\CodeHacker;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
@@ -69,6 +70,9 @@ class WC_Unit_Tests_Bootstrap {
 
 		// Set up WC-Admin config.
 		tests_add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'add_development_features' ) );
+
+		// Keep the shared DB update queue clean outside the variation gallery package tests.
+		tests_add_filter( 'init', array( $this, 'cancel_variation_gallery_migration_action' ), 21 );
 
 		// Speed things up by turning down the password hashing cost.
 		tests_add_filter(
@@ -305,6 +309,20 @@ class WC_Unit_Tests_Bootstrap {
 		}
 
 		echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
+	}
+
+	/**
+	 * Cancel the variation gallery migration scheduled during test bootstrap.
+	 *
+	 * The package scheduler is covered directly by its own tests. Leaving its
+	 * bootstrap action pending leaks into unrelated tests of the shared DB update queue.
+	 */
+	public function cancel_variation_gallery_migration_action(): void {
+		WC()->queue()->cancel_all(
+			'woocommerce_run_update_callback',
+			array( 'update_callback' => array( VariationGalleryMigration::class, 'run' ) ),
+			'woocommerce-db-updates'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -314,8 +314,17 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 * @testdox The version check schedules the automatic database update.
 	 */
 	public function test_version_check_schedules_db_auto_update(): void {
-		$update_versions = array_keys( WC_Install::get_db_update_callbacks() );
-		$from_version    = $update_versions[ count( $update_versions ) - 2 ];
+		$older_update_versions = array_filter(
+			array_keys( WC_Install::get_db_update_callbacks() ),
+			fn( $version ) => version_compare( $version, WC()->version, '<' )
+		);
+
+		$this->assertNotEmpty(
+			$older_update_versions,
+			sprintf( 'Expected at least one database update version older than WooCommerce %s.', WC()->version )
+		);
+
+		$from_version = end( $older_update_versions );
 
 		update_option( 'woocommerce_db_version', $from_version );
 		update_option( 'woocommerce_version', $from_version );

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -1,19 +1,9 @@
 <?php
 
-use Automattic\WooCommerce\Internal\VariationGallery\Package;
-
 /**
  * Tests for WC_Product_Variable.
  */
 class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
-	/**
-	 * Reset variation gallery feature-flag option leaked by individual tests.
-	 */
-	public function tearDown(): void {
-		delete_option( Package::ENABLE_OPTION_NAME );
-		parent::tearDown();
-	}
-
 	/**
 	 * @testdox 'get_available_variations' returns the variations as arrays if no parameters is passed.
 	 */
@@ -177,8 +167,6 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	 * @testdox 'get_available_variations' with 'array' return includes image and gallery data for variations that have images set.
 	 */
 	public function test_get_available_variations_array_includes_image_data_when_variation_has_images(): void {
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$image_id   = $this->create_image_attachment( 'Variation Image', 'variation-image.jpg' );
 		$gallery_id = $this->create_image_attachment( 'Variation Gallery Image', 'variation-gallery.jpg' );
 
@@ -200,8 +188,6 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	 * @testdox 'get_available_variation' exposes typed variation gallery image IDs.
 	 */
 	public function test_get_available_variation_includes_gallery_image_ids() {
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$product   = WC_Helper_Product::create_variation_product();
 		$variation = wc_get_product( $product->get_children()[0] );
 		$image_id  = wp_insert_attachment(
@@ -244,56 +230,9 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'get_available_variation' omits multi-image gallery data when the variation gallery feature flag is disabled.
-	 */
-	public function test_get_available_variation_returns_single_image_shape_when_feature_flag_disabled() {
-		update_option( Package::ENABLE_OPTION_NAME, 'no' );
-
-		$product   = WC_Helper_Product::create_variation_product();
-		$variation = wc_get_product( $product->get_children()[0] );
-		$image_id  = wp_insert_attachment(
-			array(
-				'post_title'     => 'Variation Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-		$image_ids = array(
-			wp_insert_attachment(
-				array(
-					'post_title'     => 'Variation Gallery Image 1',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			),
-			wp_insert_attachment(
-				array(
-					'post_title'     => 'Variation Gallery Image 2',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			),
-		);
-
-		update_post_meta( $image_id, '_wp_attached_file', 'variation-disabled.jpg' );
-
-		$variation->set_image_id( $image_id );
-		$variation->set_gallery_image_ids( $image_ids );
-		$variation->save();
-
-		$available_variation = $product->get_available_variation( $variation );
-
-		$this->assertSame( array(), $available_variation['gallery_image_ids'] );
-		$this->assertSame( '', $available_variation['gallery_images_html'] );
-		$this->assertSame( $image_id, $available_variation['image_id'] );
-	}
-
-	/**
 	 * @testdox 'get_available_variation' falls back to the variation's own gallery when the variation featured image is stale.
 	 */
 	public function test_get_available_variation_falls_back_to_variation_gallery_when_featured_is_stale() {
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$product              = WC_Helper_Product::create_variation_product();
 		$variation            = wc_get_product( $product->get_children()[0] );
 		$parent_featured_id   = $this->create_image_attachment( 'Parent Featured Image', 'parent-featured.jpg' );
@@ -325,8 +264,6 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	 * @testdox 'get_available_variation' falls back to the parent featured image when both the variation featured image and gallery are absent.
 	 */
 	public function test_get_available_variation_falls_back_to_parent_featured_when_variation_has_no_images() {
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$product            = WC_Helper_Product::create_variation_product();
 		$variation          = wc_get_product( $product->get_children()[0] );
 		$parent_featured_id = $this->create_image_attachment( 'Parent Featured Image', 'parent-featured.jpg' );

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -17,11 +17,24 @@ use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 
 	/**
-	 * Reset the variation gallery feature-flag option after each test so
-	 * individual cases that flip it on don't leak global state.
+	 * Restore settings modified by tests.
 	 */
 	public function tearDown(): void {
+<<<<<<< HEAD
 		delete_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME );
+=======
+		if ( $this->reviews_setting_changed ) {
+			delete_option( 'woocommerce_product_lookup_table_is_generating' );
+			as_unschedule_all_actions( '', array(), 'wc_update_product_lookup_tables' );
+
+			if ( null === $this->original_reviews_setting ) {
+				delete_option( 'woocommerce_enable_reviews' );
+			} else {
+				update_option( 'woocommerce_enable_reviews', $this->original_reviews_setting );
+			}
+		}
+
+>>>>>>> bf74658ba5 (Enable variation galleries for all stores (#67884))
 		parent::tearDown();
 	}
 
@@ -1396,11 +1409,9 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Variable add-to-cart attaches a pristine gallery snapshot to the variation script when the feature is on.
+	 * @testdox Variable add-to-cart attaches a pristine gallery snapshot to the variation script.
 	 */
 	public function test_woocommerce_variable_add_to_cart_attaches_gallery_snapshot() {
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$inline_js = $this->capture_variable_add_to_cart_inline_js();
 
 		$this->assertStringContainsString( 'wc_variation_gallery_defaults', $inline_js );
@@ -1411,21 +1422,6 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		$decoded_snapshot = json_decode( $matches[1] );
 		$this->assertIsString( $decoded_snapshot );
 		$this->assertStringContainsString( 'woocommerce-product-gallery', $decoded_snapshot );
-	}
-
-	/**
-	 * @testdox Variable add-to-cart skips the gallery snapshot when the feature is off.
-	 */
-	public function test_woocommerce_variable_add_to_cart_skips_gallery_snapshot_when_feature_off() {
-		// Set the option to 'no' explicitly rather than deleting it: an empty option makes
-		// Package::is_enabled() fall through to the canary cohort, which reads a separate
-		// option (woocommerce_remote_variant_assignment) that other tests in the same worker
-		// may have left set, non-deterministically re-enabling the feature. 'no' short-circuits.
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'no' );
-
-		$inline_js = $this->capture_variable_add_to_cart_inline_js();
-
-		$this->assertStringNotContainsString( 'wc_variation_gallery_defaults', $inline_js );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -17,28 +17,6 @@ use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 
 	/**
-	 * Restore settings modified by tests.
-	 */
-	public function tearDown(): void {
-<<<<<<< HEAD
-		delete_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME );
-=======
-		if ( $this->reviews_setting_changed ) {
-			delete_option( 'woocommerce_product_lookup_table_is_generating' );
-			as_unschedule_all_actions( '', array(), 'wc_update_product_lookup_tables' );
-
-			if ( null === $this->original_reviews_setting ) {
-				delete_option( 'woocommerce_enable_reviews' );
-			} else {
-				update_option( 'woocommerce_enable_reviews', $this->original_reviews_setting );
-			}
-		}
-
->>>>>>> bf74658ba5 (Enable variation galleries for all stores (#67884))
-		parent::tearDown();
-	}
-
-	/**
 	 * @testdox If 'wc_get_price_excluding_tax' gets an order as argument, it passes the order customer to 'WC_Tax::get_rates'.
 	 *
 	 * @testWith [true, 1, true]

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Blocks\Options as BlockOptions;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
+use Automattic\WooCommerce\Internal\VariationGallery\Package as VariationGalleryPackage;
 
 /**
  * Class WC_Core_Functions_Test
@@ -337,6 +338,29 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 		delete_option( 'woocommerce_feature_point_of_sale_enabled' );
 		wc_update_1100_enable_point_of_sale_feature();
 		$this->assertSame( 'yes', get_option( 'woocommerce_feature_point_of_sale_enabled' ) );
+	}
+
+	/**
+	 * @testdox Migration registers and removes the deprecated variation gallery feature option.
+	 */
+	public function test_wc_update_11101_remove_deprecated_variation_gallery_option(): void {
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		$db_updates = WC_Install::get_db_update_callbacks();
+		$this->assertArrayHasKey( '11.1.0-1', $db_updates );
+		$this->assertContains( 'wc_update_11101_remove_deprecated_variation_gallery_option', $db_updates['11.1.0-1'] );
+
+		delete_option( VariationGalleryPackage::ENABLE_OPTION_NAME );
+		wc_update_11101_remove_deprecated_variation_gallery_option();
+		$this->assertFalse( get_option( VariationGalleryPackage::ENABLE_OPTION_NAME ) );
+
+		update_option( VariationGalleryPackage::ENABLE_OPTION_NAME, 'no' );
+		wc_update_11101_remove_deprecated_variation_gallery_option();
+		$this->assertFalse( get_option( VariationGalleryPackage::ENABLE_OPTION_NAME ) );
+
+		update_option( VariationGalleryPackage::ENABLE_OPTION_NAME, 'yes' );
+		wc_update_11101_remove_deprecated_variation_gallery_option();
+		$this->assertFalse( get_option( VariationGalleryPackage::ENABLE_OPTION_NAME ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductGalleryUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/ProductGalleryUtilsTest.php
@@ -16,7 +16,6 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( ProductMediaGallery::ENABLE_OPTION_NAME );
-		delete_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME );
 		parent::tearDown();
 	}
 
@@ -24,8 +23,6 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	 * Test get_product_gallery_image_data method.
 	 */
 	public function test_get_product_gallery_image_data() {
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'yes' );
-
 		// Create the variable product.
 		$variable_product = \WC_Helper_Product::create_variation_product();
 
@@ -141,58 +138,9 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_product_variation_gallery_data returns the single-image
-	 * shape when the variation gallery feature flag is disabled, even when
-	 * the variation has multiple gallery images saved.
-	 */
-	public function test_get_product_variation_gallery_data_returns_single_image_when_feature_flag_disabled() {
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'no' );
-
-		$variable_product = \WC_Helper_Product::create_variation_product();
-
-		$variation_image_id = wp_insert_attachment(
-			array(
-				'post_title'     => 'Variation Featured Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-		update_post_meta( $variation_image_id, '_wp_attached_file', 'variation-featured.jpg' );
-
-		$variation_gallery_image_ids = array(
-			wp_insert_attachment(
-				array(
-					'post_title'     => 'Variation Gallery Image 1',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			),
-			wp_insert_attachment(
-				array(
-					'post_title'     => 'Variation Gallery Image 2',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			),
-		);
-
-		$variation = wc_get_product( $variable_product->get_children()[0] );
-		$variation->set_image_id( $variation_image_id );
-		$variation->set_gallery_image_ids( $variation_gallery_image_ids );
-		$variation->save();
-
-		$variation_entry = ProductGalleryUtils::get_product_variation_gallery_data( $variable_product )[ $variation->get_id() ];
-
-		$this->assertSame( $variation_image_id, $variation_entry['image_id'] );
-		$this->assertSame( array( $variation_image_id ), $variation_entry['image_ids'] );
-	}
-
-	/**
 	 * Test that variation gallery data falls back to the variation's own gallery when the variation featured image is stale.
 	 */
 	public function test_get_product_variation_gallery_data_falls_back_to_variation_gallery_when_featured_is_stale() {
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, 'yes' );
-
 		$variable_product     = \WC_Helper_Product::create_variation_product();
 		$parent_featured_id   = $this->create_image_attachment( 'Parent Featured Image', 'parent-featured.jpg' );
 		$stale_featured_id    = $this->create_image_attachment( 'Stale Variation Image', 'stale-featured.jpg' );
@@ -224,7 +172,7 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	/**
 	 * Variation has only its own featured image (no gallery) → the
 	 * variation featured replaces the parent's hero, parent gallery extras
-	 * stay. Applies whether the feature flag is on or off.
+	 * stay.
 	 */
 	public function test_get_product_variation_gallery_data_case_3_single_image_appends_parent_gallery_extras() {
 		$parent_featured_id     = $this->create_image_attachment( 'Parent Featured', 'parent-featured.jpg' );
@@ -246,8 +194,8 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Variation has its own featured plus gallery images (feature flag
-	 * on) → the variation's images replace the parent's entirely.
+	 * Variation has its own featured plus gallery images, so the variation's
+	 * images replace the parent's entirely.
 	 */
 	public function test_get_product_variation_gallery_data_case_4_multiple_images_replaces_parent_set() {
 		$parent_featured_id     = $this->create_image_attachment( 'Parent Featured', 'parent-featured.jpg' );
@@ -316,31 +264,6 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Feature flag off: Variation gallery is treated as empty even if rows exist in postmeta,
-	 * so the single-image rule applies (variation featured + parent gallery extras).
-	 */
-	public function test_get_product_variation_gallery_data_case_3_applies_with_feature_flag_off() {
-		$parent_featured_id     = $this->create_image_attachment( 'Parent Featured', 'parent-featured.jpg' );
-		$parent_gallery_extra   = $this->create_image_attachment( 'Parent Gallery Extra', 'parent-gallery-extra.jpg' );
-		$variation_featured_id  = $this->create_image_attachment( 'Variation Featured', 'variation-featured.jpg' );
-		$variation_gallery_id_a = $this->create_image_attachment( 'Variation Gallery A (ignored)', 'variation-gallery-a.jpg' );
-
-		$entry = $this->create_variation_gallery_entry(
-			$parent_featured_id,
-			array( $parent_gallery_extra ),
-			$variation_featured_id,
-			array( $variation_gallery_id_a ),
-			'no'
-		);
-
-		$this->assertSame( $variation_featured_id, $entry['image_id'] );
-		$this->assertSame(
-			array( $variation_featured_id, $parent_gallery_extra ),
-			$entry['image_ids']
-		);
-	}
-
-	/**
 	 * The variation featured is also present in the parent gallery — output
 	 * must dedup so the image doesn't render twice in a row.
 	 */
@@ -365,22 +288,18 @@ class ProductGalleryUtilsTest extends \WP_UnitTestCase {
 	/**
 	 * Create a variation gallery fixture and return the selected variation entry.
 	 *
-	 * @param int    $parent_featured_id    Parent product featured image ID.
-	 * @param int[]  $parent_gallery_ids    Parent product gallery image IDs.
-	 * @param int    $variation_featured_id Variation featured image ID.
-	 * @param int[]  $variation_gallery_ids Variation gallery image IDs.
-	 * @param string $feature_flag          Variation gallery feature flag value.
+	 * @param int   $parent_featured_id    Parent product featured image ID.
+	 * @param int[] $parent_gallery_ids    Parent product gallery image IDs.
+	 * @param int   $variation_featured_id Variation featured image ID.
+	 * @param int[] $variation_gallery_ids Variation gallery image IDs.
 	 * @return array<string, mixed>
 	 */
 	private function create_variation_gallery_entry(
 		int $parent_featured_id,
 		array $parent_gallery_ids = array(),
 		int $variation_featured_id = 0,
-		array $variation_gallery_ids = array(),
-		string $feature_flag = 'yes'
+		array $variation_gallery_ids = array()
 	): array {
-		update_option( \Automattic\WooCommerce\Internal\VariationGallery\Package::ENABLE_OPTION_NAME, $feature_flag );
-
 		$variable_product = \WC_Helper_Product::create_variation_product();
 		$variable_product->set_image_id( $parent_featured_id );
 		$variable_product->set_gallery_image_ids( $parent_gallery_ids );

--- a/plugins/woocommerce/tests/php/src/Internal/VariationGallery/PackageTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/VariationGallery/PackageTest.php
@@ -12,10 +12,28 @@ use Automattic\WooCommerce\Internal\VariationGallery\Package;
 class PackageTest extends \WC_Unit_Test_Case {
 
 	/**
+	 * Reset migration-related state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->reset_migration_state();
+	}
+
+	/**
 	 * Reset migration-related state between tests so action queue and
 	 * completion option don't leak across cases.
 	 */
 	public function tearDown(): void {
+		$this->reset_migration_state();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset migration-related options and scheduled actions.
+	 */
+	private function reset_migration_state(): void {
 		WC()->queue()->cancel_all(
 			'woocommerce_run_update_callback',
 			$this->get_migration_action_args(),
@@ -28,82 +46,22 @@ class PackageTest extends \WC_Unit_Test_Case {
 		);
 		delete_option( Migration::COMPLETED_OPTION );
 		delete_option( Package::ENABLE_OPTION_NAME );
-		delete_option( 'woocommerce_remote_variant_assignment' );
-
-		parent::tearDown();
 	}
 
 	/**
-	 * @testdox is_enabled honors an explicit 'yes' on the feature option.
+	 * @testdox is_enabled returns true now that the variation gallery is fully rolled out.
 	 */
-	public function test_is_enabled_returns_true_when_option_explicitly_yes(): void {
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-		update_option( 'woocommerce_remote_variant_assignment', 99 );
-
+	public function test_is_enabled_returns_true(): void {
 		$this->assertTrue( Package::is_enabled() );
 	}
 
 	/**
-	 * @testdox is_enabled honors an explicit 'no' on the feature option even when the store is in the canary cohort.
+	 * @testdox is_enabled returns true for a former explicit opt-out.
 	 */
-	public function test_is_enabled_returns_false_when_option_explicitly_no(): void {
+	public function test_is_enabled_returns_true_for_former_explicit_opt_out(): void {
 		update_option( Package::ENABLE_OPTION_NAME, 'no' );
-		update_option( 'woocommerce_remote_variant_assignment', 1 );
-
-		$this->assertFalse( Package::is_enabled() );
-	}
-
-	/**
-	 * @testdox is_enabled includes stores in the canary cohort when the option is unset.
-	 */
-	public function test_is_enabled_returns_true_for_canary_cohort_when_option_unset(): void {
-		delete_option( Package::ENABLE_OPTION_NAME );
-		update_option( 'woocommerce_remote_variant_assignment', 1 );
 
 		$this->assertTrue( Package::is_enabled() );
-	}
-
-	/**
-	 * @testdox is_enabled includes the last variant bucket in the canary cohort when the option is unset.
-	 */
-	public function test_is_enabled_returns_true_for_canary_cohort_boundary_when_option_unset(): void {
-		delete_option( Package::ENABLE_OPTION_NAME );
-		update_option( 'woocommerce_remote_variant_assignment', Package::CANARY_MAX_VARIANT );
-
-		$this->assertTrue( Package::is_enabled() );
-	}
-
-	/**
-	 * @testdox is_enabled excludes stores outside the canary cohort when the option is unset.
-	 */
-	public function test_is_enabled_returns_false_for_control_cohort_when_option_unset(): void {
-		delete_option( Package::ENABLE_OPTION_NAME );
-		update_option( 'woocommerce_remote_variant_assignment', Package::CANARY_MAX_VARIANT + 1 );
-
-		$this->assertFalse( Package::is_enabled() );
-	}
-
-	/**
-	 * @testdox is_enabled excludes stores with no variant assignment when the option is unset.
-	 */
-	public function test_is_enabled_returns_false_when_option_and_variant_unset(): void {
-		delete_option( Package::ENABLE_OPTION_NAME );
-		delete_option( 'woocommerce_remote_variant_assignment' );
-
-		$this->assertFalse( Package::is_enabled() );
-	}
-
-	/**
-	 * @testdox is_in_canary_cohort reports membership independently of the feature option.
-	 */
-	public function test_is_in_canary_cohort_is_independent_of_option_value(): void {
-		update_option( 'woocommerce_remote_variant_assignment', 1 );
-		update_option( Package::ENABLE_OPTION_NAME, 'no' );
-		$this->assertTrue( Package::is_in_canary_cohort() );
-
-		update_option( 'woocommerce_remote_variant_assignment', Package::CANARY_MAX_VARIANT + 1 );
-		update_option( Package::ENABLE_OPTION_NAME, 'yes' );
-		$this->assertFalse( Package::is_in_canary_cohort() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

> [!WARNING]
> Temporary CI verification PR. Do not merge.

Combine the exact variation-gallery backport commits from #67915 with the prerelease-safe install test fix from #67922, targeting `release/11.1`. This lets the release PHPUnit matrix confirm that `WC_Install_Test::test_version_check_schedules_db_auto_update` passes in the original `11.1.0-beta.1` context before the fix is backported normally.

Close this PR after CI provides the confirmation.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Bug introduced in PR #66522.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions and follow the WooCommerce Testing Instructions Guide. -->

1. Let the PHP unit-test matrix finish against the `release/11.1` merge result.
2. Confirm `WC_Install_Test::test_version_check_schedules_db_auto_update` passes in every PHP unit-test job where it runs.
3. Confirm the test no longer reports `Failed asserting that null is not null` at `class-wc-install-test.php`.
4. Compare the branch commits with #67915 and #67922 to confirm this PR contains only those two changes.
5. Use the manual variation-gallery testing instructions from #67915 for any product-level validation.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- The branch contains the two commits from #67915 followed by the test fix from #67922.
- A Git merge-tree check against the current `release/11.1` head completed without conflicts.
- PHP syntax and changed-code PHPCS passed for the test fix; `git diff --check` also passed.
- Local PHPUnit could not start because the active dependency policy rejected existing lockfile metadata and Docker was unavailable. This temporary PR exists to obtain the release CI confirmation.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually in the #67915 backport commits.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [x] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

OpenAI Codex was used to assemble the existing PR commits, verify the combined Git state, and prepare this temporary draft PR.
