### PR TITLE
Fix orphaned order notes when HPOS orders are deleted

### DIFF
--- a/plugins/woocommerce/changelog/fix-62620-hpos-order-notes-orphaned
+++ b/plugins/woocommerce/changelog/fix-62620-hpos-order-notes-orphaned
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Delete orphaned order notes (comments) when an order is permanently deleted with HPOS enabled and sync disabled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2713,6 +2713,19 @@ FROM $order_meta_table
 		);
 
 		if ( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE === $post_type ) {
+			// Delete order notes (comments) associated with this order before deleting the post,
+			// mirroring what wp_delete_post() does to ensure cache invalidation and meta cleanup.
+			$comments = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT comment_ID FROM {$wpdb->comments} WHERE comment_post_ID = %d",
+					$order_id
+				)
+			);
+
+			foreach ( $comments as $comment_id ) {
+				wp_delete_comment( $comment_id, true );
+			}
+
 			$wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->posts} WHERE ID=%d OR post_parent=%d",

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2708,24 +2708,23 @@ FROM $order_meta_table
 	protected function handle_order_deletion_with_sync_disabled( $order_id ): void {
 		global $wpdb;
 
+		// Notes are the order's own data, not the backup post's, so they shouldn't wait on a deferred post record.
+		$comments = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT comment_ID FROM {$wpdb->comments} WHERE comment_post_ID = %d",
+				$order_id
+			)
+		);
+
+		foreach ( $comments as $comment_id ) {
+			wp_delete_comment( $comment_id, true );
+		}
+
 		$post_type = $wpdb->get_var(
 			$wpdb->prepare( "SELECT post_type FROM {$wpdb->posts} WHERE ID=%d", $order_id )
 		);
 
 		if ( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE === $post_type ) {
-			// Delete order notes (comments) associated with this order before deleting the post,
-			// mirroring what wp_delete_post() does to ensure cache invalidation and meta cleanup.
-			$comments = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT comment_ID FROM {$wpdb->comments} WHERE comment_post_ID = %d",
-					$order_id
-				)
-			);
-
-			foreach ( $comments as $comment_id ) {
-				wp_delete_comment( $comment_id, true );
-			}
-
 			$wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->posts} WHERE ID=%d OR post_parent=%d",

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -4288,6 +4288,8 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$note_id  = $order->add_order_note( 'Test note' );
 		add_comment_meta( $note_id, 'test_key', 'test_value' );
 
+		$this->assertSame( 'test_value', get_comment_meta( $note_id, 'test_key', true ), 'Commentmeta should exist before the order is deleted' );
+
 		$expected_post_type = $sync_enabled_at_creation ? 'shop_order' : DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE;
 		$this->assertEquals( $expected_post_type, get_post_type( $order_id ) );
 
@@ -4295,32 +4297,6 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$order->delete( true );
 
 		$this->assertNull( get_comment( $note_id ), 'Order note should be deleted' );
-
-		global $wpdb;
-		$meta_count = $wpdb->get_var(
-			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->commentmeta} WHERE comment_id = %d", $note_id )
-		);
-		$this->assertEquals( 0, $meta_count, 'Commentmeta should be deleted along with the note' );
-	}
-
-	/**
-	 * @testDox When an order with a real (non-placeholder) post is deleted with sync disabled, the backup post record itself is preserved pending sync, alongside a deletion marker.
-	 */
-	public function test_backup_post_deferred_when_non_placeholder_order_deleted_with_sync_disabled() {
-		$this->allow_current_user_to_delete_posts();
-		$this->toggle_cot_feature_and_usage( true );
-		$this->toggle_cot_authoritative( true );
-		$this->enable_cot_sync();
-
-		$order    = OrderHelper::create_order();
-		$order_id = $order->get_id();
-
-		$this->assertNotEquals( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE, get_post_type( $order_id ) );
-
-		$this->disable_cot_sync();
-		$order->delete( true );
-
-		$this->assertNotNull( get_post( $order_id ), 'Backup post record should still exist, pending sync' );
-		$this->assert_deletion_record_existence( $order_id, true, true );
+		$this->assertEmpty( get_comment_meta( $note_id ), 'Commentmeta should be deleted along with the note' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -4265,4 +4265,84 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$order->delete();
 		$product->delete();
 	}
+
+	/**
+	 * @testDox When an order with a placeholder post is deleted with sync disabled, associated order notes (comments) are also deleted.
+	 */
+	public function test_order_notes_deleted_when_placeholder_order_deleted_with_sync_disabled() {
+		$this->allow_current_user_to_delete_posts();
+		$this->toggle_cot_feature_and_usage( true );
+		$this->toggle_cot_authoritative( true );
+		$this->disable_cot_sync();
+
+		$order = OrderHelper::create_order();
+		$order_id = $order->get_id();
+
+		// Add order notes.
+		$note1_id = $order->add_order_note( 'Test note 1' );
+		$note2_id = $order->add_order_note( 'Test note 2' );
+		$order->save();
+
+		// Verify notes exist.
+		$this->assertNotNull( get_comment( $note1_id ) );
+		$this->assertNotNull( get_comment( $note2_id ) );
+
+		// Verify this is a placeholder post type.
+		$post_type = get_post_type( $order_id );
+		$this->assertEquals( 'shop_order_placehold', $post_type );
+
+		// Delete the order.
+		$order->delete( true );
+
+		// Verify order notes are deleted.
+		$this->assertNull( get_comment( $note1_id ), 'Order note 1 should be deleted when placeholder order is deleted' );
+		$this->assertNull( get_comment( $note2_id ), 'Order note 2 should be deleted when placeholder order is deleted' );
+
+		// Verify commentmeta is also cleaned up.
+		global $wpdb;
+		$meta_count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->commentmeta} WHERE comment_id IN (%d, %d)",
+				$note1_id,
+				$note2_id
+			)
+		);
+		$this->assertEquals( 0, $meta_count, 'Commentmeta should be empty after notes are deleted' );
+	}
+
+	/**
+	 * @testDox When an order with a real post is deleted with sync disabled, order notes are preserved and a deletion marker is created.
+	 */
+	public function test_order_notes_preserved_when_non_placeholder_order_deleted_with_sync_disabled() {
+		$this->allow_current_user_to_delete_posts();
+		$this->toggle_cot_feature_and_usage( true );
+		$this->toggle_cot_authoritative( false );
+		$this->disable_cot_sync();
+
+		$order = OrderHelper::create_order();
+		$order_id = $order->get_id();
+
+		// Add an order note.
+		$note_id = $order->add_order_note( 'Test note for non-placeholder' );
+		$order->save();
+
+		$this->assertNotNull( get_comment( $note_id ) );
+
+		// Delete the order.
+		$order->delete( true );
+
+		// Verify the note is preserved (non-placeholder path keeps the post).
+		$this->assertNotNull( get_comment( $note_id ), 'Order note should be preserved when non-placeholder order is deleted with sync disabled' );
+
+		// Verify a deletion record was created.
+		global $wpdb;
+		$deletion_count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM " . self::get_meta_table_name() . " WHERE order_id = %d AND meta_key = %s",
+				$order_id,
+				\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::DELETED_RECORD_META_KEY
+			)
+		);
+		$this->assertGreaterThan( 0, $deletion_count, 'Deletion marker should exist for non-placeholder order' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -4267,82 +4267,60 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	}
 
 	/**
-	 * @testDox When an order with a placeholder post is deleted with sync disabled, associated order notes (comments) are also deleted.
+	 * @testDox Order notes (and their commentmeta) are deleted immediately when an order is deleted, regardless of whether sync was enabled when the order was created or when it's deleted.
+	 *
+	 * @testWith [false, false]
+	 *           [true, false]
+	 *           [false, true]
+	 *           [true, true]
+	 *
+	 * @param bool $sync_enabled_at_creation Whether sync was enabled when the order (and its backup post) was created.
+	 * @param bool $sync_enabled_at_deletion Whether sync is enabled when the order is deleted.
 	 */
-	public function test_order_notes_deleted_when_placeholder_order_deleted_with_sync_disabled() {
+	public function test_order_notes_deleted_regardless_of_sync_state( bool $sync_enabled_at_creation, bool $sync_enabled_at_deletion ) {
 		$this->allow_current_user_to_delete_posts();
 		$this->toggle_cot_feature_and_usage( true );
 		$this->toggle_cot_authoritative( true );
-		$this->disable_cot_sync();
+		$sync_enabled_at_creation ? $this->enable_cot_sync() : $this->disable_cot_sync();
 
-		$order = OrderHelper::create_order();
+		$order    = OrderHelper::create_order();
 		$order_id = $order->get_id();
+		$note_id  = $order->add_order_note( 'Test note' );
+		add_comment_meta( $note_id, 'test_key', 'test_value' );
 
-		// Add order notes.
-		$note1_id = $order->add_order_note( 'Test note 1' );
-		$note2_id = $order->add_order_note( 'Test note 2' );
-		$order->save();
+		$expected_post_type = $sync_enabled_at_creation ? 'shop_order' : DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE;
+		$this->assertEquals( $expected_post_type, get_post_type( $order_id ) );
 
-		// Verify notes exist.
-		$this->assertNotNull( get_comment( $note1_id ) );
-		$this->assertNotNull( get_comment( $note2_id ) );
-
-		// Verify this is a placeholder post type.
-		$post_type = get_post_type( $order_id );
-		$this->assertEquals( 'shop_order_placehold', $post_type );
-
-		// Delete the order.
+		$sync_enabled_at_deletion ? $this->enable_cot_sync() : $this->disable_cot_sync();
 		$order->delete( true );
 
-		// Verify order notes are deleted.
-		$this->assertNull( get_comment( $note1_id ), 'Order note 1 should be deleted when placeholder order is deleted' );
-		$this->assertNull( get_comment( $note2_id ), 'Order note 2 should be deleted when placeholder order is deleted' );
+		$this->assertNull( get_comment( $note_id ), 'Order note should be deleted' );
 
-		// Verify commentmeta is also cleaned up.
 		global $wpdb;
 		$meta_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->commentmeta} WHERE comment_id IN (%d, %d)",
-				$note1_id,
-				$note2_id
-			)
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->commentmeta} WHERE comment_id = %d", $note_id )
 		);
-		$this->assertEquals( 0, $meta_count, 'Commentmeta should be empty after notes are deleted' );
+		$this->assertEquals( 0, $meta_count, 'Commentmeta should be deleted along with the note' );
 	}
 
 	/**
-	 * @testDox When an order with a real post is deleted with sync disabled, order notes are preserved and a deletion marker is created.
+	 * @testDox When an order with a real (non-placeholder) post is deleted with sync disabled, the backup post record itself is preserved pending sync, alongside a deletion marker.
 	 */
-	public function test_order_notes_preserved_when_non_placeholder_order_deleted_with_sync_disabled() {
+	public function test_backup_post_deferred_when_non_placeholder_order_deleted_with_sync_disabled() {
 		$this->allow_current_user_to_delete_posts();
 		$this->toggle_cot_feature_and_usage( true );
-		$this->toggle_cot_authoritative( false );
-		$this->disable_cot_sync();
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
 
-		$order = OrderHelper::create_order();
+		$order    = OrderHelper::create_order();
 		$order_id = $order->get_id();
 
-		// Add an order note.
-		$note_id = $order->add_order_note( 'Test note for non-placeholder' );
-		$order->save();
+		$this->assertNotEquals( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE, get_post_type( $order_id ) );
 
-		$this->assertNotNull( get_comment( $note_id ) );
-
-		// Delete the order.
+		$this->disable_cot_sync();
 		$order->delete( true );
 
-		// Verify the note is preserved (non-placeholder path keeps the post).
-		$this->assertNotNull( get_comment( $note_id ), 'Order note should be preserved when non-placeholder order is deleted with sync disabled' );
-
-		// Verify a deletion record was created.
-		global $wpdb;
-		$deletion_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM " . self::get_meta_table_name() . " WHERE order_id = %d AND meta_key = %s",
-				$order_id,
-				\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::DELETED_RECORD_META_KEY
-			)
-		);
-		$this->assertGreaterThan( 0, $deletion_count, 'Deletion marker should exist for non-placeholder order' );
+		$this->assertNotNull( get_post( $order_id ), 'Backup post record should still exist, pending sync' );
+		$this->assert_deletion_record_existence( $order_id, true, true );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When HPOS is authoritative and sync is disabled, deleting an order left its notes (which are WP comments) behind in the database indefinitely, since they were only ever cleaned up as a side effect of the backup post's own deletion (which doesn't happen when sync is disabled).

This builds on the fix started in #66293, but addresses a few gaps (like deleting notes regardless of whether the backup post itself is deleted or not).

Closes #62620.

### How to test the changes in this Pull Request:

1. Enable HPOS with sync enabled: `wp wc hpos enable --with-sync`.
2. Create an order in the admin, add a private note to it, and permanently delete it right away (Trash → Delete Permanently). Confirm both the post and its notes are gone:
   ```
   # Should return nothing.
   wp db query "SELECT comment_ID FROM wp_comments WHERE comment_post_ID = <order_id>"

   # Should error out.
   wp post get <order_id>
   ```
3. Create new order (let's call it **Order A**). Once again, add a note, but don't delete the order. Confirm `wp post get <order_id>` shows `shop_order` as post type (a real post, not a placeholder).
4. Disable sync, keeping HPOS authoritative: `wp wc hpos compatibility-mode disable`.
5. Create a new order, **Order B**, and add a note. Confirm `wp post get <order_id>` shows `shop_order_placehold` as post type.
6. Permanently delete **Order B**. Confirm both the post (`wp post get <Order B ID>`) and its note (raw query as in step 2) are gone.
7. Permanently delete **Order A**. Confirm notes are gone immediately (use the query from step 2), but the backup post itself is still present (`wp post get <Order A ID>` still returns `shop_order`). This is expected, its cleanup is deferred to the sync process by design.
   _I will open other PRs for this and a few other improvements, but closing the delete gap with HPOS and no sync is more critical._
9. Re-enable sync and run `wp wc hpos sync`. Confirm the post for **Order A** is now gone too.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **next WooCommerce version**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.