### PR TITLE
Overwrite the combined translation file when publishing it fails

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooairr-31-stale-combined-translations
+++ b/plugins/woocommerce/changelog/fix-wooairr-31-stale-combined-translations
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Same-cycle regression from #67548, never present in a stable release; a Fix entry would describe a bug no 11.1.x upgrader experienced.

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -245,27 +245,33 @@ class Translations {
 		$cache_filename          = $this->get_combined_translation_filename( $plugin_domain, $locale );
 		$chunk_translations_json = wp_json_encode( $translations_from_chunks );
 
-		// Publish via a temp file so readers never observe a partial write.
+		// Publish via a temp file so readers do not observe a partial write; the fallback below
+		// gives that up rather than leave the previous pack's file in place.
 		$temp_path  = $language_dir . $cache_filename . '.' . wp_generate_password( 12, false ) . '.tmp';
 		$cache_path = $language_dir . $cache_filename;
+		$published  = false;
 
-		if ( ! $wp_filesystem->put_contents( $temp_path, $chunk_translations_json ) ) {
-			$wp_filesystem->delete( $temp_path );
-			return;
-		}
-
-		// Not WP_Filesystem_Direct::move(): it deletes the destination before renaming.
-		if ( 'direct' === get_filesystem_method() ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- Atomic replace; failure handled below.
-			if ( ! @rename( $temp_path, $cache_path ) ) {
-				$wp_filesystem->delete( $temp_path );
+		if ( $wp_filesystem->put_contents( $temp_path, $chunk_translations_json ) ) {
+			// Not WP_Filesystem_Direct::move(): it deletes the destination before renaming.
+			if ( 'direct' === get_filesystem_method() ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- Atomic replace; failure handled below.
+				$published = @rename( $temp_path, $cache_path );
+			} else {
+				// Remote filesystems: overwrite only when refreshing an existing file.
+				$published = $wp_filesystem->move( $temp_path, $cache_path, $wp_filesystem->exists( $cache_path ) );
 			}
-			return;
 		}
 
-		// Remote filesystems: overwrite only when refreshing an existing file.
-		$overwrite = $wp_filesystem->exists( $cache_path );
-		if ( ! $wp_filesystem->move( $temp_path, $cache_path, $overwrite ) ) {
+		if ( ! $published ) {
+			/*
+			 * Reached when the temp file could not be written, and when publishing it failed: the
+			 * FTP filesystems ignore the $overwrite argument and return ftp_rename() as-is, so
+			 * servers that refuse to rename onto an existing path end up here. Without an in-place
+			 * overwrite the previous language pack's file would survive, and nothing would ever
+			 * replace it: the on-demand rebuild only runs when the file is missing, and never on a
+			 * remote filesystem.
+			 */
+			$wp_filesystem->put_contents( $cache_path, $chunk_translations_json );
 			$wp_filesystem->delete( $temp_path );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -271,7 +271,18 @@ class Translations {
 			 * replace it: the on-demand rebuild only runs when the file is missing, and never on a
 			 * remote filesystem.
 			 */
-			$wp_filesystem->put_contents( $cache_path, $chunk_translations_json );
+			if ( ! $wp_filesystem->put_contents( $cache_path, $chunk_translations_json ) ) {
+				/*
+				 * An in-place write truncates the file before it can fail, so what survives may be
+				 * invalid JSON. A missing file recovers on its own - the rebuild triggers on it and
+				 * readers fall back to their own translation file - while a corrupt one is served
+				 * as-is forever.
+				 */
+				$leftover = $wp_filesystem->exists( $cache_path ) ? $wp_filesystem->get_contents( $cache_path ) : false;
+				if ( false !== $leftover && null === json_decode( $leftover, true ) ) {
+					$wp_filesystem->delete( $cache_path, false, 'f' );
+				}
+			}
 
 			// Without the type, FTPext::delete() falls through to ftp_rmdir() when the file is absent.
 			$wp_filesystem->delete( $temp_path, false, 'f' );

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -272,7 +272,9 @@ class Translations {
 			 * remote filesystem.
 			 */
 			$wp_filesystem->put_contents( $cache_path, $chunk_translations_json );
-			$wp_filesystem->delete( $temp_path );
+
+			// Without the type, FTPext::delete() falls through to ftp_rmdir() when the file is absent.
+			$wp_filesystem->delete( $temp_path, false, 'f' );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
@@ -308,6 +308,82 @@ class TranslationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Should remove the combined file when the in-place write leaves it truncated.
+	 */
+	public function test_removes_combined_file_when_fallback_write_is_truncated(): void {
+		$combined = $this->lang_dir . 'woocommerce-de_DE-' . WC_ADMIN_APP . '.json';
+		file_put_contents( $combined, '{"stale":true}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->create_chunk_json(
+			'gggggggggggggggggggggggggggggggg',
+			WC_ADMIN_DIST_JS_FOLDER . 'app/index.js',
+			array( 'Show' => array( 'Anzeigen' ) )
+		);
+
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		\WP_Filesystem();
+
+		$previous_filesystem = $GLOBALS['wp_filesystem'];
+
+		// Mirrors WP_Filesystem_Direct::put_contents() truncating the file before a short write fails.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Stub filesystem, restored below.
+		$stub                = new class( null ) extends \WP_Filesystem_Direct {
+			/**
+			 * Path the truncated write is simulated for.
+			 *
+			 * @var string
+			 */
+			public $truncate_path = '';
+
+			/**
+			 * Always reports the move as failed.
+			 *
+			 * @param string $source      Path to the source file.
+			 * @param string $destination Path to the destination file.
+			 * @param bool   $overwrite   Whether to overwrite the destination.
+			 * @return bool Always false.
+			 */
+			public function move( $source, $destination, $overwrite = false ) {
+				return false;
+			}
+
+			/**
+			 * Writes a partial payload and reports failure for the tracked path.
+			 *
+			 * @param string    $file     Path to the file.
+			 * @param string    $contents Contents to write.
+			 * @param int|false $mode     Optional file permissions.
+			 * @return bool Whether the contents were written.
+			 */
+			public function put_contents( $file, $contents, $mode = false ) {
+				if ( $file === $this->truncate_path ) {
+					parent::put_contents( $file, '{"locale_data', $mode );
+					return false;
+				}
+				return parent::put_contents( $file, $contents, $mode );
+			}
+		};
+		$stub->truncate_path = $combined;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Stub filesystem, restored below.
+		$GLOBALS['wp_filesystem'] = $stub;
+		// The direct branch renames outside the filesystem object, so route publishing through move().
+		add_filter( 'filesystem_method', array( $this, 'force_ftpext_filesystem' ), PHP_INT_MAX );
+
+		try {
+			$build = new \ReflectionMethod( Translations::class, 'build_and_save_translations' );
+			$build->setAccessible( true );
+			$build->invoke( $this->sut, $this->lang_dir, 'woocommerce', 'de_DE' );
+		} finally {
+			remove_filter( 'filesystem_method', array( $this, 'force_ftpext_filesystem' ), PHP_INT_MAX );
+			$GLOBALS['wp_filesystem'] = $previous_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the real filesystem.
+		}
+
+		$this->assertFileDoesNotExist( $combined, 'A truncated write should not be left behind for readers to parse' );
+		$this->assertSame( array(), glob( $this->lang_dir . '*.tmp' ), 'No temporary files should be left behind after a truncated write' );
+	}
+
+	/**
 	 * @testdox Should fall back to the original file when nothing can be rebuilt.
 	 */
 	public function test_falls_back_to_original_file_when_rebuild_not_possible(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
@@ -81,6 +81,15 @@ class TranslationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Forces get_filesystem_method() to report a remote filesystem.
+	 *
+	 * @return string Filesystem method.
+	 */
+	public function force_ftpext_filesystem() {
+		return 'ftpext';
+	}
+
+	/**
 	 * Writes a chunk translation JSON file in the official language pack format.
 	 *
 	 * @param string $md5_name  Fake md5 part of the filename.
@@ -193,6 +202,109 @@ class TranslationsTest extends WC_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'stale', $data, 'The stale combined file should be replaced' );
 		$this->assertSame( array( 'Produkte vergleichen' ), $data['locale_data']['messages']['Compare Products'], 'The replacement should contain the rebuilt translations' );
 		$this->assertSame( array(), glob( $this->lang_dir . '*.tmp' ), 'No temporary files should be left behind after replacing the combined file' );
+	}
+
+	/**
+	 * @testdox Should overwrite the combined file in place when a remote filesystem refuses to move onto it.
+	 */
+	public function test_replaces_existing_combined_file_when_remote_move_fails(): void {
+		$combined = $this->lang_dir . 'woocommerce-de_DE-' . WC_ADMIN_APP . '.json';
+		file_put_contents( $combined, '{"stale":true}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->create_chunk_json(
+			'dddddddddddddddddddddddddddddddd',
+			WC_ADMIN_DIST_JS_FOLDER . 'app/index.js',
+			array( 'Show' => array( 'Anzeigen' ) )
+		);
+
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		\WP_Filesystem();
+
+		$previous_filesystem = $GLOBALS['wp_filesystem'];
+
+		// Mirrors WP_Filesystem_FTPext against a server that refuses to rename onto an existing path.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Stub filesystem, restored below.
+		$GLOBALS['wp_filesystem'] = new class( null ) extends \WP_Filesystem_Direct {
+			/**
+			 * Always reports the move as failed.
+			 *
+			 * @param string $source      Path to the source file.
+			 * @param string $destination Path to the destination file.
+			 * @param bool   $overwrite   Whether to overwrite the destination.
+			 * @return bool Always false.
+			 */
+			public function move( $source, $destination, $overwrite = false ) {
+				return false;
+			}
+		};
+		add_filter( 'filesystem_method', array( $this, 'force_ftpext_filesystem' ), PHP_INT_MAX );
+
+		try {
+			$build = new \ReflectionMethod( Translations::class, 'build_and_save_translations' );
+			$build->setAccessible( true );
+			$build->invoke( $this->sut, $this->lang_dir, 'woocommerce', 'de_DE' );
+		} finally {
+			remove_filter( 'filesystem_method', array( $this, 'force_ftpext_filesystem' ), PHP_INT_MAX );
+			$GLOBALS['wp_filesystem'] = $previous_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the real filesystem.
+		}
+
+		$data = json_decode( file_get_contents( $combined ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$this->assertArrayNotHasKey( 'stale', $data, 'The previous language pack file should not survive a failed move' );
+		$this->assertSame( array( 'Anzeigen' ), $data['locale_data']['messages']['Show'], 'The refreshed translations should be written in place instead' );
+		$this->assertSame( array(), glob( $this->lang_dir . '*.tmp' ), 'No temporary files should be left behind after the fallback write' );
+	}
+
+	/**
+	 * @testdox Should overwrite the combined file in place when the temp file cannot be written.
+	 */
+	public function test_replaces_existing_combined_file_when_temp_write_fails(): void {
+		$combined = $this->lang_dir . 'woocommerce-de_DE-' . WC_ADMIN_APP . '.json';
+		file_put_contents( $combined, '{"stale":true}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->create_chunk_json(
+			'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+			WC_ADMIN_DIST_JS_FOLDER . 'app/index.js',
+			array( 'Show' => array( 'Anzeigen' ) )
+		);
+
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		\WP_Filesystem();
+
+		$previous_filesystem = $GLOBALS['wp_filesystem'];
+
+		// Mirrors a language directory that allows writing its existing files but not creating new ones.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Stub filesystem, restored below.
+		$GLOBALS['wp_filesystem'] = new class( null ) extends \WP_Filesystem_Direct {
+			/**
+			 * Rejects writes to the temp file, allowing every other write through.
+			 *
+			 * @param string    $file     Path to the file.
+			 * @param string    $contents Contents to write.
+			 * @param int|false $mode     Optional file permissions.
+			 * @return bool Whether the contents were written.
+			 */
+			public function put_contents( $file, $contents, $mode = false ) {
+				if ( str_ends_with( $file, '.tmp' ) ) {
+					return false;
+				}
+				return parent::put_contents( $file, $contents, $mode );
+			}
+		};
+
+		try {
+			$build = new \ReflectionMethod( Translations::class, 'build_and_save_translations' );
+			$build->setAccessible( true );
+			$build->invoke( $this->sut, $this->lang_dir, 'woocommerce', 'de_DE' );
+		} finally {
+			$GLOBALS['wp_filesystem'] = $previous_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the real filesystem.
+		}
+
+		$data = json_decode( file_get_contents( $combined ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$this->assertArrayNotHasKey( 'stale', $data, 'The previous language pack file should not survive a failed temp write' );
+		$this->assertSame( array( 'Anzeigen' ), $data['locale_data']['messages']['Show'], 'The refreshed translations should be written in place instead' );
+		$this->assertSame( array(), glob( $this->lang_dir . '*.tmp' ), 'No temporary files should be left behind after the fallback write' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/TranslationsTest.php
@@ -90,6 +90,15 @@ class TranslationsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Forces get_filesystem_method() to report an SSH2 filesystem.
+	 *
+	 * @return string Filesystem method.
+	 */
+	public function force_ssh2_filesystem() {
+		return 'ssh2';
+	}
+
+	/**
 	 * Writes a chunk translation JSON file in the official language pack format.
 	 *
 	 * @param string $md5_name  Fake md5 part of the filename.
@@ -305,6 +314,57 @@ class TranslationsTest extends WC_Unit_Test_Case {
 		$this->assertArrayNotHasKey( 'stale', $data, 'The previous language pack file should not survive a failed temp write' );
 		$this->assertSame( array( 'Anzeigen' ), $data['locale_data']['messages']['Show'], 'The refreshed translations should be written in place instead' );
 		$this->assertSame( array(), glob( $this->lang_dir . '*.tmp' ), 'No temporary files should be left behind after the fallback write' );
+	}
+
+	/**
+	 * @testdox Should recreate the combined file when a remote move removes it before failing.
+	 */
+	public function test_recreates_combined_file_when_remote_move_destroys_it(): void {
+		$combined = $this->lang_dir . 'woocommerce-de_DE-' . WC_ADMIN_APP . '.json';
+		file_put_contents( $combined, '{"stale":true}' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->create_chunk_json(
+			'ffffffffffffffffffffffffffffffff',
+			WC_ADMIN_DIST_JS_FOLDER . 'app/index.js',
+			array( 'Show' => array( 'Anzeigen' ) )
+		);
+
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		\WP_Filesystem();
+
+		$previous_filesystem = $GLOBALS['wp_filesystem'];
+
+		// Mirrors WP_Filesystem_SSH2::move(), which removes the destination before renaming onto it.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Stub filesystem, restored below.
+		$GLOBALS['wp_filesystem'] = new class( null ) extends \WP_Filesystem_Direct {
+			/**
+			 * Removes the destination, then reports the move as failed.
+			 *
+			 * @param string $source      Path to the source file.
+			 * @param string $destination Path to the destination file.
+			 * @param bool   $overwrite   Whether to overwrite the destination.
+			 * @return bool Always false.
+			 */
+			public function move( $source, $destination, $overwrite = false ) {
+				$this->delete( $destination, false, 'f' );
+				return false;
+			}
+		};
+		add_filter( 'filesystem_method', array( $this, 'force_ssh2_filesystem' ), PHP_INT_MAX );
+
+		try {
+			$build = new \ReflectionMethod( Translations::class, 'build_and_save_translations' );
+			$build->setAccessible( true );
+			$build->invoke( $this->sut, $this->lang_dir, 'woocommerce', 'de_DE' );
+		} finally {
+			remove_filter( 'filesystem_method', array( $this, 'force_ssh2_filesystem' ), PHP_INT_MAX );
+			$GLOBALS['wp_filesystem'] = $previous_filesystem; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the real filesystem.
+		}
+
+		$this->assertFileExists( $combined, 'A move that removes the destination should not leave the site without a combined file' );
+		$data = json_decode( file_get_contents( $combined ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$this->assertSame( array( 'Anzeigen' ), $data['locale_data']['messages']['Show'], 'The recreated file should contain the rebuilt translations' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

`build_and_save_translations()` publishes via temp + rename, and every failure path just deletes the temp and gives up:

-   `WP_Filesystem_FTPext::move()` and `FTPsockets::move()` ignore `$overwrite` and return `ftp_rename()` as-is, so on servers that refuse to rename onto an existing path the previous pack's file survives untouched.
-   `WP_Filesystem_SSH2::move()` deletes the destination first, so a failed rename there left no file at all.
-   Neither state ever repairs: the on-demand rebuild fires only when the file is missing, and returns early for every non-direct filesystem.

Falls back to an in-place `put_contents()` when the temp file cannot be written or published - what the code did before #67548. Atomic rename stays the fast path. A truncated fallback write is removed rather than served as invalid JSON.

Not shipped: `0fd1dc67d31` is in neither `11.0.1` nor `11.1.0-beta.1`. No BC impact - private method, no hook, signature, or script handle changes.

Bug introduced in PR #67548.

Linear: WOOAIRR-31

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1.  `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env -- --filter TranslationsTest` -> 10 passing.
2.  Revert `Translations.php` to trunk, re-run -> 4 failures.
3.  For a real site: run the script below with `wp eval-file`. This branch prints `REFRESHED (ok)`, trunk prints `STALE (bug)`.

<details>
<summary>Repro script</summary>

```php
<?php
use Automattic\WooCommerce\Internal\Admin\Translations;

require_once ABSPATH . 'wp-admin/includes/file.php';
require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';

WP_Filesystem(); // Defines FS_CHMOD_FILE and friends.

// Models WP_Filesystem_FTPext against a server that refuses to rename onto an existing path.
class WOOAIRR31_Remote_FS extends WP_Filesystem_Direct {
	public function move( $source, $destination, $overwrite = false ) {
		return $this->exists( $destination ) ? false : parent::move( $source, $destination, $overwrite );
	}
}

$locale   = 'nl_NL';
$domain   = 'woocommerce';
$lang_dir = WP_LANG_DIR . '/plugins/';
$combined = $lang_dir . $domain . '-' . $locale . '-' . WC_ADMIN_APP . '.json';
$chunk    = $lang_dir . $domain . '-' . $locale . '-aaaachunk.json';

wp_mkdir_p( $lang_dir );
foreach ( (array) glob( $lang_dir . $domain . '-' . $locale . '-*.json' ) as $f ) {
	unlink( $f );
}

$write_chunk = function ( $msg ) use ( $chunk, $locale ) {
	file_put_contents( $chunk, wp_json_encode( array(
		'translation-revision-date' => '2026-01-01 00:00:00+0000',
		'generator'                 => 'repro',
		'domain'                    => 'messages',
		'locale_data'               => array( 'messages' => array(
			''       => array( 'domain' => 'messages', 'lang' => $locale, 'plural-forms' => 'nplurals=2; plural=(n != 1);' ),
			'Orders' => array( $msg ),
		) ),
		'comment'                   => array( 'reference' => WC_ADMIN_DIST_JS_FOLDER . 'app/index.js' ),
	) ) );
};

$read_combined = function () use ( $combined ) {
	return file_exists( $combined )
		? ( json_decode( file_get_contents( $combined ), true )['locale_data']['messages']['Orders'][0] ?? '(no Orders key)' )
		: '(file missing)';
};

add_filter( 'determine_locale', fn() => $locale );

$translations = Translations::get_instance();
$build        = new ReflectionMethod( Translations::class, 'build_and_save_translations' );
$build->setAccessible( true );

// 1. Original language pack installs on a normal host.
$GLOBALS['wp_filesystem'] = new WP_Filesystem_Direct( null );
$write_chunk( 'PACK-V1-Bestellingen' );
$build->invoke( $translations, $lang_dir, $domain, $locale );
echo "1. initial pack (direct fs)       -> " . $read_combined() . "\n";

// 2. Language pack update arrives on an FTP host.
add_filter( 'filesystem_method', fn() => 'ftpext', PHP_INT_MAX ); // Outrank WP-CLI's own 'direct' filter.
$GLOBALS['wp_filesystem'] = new WOOAIRR31_Remote_FS( null );
$write_chunk( 'PACK-V2-Bestellingen' );
$build->invoke( $translations, $lang_dir, $domain, $locale );
echo "2. pack updated to V2 (remote fs) -> " . $read_combined() . "\n";
echo "   temp files left behind: " . count( glob( $lang_dir . '*.tmp' ) ) . "\n";

echo "VERDICT: " . ( 'PACK-V2-Bestellingen' === $read_combined() ? 'REFRESHED (ok)' : 'STALE (bug)' ) . "\n";
```

</details>

<!-- End testing instructions -->

### Testing that has already taken place:

-   Script above run on a native WP site (WP latest, PHP 8.2) against `11.0.1`, trunk, and this branch: `11.0.1` refreshes, trunk goes stale, this branch refreshes.
-   `TranslationsTest` 10/10 in wp-env (PHP 8.1). PHPCS and PHPStan clean.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

Added manually (`Type: dev`, comment-only): same-cycle regression, so a Fix entry would describe a bug no 11.1.x upgrader experienced.

### Use of AI Tools

Investigated, written, and tested with Claude Code (Opus 5). I reviewed the diff and the test evidence myself.
