### PR TITLE
Ensure inventory stock thresholds use consistent sanitization

### DIFF
--- a/plugins/woocommerce/changelog/fix-consistent-stock-threshold-sanitization
+++ b/plugins/woocommerce/changelog/fix-consistent-stock-threshold-sanitization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure low-stock thresholds are stored as non-negative integers.

--- a/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
@@ -34,7 +34,7 @@ class OptionSanitizer {
 				2
 			);
 		}
-		// Cast stock threshold fields to absolute integers to prevent storing empty values.
+		// Normalize stock threshold settings to non-negative integers.
 		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_low_stock_amount', 'absint' );
 		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount', 'absint' );
 	}

--- a/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
@@ -34,7 +34,8 @@ class OptionSanitizer {
 				2
 			);
 		}
-		// Cast "Out of stock threshold" field to absolute integer to prevent storing empty value.
+		// Cast stock threshold fields to absolute integers to prevent storing empty values.
+		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_low_stock_amount', 'absint' );
 		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount', 'absint' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Settings;
+
+use Automattic\WooCommerce\Internal\Settings\OptionSanitizer;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for OptionSanitizer.
+ */
+class OptionSanitizerTest extends WC_Unit_Test_Case {
+	/**
+	 * @testdox Stock thresholds are sanitized consistently as absolute integers.
+	 */
+	public function test_sanitizes_stock_thresholds_as_absolute_integers(): void {
+		new OptionSanitizer();
+
+		$low_stock_threshold = apply_filters(
+			'woocommerce_admin_settings_sanitize_option_woocommerce_notify_low_stock_amount',
+			'-2'
+		);
+		$no_stock_threshold  = apply_filters(
+			'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount',
+			''
+		);
+
+		$this->assertSame( 2, $low_stock_threshold, 'The low-stock threshold should be stored as an absolute integer.' );
+		$this->assertSame( 0, $no_stock_threshold, 'The out-of-stock threshold should be stored as an absolute integer.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
@@ -41,6 +41,7 @@ class OptionSanitizerTest extends WC_Unit_Test_Case {
 	public function stock_threshold_values_provider(): array {
 		return array(
 			'positive integer' => array( '3', 3 ),
+			'zero'             => array( '0', 0 ),
 			'negative integer' => array( '-2', 2 ),
 			'fraction'         => array( '2.9', 2 ),
 			'empty value'      => array( '', 0 ),

--- a/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Settings/OptionSanitizerTest.php
@@ -12,20 +12,39 @@ use WC_Unit_Test_Case;
 class OptionSanitizerTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Stock thresholds are sanitized consistently as absolute integers.
+	 * @dataProvider stock_threshold_values_provider
+	 *
+	 * @param string $value    Submitted threshold value.
+	 * @param int    $expected Expected sanitized value.
 	 */
-	public function test_sanitizes_stock_thresholds_as_absolute_integers(): void {
+	public function test_sanitizes_stock_thresholds_as_absolute_integers( string $value, int $expected ): void {
 		new OptionSanitizer();
 
 		$low_stock_threshold = apply_filters(
 			'woocommerce_admin_settings_sanitize_option_woocommerce_notify_low_stock_amount',
-			'-2'
+			$value
 		);
 		$no_stock_threshold  = apply_filters(
 			'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount',
-			''
+			$value
 		);
 
-		$this->assertSame( 2, $low_stock_threshold, 'The low-stock threshold should be stored as an absolute integer.' );
-		$this->assertSame( 0, $no_stock_threshold, 'The out-of-stock threshold should be stored as an absolute integer.' );
+		$this->assertSame( $expected, $low_stock_threshold, 'The low-stock threshold should be stored as an absolute integer.' );
+		$this->assertSame( $expected, $no_stock_threshold, 'The out-of-stock threshold should be stored as an absolute integer.' );
+	}
+
+	/**
+	 * Provides stock threshold values and their expected sanitized forms.
+	 *
+	 * @return array<string, array{string, int}>
+	 */
+	public function stock_threshold_values_provider(): array {
+		return array(
+			'positive integer' => array( '3', 3 ),
+			'negative integer' => array( '-2', 2 ),
+			'fraction'         => array( '2.9', 2 ),
+			'empty value'      => array( '', 0 ),
+			'non-numeric text' => array( 'invalid', 0 ),
+		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The out-of-stock inventory threshold is normalized as a non-negative integer before storage, while the equivalent low-stock threshold currently uses the default text-field handling. This change applies consistent integer sanitization to both inventory thresholds and adds regression coverage for invalid values.

Backward compatibility: valid non-negative integer inputs keep the same numeric meaning, but this option-specific sanitization filter now returns an integer instead of a cleaned numeric string, matching the existing out-of-stock threshold behavior. Negative, fractional, empty, or non-numeric values are normalized only when saved through the WooCommerce settings API; direct option writes are unaffected.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Start the PHP test environment with `pnpm --filter=@woocommerce/plugin-woocommerce env:test:start`.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env --filter OptionSanitizerTest`.
3. Confirm the stock-threshold sanitization test passes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Targeted `OptionSanitizerTest` PHPUnit test in the wp-env test container.
- Changed-file and full-branch PHP linting.
- Direct PHPCS validation of the new test file.
- PHPStan analysis of `OptionSanitizer.php`.
- Backward-compatibility review of the option-specific filter and settings-save path.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to help implement, test, and review this change. The resulting code and pull request were reviewed by the author.
