### PR TITLE
Fix incorrect status codes in WC_Download_Handler

### DIFF
--- a/plugins/woocommerce/changelog/67561-fix-download-handler-status-codes
+++ b/plugins/woocommerce/changelog/67561-fix-download-handler-status-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC_Download_Handler: use the actual request protocol instead of a hardcoded HTTP/1.1 for range-download status headers, and default download errors to 403 Forbidden instead of 404 Not Found.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -550,7 +550,7 @@ class WC_Download_Handler {
 				);
 				self::download_file_redirect( $file_path );
 			} else {
-				self::download_error( __( 'File not found', 'woocommerce' ) );
+				self::download_error( __( 'File not found', 'woocommerce' ), '', 404 );
 			}
 		}
 
@@ -758,7 +758,7 @@ class WC_Download_Handler {
 
 		if ( isset( $download_range['is_range_request'] ) && true === $download_range['is_range_request'] ) {
 			if ( false === $download_range['is_range_valid'] ) {
-				header( 'HTTP/1.1 416 Requested Range Not Satisfiable' );
+				status_header( 416 );
 				header( 'Content-Range: bytes 0-' . ( $file_size - 1 ) . '/' . $file_size );
 				exit;
 			}
@@ -767,7 +767,7 @@ class WC_Download_Handler {
 			$end    = $download_range['start'] + $download_range['length'] - 1;
 			$length = $download_range['length'];
 
-			header( 'HTTP/1.1 206 Partial Content' );
+			status_header( 206 );
 			header( "Accept-Ranges: 0-$file_size" );
 			header( "Content-Range: bytes $start-$end/$file_size" );
 			header( "Content-Length: $length" );
@@ -964,7 +964,7 @@ class WC_Download_Handler {
 	 * @param string  $title   Error title.
 	 * @param integer $status  Error status.
 	 */
-	private static function download_error( $message, $title = '', $status = 404 ) {
+	private static function download_error( $message, $title = '', $status = 403 ) {
 		/*
 		 * Since we will now render a message instead of serving a download, we should unwind some of the previously set
 		 * headers.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

`WC_Download_Handler` was returning incorrect HTTP status information in two places. For range-download responses, the status line was hardcoded to `HTTP/1.1`, regardless of the protocol used by the request. This now uses WordPress's `status_header()` to ensure the response reports the correct protocol, including HTTP/1.1 and HTTP/2.

Additionally, `download_error()` defaulted to `404 Not Found`. This is inconsistent with the `403 Forbidden` response already returned by WooCommerce's documented Nginx protected-directory configuration for the same failures. Returning a 404 could also result in page caches storing an incorrect response for what is actually an access failure.

Closes #51561, #51563.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

### Testing Instructions

1. Create a downloadable product (**Products → Add New**), enable **Downloadable**, and add a file under **Downloadable Files**. Create an order for the product and set the order status to **Completed** so that download permissions are granted (**WooCommerce → Orders → Add New**).

2. Get the download link for the file.
   The download URL is:

   ```
   <site-url>/?download_file=<product_id>&order=<order_key>&email=<user_email>&key=<download_id>
   ```

4. Request the file using an invalid `key` to verify the error status:

   ```bash
   curl -sD - -o /dev/null "<site-url>/?download_file=<product_id>&order=<order_key>&email=<user_email>&key=invalid"
   ```

   **Expected:** `403 Forbidden`
   **Before this fix:** `404 Not Found`

5. Request a valid byte range from the file to verify that range requests continue to return the correct status:

   ```bash
   curl -sD - -o /dev/null -H "Range: bytes=0-10" "<download-link-from-step-2>"
   ```

   **Expected:** `206 Partial Content`

6. Request an out-of-bounds range from the same file:

   ```bash
   curl -sD - -o /dev/null -H "Range: bytes=99999999-999999999" "<download-link-from-step-2>"
   ```

   **Expected:** `416 Requested Range Not Satisfiable`

### Testing that has already taken place:

- Manually verified steps 3–5 above on a local wp-env site: confirmed `403 Forbidden` on an invalid download link, and confirmed `206`/`416` range-request statuses are unaffected by the `status_header()` change.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

This PR was developed with the assistance of Claude Code.
