### PR TITLE
Fix REST product category pagination undercounting hierarchical terms

### DIFF
--- a/plugins/woocommerce/changelog/fix-67934-rest-hierarchical-term-pagination
+++ b/plugins/woocommerce/changelog/fix-67934-rest-hierarchical-term-pagination
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Count hierarchical REST term collections from the same get_terms() population so empty parents with non-empty children stay paginated.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -326,23 +326,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$query_result = $this->get_terms_for_product( $prepared_args, $request );
 			$total_terms  = $this->total_terms;
 		} else {
-			$query_result = get_terms( $taxonomy, $prepared_args );
-
-			$count_args = $prepared_args;
-			unset( $count_args['number'] );
-			unset( $count_args['offset'] );
-			$total_terms = wp_count_terms( $taxonomy, $count_args );
-
-			// Ensure we don't return results when offset is out of bounds.
-			// See https://core.trac.wordpress.org/ticket/35935.
-			if ( $prepared_args['offset'] && $prepared_args['offset'] >= $total_terms ) {
-				$query_result = array();
-			}
-
-			// wp_count_terms can return a falsy value when the term has no children.
-			if ( ! $total_terms ) {
-				$total_terms = 0;
-			}
+			$query_result = $this->get_terms_for_response( $taxonomy, $prepared_args );
+			$total_terms  = $this->total_terms;
 		}
 		$response = array();
 		if ( is_array( $query_result ) ) {
@@ -633,6 +618,71 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 */
 	protected function update_term_meta_fields( $term, $request ) {
 		return true;
+	}
+
+	/**
+	 * Query terms for a REST collection using a total that matches the returned population.
+	 *
+	 * Hierarchical taxonomies keep empty parents that have non-empty children.
+	 * `wp_count_terms()` sets `fields=count`, which disables that handling and
+	 * undercounts. Pagination headers and the out-of-bounds guard then hide
+	 * those terms from later pages.
+	 *
+	 * @param string $taxonomy      Taxonomy name.
+	 * @param array  $prepared_args Arguments for `get_terms()`, including number and offset.
+	 * @return array List of term objects for the current page. Total count in `$this->total_terms`.
+	 */
+	protected function get_terms_for_response( $taxonomy, $prepared_args ) {
+		$number = isset( $prepared_args['number'] ) ? (int) $prepared_args['number'] : 0;
+		$offset = isset( $prepared_args['offset'] ) ? (int) $prepared_args['offset'] : 0;
+
+		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+			$count_args = $prepared_args;
+			unset( $count_args['number'], $count_args['offset'] );
+
+			$terms = get_terms( $taxonomy, $count_args );
+			if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
+				$this->total_terms = 0;
+				return array();
+			}
+
+			$this->total_terms = count( $terms );
+
+			if ( $number ) {
+				if ( $offset && $offset >= $this->total_terms ) {
+					return array();
+				}
+
+				return array_values( array_slice( $terms, $offset, $number ) );
+			}
+
+			return $terms;
+		}
+
+		$terms = get_terms( $taxonomy, $prepared_args );
+
+		$count_args = $prepared_args;
+		unset( $count_args['number'], $count_args['offset'] );
+		$total_terms = wp_count_terms( $taxonomy, $count_args );
+
+		// Ensure we don't return results when offset is out of bounds.
+		// See https://core.trac.wordpress.org/ticket/35935.
+		if ( $offset && $offset >= $total_terms ) {
+			$terms = array();
+		}
+
+		// wp_count_terms can return a falsy value when the term has no children.
+		if ( ! $total_terms ) {
+			$total_terms = 0;
+		}
+
+		$this->total_terms = (int) $total_terms;
+
+		if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
+			return array();
+		}
+
+		return $terms;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -633,19 +633,23 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @return array List of term objects for the current page. Total count in `$this->total_terms`.
 	 */
 	protected function get_terms_for_response( $taxonomy, $prepared_args ) {
-		$number = isset( $prepared_args['number'] ) ? (int) $prepared_args['number'] : 0;
-		$offset = isset( $prepared_args['offset'] ) ? (int) $prepared_args['offset'] : 0;
+		$number          = isset( $prepared_args['number'] ) ? (int) $prepared_args['number'] : 0;
+		$offset          = isset( $prepared_args['offset'] ) ? (int) $prepared_args['offset'] : 0;
+		$is_hierarchical = is_taxonomy_hierarchical( $taxonomy );
+		$query_args      = $prepared_args;
 
-		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
-			$count_args = $prepared_args;
-			unset( $count_args['number'], $count_args['offset'] );
+		if ( $is_hierarchical ) {
+			unset( $query_args['number'], $query_args['offset'] );
+		}
 
-			$terms = get_terms( $taxonomy, $count_args );
-			if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
-				$this->total_terms = 0;
-				return array();
-			}
+		$terms = get_terms( array_merge( $query_args, array( 'taxonomy' => $taxonomy ) ) );
 
+		if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
+			$this->total_terms = 0;
+			return array();
+		}
+
+		if ( $is_hierarchical ) {
 			$this->total_terms = count( $terms );
 
 			if ( $number ) {
@@ -659,11 +663,9 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			return $terms;
 		}
 
-		$terms = get_terms( $taxonomy, $prepared_args );
-
 		$count_args = $prepared_args;
 		unset( $count_args['number'], $count_args['offset'] );
-		$total_terms = wp_count_terms( $taxonomy, $count_args );
+		$total_terms = wp_count_terms( array_merge( $count_args, array( 'taxonomy' => $taxonomy ) ) );
 
 		// Ensure we don't return results when offset is out of bounds.
 		// See https://core.trac.wordpress.org/ticket/35935.
@@ -677,10 +679,6 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		}
 
 		$this->total_terms = (int) $total_terms;
-
-		if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
-			return array();
-		}
 
 		return $terms;
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
@@ -380,7 +380,7 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 
 		$page_one_data = $page_one->get_data();
 		$page_two_data = $page_two->get_data();
-		$returned_ids  = array_map( static fn( $term ) => (int) $term['id'], array_merge( $page_one_data, $page_two_data ) );
+		$returned_ids  = array_map( 'intval', wp_list_pluck( array_merge( $page_one_data, $page_two_data ), 'id' ) );
 
 		$this->assertEquals( 200, $page_one->get_status() );
 		$this->assertEquals( 200, $page_two->get_status() );
@@ -392,7 +392,7 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-TotalPages'] );
 		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id ), $returned_ids );
 
-		wp_delete_post( $fixture['product']->get_id(), true );
+		WC_Helper_Product::delete_product( $fixture['product']->get_id() );
 		wp_delete_term( $child_id, 'product_cat' );
 		wp_delete_term( $parent_id, 'product_cat' );
 	}
@@ -445,8 +445,8 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-TotalPages'] );
 		$this->assertContains( (int) $page_two_data[0]['id'], $parent_ids );
 
-		wp_delete_post( $first['product']->get_id(), true );
-		wp_delete_post( $second['product']->get_id(), true );
+		WC_Helper_Product::delete_product( $first['product']->get_id() );
+		WC_Helper_Product::delete_product( $second['product']->get_id() );
 		wp_delete_term( (int) $first['child']['term_id'], 'product_cat' );
 		wp_delete_term( (int) $second['child']['term_id'], 'product_cat' );
 		wp_delete_term( $parent_ids[0], 'product_cat' );
@@ -461,14 +461,11 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 	 */
 	private function create_empty_parent_with_nonempty_child( string $prefix ): array {
 		$parent = wp_insert_term( $prefix . ' Parent', 'product_cat' );
-		$this->assertIsArray( $parent );
-
-		$child = wp_insert_term(
+		$child  = wp_insert_term(
 			$prefix . ' Child',
 			'product_cat',
 			array( 'parent' => $parent['term_id'] )
 		);
-		$this->assertIsArray( $child );
 
 		$product = $this->create_test_product();
 		wp_set_object_terms( $product->get_id(), array( $child['term_id'] ), 'product_cat' );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller-test.php
@@ -327,4 +327,156 @@ class WC_REST_Product_Categories_Controller_Test extends WC_REST_Unit_Test_Case 
 
 		$this->assertEquals( 201, $response->get_status() );
 	}
+
+	/**
+	 * @testdox hide_empty pagination keeps empty parents that have non-empty children.
+	 */
+	public function test_hide_empty_pagination_includes_empty_parents_with_nonempty_children() {
+		$fixture   = $this->create_empty_parent_with_nonempty_child( '67934 Paginate ' . uniqid() );
+		$parent_id = (int) $fixture['parent']['term_id'];
+		$child_id  = (int) $fixture['child']['term_id'];
+
+		$full_response = $this->make_categories_request(
+			'',
+			array(
+				'hide_empty' => true,
+				'include'    => array( $parent_id, $child_id ),
+				'per_page'   => 100,
+				'page'       => 1,
+			)
+		);
+		$full_data     = $full_response->get_data();
+		$full_headers  = $full_response->get_headers();
+
+		$this->assertEquals( 200, $full_response->get_status() );
+		$this->assertCount( 2, $full_data );
+		$this->assertNotNull( $this->find_category_in_response( $full_data, $parent_id ) );
+		$this->assertNotNull( $this->find_category_in_response( $full_data, $child_id ) );
+		$this->assertSame( 2, (int) $full_headers['X-WP-Total'] );
+		$this->assertSame( 1, (int) $full_headers['X-WP-TotalPages'] );
+
+		$page_one = $this->make_categories_request(
+			'',
+			array(
+				'hide_empty' => true,
+				'include'    => array( $parent_id, $child_id ),
+				'orderby'    => 'name',
+				'order'      => 'asc',
+				'per_page'   => 1,
+				'page'       => 1,
+			)
+		);
+		$page_two = $this->make_categories_request(
+			'',
+			array(
+				'hide_empty' => true,
+				'include'    => array( $parent_id, $child_id ),
+				'orderby'    => 'name',
+				'order'      => 'asc',
+				'per_page'   => 1,
+				'page'       => 2,
+			)
+		);
+
+		$page_one_data = $page_one->get_data();
+		$page_two_data = $page_two->get_data();
+		$returned_ids  = array_map( static fn( $term ) => (int) $term['id'], array_merge( $page_one_data, $page_two_data ) );
+
+		$this->assertEquals( 200, $page_one->get_status() );
+		$this->assertEquals( 200, $page_two->get_status() );
+		$this->assertCount( 1, $page_one_data );
+		$this->assertCount( 1, $page_two_data, 'Page 2 must remain reachable when an empty parent has a non-empty child.' );
+		$this->assertSame( 2, (int) $page_one->get_headers()['X-WP-Total'] );
+		$this->assertSame( 2, (int) $page_one->get_headers()['X-WP-TotalPages'] );
+		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-Total'] );
+		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-TotalPages'] );
+		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id ), $returned_ids );
+
+		wp_delete_post( $fixture['product']->get_id(), true );
+		wp_delete_term( $child_id, 'product_cat' );
+		wp_delete_term( $parent_id, 'product_cat' );
+	}
+
+	/**
+	 * @testdox hide_empty parent=0 pagination keeps empty top-level parents that have non-empty children.
+	 */
+	public function test_hide_empty_parent_zero_pagination_includes_empty_parents() {
+		$first      = $this->create_empty_parent_with_nonempty_child( '67934 TopA ' . uniqid() );
+		$second     = $this->create_empty_parent_with_nonempty_child( '67934 TopB ' . uniqid() );
+		$parent_ids = array(
+			(int) $first['parent']['term_id'],
+			(int) $second['parent']['term_id'],
+		);
+
+		$full_response = $this->make_categories_request(
+			'',
+			array(
+				'hide_empty' => true,
+				'parent'     => 0,
+				'include'    => $parent_ids,
+				'per_page'   => 100,
+				'page'       => 1,
+			)
+		);
+		$full_data     = $full_response->get_data();
+
+		$this->assertEquals( 200, $full_response->get_status() );
+		$this->assertCount( 2, $full_data );
+		$this->assertSame( 2, (int) $full_response->get_headers()['X-WP-Total'] );
+		$this->assertSame( 1, (int) $full_response->get_headers()['X-WP-TotalPages'] );
+
+		$page_two = $this->make_categories_request(
+			'',
+			array(
+				'hide_empty' => true,
+				'parent'     => 0,
+				'include'    => $parent_ids,
+				'orderby'    => 'name',
+				'order'      => 'asc',
+				'per_page'   => 1,
+				'page'       => 2,
+			)
+		);
+		$page_two_data = $page_two->get_data();
+
+		$this->assertEquals( 200, $page_two->get_status() );
+		$this->assertCount( 1, $page_two_data, 'Page 2 of parent=0 must return the remaining empty parent.' );
+		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-Total'] );
+		$this->assertSame( 2, (int) $page_two->get_headers()['X-WP-TotalPages'] );
+		$this->assertContains( (int) $page_two_data[0]['id'], $parent_ids );
+
+		wp_delete_post( $first['product']->get_id(), true );
+		wp_delete_post( $second['product']->get_id(), true );
+		wp_delete_term( (int) $first['child']['term_id'], 'product_cat' );
+		wp_delete_term( (int) $second['child']['term_id'], 'product_cat' );
+		wp_delete_term( $parent_ids[0], 'product_cat' );
+		wp_delete_term( $parent_ids[1], 'product_cat' );
+	}
+
+	/**
+	 * Create an empty parent category whose child has a product assigned.
+	 *
+	 * @param string $prefix Unique name prefix.
+	 * @return array{parent: array, child: array, product: WC_Product_Simple}
+	 */
+	private function create_empty_parent_with_nonempty_child( string $prefix ): array {
+		$parent = wp_insert_term( $prefix . ' Parent', 'product_cat' );
+		$this->assertIsArray( $parent );
+
+		$child = wp_insert_term(
+			$prefix . ' Child',
+			'product_cat',
+			array( 'parent' => $parent['term_id'] )
+		);
+		$this->assertIsArray( $child );
+
+		$product = $this->create_test_product();
+		wp_set_object_terms( $product->get_id(), array( $child['term_id'] ), 'product_cat' );
+
+		return array(
+			'parent'  => $parent,
+			'child'   => $child,
+			'product' => $product,
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`GET /wc/v3/products/categories?hide_empty=true` builds the body with `get_terms()`, which keeps empty parent categories that have non-empty children. The collection total used a separate `wp_count_terms()` call. That path sets `fields=count`, which turns off hierarchical handling and undercounts those parents.

WooCommerce then writes `X-WP-Total` / `X-WP-TotalPages` from the low count and clears the body when `offset >= total`. With `per_page` equal to that undercount, page 2 is treated as out of bounds and the remaining valid categories never come back.

Hierarchical collections now count and paginate the same `get_terms()` population. Non-hierarchical taxonomies still use `wp_count_terms()`.

Fixes #67934

### How to test the changes in this Pull Request:

1. Create an empty parent product category and a child category under it.
2. Assign a published product only to the child. Leave the parent with no products of its own.
3. Call `GET /wp-json/wc/v3/products/categories?hide_empty=true&per_page=100&page=1`.
4. Confirm the empty parent is in the body and `X-WP-Total` equals the body count.
5. Call the same endpoint with `per_page` equal to that total minus 1, then request `page=2`.
6. Confirm page 2 returns the remaining category instead of an empty list, and that both pages report the same `X-WP-Total`.
7. Repeat with `parent=0` so only top-level categories are requested.

### Testing that has already taken place:

Added PHPUnit coverage in `WC_REST_Product_Categories_Controller_Test`:

- `hide_empty` pagination returns both the empty parent and its non-empty child, with matching totals.
- `parent=0` pagination still returns empty top-level parents that have non-empty children.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

A changelog file is already included: `plugins/woocommerce/changelog/fix-67934-rest-hierarchical-term-pagination`.
