### PR TITLE
Use enum constants in developer docs code examples

### DIFF
--- a/docs/features/orders/high-performance-order-storage/wc-order-query-improvements.md
+++ b/docs/features/orders/high-performance-order-storage/wc-order-query-improvements.md
@@ -128,7 +128,7 @@ $orders = wc_get_orders(
 // Obtain orders either "on-hold" or "pending" that have metadata `weight` >= 50 and metadata `color` or `size` is set.
 
 $query_args = array(
-    'status' => array( 'pending', 'on-hold' ),
+    'status' => array( \Automattic\WooCommerce\Enums\OrderStatus::PENDING, \Automattic\WooCommerce\Enums\OrderStatus::ON_HOLD ),
     'meta_query' => array(
         array(
             'key'     => 'weight',

--- a/docs/features/orders/wc-get-orders.md
+++ b/docs/features/orders/wc-get-orders.md
@@ -75,7 +75,7 @@ Query parameters/arguments that can be used with these functions are described b
 
 | Parameter | Description |
 | --- | --- |
-| **status** | Accepts an array of strings: by default is set to the keys of `wc_get_order_statuses()`. |
+| **status** | Accepts an array of strings: by default is set to the keys of `wc_get_order_statuses()`. Both `wc-`-prefixed (`'wc-processing'`) and unprefixed (`'processing'`) values are accepted. See the [OrderInternalStatus](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/OrderInternalStatus.php) and [OrderStatus](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Enums/OrderStatus.php) constant classes. |
 | **type** | Accepts a string: `'shop_order'`, `'shop_order_refund'`, or a custom order type. |
 | **version** | Accepts a string: WooCommerce version number the order was created in. |
 | **created_via** | Accepts a string: 'checkout', 'rest-api', or a custom creation method slug. |
@@ -111,6 +111,17 @@ $orders = wc_get_orders( array( 'return' => 'ids' ) );
 // Get orders processing and on-hold.
 $args = array(
     'status' => array( 'wc-processing', 'wc-on-hold' ),
+);
+$orders = wc_get_orders( $args );
+```
+
+```php
+// Using constant classes for status.
+$args = array(
+    'status' => array(
+        \Automattic\WooCommerce\Enums\OrderInternalStatus::PROCESSING,
+        \Automattic\WooCommerce\Enums\OrderInternalStatus::ON_HOLD,
+    ),
 );
 $orders = wc_get_orders( $args );
 ```

--- a/docs/features/payments/payment-gateway-api.md
+++ b/docs/features/payments/payment-gateway-api.md
@@ -158,7 +158,7 @@ global $woocommerce;
 $order = new WC_Order( $order_id );
 
     // Mark as on-hold (we're awaiting the cheque)
-    $order->update_status('on-hold', __( 'Awaiting cheque payment', 'woocommerce' ));
+    $order->update_status(\Automattic\WooCommerce\Enums\OrderStatus::ON_HOLD, __( 'Awaiting cheque payment', 'woocommerce' ));
 
     // Remove cart
     $woocommerce->cart->empty_cart();
@@ -204,7 +204,7 @@ Updating the order status can be done using functions in the order class. You sh
 
 ```php
 $order = new WC_Order( $order_id );
-$order->update_status('on-hold', __('Awaiting cheque payment', 'woothemes'));
+$order->update_status(\Automattic\WooCommerce\Enums\OrderStatus::ON_HOLD, __('Awaiting cheque payment', 'woothemes'));
 ```
 
 The above example updates the status to On-Hold and adds a note informing the owner that it is awaiting a Cheque. You can add notes without updating the order status; this is used for adding a debug message:

--- a/docs/features/products/wc-get-products.md
+++ b/docs/features/products/wc-get-products.md
@@ -89,6 +89,11 @@ $products = wc_get_products( array( 'type' => 'external' ) );
 ```
 
 ```php
+// Using constant class for type.
+$products = wc_get_products( array( 'type' => \Automattic\WooCommerce\Enums\ProductType::EXTERNAL ) );
+```
+
+```php
 // Get external products limited to specific IDs.
 $args = array(
     'type' => 'external',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `Automattic\WooCommerce\Enums` constant classes are public API that extension developers are encouraged to use, but most developer docs code examples still show only raw string literals. This updates the examples to model the constants, following the pattern established in `wc-get-products.md` (PR #54696) of showing the literal example alongside a "Using constant class" companion:

- `wc-get-orders.md`: documents that `status` accepts both `wc-`-prefixed and unprefixed values, links the `OrderInternalStatus`/`OrderStatus` constant classes, and adds a constant-based companion example.
- `wc-get-products.md`: adds the missing constant companion example for `type` (`ProductType::EXTERNAL`).
- `payment-gateway-api.md`: the two `update_status( 'on-hold', ... )` gateway examples now use `OrderStatus::ON_HOLD`.
- `wc-order-query-improvements.md`: the advanced HPOS query example now uses `OrderStatus::PENDING` / `OrderStatus::ON_HOLD`.

JSON payloads (Store API), CLI output, and JS/TS examples intentionally keep string values — the PHP constants do not apply there.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1. Review the four changed docs pages and confirm each constant reference matches the real value in `plugins/woocommerce/src/Enums/` (e.g. `OrderInternalStatus::PROCESSING` is `'wc-processing'`).
2. Confirm the updated snippets remain copy-paste runnable in a plugin context (fully qualified class names, no `use` statements required).

<!-- End testing instructions -->

### Testing that has already taken place:

Verified each constant name and value against `plugins/woocommerce/src/Enums/`. `markdownlint` passes with 0 errors on all four files.

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

-   [ ] Automatically create a changelog entry from the details below.

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Developer documentation only; nothing shipped to merchants.

</details>

### Release Communication

<!-- release-communication-section -->
Select the release communication labels this PR needs:

- [ ] **Feature Highlight** - For user-facing features (what changed, user impact)
- [ ] **Developer Advisory** - For developer-facing changes (what changed, how to detect, actions needed)

<details>
<summary>When to use each?</summary>

**Feature Highlight**: New features, UI changes, or improvements that merchants/store owners will notice.

- Example: "New bulk editing for products", "Improved checkout performance"

**Developer Advisory**: Breaking changes, deprecations, or changes that affect themes/plugins/extensions.

- Example: "Hook signature change", "Deprecated filter", "REST API field removed"

Selected labels are applied when the pull request is merged.
</details>

### Use of AI Tools

This PR was written with the help of Claude Code; every constant name and value was verified against the codebase by the author.