### PR TITLE
Exclude payment settings from Blueprint exports

### DIFF
--- a/plugins/woocommerce/changelog/fix-blueprint-exclude-payment-settings
+++ b/plugins/woocommerce/changelog/fix-blueprint-exclude-payment-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude payment settings from Blueprint exports and clarify this in the export interface.

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -188,7 +188,7 @@ const Blueprint = () => {
 			<h4>{ __( 'Export', 'woocommerce' ) }</h4>
 			<p className="blueprint-settings-export-intro">
 				{ __(
-					'Select the settings, plugins, and themes to export as a .json file.',
+					'Select the settings, plugins, and themes to export as a .json file. Payment settings are not exported and must be configured manually after import.',
 					'woocommerce'
 				) }
 			</p>

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -45316,12 +45316,6 @@ parameters:
 			path: src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
 
 		-
-			message: '#^Argument of an invalid type string supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
-
-		-
 			message: '#^Property WooCommerce\:\:\$integrations \(WC_Integrations\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
@@ -9,7 +9,9 @@ use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
 use Automattic\WooCommerce\Blueprint\Steps\Step;
 
 /**
- * ExportWCPaymentGateways class
+ * Legacy payment gateways exporter.
+ *
+ * @deprecated 11.2.0 Payment settings are no longer included in Blueprint exports.
  */
 class ExportWCPaymentGateways implements StepExporter {
 	/**
@@ -25,17 +27,7 @@ class ExportWCPaymentGateways implements StepExporter {
 	 * @return Step
 	 */
 	public function export(): Step {
-		$options = array();
-		$this->maybe_hide_wcpay_gateways();
-		foreach ( $this->get_wc_payment_gateways() as $id => $payment_gateway ) {
-			if ( in_array( $id, $this->exclude_ids, true ) ) {
-				continue;
-			}
-
-			$options[ 'woocommerce_' . $id . '_settings' ] = $payment_gateway->settings;
-		}
-
-		return new SetSiteOptions( $options );
+		return new SetSiteOptions();
 	}
 
 	/**
@@ -82,7 +74,7 @@ class ExportWCPaymentGateways implements StepExporter {
 	 * @return string
 	 */
 	public function get_description() {
-		return __( 'Includes all settings in WooCommerce | Settings | Payments.', 'woocommerce' );
+		return __( 'Payment settings are not included in Blueprint exports.', 'woocommerce' );
 	}
 
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Admin\Features\Blueprint;
 
-use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCPaymentGateways;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsAccount;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsAdvanced;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsEmails;
@@ -80,7 +79,6 @@ class Init {
 			ExportWCSettingsProducts::class,
 			ExportWCSettingsTax::class,
 			ExportWCSettingsShipping::class,
-			ExportWCPaymentGateways::class,
 			ExportWCSettingsAccount::class,
 			ExportWCSettingsEmails::class,
 			ExportWCSettingsIntegrations::class,
@@ -197,7 +195,7 @@ class Init {
 		return array(
 			array(
 				'id'          => 'settings',
-				'description' => __( 'Includes all the items featured in WooCommerce | Settings.', 'woocommerce' ),
+				'description' => __( 'Includes WooCommerce settings except payment settings, which must be configured manually after import.', 'woocommerce' ),
 				'label'       => __( 'WooCommerce Settings', 'woocommerce' ),
 				'icon'        => 'settings',
 				'items'       => array_map(

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGatewaysTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGatewaysTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCPaymentGateways;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the legacy payment gateways Blueprint exporter.
+ */
+class ExportWCPaymentGatewaysTest extends WC_Unit_Test_Case {
+	/**
+	 * The System Under Test.
+	 *
+	 * @var ExportWCPaymentGateways
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new class() extends ExportWCPaymentGateways {
+			/**
+			 * Return a gateway containing representative settings.
+			 *
+			 * @return array
+			 */
+			public function get_wc_payment_gateways() {
+				return array(
+					'example' => (object) array(
+						'settings' => array(
+							'enabled' => 'yes',
+							'title'   => 'Example gateway',
+						),
+					),
+				);
+			}
+		};
+	}
+
+	/**
+	 * @testdox Should not export payment settings.
+	 */
+	public function test_export_returns_empty_options(): void {
+		$export = $this->sut->export()->prepare_json_array();
+
+		$this->assertEquals( (object) array(), $export['options'], 'Payment settings should not be included in Blueprint exports.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint;
 
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCPaymentGateways;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Init;
 use Automattic\WooCommerce\Tests\Admin\Features\Blueprint\Stubs\DummyExporter;
 use Automattic\WooCommerce\Tests\Admin\Features\Blueprint\Stubs\ThemeStub;
@@ -204,7 +205,7 @@ class InitTest extends MockeryTestCase {
 		$expected = array(
 			array(
 				'id'          => 'settings',
-				'description' => 'Includes all the items featured in WooCommerce | Settings.',
+				'description' => 'Includes WooCommerce settings except payment settings, which must be configured manually after import.',
 				'label'       => 'WooCommerce Settings',
 				'icon'        => 'settings',
 				'items'       => array(
@@ -233,6 +234,15 @@ class InitTest extends MockeryTestCase {
 		);
 
 		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * @testdox Should not register payment settings for Blueprint export.
+	 */
+	public function test_get_woo_exporters_excludes_payment_settings(): void {
+		$exporter_classes = array_map( 'get_class', $this->init->get_woo_exporters() );
+
+		$this->assertNotContains( ExportWCPaymentGateways::class, $exporter_classes, 'Payment settings must not be available as a Blueprint export step.' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

Payment configurations are store-specific and must be completed manually after a Blueprint import. This PR:

- removes Payments from the WooCommerce settings available for Blueprint export;
- keeps the legacy `ExportWCPaymentGateways` class loadable, but deprecates it and makes it return an empty `setSiteOptions` step; and
- updates the Blueprint interface guidance to explain that payment settings need manual configuration after import.

`ExportWCPaymentGateways` remains available for compatibility, but it is no longer registered by default. Direct consumers of the `wcPaymentGateways` exporter no longer receive payment settings. This is an intentional behavior change. The change introduces no new global-state or install-layout assumptions. It was tested on single-site; multisite was not tested.

Bug introduced in PR #54301.

### Screenshots or screen recordings

#### Updated export guidance

<img width="1280" height="720" alt="Blueprint export guidance showing payment settings must be configured manually" src="https://github.com/user-attachments/assets/277b0144-7e1b-4cb0-951a-a19480ae5f5f" />

#### WooCommerce settings available for export

<img width="1280" height="1430" alt="Expanded WooCommerce settings list without Payments" src="https://github.com/user-attachments/assets/ca73e72d-f3ee-4c27-b4e7-6e7239bcfefe" />

### How to test the changes in this Pull Request

1. Build and start WooCommerce with `pnpm wc:build` and `pnpm wc:env`.
2. If necessary, enable Blueprints under **WooCommerce > Settings > Advanced > Features**.
3. Visit **WooCommerce > Settings > Advanced > Blueprint**.
4. Verify the page explains that payment settings are not exported and shows nine WooCommerce settings groups.
5. Expand **WooCommerce Settings** and verify **Payments** is not listed.
6. Configure representative non-payment settings and a payment gateway, then export all nine WooCommerce settings groups.
7. Verify the exported Blueprint contains the non-payment values but no payment settings step, payment option, or payment value.
8. Import that exact file into a reset store in Coming Soon mode.
9. Verify the non-payment options and table-backed tax/shipping records were imported while the payment gateway remains unconfigured.
10. Run the focused PHP tests:

   ```sh
   pnpm test:php:env -- --filter '/(ExportWCPaymentGatewaysTest|InitTest)/'
   ```

### Testing that has already taken place

- Focused PHP tests in the wp-env test environment (PHP 8.1): 21 tests, 56 assertions.
- End-to-end CLI round trip using the exact exported file on a reset wp-env store.
- End-to-end admin REST round trip on a reset store in Coming Soon mode: all nine settings groups produced 19 steps (10 `setSiteOptions`, nine `runSql`), and all 19 import-step responses succeeded using the import session token.
- Verified imported general, product, tax, account, email, shipping-zone, shipping-method, shipping-rate, tax-class, tax-rate, and tax-location values. The deliberately fake BACS payment option and marker were absent from the export and remained absent after import.
- Rendered local verification of the updated guidance, group count, and expanded settings list.
- Full WooCommerce PHPStan analysis (2,081 files), including removal of the obsolete payment exporter baseline entry.
- Changed-file PHP lint and full branch JavaScript/PHP lint.
- Changelog validation.
- Full WooCommerce build.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

Codex was used to inspect the Blueprint export path, implement the change, add regression coverage, and run local verification. Darren reviewed the work and remains responsible for the change.

*\*left by Biff (AI agent) on behalf of Darren*
