### PR TITLE
Keep loosely typed dashboard sections from the defaults filter reachable

### DIFF
--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { isValidElement, useEffect, useMemo, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { partial } from 'lodash';
 import { Dropdown, Button } from '@wordpress/components';
@@ -470,11 +470,15 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 											section.title
 										) }
 									>
-										<Icon
-											className={ section.key + '__icon' }
-											icon={ section.icon }
-											size={ 30 }
-										/>
+										{ isValidElement( section.icon ) && (
+											<Icon
+												className={
+													section.key + '__icon'
+												}
+												icon={ section.icon }
+												size={ 30 }
+											/>
+										) }
 										<span className="woocommerce-dashboard-section__add-more-btn-title">
 											{ section.title }
 										</span>

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -42,9 +42,11 @@ const DASHBOARD_FILTERS_FILTER = 'woocommerce_admin_dashboard_filters';
 const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
 
 /**
- * A stored section is only usable when it carries the `key` that ties it back to
- * a default section. Corrupted `dashboard_sections` preferences have been seen
- * holding `null` entries, which used to crash the whole dashboard.
+ * A section is only usable when it carries the `key` that ties it back to a
+ * default section. Corrupted `dashboard_sections` preferences have been seen
+ * holding `null` entries, which used to crash the whole dashboard. The key is
+ * matched by strict equality and round trips through the stored JSON, so a
+ * string and a finite number both tie a section back to its default.
  *
  * @param {*} section Entry of the stored `dashboard_sections` preference.
  * @return {boolean} Whether the entry can be merged with a default section.
@@ -52,7 +54,7 @@ const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
 const isValidSection = ( section ) =>
 	!! section &&
 	typeof section === 'object' &&
-	typeof section.key === 'string';
+	( typeof section.key === 'string' || Number.isFinite( section.key ) );
 
 /**
  * Stored fields that take the dashboard down, or make a section unreachable,
@@ -70,6 +72,23 @@ const FIELD_CHECKS = {
 	hiddenBlocks: Array.isArray,
 	isVisible: ( value ) => typeof value === 'boolean',
 	title: ( value ) => typeof value === 'string',
+};
+
+/**
+ * How to read a field a default section holds the wrong type for. Nothing sits
+ * behind a default to patch it up from, so dropping the field would leave it
+ * `undefined`: every section component dereferences `hiddenBlocks`, and an
+ * `undefined` `isVisible` hides the section without listing it under "Add more
+ * sections", which is the one state a merchant cannot get out of. The dashboard
+ * has always rendered any truthy `isVisible` and printed any numeric `title`, so
+ * the value is converted instead of dropped.
+ *
+ * @type {Object.<string, function(*): *>}
+ */
+const FIELD_FALLBACKS = {
+	hiddenBlocks: () => [],
+	isVisible: ( value ) => !! value,
+	title: ( value ) => ( typeof value === 'number' ? String( value ) : '' ),
 };
 
 /**
@@ -167,14 +186,34 @@ const isUsableDefaultSection = ( section ) =>
 	isValidSection( section ) && !! section.component;
 
 /**
+ * A default section holding a value the dashboard can read for every field it
+ * dereferences. Dropping the field is what the stored preference does, and it
+ * only works there because a default backs it up. A default has nothing behind
+ * it, so its fields are converted rather than dropped.
+ *
+ * @param {section} section Entry returned by the default sections filter.
+ * @return {section} Copy of the section, holding only usable values.
+ */
+const toUsableDefaultSection = ( section ) => {
+	const usable = { ...section };
+
+	Object.entries( FIELD_CHECKS ).forEach( ( [ field, isUsable ] ) => {
+		if ( ! isUsable( usable[ field ] ) ) {
+			usable[ field ] = FIELD_FALLBACKS[ field ]( usable[ field ] );
+		}
+	} );
+
+	return usable;
+};
+
+/**
  * Copy of the default sections, throwing a descriptive error when the
  * `woocommerce_dashboard_default_sections` filter returned something unusable.
- * The filter is a third party surface, so its entries get the same treatment as
- * the stored ones: an entry no section can be built from is dropped, and a
- * corrupted field is dropped so it cannot overwrite a valid stored value.
- * Nothing sits behind a default to patch a field up from, except `hiddenBlocks`
- * which every section component dereferences, so that one falls back to an
- * empty list.
+ * The filter is a third party surface, so an entry no section can be built from
+ * is dropped. Everything else is kept: the filter is a released extension point
+ * that never enforced the documented types, and the dashboard is the last thing
+ * standing between an extension's section and the merchant, so a field it
+ * cannot read is converted instead of costing them the section.
  *
  * @return {Array.<section>} Default sections.
  */
@@ -187,15 +226,7 @@ const getDefaultSections = () => {
 
 	return defaultSections
 		.filter( isUsableDefaultSection )
-		.map( ( section ) => {
-			const usable = deleteUnusableFields( { ...section } );
-
-			if ( ! Array.isArray( usable.hiddenBlocks ) ) {
-				usable.hiddenBlocks = [];
-			}
-
-			return usable;
-		} );
+		.map( toUsableDefaultSection );
 };
 
 export const mergeSectionsWithDefaults = ( prefSections ) => {

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -196,14 +196,71 @@ describe( 'mergeSectionsWithDefaults', () => {
 		expect( charts.hiddenBlocks ).toEqual( [] );
 	} );
 
-	it( 'does not fall back to a corrupted default field', () => {
+	it( 'falls back to a readable value for a corrupted default title', () => {
+		// The title is rendered as a React child by every section header.
 		mockDefaultSections = [ { ...DEFAULT_SECTIONS[ 1 ], title: {} } ];
 
 		const [ charts ] = mergeSectionsWithDefaults( [
 			{ key: 'charts', title: { rendered: 'My charts' } },
 		] );
 
-		expect( charts.title ).toBeUndefined();
+		expect( charts.title ).toBe( '' );
+	} );
+
+	it( 'keeps a default section that registers a truthy isVisible', () => {
+		// The filter never enforced a boolean and the dashboard rendered any
+		// truthy value, so dropping it would make the section unreachable.
+		mockDefaultSections = [
+			{ ...DEFAULT_SECTIONS[ 0 ], isVisible: 1 },
+			{ ...DEFAULT_SECTIONS[ 1 ], isVisible: 'yes' },
+		];
+
+		const sections = mergeSectionsWithDefaults( undefined );
+
+		expect( sections.map( ( section ) => section.isVisible ) ).toEqual( [
+			true,
+			true,
+		] );
+	} );
+
+	it( 'offers a default section that registers a falsy isVisible', () => {
+		// `undefined` is neither visible nor listed under "Add more sections".
+		mockDefaultSections = [
+			{ ...DEFAULT_SECTIONS[ 0 ], isVisible: 0 },
+			{ ...DEFAULT_SECTIONS[ 1 ], isVisible: undefined },
+		];
+
+		const sections = mergeSectionsWithDefaults( undefined );
+
+		expect( sections.map( ( section ) => section.isVisible ) ).toEqual( [
+			false,
+			false,
+		] );
+	} );
+
+	it( 'keeps a default section that registers a numeric title', () => {
+		// React prints a number, so the header rendered it before.
+		mockDefaultSections = [ { ...DEFAULT_SECTIONS[ 1 ], title: 2026 } ];
+
+		const [ charts ] = mergeSectionsWithDefaults( undefined );
+
+		expect( charts.title ).toBe( '2026' );
+	} );
+
+	it( 'keeps a default section keyed by a number', () => {
+		// The key is matched by strict equality and round trips through the
+		// stored JSON, so a number ties the section back to its default.
+		mockDefaultSections = [ { ...DEFAULT_SECTIONS[ 1 ], key: 42 } ];
+
+		const sections = mergeSectionsWithDefaults( [
+			{ key: 42, title: 'My charts' },
+		] );
+
+		expect( sections ).toHaveLength( 1 );
+		expect( sections[ 0 ] ).toMatchObject( {
+			key: 42,
+			title: 'My charts',
+		} );
 	} );
 } );
 
@@ -234,6 +291,25 @@ describe( 'CustomizableDashboard', () => {
 
 		expect( getByText( 'Performance' ) ).toBeInTheDocument();
 		expect( getByText( 'Charts' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a registered section that is visible by a truthy value', () => {
+		// An extension section registered the way the released dashboard
+		// accepted it, on a store that never customized the dashboard.
+		mockDefaultSections = [
+			...DEFAULT_SECTIONS,
+			{
+				key: 'my-extension',
+				component: () => null,
+				title: 'Mine',
+				isVisible: 1,
+				hiddenBlocks: [],
+			},
+		];
+
+		const { getByText } = renderDashboard( undefined );
+
+		expect( getByText( 'Mine' ) ).toBeInTheDocument();
 	} );
 
 	it( 'repairs a corrupted preference once, without the React nodes', () => {

--- a/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/test/customizable.js
@@ -312,6 +312,48 @@ describe( 'CustomizableDashboard', () => {
 		expect( getByText( 'Mine' ) ).toBeInTheDocument();
 	} );
 
+	it( 'offers a hidden section the filter registered without an icon', () => {
+		// `Icon` clones the icon it is handed, so anything but a React element
+		// throws where the merchant goes to bring the section back.
+		mockDefaultSections = [
+			...DEFAULT_SECTIONS,
+			{
+				key: 'my-extension',
+				component: () => null,
+				title: 'Mine',
+				isVisible: 0,
+				hiddenBlocks: [],
+			},
+		];
+
+		const { getByTitle } = renderDashboard( undefined );
+		fireEvent.click( getByTitle( 'Add more sections' ) );
+
+		expect( getByTitle( 'Add Mine section' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the icon of a hidden section that provides one', () => {
+		mockDefaultSections = [
+			...DEFAULT_SECTIONS,
+			{
+				key: 'my-extension',
+				component: () => null,
+				title: 'Mine',
+				isVisible: false,
+				icon: <svg />,
+				hiddenBlocks: [],
+			},
+		];
+
+		// The dropdown renders in a popover, so it lands outside `container`.
+		const { baseElement, getByTitle } = renderDashboard( undefined );
+		fireEvent.click( getByTitle( 'Add more sections' ) );
+
+		expect(
+			baseElement.querySelector( '.my-extension__icon' )
+		).toBeInTheDocument();
+	} );
+
 	it( 'repairs a corrupted preference once, without the React nodes', () => {
 		const { rerender } = renderDashboard( [ null, null ] );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

`getDefaultSections()` ran the stored preference's `deleteUnusableFields` over the entries returned by `woocommerce_dashboard_default_sections`. Dropping a field is right for a stored section, because a default backs it up, but nothing sits behind a default. An extension registering `isVisible: 1` or `'yes'` ended up with `isVisible === undefined`, and since the render gate is truthiness while "Add more sections" filters `=== false`, the section was neither shown nor offered. The merchant had no way to bring it back. The same deletion blanked a non-string `title`, and a non-string `key` dropped the entry outright.

Defaults now convert an unusable field instead of dropping it: `hiddenBlocks` falls back to an empty list, `isVisible` to the truthiness the render gate has always used, and a numeric `title` to the string it was rendered as. A finite number is accepted as a section key again, since the key is matched by strict equality and round trips through the stored JSON. An entry with no `component` is still dropped, because rendering one takes the whole dashboard down.

The tightening this relaxes is only on trunk, so no released version is affected.

(For Bug Fixes) Bug introduced in PR #67888.

Closes WOOAIRR-122.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Drop this into a mu-plugin, which registers four sections through the filter the way an extension would:

    ```php
    <?php
    add_action(
        'admin_enqueue_scripts',
        function () {
            $js = <<<'JS'
    ( function ( hooks ) {
        function makeSection( label ) {
            return function ( props ) {
                return window.wp.element.createElement(
                    'div',
                    { className: 'repro-section' },
                    'Section ' + label + ' | title=' + JSON.stringify( props.title )
                );
            };
        }

        hooks.addFilter(
            'woocommerce_dashboard_default_sections',
            'repro/sections',
            function ( sections ) {
                return sections.concat( [
                    { key: 'repro-boolean', component: makeSection( 'boolean' ), title: 'Boolean', isVisible: true, hiddenBlocks: [] },
                    { key: 'repro-truthy', component: makeSection( 'truthy' ), title: 'Truthy', isVisible: 1, hiddenBlocks: [] },
                    { key: 'repro-yes', component: makeSection( 'yes' ), title: 'Yes', isVisible: 'yes', hiddenBlocks: [] },
                    { key: 'repro-falsy', component: makeSection( 'falsy' ), title: 'Falsy', isVisible: 0, hiddenBlocks: [] },
                    { key: 'repro-title', component: makeSection( 'title' ), title: 2026, isVisible: true, hiddenBlocks: [] },
                ] );
            }
        );
    } )( window.wp.hooks );
    JS;
            wp_add_inline_script( 'wp-hooks', $js );
        }
    );
    ```

2. Make sure the admin user has no stored dashboard preference: `wp user meta delete <user> woocommerce_admin_dashboard_sections`.
3. Open **Analytics > Overview** on trunk without this branch. Only `repro-boolean` renders. `repro-truthy` and `repro-yes` are gone, `repro-falsy` is gone, there is no "Add more sections" button at all, and `repro-title` renders with `title=undefined`.
4. Check out this branch, run `pnpm --filter='@woocommerce/plugin-woocommerce' build`, and reload. `repro-boolean`, `repro-truthy`, `repro-yes` and `repro-title` all render, `repro-title` gets `title="2026"`, and `repro-falsy` is offered under "Add more sections".
5. Confirm the hardening from #67888 still holds: set a corrupted preference with `wp user meta update <user> woocommerce_admin_dashboard_sections '[null,null]'`, reload, and the dashboard renders the defaults and repairs the stored value instead of crashing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested on a local WordPress 7.1 / PHP 8.3 install with a fresh store, running the steps above.

- Reproduced the loss before the change and confirmed every case renders after it.
- Confirmed a corrupted `[null,null]` preference still falls back to the defaults and repairs itself, and that the repaired value now persists the extension sections with `isVisible: true` and the normalized title rather than losing them.
- `pnpm --filter=@woocommerce/admin-library run test:js -- dashboard/` passes, 46 tests. The 6 new and changed tests in `dashboard/test/customizable.js` fail against trunk without the source change.
- eslint clean on both changed files.

This was found by the AI regression review pipeline against #67888.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The behavior this restores was only ever tightened on trunk, in #67888, which has not shipped in a release. There is nothing here for a merchant or an extension developer to read about.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Claude Code was used to investigate the report, write the change and the tests, and verify it in a local environment. I reviewed the result and take responsibility for it.