### PR TITLE
Fix variation bulk actions racing unsaved changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-bulk-save-race
+++ b/plugins/woocommerce/changelog/fix-variation-bulk-save-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent bulk variation edits from racing unsaved variation changes.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -696,9 +696,10 @@ jQuery( function ( $ ) {
 		 * Check if have some changes before leave the page
 		 *
 		 * @param {Function} callback Called once saving is complete
+		 * @param {Function} onError  Called when saving fails
 		 * @return {Bool}
 		 */
-		check_for_changes: function ( callback ) {
+		check_for_changes: function ( callback, onError ) {
 			var need_update = $( '#variable_product_options' ).find(
 				'.woocommerce_variations .variation-needs-update'
 			);
@@ -710,15 +711,8 @@ jQuery( function ( $ ) {
 					)
 				) {
 					wc_meta_boxes_product_variations_ajax.save_changes(
-						function ( response, success ) {
-							if ( typeof callback === 'function' ) {
-								window.setTimeout( function () {
-									callback(
-										false === success ? false : response
-									);
-								}, 0 );
-							}
-						}
+						callback,
+						onError
 					);
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
@@ -846,13 +840,15 @@ jQuery( function ( $ ) {
 		 * Save variations changes
 		 *
 		 * @param {Function} callback Called once saving is complete
+		 * @param {Function} onError  Called when saving fails
 		 */
-		save_changes: function ( callback ) {
+		save_changes: function ( callback, onError ) {
 			var wrapper = $( '#variable_product_options' ).find(
 					'.woocommerce_variations'
 				),
 				need_update = $( '.variation-needs-update', wrapper ),
-				data = {};
+				data = {},
+				request;
 
 			// Save only with products need update.
 			if ( 0 < need_update.length ) {
@@ -868,11 +864,11 @@ jQuery( function ( $ ) {
 					woocommerce_admin_meta_boxes_variations.post_id;
 				data[ 'product-type' ] = $( '#product-type' ).val();
 
-				$.ajax( {
+				request = $.ajax( {
 					url: woocommerce_admin_meta_boxes_variations.ajax_url,
 					data: data,
 					type: 'POST',
-					success: function ( response ) {
+					success: function () {
 						// Allow change page, delete and add new variations
 						need_update.removeClass( 'variation-needs-update' );
 						$(
@@ -882,20 +878,20 @@ jQuery( function ( $ ) {
 						$( '#woocommerce-product-data' ).trigger(
 							'woocommerce_variations_saved'
 						);
-
-						if ( typeof callback === 'function' ) {
-							callback( response, true );
-						}
-					},
-					error: function () {
-						if ( typeof callback === 'function' ) {
-							callback( null, false );
-						}
-					},
-					complete: function () {
-						wc_meta_boxes_product_variations_ajax.unblock();
 					},
 				} );
+
+				request.always( function () {
+					wc_meta_boxes_product_variations_ajax.unblock();
+				} );
+
+				if ( typeof callback === 'function' ) {
+					request.done( callback );
+				}
+
+				if ( typeof onError === 'function' ) {
+					request.fail( onError );
+				}
 			}
 		},
 
@@ -910,13 +906,8 @@ jQuery( function ( $ ) {
 			);
 
 			wc_meta_boxes_product_variations_ajax.save_changes( function (
-				error,
-				success
+				error
 			) {
-				if ( false === success ) {
-					return;
-				}
-
 				var wrapper = $( '#variable_product_options' ).find(
 						'.woocommerce_variations'
 					),
@@ -962,11 +953,7 @@ jQuery( function ( $ ) {
 		/**
 		 * After saved, continue with form submission
 		 */
-		save_on_submit_done: function ( response, success ) {
-			if ( false === success ) {
-				return;
-			}
-
+		save_on_submit_done: function () {
 			var postForm = $( 'form#post' ),
 				callerid = postForm.data( 'callerid' );
 
@@ -1408,12 +1395,7 @@ jQuery( function ( $ ) {
 					break;
 			}
 
-			var run_bulk_action = function ( response ) {
-				if ( false === response ) {
-					$( '#field_to_edit' ).val( 'bulk_actions' );
-					return;
-				}
-
+			var run_bulk_action = function () {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				$.ajax( {
@@ -1453,7 +1435,10 @@ jQuery( function ( $ ) {
 					run_bulk_action();
 				} else if (
 					! wc_meta_boxes_product_variations_ajax.check_for_changes(
-						run_bulk_action
+						run_bulk_action,
+						function () {
+							$( '#field_to_edit' ).val( 'bulk_actions' );
+						}
 					)
 				) {
 					need_update.addClass( 'variation-needs-update' );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -709,15 +709,17 @@ jQuery( function ( $ ) {
 						woocommerce_admin_meta_boxes_variations.i18n_edited_variations
 					)
 				) {
-					wc_meta_boxes_product_variations_ajax.save_changes( function (
-						response
-					) {
-						if ( typeof callback === 'function' ) {
-							window.setTimeout( function () {
-								callback( response );
-							}, 0 );
+					wc_meta_boxes_product_variations_ajax.save_changes(
+						function ( response, success ) {
+							if ( typeof callback === 'function' ) {
+								window.setTimeout( function () {
+									callback(
+										false === success ? false : response
+									);
+								}, 0 );
+							}
 						}
-					} );
+					);
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
 					return false;
@@ -882,7 +884,12 @@ jQuery( function ( $ ) {
 						);
 
 						if ( typeof callback === 'function' ) {
-							callback( response );
+							callback( response, true );
+						}
+					},
+					error: function () {
+						if ( typeof callback === 'function' ) {
+							callback( null, false );
 						}
 					},
 					complete: function () {
@@ -903,8 +910,13 @@ jQuery( function ( $ ) {
 			);
 
 			wc_meta_boxes_product_variations_ajax.save_changes( function (
-				error
+				error,
+				success
 			) {
+				if ( false === success ) {
+					return;
+				}
+
 				var wrapper = $( '#variable_product_options' ).find(
 						'.woocommerce_variations'
 					),
@@ -950,7 +962,11 @@ jQuery( function ( $ ) {
 		/**
 		 * After saved, continue with form submission
 		 */
-		save_on_submit_done: function () {
+		save_on_submit_done: function ( response, success ) {
+			if ( false === success ) {
+				return;
+			}
+
 			var postForm = $( 'form#post' ),
 				callerid = postForm.data( 'callerid' );
 
@@ -1242,6 +1258,9 @@ jQuery( function ( $ ) {
 		do_variation_action: function () {
 			var do_variation_action = $( this ).val(),
 				data = {},
+				need_update = $( '#variable_product_options' ).find(
+					'.woocommerce_variations .variation-needs-update'
+				),
 				changes = 0,
 				value,
 				cancel = false;
@@ -1389,7 +1408,12 @@ jQuery( function ( $ ) {
 					break;
 			}
 
-			var run_bulk_action = function () {
+			var run_bulk_action = function ( response ) {
+				if ( false === response ) {
+					$( '#field_to_edit' ).val( 'bulk_actions' );
+					return;
+				}
+
 				wc_meta_boxes_product_variations_ajax.block();
 
 				$.ajax( {
@@ -1423,13 +1447,16 @@ jQuery( function ( $ ) {
 					$( '#variable_product_options' )
 						.find( '.variation-needs-update' )
 						.removeClass( 'variation-needs-update' );
-					$( '.generate_variations' ).text( 'Generate variations' );
+					$( '.generate_variations' ).text(
+						woocommerce_admin_meta_boxes_variations.i18n_generate_variations
+					);
 					run_bulk_action();
 				} else if (
 					! wc_meta_boxes_product_variations_ajax.check_for_changes(
 						run_bulk_action
 					)
 				) {
+					need_update.addClass( 'variation-needs-update' );
 					$( '#field_to_edit' ).val( 'bulk_actions' );
 				}
 			}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -884,7 +884,8 @@ jQuery( function ( $ ) {
 						if ( typeof callback === 'function' ) {
 							callback( response );
 						}
-
+					},
+					complete: function () {
 						wc_meta_boxes_product_variations_ajax.unblock();
 					},
 				} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -695,9 +695,10 @@ jQuery( function ( $ ) {
 		/**
 		 * Check if have some changes before leave the page
 		 *
+		 * @param {Function} callback Called once saving is complete
 		 * @return {Bool}
 		 */
-		check_for_changes: function () {
+		check_for_changes: function ( callback ) {
 			var need_update = $( '#variable_product_options' ).find(
 				'.woocommerce_variations .variation-needs-update'
 			);
@@ -708,11 +709,21 @@ jQuery( function ( $ ) {
 						woocommerce_admin_meta_boxes_variations.i18n_edited_variations
 					)
 				) {
-					wc_meta_boxes_product_variations_ajax.save_changes();
+					wc_meta_boxes_product_variations_ajax.save_changes( function (
+						response
+					) {
+						if ( typeof callback === 'function' ) {
+							window.setTimeout( function () {
+								callback( response );
+							}, 0 );
+						}
+					} );
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
 					return false;
 				}
+			} else if ( typeof callback === 'function' ) {
+				callback();
 			}
 
 			return true;
@@ -1377,18 +1388,7 @@ jQuery( function ( $ ) {
 					break;
 			}
 
-			if ( cancel ) {
-				$( '#field_to_edit' ).val( 'bulk_actions' );
-			} else {
-				if ( 'delete_all' === do_variation_action && data.allowed ) {
-					$( '#variable_product_options' )
-						.find( '.variation-needs-update' )
-						.removeClass( 'variation-needs-update' );
-					$( '.generate_variations' ).text( 'Generate variations' );
-				} else {
-					wc_meta_boxes_product_variations_ajax.check_for_changes();
-				}
-
+			var run_bulk_action = function () {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				$.ajax( {
@@ -1413,6 +1413,24 @@ jQuery( function ( $ ) {
 						$( '#field_to_edit' ).val( 'bulk_actions' );
 					}
 				});
+			};
+
+			if ( cancel ) {
+				$( '#field_to_edit' ).val( 'bulk_actions' );
+			} else {
+				if ( 'delete_all' === do_variation_action && data.allowed ) {
+					$( '#variable_product_options' )
+						.find( '.variation-needs-update' )
+						.removeClass( 'variation-needs-update' );
+					$( '.generate_variations' ).text( 'Generate variations' );
+					run_bulk_action();
+				} else if (
+					! wc_meta_boxes_product_variations_ajax.check_for_changes(
+						run_bulk_action
+					)
+				) {
+					$( '#field_to_edit' ).val( 'bulk_actions' );
+				}
 			}
 		},
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -593,6 +593,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_scheduled_sale_end'             => esc_js( __( 'Sale end date (YYYY-MM-DD format or leave blank)', 'woocommerce' ) ),
 					'i18n_scheduled_sale_end_before_start' => esc_js( __( 'The sale end date cannot be earlier than the sale start date.', 'woocommerce' ) ),
 					'i18n_edited_variations'              => esc_js( __( 'Save changes before changing page?', 'woocommerce' ) ),
+					'i18n_generate_variations'            => esc_js( __( 'Generate variations', 'woocommerce' ) ),
 					'i18n_variation_count_single'         => esc_js( __( '1 variation', 'woocommerce' ) ),
 					'i18n_variation_count_plural'         => esc_js( __( '%qty% variations', 'woocommerce' ) ),
 					'i18n_variation_cost_remove_warning'  => esc_js( __( 'The custom cost of goods sold values will revert back to their defaults for all the variations. Would you like to continue?', 'woocommerce' ) ),

--- a/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
@@ -32,6 +32,8 @@ const lowStockAmount = '10';
 let productId_indivEdit: number,
 	productId_bulkEdit: number,
 	productId_bulkEditAfterSave: number,
+	productId_bulkEditAfterFailedSave: number,
+	productId_bulkEditAfterDismissedSave: number,
 	productId_deleteAll: number,
 	productId_manageStock: number,
 	productId_variationDefaults: number,
@@ -84,6 +86,27 @@ async function gotToVariationsTab( page: Page ) {
 	} );
 }
 
+async function waitForSignal(
+	signal: Promise< void >,
+	failureMessage: string
+) {
+	let timeoutId: ReturnType< typeof setTimeout > | undefined;
+	const timeout = new Promise< never >( ( _, reject ) => {
+		timeoutId = setTimeout(
+			() => reject( new Error( failureMessage ) ),
+			5_000
+		);
+	} );
+
+	try {
+		await Promise.race( [ signal, timeout ] );
+	} finally {
+		if ( timeoutId ) {
+			clearTimeout( timeoutId );
+		}
+	}
+}
+
 test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -111,6 +134,26 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 
 			await createVariations(
 				productId_bulkEditAfterSave,
+				sampleVariations
+			);
+		} );
+
+		await test.step( 'Create variable product for failed save before bulk edit test', async () => {
+			productId_bulkEditAfterFailedSave =
+				await createVariableProduct( productAttributes );
+
+			await createVariations(
+				productId_bulkEditAfterFailedSave,
+				sampleVariations
+			);
+		} );
+
+		await test.step( 'Create variable product for dismissed save before bulk edit test', async () => {
+			productId_bulkEditAfterDismissedSave =
+				await createVariableProduct( productAttributes );
+
+			await createVariations(
+				productId_bulkEditAfterDismissedSave,
 				sampleVariations
 			);
 		} );
@@ -414,7 +457,10 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 			if ( action === 'woocommerce_save_variations' ) {
 				requests.push( action );
 				markSaveRequestStarted();
-				await saveRequestReleased;
+				await waitForSignal(
+					saveRequestReleased,
+					'Timed out waiting to release the variation save request.'
+				);
 			} else if ( action === 'woocommerce_bulk_edit_variations' ) {
 				requests.push( action );
 				markBulkRequestStarted();
@@ -458,7 +504,10 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Confirm the bulk request waits for the variation save.', async () => {
-			await saveRequestStarted;
+			await waitForSignal(
+				saveRequestStarted,
+				'Timed out waiting for the variation save request to start.'
+			);
 			await page.evaluate(
 				() =>
 					new Promise( ( resolve ) =>
@@ -471,7 +520,10 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 			expect( requests ).toEqual( [ 'woocommerce_save_variations' ] );
 
 			releaseSaveRequest();
-			await bulkRequestStarted;
+			await waitForSignal(
+				bulkRequestStarted,
+				'Timed out waiting for the bulk edit request to start.'
+			);
 
 			expect( requests ).toEqual( [
 				'woocommerce_save_variations',
@@ -480,24 +532,177 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Confirm the bulk price remains after both requests complete.', async () => {
-			await page.waitForFunction(
-				() =>
-					! document.querySelector(
-						'#woocommerce-product-data .blockUI'
-					)
+			await expect( async () => {
+				await expect(
+					page.locator( '#woocommerce-product-data .blockUI' )
+				).toHaveCount( 0 );
+				await page
+					.getByRole( 'link', { name: 'Expand' } )
+					.first()
+					.click();
+
+				const priceInputs = page.getByRole( 'textbox', {
+					name: 'Regular price',
+				} );
+				const count = await priceInputs.count();
+
+				expect( count ).toBeGreaterThan( 0 );
+
+				for ( let index = 0; index < count; index++ ) {
+					await expect( priceInputs.nth( index ) ).toHaveValue(
+						variationThreePrice
+					);
+				}
+			} ).toPass();
+		} );
+	} );
+
+	test( 'does not bulk edit when saving unsaved variation changes fails', async ( {
+		page,
+	} ) => {
+		let bulkRequestCount = 0;
+		let markSaveRequestFailed: () => void = () => {};
+		const saveRequestFailed = new Promise< void >( ( resolve ) => {
+			markSaveRequestFailed = resolve;
+		} );
+
+		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
+			const data = new URLSearchParams(
+				route.request().postData() ?? ''
 			);
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const action = data.get( 'action' );
 
-			const priceInputs = page.getByRole( 'textbox', {
-				name: 'Regular price',
-			} );
-			const count = await priceInputs.count();
-
-			for ( let index = 0; index < count; index++ ) {
-				await expect( priceInputs.nth( index ) ).toHaveValue(
-					variationThreePrice
-				);
+			if ( action === 'woocommerce_save_variations' ) {
+				await route.fulfill( {
+					status: 500,
+					contentType: 'text/plain',
+					body: 'Variation save failed',
+				} );
+				markSaveRequestFailed();
+				return;
 			}
+
+			if ( action === 'woocommerce_bulk_edit_variations' ) {
+				bulkRequestCount++;
+			}
+
+			await route.continue();
+		} );
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productId_bulkEditAfterFailedSave }&action=edit#variable_product_options`
+			);
+		} );
+
+		await gotToVariationsTab( page );
+
+		const firstVariation = page.locator( '.woocommerce_variation' ).first();
+
+		await test.step( 'Edit a variation without saving.', async () => {
+			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			await firstVariation
+				.getByRole( 'textbox', { name: 'Regular price' } )
+				.fill( variationTwoPrice );
+			await expect( firstVariation ).toHaveClass(
+				/variation-needs-update/
+			);
+		} );
+
+		await test.step( 'Start a bulk price update.', async () => {
+			page.on( 'dialog', async ( dialog ) => {
+				await dialog.accept(
+					dialog.type() === 'prompt' ? variationThreePrice : undefined
+				);
+			} );
+
+			await page
+				.locator( '#field_to_edit' )
+				.selectOption( 'variable_regular_price' );
+		} );
+
+		await test.step( 'Keep the bulk action cancelled after the save fails.', async () => {
+			await waitForSignal(
+				saveRequestFailed,
+				'Timed out waiting for the variation save request to fail.'
+			);
+			await expect( page.locator( '#field_to_edit' ) ).toHaveValue(
+				'bulk_actions'
+			);
+			await expect(
+				page.locator( '#woocommerce-product-data .blockUI' )
+			).toHaveCount( 0 );
+			await expect( firstVariation ).toHaveClass(
+				/variation-needs-update/
+			);
+			expect( bulkRequestCount ).toBe( 0 );
+		} );
+	} );
+
+	test( 'keeps unsaved variation changes when the save prompt is dismissed', async ( {
+		page,
+	} ) => {
+		let bulkRequestCount = 0;
+
+		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
+			const data = new URLSearchParams(
+				route.request().postData() ?? ''
+			);
+
+			if ( data.get( 'action' ) === 'woocommerce_bulk_edit_variations' ) {
+				bulkRequestCount++;
+			}
+
+			await route.continue();
+		} );
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productId_bulkEditAfterDismissedSave }&action=edit#variable_product_options`
+			);
+		} );
+
+		await gotToVariationsTab( page );
+
+		const firstVariation = page.locator( '.woocommerce_variation' ).first();
+		const regularPrice = firstVariation.getByRole( 'textbox', {
+			name: 'Regular price',
+		} );
+
+		await test.step( 'Edit a variation without saving.', async () => {
+			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			await regularPrice.fill( variationTwoPrice );
+			await expect( firstVariation ).toHaveClass(
+				/variation-needs-update/
+			);
+		} );
+
+		await test.step( 'Dismiss the save confirmation before a bulk edit.', async () => {
+			page.on( 'dialog', async ( dialog ) => {
+				if ( dialog.type() === 'prompt' ) {
+					await dialog.accept( variationThreePrice );
+				} else {
+					await dialog.dismiss();
+				}
+			} );
+
+			await page
+				.locator( '#field_to_edit' )
+				.selectOption( 'variable_regular_price' );
+		} );
+
+		await test.step( 'Keep the unsaved variation available for a later save.', async () => {
+			await expect( page.locator( '#field_to_edit' ) ).toHaveValue(
+				'bulk_actions'
+			);
+			await expect( firstVariation ).toHaveClass(
+				/variation-needs-update/
+			);
+			await expect( regularPrice ).toHaveValue( variationTwoPrice );
+			await expect(
+				page.getByRole( 'button', { name: 'Save changes' } )
+			).toBeEnabled();
+			expect( bulkRequestCount ).toBe( 0 );
 		} );
 	} );
 

--- a/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
@@ -31,6 +31,7 @@ const lowStockAmount = '10';
 
 let productId_indivEdit: number,
 	productId_bulkEdit: number,
+	productId_bulkEditAfterSave: number,
 	productId_deleteAll: number,
 	productId_manageStock: number,
 	productId_variationDefaults: number,
@@ -102,6 +103,16 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 				await createVariableProduct( productAttributes );
 
 			await createVariations( productId_bulkEdit, sampleVariations );
+		} );
+
+		await test.step( 'Create variable product for bulk edit after save test', async () => {
+			productId_bulkEditAfterSave =
+				await createVariableProduct( productAttributes );
+
+			await createVariations(
+				productId_bulkEditAfterSave,
+				sampleVariations
+			);
 		} );
 
 		await test.step( 'Create variable product for "delete all" test', async () => {
@@ -373,6 +384,119 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 
 			for ( let i = 0; i < count; i++ ) {
 				await expect( checkBoxes.nth( i ) ).toBeChecked();
+			}
+		} );
+	} );
+
+	test( 'waits for unsaved variation changes before bulk editing', async ( {
+		page,
+	} ) => {
+		const requests: string[] = [];
+		let releaseSaveRequest: () => void = () => {};
+		let markSaveRequestStarted: () => void = () => {};
+		let markBulkRequestStarted: () => void = () => {};
+		const saveRequestReleased = new Promise< void >( ( resolve ) => {
+			releaseSaveRequest = resolve;
+		} );
+		const saveRequestStarted = new Promise< void >( ( resolve ) => {
+			markSaveRequestStarted = resolve;
+		} );
+		const bulkRequestStarted = new Promise< void >( ( resolve ) => {
+			markBulkRequestStarted = resolve;
+		} );
+
+		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
+			const data = new URLSearchParams(
+				route.request().postData() ?? ''
+			);
+			const action = data.get( 'action' );
+
+			if ( action === 'woocommerce_save_variations' ) {
+				requests.push( action );
+				markSaveRequestStarted();
+				await saveRequestReleased;
+			} else if ( action === 'woocommerce_bulk_edit_variations' ) {
+				requests.push( action );
+				markBulkRequestStarted();
+			}
+
+			await route.continue();
+		} );
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productId_bulkEditAfterSave }&action=edit#variable_product_options`
+			);
+		} );
+
+		await gotToVariationsTab( page );
+
+		await test.step( 'Edit a variation without saving.', async () => {
+			const firstVariation = page
+				.locator( '.woocommerce_variation' )
+				.first();
+
+			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			await firstVariation
+				.getByRole( 'textbox', { name: 'Regular price' } )
+				.fill( variationTwoPrice );
+			await expect( firstVariation ).toHaveClass(
+				/variation-needs-update/
+			);
+		} );
+
+		await test.step( 'Start a bulk price update.', async () => {
+			page.on( 'dialog', async ( dialog ) => {
+				await dialog.accept(
+					dialog.type() === 'prompt' ? variationThreePrice : undefined
+				);
+			} );
+
+			await page
+				.locator( '#field_to_edit' )
+				.selectOption( 'variable_regular_price' );
+		} );
+
+		await test.step( 'Confirm the bulk request waits for the variation save.', async () => {
+			await saveRequestStarted;
+			await page.evaluate(
+				() =>
+					new Promise( ( resolve ) =>
+						requestAnimationFrame( () =>
+							requestAnimationFrame( resolve )
+						)
+					)
+			);
+
+			expect( requests ).toEqual( [ 'woocommerce_save_variations' ] );
+
+			releaseSaveRequest();
+			await bulkRequestStarted;
+
+			expect( requests ).toEqual( [
+				'woocommerce_save_variations',
+				'woocommerce_bulk_edit_variations',
+			] );
+		} );
+
+		await test.step( 'Confirm the bulk price remains after both requests complete.', async () => {
+			await page.waitForFunction(
+				() =>
+					! document.querySelector(
+						'#woocommerce-product-data .blockUI'
+					)
+			);
+			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+
+			const priceInputs = page.getByRole( 'textbox', {
+				name: 'Regular price',
+			} );
+			const count = await priceInputs.count();
+
+			for ( let index = 0; index < count; index++ ) {
+				await expect( priceInputs.nth( index ) ).toHaveValue(
+					variationThreePrice
+				);
 			}
 		} );
 	} );

--- a/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
+++ b/plugins/woocommerce/tests/e2e/tests/product/update-variations.spec.ts
@@ -33,7 +33,6 @@ let productId_indivEdit: number,
 	productId_bulkEdit: number,
 	productId_bulkEditAfterSave: number,
 	productId_bulkEditAfterFailedSave: number,
-	productId_bulkEditAfterDismissedSave: number,
 	productId_deleteAll: number,
 	productId_manageStock: number,
 	productId_variationDefaults: number,
@@ -86,27 +85,6 @@ async function gotToVariationsTab( page: Page ) {
 	} );
 }
 
-async function waitForSignal(
-	signal: Promise< void >,
-	failureMessage: string
-) {
-	let timeoutId: ReturnType< typeof setTimeout > | undefined;
-	const timeout = new Promise< never >( ( _, reject ) => {
-		timeoutId = setTimeout(
-			() => reject( new Error( failureMessage ) ),
-			5_000
-		);
-	} );
-
-	try {
-		await Promise.race( [ signal, timeout ] );
-	} finally {
-		if ( timeoutId ) {
-			clearTimeout( timeoutId );
-		}
-	}
-}
-
 test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
@@ -144,16 +122,6 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 
 			await createVariations(
 				productId_bulkEditAfterFailedSave,
-				sampleVariations
-			);
-		} );
-
-		await test.step( 'Create variable product for dismissed save before bulk edit test', async () => {
-			productId_bulkEditAfterDismissedSave =
-				await createVariableProduct( productAttributes );
-
-			await createVariations(
-				productId_bulkEditAfterDismissedSave,
 				sampleVariations
 			);
 		} );
@@ -434,18 +402,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 	test( 'waits for unsaved variation changes before bulk editing', async ( {
 		page,
 	} ) => {
-		const requests: string[] = [];
+		let saveRequestStarted = false;
+		let bulkRequestCount = 0;
 		let releaseSaveRequest: () => void = () => {};
-		let markSaveRequestStarted: () => void = () => {};
-		let markBulkRequestStarted: () => void = () => {};
 		const saveRequestReleased = new Promise< void >( ( resolve ) => {
 			releaseSaveRequest = resolve;
-		} );
-		const saveRequestStarted = new Promise< void >( ( resolve ) => {
-			markSaveRequestStarted = resolve;
-		} );
-		const bulkRequestStarted = new Promise< void >( ( resolve ) => {
-			markBulkRequestStarted = resolve;
 		} );
 
 		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
@@ -455,15 +416,10 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 			const action = data.get( 'action' );
 
 			if ( action === 'woocommerce_save_variations' ) {
-				requests.push( action );
-				markSaveRequestStarted();
-				await waitForSignal(
-					saveRequestReleased,
-					'Timed out waiting to release the variation save request.'
-				);
+				saveRequestStarted = true;
+				await saveRequestReleased;
 			} else if ( action === 'woocommerce_bulk_edit_variations' ) {
-				requests.push( action );
-				markBulkRequestStarted();
+				bulkRequestCount++;
 			}
 
 			await route.continue();
@@ -504,67 +460,33 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Confirm the bulk request waits for the variation save.', async () => {
-			await waitForSignal(
-				saveRequestStarted,
-				'Timed out waiting for the variation save request to start.'
-			);
-			await page.evaluate(
-				() =>
-					new Promise( ( resolve ) =>
-						requestAnimationFrame( () =>
-							requestAnimationFrame( resolve )
+			await expect.poll( () => saveRequestStarted ).toBe( true );
+
+			try {
+				await page.evaluate(
+					() =>
+						new Promise( ( resolve ) =>
+							requestAnimationFrame( () =>
+								requestAnimationFrame( resolve )
+							)
 						)
-					)
+				);
+				expect( bulkRequestCount ).toBe( 0 );
+			} finally {
+				releaseSaveRequest();
+			}
+
+			await expect.poll( () => bulkRequestCount ).toBe( 1 );
+			await expect( page.locator( '#field_to_edit' ) ).toHaveValue(
+				'bulk_actions'
 			);
-
-			expect( requests ).toEqual( [ 'woocommerce_save_variations' ] );
-
-			releaseSaveRequest();
-			await waitForSignal(
-				bulkRequestStarted,
-				'Timed out waiting for the bulk edit request to start.'
-			);
-
-			expect( requests ).toEqual( [
-				'woocommerce_save_variations',
-				'woocommerce_bulk_edit_variations',
-			] );
-		} );
-
-		await test.step( 'Confirm the bulk price remains after both requests complete.', async () => {
-			await expect( async () => {
-				await expect(
-					page.locator( '#woocommerce-product-data .blockUI' )
-				).toHaveCount( 0 );
-				await page
-					.getByRole( 'link', { name: 'Expand' } )
-					.first()
-					.click();
-
-				const priceInputs = page.getByRole( 'textbox', {
-					name: 'Regular price',
-				} );
-				const count = await priceInputs.count();
-
-				expect( count ).toBeGreaterThan( 0 );
-
-				for ( let index = 0; index < count; index++ ) {
-					await expect( priceInputs.nth( index ) ).toHaveValue(
-						variationThreePrice
-					);
-				}
-			} ).toPass();
 		} );
 	} );
 
-	test( 'does not bulk edit when saving unsaved variation changes fails', async ( {
+	test( 'does not bulk edit when saving variation changes fails', async ( {
 		page,
 	} ) => {
 		let bulkRequestCount = 0;
-		let markSaveRequestFailed: () => void = () => {};
-		const saveRequestFailed = new Promise< void >( ( resolve ) => {
-			markSaveRequestFailed = resolve;
-		} );
 
 		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
 			const data = new URLSearchParams(
@@ -578,7 +500,6 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 					contentType: 'text/plain',
 					body: 'Variation save failed',
 				} );
-				markSaveRequestFailed();
 				return;
 			}
 
@@ -622,10 +543,6 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Keep the bulk action cancelled after the save fails.', async () => {
-			await waitForSignal(
-				saveRequestFailed,
-				'Timed out waiting for the variation save request to fail.'
-			);
 			await expect( page.locator( '#field_to_edit' ) ).toHaveValue(
 				'bulk_actions'
 			);
@@ -635,73 +552,6 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 			await expect( firstVariation ).toHaveClass(
 				/variation-needs-update/
 			);
-			expect( bulkRequestCount ).toBe( 0 );
-		} );
-	} );
-
-	test( 'keeps unsaved variation changes when the save prompt is dismissed', async ( {
-		page,
-	} ) => {
-		let bulkRequestCount = 0;
-
-		await page.route( '**/wp-admin/admin-ajax.php', async ( route ) => {
-			const data = new URLSearchParams(
-				route.request().postData() ?? ''
-			);
-
-			if ( data.get( 'action' ) === 'woocommerce_bulk_edit_variations' ) {
-				bulkRequestCount++;
-			}
-
-			await route.continue();
-		} );
-
-		await test.step( 'Go to the "Edit product" page.', async () => {
-			await page.goto(
-				`wp-admin/post.php?post=${ productId_bulkEditAfterDismissedSave }&action=edit#variable_product_options`
-			);
-		} );
-
-		await gotToVariationsTab( page );
-
-		const firstVariation = page.locator( '.woocommerce_variation' ).first();
-		const regularPrice = firstVariation.getByRole( 'textbox', {
-			name: 'Regular price',
-		} );
-
-		await test.step( 'Edit a variation without saving.', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
-			await regularPrice.fill( variationTwoPrice );
-			await expect( firstVariation ).toHaveClass(
-				/variation-needs-update/
-			);
-		} );
-
-		await test.step( 'Dismiss the save confirmation before a bulk edit.', async () => {
-			page.on( 'dialog', async ( dialog ) => {
-				if ( dialog.type() === 'prompt' ) {
-					await dialog.accept( variationThreePrice );
-				} else {
-					await dialog.dismiss();
-				}
-			} );
-
-			await page
-				.locator( '#field_to_edit' )
-				.selectOption( 'variable_regular_price' );
-		} );
-
-		await test.step( 'Keep the unsaved variation available for a later save.', async () => {
-			await expect( page.locator( '#field_to_edit' ) ).toHaveValue(
-				'bulk_actions'
-			);
-			await expect( firstVariation ).toHaveClass(
-				/variation-needs-update/
-			);
-			await expect( regularPrice ).toHaveValue( variationTwoPrice );
-			await expect(
-				page.getByRole( 'button', { name: 'Save changes' } )
-			).toBeEnabled();
 			expect( bulkRequestCount ).toBe( 0 );
 		} );
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Variation bulk actions could start while unsaved variation changes were still being saved. The two requests could then finish out of order, allowing the older save request to overwrite the successful bulk edit.

This change waits for the variation save to succeed before starting the bulk action. Cancelling the save confirmation also prevents the bulk request from running.

The regression test holds the save request open and verifies that the bulk edit does not begin until the save is released. It then confirms that the final bulk price remains applied to every variation.

Closes #67901.

### How to test the changes in this Pull Request:

1. Create a variable product with at least two variations.
2. Change a variation field without selecting **Save changes**.
3. Select **Regular prices** from the bulk actions menu and confirm the save prompt.
4. Enter a bulk price.
5. Confirm that the save completes first and the bulk price remains applied to every variation.
6. Repeat the flow but cancel the save prompt. Confirm that no bulk edit is applied.

### Testing that has already taken place:

Tested in the WooCommerce E2E environment with WordPress, WooCommerce trunk, the default theme, and generated variable products.

* The new browser regression test failed against the original code because both requests started concurrently.
* The regression test passes with this change and verifies request order plus persisted prices.
* The focused test completed with 3 passing checks and 1 skipped setup check.
* ESLint for the legacy variation script passes.
* The changed JavaScript lint task passes with no errors.
* Prettier and `git diff --check` pass.
* Classic assets and WooCommerce Admin builds pass.

A broader run of the existing variation suite found one unrelated current trunk failure in `can set variation defaults`. The same missing `Colour` label failure reproduces when that test is run by itself.

### Milestone

- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**

### Changelog entry

A patch fix changelog file is included in this branch.

### Release Communication

No release communication label is required.
