### PR TITLE
Guard Product Filters block gap values

### DIFF
--- a/plugins/woocommerce/changelog/wooairr-126-product-filters-block-gap-guard
+++ b/plugins/woocommerce/changelog/wooairr-126-product-filters-block-gap-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent invalid Product Filters block spacing values from being rendered.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -236,7 +236,7 @@ class ProductFilters extends AbstractBlock {
 		}
 
 		$block_gap = $attributes['style']['spacing']['blockGap'] ?? '';
-		if ( '' !== $block_gap ) {
+		if ( is_string( $block_gap ) && '' !== $block_gap ) {
 			$styles[] = sprintf( '--wc-product-filter-block-spacing: %s', StyleAttributesUtils::get_spacing_value( $block_gap ) );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

PR #67870 allowed unsupported non-string `blockGap` values into CSS generation. Require a non-empty string while preserving valid `"0"` spacing.

Bug introduced in PR #67870.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set a Product Filters block's spacing to `0`.
2. Confirm the frontend uses `--wc-product-filter-block-spacing: 0;`.
3. Confirm a non-string `blockGap` does not generate the property.

<!-- End testing instructions -->

### Testing that has already taken place:

PHP lint, branch lint, PHPStan, syntax, and whitespace checks passed. PHPUnit was blocked by full local Docker storage.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Comment</summary>

#### Comment

Created manually.

</details>

### Release Communication

<!-- release-communication-section -->
- [ ] **Feature Highlight**
- [ ] **Developer Advisory**

### Use of AI Tools

Codex implemented and reviewed the change and drafted this PR description.
