### PR TITLE
Add filter to control customer email verification status

### DIFF
--- a/plugins/woocommerce/changelog/67049-add-customer-email-is-verified-filter
+++ b/plugins/woocommerce/changelog/67049-add-customer-email-is-verified-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add the `woocommerce_customer_email_is_verified` filter to `EmailVerificationService::is_verified()`, allowing extensions that manage their own email-verification state to mark a customer's email as verified or unverified.

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -77,10 +77,7 @@ class EmailVerificationService {
 	 * @return bool True when the stored verified email matches the user's current email.
 	 */
 	public function is_verified( int $user_id ): bool {
-		$verified_email = (string) Users::get_site_user_meta( $user_id, self::VERIFIED_META );
-
-		// Both sides are lower-cased (stored that way, get_account_email() normalises), so === is exact.
-		$is_verified = '' !== $verified_email && $verified_email === $this->get_account_email( $user_id );
+		$is_verified = $this->has_verified_email( $user_id );
 
 		/**
 		 * Filters whether a customer's current account email address is considered verified.
@@ -97,11 +94,30 @@ class EmailVerificationService {
 	}
 
 	/**
+	 * Return whether the stored verified-email meta matches the user's current account email.
+	 *
+	 * Unlike {@see self::is_verified()} this reflects only the persisted state — the
+	 * 'woocommerce_customer_email_is_verified' filter is not applied — so write paths such as
+	 * {@see self::mark_verified()} stay consistent however extensions filter the reported status.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return bool True when the stored verified email matches the user's current email.
+	 */
+	private function has_verified_email( int $user_id ): bool {
+		$verified_email = (string) Users::get_site_user_meta( $user_id, self::VERIFIED_META );
+
+		// Both sides are lower-cased (stored that way, get_account_email() normalises), so === is exact.
+		return '' !== $verified_email && $verified_email === $this->get_account_email( $user_id );
+	}
+
+	/**
 	 * Mark the given user as having verified their current account email address.
 	 *
 	 * Stores the verified email address, clears any pending key, and fires the
-	 * {@see 'woocommerce_customer_email_verified'} action. No-ops if the user is already
-	 * verified for their current email.
+	 * {@see 'woocommerce_customer_email_verified'} action. No-ops only when the persisted
+	 * verified email already matches the current account email — the
+	 * 'woocommerce_customer_email_is_verified' filter does not gate the write, so an extension
+	 * filtering the reported status can neither block persistence nor cause a duplicate action.
 	 *
 	 * @since 11.0.0
 	 *
@@ -109,7 +125,7 @@ class EmailVerificationService {
 	 * @return void
 	 */
 	public function mark_verified( int $user_id ): void {
-		if ( $this->is_verified( $user_id ) ) {
+		if ( $this->has_verified_email( $user_id ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
+++ b/plugins/woocommerce/src/Internal/CustomerEmailVerification/EmailVerificationService.php
@@ -67,6 +67,10 @@ class EmailVerificationService {
 	 * account email, so changing the account email automatically invalidates the
 	 * status — no change event needs to be observed.
 	 *
+	 * The result is filterable via {@see 'woocommerce_customer_email_is_verified'}, so
+	 * extensions that manage their own verification state can mark customers as verified
+	 * (or unverified) without writing the verified-status meta.
+	 *
 	 * @since 11.0.0
 	 *
 	 * @param int $user_id WordPress user ID.
@@ -76,7 +80,20 @@ class EmailVerificationService {
 		$verified_email = (string) Users::get_site_user_meta( $user_id, self::VERIFIED_META );
 
 		// Both sides are lower-cased (stored that way, get_account_email() normalises), so === is exact.
-		return '' !== $verified_email && $verified_email === $this->get_account_email( $user_id );
+		$is_verified = '' !== $verified_email && $verified_email === $this->get_account_email( $user_id );
+
+		/**
+		 * Filters whether a customer's current account email address is considered verified.
+		 *
+		 * Allows extensions that manage their own email-verification state to report a customer
+		 * as verified (or unverified) without writing the verified-status meta.
+		 *
+		 * @param bool $is_verified Whether the customer's current account email is verified.
+		 * @param int  $user_id     WordPress user ID.
+		 *
+		 * @since 11.1.0
+		 */
+		return (bool) apply_filters( 'woocommerce_customer_email_is_verified', $is_verified, $user_id );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -206,4 +206,61 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $this->sut->is_verified( $user_id ), 'Non-email profile changes must not invalidate verification' );
 	}
+
+	/**
+	 * @testdox The is_verified filter should mark an unverified user as verified.
+	 */
+	public function test_is_verified_filter_marks_unverified_user_verified(): void {
+		$user_id = wc_create_new_customer( 'filter-verify@example.com', 'filterverify', 'pw' );
+
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+
+		$filtered = $this->sut->is_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+
+		$this->assertTrue( $filtered, 'The filter should be able to mark an unverified user as verified' );
+		$this->assertFalse( $this->sut->is_verified( $user_id ), 'Removing the filter should restore the unfiltered status' );
+	}
+
+	/**
+	 * @testdox The is_verified filter should mark a verified user as unverified.
+	 */
+	public function test_is_verified_filter_marks_verified_user_unverified(): void {
+		$user_id = wc_create_new_customer( 'filter-unverify@example.com', 'filterunverify', 'pw' );
+		$this->sut->mark_verified( $user_id );
+
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+
+		$filtered = $this->sut->is_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+
+		$this->assertFalse( $filtered, 'The filter should be able to mark a verified user as unverified' );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'Removing the filter should restore the unfiltered status' );
+	}
+
+	/**
+	 * @testdox The is_verified filter should receive the unfiltered status and the user ID.
+	 */
+	public function test_is_verified_filter_receives_status_and_user_id(): void {
+		$user_id = wc_create_new_customer( 'filter-args@example.com', 'filterargs', 'pw' );
+		$this->sut->mark_verified( $user_id );
+
+		$received_status  = null;
+		$received_user_id = null;
+		$listener         = static function ( $is_verified, $id ) use ( &$received_status, &$received_user_id ) {
+			$received_status  = $is_verified;
+			$received_user_id = $id;
+			return $is_verified;
+		};
+		add_filter( 'woocommerce_customer_email_is_verified', $listener, 10, 2 );
+
+		$this->sut->is_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', $listener );
+
+		$this->assertTrue( $received_status, 'The filter should receive the unfiltered verification status' );
+		$this->assertSame( $user_id, $received_user_id, 'The filter should receive the user ID' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CustomerEmailVerification/EmailVerificationServiceTest.php
@@ -263,4 +263,95 @@ class EmailVerificationServiceTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $received_status, 'The filter should receive the unfiltered verification status' );
 		$this->assertSame( $user_id, $received_user_id, 'The filter should receive the user ID' );
 	}
+
+	/**
+	 * @testdox mark_verified should persist and fire the hook for an unverified user even when the filter reports verified.
+	 */
+	public function test_mark_verified_persists_for_unverified_user_when_filter_forces_verified(): void {
+		$user_id = wc_create_new_customer( 'filter-mark@example.com', 'filtermark', 'pw' );
+		$key     = $this->sut->create_verification_key( $user_id );
+
+		$hook_calls = 0;
+		$listener   = static function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'woocommerce_customer_email_verified', $listener );
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+
+		$this->sut->mark_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+		remove_action( 'woocommerce_customer_email_verified', $listener );
+
+		$this->assertSame( 1, $hook_calls, 'The filter reporting verified should not block the verified action' );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'The filter reporting verified should not block persisting the meta' );
+		$this->assertFalse( $this->sut->check_verification_key( $user_id, $key ), 'The filter reporting verified should not block consuming the pending key' );
+	}
+
+	/**
+	 * @testdox mark_verified should stay a no-op for a verified user even when the filter reports verified.
+	 */
+	public function test_mark_verified_noops_for_verified_user_when_filter_forces_verified(): void {
+		$user_id = wc_create_new_customer( 'filter-mark-verified@example.com', 'filtermarkverified', 'pw' );
+		$this->sut->mark_verified( $user_id );
+
+		$hook_calls = 0;
+		$listener   = static function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'woocommerce_customer_email_verified', $listener );
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+
+		$this->sut->mark_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_true' );
+		remove_action( 'woocommerce_customer_email_verified', $listener );
+
+		$this->assertSame( 0, $hook_calls, 'An already persisted verified user should not re-fire the verified action' );
+	}
+
+	/**
+	 * @testdox mark_verified should persist and fire the hook for an unverified user even when the filter reports unverified.
+	 */
+	public function test_mark_verified_persists_for_unverified_user_when_filter_forces_unverified(): void {
+		$user_id = wc_create_new_customer( 'filter-mark-false@example.com', 'filtermarkfalse', 'pw' );
+
+		$hook_calls = 0;
+		$listener   = static function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'woocommerce_customer_email_verified', $listener );
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+
+		$this->sut->mark_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+		remove_action( 'woocommerce_customer_email_verified', $listener );
+
+		$this->assertSame( 1, $hook_calls, 'The filter reporting unverified should not change a normal mark' );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'The user should be persisted as verified' );
+	}
+
+	/**
+	 * @testdox mark_verified should stay a no-op for a verified user even when the filter reports unverified.
+	 */
+	public function test_mark_verified_noops_for_verified_user_when_filter_forces_unverified(): void {
+		$user_id = wc_create_new_customer( 'filter-noop-false@example.com', 'filternoopfalse', 'pw' );
+		$this->sut->mark_verified( $user_id );
+
+		$hook_calls = 0;
+		$listener   = static function () use ( &$hook_calls ) {
+			++$hook_calls;
+		};
+		add_action( 'woocommerce_customer_email_verified', $listener );
+		add_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+
+		$this->sut->mark_verified( $user_id );
+
+		remove_filter( 'woocommerce_customer_email_is_verified', '__return_false' );
+		remove_action( 'woocommerce_customer_email_verified', $listener );
+
+		$this->assertSame( 0, $hook_calls, 'The filter reporting unverified should not re-fire the verified action for a persisted verified user' );
+		$this->assertTrue( $this->sut->is_verified( $user_id ), 'The persisted verified status should remain' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Adds a `woocommerce_customer_email_is_verified` filter to `EmailVerificationService::is_verified()`, so extensions can control the verification status directly. 

Closes #67049.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Log in as a customer with an unverified email and go to My Account > Orders. The email confirmation prompt should be visible.
2. Add `add_filter( 'woocommerce_customer_email_is_verified', '__return_true' );` (e.g. via a snippets plugin or must-use plugin).
3. Reload My Account > Orders. The prompt should no longer appear.
4. Remove the snippet and reload. The prompt should return.

<!-- End testing instructions -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

This PR was drafted with AI assistance (OpenCode); the changes have been reviewed and verified by the contributor.