### PR TITLE
Fix coupon double-discounting on REST orders with posted line totals

### DIFF
--- a/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
+++ b/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Calculate coupon discounts from manually edited order line item totals instead of the original prices, and stop coupon application from discarding those manual edits.
+In the admin order editor, calculate coupon discounts from manually edited order line item totals instead of the original prices, and stop coupon application from discarding those manual edits.

--- a/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
+++ b/plugins/woocommerce/changelog/fix-28591-coupon-discount-on-edited-order-totals
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-In the admin order editor, calculate coupon discounts from manually edited order line item totals instead of the original prices, and stop coupon application from discarding those manual edits.
+Fix coupons applied in the order editor ignoring manually edited line item totals.

--- a/plugins/woocommerce/changelog/fix-wooairr-128-editor-scoped-subtotal-sync
+++ b/plugins/woocommerce/changelog/fix-wooairr-128-editor-scoped-subtotal-sync
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Same-cycle regression from #67731, never present in a stable release; REST orders with posted line totals and coupon codes were double-discounted.

--- a/plugins/woocommerce/changelog/fix-wooairr-128-editor-scoped-subtotal-sync
+++ b/plugins/woocommerce/changelog/fix-wooairr-128-editor-scoped-subtotal-sync
@@ -1,3 +1,3 @@
 Significance: patch
 Type: dev
-Comment: Same-cycle regression from #67731, never present in a stable release; REST orders with posted line totals and coupon codes were double-discounted.
+Comment: Same-cycle fix for a #67731 regression, never released.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1441,9 +1441,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Apply a coupon to the order and recalculate totals.
 	 *
 	 * @since 3.2.0
-	 * @since 11.2.0 When no coupons are applied yet, line items whose totals were manually
-	 *               edited have their subtotals synced to those totals first, so discounts
-	 *               are calculated from the edited prices rather than the original ones.
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
 	 * @return true|WP_Error True if applied, error if not.
 	 */
@@ -1476,18 +1473,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		// With no coupons applied, a line total differing from its subtotal is a manual price
-		// adjustment. Adopt it as the new pre-discount price, otherwise discounts would be
-		// calculated from the original price and recalculations would discard the adjustment.
-		// With coupons already applied this is skipped: the difference also contains their
-		// discounts and the manual portion cannot be separated out.
-		$original_subtotals = empty( $applied_coupons ) ? $this->sync_subtotals_with_manually_edited_totals() : array();
-
 		$discounts = new WC_Discounts( $this );
 		$applied   = $discounts->apply_coupon( $coupon );
 
 		if ( is_wp_error( $applied ) ) {
-			$this->restore_item_subtotals( $original_subtotals );
 			return $applied;
 		}
 
@@ -1497,7 +1486,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( $data_store && 0 === $this->get_customer_id() ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
-				$this->restore_item_subtotals( $original_subtotals );
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),
@@ -1539,6 +1527,33 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		wc_update_coupon_usage_counts( $this->get_id() );
 
 		return true;
+	}
+
+	/**
+	 * Apply a coupon treating manually edited line item totals as the pre-discount price.
+	 *
+	 * When the order has no coupons yet, line items whose total differs from their subtotal
+	 * adopt that total as the new subtotal, so the discount is calculated from the edited
+	 * price and recalculations keep the manual adjustment. On failure the original subtotals
+	 * are restored. Only call this when the difference is known to be a manual edit;
+	 * otherwise use apply_coupon().
+	 *
+	 * @since 11.2.0
+	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
+	 * @return true|WP_Error True if applied, error if not.
+	 */
+	public function apply_coupon_using_edited_totals( $raw_coupon ) {
+		// With coupons already applied the subtotal/total difference also contains their
+		// discounts and the manual portion cannot be separated out, so it is left alone.
+		$original_subtotals = empty( $this->get_items( 'coupon' ) ) ? $this->sync_subtotals_with_manually_edited_totals() : array();
+
+		$applied = $this->apply_coupon( $raw_coupon );
+
+		if ( is_wp_error( $applied ) ) {
+			$this->restore_item_subtotals( $original_subtotals );
+		}
+
+		return $applied;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1535,8 +1535,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * When the order has no coupons yet, line items whose total differs from their subtotal
 	 * adopt that total as the new subtotal, so the discount is calculated from the edited
 	 * price and recalculations keep the manual adjustment. On failure the original subtotals
-	 * are restored. Only call this when the difference is known to be a manual edit;
-	 * otherwise use apply_coupon().
+	 * are restored. Call this only where a subtotal/total difference is meant to be treated
+	 * as a manual edit, such as the admin order editor; otherwise use apply_coupon().
 	 *
 	 * @since 11.2.0
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -84,8 +84,10 @@ class CouponsController {
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
 
-		$code   = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$result = $order->apply_coupon( $code );
+		$code = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		// In the order editor a line total differing from its subtotal is a manual price edit.
+		$result = $order->apply_coupon_using_edited_totals( $code );
 
 		if ( is_wp_error( $result ) ) {
 			throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -86,7 +86,8 @@ class CouponsController {
 
 		$code = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		// In the order editor a line total differing from its subtotal is a manual price edit.
+		// A line total differing from its subtotal is treated as a manual price edit here. That is
+		// the editor's best guess: a difference recorded by REST or an extension is adopted the same way.
 		$result = $order->apply_coupon_using_edited_totals( $code );
 
 		if ( is_wp_error( $result ) ) {

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -357,13 +357,34 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		);
 		$order  = $this->create_order_with_manually_edited_total();
 
-		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon_using_edited_totals( $coupon->get_code() ) );
 
 		$item = current( $order->get_items() );
 		$this->assertEquals( 50, $item->get_subtotal(), 'Edited line total should become the new pre-discount price' );
 		$this->assertEquals( 45, $item->get_total(), 'Discount should be taken off the edited price' );
 		$this->assertEquals( 5, $order->get_discount_total(), 'Discount should be 10% of the edited price' );
 		$this->assertEquals( 45, $order->get_total() );
+	}
+
+	/**
+	 * @testdox Plain apply_coupon() calculates the discount from the stored subtotal, leaving edited totals alone.
+	 */
+	public function test_apply_coupon_keeps_stored_subtotals() {
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'percent_coupon_no_sync',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+		$order  = $this->create_order_with_manually_edited_total();
+
+		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 100, $item->get_subtotal(), 'apply_coupon() should not adopt the edited total as a new subtotal' );
+		$this->assertEquals( 90, $item->get_total(), 'The discount should be calculated from the stored subtotal' );
+		$this->assertEquals( 10, $order->get_discount_total() );
 	}
 
 	/**
@@ -380,7 +401,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		);
 		$order = $this->create_order_with_manually_edited_total();
 
-		$this->assertWPError( $order->apply_coupon( 'expired_coupon_28591' ) );
+		$this->assertWPError( $order->apply_coupon_using_edited_totals( 'expired_coupon_28591' ) );
 
 		$item = current( $order->get_items() );
 		$this->assertEquals( 100, $item->get_subtotal(), 'Failed coupon application should not change the subtotal' );
@@ -400,7 +421,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		);
 		$order  = $this->create_order_with_manually_edited_total();
 
-		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon_using_edited_totals( $coupon->get_code() ) );
 		$this->assertTrue( $order->remove_coupon( $coupon->get_code() ) );
 
 		$item = current( $order->get_items() );
@@ -428,7 +449,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$order->set_billing_email( $guest_email );
 		$order->save();
 
-		$this->assertWPError( $order->apply_coupon( $coupon->get_code() ) );
+		$this->assertWPError( $order->apply_coupon_using_edited_totals( $coupon->get_code() ) );
 
 		$item = current( $order->get_items() );
 		$this->assertEquals( 100, $item->get_subtotal(), 'Usage-limit rejection should not change the subtotal' );
@@ -455,8 +476,8 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		);
 		$order          = $this->create_order_with_manually_edited_total();
 
-		$this->assertTrue( $order->apply_coupon( $percent_coupon->get_code() ) );
-		$this->assertTrue( $order->apply_coupon( $fixed_coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon_using_edited_totals( $percent_coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon_using_edited_totals( $fixed_coupon->get_code() ) );
 
 		$item = current( $order->get_items() );
 		$this->assertEquals( 50, $item->get_subtotal(), 'Second coupon application should not re-sync the subtotal' );
@@ -516,7 +537,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		);
 		$order  = $this->create_taxed_order_with_manually_edited_total();
 
-		$this->assertTrue( $order->apply_coupon( $coupon->get_code() ) );
+		$this->assertTrue( $order->apply_coupon_using_edited_totals( $coupon->get_code() ) );
 
 		$item  = current( $order->get_items() );
 		$taxes = $item->get_taxes();
@@ -544,7 +565,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 
 		$original_taxes = current( $order->get_items() )->get_taxes();
 
-		$this->assertWPError( $order->apply_coupon( 'expired_coupon_28591_tax' ) );
+		$this->assertWPError( $order->apply_coupon_using_edited_totals( 'expired_coupon_28591_tax' ) );
 
 		$item = current( $order->get_items() );
 		$this->assertEquals( 100, $item->get_subtotal() );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -409,6 +409,19 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox A nonexistent coupon code is rejected before validation and leaves manually edited line items unchanged.
+	 */
+	public function test_apply_coupon_unknown_code_keeps_manually_edited_line_items() {
+		$order = $this->create_order_with_manually_edited_total();
+
+		$this->assertWPError( $order->apply_coupon_using_edited_totals( 'no_such_coupon_28591' ) );
+
+		$item = current( $order->get_items() );
+		$this->assertEquals( 100, $item->get_subtotal(), 'A rejected unknown code should not change the subtotal' );
+		$this->assertEquals( 50, $item->get_total(), 'A rejected unknown code should not change the total' );
+	}
+
+	/**
 	 * @testdox Removing a coupon restores the manually edited line total, not the original price.
 	 */
 	public function test_remove_coupon_restores_manually_edited_line_total() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -399,6 +399,44 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * @testdox Applying a coupon in the order editor calculates the discount from a manually edited line total.
+	 */
+	public function test_add_coupon_discount_uses_manually_edited_line_total() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$coupon = new WC_Coupon();
+		$coupon->set_code( '10off-edited' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->calculate_totals();
+		foreach ( $order->get_items() as $item ) {
+			$item->set_total( 50 );
+			$item->save();
+		}
+		$order->calculate_totals();
+		$order->save();
+
+		wc_get_container()->get( CouponsController::class )->add_coupon_discount(
+			array(
+				'order_id' => $order->get_id(),
+				'coupon'   => $coupon->get_code(),
+			)
+		);
+
+		$order = wc_get_order( $order->get_id() );
+		$item  = current( $order->get_items() );
+		$this->assertEquals( 50, $item->get_subtotal(), 'The edited line total should become the new pre-discount price' );
+		$this->assertEquals( 45, $item->get_total(), 'The discount should be taken off the edited price' );
+		$this->assertEquals( 45, $order->get_total() );
+	}
+
+	/**
 	 * Describe JSON search, particularly as it relates to handling searches for users in a
 	 * multisite context (it should generally not be possible to retrieve information about
 	 * users who have not been added to the current blog).

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1592,7 +1592,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @param float  $edited_total  Manually edited line total, 0 to keep the original price.
 	 * @return WC_Order
 	 */
-	private function create_order_for_coupon_replacement( string $billing_email, float $edited_total = 0 ): WC_Order {
+	private function create_guest_order_with_product( string $billing_email, float $edited_total = 0 ): WC_Order {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 100 );
 		$product->save();
@@ -1666,7 +1666,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		$order = $this->create_order_for_coupon_replacement( 'edited-ok-customer@example.com', 50 );
+		$order = $this->create_guest_order_with_product( 'edited-ok-customer@example.com', 50 );
 
 		$response = $this->put_coupon_lines( $order->get_id(), array( 'edited-percent' ) );
 
@@ -1726,7 +1726,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		$order   = $this->create_order_for_coupon_replacement( 'update-coupon-customer@example.com' );
+		$order   = $this->create_guest_order_with_product( 'update-coupon-customer@example.com' );
 		$item_id = key( $order->get_items() );
 
 		$request = new \WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1584,4 +1584,170 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 0, $reloaded->get_variation_id(), 'Switching to a simple product by SKU should clear variation_id.' );
 		$this->assertSame( $simple->get_id(), $reloaded->get_product()->get_id(), 'The line item should resolve to the product selected by SKU.' );
 	}
+
+	/**
+	 * Create a pending order with one $100 product, optionally with its line total manually edited.
+	 *
+	 * @param string $billing_email Billing email (the order stays a guest order).
+	 * @param float  $edited_total  Manually edited line total, 0 to keep the original price.
+	 * @return WC_Order
+	 */
+	private function create_order_for_coupon_replacement( string $billing_email, float $edited_total = 0 ): WC_Order {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->set_billing_email( $billing_email );
+		$order->add_product( $product, 1 );
+		$order->calculate_totals();
+
+		if ( $edited_total > 0 ) {
+			foreach ( $order->get_items() as $item ) {
+				$item->set_total( $edited_total );
+				$item->save();
+			}
+			$order->calculate_totals();
+		}
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Dispatch a PUT request replacing the order's coupons with the given codes.
+	 *
+	 * @param int      $order_id Order ID.
+	 * @param string[] $codes    Coupon codes for the request's coupon_lines.
+	 * @return WP_REST_Response
+	 */
+	private function put_coupon_lines( int $order_id, array $codes ): WP_REST_Response {
+		$request = new \WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order_id );
+		$request->set_body_params(
+			array(
+				'coupon_lines' => array_map(
+					function ( $code ) {
+						return array( 'code' => $code );
+					},
+					$codes
+				),
+			)
+		);
+
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Get the coupon codes currently applied to an order, freshly loaded from the database.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return string[]
+	 */
+	private function get_reloaded_coupon_codes( int $order_id ): array {
+		return array_values(
+			array_map(
+				function ( $coupon ) {
+					return $coupon->get_code();
+				},
+				wc_get_order( $order_id )->get_items( 'coupon' )
+			)
+		);
+	}
+
+	/**
+	 * @testdox A coupon applied via REST calculates the discount from the stored subtotal, not a manually edited total.
+	 */
+	public function test_valid_coupon_applies_to_manually_edited_order(): void {
+		WC_Helper_Coupon::create_coupon(
+			'edited-percent',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+
+		$order = $this->create_order_for_coupon_replacement( 'edited-ok-customer@example.com', 50 );
+
+		$response = $this->put_coupon_lines( $order->get_id(), array( 'edited-percent' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'edited-percent' ), $this->get_reloaded_coupon_codes( $order->get_id() ) );
+		$this->assertEquals( 90, wc_get_order( $order->get_id() )->get_total(), 'The discount should be taken off the stored subtotal, not the edited total' );
+	}
+
+	/**
+	 * @testdox Creating an order with explicitly posted line totals and a coupon keeps the posted subtotal as the pre-discount price.
+	 */
+	public function test_create_with_posted_line_totals_and_coupon_does_not_double_discount(): void {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+		WC_Helper_Coupon::create_coupon(
+			'created-percent',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc/v3/orders' );
+		$request->set_body_params(
+			array(
+				'billing'      => array( 'email' => 'create-coupon-customer@example.com' ),
+				'line_items'   => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 1,
+						'subtotal'   => '100',
+						'total'      => '90',
+					),
+				),
+				'coupon_lines' => array( array( 'code' => 'created-percent' ) ),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertEquals( 100, $data['line_items'][0]['subtotal'], 'The posted subtotal should stay the pre-discount price' );
+		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The discount should be calculated from the posted subtotal, not stacked on the posted total' );
+		$this->assertEquals( 10, $data['discount_total'] );
+	}
+
+	/**
+	 * @testdox Updating an order with explicitly posted line totals and a coupon keeps the posted subtotal as the pre-discount price.
+	 */
+	public function test_update_with_posted_line_totals_and_coupon_does_not_double_discount(): void {
+		WC_Helper_Coupon::create_coupon(
+			'updated-percent',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => '10',
+			)
+		);
+
+		$order   = $this->create_order_for_coupon_replacement( 'update-coupon-customer@example.com' );
+		$item_id = key( $order->get_items() );
+
+		$request = new \WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_body_params(
+			array(
+				'line_items'   => array(
+					array(
+						'id'       => $item_id,
+						'subtotal' => '100',
+						'total'    => '90',
+					),
+				),
+				'coupon_lines' => array( array( 'code' => 'updated-percent' ) ),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEquals( 100, $data['line_items'][0]['subtotal'], 'The posted subtotal should stay the pre-discount price' );
+		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The discount should be calculated from the posted subtotal, not stacked on the posted total' );
+		$this->assertEquals( 10, $data['discount_total'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -1699,7 +1699,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 						'product_id' => $product->get_id(),
 						'quantity'   => 1,
 						'subtotal'   => '100',
-						'total'      => '90',
+						'total'      => '95',
 					),
 				),
 				'coupon_lines' => array( array( 'code' => 'created-percent' ) ),
@@ -1710,7 +1710,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( 201, $response->get_status() );
 		$this->assertEquals( 100, $data['line_items'][0]['subtotal'], 'The posted subtotal should stay the pre-discount price' );
-		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The discount should be calculated from the posted subtotal, not stacked on the posted total' );
+		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The total should be recalculated from the posted subtotal, not from or on top of the posted total' );
 		$this->assertEquals( 10, $data['discount_total'] );
 	}
 
@@ -1736,7 +1736,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 					array(
 						'id'       => $item_id,
 						'subtotal' => '100',
-						'total'    => '90',
+						'total'    => '95',
 					),
 				),
 				'coupon_lines' => array( array( 'code' => 'updated-percent' ) ),
@@ -1747,7 +1747,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertEquals( 100, $data['line_items'][0]['subtotal'], 'The posted subtotal should stay the pre-discount price' );
-		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The discount should be calculated from the posted subtotal, not stacked on the posted total' );
+		$this->assertEquals( 90, $data['line_items'][0]['total'], 'The total should be recalculated from the posted subtotal, not from or on top of the posted total' );
 		$this->assertEquals( 10, $data['discount_total'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

#67731 made `apply_coupon()` treat any line item whose total differs from its subtotal as manually edited, adopting the total as the new pre-discount price. That guess is only correct in the admin order editor: REST orders posting `line_items` with `subtotal != total` alongside `coupon_lines` got double-discounted. This restores `apply_coupon()` to its previous behavior and moves the edited-totals handling into a new `apply_coupon_using_edited_totals()` method that only the order editor uses, keeping the #28591 fix.

Bug introduced in PR #67731.

Fixes WOOAIRR-128.

### BC (developer advisory):

The new public `apply_coupon_using_edited_totals` method is additive. A third-party subclass already declaring a method with this exact name and an incompatible signature would fatal on load; the name is new in 11.2.0, so a collision is unlikely.

### How to test the changes in this Pull Request:

1. Create a 10% percent coupon.
2. `POST /wc/v3/orders` with `line_items: [{"product_id": <id>, "quantity": 1, "subtotal": "100", "total": "95"}]` and `coupon_lines: [{"code": "<coupon>"}]`.
3. The response line item should be subtotal 100 / total 90 with `discount_total` 10 - the discount is recalculated from the posted subtotal (on trunk the subtotal is overwritten to 95 and the response comes back 95 / 85.5).
4. In the admin order editor, create a new order with a $100 product, edit the line total to $50, then apply the coupon: the discount should be $5, confirming the #28591 fix still works.

### Testing already done:

- Unit tests covering REST create/update/replace with posted line totals, plain `apply_coupon()`, and the order editor flow.
- `lint:changes:branch` and PHPStan clean.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

Changelog entry created manually (comment-only: same-cycle regression, never in a stable release).

### Release Communication

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [x] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

### Use of AI Tools

This PR was developed with AI assistance (Claude Code): investigation, implementation, tests, and verification were AI-generated and human-reviewed.
