### PR TITLE
Fix duplicate orders created by concurrent checkout submissions

### DIFF
--- a/plugins/woocommerce/changelog/fix-checkout-concurrent-duplicate-orders
+++ b/plugins/woocommerce/changelog/fix-checkout-concurrent-duplicate-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate orders being created when concurrent checkout submissions (double-clicks, load-balancer or proxy retries on timeout) race each other, by serializing order creation per shopper. Applies to both the classic/shortcode checkout and the block-based Checkout block / Store API.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1500,7 +1500,7 @@ class WC_Checkout {
 				 * through the gateway call itself, unlike the creation lock, because that call is exactly what
 				 * this is protecting.
 				 */
-				$payment_lock       = wc_get_container()->get( CheckoutOrderLock::class );
+				$payment_lock       = new CheckoutOrderLock( CheckoutOrderLock::PAYMENT_STALE_LOCK_THRESHOLD );
 				$payment_lock_key   = 'order_payment_' . $order_id;
 				$payment_lock_token = $payment_lock->acquire( $payment_lock_key );
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1447,17 +1447,23 @@ class WC_Checkout {
 					if ( WC()->session instanceof WC_Session_Handler ) {
 						wp_cache_delete( WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP ) . $lock_key, WC_SESSION_CACHE_GROUP );
 						$persisted_session_data = WC()->session->get_session( $lock_key );
-						if ( is_array( $persisted_session_data ) && array_key_exists( 'order_awaiting_payment', $persisted_session_data ) ) {
-							WC()->session->set( 'order_awaiting_payment', $persisted_session_data['order_awaiting_payment'] );
+						if ( is_array( $persisted_session_data ) ) {
+							// Absent, not just present-and-different, matters here: with no key at all in the
+							// persisted store, an in-memory value from earlier in this request would otherwise
+							// survive the refresh unchanged and create_order() could resume an order the persisted
+							// session no longer references. set( ..., null ) clears it the same way an absent key
+							// already means "no pending order" everywhere else this value is read.
+							WC()->session->set( 'order_awaiting_payment', $persisted_session_data['order_awaiting_payment'] ?? null );
 						}
 					}
 
 					$order_id = $this->create_order( $posted_data );
-					$order    = wc_get_order( $order_id );
 
 					if ( is_wp_error( $order_id ) ) {
 						throw new Exception( $order_id->get_error_message() );
 					}
+
+					$order = wc_get_order( $order_id );
 
 					if ( ! $order ) {
 						throw new Exception( __( 'Unable to create order.', 'woocommerce' ) );
@@ -1483,20 +1489,44 @@ class WC_Checkout {
 					array( 'order_object' => $order )
 				);
 
-				/**
-				 * Note that woocommerce_cart_needs_payment is only used in
-				 * WC_Checkout::process_checkout() to keep backwards compatibility.
-				 * Use woocommerce_order_needs_payment instead.
-				 *
-				 * Note that at this point you can't rely on the Cart Object anymore,
-				 * since it could be empty see:
-				 * https://github.com/woocommerce/woocommerce/issues/24631
+				/*
+				 * The order-creation lock above is released before this point specifically so a slow or off-site
+				 * gateway can never hold it - but that means a request that was waiting on it, and resumed this
+				 * same order rather than creating a new one, reaches this exact point too. Without a separate
+				 * claim scoped to this order, both requests would independently decide the order needs payment and
+				 * both call the gateway, which can charge a non-idempotent gateway twice for one order. Keyed by
+				 * order ID (not by shopper, like the creation lock above) since this is guarding "only one caller
+				 * may process payment for order N", not "only one caller may create shopper X's order". Held
+				 * through the gateway call itself, unlike the creation lock, because that call is exactly what
+				 * this is protecting.
 				 */
+				$payment_lock       = wc_get_container()->get( CheckoutOrderLock::class );
+				$payment_lock_key   = 'order_payment_' . $order_id;
+				$payment_lock_token = $payment_lock->acquire( $payment_lock_key );
 
-				if ( apply_filters( 'woocommerce_cart_needs_payment', $order->needs_payment(), WC()->cart ) ) {
-					$this->process_order_payment( $order_id, $posted_data['payment_method'] );
-				} else {
-					$this->process_order_without_payment( $order_id );
+				if ( null === $payment_lock_token ) {
+					throw new Exception( __( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ) );
+				}
+
+				try {
+					/**
+					 * Note that woocommerce_cart_needs_payment is only used in
+					 * WC_Checkout::process_checkout() to keep backwards compatibility.
+					 * Use woocommerce_order_needs_payment instead.
+					 *
+					 * Note that at this point you can't rely on the Cart Object anymore,
+					 * since it could be empty see:
+					 * https://github.com/woocommerce/woocommerce/issues/24631
+					 *
+					 * @since 3.0.0 or earlier
+					 */
+					if ( apply_filters( 'woocommerce_cart_needs_payment', $order->needs_payment(), WC()->cart ) ) {
+						$this->process_order_payment( $order_id, $posted_data['payment_method'] );
+					} else {
+						$this->process_order_without_payment( $order_id );
+					}
+				} finally {
+					$payment_lock->release( $payment_lock_key, $payment_lock_token );
 				}
 			}
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -10,6 +10,7 @@
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Internal\Checkout\CheckoutOrderLock;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
 use Automattic\WooCommerce\Internal\Tax\TaxRateDataStore;
 
@@ -1408,15 +1409,58 @@ class WC_Checkout {
 
 			if ( empty( $posted_data['woocommerce_checkout_update_totals'] ) && 0 === wc_notice_count( 'error' ) ) {
 				$this->process_customer( $posted_data );
-				$order_id = $this->create_order( $posted_data );
-				$order    = wc_get_order( $order_id );
 
-				if ( is_wp_error( $order_id ) ) {
-					throw new Exception( $order_id->get_error_message() );
+				/*
+				 * Concurrent submissions for the same shopper (double-clicks, proxy/load-balancer retries on
+				 * timeout) would otherwise all read an empty 'order_awaiting_payment' session value and each
+				 * create their own order, since that session value isn't written until process_order_payment()
+				 * runs - after create_order() has already returned. Serialize that whole window per shopper, and
+				 * make the pending-order reference durable before releasing, so a request that was waiting resumes
+				 * this order instead of creating a duplicate. Released well before process_order_payment() calls
+				 * out to the payment gateway, which can hang or redirect off-site.
+				 */
+				$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+				$lock_key      = (string) WC()->session->get_customer_id();
+				$lock_token    = $checkout_lock->acquire( $lock_key );
+
+				if ( null === $lock_token ) {
+					throw new Exception( __( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ) );
 				}
 
-				if ( ! $order ) {
-					throw new Exception( __( 'Unable to create order.', 'woocommerce' ) );
+				try {
+					/*
+					 * WC_Session only ever reads its own in-memory copy of the session data, loaded once when this
+					 * request started - it is never re-fetched mid-request. If this request was just waiting on the
+					 * lock above, the request that held it may have written a fresh 'order_awaiting_payment' to the
+					 * persisted session store after this request's copy was already loaded, so that write would
+					 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
+					 * stale copy of the rest of the session) so create_order()'s own pending-order check, a few
+					 * lines below, sees it and resumes that order instead of also creating one.
+					 */
+					if ( WC()->session instanceof WC_Session_Handler ) {
+						$persisted_session_data = WC()->session->get_session( $lock_key );
+						if ( is_array( $persisted_session_data ) && array_key_exists( 'order_awaiting_payment', $persisted_session_data ) ) {
+							WC()->session->set( 'order_awaiting_payment', $persisted_session_data['order_awaiting_payment'] );
+						}
+					}
+
+					$order_id = $this->create_order( $posted_data );
+					$order    = wc_get_order( $order_id );
+
+					if ( is_wp_error( $order_id ) ) {
+						throw new Exception( $order_id->get_error_message() );
+					}
+
+					if ( ! $order ) {
+						throw new Exception( __( 'Unable to create order.', 'woocommerce' ) );
+					}
+
+					WC()->session->set( 'order_awaiting_payment', $order_id );
+					if ( WC()->session instanceof WC_Session_Handler ) {
+						WC()->session->save_data();
+					}
+				} finally {
+					$checkout_lock->release( $lock_key, $lock_token );
 				}
 
 				wc_log_order_step(

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1508,6 +1508,20 @@ class WC_Checkout {
 					throw new Exception( __( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ) );
 				}
 
+				// A successful payment ends in wp_safe_redirect()+exit or wp_send_json() (which also terminates
+				// via wp_die()) inside process_order_payment(), neither of which runs a pending finally block - so
+				// on the common, successful path the release() below would never run, leaving this row in
+				// wp_options permanently (STALE_LOCK_THRESHOLD only lets a *future* contender take it over, it
+				// never deletes an abandoned row nobody else ever asks for again). WordPress's own 'shutdown'
+				// action (registered via register_shutdown_function() in core) still fires after exit(), same
+				// pattern WC_Cache_Helper::delete_transients_on_shutdown() already uses elsewhere - hook it as a
+				// guaranteed fallback release. release() is safe to call twice: the finally below, on any path
+				// that returns normally instead, releases first, and this just won't match a row by then.
+				$release_payment_lock_on_shutdown = function () use ( $payment_lock, $payment_lock_key, $payment_lock_token ) {
+					$payment_lock->release( $payment_lock_key, $payment_lock_token );
+				};
+				add_action( 'shutdown', $release_payment_lock_on_shutdown );
+
 				try {
 					/**
 					 * Note that woocommerce_cart_needs_payment is only used in

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1436,8 +1436,16 @@ class WC_Checkout {
 					 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
 					 * stale copy of the rest of the session) so create_order()'s own pending-order check, a few
 					 * lines below, sees it and resumes that order instead of also creating one.
+					 *
+					 * get_session() is itself cache-aware ($wpdb is only queried on a cache miss), and this
+					 * request's own session bootstrap (restore_session_data(), on every request via 'init') already
+					 * called it once for this exact customer before checkout ever ran - the concurrent holder's
+					 * write can easily land after that, leaving a stale cached copy under this key regardless of
+					 * whether the cache is the default per-request store or a shared backend like Redis. Evict it
+					 * first so get_session() is forced to hit the database rather than that stale entry.
 					 */
 					if ( WC()->session instanceof WC_Session_Handler ) {
+						wp_cache_delete( WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP ) . $lock_key, WC_SESSION_CACHE_GROUP );
 						$persisted_session_data = WC()->session->get_session( $lock_key );
 						if ( is_array( $persisted_session_data ) && array_key_exists( 'order_awaiting_payment', $persisted_session_data ) ) {
 							WC()->session->set( 'order_awaiting_payment', $persisted_session_data['order_awaiting_payment'] );

--- a/plugins/woocommerce/src/Internal/Checkout/CheckoutOrderLock.php
+++ b/plugins/woocommerce/src/Internal/Checkout/CheckoutOrderLock.php
@@ -66,12 +66,56 @@ class CheckoutOrderLock {
 	const STALE_LOCK_THRESHOLD = 30.0;
 
 	/**
+	 * A staleness threshold calibrated for a lock held through a synchronous payment-gateway call, rather than
+	 * STALE_LOCK_THRESHOLD's order-creation-oriented default. A gateway's own HTTP call to its payment processor
+	 * can legitimately run well past 30 seconds (retries, 3-D Secure round trips, a slow processor) without the
+	 * request having crashed, and taking over a lock still held by a genuinely in-flight call would reintroduce
+	 * the exact double-charge race the lock exists to prevent. Pass to the constructor for a lock instance guarding
+	 * payment processing specifically; resolve it via `new self( ... )`, not the DI container - see the
+	 * constructor for why.
+	 *
+	 * @since 11.2.0
+	 */
+	const PAYMENT_STALE_LOCK_THRESHOLD = 90.0;
+
+	/**
+	 * How long a held lock is allowed to go without being released before this instance presumes it abandoned.
+	 * Defaults to STALE_LOCK_THRESHOLD; overridable via the constructor for a caller whose critical section can
+	 * legitimately run longer than that default reflects (see the constructor).
+	 *
+	 * @since 11.2.0
+	 * @var float
+	 */
+	private float $stale_lock_threshold;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param float|null $stale_lock_threshold Overrides STALE_LOCK_THRESHOLD for this instance, in seconds. Pass a
+	 *                                         longer value for a caller whose critical section can legitimately run
+	 *                                         longer than the default reflects - a synchronous payment-gateway
+	 *                                         call, for instance, can take longer than the option-table writes and
+	 *                                         hook calls order creation involves, and using the same short default
+	 *                                         for both would let a contender steal the lock mid-call, reintroducing
+	 *                                         the exact race being guarded against. Resolve such a caller with
+	 *                                         `new self( ... )` rather than the DI container, which always returns
+	 *                                         the same singleton instance and so cannot serve two different
+	 *                                         thresholds at once. Defaults to STALE_LOCK_THRESHOLD.
+	 */
+	public function __construct( ?float $stale_lock_threshold = null ) {
+		$this->stale_lock_threshold = $stale_lock_threshold ?? self::STALE_LOCK_THRESHOLD;
+	}
+
+	/**
 	 * Attempt to acquire the lock for the given key.
 	 *
 	 * Retries with a short delay for up to ACQUIRE_WAIT_BUDGET seconds in total before giving up, so a request
 	 * that loses a tight race gets a real chance to proceed once the winner releases. A held lock is only taken
-	 * over if it is already older than STALE_LOCK_THRESHOLD; otherwise this simply gives up once
-	 * ACQUIRE_WAIT_BUDGET elapses, leaving a possibly-still-active holder's lock alone.
+	 * over if it is already older than this instance's staleness threshold (STALE_LOCK_THRESHOLD unless overridden
+	 * via the constructor); otherwise this simply gives up once ACQUIRE_WAIT_BUDGET elapses, leaving a
+	 * possibly-still-active holder's lock alone.
 	 *
 	 * @since 11.2.0
 	 *
@@ -112,7 +156,7 @@ class CheckoutOrderLock {
 
 					// The lock row exists; take it over only if it was acquired long enough ago to be presumed
 					// abandoned, rather than merely still in use by an active (if slow) holder.
-					$stale_before = number_format( $now - self::STALE_LOCK_THRESHOLD, 6, '.', '' );
+					$stale_before = number_format( $now - $this->stale_lock_threshold, 6, '.', '' );
 					$takeover     = $wpdb->prepare(
 						"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 						$token,

--- a/plugins/woocommerce/src/Internal/Checkout/CheckoutOrderLock.php
+++ b/plugins/woocommerce/src/Internal/Checkout/CheckoutOrderLock.php
@@ -1,0 +1,210 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Checkout;
+
+/**
+ * A self-healing mutex used to serialize order creation for a single shopper during checkout.
+ *
+ * Concurrent checkout submissions for the same shopper (double-clicks, load-balancer/proxy retries on timeout,
+ * duplicate AJAX requests) can each pass validation before any of them has persisted an order, so each one creates
+ * its own order. The lock is claimed for the duration of that window only (order creation plus the pending-order
+ * session reference being made durable), never for the payment gateway call that follows, so a slow or off-site
+ * gateway can never hold the lock.
+ *
+ * The lock lives in the options table (rather than a MySQL named lock such as GET_LOCK()) so it is naturally
+ * scoped to this install's wp_options and routes to the primary database like any other write, avoiding the
+ * replica-routing and server-global-namespace pitfalls of GET_LOCK. Modeled on WC_Install::create_lock() and
+ * BatchProcessingController's own option-row mutex.
+ *
+ * @since 11.2.0
+ */
+class CheckoutOrderLock {
+
+	/**
+	 * Option name prefix for a held lock. The full option name is this prefix plus a hash of the lock key, so an
+	 * arbitrary (and potentially long) key such as a guest session ID stays within the options table's column
+	 * limit.
+	 *
+	 * @since 11.2.0
+	 */
+	const LOCK_OPTION_PREFIX = 'wc_checkout_order_lock_';
+
+	/**
+	 * Total time (in seconds, fractional) a contending request retries acquiring a held lock before giving up and
+	 * letting the shopper know their order is already being processed.
+	 *
+	 * This bounds how long a losing request keeps the shopper waiting, so it is deliberately short. It is NOT how
+	 * long a lock is allowed to be held for - see STALE_LOCK_THRESHOLD - a contender that gives up here has not
+	 * necessarily decided the holder is dead, only that it is not worth waiting on synchronously any longer.
+	 *
+	 * @since 11.2.0
+	 */
+	const ACQUIRE_WAIT_BUDGET = 5.0;
+
+	/**
+	 * Number of polling attempts within ACQUIRE_WAIT_BUDGET.
+	 *
+	 * @since 11.2.0
+	 */
+	const ACQUIRE_RETRY_ATTEMPTS = 20;
+
+	/**
+	 * How long (in seconds) a held lock is allowed to go without being released before it is presumed abandoned
+	 * (the holding request crashed or otherwise never reached release()) and can be taken over.
+	 *
+	 * This is deliberately much longer than ACQUIRE_WAIT_BUDGET. Order creation runs third-party hooks
+	 * (`woocommerce_checkout_create_order`, `woocommerce_checkout_update_order_meta`) that can call out to external
+	 * services (tax, inventory, CRM sync) and legitimately take longer than a contender is willing to wait
+	 * synchronously. Using the same short value for both would let a contender steal the lock from a holder that
+	 * is merely slow, not dead, reintroducing the exact duplicate-order race this class exists to close; a
+	 * genuinely crashed holder's lock is still reclaimed, just not necessarily by the first request that notices
+	 * it is held.
+	 *
+	 * @since 11.2.0
+	 */
+	const STALE_LOCK_THRESHOLD = 30.0;
+
+	/**
+	 * Attempt to acquire the lock for the given key.
+	 *
+	 * Retries with a short delay for up to ACQUIRE_WAIT_BUDGET seconds in total before giving up, so a request
+	 * that loses a tight race gets a real chance to proceed once the winner releases. A held lock is only taken
+	 * over if it is already older than STALE_LOCK_THRESHOLD; otherwise this simply gives up once
+	 * ACQUIRE_WAIT_BUDGET elapses, leaving a possibly-still-active holder's lock alone.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string $key Arbitrary identifier to scope the lock to (e.g. a customer/session ID). Two callers using
+	 *                    the same key contend for the same lock; different keys never contend with each other.
+	 * @return string|null The token to pass to release(), or null if the lock could not be acquired.
+	 */
+	public function acquire( string $key ): ?string {
+		global $wpdb;
+
+		$option_name = $this->get_option_name( $key );
+		$attempts    = max( 1, self::ACQUIRE_RETRY_ATTEMPTS );
+		$delay_micro = (int) ( ( self::ACQUIRE_WAIT_BUDGET / $attempts ) * 1_000_000 );
+
+		// A contended INSERT fails on the duplicate key by design, so silence wpdb error reporting to keep that
+		// expected-failure path from spamming the log in debug mode; restore the prior setting when done. Any
+		// unexpected failure (not the duplicate-key case) is still surfaced via wc_get_logger() below.
+		$suppress = $wpdb->suppress_errors( true );
+		try {
+			for ( $attempt = 0; $attempt < $attempts; $attempt++ ) {
+				$now   = microtime( true );
+				$token = number_format( $now, 6, '.', '' );
+
+				// The unique option_name key makes this INSERT a mutex: it fails when the lock row already exists.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$acquired = $wpdb->insert(
+					$wpdb->options,
+					array(
+						'option_name'  => $option_name,
+						'option_value' => $token,
+						'autoload'     => 'no',
+					),
+					array( '%s', '%s', '%s' )
+				);
+
+				if ( ! $acquired ) {
+					$this->maybe_log_unexpected_db_error( $wpdb, 'acquire (insert)', $key );
+
+					// The lock row exists; take it over only if it was acquired long enough ago to be presumed
+					// abandoned, rather than merely still in use by an active (if slow) holder.
+					$stale_before = number_format( $now - self::STALE_LOCK_THRESHOLD, 6, '.', '' );
+					$takeover     = $wpdb->prepare(
+						"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+						$token,
+						$option_name,
+						$stale_before
+					);
+					if ( is_string( $takeover ) ) {
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+						$acquired = $wpdb->query( $takeover );
+					}
+				}
+
+				if ( $acquired ) {
+					return $token;
+				}
+
+				if ( $attempt < $attempts - 1 && $delay_micro > 0 ) {
+					usleep( $delay_micro );
+				}
+			}
+
+			return null;
+		} finally {
+			$wpdb->suppress_errors( $suppress );
+		}
+	}
+
+	/**
+	 * Release a lock previously acquired with acquire().
+	 *
+	 * The delete is conditional on the stored value still matching the token returned by acquire(), so a lock that
+	 * went stale and was taken over by another request is never released out from under it.
+	 *
+	 * @since 11.2.0
+	 *
+	 * @param string $key   The same key passed to acquire().
+	 * @param string $token The token returned by acquire().
+	 */
+	public function release( string $key, string $token ): void {
+		global $wpdb;
+
+		$suppress = $wpdb->suppress_errors( true );
+		try {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete(
+				$wpdb->options,
+				array(
+					'option_name'  => $this->get_option_name( $key ),
+					'option_value' => $token,
+				),
+				array( '%s', '%s' )
+			);
+		} finally {
+			$wpdb->suppress_errors( $suppress );
+		}
+	}
+
+	/**
+	 * Build the options-table row name for a lock key.
+	 *
+	 * @param string $key Arbitrary lock key.
+	 * @return string
+	 */
+	private function get_option_name( string $key ): string {
+		return self::LOCK_OPTION_PREFIX . md5( $key );
+	}
+
+	/**
+	 * Log a failed insert if it does not look like the expected duplicate-key contention case.
+	 *
+	 * The suppress_errors() call above silences wpdb's own error reporting for the (expected, frequent) case of losing the race
+	 * on the unique key, but that means a genuine database problem (connection loss, disk full, a missing table)
+	 * would otherwise fail exactly the same way and be indistinguishable from ordinary lock contention - visible
+	 * to the shopper only as "please wait and try again", with nothing in the logs to explain why every attempt
+	 * is failing. This keeps the fail-safe behaviour (the lock is still denied either way) while surfacing the
+	 * unexpected case for diagnosis.
+	 *
+	 * @param \wpdb  $wpdb Database access object.
+	 * @param string $step Where the failure occurred, for the log message.
+	 * @param string $key  The lock key involved, for the log message.
+	 */
+	private function maybe_log_unexpected_db_error( \wpdb $wpdb, string $step, string $key ): void {
+		if ( '' === $wpdb->last_error || false !== stripos( $wpdb->last_error, 'Duplicate entry' ) ) {
+			return;
+		}
+
+		wc_get_logger()->error(
+			sprintf( 'CheckoutOrderLock: unexpected database error during %s: %s', $step, $wpdb->last_error ),
+			array(
+				'source'   => 'checkout-order-lock',
+				'lock_key' => $key,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -789,44 +789,65 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function create_or_update_draft_order( \WP_REST_Request $request ) {
 		/*
+		 * get_route_response() (GET) and get_route_update_response() (PATCH/PUT) both already resolve
+		 * $this->order via get_draft_order() before ever calling this method, and only call it at all when that
+		 * resolved to an existing order - so for either of them $this->order is already set on entry, and the
+		 * line below can only ever take its "update" branch, never "create new". Only process_order() (POST, the
+		 * actual place-order submission) can reach this method with $this->order still unset, since it's the one
+		 * caller that doesn't pre-resolve it - that's the only path that can create a new order, so it's the only
+		 * one that needs the lock below. Determined once, up front, because the "reuse the pending order" line
+		 * itself mutates $this->order.
+		 */
+		$may_create_new_order = ( null === $this->order );
+
+		/*
 		 * Concurrent submissions for the same shopper (double-clicks, proxy/load-balancer retries on timeout)
 		 * would otherwise all read an empty 'store_api_draft_order' session value below and each create their
 		 * own order, since that session value isn't written until the very end of this method. Serialize the
 		 * whole read-decide-create-write sequence per shopper so a request that was waiting resumes the order
 		 * the other request created instead of also creating one. Released before process_payment()/
 		 * process_without_payment() are called back in process_order(), so a slow or off-site gateway can never
-		 * hold the lock.
+		 * hold the lock. Scoped to the POST/create path only (see above) - a GET or PATCH for the same shopper,
+		 * arriving while a POST holds this lock, would otherwise itself block for the full ACQUIRE_WAIT_BUDGET
+		 * and could then fail with a "your order is already being processed" error that has nothing to do with
+		 * what it was actually doing.
 		 */
-		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
-		$lock_key      = (string) WC()->session->get_customer_id();
-		$lock_token    = $checkout_lock->acquire( $lock_key );
+		$checkout_lock = null;
+		$lock_key      = null;
+		$lock_token    = null;
 
-		if ( null === $lock_token ) {
-			throw new RouteException(
-				'woocommerce_rest_checkout_order_locked',
-				esc_html__( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ),
-				409
-			);
+		if ( $may_create_new_order ) {
+			$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+			$lock_key      = (string) WC()->session->get_customer_id();
+			$lock_token    = $checkout_lock->acquire( $lock_key );
+
+			if ( null === $lock_token ) {
+				throw new RouteException(
+					'woocommerce_rest_checkout_order_locked',
+					esc_html__( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ),
+					409
+				);
+			}
 		}
 
 		try {
-			/*
-			 * WC_Session only ever reads its own in-memory copy of the session data, loaded once when this
-			 * request started - it is never re-fetched mid-request. If this request was just waiting on the
-			 * lock above, the request that held it may have written a fresh 'store_api_draft_order' to the
-			 * persisted session store after this request's copy was already loaded, so that write would
-			 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
-			 * stale copy of the rest of the session) so get_draft_order() below sees it and resumes that order
-			 * instead of also creating one.
-			 *
-			 * get_session() is itself cache-aware ($wpdb is only queried on a cache miss), and this request's
-			 * own session bootstrap (restore_session_data(), on every request via 'init') already called it once
-			 * for this exact customer before this route ever ran - the concurrent holder's write can easily land
-			 * after that, leaving a stale cached copy under this key regardless of whether the cache is the
-			 * default per-request store or a shared backend like Redis. Evict it first so get_session() is forced
-			 * to hit the database rather than that stale entry.
-			 */
-			if ( WC()->session instanceof \WC_Session_Handler ) {
+			if ( null !== $lock_key && WC()->session instanceof \WC_Session_Handler ) {
+				/*
+				 * WC_Session only ever reads its own in-memory copy of the session data, loaded once when this
+				 * request started - it is never re-fetched mid-request. If this request was just waiting on the
+				 * lock above, the request that held it may have written a fresh 'store_api_draft_order' to the
+				 * persisted session store after this request's copy was already loaded, so that write would
+				 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
+				 * stale copy of the rest of the session) so get_draft_order() below sees it and resumes that order
+				 * instead of also creating one.
+				 *
+				 * get_session() is itself cache-aware ($wpdb is only queried on a cache miss), and this request's
+				 * own session bootstrap (restore_session_data(), on every request via 'init') already called it once
+				 * for this exact customer before this route ever ran - the concurrent holder's write can easily land
+				 * after that, leaving a stale cached copy under this key regardless of whether the cache is the
+				 * default per-request store or a shared backend like Redis. Evict it first so get_session() is forced
+				 * to hit the database rather than that stale entry.
+				 */
 				wp_cache_delete( \WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP ) . $lock_key, WC_SESSION_CACHE_GROUP );
 				$persisted_session_data = WC()->session->get_session( $lock_key );
 				if ( is_array( $persisted_session_data ) && array_key_exists( 'store_api_draft_order', $persisted_session_data ) ) {
@@ -912,12 +933,14 @@ class Checkout extends AbstractCartRoute {
 			// on the lock above depends on being able to read this as soon as it acquires the lock, which may be
 			// well before this request's normal end-of-request session save.
 			$this->set_draft_order_id( $this->order->get_id() );
-			if ( WC()->session instanceof \WC_Session_Handler ) {
+			if ( $may_create_new_order && WC()->session instanceof \WC_Session_Handler ) {
 				WC()->session->save_data();
 			}
 			wc_log_order_step( '[Store API #4::create_or_update_draft_order] Set order draft id', array( 'order_object' => $this->order ) );
 		} finally {
-			$checkout_lock->release( $lock_key, $lock_token );
+			if ( null !== $checkout_lock && null !== $lock_key && null !== $lock_token ) {
+				$checkout_lock->release( $lock_key, $lock_token );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -709,7 +709,7 @@ class Checkout extends AbstractCartRoute {
 		 * order N", not "only one caller may create shopper X's order". Held through the gateway call itself,
 		 * unlike the creation lock, because that call is exactly what this is protecting.
 		 */
-		$payment_lock       = wc_get_container()->get( CheckoutOrderLock::class );
+		$payment_lock       = new CheckoutOrderLock( CheckoutOrderLock::PAYMENT_STALE_LOCK_THRESHOLD );
 		$payment_lock_key   = 'order_payment_' . $this->order->get_id();
 		$payment_lock_token = $payment_lock->acquire( $payment_lock_key );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -699,10 +699,36 @@ class Checkout extends AbstractCartRoute {
 		 */
 		$payment_result = new PaymentResult();
 
-		if ( $this->order->needs_payment() ) {
-			$this->process_payment( $request, $payment_result );
-		} else {
-			$this->process_without_payment( $request, $payment_result );
+		/*
+		 * The order-creation lock in create_or_update_draft_order() is released before this point specifically so
+		 * a slow or off-site gateway can never hold it - but that means a request that was waiting on it, and
+		 * resumed this same order rather than creating a new one, reaches this exact point too. Without a separate
+		 * claim scoped to this order, both requests would independently decide the order needs payment and both
+		 * call the gateway, which can charge a non-idempotent gateway twice for one order. Keyed by order ID (not
+		 * by shopper, like the creation lock) since this is guarding "only one caller may process payment for
+		 * order N", not "only one caller may create shopper X's order". Held through the gateway call itself,
+		 * unlike the creation lock, because that call is exactly what this is protecting.
+		 */
+		$payment_lock       = wc_get_container()->get( CheckoutOrderLock::class );
+		$payment_lock_key   = 'order_payment_' . $this->order->get_id();
+		$payment_lock_token = $payment_lock->acquire( $payment_lock_key );
+
+		if ( null === $payment_lock_token ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_order_locked',
+				esc_html__( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ),
+				409
+			);
+		}
+
+		try {
+			if ( $this->order->needs_payment() ) {
+				$this->process_payment( $request, $payment_result );
+			} else {
+				$this->process_without_payment( $request, $payment_result );
+			}
+		} finally {
+			$payment_lock->release( $payment_lock_key, $payment_lock_token );
 		}
 
 		wc_log_order_step(
@@ -850,8 +876,13 @@ class Checkout extends AbstractCartRoute {
 				 */
 				wp_cache_delete( \WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP ) . $lock_key, WC_SESSION_CACHE_GROUP );
 				$persisted_session_data = WC()->session->get_session( $lock_key );
-				if ( is_array( $persisted_session_data ) && array_key_exists( 'store_api_draft_order', $persisted_session_data ) ) {
-					WC()->session->set( 'store_api_draft_order', $persisted_session_data['store_api_draft_order'] );
+				if ( is_array( $persisted_session_data ) ) {
+					// Absent, not just present-and-different, matters here: with no key at all in the persisted
+					// store, an in-memory value from earlier in this request (or from before an unset elsewhere)
+					// would otherwise survive the refresh unchanged and get_draft_order() could reuse an order the
+					// persisted session no longer references. set( ..., null ) clears it the same way an absent
+					// key already means "no draft order" everywhere else this value is read.
+					WC()->session->set( 'store_api_draft_order', $persisted_session_data['store_api_draft_order'] ?? null );
 				}
 			}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStockException;
 use Automattic\WooCommerce\StoreApi\Utilities\CheckoutTrait;
+use Automattic\WooCommerce\Internal\Checkout\CheckoutOrderLock;
 
 /**
  * Checkout class.
@@ -787,83 +788,129 @@ class Checkout extends AbstractCartRoute {
 	 * @throws RouteException On error.
 	 */
 	private function create_or_update_draft_order( \WP_REST_Request $request ) {
-		// Reuse the failed/pending order from the customer's session if one exists; otherwise the POST flow would orphan it by creating a fresh order on every retry.
-		$this->order = $this->order ?? $this->get_draft_order();
-
-		if ( ! $this->order ) {
-			$this->order = $this->order_controller->create_order_from_cart();
-			wc_log_order_step( '[Store API #4::create_or_update_draft_order] Created order from cart', array( 'order_object' => $this->order ) );
-
-			/**
-			 * Fires once when the Store API checkout draft order is first materialised.
-			 *
-			 * Use this hook for first-touch logic that should only run when the draft
-			 * order is initially created (e.g. analytics, abandoned-cart trackers). As
-			 * of WooCommerce 10.8.0 the Store API defers draft order creation to
-			 * place-order time, so this action fires once at POST rather than on the
-			 * first PATCH.
-			 *
-			 * @since 10.8.0
-			 *
-			 * @param \WC_Order $order Order object.
-			 */
-			do_action( 'woocommerce_store_api_checkout_order_created', $this->order );
-		} else {
-			$this->order_controller->update_order_from_cart( $this->order, true );
-			wc_log_order_step( '[Store API #4::create_or_update_draft_order] Updated order from cart', array( 'order_object' => $this->order ) );
-		}
-
-		wc_do_deprecated_action(
-			'__experimental_woocommerce_blocks_checkout_update_order_meta',
-			array(
-				$this->order,
-			),
-			'6.3.0',
-			'woocommerce_store_api_checkout_update_order_meta',
-			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
-		);
-
-		wc_do_deprecated_action(
-			'woocommerce_blocks_checkout_update_order_meta',
-			array(
-				$this->order,
-			),
-			'7.2.0',
-			'woocommerce_store_api_checkout_update_order_meta',
-			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
-		);
-
-		/**
-		 * Fires when the Checkout Block/Store API updates an order's meta data.
-		 *
-		 * This hook gives extensions the chance to add or update meta data on the $order.
-		 * Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.
-		 *
-		 * This is similar to existing core hook woocommerce_checkout_update_order_meta.
-		 * We're using a new action:
-		 * - To keep the interface focused (only pass $order, not passing request data).
-		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
-		 *
-		 * @since 7.2.0
-		 *
-		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
-		 *
-		 * @param \WC_Order $order Order object.
+		/*
+		 * Concurrent submissions for the same shopper (double-clicks, proxy/load-balancer retries on timeout)
+		 * would otherwise all read an empty 'store_api_draft_order' session value below and each create their
+		 * own order, since that session value isn't written until the very end of this method. Serialize the
+		 * whole read-decide-create-write sequence per shopper so a request that was waiting resumes the order
+		 * the other request created instead of also creating one. Released before process_payment()/
+		 * process_without_payment() are called back in process_order(), so a slow or off-site gateway can never
+		 * hold the lock.
 		 */
-		do_action( 'woocommerce_store_api_checkout_update_order_meta', $this->order );
+		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+		$lock_key      = (string) WC()->session->get_customer_id();
+		$lock_token    = $checkout_lock->acquire( $lock_key );
 
-		// Confirm order is valid before proceeding further.
-		if ( ! $this->order instanceof \WC_Order ) {
+		if ( null === $lock_token ) {
 			throw new RouteException(
-				'woocommerce_rest_checkout_missing_order',
-				esc_html__( 'Unable to create order', 'woocommerce' ),
-				500
+				'woocommerce_rest_checkout_order_locked',
+				esc_html__( 'Your order is already being processed. Please wait a moment before trying again.', 'woocommerce' ),
+				409
 			);
 		}
 
-		// Store order ID to session.
-		$this->set_draft_order_id( $this->order->get_id() );
-		wc_log_order_step( '[Store API #4::create_or_update_draft_order] Set order draft id', array( 'order_object' => $this->order ) );
+		try {
+			/*
+			 * WC_Session only ever reads its own in-memory copy of the session data, loaded once when this
+			 * request started - it is never re-fetched mid-request. If this request was just waiting on the
+			 * lock above, the request that held it may have written a fresh 'store_api_draft_order' to the
+			 * persisted session store after this request's copy was already loaded, so that write would
+			 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
+			 * stale copy of the rest of the session) so get_draft_order() below sees it and resumes that order
+			 * instead of also creating one.
+			 */
+			if ( WC()->session instanceof \WC_Session_Handler ) {
+				$persisted_session_data = WC()->session->get_session( $lock_key );
+				if ( is_array( $persisted_session_data ) && array_key_exists( 'store_api_draft_order', $persisted_session_data ) ) {
+					WC()->session->set( 'store_api_draft_order', $persisted_session_data['store_api_draft_order'] );
+				}
+			}
+
+			// Reuse the failed/pending order from the customer's session if one exists; otherwise the POST flow would orphan it by creating a fresh order on every retry.
+			$this->order = $this->order ?? $this->get_draft_order();
+
+			if ( ! $this->order ) {
+				$this->order = $this->order_controller->create_order_from_cart();
+				wc_log_order_step( '[Store API #4::create_or_update_draft_order] Created order from cart', array( 'order_object' => $this->order ) );
+
+				/**
+				 * Fires once when the Store API checkout draft order is first materialised.
+				 *
+				 * Use this hook for first-touch logic that should only run when the draft
+				 * order is initially created (e.g. analytics, abandoned-cart trackers). As
+				 * of WooCommerce 10.8.0 the Store API defers draft order creation to
+				 * place-order time, so this action fires once at POST rather than on the
+				 * first PATCH.
+				 *
+				 * @since 10.8.0
+				 *
+				 * @param \WC_Order $order Order object.
+				 */
+				do_action( 'woocommerce_store_api_checkout_order_created', $this->order );
+			} else {
+				$this->order_controller->update_order_from_cart( $this->order, true );
+				wc_log_order_step( '[Store API #4::create_or_update_draft_order] Updated order from cart', array( 'order_object' => $this->order ) );
+			}
+
+			wc_do_deprecated_action(
+				'__experimental_woocommerce_blocks_checkout_update_order_meta',
+				array(
+					$this->order,
+				),
+				'6.3.0',
+				'woocommerce_store_api_checkout_update_order_meta',
+				'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
+			);
+
+			wc_do_deprecated_action(
+				'woocommerce_blocks_checkout_update_order_meta',
+				array(
+					$this->order,
+				),
+				'7.2.0',
+				'woocommerce_store_api_checkout_update_order_meta',
+				'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
+			);
+
+			/**
+			 * Fires when the Checkout Block/Store API updates an order's meta data.
+			 *
+			 * This hook gives extensions the chance to add or update meta data on the $order.
+			 * Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.
+			 *
+			 * This is similar to existing core hook woocommerce_checkout_update_order_meta.
+			 * We're using a new action:
+			 * - To keep the interface focused (only pass $order, not passing request data).
+			 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
+			 *
+			 * @since 7.2.0
+			 *
+			 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
+			 *
+			 * @param \WC_Order $order Order object.
+			 */
+			do_action( 'woocommerce_store_api_checkout_update_order_meta', $this->order );
+
+			// Confirm order is valid before proceeding further.
+			if ( ! $this->order instanceof \WC_Order ) {
+				throw new RouteException(
+					'woocommerce_rest_checkout_missing_order',
+					esc_html__( 'Unable to create order', 'woocommerce' ),
+					500
+				);
+			}
+
+			// Store order ID to session, and make it durable immediately - a concurrent request that is waiting
+			// on the lock above depends on being able to read this as soon as it acquires the lock, which may be
+			// well before this request's normal end-of-request session save.
+			$this->set_draft_order_id( $this->order->get_id() );
+			if ( WC()->session instanceof \WC_Session_Handler ) {
+				WC()->session->save_data();
+			}
+			wc_log_order_step( '[Store API #4::create_or_update_draft_order] Set order draft id', array( 'order_object' => $this->order ) );
+		} finally {
+			$checkout_lock->release( $lock_key, $lock_token );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -818,8 +818,16 @@ class Checkout extends AbstractCartRoute {
 			 * otherwise be invisible here. Refresh this one key from the persisted store (not the request's
 			 * stale copy of the rest of the session) so get_draft_order() below sees it and resumes that order
 			 * instead of also creating one.
+			 *
+			 * get_session() is itself cache-aware ($wpdb is only queried on a cache miss), and this request's
+			 * own session bootstrap (restore_session_data(), on every request via 'init') already called it once
+			 * for this exact customer before this route ever ran - the concurrent holder's write can easily land
+			 * after that, leaving a stale cached copy under this key regardless of whether the cache is the
+			 * default per-request store or a shared backend like Redis. Evict it first so get_session() is forced
+			 * to hit the database rather than that stale entry.
 			 */
 			if ( WC()->session instanceof \WC_Session_Handler ) {
+				wp_cache_delete( \WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP ) . $lock_key, WC_SESSION_CACHE_GROUP );
 				$persisted_session_data = WC()->session->get_session( $lock_key );
 				if ( is_array( $persisted_session_data ) && array_key_exists( 'store_api_draft_order', $persisted_session_data ) ) {
 					WC()->session->set( 'store_api_draft_order', $persisted_session_data['store_api_draft_order'] );

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -908,4 +908,97 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			'The pre-existing order must be resumed, not duplicated, once this request refreshes the stale session value.'
 		);
 	}
+
+	/**
+	 * @testdox process_checkout() should not call the payment gateway when another request already holds the payment-processing claim for this exact order - the case where two requests both resumed the same order past the creation lock (which is released before payment) and would otherwise both call the gateway.
+	 */
+	public function test_process_checkout_does_not_process_payment_when_another_request_holds_the_orders_payment_lock() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'virtual' => true ) );
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		$customer_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		$bacs_gateway          = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_BACS::ID ];
+		$bacs_was_enabled      = $bacs_gateway->enabled;
+		$bacs_gateway->enabled = 'yes';
+
+		add_filter(
+			'woocommerce_countries_allowed_countries',
+			function () {
+				return array( 'US' => 'United States (US)' );
+			}
+		);
+
+		$_POST    = array(
+			'woocommerce-process-checkout-nonce' => wp_create_nonce( 'woocommerce-process_checkout' ),
+			'ship_to_different_address'          => '0',
+			'payment_method'                     => WC_Gateway_BACS::ID,
+			'billing_first_name'                 => 'Jane',
+			'billing_last_name'                  => 'Doe',
+			'billing_address_1'                  => '123 Main St',
+			'billing_city'                       => 'New York',
+			'billing_state'                      => 'NY',
+			'billing_postcode'                   => '10001',
+			'billing_country'                    => 'US',
+			'billing_email'                      => 'jane@example.com',
+			'billing_phone'                      => '5555555555',
+		);
+		$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Building the request fixture, not processing real input.
+
+		// Claim the payment lock for the order the moment it exists - simulating another request that resumed
+		// this same order past the (already-released) creation lock and reached the payment step first.
+		$payment_lock       = wc_get_container()->get( CheckoutOrderLock::class );
+		$captured_lock      = null;
+		$claim_payment_lock = function ( $order_id ) use ( $payment_lock, &$captured_lock ) {
+			$token         = $payment_lock->acquire( 'order_payment_' . $order_id );
+			$captured_lock = array(
+				'key'   => 'order_payment_' . $order_id,
+				'token' => $token,
+			);
+		};
+		add_action( 'woocommerce_checkout_order_processed', $claim_payment_lock );
+
+		try {
+			$this->sut->process_checkout();
+		} finally {
+			remove_action( 'woocommerce_checkout_order_processed', $claim_payment_lock );
+			remove_all_filters( 'woocommerce_countries_allowed_countries' );
+			$bacs_gateway->enabled = $bacs_was_enabled;
+			$_POST                 = array();
+			$_REQUEST              = array();
+			WC()->cart->empty_cart();
+			if ( $captured_lock ) {
+				$payment_lock->release( $captured_lock['key'], $captured_lock['token'] );
+			}
+		}
+
+		$this->assertNotNull( $captured_lock['token'] ?? null, 'Test setup: must be able to claim the payment lock from the hook.' );
+
+		$orders = wc_get_orders(
+			array(
+				'customer' => $customer_id,
+				'return'   => 'ids',
+			)
+		);
+		$this->assertCount( 1, $orders, 'Test setup: exactly one order must have been created.' );
+
+		$order = wc_get_order( $orders[0] );
+		$this->assertTrue(
+			$order->has_status( array( 'pending', 'failed' ) ),
+			'The gateway must not have been called while another request holds the payment lock for this order - order status should remain unpaid, not ' . $order->get_status()
+		);
+
+		$notices      = wc_get_notices( 'error' );
+		$found_notice = false;
+		foreach ( $notices as $notice ) {
+			if ( false !== strpos( $notice['notice'], 'already being processed' ) ) {
+				$found_notice = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_notice, 'The concurrent-payment notice must be shown to the shopper.' );
+
+		wc_clear_notices();
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -874,9 +874,21 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		);
 		$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Building the request fixture, not processing real input.
 
+		// process_checkout() ends, on success, by redirecting or sending a JSON response and terminating the
+		// script - neither of which a PHPUnit process should be allowed to do. Order creation/resumption (what
+		// this test actually verifies) is fully resolved by the time woocommerce_checkout_order_processed fires,
+		// still well before that terminal response - throw from it to stop process_checkout() right there. The
+		// whole method body is one try/catch, so this is caught and turned into a harmless notice, same as any
+		// other Exception raised during checkout.
+		$stop_before_terminal_response = function () {
+			throw new Exception( 'Stopping before process_checkout() reaches its terminal response, for this test only.' );
+		};
+		add_action( 'woocommerce_checkout_order_processed', $stop_before_terminal_response );
+
 		try {
 			$this->sut->process_checkout();
 		} finally {
+			remove_action( 'woocommerce_checkout_order_processed', $stop_before_terminal_response );
 			remove_all_filters( 'woocommerce_countries_allowed_countries' );
 			$_POST    = array();
 			$_REQUEST = array();

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -830,6 +830,13 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		);
 		$this->assertIsInt( $existing_order_id, 'Test setup: the pre-existing order must be created successfully.' );
 
+		// Simulate this request's own normal session bootstrap: restore_session_data() calls get_session() for
+		// this exact customer on every request (via 'init'), before checkout code ever runs, which warms the
+		// cache-aware get_session() lookup with whatever's in the persisted store at that point (still nothing,
+		// here). Without this, the test wouldn't prove the refresh survives an already-warm cache entry - only
+		// that it works against a key that was never read before, which isn't the real-world timing.
+		WC()->session->get_session( (string) WC()->session->get_customer_id() );
+
 		// This request's own WC()->session already has no 'order_awaiting_payment' in memory (create_order() above
 		// never writes it - only process_checkout() does) - matching a request that loaded its session snapshot
 		// before another request's write. Write directly to the persisted sessions table, bypassing WC()->session's

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Tests\Checkout.
  */
 
+use Automattic\WooCommerce\Internal\Checkout\CheckoutOrderLock;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
 /**
@@ -708,5 +709,184 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->assertInstanceOf( WP_Error::class, $result, 'create_order() should return a WP_Error when line items were not persisted.' );
 		$this->assertSame( 'checkout-error', $result->get_error_code(), 'Error code should come from the checkout try/catch path.' );
 		$this->assertStringContainsString( 'Order items could not be saved', $result->get_error_message(), 'Error message should surface the defense-in-depth guard message.' );
+	}
+
+	/**
+	 * @testdox process_checkout() should fail fast without creating a duplicate order when another request already holds this shopper's checkout lock.
+	 */
+	public function test_process_checkout_fails_fast_when_lock_is_held_by_another_request() {
+		$product = WC_Helper_Product::create_simple_product( true, array( 'virtual' => true ) );
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		$customer_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		// BACS is disabled by default in the test install; force it available regardless of its stored settings.
+		$bacs_gateway          = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_BACS::ID ];
+		$bacs_was_enabled      = $bacs_gateway->enabled;
+		$bacs_gateway->enabled = 'yes';
+
+		add_filter(
+			'woocommerce_countries_allowed_countries',
+			function () {
+				return array( 'US' => 'United States (US)' );
+			}
+		);
+
+		$_POST    = array(
+			'woocommerce-process-checkout-nonce' => wp_create_nonce( 'woocommerce-process_checkout' ),
+			'ship_to_different_address'          => '0',
+			'payment_method'                     => WC_Gateway_BACS::ID,
+			'billing_first_name'                 => 'Jane',
+			'billing_last_name'                  => 'Doe',
+			'billing_address_1'                  => '123 Main St',
+			'billing_city'                       => 'New York',
+			'billing_state'                      => 'NY',
+			'billing_postcode'                   => '10001',
+			'billing_country'                    => 'US',
+			'billing_email'                      => 'jane@example.com',
+			'billing_phone'                      => '5555555555',
+		);
+		$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Building the request fixture, not processing real input.
+
+		// Simulate another request already in the middle of creating an order for this same shopper.
+		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+		$lock_key      = (string) WC()->session->get_customer_id();
+		$lock_token    = $checkout_lock->acquire( $lock_key );
+		$this->assertNotNull( $lock_token, 'Test setup: must be able to acquire the lock to simulate a concurrent holder.' );
+
+		$orders_before = wc_get_orders(
+			array(
+				'customer' => $customer_id,
+				'return'   => 'ids',
+			)
+		);
+
+		try {
+			$this->sut->process_checkout();
+		} finally {
+			$checkout_lock->release( $lock_key, $lock_token );
+			remove_all_filters( 'woocommerce_countries_allowed_countries' );
+			$bacs_gateway->enabled = $bacs_was_enabled;
+			$_POST                 = array();
+			$_REQUEST              = array();
+			WC()->cart->empty_cart();
+		}
+
+		$orders_after = wc_get_orders(
+			array(
+				'customer' => $customer_id,
+				'return'   => 'ids',
+			)
+		);
+
+		$this->assertSame( $orders_before, $orders_after, 'No order should be created while another request holds this shopper\'s lock.' );
+
+		$notices      = wc_get_notices( 'error' );
+		$found_notice = false;
+		foreach ( $notices as $notice ) {
+			if ( false !== strpos( $notice['notice'], 'already being processed' ) ) {
+				$found_notice = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_notice, 'The concurrent-checkout notice must be shown to the shopper.' );
+
+		wc_clear_notices();
+	}
+
+	/**
+	 * @testdox process_checkout() should resume an order another request already durably saved for this shopper, rather than creating a duplicate, even though this request's own session data was loaded before that write happened.
+	 */
+	public function test_process_checkout_resumes_an_order_saved_by_another_request_after_this_requests_session_was_loaded() {
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'virtual'       => true,
+				'regular_price' => 0,
+				'price'         => 0,
+			)
+		);
+		WC()->cart->add_to_cart( $product->get_id() );
+
+		$customer_id = $this->factory->user->create( array( 'role' => 'customer' ) );
+		wp_set_current_user( $customer_id );
+
+		add_filter(
+			'woocommerce_countries_allowed_countries',
+			function () {
+				return array( 'US' => 'United States (US)' );
+			}
+		);
+
+		// Create the order this test will simulate another, concurrent request having already created and durably
+		// saved. This mirrors what that other request's create_order() call would have produced: same cart, so the
+		// same cart hash create_order()'s own resume check matches on.
+		$existing_order_id = $this->sut->create_order(
+			array(
+				'payment_method' => WC_Gateway_BACS::ID,
+				'billing_email'  => 'jane@example.com',
+			)
+		);
+		$this->assertIsInt( $existing_order_id, 'Test setup: the pre-existing order must be created successfully.' );
+
+		// This request's own WC()->session already has no 'order_awaiting_payment' in memory (create_order() above
+		// never writes it - only process_checkout() does) - matching a request that loaded its session snapshot
+		// before another request's write. Write directly to the persisted sessions table, bypassing WC()->session's
+		// own set()/save_data(), to simulate that other request's write landing in the shared, persisted store
+		// without this request's already-loaded in-memory copy knowing about it.
+		global $wpdb;
+		$sessions_table = $wpdb->prefix . 'woocommerce_sessions';
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$sessions_table} (session_key, session_value, session_expiry) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE session_value = VALUES(session_value), session_expiry = VALUES(session_expiry)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				(string) WC()->session->get_customer_id(),
+				maybe_serialize( array( 'order_awaiting_payment' => $existing_order_id ) ),
+				time() + HOUR_IN_SECONDS
+			)
+		);
+
+		$this->assertSame(
+			0,
+			absint( WC()->session->get( 'order_awaiting_payment' ) ),
+			'Test setup: this request\'s in-memory session must still show no pending order at this point.'
+		);
+
+		$_POST    = array(
+			'woocommerce-process-checkout-nonce' => wp_create_nonce( 'woocommerce-process_checkout' ),
+			'ship_to_different_address'          => '0',
+			'billing_first_name'                 => 'Jane',
+			'billing_last_name'                  => 'Doe',
+			'billing_address_1'                  => '123 Main St',
+			'billing_city'                       => 'New York',
+			'billing_state'                      => 'NY',
+			'billing_postcode'                   => '10001',
+			'billing_country'                    => 'US',
+			'billing_email'                      => 'jane@example.com',
+			'billing_phone'                      => '5555555555',
+		);
+		$_REQUEST = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Building the request fixture, not processing real input.
+
+		try {
+			$this->sut->process_checkout();
+		} finally {
+			remove_all_filters( 'woocommerce_countries_allowed_countries' );
+			$_POST    = array();
+			$_REQUEST = array();
+			WC()->cart->empty_cart();
+		}
+
+		$orders = wc_get_orders(
+			array(
+				'customer' => $customer_id,
+				'return'   => 'ids',
+			)
+		);
+
+		$this->assertSame(
+			array( $existing_order_id ),
+			$orders,
+			'The pre-existing order must be resumed, not duplicated, once this request refreshes the stale session value.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3300,10 +3300,19 @@ class Checkout extends \WP_Test_REST_TestCase {
 		$existing_order->set_status( 'checkout-draft' );
 		$existing_order->save();
 
+		// Simulate this request's own normal session bootstrap: restore_session_data() calls the cache-aware
+		// get_session() for this exact customer on every request (via 'init'), before the route ever runs. This
+		// warms the cache with whatever's in the persisted store at that point (still nothing, here) - without
+		// this, the test wouldn't prove the route's refresh survives an already-warm cache entry, only that it
+		// works against a key nothing had read yet, which isn't the real-world timing the fix targets.
+		WC()->session->get_session( (string) WC()->session->get_customer_id() );
+
 		// This request's own in-memory session has no 'store_api_draft_order' yet - matching a request that loaded
 		// its session snapshot before another request's write. Write directly to the persisted sessions table,
 		// bypassing WC()->session's own set()/save_data(), to simulate that other request's write landing in the
-		// shared, persisted store without this request's already-loaded in-memory copy knowing about it.
+		// shared, persisted store without this request's already-loaded in-memory copy - or its now-stale cache
+		// entry from the warm-up above - knowing about it. The route itself is responsible for busting that cache
+		// entry before re-reading; this test deliberately does not do that job for it.
 		global $wpdb;
 		$sessions_table = $wpdb->prefix . 'woocommerce_sessions';
 		$wpdb->query(
@@ -3314,11 +3323,6 @@ class Checkout extends \WP_Test_REST_TestCase {
 				time() + HOUR_IN_SECONDS
 			)
 		);
-		// A real concurrent write from another process would update the shared object cache the same way
-		// save_data() does; this direct SQL write bypasses that, and within a single PHPUnit process the
-		// non-persistent object cache survives across test methods, so a stale cached session would otherwise
-		// mask this write the same way it never would in production.
-		\WC_Cache_Helper::invalidate_cache_group( WC_SESSION_CACHE_GROUP );
 
 		$this->assertSame(
 			0,

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3352,11 +3352,16 @@ class Checkout extends \WP_Test_REST_TestCase {
 	 * already being processed" error that has nothing to do with what it was actually doing.
 	 */
 	public function test_get_does_not_contend_for_the_checkout_lock_held_by_a_post() {
-		$post_request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$post_request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$post_request->set_body_params( $this->get_minimal_post_data() );
-		$post_response = rest_get_server()->dispatch( $post_request );
-		$this->assertSame( 200, $post_response->get_status(), print_r( $post_response->get_data(), true ) );
+		// 'checkout-draft' is the status create_order_from_cart() gives a freshly-materialised draft order, and
+		// is_valid_draft_order() accepts it unconditionally - established directly (rather than via a real POST
+		// first) so the GET below is guaranteed to take the existing-order path this test actually verifies,
+		// rather than possibly finding no draft order (e.g. because a prior successful POST already completed
+		// and cleared its session reference) and trivially passing without exercising it at all.
+		$existing_order = new \WC_Order();
+		$existing_order->set_status( 'checkout-draft' );
+		$existing_order->save();
+		WC()->session->set( 'store_api_draft_order', $existing_order->get_id() );
+		WC()->session->save_data();
 
 		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
 		$lock_key      = (string) WC()->session->get_customer_id();
@@ -3375,6 +3380,11 @@ class Checkout extends \WP_Test_REST_TestCase {
 			200,
 			$get_response->get_status(),
 			'A GET for an existing draft order must succeed even while a POST holds the lock, not contend for it: ' . print_r( $get_response->get_data(), true )
+		);
+		$this->assertSame(
+			$existing_order->get_id(),
+			$get_response->get_data()['order_id'] ?? null,
+			'The GET must actually return the existing draft order, proving it took the existing-order path this test is verifying.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -3343,4 +3343,38 @@ class Checkout extends \WP_Test_REST_TestCase {
 			'The pre-existing order must be resumed, not duplicated, once the route refreshes the stale session value.'
 		);
 	}
+
+	/**
+	 * A GET (or PATCH) for a shopper who already has a draft order must not contend for the checkout lock -
+	 * only a POST (the actual place-order submission) can create a new order, so only it needs the lock. Without
+	 * this, a page load or a live totals recalculation happening to overlap with that same shopper's order
+	 * submission would itself block for the lock's full wait budget and could then fail with a "your order is
+	 * already being processed" error that has nothing to do with what it was actually doing.
+	 */
+	public function test_get_does_not_contend_for_the_checkout_lock_held_by_a_post() {
+		$post_request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$post_request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$post_request->set_body_params( $this->get_minimal_post_data() );
+		$post_response = rest_get_server()->dispatch( $post_request );
+		$this->assertSame( 200, $post_response->get_status(), print_r( $post_response->get_data(), true ) );
+
+		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+		$lock_key      = (string) WC()->session->get_customer_id();
+		$lock_token    = $checkout_lock->acquire( $lock_key );
+		$this->assertNotNull( $lock_token, 'Test setup: must be able to acquire the lock to simulate a POST in progress.' );
+
+		try {
+			$get_request = new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
+			$get_request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+			$get_response = rest_get_server()->dispatch( $get_request );
+		} finally {
+			$checkout_lock->release( $lock_key, $lock_token );
+		}
+
+		$this->assertSame(
+			200,
+			$get_response->get_status(),
+			'A GET for an existing draft order must succeed even while a POST holds the lock, not contend for it: ' . print_r( $get_response->get_data(), true )
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\StoreApi\Formatters\HtmlFormatter;
 use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\Internal\Checkout\CheckoutOrderLock;
 use Automattic\WooCommerce\StoreApi\Routes\V1\Checkout as CheckoutRoute;
 use Automattic\WooCommerce\StoreApi\Routes\V1\CheckoutOrder as CheckoutOrderRoute;
 use Automattic\WooCommerce\StoreApi\SchemaController;
@@ -3230,5 +3231,112 @@ class Checkout extends \WP_Test_REST_TestCase {
 
 		$this->assertSame( 500, $response->get_status(), 'A cart session failure should return a Store API error response.' );
 		$this->assertSame( 'woocommerce_rest_unknown_server_error', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Build the minimal valid POST body for the checkout route, matching the fixture cart from setUp().
+	 *
+	 * @return array
+	 */
+	private function get_minimal_post_data(): array {
+		return array(
+			'billing_address' => (object) array(
+				'first_name' => 'test',
+				'last_name'  => 'test',
+				'company'    => '',
+				'address_1'  => 'test',
+				'address_2'  => '',
+				'city'       => 'test',
+				'state'      => '',
+				'postcode'   => 'cb241ab',
+				'country'    => 'GB',
+				'phone'      => '',
+				'email'      => 'testaccount@test.com',
+			),
+			'payment_method'  => WC_Gateway_BACS::ID,
+		);
+	}
+
+	/**
+	 * Ensure the checkout route fails fast, without creating a duplicate order, when another request already
+	 * holds this shopper's checkout lock.
+	 */
+	public function test_post_data_fails_fast_when_lock_is_held_by_another_request() {
+		$checkout_lock = wc_get_container()->get( CheckoutOrderLock::class );
+		$lock_key      = (string) WC()->session->get_customer_id();
+		$lock_token    = $checkout_lock->acquire( $lock_key );
+		$this->assertNotNull( $lock_token, 'Test setup: must be able to acquire the lock to simulate a concurrent holder.' );
+
+		$orders_before = wc_get_orders( array( 'return' => 'ids' ) );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params( $this->get_minimal_post_data() );
+
+		try {
+			$response = rest_get_server()->dispatch( $request );
+		} finally {
+			$checkout_lock->release( $lock_key, $lock_token );
+		}
+
+		$this->assertSame( 409, $response->get_status(), print_r( $response->get_data(), true ) );
+		$this->assertSame( 'woocommerce_rest_checkout_order_locked', $response->get_data()['code'] );
+		$this->assertSame(
+			$orders_before,
+			wc_get_orders( array( 'return' => 'ids' ) ),
+			'No order should be created while another request holds this shopper\'s lock.'
+		);
+	}
+
+	/**
+	 * Ensure the checkout route resumes an order another request already durably saved for this shopper, rather
+	 * than creating a duplicate, even though this request's own session data was loaded before that write
+	 * happened - the same staleness gap that had to be closed for the classic/shortcode checkout.
+	 */
+	public function test_post_data_resumes_an_order_saved_by_another_request_after_this_requests_session_was_loaded() {
+		// 'checkout-draft' is the status create_order_from_cart() gives a freshly-materialised draft order, and
+		// is_valid_draft_order() accepts it unconditionally - no cart-hash or total matching required.
+		$existing_order = new \WC_Order();
+		$existing_order->set_status( 'checkout-draft' );
+		$existing_order->save();
+
+		// This request's own in-memory session has no 'store_api_draft_order' yet - matching a request that loaded
+		// its session snapshot before another request's write. Write directly to the persisted sessions table,
+		// bypassing WC()->session's own set()/save_data(), to simulate that other request's write landing in the
+		// shared, persisted store without this request's already-loaded in-memory copy knowing about it.
+		global $wpdb;
+		$sessions_table = $wpdb->prefix . 'woocommerce_sessions';
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$sessions_table} (session_key, session_value, session_expiry) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE session_value = VALUES(session_value), session_expiry = VALUES(session_expiry)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				(string) WC()->session->get_customer_id(),
+				maybe_serialize( array( 'store_api_draft_order' => $existing_order->get_id() ) ),
+				time() + HOUR_IN_SECONDS
+			)
+		);
+		// A real concurrent write from another process would update the shared object cache the same way
+		// save_data() does; this direct SQL write bypasses that, and within a single PHPUnit process the
+		// non-persistent object cache survives across test methods, so a stale cached session would otherwise
+		// mask this write the same way it never would in production.
+		\WC_Cache_Helper::invalidate_cache_group( WC_SESSION_CACHE_GROUP );
+
+		$this->assertSame(
+			0,
+			WC()->session->get( 'store_api_draft_order', 0 ),
+			'Test setup: this request\'s in-memory session must still show no draft order at this point.'
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params( $this->get_minimal_post_data() );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), print_r( $response->get_data(), true ) );
+		$this->assertSame(
+			$existing_order->get_id(),
+			$response->get_data()['order_id'] ?? null,
+			'The pre-existing order must be resumed, not duplicated, once the route refreshes the stale session value.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
@@ -89,9 +89,11 @@ class CheckoutOrderLockTest extends WC_Unit_Test_Case {
 		$token_a = $this->sut->acquire( 'customer-a' );
 		$token_b = $this->sut->acquire( 'customer-b' );
 
+		// Not asserting token_a !== token_b: tokens are formatted timestamps, and two acquisitions can legitimately
+		// land on the same microtime() value without meaning anything about lock ownership - the option name
+		// (which embeds the key) is what actually keeps these two locks independent, not the token value.
 		$this->assertNotNull( $token_a, 'The first key must acquire its own lock.' );
 		$this->assertNotNull( $token_b, 'A different key must acquire its own lock, unaffected by the first.' );
-		$this->assertNotSame( $token_a, $token_b );
 	}
 
 	/**
@@ -195,5 +197,33 @@ class CheckoutOrderLockTest extends WC_Unit_Test_Case {
 			$this->lock_row_value( 'customer-1' ),
 			'The lock must be released once the shutdown callback runs, even without a normal release() call.'
 		);
+	}
+
+	/**
+	 * @testdox A custom staleness threshold passed to the constructor is honored, distinct from the class default -
+	 *          the mechanism PAYMENT_STALE_LOCK_THRESHOLD relies on to give a lock guarding a synchronous payment-
+	 *          gateway call more headroom than the shorter, order-creation-oriented default.
+	 */
+	public function test_constructor_accepts_a_custom_stale_lock_threshold(): void {
+		global $wpdb;
+
+		// A lock "acquired" 1 second ago is fresh under the class default (30s) but stale under a short custom
+		// threshold - proving it's the constructor argument, not just the class constant, that acquire() honors.
+		$stale_token = number_format( microtime( true ) - 1, 6, '.', '' );
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => CheckoutOrderLock::LOCK_OPTION_PREFIX . md5( 'customer-1' ),
+				'option_value' => $stale_token,
+				'autoload'     => 'no',
+			),
+			array( '%s', '%s', '%s' )
+		);
+
+		$short_threshold_lock = new CheckoutOrderLock( 0.5 );
+		$token                = $short_threshold_lock->acquire( 'customer-1' );
+
+		$this->assertNotNull( $token, 'A lock older than this instance\'s custom (shorter) threshold must be takeable over.' );
+		$this->assertNotSame( $stale_token, $token );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
@@ -1,0 +1,174 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Checkout;
+
+use Automattic\WooCommerce\Internal\Checkout\CheckoutOrderLock;
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the CheckoutOrderLock class.
+ */
+class CheckoutOrderLockTest extends WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var CheckoutOrderLock
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new CheckoutOrderLock();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'wc\\_checkout\\_order\\_lock\\_%'" );
+		parent::tearDown();
+	}
+
+	/**
+	 * Read the raw stored value of a lock's options-table row, or null when no lock is held.
+	 *
+	 * @param string $key Lock key.
+	 * @return string|null
+	 */
+	private function lock_row_value( string $key ): ?string {
+		global $wpdb;
+
+		$option_name = CheckoutOrderLock::LOCK_OPTION_PREFIX . md5( $key );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$value = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", $option_name ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		return null === $value ? null : (string) $value;
+	}
+
+	/**
+	 * @testdox Should acquire a free lock and return a non-null token.
+	 */
+	public function test_acquire_returns_token_when_lock_is_free(): void {
+		$token = $this->sut->acquire( 'customer-1' );
+
+		$this->assertNotNull( $token, 'A free lock must be acquirable.' );
+	}
+
+	/**
+	 * @testdox Should persist an options-table row matching the returned token while the lock is held.
+	 */
+	public function test_acquire_persists_matching_lock_row(): void {
+		$token = $this->sut->acquire( 'customer-1' );
+
+		$this->assertSame( $token, $this->lock_row_value( 'customer-1' ), 'The stored row value must match the returned token.' );
+	}
+
+	/**
+	 * @testdox Should delete the lock row on release.
+	 */
+	public function test_release_deletes_the_lock_row(): void {
+		$token = $this->sut->acquire( 'customer-1' );
+		$this->sut->release( 'customer-1', $token );
+
+		$this->assertNull( $this->lock_row_value( 'customer-1' ), 'The lock row must be gone after release.' );
+	}
+
+	/**
+	 * @testdox Should scope locks independently per key, so one key's lock never blocks another key.
+	 */
+	public function test_locks_are_scoped_independently_per_key(): void {
+		$token_a = $this->sut->acquire( 'customer-a' );
+		$token_b = $this->sut->acquire( 'customer-b' );
+
+		$this->assertNotNull( $token_a, 'The first key must acquire its own lock.' );
+		$this->assertNotNull( $token_b, 'A different key must acquire its own lock, unaffected by the first.' );
+		$this->assertNotSame( $token_a, $token_b );
+	}
+
+	/**
+	 * @testdox Should fail to acquire, and leave the row untouched, when another request holds a recently-acquired (not yet stale) lock.
+	 */
+	public function test_acquire_fails_when_another_request_holds_a_fresh_lock(): void {
+		global $wpdb;
+
+		// Simulate another request holding the lock: insert the row directly with an "acquired at" time of now.
+		$foreign_token = number_format( microtime( true ), 6, '.', '' );
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => CheckoutOrderLock::LOCK_OPTION_PREFIX . md5( 'customer-1' ),
+				'option_value' => $foreign_token,
+				'autoload'     => 'no',
+			),
+			array( '%s', '%s', '%s' )
+		);
+
+		$token = $this->sut->acquire( 'customer-1' );
+
+		$this->assertNull( $token, 'Acquisition must fail while another request holds a lock that is not yet stale.' );
+		$this->assertSame(
+			$foreign_token,
+			$this->lock_row_value( 'customer-1' ),
+			'A holder that is not yet stale must be left in place, not stolen or released, even once this caller gives up waiting.'
+		);
+	}
+
+	/**
+	 * @testdox Should take over a stale lock left by a crashed request, even though it is older than the (much shorter) wait budget.
+	 */
+	public function test_acquire_takes_over_a_stale_lock(): void {
+		global $wpdb;
+
+		// A lock row acquired long enough ago to exceed STALE_LOCK_THRESHOLD represents a crashed holder.
+		$stale_token = number_format( microtime( true ) - CheckoutOrderLock::STALE_LOCK_THRESHOLD - 1, 6, '.', '' );
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => CheckoutOrderLock::LOCK_OPTION_PREFIX . md5( 'customer-1' ),
+				'option_value' => $stale_token,
+				'autoload'     => 'no',
+			),
+			array( '%s', '%s', '%s' )
+		);
+
+		$token = $this->sut->acquire( 'customer-1' );
+
+		$this->assertNotNull( $token, 'A stale lock must be takeable over.' );
+		$this->assertNotSame( $stale_token, $token );
+		$this->assertSame( $token, $this->lock_row_value( 'customer-1' ) );
+	}
+
+	/**
+	 * @testdox Should not delete a lock row whose value no longer matches the token being released (taken over by another request).
+	 */
+	public function test_release_leaves_a_lock_taken_over_by_another_request(): void {
+		global $wpdb;
+
+		$token = $this->sut->acquire( 'customer-1' );
+
+		// Simulate another request taking over the lock by overwriting the row's value directly.
+		$other_token = number_format( microtime( true ) + 1, 6, '.', '' );
+		$wpdb->update(
+			$wpdb->options,
+			array( 'option_value' => $other_token ),
+			array( 'option_name' => CheckoutOrderLock::LOCK_OPTION_PREFIX . md5( 'customer-1' ) )
+		);
+
+		$this->sut->release( 'customer-1', $token );
+
+		$this->assertSame(
+			$other_token,
+			$this->lock_row_value( 'customer-1' ),
+			'Release must be scoped to the caller\'s own token, so a lock another request now owns is not deleted.'
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Checkout/CheckoutOrderLockTest.php
@@ -171,4 +171,29 @@ class CheckoutOrderLockTest extends WC_Unit_Test_Case {
 			'Release must be scoped to the caller\'s own token, so a lock another request now owns is not deleted.'
 		);
 	}
+
+	/**
+	 * @testdox The closure registered via add_action( 'shutdown', ... ) - the pattern used to guarantee a payment
+	 *          lock is released even when the holder's request terminates via exit()/wp_die() before reaching a
+	 *          normal release() call - correctly releases the lock when invoked.
+	 */
+	public function test_shutdown_release_closure_releases_the_lock(): void {
+		$token = $this->sut->acquire( 'customer-1' );
+		$this->assertNotNull( $token, 'Test setup: must be able to acquire the lock.' );
+
+		// The same closure shape registered via add_action( 'shutdown', ... ) in production, invoked directly here
+		// rather than through a real do_action( 'shutdown' ) - that hook also carries unrelated WordPress core
+		// callbacks (output-buffer flushing among them) that have nothing to do with what this is verifying and
+		// make PHPUnit flag the test as risky. WordPress's own 'shutdown' action firing this closure at all is
+		// core's well-tested add_action()/do_action() plumbing, not something this needs to re-prove.
+		$release_on_shutdown = function () use ( $token ) {
+			$this->sut->release( 'customer-1', $token );
+		};
+		$release_on_shutdown();
+
+		$this->assertNull(
+			$this->lock_row_value( 'customer-1' ),
+			'The lock must be released once the shutdown callback runs, even without a normal release() call.'
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Concurrent checkout submissions for the same shopper (double-clicks, load-balancer/proxy retries on timeout) can each read an empty "pending order" session value and independently create their own order, since that session value isn't written until after the order is created. On multi-pod/load-balanced deployments this reliably produces duplicate orders and duplicate gateway charges. This affects **both** checkout entry points, which track the pending order in session independently:

-   Classic/shortcode checkout: `WC_Checkout::process_checkout()` reads `order_awaiting_payment` from session, and only `process_order_payment()` (called after `create_order()` returns) writes it back.
-   Block-based Checkout block / Store API: `Checkout::create_or_update_draft_order()` reads `store_api_draft_order` from session, and only writes it back at the end of that same method.

Both are the same class of race with the same root cause; this PR fixes both with the same mechanism.

Adds a short-lived, self-healing per-shopper lock (`CheckoutOrderLock`, modeled on `WC_Install::create_lock()` and `BatchProcessingController`'s own options-table mutex — deliberately not a MySQL `GET_LOCK()`, to avoid the replica-routing and server-global-namespace pitfalls that come with named locks on scaled deployments) around each flow's order-creation window. The lock is held only from just before order creation through the pending-order session reference being made durable, and is always released before the payment gateway is called — a slow or off-site gateway can never hold it.

A previous attempt at the classic-checkout half of this (#65588) modified `create_order()` directly, which @jorgeatorres flagged as changing its public API contract (silently wiping the cart on next page load for any other caller) and only guarding sequential retries rather than true concurrency. This PR takes a different approach for both flows: neither `WC_Checkout::create_order()` nor the Store API's order-building internals are changed — the fix lives entirely at the two call sites that already own the read-decide-create-write sequence.

One subtlety worth flagging explicitly for review: `WC_Session` only ever reads its own in-memory copy of session data, loaded once at the start of a request — it is never re-fetched mid-request. That means a request that was waiting on the lock and then acquires it after the original holder releases would still read its own *stale* pre-wait session snapshot and create a duplicate anyway, even though the two requests were correctly serialized. Both flows explicitly refresh the one relevant session key from the persisted session store (not the rest of the request's session data) immediately after acquiring the lock, so a waiting request correctly resumes the order the other request just created.

Closes #62659.

### Screenshots or screen recordings:

Not applicable - no UI changes.

### How to test the changes in this Pull Request:

1. Automated coverage:
    - `CheckoutOrderLockTest` unit-tests the lock primitive directly: acquire/release, stale-lock takeover after `STALE_LOCK_THRESHOLD`, a held-but-not-yet-stale lock is left alone even once a contender's `ACQUIRE_WAIT_BUDGET` elapses, and per-key isolation.
    - `WC_Checkout_Test::test_process_checkout_fails_fast_when_lock_is_held_by_another_request` and the equivalent `Checkout::test_post_data_fails_fast_when_lock_is_held_by_another_request` in the Store API test suite each pre-acquire the lock to simulate a genuinely concurrent request, then assert the route fails fast with a clear message and creates zero orders, rather than creating a duplicate.
    - `WC_Checkout_Test::test_process_checkout_resumes_an_order_saved_by_another_request_after_this_requests_session_was_loaded` and its Store API equivalent `Checkout::test_post_data_resumes_an_order_saved_by_another_request_after_this_requests_session_was_loaded` reproduce the session-staleness scenario above: a "concurrent" request's write is simulated via a direct write to the persisted sessions table (bypassing this request's own session object), and both assert the pre-existing order is resumed rather than duplicated.
2. Manual/load reproduction for classic checkout (mirrors the original issue report): add a product to the cart on the checkout page, then from the browser console fire several concurrent requests to `?wc-ajax=checkout` with identical form data (see the reproduction script in #62659). Before this fix, each concurrent request creates its own order. After, exactly one order is created; any request that loses the race gets a "Your order is already being processed" notice instead of a duplicate order.
3. Manual/load reproduction for the Checkout block: with the block-based checkout active, fire several concurrent `POST` requests to `/wc/store/v1/checkout` with the same cart/session. Before this fix, each creates its own order. After, exactly one order is created; a losing request gets a 409 response instead.
4. Confirm no regression to the normal single-request checkout flow in both entry points (place a normal order end-to-end with a couple of different payment gateways, on both the shortcode checkout and the Checkout block).

### Testing that has already taken place:

Ran the full PHPUnit suite locally via `wp-env` (PHP 8.1) - all tests pass (100/100 across the touched test classes: `WC_Checkout_Test`, `CheckoutOrderLockTest`, and the Store API `Checkout` route test suite). Ran `phpcs`/`phpcs-changed` (diff-scoped) and `phpstan` against every changed source file - both clean. Verified the new integration tests genuinely exercise the lock's real contention/timeout behavior (not mocked - the contention tests take ~5s wall time, matching the lock's `ACQUIRE_WAIT_BUDGET`). Also confirmed, by reverting to a clean trunk checkout, that an unrelated pre-existing test-order-dependent failure in `WC_Settings_Advanced_Test` reproduces identically without this change, so it isn't a regression introduced here.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment
Created manually (see `plugins/woocommerce/changelog/fix-checkout-concurrent-duplicate-orders`).
</details>

### Release Communication

- [ ] Feature Highlight
- [ ] Developer Advisory

### Use of AI Tools

This PR was developed with Claude Code (Anthropic), used for the research/scoping of the issue and prior PR feedback, writing the implementation and tests, and running the local verification described above. All code was reviewed by me before submission.
