### PR TITLE
Handle download stream read failures

### DIFF
--- a/plugins/woocommerce/changelog/fix-woo6-122-download-read-failure
+++ b/plugins/woocommerce/changelog/fix-woo6-122-download-read-failure
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Handle read errors while streaming ranged downloads.
+Handle read errors while streaming product downloads.

--- a/plugins/woocommerce/changelog/fix-woo6-122-download-read-failure
+++ b/plugins/woocommerce/changelog/fix-woo6-122-download-read-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle read errors while streaming ranged downloads.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -863,7 +863,14 @@ class WC_Download_Handler {
 					$read_length = $end - $p + 1;
 				}
 
-				echo @fread( $handle, $read_length ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_system_read_fread
+				$chunk = @fread( $handle, $read_length ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Streamed downloads require fread(); suppress warnings so they do not corrupt the binary response, and handle false below.
+
+				if ( false === $chunk ) {
+					@fclose( $handle ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- The read has already failed; suppress close warnings and report failure below.
+					return false;
+				}
+
+				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
 				$p = @ftell( $handle ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 				if ( ob_get_length() ) {

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -497,8 +497,9 @@ class WC_Download_Handler {
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
 
-		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
-		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
+		$start      = isset( $download_range['start'] ) ? $download_range['start'] : 0;
+		$length     = isset( $download_range['length'] ) ? $download_range['length'] : 0;
+		$bytes_sent = 0;
 
 		if ( $parsed_file_path['remote_file'] ) {
 			// Open the remote file before sending our own headers, so the filename announced by
@@ -518,15 +519,19 @@ class WC_Download_Handler {
 				);
 
 				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range, true );
-				$served = self::readfile_from_handle( $handle, $start, $length );
+				$served = self::readfile_from_handle( $handle, $start, $length, $bytes_sent );
 			}
 		} else {
 			self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
-			$served = self::readfile_chunked( $parsed_file_path['file_path'], $start, $length );
+			$served = self::readfile_chunked_with_output_tracking( $parsed_file_path['file_path'], $start, $length, $bytes_sent );
 		}
 
 		if ( ! $served ) {
-			if ( $parsed_file_path['remote_file'] && 'yes' === get_option( 'woocommerce_downloads_redirect_fallback_allowed' ) ) {
+			if ( $bytes_sent > 0 ) {
+				wc_get_logger()->warning(
+					__( 'A file could not be completely served using the Force Download method because the response had already started.', 'woocommerce' )
+				);
+			} elseif ( $parsed_file_path['remote_file'] && 'yes' === get_option( 'woocommerce_downloads_redirect_fallback_allowed' ) ) {
 				wc_get_logger()->warning(
 					sprintf(
 						/* translators: %1$s contains the filepath of the digital asset. */
@@ -817,6 +822,21 @@ class WC_Download_Handler {
 	 * @return bool Success or fail
 	 */
 	public static function readfile_chunked( $file, $start = 0, $length = 0 ) {
+		$bytes_sent = 0;
+
+		return self::readfile_chunked_with_output_tracking( $file, $start, $length, $bytes_sent );
+	}
+
+	/**
+	 * Read a file in chunks while tracking how many bytes were emitted.
+	 *
+	 * @param string $file       File.
+	 * @param int    $start      Byte offset/position of the beginning from which to read from the file.
+	 * @param int    $length     Length of the chunk to be read from the file in bytes, 0 means full file.
+	 * @param int    $bytes_sent Number of bytes emitted.
+	 * @return bool Success or fail
+	 */
+	private static function readfile_chunked_with_output_tracking( $file, $start, $length, &$bytes_sent ) {
 		// Define before attempting to open the file: the constant has always been defined even
 		// when the open fails, and external code may rely on that side effect.
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
@@ -833,18 +853,19 @@ class WC_Download_Handler {
 			$length = (int) @filesize( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Remote paths make filesize error; false is handled by the cast (0 means read until EOF).
 		}
 
-		return self::readfile_from_handle( $handle, $start, $length );
+		return self::readfile_from_handle( $handle, $start, $length, $bytes_sent );
 	}
 
 	/**
 	 * Read an already-open file handle in chunks and echo its content.
 	 *
-	 * @param resource $handle Open file handle, e.g. from `fopen()`.
-	 * @param int      $start  Byte offset/position of the beginning from which to read from the file.
-	 * @param int      $length Length of the chunk to be read from the file in bytes, 0 means until the end of file.
+	 * @param resource $handle     Open file handle, e.g. from `fopen()`.
+	 * @param int      $start      Byte offset/position of the beginning from which to read from the file.
+	 * @param int      $length     Length of the chunk to be read from the file in bytes, 0 means until the end of file.
+	 * @param int      $bytes_sent Number of bytes emitted.
 	 * @return bool Success or fail
 	 */
-	private static function readfile_from_handle( $handle, $start = 0, $length = 0 ) {
+	private static function readfile_from_handle( $handle, $start, $length, &$bytes_sent ) {
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
 			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
 		}
@@ -871,6 +892,7 @@ class WC_Download_Handler {
 				}
 
 				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
+				$bytes_sent += strlen( $chunk );
 				$p = @ftell( $handle ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 				if ( ob_get_length() ) {
@@ -880,7 +902,15 @@ class WC_Download_Handler {
 			}
 		} else {
 			while ( ! @feof( $handle ) ) { // @codingStandardsIgnoreLine.
-				echo @fread( $handle, $read_length ); // @codingStandardsIgnoreLine.
+				$chunk = @fread( $handle, $read_length ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Streamed downloads require fread(); suppress warnings so they do not corrupt the binary response, and handle false below.
+
+				if ( false === $chunk ) {
+					@fclose( $handle ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- The read has already failed; suppress close warnings and report failure below.
+					return false;
+				}
+
+				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
+				$bytes_sent += strlen( $chunk );
 				if ( ob_get_length() ) {
 					ob_flush();
 					flush();

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -497,9 +497,9 @@ class WC_Download_Handler {
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
 
-		$start      = isset( $download_range['start'] ) ? $download_range['start'] : 0;
-		$length     = isset( $download_range['length'] ) ? $download_range['length'] : 0;
-		$bytes_sent = 0;
+		$start            = isset( $download_range['start'] ) ? $download_range['start'] : 0;
+		$length           = isset( $download_range['length'] ) ? $download_range['length'] : 0;
+		$response_started = false;
 
 		if ( $parsed_file_path['remote_file'] ) {
 			// Open the remote file before sending our own headers, so the filename announced by
@@ -519,15 +519,15 @@ class WC_Download_Handler {
 				);
 
 				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range, true );
-				$served = self::readfile_from_handle( $handle, $start, $length, $bytes_sent );
+				$served = self::readfile_from_handle( $handle, $start, $length, $response_started );
 			}
 		} else {
 			self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
-			$served = self::readfile_chunked_with_output_tracking( $parsed_file_path['file_path'], $start, $length, $bytes_sent );
+			$served = self::readfile_chunked_with_response_tracking( $parsed_file_path['file_path'], $start, $length, $response_started );
 		}
 
 		if ( ! $served ) {
-			if ( $bytes_sent > 0 ) {
+			if ( $response_started ) {
 				wc_get_logger()->warning(
 					__( 'A file could not be completely served using the Force Download method because the response had already started.', 'woocommerce' )
 				);
@@ -822,21 +822,21 @@ class WC_Download_Handler {
 	 * @return bool Success or fail
 	 */
 	public static function readfile_chunked( $file, $start = 0, $length = 0 ) {
-		$bytes_sent = 0;
+		$response_started = false;
 
-		return self::readfile_chunked_with_output_tracking( $file, $start, $length, $bytes_sent );
+		return self::readfile_chunked_with_response_tracking( $file, $start, $length, $response_started );
 	}
 
 	/**
-	 * Read a file in chunks while tracking how many bytes were emitted.
+	 * Read a file in chunks while tracking whether the response started.
 	 *
-	 * @param string $file       File.
-	 * @param int    $start      Byte offset/position of the beginning from which to read from the file.
-	 * @param int    $length     Length of the chunk to be read from the file in bytes, 0 means full file.
-	 * @param int    $bytes_sent Number of bytes emitted.
+	 * @param string $file             File.
+	 * @param int    $start            Byte offset/position of the beginning from which to read from the file.
+	 * @param int    $length           Length of the chunk to be read from the file in bytes, 0 means full file.
+	 * @param bool   $response_started Whether any response bytes were emitted.
 	 * @return bool Success or fail
 	 */
-	private static function readfile_chunked_with_output_tracking( $file, $start, $length, &$bytes_sent ) {
+	private static function readfile_chunked_with_response_tracking( $file, $start, $length, &$response_started ) {
 		// Define before attempting to open the file: the constant has always been defined even
 		// when the open fails, and external code may rely on that side effect.
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
@@ -853,19 +853,19 @@ class WC_Download_Handler {
 			$length = (int) @filesize( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Remote paths make filesize error; false is handled by the cast (0 means read until EOF).
 		}
 
-		return self::readfile_from_handle( $handle, $start, $length, $bytes_sent );
+		return self::readfile_from_handle( $handle, $start, $length, $response_started );
 	}
 
 	/**
 	 * Read an already-open file handle in chunks and echo its content.
 	 *
-	 * @param resource $handle     Open file handle, e.g. from `fopen()`.
-	 * @param int      $start      Byte offset/position of the beginning from which to read from the file.
-	 * @param int      $length     Length of the chunk to be read from the file in bytes, 0 means until the end of file.
-	 * @param int      $bytes_sent Number of bytes emitted.
+	 * @param resource $handle           Open file handle, e.g. from `fopen()`.
+	 * @param int      $start            Byte offset/position of the beginning from which to read from the file.
+	 * @param int      $length           Length of the chunk to be read from the file in bytes, 0 means until the end of file.
+	 * @param bool     $response_started Whether any response bytes were emitted.
 	 * @return bool Success or fail
 	 */
-	private static function readfile_from_handle( $handle, $start, $length, &$bytes_sent ) {
+	private static function readfile_from_handle( $handle, $start, $length, &$response_started ) {
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
 			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
 		}
@@ -892,7 +892,9 @@ class WC_Download_Handler {
 				}
 
 				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
-				$bytes_sent += strlen( $chunk );
+				if ( '' !== $chunk ) {
+					$response_started = true;
+				}
 				$p = @ftell( $handle ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 				if ( ob_get_length() ) {
@@ -910,7 +912,9 @@ class WC_Download_Handler {
 				}
 
 				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
-				$bytes_sent += strlen( $chunk );
+				if ( '' !== $chunk ) {
+					$response_started = true;
+				}
 				if ( ob_get_length() ) {
 					ob_flush();
 					flush();

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -21,6 +21,15 @@ class WC_Download_Handler {
 	 */
 	public const TRACK_DOWNLOAD_CALLBACK = 'track_partial_download';
 
+	/** Successful completion of a streamed file read. */
+	private const READ_RESULT_SUCCESS = 'success';
+
+	/** A streamed file read failed before emitting any file data. */
+	private const READ_RESULT_FAILURE_BEFORE_OUTPUT = 'failure_before_output';
+
+	/** A streamed file read failed after emitting file data. */
+	private const READ_RESULT_FAILURE_AFTER_OUTPUT = 'failure_after_output';
+
 	/**
 	 * Hook in methods.
 	 */
@@ -497,9 +506,8 @@ class WC_Download_Handler {
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
 
-		$start            = isset( $download_range['start'] ) ? $download_range['start'] : 0;
-		$length           = isset( $download_range['length'] ) ? $download_range['length'] : 0;
-		$response_started = false;
+		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
+		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
 
 		if ( $parsed_file_path['remote_file'] ) {
 			// Open the remote file before sending our own headers, so the filename announced by
@@ -507,7 +515,7 @@ class WC_Download_Handler {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streaming a remote file needs fopen (WP_Filesystem cannot stream); a false return is handled below.
 			$handle = @fopen( $parsed_file_path['file_path'], 'r' );
 
-			$served = false;
+			$read_result = self::READ_RESULT_FAILURE_BEFORE_OUTPUT;
 			if ( false !== $handle ) {
 				$response_headers = stream_get_meta_data( $handle )['wrapper_data'] ?? array();
 				$filename         = self::resolve_filename_from_response_headers(
@@ -519,19 +527,20 @@ class WC_Download_Handler {
 				);
 
 				self::download_headers( $parsed_file_path['file_path'], $filename, $download_range, true );
-				$served = self::readfile_from_handle( $handle, $start, $length, $response_started );
+				$read_result = self::readfile_from_handle( $handle, $start, $length );
 			}
 		} else {
 			self::download_headers( $parsed_file_path['file_path'], $filename, $download_range );
-			$served = self::readfile_chunked_with_response_tracking( $parsed_file_path['file_path'], $start, $length, $response_started );
+			$read_result = self::readfile_chunked_with_result( $parsed_file_path['file_path'], $start, $length );
 		}
 
-		if ( ! $served ) {
-			if ( $response_started ) {
+		if ( self::READ_RESULT_SUCCESS !== $read_result ) {
+			if ( self::READ_RESULT_FAILURE_AFTER_OUTPUT === $read_result ) {
 				wc_get_logger()->warning(
 					__( 'A file could not be completely served using the Force Download method because the response had already started.', 'woocommerce' )
 				);
 			} elseif ( $parsed_file_path['remote_file'] && 'yes' === get_option( 'woocommerce_downloads_redirect_fallback_allowed' ) ) {
+				self::remove_download_headers();
 				wc_get_logger()->warning(
 					sprintf(
 						/* translators: %1$s contains the filepath of the digital asset. */
@@ -822,21 +831,18 @@ class WC_Download_Handler {
 	 * @return bool Success or fail
 	 */
 	public static function readfile_chunked( $file, $start = 0, $length = 0 ) {
-		$response_started = false;
-
-		return self::readfile_chunked_with_response_tracking( $file, $start, $length, $response_started );
+		return self::READ_RESULT_SUCCESS === self::readfile_chunked_with_result( $file, $start, $length );
 	}
 
 	/**
-	 * Read a file in chunks while tracking whether the response started.
+	 * Read a file in chunks and report when a failure follows partial output.
 	 *
-	 * @param string $file             File.
-	 * @param int    $start            Byte offset/position of the beginning from which to read from the file.
-	 * @param int    $length           Length of the chunk to be read from the file in bytes, 0 means full file.
-	 * @param bool   $response_started Whether any response bytes were emitted.
-	 * @return bool Success or fail
+	 * @param string $file   File.
+	 * @param int    $start  Byte offset/position of the beginning from which to read from the file.
+	 * @param int    $length Length of the chunk to be read from the file in bytes, 0 means full file.
+	 * @return string One of the READ_RESULT_* constants.
 	 */
-	private static function readfile_chunked_with_response_tracking( $file, $start, $length, &$response_started ) {
+	private static function readfile_chunked_with_result( $file, $start, $length ) {
 		// Define before attempting to open the file: the constant has always been defined even
 		// when the open fails, and external code may rely on that side effect.
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
@@ -846,31 +852,31 @@ class WC_Download_Handler {
 		$handle = @fopen( $file, 'r' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
 
 		if ( false === $handle ) {
-			return false;
+			return self::READ_RESULT_FAILURE_BEFORE_OUTPUT;
 		}
 
 		if ( ! $length ) {
 			$length = (int) @filesize( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Remote paths make filesize error; false is handled by the cast (0 means read until EOF).
 		}
 
-		return self::readfile_from_handle( $handle, $start, $length, $response_started );
+		return self::readfile_from_handle( $handle, $start, $length );
 	}
 
 	/**
 	 * Read an already-open file handle in chunks and echo its content.
 	 *
-	 * @param resource $handle           Open file handle, e.g. from `fopen()`.
-	 * @param int      $start            Byte offset/position of the beginning from which to read from the file.
-	 * @param int      $length           Length of the chunk to be read from the file in bytes, 0 means until the end of file.
-	 * @param bool     $response_started Whether any response bytes were emitted.
-	 * @return bool Success or fail
+	 * @param resource $handle Open file handle, e.g. from `fopen()`.
+	 * @param int      $start  Byte offset/position of the beginning from which to read from the file.
+	 * @param int      $length Length of the chunk to be read from the file in bytes, 0 means until the end of file.
+	 * @return string One of the READ_RESULT_* constants.
 	 */
-	private static function readfile_from_handle( $handle, $start, $length, &$response_started ) {
+	private static function readfile_from_handle( $handle, $start = 0, $length = 0 ) {
 		if ( ! defined( 'WC_CHUNK_SIZE' ) ) {
 			define( 'WC_CHUNK_SIZE', 1024 * 1024 );
 		}
 
 		$read_length = (int) WC_CHUNK_SIZE;
+		$output_sent = false;
 
 		if ( $length ) {
 			$end = $start + $length - 1;
@@ -888,13 +894,11 @@ class WC_Download_Handler {
 
 				if ( false === $chunk ) {
 					@fclose( $handle ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- The read has already failed; suppress close warnings and report failure below.
-					return false;
+					return $output_sent ? self::READ_RESULT_FAILURE_AFTER_OUTPUT : self::READ_RESULT_FAILURE_BEFORE_OUTPUT;
 				}
 
 				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
-				if ( '' !== $chunk ) {
-					$response_started = true;
-				}
+				$output_sent = $output_sent || '' !== $chunk;
 				$p = @ftell( $handle ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 				if ( ob_get_length() ) {
@@ -908,13 +912,11 @@ class WC_Download_Handler {
 
 				if ( false === $chunk ) {
 					@fclose( $handle ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- The read has already failed; suppress close warnings and report failure below.
-					return false;
+					return $output_sent ? self::READ_RESULT_FAILURE_AFTER_OUTPUT : self::READ_RESULT_FAILURE_BEFORE_OUTPUT;
 				}
 
 				echo $chunk; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Download chunks are raw binary data and must not be HTML-escaped.
-				if ( '' !== $chunk ) {
-					$response_started = true;
-				}
+				$output_sent = $output_sent || '' !== $chunk;
 				if ( ob_get_length() ) {
 					ob_flush();
 					flush();
@@ -922,7 +924,12 @@ class WC_Download_Handler {
 			}
 		}
 
-		return @fclose( $handle ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Suppress close warnings so they do not corrupt the binary response, and report failure below.
+		if ( @fclose( $handle ) ) {
+			return self::READ_RESULT_SUCCESS;
+		}
+
+		return $output_sent ? self::READ_RESULT_FAILURE_AFTER_OUTPUT : self::READ_RESULT_FAILURE_BEFORE_OUTPUT;
 	}
 
 	/**
@@ -942,6 +949,15 @@ class WC_Download_Handler {
 	}
 
 	/**
+	 * Remove headers that describe a streamed download before sending another response type.
+	 */
+	private static function remove_download_headers(): void {
+		foreach ( array( 'Content-Type', 'Content-Description', 'Content-Disposition', 'Content-Transfer-Encoding', 'Content-Length', 'Content-Range', 'Accept-Ranges' ) as $header ) {
+			header_remove( $header );
+		}
+	}
+
+	/**
 	 * Die with an error message if the download fails.
 	 *
 	 * @param string  $message Error message.
@@ -956,10 +972,8 @@ class WC_Download_Handler {
 		if ( headers_sent() ) {
 			wc_get_logger()->log( 'warning', __( 'Headers already sent when generating download error message.', 'woocommerce' ) );
 		} else {
+			self::remove_download_headers();
 			header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
-			header_remove( 'Content-Description;' );
-			header_remove( 'Content-Disposition' );
-			header_remove( 'Content-Transfer-Encoding' );
 		}
 
 		if ( ! strstr( $message, '<a ' ) ) {

--- a/plugins/woocommerce/tests/php/helpers/FakeRemoteStreamWrapper.php
+++ b/plugins/woocommerce/tests/php/helpers/FakeRemoteStreamWrapper.php
@@ -16,7 +16,8 @@ declare( strict_types = 1 );
  *     // ...
  *     stream_wrapper_restore( 'http' );
  *
- * Only the operations the download handler performs are implemented; the stream is always empty.
+ * Only the operations the download handler performs are implemented; the stream is empty unless
+ * configured to fail reads.
  * Parameter names and signatures are fixed by PHP's streamWrapper prototype, so unused ones are
  * expected: https://www.php.net/manual/en/class.streamwrapper.php
  *
@@ -28,6 +29,20 @@ declare( strict_types = 1 );
  * phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
  */
 class FakeRemoteStreamWrapper {
+
+	/**
+	 * Whether reads should fail.
+	 *
+	 * @var bool
+	 */
+	public static $fail_reads = false;
+
+	/**
+	 * Whether the stream was closed.
+	 *
+	 * @var bool
+	 */
+	public static $closed = false;
 
 	/**
 	 * Stream context, assigned by PHP when the wrapper is instantiated.
@@ -46,6 +61,7 @@ class FakeRemoteStreamWrapper {
 	 * @return bool
 	 */
 	public function stream_open( $path, $mode, $options, &$opened_path ) {
+		self::$closed = false;
 		return true;
 	}
 
@@ -53,9 +69,13 @@ class FakeRemoteStreamWrapper {
 	 * Read from the stream.
 	 *
 	 * @param int $count Bytes to read.
-	 * @return string
+	 * @return string|false
 	 */
 	public function stream_read( $count ) {
+		if ( self::$fail_reads ) {
+			return false;
+		}
+
 		return '';
 	}
 
@@ -65,7 +85,27 @@ class FakeRemoteStreamWrapper {
 	 * @return bool
 	 */
 	public function stream_eof() {
+		return ! self::$fail_reads;
+	}
+
+	/**
+	 * Seek within the stream.
+	 *
+	 * @param int $offset Seek offset.
+	 * @param int $whence Seek origin.
+	 * @return bool
+	 */
+	public function stream_seek( $offset, $whence ) {
 		return true;
+	}
+
+	/**
+	 * Get the current stream position.
+	 *
+	 * @return int
+	 */
+	public function stream_tell() {
+		return 0;
 	}
 
 	/**
@@ -83,6 +123,7 @@ class FakeRemoteStreamWrapper {
 	 * @return bool
 	 */
 	public function stream_close() {
+		self::$closed = true;
 		return true;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -548,6 +548,58 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox readfile_chunked() should emit binary download bytes unchanged.
+	 */
+	public function test_readfile_chunked_emits_binary_data_unchanged(): void {
+		$binary_content = "\x00\xFF\xFE<script>&\x80";
+		$temp_file      = wp_tempnam( 'wc-download-handler-streaming' );
+
+		file_put_contents( $temp_file, $binary_content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture written to the temp directory.
+
+		$output = '';
+		ob_start(
+			function ( $chunk ) use ( &$output ) {
+				$output .= $chunk;
+				return '';
+			}
+		);
+
+		try {
+			$served = WC_Download_Handler::readfile_chunked( $temp_file, 0, strlen( $binary_content ) );
+		} finally {
+			ob_end_clean();
+			wp_delete_file( $temp_file );
+		}
+
+		$this->assertTrue( $served, 'A complete binary stream should be reported as served.' );
+		$this->assertSame( $binary_content, $output, 'Binary download bytes must not be escaped or otherwise transformed.' );
+	}
+
+	/**
+	 * @testdox readfile_chunked() should stop and report failure when a ranged stream read fails.
+	 */
+	public function test_readfile_chunked_reports_ranged_read_failure(): void {
+		$scheme = 'wc-failing-download';
+
+		FakeRemoteStreamWrapper::$fail_reads = true;
+		stream_wrapper_register( $scheme, FakeRemoteStreamWrapper::class );
+
+		ob_start();
+
+		try {
+			$served = WC_Download_Handler::readfile_chunked( $scheme . '://fixture', 0, 4 );
+		} finally {
+			$output = ob_get_clean();
+			stream_wrapper_unregister( $scheme );
+			FakeRemoteStreamWrapper::$fail_reads = false;
+		}
+
+		$this->assertFalse( $served, 'A failed fread() call should make the download fail.' );
+		$this->assertSame( '', $output, 'A failed read should not append anything to the download response.' );
+		$this->assertTrue( FakeRemoteStreamWrapper::$closed, 'The failed stream should be closed immediately.' );
+	}
+
+	/**
 	 * @testdox The Content-Type fallback to the resolved filename should apply to remote files only.
 	 */
 	public function test_content_type_fallback_applies_only_to_remote_files(): void {

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -576,9 +576,13 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox readfile_chunked() should stop and report failure when a ranged stream read fails.
+	 * @testdox readfile_chunked() should stop and report failure when a stream read fails.
+	 *
+	 * @dataProvider provider_stream_lengths
+	 *
+	 * @param int $length Requested download length, where zero means until EOF.
 	 */
-	public function test_readfile_chunked_reports_ranged_read_failure(): void {
+	public function test_readfile_chunked_reports_read_failure( int $length ): void {
 		$scheme = 'wc-failing-download';
 
 		FakeRemoteStreamWrapper::$fail_reads = true;
@@ -587,7 +591,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 		ob_start();
 
 		try {
-			$served = WC_Download_Handler::readfile_chunked( $scheme . '://fixture', 0, 4 );
+			$served = WC_Download_Handler::readfile_chunked( $scheme . '://fixture', 0, $length );
 		} finally {
 			$output = ob_get_clean();
 			stream_wrapper_unregister( $scheme );
@@ -597,6 +601,18 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 		$this->assertFalse( $served, 'A failed fread() call should make the download fail.' );
 		$this->assertSame( '', $output, 'A failed read should not append anything to the download response.' );
 		$this->assertTrue( FakeRemoteStreamWrapper::$closed, 'The failed stream should be closed immediately.' );
+	}
+
+	/**
+	 * Download lengths for failed-stream coverage.
+	 *
+	 * @return array<string, array<int>>
+	 */
+	public function provider_stream_lengths(): array {
+		return array(
+			'requested range'       => array( 4 ),
+			'read until stream EOF' => array( 0 ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Handle `fread()` failures while WooCommerce streams Force Downloads, without allowing PHP warnings to corrupt the binary response.

The public `readfile_chunked()` signature and successful output are unchanged. A failed read now closes the stream and returns `false`. If a failure occurs after response bytes have already been emitted, WooCommerce logs a generic warning and terminates the response instead of appending an HTML error or attempting a redirect after binary content. Failures before any bytes are emitted continue through the existing redirect-fallback or download-error behavior.

Security and compatibility review:

- Download authorization, path parsing, range validation, and successful-response headers are unchanged. Before-output failures now remove stale download metadata before returning an HTML error or redirect.
- Raw chunks remain intentionally unescaped binary data; the focused test verifies byte-for-byte output.
- The new partial-response warning deliberately omits the asset path/URL so signed query parameters are not added to logs.
- No public method signature, hook, or filter changes. The only new helper is private.
- No multisite or install-layout behavior changes; multisite was not separately tested.

### How to test the changes in this Pull Request:

1. Run `pnpm test:php:env --filter WC_Download_Handler_Tests` from `plugins/woocommerce`.
2. Configure **Force downloads** and create a completed guest order containing a downloadable product.
3. Open its customer download URL and confirm the response contains the original file bytes and attachment headers.
4. Repeat with a valid `Range` header and confirm the response is `206 Partial Content` with the exact requested bytes.
5. Confirm a URL with an invalid download key remains denied.

### Testing that has already taken place:

- Focused PHPUnit class on PHP 8.1: 30 tests, 52 assertions passed.
- PHPCS changed-file lint and full branch-diff lint passed with no warnings.
- PHPStan passed for the production class and standalone stream helper. The legacy PHPUnit file is outside the configured PHPStan test bootstrap and was validated by PHPUnit instead.
- Local wp-env HTTP testing with WooCommerce as the only active plugin:
  - A completed guest order downloaded all 36 fixture bytes with `200 OK`; size and SHA-256 matched.
  - `Range: bytes=4-11` returned the exact eight requested bytes with `206 Partial Content` and the expected range headers.
  - An invalid download key returned `404` without download headers.
  - A controlled first-read failure returned the normal `404` HTML error without stale download headers.
  - A controlled stream interruption after two bytes returned only those binary bytes, with no redirect or appended HTML error, and logged the generic partial-response warning.
  - With remote redirect fallback enabled, a controlled first-read failure returned a clean `302` without stale download metadata.
- No UI changes; screenshots are not applicable.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A patch/fix changelog entry was added manually.

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

### Release Communication

- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

### Use of AI Tools

Codex was used to port, refine, test, and critically review this change. The final diff, backward-compatibility impact, security impact, and runtime results were reviewed before submission.
