### PR TITLE
Hide CoD email instructions once payment is no longer outstanding

### DIFF
--- a/plugins/woocommerce/changelog/fix-55413-cod-email-instructions-after-completion
+++ b/plugins/woocommerce/changelog/fix-55413-cod-email-instructions-after-completion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop showing Cash on Delivery instructions in order emails once the order is completed, cancelled, refunded, or failed.

--- a/plugins/woocommerce/changelog/fix-55413-cod-email-instructions-after-completion
+++ b/plugins/woocommerce/changelog/fix-55413-cod-email-instructions-after-completion
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Stop showing Cash on Delivery instructions in order emails once the order is completed, cancelled, refunded, or failed.
+Stop showing Cash on Delivery instructions in order emails once the order is completed.

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -371,9 +371,33 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-		if ( $this->instructions && ! $sent_to_admin && $this->id === $order->get_payment_method() ) {
-			echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
+		if ( ! $this->instructions || $sent_to_admin || $this->id !== $order->get_payment_method() ) {
+			return;
 		}
+
+		/**
+		 * Filter the order statuses for which CoD instructions are included in emails.
+		 *
+		 * Payment for CoD orders is collected on delivery, so the instructions are only
+		 * relevant while payment is still outstanding.
+		 *
+		 * @since 11.2.0
+		 *
+		 * @param string[] $instructions_order_statuses Order statuses for which to show the
+		 *                                               instructions. Default array( 'pending', 'on-hold', 'processing' ).
+		 * @param WC_Order $order                        The order object.
+		 */
+		$instructions_order_statuses = apply_filters(
+			'woocommerce_cod_email_instructions_order_status',
+			array( OrderStatus::PENDING, OrderStatus::ON_HOLD, OrderStatus::PROCESSING ),
+			$order
+		);
+
+		if ( ! $order->has_status( $instructions_order_statuses ) ) {
+			return;
+		}
+
+		echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -371,33 +371,24 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-		if ( ! $this->instructions || $sent_to_admin || $this->id !== $order->get_payment_method() ) {
-			return;
+		if ( $this->instructions && ! $sent_to_admin && self::ID === $order->get_payment_method() ) {
+			/**
+			 * Filter the email instructions order statuses.
+			 *
+			 * @since 11.2.0
+			 *
+			 * @param string[] $statuses The default statuses.
+			 * @param object   $order    The order object.
+			 */
+			$instructions_order_statuses = apply_filters(
+				'woocommerce_cod_email_instructions_order_status',
+				array( OrderStatus::PENDING, OrderStatus::ON_HOLD, OrderStatus::PROCESSING ),
+				$order
+			);
+			if ( $order->has_status( $instructions_order_statuses ) ) {
+				echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
+			}
 		}
-
-		/**
-		 * Filter the order statuses for which CoD instructions are included in emails.
-		 *
-		 * Payment for CoD orders is collected on delivery, so the instructions are only
-		 * relevant while payment is still outstanding.
-		 *
-		 * @since 11.2.0
-		 *
-		 * @param string[] $instructions_order_statuses Order statuses for which to show the
-		 *                                               instructions. Default array( 'pending', 'on-hold', 'processing' ).
-		 * @param WC_Order $order                        The order object.
-		 */
-		$instructions_order_statuses = apply_filters(
-			'woocommerce_cod_email_instructions_order_status',
-			array( OrderStatus::PENDING, OrderStatus::ON_HOLD, OrderStatus::PROCESSING ),
-			$order
-		);
-
-		if ( ! $order->has_status( $instructions_order_statuses ) ) {
-			return;
-		}
-
-		echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -371,23 +371,8 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-		if ( $this->instructions && ! $sent_to_admin && self::ID === $order->get_payment_method() ) {
-			/**
-			 * Filter the email instructions order statuses.
-			 *
-			 * @since 11.2.0
-			 *
-			 * @param string[] $statuses The default statuses.
-			 * @param object   $order    The order object.
-			 */
-			$instructions_order_statuses = apply_filters(
-				'woocommerce_cod_email_instructions_order_status',
-				array( OrderStatus::PENDING, OrderStatus::ON_HOLD, OrderStatus::PROCESSING ),
-				$order
-			);
-			if ( $order->has_status( $instructions_order_statuses ) ) {
-				echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
-			}
+		if ( $this->instructions && ! $sent_to_admin && $this->id === $order->get_payment_method() && ! $order->has_status( OrderStatus::COMPLETED ) ) {
+			echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 		}
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/payment-gateways/cod.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/payment-gateways/cod.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Enums\OrderStatus;
 
 /**
  * Class WC_Tests_Payment_Gateway_COD
@@ -126,5 +127,85 @@ class WC_Tests_Payment_Gateway_COD extends WC_Unit_Test_Case {
 				$GLOBALS['wp']->query_vars['order-pay'] = $order_pay_query_var;
 			}
 		}
+	}
+
+	/**
+	 * Render the COD email instructions for an order with the given status.
+	 *
+	 * @param string $order_status  Status to set on the order.
+	 * @param bool   $sent_to_admin Whether the email is sent to the admin.
+	 * @return string The rendered output.
+	 */
+	private function get_email_instructions_output( $order_status, $sent_to_admin = false ) {
+		$gateway               = new WC_Gateway_COD();
+		$gateway->instructions = 'Please have exact change ready.';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( WC_Gateway_COD::ID );
+		$order->set_status( $order_status );
+		$order->save();
+
+		ob_start();
+		$gateway->email_instructions( $order, $sent_to_admin );
+		return ob_get_clean();
+	}
+
+	/**
+	 * @testdox Instructions are shown for orders where COD payment is still outstanding.
+	 *
+	 * @dataProvider provider_unpaid_order_statuses
+	 * @param string $order_status Status to set on the order.
+	 */
+	public function test_email_instructions_are_included_for_unpaid_orders( $order_status ) {
+		$output = $this->get_email_instructions_output( $order_status );
+
+		$this->assertStringContainsString(
+			'Please have exact change ready.',
+			$output,
+			"COD instructions should be shown for orders with the '{$order_status}' status"
+		);
+	}
+
+	/**
+	 * Order statuses for which COD payment has not been collected yet.
+	 *
+	 * @return array
+	 */
+	public function provider_unpaid_order_statuses() {
+		return array(
+			'pending'    => array( OrderStatus::PENDING ),
+			'on-hold'    => array( OrderStatus::ON_HOLD ),
+			'processing' => array( OrderStatus::PROCESSING ),
+		);
+	}
+
+	/**
+	 * @testdox Instructions are hidden once the order is settled and no longer awaiting payment.
+	 *
+	 * @dataProvider provider_settled_order_statuses
+	 * @param string $order_status Status to set on the order.
+	 */
+	public function test_email_instructions_are_omitted_for_settled_orders( $order_status ) {
+		$output = $this->get_email_instructions_output( $order_status );
+
+		$this->assertSame(
+			'',
+			$output,
+			"COD instructions should be hidden for orders with the '{$order_status}' status"
+		);
+	}
+
+	/**
+	 * Order statuses for which COD instructions are no longer relevant.
+	 *
+	 * @return array
+	 */
+	public function provider_settled_order_statuses() {
+		return array(
+			'completed' => array( OrderStatus::COMPLETED ),
+			'cancelled' => array( OrderStatus::CANCELLED ),
+			'refunded'  => array( OrderStatus::REFUNDED ),
+			'failed'    => array( OrderStatus::FAILED ),
+		);
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/payment-gateways/cod.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/payment-gateways/cod.php
@@ -151,12 +151,12 @@ class WC_Tests_Payment_Gateway_COD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Instructions are shown for orders where COD payment is still outstanding.
+	 * @testdox Instructions are shown while the order has not been completed.
 	 *
-	 * @dataProvider provider_unpaid_order_statuses
+	 * @dataProvider provider_non_completed_order_statuses
 	 * @param string $order_status Status to set on the order.
 	 */
-	public function test_email_instructions_are_included_for_unpaid_orders( $order_status ) {
+	public function test_email_instructions_are_included_for_non_completed_orders( $order_status ) {
 		$output = $this->get_email_instructions_output( $order_status );
 
 		$this->assertStringContainsString(
@@ -167,45 +167,27 @@ class WC_Tests_Payment_Gateway_COD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Order statuses for which COD payment has not been collected yet.
+	 * Order statuses that do not mark the order as completed.
 	 *
 	 * @return array
 	 */
-	public function provider_unpaid_order_statuses() {
+	public function provider_non_completed_order_statuses() {
 		return array(
 			'pending'    => array( OrderStatus::PENDING ),
 			'on-hold'    => array( OrderStatus::ON_HOLD ),
 			'processing' => array( OrderStatus::PROCESSING ),
+			'cancelled'  => array( OrderStatus::CANCELLED ),
+			'refunded'   => array( OrderStatus::REFUNDED ),
+			'failed'     => array( OrderStatus::FAILED ),
 		);
 	}
 
 	/**
-	 * @testdox Instructions are hidden once the order is settled and no longer awaiting payment.
-	 *
-	 * @dataProvider provider_settled_order_statuses
-	 * @param string $order_status Status to set on the order.
+	 * @testdox Instructions are hidden once the order is completed.
 	 */
-	public function test_email_instructions_are_omitted_for_settled_orders( $order_status ) {
-		$output = $this->get_email_instructions_output( $order_status );
+	public function test_email_instructions_are_omitted_for_completed_orders() {
+		$output = $this->get_email_instructions_output( OrderStatus::COMPLETED );
 
-		$this->assertSame(
-			'',
-			$output,
-			"COD instructions should be hidden for orders with the '{$order_status}' status"
-		);
-	}
-
-	/**
-	 * Order statuses for which COD instructions are no longer relevant.
-	 *
-	 * @return array
-	 */
-	public function provider_settled_order_statuses() {
-		return array(
-			'completed' => array( OrderStatus::COMPLETED ),
-			'cancelled' => array( OrderStatus::CANCELLED ),
-			'refunded'  => array( OrderStatus::REFUNDED ),
-			'failed'    => array( OrderStatus::FAILED ),
-		);
+		$this->assertSame( '', $output, 'COD instructions should be hidden for completed orders' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cash on Delivery instructions were displayed in customer order emails regardless of the order status, including after an order was completed, cancelled, refunded, or failed. This could be misleading, as payment may have already been collected or the order may no longer be active.

`WC_Gateway_COD::email_instructions()` now skips the instructions when the order has the `completed` status. Every other status is untouched, so the instructions still appear for `pending`, `on-hold`, `processing`, `cancelled`, `refunded` and `failed` orders exactly as before.


Closes #55413.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

#### Before

https://github.com/user-attachments/assets/7c421b60-57a5-4988-9fe8-588482c9d756

#### After

https://github.com/user-attachments/assets/2b36bf0d-a336-4762-a7e0-9aa9e8a76490

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Go to `WooCommerce → Settings → Payments → Take offline payments → Cash on delivery`, enable it, and set some text in the "Instructions" field.
2. Create an order paid via Cash on delivery with a valid billing email.
3. Set the status to **Processing** and resend the email (**Order actions → Send order details to customer**). Confirm the instructions appear.
4. Set the status to **Completed** and resend. Confirm the instructions are **not** in the email.
5. Set the status to **Cancelled**, then **Refunded**, then **Failed**, resending each time. Confirm the instructions still appear for all three — only completed orders omit them.

### Testing that has already taken place:

- Unit tests in `WC_Tests_Payment_Gateway_COD` cover both sides of the rule: instructions are rendered for `pending`, `on-hold`, `processing`, `cancelled`, `refunded` and `failed`, and omitted for `completed`.
- Manually verified on a local `wp-env` + Mailpit setup.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

This PR was developed with the assistance of Claude Code.
