### PR TITLE
Document legacy product and payment markup contracts

### DIFF
--- a/plugins/woocommerce/changelog/dev-markup-contract-suppressions
+++ b/plugins/woocommerce/changelog/dev-markup-contract-suppressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document intentional product, order, and payment markup contracts with exact coding-standard annotations.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -240,7 +240,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Render column: thumb.
 	 */
 	protected function render_thumb_column() {
-		echo '<a href="' . esc_url( get_edit_post_link( $this->object->get_id() ) ) . '">' . $this->object->get_image( 'thumbnail' ) . '</a>'; // WPCS: XSS ok.
+		echo '<a href="' . esc_url( get_edit_post_link( $this->object->get_id() ) ) . '">' . $this->object->get_image( 'thumbnail' ) . '</a>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_image() returns HTML, including output from the public product image filter.
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-embed.php
+++ b/plugins/woocommerce/includes/class-wc-embed.php
@@ -76,7 +76,7 @@ class WC_Embed {
 
 		// Make sure we're only affecting embedded products.
 		if ( self::is_embedded_product() ) {
-			echo '<p><span class="wc-embed-price">' . $_product->get_price_html() . '</span></p>'; // WPCS: XSS ok.
+			echo '<p><span class="wc-embed-price">' . $_product->get_price_html() . '</span></p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_price_html() returns HTML, including output from the public product price filter.
 
 			if ( ! post_password_required( $post ) && ! empty( $post->post_excerpt ) ) {
 				ob_start();

--- a/plugins/woocommerce/includes/class-wc-order-item-meta.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-meta.php
@@ -105,7 +105,7 @@ class WC_Order_Item_Meta {
 		if ( $return ) {
 			return $output;
 		} else {
-			echo $output; // WPCS: XSS ok.
+			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Base meta values are KSES-sanitized before the public legacy HTML filter.
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-cc.php
@@ -86,7 +86,7 @@ class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 			<?php do_action( 'woocommerce_credit_card_form_start', $this->id ); ?>
 			<?php
 			foreach ( $fields as $field ) {
-				echo $field; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				echo $field; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The public gateway field filter intentionally returns HTML; default fields escape dynamic data.
 			}
 			?>
 			<?php do_action( 'woocommerce_credit_card_form_end', $this->id ); ?>

--- a/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-echeck.php
+++ b/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-echeck.php
@@ -62,7 +62,7 @@ class WC_Payment_Gateway_ECheck extends WC_Payment_Gateway {
 			<?php do_action( 'woocommerce_echeck_form_start', $this->id ); ?>
 			<?php
 			foreach ( $fields as $field ) {
-				echo $field; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				echo $field; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The public gateway field filter intentionally returns HTML; default fields escape dynamic data.
 			}
 			?>
 			<?php do_action( 'woocommerce_echeck_form_end', $this->id ); ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Five legacy output sites rely on HTML-returning helpers or public HTML filters, but their suppressions use broad or obsolete annotations without reasons. Replace them with line-scoped annotations for the exact current PHPCS diagnostic and document why HTML is intentionally preserved at each output boundary.

This is comment-only: rendered output, public APIs and filters, multisite behavior, and install-layout behavior are unchanged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce lint:changes:branch` and confirm it passes.
2. Run the `WordPress.Security.EscapeOutput` sniff on the five changed PHP files and confirm none of the changed lines are reported.
3. Repeat with PHPCS annotations disabled and confirm each changed output line reports `WordPress.Security.EscapeOutput.OutputNotEscaped`.
4. Inspect the PHP diff and confirm that only comments changed; no executable PHP tokens differ from `trunk`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Changed-line PHPCS passed against `origin/trunk` for all five PHP files.
- With annotations disabled, each changed line reports the exact `WordPress.Security.EscapeOutput.OutputNotEscaped` diagnostic. With annotations enabled, the changed lines are clean.
- Compared PHP token streams for each changed file after removing comments and docblocks; all five are identical to `origin/trunk`.
- Reviewed the affected helper and filter contracts for security, backward compatibility, and performance impact. The changes do not alter runtime behavior, and no UI testing or screenshots are applicable.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex was used to inspect the suppression sites, update the comments, and run the validation described above. The resulting diff was critically reviewed for security and backward compatibility.
