### PR TITLE
Fix email verification prompt for guest checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-verification-guest-checkout-prompt
+++ b/plugins/woocommerce/changelog/fix-email-verification-guest-checkout-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Suppress the customer email verification prompt when guest checkout is disabled.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -224,19 +224,12 @@ class VerificationController {
 		$user_id     = get_current_user_id();
 		$should_show = (bool) $user_id;
 
-		if ( $should_show && 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) {
-			$should_show = false;
-		}
+		$should_show = $should_show && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
+		$should_show = $should_show && ! $this->service->is_verified( $user_id );
 
-		if ( $should_show && $this->service->is_verified( $user_id ) ) {
-			$should_show = false;
-		}
-
-		if ( $should_show ) {
-			// A temporary-password account already has a set-password link (which also verifies on use),
-			// surfaced by the temporary-password notice — don't show a second prompt alongside it.
-			$should_show = ! get_user_option( 'default_password_nag', $user_id );
-		}
+		// A temporary-password account already has a set-password link (which also verifies on use),
+		// surfaced by the temporary-password notice — don't show a second prompt alongside it.
+		$should_show = $should_show && ! get_user_option( 'default_password_nag', $user_id );
 
 		/**
 		 * Filter whether to show the verification prompt for a given user.
@@ -246,7 +239,7 @@ class VerificationController {
 		 * @param bool $should_show Whether to show the prompt.
 		 * @param int  $user_id     The WordPress user ID of the customer.
 		 */
-		return apply_filters( 'woocommerce_customer_email_verification_should_show_prompt', $should_show, $user_id );
+		return (bool) apply_filters( 'woocommerce_customer_email_verification_should_show_prompt', $should_show, $user_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -210,33 +210,32 @@ class VerificationController {
 	/**
 	 * Return whether the verification prompt should be shown for the current user.
 	 *
-	 * True for a logged-in, unverified customer, except one still using a temporary password (those
-	 * confirm via their set-password link, so the temporary-password notice already covers it). This
-	 * must not depend on whether matching guest orders exist, because that would disclose order
-	 * existence before the customer proves they control the email address. It can depend on whether
-	 * the store has accepted any guest orders at all, because that is not customer-specific.
+	 * This cannot depend on whether matching guest orders exist, since that would disclose order
+	 * existence before the customer proves they control the email address.
 	 *
 	 * @since 11.0.0
 	 *
 	 * @return bool
 	 */
 	public function should_show_prompt(): bool {
-		$user_id     = get_current_user_id();
-		$should_show = (bool) $user_id;
+		$user_id = get_current_user_id();
 
-		$should_show = $should_show && wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
-		$should_show = $should_show && ! $this->service->is_verified( $user_id );
+		if ( ! $user_id || $this->service->is_verified( $user_id ) ) {
+			return false;
+		}
+
+		$should_show = wc_string_to_bool( get_option( 'woocommerce_enable_guest_checkout' ) );
 
 		// A temporary-password account already has a set-password link (which also verifies on use),
-		// surfaced by the temporary-password notice — don't show a second prompt alongside it.
+		// surfaced by the temporary-password notice, so skip a second prompt alongside it.
 		$should_show = $should_show && ! get_user_option( 'default_password_nag', $user_id );
 
 		/**
-		 * Filter whether to show the verification prompt for a given user.
+		 * Filter whether to show the verification prompt for an unverified user.
 		 *
 		 * @since 11.1.0
 		 *
-		 * @param bool $should_show Whether to show the prompt.
+		 * @param bool $should_show Whether to show the prompt, before this filter runs.
 		 * @param int  $user_id     The WordPress user ID of the customer.
 		 */
 		return (bool) apply_filters( 'woocommerce_customer_email_verification_should_show_prompt', $should_show, $user_id );

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/VerificationController.php
@@ -213,30 +213,40 @@ class VerificationController {
 	 * True for a logged-in, unverified customer, except one still using a temporary password (those
 	 * confirm via their set-password link, so the temporary-password notice already covers it). This
 	 * must not depend on whether matching guest orders exist, because that would disclose order
-	 * existence before the customer proves they control the email address.
+	 * existence before the customer proves they control the email address. It can depend on whether
+	 * the store has accepted any guest orders at all, because that is not customer-specific.
 	 *
 	 * @since 11.0.0
 	 *
 	 * @return bool
 	 */
 	public function should_show_prompt(): bool {
-		$user_id = get_current_user_id();
+		$user_id     = get_current_user_id();
+		$should_show = (bool) $user_id;
 
-		if ( ! $user_id ) {
-			return false;
+		if ( $should_show && 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) {
+			$should_show = false;
 		}
 
-		if ( $this->service->is_verified( $user_id ) ) {
-			return false;
+		if ( $should_show && $this->service->is_verified( $user_id ) ) {
+			$should_show = false;
 		}
 
-		// A temporary-password account already has a set-password link (which also verifies on use),
-		// surfaced by the temporary-password notice — don't show a second prompt alongside it.
-		if ( get_user_option( 'default_password_nag', $user_id ) ) {
-			return false;
+		if ( $should_show ) {
+			// A temporary-password account already has a set-password link (which also verifies on use),
+			// surfaced by the temporary-password notice — don't show a second prompt alongside it.
+			$should_show = ! get_user_option( 'default_password_nag', $user_id );
 		}
 
-		return true;
+		/**
+		 * Filter whether to show the verification prompt for a given user.
+		 *
+		 * @since 11.1.0
+		 *
+		 * @param bool $should_show Whether to show the prompt.
+		 * @param int  $user_id     The WordPress user ID of the customer.
+		 */
+		return apply_filters( 'woocommerce_customer_email_verification_should_show_prompt', $should_show, $user_id );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -158,17 +158,8 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $user_id );
 		update_option( 'woocommerce_enable_guest_checkout', 'no' );
 
-		$override = static function ( bool $show ): bool {
-			unset( $show );
-			return true;
-		};
-
-		add_filter( 'woocommerce_customer_email_verification_should_show_prompt', $override );
-		try {
-			$this->assertTrue( $this->sut->should_show_prompt(), 'The prompt default should be overrideable by filter.' );
-		} finally {
-			remove_filter( 'woocommerce_customer_email_verification_should_show_prompt', $override );
-		}
+		add_filter( 'woocommerce_customer_email_verification_should_show_prompt', '__return_true' );
+		$this->assertTrue( $this->sut->should_show_prompt(), 'The prompt default should be overrideable by filter.' );
 	}
 
 	/**
@@ -192,6 +183,18 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		$this->service->mark_verified( $user_id );
 
 		$this->assertFalse( $this->sut->should_show_prompt(), 'Verified customers should not see the prompt' );
+	}
+
+	/**
+	 * @testdox should_show_prompt never applies the filter for a verified customer.
+	 */
+	public function test_should_show_prompt_ignores_filter_for_verified_customer(): void {
+		$user_id = wc_create_new_customer( 'prompt-verified-filtered@example.com', 'promptverifiedfiltered', 'pw' );
+		wp_set_current_user( $user_id );
+		$this->service->mark_verified( $user_id );
+
+		add_filter( 'woocommerce_customer_email_verification_should_show_prompt', '__return_true' );
+		$this->assertFalse( $this->sut->should_show_prompt(), 'A verified customer should never see the prompt, even if a filter tries to force it on.' );
 	}
 
 	// -------------------------------------------------------------------------

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/MyAccountPromptTest.php
@@ -27,12 +27,21 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	private $service;
 
 	/**
+	 * Previous guest checkout option value.
+	 *
+	 * @var mixed
+	 */
+	private $previous_guest_checkout_option;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->service = wc_get_container()->get( EmailVerificationService::class );
-		$this->sut     = wc_get_container()->get( VerificationController::class );
+		$this->service                        = wc_get_container()->get( EmailVerificationService::class );
+		$this->sut                            = wc_get_container()->get( VerificationController::class );
+		$this->previous_guest_checkout_option = get_option( 'woocommerce_enable_guest_checkout', null );
+		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
 	}
 
 	/**
@@ -41,7 +50,23 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		wp_set_current_user( 0 );
 		wc_clear_notices();
+		$this->restore_option( 'woocommerce_enable_guest_checkout', $this->previous_guest_checkout_option );
 		parent::tearDown();
+	}
+
+	/**
+	 * Restore an option to its previous value.
+	 *
+	 * @param string $option_name    Option name.
+	 * @param mixed  $previous_value Previous option value, or null if it did not exist.
+	 */
+	private function restore_option( string $option_name, $previous_value ): void {
+		if ( null === $previous_value ) {
+			delete_option( $option_name );
+			return;
+		}
+
+		update_option( $option_name, $previous_value );
 	}
 
 	/**
@@ -112,6 +137,38 @@ class MyAccountPromptTest extends WC_Unit_Test_Case {
 		wp_set_current_user( $user_id );
 
 		$this->assertTrue( $this->sut->should_show_prompt(), 'Prompt visibility must not reveal whether matching guest orders exist' );
+	}
+
+	/**
+	 * @testdox should_show_prompt returns false when guest checkout is disabled.
+	 */
+	public function test_should_show_prompt_returns_false_when_guest_checkout_is_disabled(): void {
+		$user_id = wc_create_new_customer( 'prompt-guest-disabled@example.com', 'promptguestdisabled', 'pw' );
+		wp_set_current_user( $user_id );
+		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+
+		$this->assertFalse( $this->sut->should_show_prompt(), 'The prompt should not show when guest checkout is disabled.' );
+	}
+
+	/**
+	 * @testdox should_show_prompt allows filters to override the guest checkout default.
+	 */
+	public function test_should_show_prompt_allows_filter_to_override_guest_checkout_default(): void {
+		$user_id = wc_create_new_customer( 'prompt-guest-disabled-filtered@example.com', 'promptguestdisabledfiltered', 'pw' );
+		wp_set_current_user( $user_id );
+		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+
+		$override = static function ( bool $show ): bool {
+			unset( $show );
+			return true;
+		};
+
+		add_filter( 'woocommerce_customer_email_verification_should_show_prompt', $override );
+		try {
+			$this->assertTrue( $this->sut->should_show_prompt(), 'The prompt default should be overrideable by filter.' );
+		} finally {
+			remove_filter( 'woocommerce_customer_email_verification_should_show_prompt', $override );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

[Context](https://developer.woocommerce.com/2026/08/18/woocommerce-11-1-pre-release/#comment-212861)

Currently we prompt all users with the verification prompt in their account view to link guest orders, regardless of whether the site even accepts them. This PR makes two changes:

1. Don't show the prompt if the site does not accept guest orders.
2. Adds a filter, allowing users to override this value if they would like to.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:

Not applicable. No visual changes when guest checkout remains enabled; when disabled, the existing prompt is suppressed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Disable guest checkout in WooCommerce settings.
3. Log in as an unverified customer and open My Account > Orders.
4. Confirm the email verification prompt is not displayed.
5. Add a temporary callback to `woocommerce_customer_email_verification_should_show_prompt` that returns `true`.
6. Refresh My Account > Orders and confirm the prompt can still be forced on by the filter.

<!-- End testing instructions -->

### Testing that has already taken place:

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

Drafted with AI assistance and reviewed before submission.